### PR TITLE
feat: in-app editor view with workspace changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
 		"lucide-react": "^1.7.0",
+		"monaco-editor": "^0.55.1",
 		"react": "19.2.0",
 		"react-dom": "19.2.0",
 		"react-loading-skeleton": "^3.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       lucide-react:
         specifier: ^1.7.0
         version: 1.7.0(react@19.2.0)
+      monaco-editor:
+        specifier: ^0.55.1
+        version: 0.55.1
       react:
         specifier: 19.2.0
         version: 19.2.0
@@ -1945,6 +1948,9 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
+  dompurify@3.2.7:
+    resolution: {integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==}
+
   dompurify@3.3.3:
     resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
 
@@ -2590,6 +2596,11 @@ packages:
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
+  marked@14.0.0:
+    resolution: {integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==}
+    engines: {node: '>= 18'}
+    hasBin: true
+
   marked@16.4.2:
     resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
     engines: {node: '>= 20'}
@@ -2787,6 +2798,9 @@ packages:
 
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
+  monaco-editor@0.55.1:
+    resolution: {integrity: sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -5392,6 +5406,10 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
+  dompurify@3.2.7:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
   dompurify@3.3.3:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
@@ -6043,6 +6061,8 @@ snapshots:
 
   markdown-table@3.0.4: {}
 
+  marked@14.0.0: {}
+
   marked@16.4.2: {}
 
   marked@17.0.5: {}
@@ -6456,6 +6476,11 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.3
+
+  monaco-editor@0.55.1:
+    dependencies:
+      dompurify: 3.2.7
+      marked: 14.0.0
 
   ms@2.1.3: {}
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -69,6 +69,8 @@ pub fn run() {
             models::unpin_workspace,
             models::list_editor_files,
             models::list_editor_files_with_content,
+            models::list_workspace_changes,
+            models::list_workspace_changes_with_content,
             models::read_editor_file,
             models::set_workspace_manual_status,
             models::detect_installed_editors,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -67,18 +67,23 @@ pub fn run() {
             models::mark_workspace_unread,
             models::pin_workspace,
             models::unpin_workspace,
+            models::list_editor_files,
+            models::list_editor_files_with_content,
+            models::read_editor_file,
             models::set_workspace_manual_status,
             models::detect_installed_editors,
             models::open_workspace_in_editor,
             models::permanently_delete_workspace,
             models::restore_workspace,
+            models::stat_editor_file,
             models::start_github_identity_connect,
             models::conductor_source_available,
             models::list_conductor_repos,
             models::list_conductor_workspaces,
             models::import_conductor_workspaces,
             models::update_app_settings,
-            models::update_session_settings
+            models::update_session_settings,
+            models::write_editor_file
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/models/editor_files.rs
+++ b/src-tauri/src/models/editor_files.rs
@@ -10,7 +10,7 @@ use anyhow::{bail, Context, Result};
 use serde::Serialize;
 use uuid::Uuid;
 
-use super::workspaces;
+use super::{git_ops, workspaces};
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -193,6 +193,168 @@ pub fn list_editor_files_with_content(
         .collect();
 
     Ok(EditorFilesWithContentResponse { items, prefetched })
+}
+
+/// List files changed on the current branch relative to the default branch (main/master),
+/// including both committed and uncommitted changes.
+pub fn list_workspace_changes(workspace_root_path: &str) -> Result<Vec<EditorFileListItem>> {
+    let workspace_root = Path::new(workspace_root_path);
+    if !workspace_root.is_absolute() || !workspace_root.is_dir() {
+        bail!(
+            "Workspace root is not a valid directory: {}",
+            workspace_root.display()
+        );
+    }
+
+    let merge_base = find_merge_base(workspace_root)?;
+
+    // Committed changes: merge-base..HEAD
+    let committed_output = git_ops::run_git(
+        ["diff", "--name-status", merge_base.as_str(), "HEAD"],
+        Some(workspace_root),
+    )
+    .unwrap_or_default();
+
+    // Unstaged changes
+    let unstaged_output =
+        git_ops::run_git(["diff", "--name-status"], Some(workspace_root)).unwrap_or_default();
+
+    // Staged changes
+    let staged_output =
+        git_ops::run_git(["diff", "--name-status", "--cached"], Some(workspace_root))
+            .unwrap_or_default();
+
+    // Untracked files
+    let untracked_output = git_ops::run_git(
+        ["ls-files", "--others", "--exclude-standard"],
+        Some(workspace_root),
+    )
+    .unwrap_or_default();
+
+    let mut file_map = std::collections::BTreeMap::<String, String>::new();
+
+    // Layer in order: committed first, then staged, then unstaged (latest wins)
+    parse_name_status_into(&committed_output, &mut file_map);
+    parse_name_status_into(&staged_output, &mut file_map);
+    parse_name_status_into(&unstaged_output, &mut file_map);
+
+    // Untracked files are all "A" (added)
+    for line in untracked_output.lines() {
+        let path = line.trim();
+        if !path.is_empty() {
+            file_map
+                .entry(path.to_string())
+                .or_insert_with(|| "A".to_string());
+        }
+    }
+
+    // Remove deleted files that no longer exist (D status stays — it's informational)
+    Ok(file_map
+        .into_iter()
+        .map(|(relative_path, status)| {
+            let absolute = workspace_root.join(&relative_path);
+            let name = Path::new(&relative_path)
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_else(|| relative_path.clone());
+            EditorFileListItem {
+                path: relative_path,
+                absolute_path: absolute.display().to_string(),
+                name,
+                status,
+            }
+        })
+        .collect())
+}
+
+/// List workspace changes and eagerly read their contents in a single IPC call.
+pub fn list_workspace_changes_with_content(
+    workspace_root_path: &str,
+) -> Result<EditorFilesWithContentResponse> {
+    let items = list_workspace_changes(workspace_root_path)?;
+
+    const MAX_PREFETCH_BYTES: u64 = 1_048_576; // 1 MB
+
+    let prefetched = items
+        .iter()
+        .filter(|item| item.status != "D")
+        .filter_map(|item| {
+            let path = Path::new(&item.absolute_path);
+            let metadata = fs::metadata(path).ok()?;
+            if metadata.len() > MAX_PREFETCH_BYTES {
+                return None;
+            }
+            let bytes = fs::read(path).ok()?;
+            let content = String::from_utf8(bytes).ok()?;
+            Some(EditorFilePrefetchItem {
+                absolute_path: item.absolute_path.clone(),
+                content,
+            })
+        })
+        .collect();
+
+    Ok(EditorFilesWithContentResponse { items, prefetched })
+}
+
+/// Find the merge-base commit between HEAD and the default branch.
+fn find_merge_base(workspace_root: &Path) -> Result<String> {
+    // Try main, then master
+    for branch in &["refs/heads/main", "refs/heads/master"] {
+        if let Ok(base) = git_ops::run_git(["merge-base", "HEAD", *branch], Some(workspace_root)) {
+            if !base.trim().is_empty() {
+                return Ok(base.trim().to_string());
+            }
+        }
+    }
+
+    // Fallback: empty tree object (treats all files as added)
+    let empty_tree = git_ops::run_git(
+        ["hash-object", "-t", "tree", "/dev/null"],
+        Some(workspace_root),
+    )
+    .context("Failed to generate empty tree hash")?;
+    Ok(empty_tree.trim().to_string())
+}
+
+/// Parse `git diff --name-status` output into a path→status map.
+fn parse_name_status_into(output: &str, map: &mut std::collections::BTreeMap<String, String>) {
+    for line in output.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        // Format: "M\tpath" or "R100\told\tnew" (rename)
+        let mut parts = line.splitn(2, '\t');
+        let Some(raw_status) = parts.next() else {
+            continue;
+        };
+        let Some(path) = parts.next() else {
+            continue;
+        };
+
+        // Normalize status: R(ename) → A for the new path, C(opy) → A
+        let status = match raw_status.chars().next() {
+            Some('M') => "M",
+            Some('A') => "A",
+            Some('D') => "D",
+            Some('R') => {
+                // Rename: "R100\told\tnew" — treat new path as Added
+                if let Some(new_path) = path.split('\t').nth(1) {
+                    map.insert(new_path.to_string(), "A".to_string());
+                }
+                // Mark old path as deleted
+                if let Some(old_path) = path.split('\t').next() {
+                    map.insert(old_path.to_string(), "D".to_string());
+                }
+                continue;
+            }
+            Some('C') => "A",
+            Some('T') => "M", // Type change
+            _ => "M",         // Unknown → treat as modified
+        };
+
+        map.insert(path.to_string(), status.to_string());
+    }
 }
 
 fn resolve_allowed_path(path: &Path, require_existing: bool) -> Result<PathBuf> {

--- a/src-tauri/src/models/editor_files.rs
+++ b/src-tauri/src/models/editor_files.rs
@@ -1,0 +1,632 @@
+use std::{
+    ffi::OsString,
+    fs,
+    io::Write,
+    path::{Path, PathBuf},
+    time::UNIX_EPOCH,
+};
+
+use anyhow::{bail, Context, Result};
+use serde::Serialize;
+use uuid::Uuid;
+
+use super::workspaces;
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EditorFileReadResponse {
+    pub path: String,
+    pub content: String,
+    pub mtime_ms: i64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EditorFileWriteResponse {
+    pub path: String,
+    pub mtime_ms: i64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EditorFileStatResponse {
+    pub path: String,
+    pub exists: bool,
+    pub is_file: bool,
+    pub mtime_ms: Option<i64>,
+    pub size: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EditorFileListItem {
+    pub path: String,
+    pub absolute_path: String,
+    pub name: String,
+    pub status: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EditorFilePrefetchItem {
+    pub absolute_path: String,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EditorFilesWithContentResponse {
+    pub items: Vec<EditorFileListItem>,
+    pub prefetched: Vec<EditorFilePrefetchItem>,
+}
+
+pub fn read_editor_file(path: &str) -> Result<EditorFileReadResponse> {
+    let resolved_path = resolve_allowed_path(Path::new(path), true)?;
+    let metadata = fs::metadata(&resolved_path)
+        .with_context(|| format!("Failed to stat editor file {}", resolved_path.display()))?;
+
+    if !metadata.is_file() {
+        bail!("Editor target is not a file: {}", resolved_path.display());
+    }
+
+    let bytes = fs::read(&resolved_path)
+        .with_context(|| format!("Failed to read editor file {}", resolved_path.display()))?;
+    let content = String::from_utf8(bytes).with_context(|| {
+        format!(
+            "Editor file is not valid UTF-8: {}",
+            resolved_path.display()
+        )
+    })?;
+
+    Ok(EditorFileReadResponse {
+        path: resolved_path.display().to_string(),
+        content,
+        mtime_ms: metadata_mtime_ms(&metadata)?,
+    })
+}
+
+pub fn write_editor_file(path: &str, content: &str) -> Result<EditorFileWriteResponse> {
+    let resolved_path = resolve_allowed_path(Path::new(path), true)?;
+    let metadata = fs::metadata(&resolved_path)
+        .with_context(|| format!("Failed to stat editor file {}", resolved_path.display()))?;
+
+    if !metadata.is_file() {
+        bail!("Editor target is not a file: {}", resolved_path.display());
+    }
+
+    atomic_write_file(&resolved_path, content.as_bytes())?;
+
+    let updated_metadata = fs::metadata(&resolved_path).with_context(|| {
+        format!(
+            "Failed to stat editor file after save {}",
+            resolved_path.display()
+        )
+    })?;
+
+    Ok(EditorFileWriteResponse {
+        path: resolved_path.display().to_string(),
+        mtime_ms: metadata_mtime_ms(&updated_metadata)?,
+    })
+}
+
+pub fn stat_editor_file(path: &str) -> Result<EditorFileStatResponse> {
+    let resolved_path = resolve_allowed_path(Path::new(path), false)?;
+
+    match fs::metadata(&resolved_path) {
+        Ok(metadata) => Ok(EditorFileStatResponse {
+            path: resolved_path.display().to_string(),
+            exists: true,
+            is_file: metadata.is_file(),
+            mtime_ms: Some(metadata_mtime_ms(&metadata)?),
+            size: Some(metadata.len() as i64),
+        }),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(EditorFileStatResponse {
+            path: resolved_path.display().to_string(),
+            exists: false,
+            is_file: false,
+            mtime_ms: None,
+            size: None,
+        }),
+        Err(error) => Err(error)
+            .with_context(|| format!("Failed to stat editor file {}", resolved_path.display())),
+    }
+}
+
+pub fn list_editor_files(workspace_root_path: &str) -> Result<Vec<EditorFileListItem>> {
+    let workspace_root = resolve_allowed_path(Path::new(workspace_root_path), true)?;
+    let metadata = fs::metadata(&workspace_root)
+        .with_context(|| format!("Failed to stat workspace root {}", workspace_root.display()))?;
+
+    if !metadata.is_dir() {
+        bail!(
+            "Workspace root is not a directory: {}",
+            workspace_root.display()
+        );
+    }
+
+    let mut discovered_files = Vec::<PathBuf>::new();
+    collect_editor_files(&workspace_root, &workspace_root, &mut discovered_files)?;
+    discovered_files.sort_by(|left, right| {
+        editor_file_sort_key(&workspace_root, left)
+            .cmp(&editor_file_sort_key(&workspace_root, right))
+    });
+    discovered_files.truncate(24);
+
+    Ok(discovered_files
+        .into_iter()
+        .filter_map(|path| {
+            let relative_path = path.strip_prefix(&workspace_root).ok()?;
+            Some(EditorFileListItem {
+                path: relative_path.to_string_lossy().replace('\\', "/"),
+                absolute_path: path.display().to_string(),
+                name: path.file_name()?.to_string_lossy().to_string(),
+                status: "M".to_string(),
+            })
+        })
+        .collect())
+}
+
+/// List workspace files and eagerly read their contents in a single IPC call.
+/// Files larger than 1 MB or non-UTF-8 files are skipped in the prefetch list.
+pub fn list_editor_files_with_content(
+    workspace_root_path: &str,
+) -> Result<EditorFilesWithContentResponse> {
+    let items = list_editor_files(workspace_root_path)?;
+
+    const MAX_PREFETCH_BYTES: u64 = 1_048_576; // 1 MB
+
+    let prefetched = items
+        .iter()
+        .filter_map(|item| {
+            let path = Path::new(&item.absolute_path);
+            let metadata = fs::metadata(path).ok()?;
+            if metadata.len() > MAX_PREFETCH_BYTES {
+                return None;
+            }
+            let bytes = fs::read(path).ok()?;
+            let content = String::from_utf8(bytes).ok()?;
+            Some(EditorFilePrefetchItem {
+                absolute_path: item.absolute_path.clone(),
+                content,
+            })
+        })
+        .collect();
+
+    Ok(EditorFilesWithContentResponse { items, prefetched })
+}
+
+fn resolve_allowed_path(path: &Path, require_existing: bool) -> Result<PathBuf> {
+    if !path.is_absolute() {
+        bail!("Editor file paths must be absolute: {}", path.display());
+    }
+
+    let normalized_path = if require_existing || path.exists() {
+        path.canonicalize()
+            .with_context(|| format!("Failed to resolve editor file {}", path.display()))?
+    } else {
+        canonicalize_missing_path(path)?
+    };
+
+    let workspace_roots = allowed_workspace_roots()?;
+
+    if workspace_roots.is_empty() {
+        bail!("No workspace roots are available for in-app editing");
+    }
+
+    if workspace_roots
+        .iter()
+        .any(|workspace_root| normalized_path.starts_with(workspace_root))
+    {
+        return Ok(normalized_path);
+    }
+
+    bail!(
+        "Editor file must live inside a workspace root: {}",
+        path.display()
+    )
+}
+
+fn allowed_workspace_roots() -> Result<Vec<PathBuf>> {
+    let mut workspace_roots = Vec::new();
+
+    for record in workspaces::load_workspace_records()? {
+        let workspace_dir =
+            crate::data_dir::workspace_dir(&record.repo_name, &record.directory_name)
+                .with_context(|| {
+                    format!(
+                        "Failed to resolve workspace directory for {}/{}",
+                        record.repo_name, record.directory_name
+                    )
+                })?;
+
+        if !workspace_dir.is_dir() {
+            continue;
+        }
+
+        workspace_roots.push(workspace_dir.canonicalize().with_context(|| {
+            format!(
+                "Failed to resolve workspace root {}",
+                workspace_dir.display()
+            )
+        })?);
+    }
+
+    workspace_roots.sort();
+    workspace_roots.dedup();
+
+    Ok(workspace_roots)
+}
+
+fn collect_editor_files(
+    workspace_root: &Path,
+    current_dir: &Path,
+    discovered_files: &mut Vec<PathBuf>,
+) -> Result<()> {
+    if discovered_files.len() >= 48 {
+        return Ok(());
+    }
+
+    let mut entries = fs::read_dir(current_dir)
+        .with_context(|| {
+            format!(
+                "Failed to read workspace directory {}",
+                current_dir.display()
+            )
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .with_context(|| {
+            format!(
+                "Failed to iterate workspace directory {}",
+                current_dir.display()
+            )
+        })?;
+
+    entries.sort_by_key(|entry| entry.file_name());
+
+    for entry in entries {
+        if discovered_files.len() >= 48 {
+            break;
+        }
+
+        let entry_path = entry.path();
+        let file_type = entry.file_type().with_context(|| {
+            format!("Failed to inspect workspace entry {}", entry_path.display())
+        })?;
+
+        if file_type.is_dir() {
+            if should_skip_editor_dir(workspace_root, &entry_path) {
+                continue;
+            }
+
+            collect_editor_files(workspace_root, &entry_path, discovered_files)?;
+            continue;
+        }
+
+        if file_type.is_file() && should_include_editor_file(&entry_path) {
+            discovered_files.push(entry_path);
+        }
+    }
+
+    Ok(())
+}
+
+fn should_skip_editor_dir(workspace_root: &Path, path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
+        return true;
+    };
+
+    matches!(
+        name,
+        ".git"
+            | "node_modules"
+            | "dist"
+            | "build"
+            | "coverage"
+            | "target"
+            | ".next"
+            | ".turbo"
+            | ".cache"
+            | ".venv"
+            | "__pycache__"
+    ) || (name.starts_with('.') && path != workspace_root)
+}
+
+fn should_include_editor_file(path: &Path) -> bool {
+    let Some(file_name) = path.file_name().and_then(|value| value.to_str()) else {
+        return false;
+    };
+
+    if matches!(
+        file_name,
+        "package.json"
+            | "pnpm-lock.yaml"
+            | "bun.lock"
+            | "Cargo.toml"
+            | "Cargo.lock"
+            | "tsconfig.json"
+            | "vite.config.ts"
+            | "README.md"
+            | "AGENTS.md"
+            | "DESIGN.md"
+    ) {
+        return true;
+    }
+
+    matches!(
+        path.extension().and_then(|value| value.to_str()),
+        Some(
+            "ts" | "tsx"
+                | "js"
+                | "jsx"
+                | "rs"
+                | "json"
+                | "toml"
+                | "md"
+                | "css"
+                | "html"
+                | "yml"
+                | "yaml"
+                | "py"
+                | "go"
+                | "java"
+                | "swift"
+                | "kt"
+        )
+    )
+}
+
+fn editor_file_sort_key(workspace_root: &Path, path: &Path) -> (usize, usize, String) {
+    let relative = path
+        .strip_prefix(workspace_root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/");
+    let depth = relative.matches('/').count();
+    let priority = if relative.starts_with("src/") {
+        0
+    } else if relative.starts_with("app/")
+        || relative.starts_with("lib/")
+        || relative.starts_with("components/")
+    {
+        1
+    } else if depth == 0 {
+        2
+    } else {
+        3
+    };
+
+    (priority, depth, relative)
+}
+
+fn atomic_write_file(path: &Path, content: &[u8]) -> Result<()> {
+    let parent = path
+        .parent()
+        .with_context(|| format!("Editor file has no parent directory: {}", path.display()))?;
+    let file_name = path
+        .file_name()
+        .with_context(|| format!("Editor file has no file name: {}", path.display()))?
+        .to_string_lossy();
+    let temp_path = parent.join(format!(".{file_name}.helmor-{}", Uuid::new_v4()));
+
+    let write_result = (|| -> Result<()> {
+        let mut temp_file = fs::OpenOptions::new()
+            .create_new(true)
+            .truncate(true)
+            .write(true)
+            .open(&temp_path)
+            .with_context(|| {
+                format!("Failed to create temp editor file {}", temp_path.display())
+            })?;
+
+        temp_file
+            .write_all(content)
+            .with_context(|| format!("Failed to write temp editor file {}", temp_path.display()))?;
+        temp_file
+            .sync_all()
+            .with_context(|| format!("Failed to flush temp editor file {}", temp_path.display()))?;
+
+        if let Ok(metadata) = fs::metadata(path) {
+            fs::set_permissions(&temp_path, metadata.permissions()).with_context(|| {
+                format!(
+                    "Failed to copy permissions onto temp editor file {}",
+                    temp_path.display()
+                )
+            })?;
+        }
+
+        fs::rename(&temp_path, path).with_context(|| {
+            format!(
+                "Failed to replace editor file {} with {}",
+                path.display(),
+                temp_path.display()
+            )
+        })?;
+
+        Ok(())
+    })();
+
+    if write_result.is_err() {
+        let _ = fs::remove_file(&temp_path);
+    }
+
+    write_result
+}
+
+fn canonicalize_missing_path(path: &Path) -> Result<PathBuf> {
+    let mut missing_segments = Vec::<OsString>::new();
+    let mut current = path;
+
+    while !current.exists() {
+        let segment = current
+            .file_name()
+            .with_context(|| format!("Editor path has no file name: {}", path.display()))?;
+        missing_segments.push(segment.to_os_string());
+        current = current
+            .parent()
+            .with_context(|| format!("Editor path has no parent: {}", path.display()))?;
+    }
+
+    let mut resolved = current
+        .canonicalize()
+        .with_context(|| format!("Failed to resolve editor parent {}", current.display()))?;
+
+    for segment in missing_segments.iter().rev() {
+        resolved.push(segment);
+    }
+
+    Ok(resolved)
+}
+
+fn metadata_mtime_ms(metadata: &fs::Metadata) -> Result<i64> {
+    let duration = metadata
+        .modified()
+        .context("Failed to read file modification time")?
+        .duration_since(UNIX_EPOCH)
+        .context("File modification time predates the Unix epoch")?;
+
+    i64::try_from(duration.as_millis()).context("File modification time exceeds i64 range")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data_dir::TEST_ENV_LOCK as TEST_LOCK;
+    use rusqlite::Connection;
+
+    struct TestDataDir {
+        root: PathBuf,
+    }
+
+    impl TestDataDir {
+        fn new(name: &str) -> Self {
+            let root = std::env::temp_dir().join(format!("helmor-test-{name}-{}", Uuid::new_v4()));
+            std::env::set_var("HELMOR_DATA_DIR", root.display().to_string());
+            crate::data_dir::ensure_directory_structure().unwrap();
+
+            let connection = Connection::open(crate::data_dir::db_path().unwrap()).unwrap();
+            crate::schema::ensure_schema(&connection).unwrap();
+
+            Self { root }
+        }
+    }
+
+    impl Drop for TestDataDir {
+        fn drop(&mut self) {
+            std::env::remove_var("HELMOR_DATA_DIR");
+            let _ = fs::remove_dir_all(&self.root);
+        }
+    }
+
+    struct EditorFilesHarness {
+        _test_dir: TestDataDir,
+        workspace_dir: PathBuf,
+        outside_dir: PathBuf,
+    }
+
+    impl EditorFilesHarness {
+        fn new() -> Self {
+            let test_dir = TestDataDir::new("editor-files");
+            let source_repo_root = test_dir.root.join("source-repo");
+            fs::create_dir_all(&source_repo_root).unwrap();
+
+            let connection = Connection::open(crate::data_dir::db_path().unwrap()).unwrap();
+            connection
+                .execute(
+                    "INSERT INTO repos (id, name, root_path) VALUES ('repo-1', 'helmor', ?1)",
+                    [source_repo_root.display().to_string()],
+                )
+                .unwrap();
+            connection
+                .execute(
+                    "INSERT INTO workspaces (id, repository_id, directory_name, state, derived_status) VALUES ('workspace-1', 'repo-1', 'editor-mode', 'ready', 'in-progress')",
+                    [],
+                )
+                .unwrap();
+
+            let workspace_dir = crate::data_dir::workspace_dir("helmor", "editor-mode").unwrap();
+            fs::create_dir_all(&workspace_dir).unwrap();
+
+            let outside_dir = test_dir.root.join("outside");
+            fs::create_dir_all(&outside_dir).unwrap();
+
+            Self {
+                _test_dir: test_dir,
+                workspace_dir,
+                outside_dir,
+            }
+        }
+    }
+
+    #[test]
+    fn read_editor_file_rejects_paths_outside_workspace_roots() {
+        let _lock = TEST_LOCK.lock().unwrap_or_else(|error| error.into_inner());
+        let harness = EditorFilesHarness::new();
+        let outside_file = harness.outside_dir.join("not-allowed.ts");
+        fs::write(&outside_file, "console.log('x')\n").unwrap();
+
+        let error = read_editor_file(outside_file.to_str().unwrap()).unwrap_err();
+
+        assert!(
+            format!("{error:#}").contains("inside a workspace root"),
+            "unexpected error: {error:#}"
+        );
+    }
+
+    #[test]
+    fn write_editor_file_replaces_existing_file_contents() {
+        let _lock = TEST_LOCK.lock().unwrap_or_else(|error| error.into_inner());
+        let harness = EditorFilesHarness::new();
+        let allowed_file = harness.workspace_dir.join("src").join("App.tsx");
+        fs::create_dir_all(allowed_file.parent().unwrap()).unwrap();
+        fs::write(&allowed_file, "const before = true;\n").unwrap();
+
+        let response =
+            write_editor_file(allowed_file.to_str().unwrap(), "const after = true;\n").unwrap();
+
+        assert_eq!(
+            fs::read_to_string(&allowed_file).unwrap(),
+            "const after = true;\n"
+        );
+        assert!(response.mtime_ms > 0);
+    }
+
+    #[test]
+    fn stat_editor_file_reports_missing_files_inside_workspace_roots() {
+        let _lock = TEST_LOCK.lock().unwrap_or_else(|error| error.into_inner());
+        let harness = EditorFilesHarness::new();
+        let missing_file = harness.workspace_dir.join("src").join("missing.ts");
+
+        let response = stat_editor_file(missing_file.to_str().unwrap()).unwrap();
+
+        assert_eq!(
+            PathBuf::from(&response.path),
+            canonicalize_missing_path(&missing_file).unwrap()
+        );
+        assert!(!response.exists);
+        assert!(!response.is_file);
+        assert_eq!(response.mtime_ms, None);
+        assert_eq!(response.size, None);
+    }
+
+    #[test]
+    fn list_editor_files_returns_existing_workspace_files() {
+        let _lock = TEST_LOCK.lock().unwrap_or_else(|error| error.into_inner());
+        let harness = EditorFilesHarness::new();
+        let src_dir = harness.workspace_dir.join("src");
+        fs::create_dir_all(&src_dir).unwrap();
+        let app_file = src_dir.join("App.tsx");
+        fs::write(&app_file, "export const app = true;\n").unwrap();
+        fs::write(harness.workspace_dir.join("README.md"), "# Demo\n").unwrap();
+
+        let files = list_editor_files(harness.workspace_dir.to_str().unwrap()).unwrap();
+
+        assert!(!files.is_empty());
+        let expected_app_file = app_file.canonicalize().unwrap();
+        assert!(files
+            .iter()
+            .any(|file| PathBuf::from(&file.absolute_path) == expected_app_file));
+        assert!(files
+            .iter()
+            .all(|file| Path::new(&file.absolute_path).is_file()));
+    }
+}

--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -1,5 +1,6 @@
 pub mod auth;
 pub mod db;
+pub mod editor_files;
 pub mod git_ops;
 pub mod github_cli;
 pub mod helpers;
@@ -432,6 +433,40 @@ pub fn open_workspace_in_editor(workspace_id: String, editor: String) -> CmdResu
     let _ = home; // suppress unused warning
     result.with_context(|| format!("Failed to open {editor}"))?;
     Ok(())
+}
+
+#[tauri::command]
+pub fn read_editor_file(path: String) -> CmdResult<editor_files::EditorFileReadResponse> {
+    Ok(editor_files::read_editor_file(&path)?)
+}
+
+#[tauri::command]
+pub fn list_editor_files(
+    workspace_root_path: String,
+) -> CmdResult<Vec<editor_files::EditorFileListItem>> {
+    Ok(editor_files::list_editor_files(&workspace_root_path)?)
+}
+
+#[tauri::command]
+pub fn list_editor_files_with_content(
+    workspace_root_path: String,
+) -> CmdResult<editor_files::EditorFilesWithContentResponse> {
+    Ok(editor_files::list_editor_files_with_content(
+        &workspace_root_path,
+    )?)
+}
+
+#[tauri::command]
+pub fn write_editor_file(
+    path: String,
+    content: String,
+) -> CmdResult<editor_files::EditorFileWriteResponse> {
+    Ok(editor_files::write_editor_file(&path, &content)?)
+}
+
+#[tauri::command]
+pub fn stat_editor_file(path: String) -> CmdResult<editor_files::EditorFileStatResponse> {
+    Ok(editor_files::stat_editor_file(&path)?)
 }
 
 #[tauri::command]

--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -457,6 +457,22 @@ pub fn list_editor_files_with_content(
 }
 
 #[tauri::command]
+pub fn list_workspace_changes(
+    workspace_root_path: String,
+) -> CmdResult<Vec<editor_files::EditorFileListItem>> {
+    Ok(editor_files::list_workspace_changes(&workspace_root_path)?)
+}
+
+#[tauri::command]
+pub fn list_workspace_changes_with_content(
+    workspace_root_path: String,
+) -> CmdResult<editor_files::EditorFilesWithContentResponse> {
+    Ok(editor_files::list_workspace_changes_with_content(
+        &workspace_root_path,
+    )?)
+}
+
+#[tauri::command]
 pub fn write_editor_file(
     path: String,
     content: String,

--- a/src/App.editor-mode.test.tsx
+++ b/src/App.editor-mode.test.tsx
@@ -1,0 +1,285 @@
+import {
+	cleanup,
+	render,
+	screen,
+	waitFor,
+	within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiMocks = vi.hoisted(() => ({
+	loadWorkspaceGroups: vi.fn(),
+	loadArchivedWorkspaces: vi.fn(),
+	loadWorkspaceDetail: vi.fn(),
+	loadWorkspaceSessions: vi.fn(),
+	loadSessionMessages: vi.fn(),
+}));
+
+vi.mock("./App.css", () => ({}));
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+	open: vi.fn(),
+}));
+
+vi.mock("./lib/api", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./lib/api")>();
+
+	return {
+		...actual,
+		loadWorkspaceGroups: apiMocks.loadWorkspaceGroups,
+		loadArchivedWorkspaces: apiMocks.loadArchivedWorkspaces,
+		loadWorkspaceDetail: apiMocks.loadWorkspaceDetail,
+		loadWorkspaceSessions: apiMocks.loadWorkspaceSessions,
+		loadSessionMessages: apiMocks.loadSessionMessages,
+	};
+});
+
+vi.mock("./components/workspace-editor-surface", () => ({
+	WorkspaceEditorSurface: (props: {
+		editorSession: {
+			path: string;
+			dirty?: boolean;
+			kind: "file" | "diff";
+			inline?: boolean;
+			originalText?: string;
+			modifiedText?: string;
+		};
+		onChangeSession: (session: Record<string, unknown>) => void;
+		onExit: () => void;
+	}) => (
+		<div aria-label="Mock editor surface">
+			<div>{props.editorSession.path}</div>
+			<div>{props.editorSession.kind}</div>
+			<button type="button" onClick={props.onExit}>
+				Back to chat
+			</button>
+			<button
+				type="button"
+				onClick={() =>
+					props.onChangeSession({
+						...props.editorSession,
+						dirty: true,
+						modifiedText: "updated",
+					})
+				}
+			>
+				Mark dirty
+			</button>
+		</div>
+	),
+}));
+
+import App from "./App";
+
+function createWorkspaceDetail() {
+	return {
+		id: "workspace-1",
+		title: "Workspace One",
+		repoId: "repo-1",
+		repoName: "helmor",
+		directoryName: "editor-mode",
+		state: "ready",
+		hasUnread: false,
+		workspaceUnread: 0,
+		sessionUnreadTotal: 0,
+		unreadSessionCount: 0,
+		derivedStatus: "in-progress",
+		manualStatus: null,
+		activeSessionId: "session-1",
+		activeSessionTitle: "Session One",
+		activeSessionAgentType: "claude",
+		activeSessionStatus: "idle",
+		branch: "main",
+		initializationParentBranch: "main",
+		intendedTargetBranch: "main",
+		notes: null,
+		pinnedAt: null,
+		prTitle: null,
+		prDescription: null,
+		archiveCommit: null,
+		sessionCount: 1,
+		messageCount: 1,
+		attachmentCount: 0,
+		rootPath: "/tmp/helmor-workspace",
+	};
+}
+
+function createWorkspaceSessions() {
+	return [
+		{
+			id: "session-1",
+			workspaceId: "workspace-1",
+			title: "Session One",
+			agentType: "claude",
+			status: "idle",
+			model: "opus-1m",
+			permissionMode: "default",
+			providerSessionId: null,
+			unreadCount: 0,
+			contextTokenCount: 0,
+			contextUsedPercent: null,
+			thinkingEnabled: true,
+			fastMode: false,
+			agentPersonality: null,
+			createdAt: "2026-04-06T00:00:00Z",
+			updatedAt: "2026-04-06T00:00:00Z",
+			lastUserMessageAt: null,
+			resumeSessionAt: null,
+			isHidden: false,
+			isCompacting: false,
+			active: true,
+		},
+	];
+}
+
+function createMessages() {
+	return [
+		{
+			id: "message-1",
+			sessionId: "session-1",
+			role: "assistant",
+			content: "hello",
+			contentIsJson: false,
+			createdAt: "2026-04-06T00:00:00Z",
+			sentAt: "2026-04-06T00:00:00Z",
+			cancelledAt: null,
+			model: "opus-1m",
+			sdkMessageId: null,
+			lastAssistantMessageId: null,
+			turnId: null,
+			isResumableMessage: null,
+			attachmentCount: 0,
+		},
+	];
+}
+
+async function renderReadyApp() {
+	render(<App />);
+
+	await waitFor(() => {
+		expect(screen.getByRole("button", { name: "Workspace One" })).toBeVisible();
+	});
+
+	await waitFor(() => {
+		expect(
+			within(screen.getByLabelText("Inspector sidebar")).getByText("App.tsx"),
+		).toBeVisible();
+	});
+}
+
+describe("App editor mode", () => {
+	beforeEach(() => {
+		window.localStorage.clear();
+		apiMocks.loadWorkspaceGroups.mockReset();
+		apiMocks.loadArchivedWorkspaces.mockReset();
+		apiMocks.loadWorkspaceDetail.mockReset();
+		apiMocks.loadWorkspaceSessions.mockReset();
+		apiMocks.loadSessionMessages.mockReset();
+
+		apiMocks.loadWorkspaceGroups.mockResolvedValue([
+			{
+				id: "progress",
+				label: "In progress",
+				tone: "progress",
+				rows: [
+					{
+						id: "workspace-1",
+						title: "Workspace One",
+						repoName: "helmor",
+						state: "ready",
+					},
+				],
+			},
+			{
+				id: "done",
+				label: "Done",
+				tone: "done",
+				rows: [],
+			},
+			{
+				id: "review",
+				label: "In review",
+				tone: "review",
+				rows: [],
+			},
+			{
+				id: "backlog",
+				label: "Backlog",
+				tone: "backlog",
+				rows: [],
+			},
+			{
+				id: "canceled",
+				label: "Canceled",
+				tone: "canceled",
+				rows: [],
+			},
+		]);
+		apiMocks.loadArchivedWorkspaces.mockResolvedValue([]);
+		apiMocks.loadWorkspaceDetail.mockResolvedValue(createWorkspaceDetail());
+		apiMocks.loadWorkspaceSessions.mockResolvedValue(createWorkspaceSessions());
+		apiMocks.loadSessionMessages.mockResolvedValue(createMessages());
+	});
+
+	afterEach(() => {
+		cleanup();
+		vi.restoreAllMocks();
+	});
+
+	it("enters editor mode from inspector and returns to chat", async () => {
+		const user = userEvent.setup();
+		await renderReadyApp();
+		const inspector = screen.getByLabelText("Inspector sidebar");
+
+		await user.click(within(inspector).getByText("App.tsx"));
+
+		expect(
+			screen.queryByLabelText("Workspace sidebar"),
+		).not.toBeInTheDocument();
+		expect(screen.getByLabelText("Inspector sidebar")).toBeInTheDocument();
+		expect(screen.getByLabelText("Mock editor surface")).toBeInTheDocument();
+		expect(
+			screen.getByText("/tmp/helmor-workspace/src/App.tsx"),
+		).toBeInTheDocument();
+
+		await user.click(screen.getByRole("button", { name: "Back to chat" }));
+
+		expect(screen.getByLabelText("Workspace sidebar")).toBeInTheDocument();
+		expect(
+			screen.queryByLabelText("Mock editor surface"),
+		).not.toBeInTheDocument();
+	});
+
+	it("prompts before leaving editor mode with dirty changes", async () => {
+		const user = userEvent.setup();
+		const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+		await renderReadyApp();
+		const inspector = screen.getByLabelText("Inspector sidebar");
+
+		await user.click(within(inspector).getByText("App.tsx"));
+		await user.click(screen.getByRole("button", { name: "Mark dirty" }));
+		await user.click(screen.getByRole("button", { name: "Back to chat" }));
+
+		expect(confirmSpy).toHaveBeenCalled();
+		expect(screen.getByLabelText("Mock editor surface")).toBeInTheDocument();
+		expect(
+			screen.queryByLabelText("Workspace sidebar"),
+		).not.toBeInTheDocument();
+	});
+
+	it("prompts before switching files when the editor is dirty", async () => {
+		const user = userEvent.setup();
+		const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+		await renderReadyApp();
+		const inspector = screen.getByLabelText("Inspector sidebar");
+
+		await user.click(within(inspector).getByText("App.tsx"));
+		await user.click(screen.getByRole("button", { name: "Mark dirty" }));
+		await user.click(within(inspector).getByText("api.ts"));
+
+		expect(confirmSpy).toHaveBeenCalled();
+		expect(
+			screen.getByText("/tmp/helmor-workspace/src/App.tsx"),
+		).toBeInTheDocument();
+	});
+});

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -18,6 +18,7 @@ vi.mock("@tauri-apps/plugin-dialog", () => ({
 }));
 
 const SIDEBAR_WIDTH_STORAGE_KEY = "helmor.workspaceSidebarWidth";
+const INSPECTOR_WIDTH_STORAGE_KEY = "helmor.workspaceInspectorWidth";
 
 describe("App", () => {
 	beforeEach(() => {
@@ -34,6 +35,7 @@ describe("App", () => {
 
 		const shell = screen.getByRole("main", { name: "Application shell" });
 		const sidebar = screen.getByLabelText("Workspace sidebar");
+		const inspector = screen.getByLabelText("Inspector sidebar");
 		const panel = screen.getByLabelText("Workspace panel");
 		const dragRegion = screen.getByLabelText("Workspace panel drag region");
 		const viewport = screen.getByLabelText("Workspace viewport");
@@ -41,6 +43,9 @@ describe("App", () => {
 		const input = screen.getByLabelText("Workspace input");
 		const resizeHandle = screen.getByRole("separator", {
 			name: "Resize sidebar",
+		});
+		const inspectorResizeHandle = screen.getByRole("separator", {
+			name: "Resize inspector sidebar",
 		});
 		const doneGroup = screen.getByRole("button", { name: "Done" });
 		const progressGroup = screen.getByRole("button", { name: "In progress" });
@@ -66,6 +71,28 @@ describe("App", () => {
 		expect(sidebar).toHaveClass("bg-app-sidebar");
 		expect(sidebar).toHaveClass("overflow-hidden");
 		expect(sidebar).toHaveStyle({ width: "336px" });
+		expect(inspector).toHaveClass("bg-app-sidebar");
+		expect(inspector).toHaveClass("overflow-hidden");
+		expect(inspector).toHaveStyle({ width: "336px" });
+		expect(
+			screen.getByLabelText("Inspector section Changes"),
+		).toBeInTheDocument();
+		expect(
+			screen.getByLabelText("Inspector section Actions"),
+		).toBeInTheDocument();
+		expect(screen.getByLabelText("Inspector section Tabs")).toBeInTheDocument();
+		expect(screen.getByLabelText("Changes panel body")).toBeInTheDocument();
+		expect(screen.getByLabelText("Changes panel body")).toHaveStyle({
+			height: "120px",
+		});
+		expect(screen.getByLabelText("Actions panel body")).toBeInTheDocument();
+		expect(screen.getByLabelText("Actions panel body")).toHaveStyle({
+			height: "120px",
+		});
+		expect(screen.getByLabelText("Inspector tabs body")).toBeInTheDocument();
+		expect(screen.getByRole("tab", { name: "Setup" })).toBeInTheDocument();
+		expect(screen.getByRole("tab", { name: "Run" })).toBeInTheDocument();
+		expect(screen.queryByText("Terminal")).not.toBeInTheDocument();
 		expect(panel).toHaveClass("relative");
 		expect(panel).toHaveClass("bg-app-elevated");
 		expect(dragRegion).toHaveAttribute("data-tauri-drag-region");
@@ -77,6 +104,7 @@ describe("App", () => {
 			"Ask to make changes, @mention files, run /commands",
 		);
 		expect(resizeHandle).toHaveAttribute("aria-valuenow", "336");
+		expect(inspectorResizeHandle).toHaveAttribute("aria-valuenow", "336");
 		expect(safeAreas).toHaveLength(1);
 		expect(avatars).toHaveLength(11);
 		expect(groupsScrollRegion).toHaveClass("overflow-hidden");
@@ -97,6 +125,26 @@ describe("App", () => {
 		expect(screen.queryByText("Cambridge")).not.toBeInTheDocument();
 		await user.click(progressGroup);
 		expect(screen.getByText("Cambridge")).toBeInTheDocument();
+	});
+
+	it("collapses the inspector tabs section while leaving the first two panels expanded", async () => {
+		const user = userEvent.setup();
+		render(<App />);
+
+		const tabsSection = screen.getByLabelText("Inspector section Tabs");
+
+		expect(screen.getByLabelText("Changes panel body")).toBeInTheDocument();
+		expect(screen.getByLabelText("Actions panel body")).toBeInTheDocument();
+		expect(screen.getByLabelText("Inspector tabs body")).toBeInTheDocument();
+
+		await user.click(screen.getByLabelText("Toggle inspector tabs section"));
+
+		expect(screen.getByLabelText("Changes panel body")).toBeInTheDocument();
+		expect(screen.getByLabelText("Actions panel body")).toBeInTheDocument();
+		expect(
+			screen.queryByLabelText("Inspector tabs body"),
+		).not.toBeInTheDocument();
+		expect(tabsSection.parentElement).toHaveClass("mt-auto");
 	});
 
 	it("resizes the sidebar and persists the width", async () => {
@@ -129,17 +177,56 @@ describe("App", () => {
 		expect(window.localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY)).toBe("360");
 	});
 
+	it("resizes the inspector sidebar and persists the width", async () => {
+		render(<App />);
+
+		const inspector = screen.getByLabelText("Inspector sidebar");
+		const resizeHandle = screen.getByRole("separator", {
+			name: "Resize inspector sidebar",
+		});
+
+		fireEvent.mouseDown(resizeHandle, { clientX: 1200 });
+
+		await waitFor(() => {
+			expect(document.body.style.cursor).toBe("ew-resize");
+		});
+
+		fireEvent.mouseMove(window, { clientX: 1172 });
+
+		await waitFor(() => {
+			expect(inspector).toHaveStyle({ width: "364px" });
+			expect(resizeHandle).toHaveAttribute("aria-valuenow", "364");
+		});
+
+		fireEvent.mouseUp(window);
+
+		await waitFor(() => {
+			expect(document.body.style.cursor).toBe("");
+		});
+
+		expect(window.localStorage.getItem(INSPECTOR_WIDTH_STORAGE_KEY)).toBe(
+			"364",
+		);
+	});
+
 	it("restores the saved sidebar width from localStorage", () => {
 		window.localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, "404");
+		window.localStorage.setItem(INSPECTOR_WIDTH_STORAGE_KEY, "388");
 
 		render(<App />);
 
 		expect(screen.getByLabelText("Workspace sidebar")).toHaveStyle({
 			width: "404px",
 		});
+		expect(screen.getByLabelText("Inspector sidebar")).toHaveStyle({
+			width: "388px",
+		});
 		expect(
 			screen.getByRole("separator", { name: "Resize sidebar" }),
 		).toHaveAttribute("aria-valuenow", "404");
+		expect(
+			screen.getByRole("separator", { name: "Resize inspector sidebar" }),
+		).toHaveAttribute("aria-valuenow", "388");
 	});
 
 	it("falls back to repo-name initials when a workspace has no icon", () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,6 +45,7 @@ import {
 	ToastViewport,
 } from "./components/ui/toast";
 import { WorkspaceConversationContainer } from "./components/workspace-conversation-container";
+import { WorkspaceEditorSurface } from "./components/workspace-editor-surface";
 import { WorkspaceInspectorSidebar } from "./components/workspace-inspector-sidebar";
 import { WorkspacesSidebarContainer } from "./components/workspaces-sidebar-container";
 import {
@@ -66,6 +67,8 @@ import {
 	type WorkspaceSessionSummary,
 } from "./lib/api";
 import { shouldTrackDevCacheStats } from "./lib/dev-render-debug";
+import type { EditorSessionState } from "./lib/editor-session";
+import { isPathWithinRoot } from "./lib/editor-session";
 import {
 	archivedWorkspacesQueryOptions,
 	createHelmorQueryClient,
@@ -304,6 +307,12 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 	const [displayedSessionId, setDisplayedSessionId] = useState<string | null>(
 		null,
 	);
+	const [workspaceViewMode, setWorkspaceViewMode] = useState<
+		"conversation" | "editor"
+	>("conversation");
+	const [editorSession, setEditorSession] = useState<EditorSessionState | null>(
+		null,
+	);
 	const [workspaceToasts, setWorkspaceToasts] = useState<WorkspaceToast[]>([]);
 	const [sendingWorkspaceIds, setSendingWorkspaceIds] = useState<Set<string>>(
 		() => new Set(),
@@ -341,6 +350,18 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 		() => (navigationArchivedQuery.data ?? []).map(summaryToArchivedRow),
 		[navigationArchivedQuery.data],
 	);
+	const selectedWorkspaceDetailQuery = useQuery({
+		...workspaceDetailQueryOptions(selectedWorkspaceId ?? "__none__"),
+		enabled: isIdentityConnected && selectedWorkspaceId !== null,
+	});
+	const workspaceRootPath =
+		selectedWorkspaceDetailQuery.data?.rootPath ??
+		(selectedWorkspaceId
+			? queryClient.getQueryData<WorkspaceDetail | null>(
+					helmorQueryKeys.workspaceDetail(selectedWorkspaceId),
+				)?.rootPath
+			: null) ??
+		null;
 
 	useEffect(() => {
 		void isConductorAvailable().then(setConductorAvailable);
@@ -393,6 +414,8 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 		setDisplayedWorkspaceId(null);
 		setSelectedSessionId(null);
 		setDisplayedSessionId(null);
+		setWorkspaceViewMode("conversation");
+		setEditorSession(null);
 	}, []);
 
 	useEffect(() => {
@@ -402,6 +425,19 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 	useEffect(() => {
 		selectedSessionIdRef.current = selectedSessionId;
 	}, [selectedSessionId]);
+
+	useEffect(() => {
+		if (!editorSession) {
+			return;
+		}
+
+		if (isPathWithinRoot(editorSession.path, workspaceRootPath)) {
+			return;
+		}
+
+		setWorkspaceViewMode("conversation");
+		setEditorSession(null);
+	}, [editorSession, workspaceRootPath]);
 
 	useEffect(() => {
 		document.documentElement.classList.toggle("dark", theme === "dark");
@@ -626,6 +662,80 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 				);
 			}
 		};
+
+	const confirmDiscardEditorChanges = useCallback(
+		(action: string) => {
+			if (!editorSession?.dirty) {
+				return true;
+			}
+
+			if (typeof window === "undefined") {
+				return false;
+			}
+
+			return window.confirm(
+				`You have unsaved changes in ${editorSession.path}. Discard them and ${action}?`,
+			);
+		},
+		[editorSession],
+	);
+
+	const handleEditorSurfaceError = useCallback(
+		(description: string, title = "Editor action failed") => {
+			pushWorkspaceToast(description, title);
+		},
+		[pushWorkspaceToast],
+	);
+
+	const handleOpenEditorFile = useCallback(
+		(path: string) => {
+			if (!workspaceRootPath) {
+				pushWorkspaceToast(
+					"Open a workspace with a resolved root path before using the in-app editor.",
+					"Editor unavailable",
+				);
+				return;
+			}
+
+			if (editorSession?.path === path) {
+				return;
+			}
+
+			if (!confirmDiscardEditorChanges("open another file")) {
+				return;
+			}
+
+			setWorkspaceViewMode("editor");
+			setEditorSession({
+				kind: "file",
+				path,
+				inline: false,
+				dirty: false,
+			});
+		},
+		[
+			confirmDiscardEditorChanges,
+			editorSession?.path,
+			pushWorkspaceToast,
+			workspaceRootPath,
+		],
+	);
+
+	const handleEditorSessionChange = useCallback(
+		(session: EditorSessionState) => {
+			setEditorSession(session);
+		},
+		[],
+	);
+
+	const handleExitEditorMode = useCallback(() => {
+		if (!confirmDiscardEditorChanges("return to chat")) {
+			return;
+		}
+
+		setWorkspaceViewMode("conversation");
+		setEditorSession(null);
+	}, [confirmDiscardEditorChanges]);
 
 	const primeWorkspaceDisplay = useCallback(
 		async (workspaceId: string) => {
@@ -954,7 +1064,7 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 	}, [displayedSessionId, displayedWorkspaceId, queryClient]);
 
 	useEffect(() => {
-		if (!isIdentityConnected) {
+		if (!isIdentityConnected || workspaceViewMode === "editor") {
 			return;
 		}
 
@@ -997,7 +1107,12 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 		return () => {
 			window.removeEventListener("keydown", handleWindowKeyDown, true);
 		};
-	}, [handleNavigateSessions, handleNavigateWorkspaces, isIdentityConnected]);
+	}, [
+		handleNavigateSessions,
+		handleNavigateWorkspaces,
+		isIdentityConnected,
+		workspaceViewMode,
+	]);
 
 	return (
 		<ToastProvider swipeDirection="right">
@@ -1016,174 +1131,197 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 					className="relative h-screen overflow-hidden bg-app-base font-sans text-app-foreground antialiased"
 				>
 					<div className="relative flex h-full min-h-0 bg-app-sidebar">
-						<aside
-							aria-label="Workspace sidebar"
-							className="relative h-full shrink-0 overflow-hidden bg-app-sidebar"
-							style={{ width: `${sidebarWidth}px` }}
-						>
-							<WorkspacesSidebarContainer
-								selectedWorkspaceId={selectedWorkspaceId}
-								sendingWorkspaceIds={sendingWorkspaceIds}
-								onSelectWorkspace={handleSelectWorkspace}
-								pushWorkspaceToast={pushWorkspaceToast}
-							/>
-							<div className="absolute bottom-3 left-3 z-20">
-								<SettingsButton onClick={onOpenSettings} />
-							</div>
-						</aside>
+						{workspaceViewMode === "conversation" && (
+							<>
+								<aside
+									aria-label="Workspace sidebar"
+									className="relative h-full shrink-0 overflow-hidden bg-app-sidebar"
+									style={{ width: `${sidebarWidth}px` }}
+								>
+									<WorkspacesSidebarContainer
+										selectedWorkspaceId={selectedWorkspaceId}
+										sendingWorkspaceIds={sendingWorkspaceIds}
+										onSelectWorkspace={handleSelectWorkspace}
+										pushWorkspaceToast={pushWorkspaceToast}
+									/>
+									<div className="absolute bottom-3 left-3 z-20">
+										<SettingsButton onClick={onOpenSettings} />
+									</div>
+								</aside>
 
-						<div
-							role="separator"
-							tabIndex={0}
-							aria-label="Resize sidebar"
-							aria-orientation="vertical"
-							aria-valuemin={MIN_SIDEBAR_WIDTH}
-							aria-valuemax={MAX_SIDEBAR_WIDTH}
-							aria-valuenow={sidebarWidth}
-							onMouseDown={handleResizeStart("sidebar")}
-							onKeyDown={handleResizeKeyDown("sidebar")}
-							className="group absolute inset-y-0 z-30 cursor-ew-resize touch-none outline-none"
-							style={{
-								left: `${sidebarWidth - SIDEBAR_RESIZE_HIT_AREA / 2}px`,
-								width: `${SIDEBAR_RESIZE_HIT_AREA}px`,
-							}}
-						>
-							<span
-								aria-hidden="true"
-								className={`pointer-events-none absolute inset-y-0 left-1/2 -translate-x-1/2 transition-[width,background-color,box-shadow] ${
-									isSidebarResizing
-										? "w-[2px] bg-app-foreground/80 shadow-[0_0_12px_rgba(250,249,246,0.2)]"
-										: "w-px bg-app-border group-hover:w-[2px] group-hover:bg-app-foreground-soft/75 group-hover:shadow-[0_0_10px_rgba(250,249,246,0.08)] group-focus-visible:w-[2px] group-focus-visible:bg-app-foreground-soft/75"
-								}`}
-							/>
-						</div>
+								<div
+									role="separator"
+									tabIndex={0}
+									aria-label="Resize sidebar"
+									aria-orientation="vertical"
+									aria-valuemin={MIN_SIDEBAR_WIDTH}
+									aria-valuemax={MAX_SIDEBAR_WIDTH}
+									aria-valuenow={sidebarWidth}
+									onMouseDown={handleResizeStart("sidebar")}
+									onKeyDown={handleResizeKeyDown("sidebar")}
+									className="group absolute inset-y-0 z-30 cursor-ew-resize touch-none outline-none"
+									style={{
+										left: `${sidebarWidth - SIDEBAR_RESIZE_HIT_AREA / 2}px`,
+										width: `${SIDEBAR_RESIZE_HIT_AREA}px`,
+									}}
+								>
+									<span
+										aria-hidden="true"
+										className={`pointer-events-none absolute inset-y-0 left-1/2 -translate-x-1/2 transition-[width,background-color,box-shadow] ${
+											isSidebarResizing
+												? "w-[2px] bg-app-foreground/80 shadow-[0_0_12px_rgba(250,249,246,0.2)]"
+												: "w-px bg-app-border group-hover:w-[2px] group-hover:bg-app-foreground-soft/75 group-hover:shadow-[0_0_10px_rgba(250,249,246,0.08)] group-focus-visible:w-[2px] group-focus-visible:bg-app-foreground-soft/75"
+										}`}
+									/>
+								</div>
+							</>
+						)}
 
 						<section
 							aria-label="Workspace panel"
-							className="relative my-1 mr-1 flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl bg-app-elevated"
+							className={`relative flex min-h-0 flex-1 flex-col overflow-hidden bg-app-elevated ${workspaceViewMode === "editor" ? "" : "my-1 mr-1"}`}
 						>
-							<div
-								aria-label="Workspace panel drag region"
-								className="absolute inset-x-0 top-0 z-10 h-[2.6rem] bg-transparent"
-								data-tauri-drag-region
-							/>
+							{workspaceViewMode === "conversation" && (
+								<>
+									<div
+										aria-label="Workspace panel drag region"
+										className="absolute inset-x-0 top-0 z-10 h-[2.6rem] bg-transparent"
+										data-tauri-drag-region
+									/>
 
-							<div className="absolute right-4 top-[0.55rem] z-30 flex items-center gap-1">
-								{selectedWorkspaceId &&
-									installedEditors.length > 0 &&
-									preferredEditor && (
-										<div className="flex items-center rounded-md border border-app-border/40 bg-app-elevated/50">
-											<button
-												type="button"
-												aria-label={`Open in ${preferredEditor.name}`}
-												title={`Open in ${preferredEditor.name}`}
-												onClick={() =>
-													void openWorkspaceInEditor(
-														selectedWorkspaceId,
-														preferredEditor.id as "cursor" | "vscode",
-													).catch((e) =>
-														pushWorkspaceToast(
-															String(e),
-															`Failed to open ${preferredEditor.name}`,
-														),
-													)
-												}
-												className="flex size-6 items-center justify-center rounded-l-[5px] text-app-muted transition-colors hover:bg-app-foreground/[0.07] hover:text-app-foreground focus-visible:outline-none"
-											>
-												<EditorIcon
-													editorId={preferredEditor.id}
-													className="size-3.5"
-												/>
-											</button>
-											<DropdownMenu>
-												<DropdownMenuTrigger className="flex h-6 w-4 items-center justify-center rounded-r-[5px] border-l border-app-border/40 text-app-muted transition-colors hover:bg-app-foreground/[0.07] hover:text-app-foreground focus-visible:outline-none">
-													<ChevronDown className="size-2.5" strokeWidth={2} />
-												</DropdownMenuTrigger>
-												<DropdownMenuContent
-													side="bottom"
-													align="end"
-													sideOffset={6}
-													className="min-w-[11rem]"
-												>
-													{installedEditors.map((editor) => (
-														<DropdownMenuItem
-															key={editor.id}
-															onClick={() => {
-																setPreferredEditorId(editor.id);
-																void openWorkspaceInEditor(
-																	selectedWorkspaceId,
-																	editor.id as "cursor" | "vscode",
-																).catch((e) =>
-																	pushWorkspaceToast(
-																		String(e),
-																		`Failed to open ${editor.name}`,
-																	),
-																);
-															}}
-															className="flex items-center gap-2"
-														>
-															<EditorIcon
-																editorId={editor.id}
-																className="size-4 shrink-0"
+									<div className="absolute right-4 top-[0.55rem] z-30 flex items-center gap-1">
+										{selectedWorkspaceId &&
+											installedEditors.length > 0 &&
+											preferredEditor && (
+												<div className="flex items-center rounded-md border border-app-border/40 bg-app-elevated/50">
+													<button
+														type="button"
+														aria-label={`Open in ${preferredEditor.name}`}
+														title={`Open in ${preferredEditor.name}`}
+														onClick={() =>
+															void openWorkspaceInEditor(
+																selectedWorkspaceId,
+																preferredEditor.id as "cursor" | "vscode",
+															).catch((e) =>
+																pushWorkspaceToast(
+																	String(e),
+																	`Failed to open ${preferredEditor.name}`,
+																),
+															)
+														}
+														className="flex size-6 items-center justify-center rounded-l-[5px] text-app-muted transition-colors hover:bg-app-foreground/[0.07] hover:text-app-foreground focus-visible:outline-none"
+													>
+														<EditorIcon
+															editorId={preferredEditor.id}
+															className="size-3.5"
+														/>
+													</button>
+													<DropdownMenu>
+														<DropdownMenuTrigger className="flex h-6 w-4 items-center justify-center rounded-r-[5px] border-l border-app-border/40 text-app-muted transition-colors hover:bg-app-foreground/[0.07] hover:text-app-foreground focus-visible:outline-none">
+															<ChevronDown
+																className="size-2.5"
+																strokeWidth={2}
 															/>
-															<span className="font-medium">{editor.name}</span>
-															{editor.id === preferredEditor.id && (
-																<Check className="ml-auto size-3.5 text-app-foreground-soft" />
-															)}
-														</DropdownMenuItem>
-													))}
-												</DropdownMenuContent>
-											</DropdownMenu>
-										</div>
-									)}
-								{conductorAvailable && (
-									<Button
-										variant="ghost"
-										size="icon-xs"
-										aria-label="Import from Conductor"
-										onClick={() => setImportDialogOpen(true)}
-										title="Import workspaces from Conductor"
-										className="text-app-muted hover:text-app-foreground"
-									>
-										<FolderInput className="size-3.5" strokeWidth={1.8} />
-									</Button>
-								)}
-								<Button
-									variant="ghost"
-									size="icon-xs"
-									aria-label="Toggle theme"
-									onClick={toggleTheme}
-									className="text-app-muted hover:text-app-foreground"
-								>
-									{theme === "dark" ? (
-										<Sun className="size-3.5" strokeWidth={1.8} />
-									) : (
-										<Moon className="size-3.5" strokeWidth={1.8} />
-									)}
-								</Button>
-								<GithubStatusMenu
-									identityState={githubIdentityState}
-									onDisconnectGithub={() => {
-										void handleDisconnectGithubIdentity();
-									}}
-								/>
-							</div>
+														</DropdownMenuTrigger>
+														<DropdownMenuContent
+															side="bottom"
+															align="end"
+															sideOffset={6}
+															className="min-w-[11rem]"
+														>
+															{installedEditors.map((editor) => (
+																<DropdownMenuItem
+																	key={editor.id}
+																	onClick={() => {
+																		setPreferredEditorId(editor.id);
+																		void openWorkspaceInEditor(
+																			selectedWorkspaceId,
+																			editor.id as "cursor" | "vscode",
+																		).catch((e) =>
+																			pushWorkspaceToast(
+																				String(e),
+																				`Failed to open ${editor.name}`,
+																			),
+																		);
+																	}}
+																	className="flex items-center gap-2"
+																>
+																	<EditorIcon
+																		editorId={editor.id}
+																		className="size-4 shrink-0"
+																	/>
+																	<span className="font-medium">
+																		{editor.name}
+																	</span>
+																	{editor.id === preferredEditor.id && (
+																		<Check className="ml-auto size-3.5 text-app-foreground-soft" />
+																	)}
+																</DropdownMenuItem>
+															))}
+														</DropdownMenuContent>
+													</DropdownMenu>
+												</div>
+											)}
+										{conductorAvailable && (
+											<Button
+												variant="ghost"
+												size="icon-xs"
+												aria-label="Import from Conductor"
+												onClick={() => setImportDialogOpen(true)}
+												title="Import workspaces from Conductor"
+												className="text-app-muted hover:text-app-foreground"
+											>
+												<FolderInput className="size-3.5" strokeWidth={1.8} />
+											</Button>
+										)}
+										<Button
+											variant="ghost"
+											size="icon-xs"
+											aria-label="Toggle theme"
+											onClick={toggleTheme}
+											className="text-app-muted hover:text-app-foreground"
+										>
+											{theme === "dark" ? (
+												<Sun className="size-3.5" strokeWidth={1.8} />
+											) : (
+												<Moon className="size-3.5" strokeWidth={1.8} />
+											)}
+										</Button>
+										<GithubStatusMenu
+											identityState={githubIdentityState}
+											onDisconnectGithub={() => {
+												void handleDisconnectGithubIdentity();
+											}}
+										/>
+									</div>
+								</>
+							)}
 
 							<div
 								aria-label="Workspace viewport"
 								className="flex min-h-0 flex-1 flex-col bg-app-elevated"
 							>
-								<WorkspaceConversationContainer
-									selectedWorkspaceId={selectedWorkspaceId}
-									displayedWorkspaceId={displayedWorkspaceId}
-									selectedSessionId={selectedSessionId}
-									displayedSessionId={displayedSessionId}
-									onSelectSession={handleSelectSession}
-									onResolveDisplayedSession={handleResolveDisplayedSession}
-									onSendingWorkspacesChange={setSendingWorkspaceIds}
-								/>
+								{workspaceViewMode === "editor" && editorSession ? (
+									<WorkspaceEditorSurface
+										editorSession={editorSession}
+										workspaceRootPath={workspaceRootPath}
+										onChangeSession={handleEditorSessionChange}
+										onExit={handleExitEditorMode}
+										onError={handleEditorSurfaceError}
+									/>
+								) : (
+									<WorkspaceConversationContainer
+										selectedWorkspaceId={selectedWorkspaceId}
+										displayedWorkspaceId={displayedWorkspaceId}
+										selectedSessionId={selectedSessionId}
+										displayedSessionId={displayedSessionId}
+										onSelectSession={handleSelectSession}
+										onResolveDisplayedSession={handleResolveDisplayedSession}
+										onSendingWorkspacesChange={setSendingWorkspaceIds}
+									/>
+								)}
 							</div>
-							<ChatCacheDebugHud />
+							{workspaceViewMode === "conversation" && <ChatCacheDebugHud />}
 						</section>
 
 						<div
@@ -1217,7 +1355,12 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 							className="relative h-full shrink-0 overflow-hidden bg-app-sidebar"
 							style={{ width: `${inspectorWidth}px` }}
 						>
-							<WorkspaceInspectorSidebar />
+							<WorkspaceInspectorSidebar
+								workspaceRootPath={workspaceRootPath}
+								editorMode={workspaceViewMode === "editor"}
+								activeEditorPath={editorSession?.path ?? null}
+								onOpenEditorFile={handleOpenEditorFile}
+							/>
 						</aside>
 					</div>
 				</main>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,6 +45,7 @@ import {
 	ToastViewport,
 } from "./components/ui/toast";
 import { WorkspaceConversationContainer } from "./components/workspace-conversation-container";
+import { WorkspaceInspectorSidebar } from "./components/workspace-inspector-sidebar";
 import { WorkspacesSidebarContainer } from "./components/workspaces-sidebar-container";
 import {
 	cancelGithubIdentityConnect,
@@ -87,6 +88,7 @@ import {
 } from "./lib/workspace-helpers";
 
 const SIDEBAR_WIDTH_STORAGE_KEY = "helmor.workspaceSidebarWidth";
+const INSPECTOR_WIDTH_STORAGE_KEY = "helmor.workspaceInspectorWidth";
 const DEFAULT_SIDEBAR_WIDTH = 336;
 const MIN_SIDEBAR_WIDTH = 220;
 const MAX_SIDEBAR_WIDTH = 520;
@@ -134,13 +136,13 @@ function clampSidebarWidth(width: number) {
 	return Math.min(MAX_SIDEBAR_WIDTH, Math.max(MIN_SIDEBAR_WIDTH, width));
 }
 
-function getInitialSidebarWidth() {
+function getInitialSidebarWidth(storageKey = SIDEBAR_WIDTH_STORAGE_KEY) {
 	if (typeof window === "undefined") {
 		return DEFAULT_SIDEBAR_WIDTH;
 	}
 
 	try {
-		const storedWidth = window.localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY);
+		const storedWidth = window.localStorage.getItem(storageKey);
 
 		if (!storedWidth) {
 			return DEFAULT_SIDEBAR_WIDTH;
@@ -282,9 +284,13 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 	const [githubIdentityState, setGithubIdentityState] =
 		useState<GithubIdentityState>(getInitialGithubIdentityState);
 	const [sidebarWidth, setSidebarWidth] = useState(getInitialSidebarWidth);
+	const [inspectorWidth, setInspectorWidth] = useState(() =>
+		getInitialSidebarWidth(INSPECTOR_WIDTH_STORAGE_KEY),
+	);
 	const [resizeState, setResizeState] = useState<{
 		pointerX: number;
 		sidebarWidth: number;
+		target: "sidebar" | "inspector";
 	} | null>(null);
 	const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(
 		null,
@@ -319,7 +325,8 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 		installedEditors[0] ??
 		null;
 	const [importDialogOpen, setImportDialogOpen] = useState(false);
-	const isResizing = resizeState !== null;
+	const isSidebarResizing = resizeState?.target === "sidebar";
+	const isInspectorResizing = resizeState?.target === "inspector";
 	const isIdentityConnected = githubIdentityState.status === "connected";
 	const navigationGroupsQuery = useQuery({
 		...workspaceGroupsQueryOptions(),
@@ -458,16 +465,34 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 	}, [sidebarWidth]);
 
 	useEffect(() => {
+		try {
+			window.localStorage.setItem(
+				INSPECTOR_WIDTH_STORAGE_KEY,
+				String(inspectorWidth),
+			);
+		} catch {
+			// Ignore storage failures and keep the current in-memory width.
+		}
+	}, [inspectorWidth]);
+
+	useEffect(() => {
 		if (!resizeState) {
 			return;
 		}
 
 		const handleMouseMove = (event: globalThis.MouseEvent) => {
-			setSidebarWidth(
-				clampSidebarWidth(
-					resizeState.sidebarWidth + event.clientX - resizeState.pointerX,
-				),
-			);
+			const deltaX = event.clientX - resizeState.pointerX;
+			const nextWidth =
+				resizeState.target === "sidebar"
+					? resizeState.sidebarWidth + deltaX
+					: resizeState.sidebarWidth - deltaX;
+
+			if (resizeState.target === "sidebar") {
+				setSidebarWidth(clampSidebarWidth(nextWidth));
+				return;
+			}
+
+			setInspectorWidth(clampSidebarWidth(nextWidth));
 		};
 		const handleMouseUp = () => {
 			setResizeState(null);
@@ -559,29 +584,48 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 		}
 	}, []);
 
-	const handleResizeStart = (event: MouseEvent<HTMLDivElement>) => {
-		event.preventDefault();
-		setResizeState({
-			pointerX: event.clientX,
-			sidebarWidth,
-		});
-	};
-
-	const handleResizeKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-		if (event.key === "ArrowLeft") {
+	const handleResizeStart =
+		(target: "sidebar" | "inspector") =>
+		(event: MouseEvent<HTMLDivElement>) => {
 			event.preventDefault();
-			setSidebarWidth((currentWidth) =>
-				clampSidebarWidth(currentWidth - SIDEBAR_RESIZE_STEP),
-			);
-		}
+			setResizeState({
+				pointerX: event.clientX,
+				sidebarWidth: target === "sidebar" ? sidebarWidth : inspectorWidth,
+				target,
+			});
+		};
 
-		if (event.key === "ArrowRight") {
-			event.preventDefault();
-			setSidebarWidth((currentWidth) =>
-				clampSidebarWidth(currentWidth + SIDEBAR_RESIZE_STEP),
-			);
-		}
-	};
+	const handleResizeKeyDown =
+		(target: "sidebar" | "inspector") =>
+		(event: KeyboardEvent<HTMLDivElement>) => {
+			if (event.key === "ArrowLeft") {
+				event.preventDefault();
+				if (target === "sidebar") {
+					setSidebarWidth((currentWidth) =>
+						clampSidebarWidth(currentWidth - SIDEBAR_RESIZE_STEP),
+					);
+					return;
+				}
+
+				setInspectorWidth((currentWidth) =>
+					clampSidebarWidth(currentWidth + SIDEBAR_RESIZE_STEP),
+				);
+			}
+
+			if (event.key === "ArrowRight") {
+				event.preventDefault();
+				if (target === "sidebar") {
+					setSidebarWidth((currentWidth) =>
+						clampSidebarWidth(currentWidth + SIDEBAR_RESIZE_STEP),
+					);
+					return;
+				}
+
+				setInspectorWidth((currentWidth) =>
+					clampSidebarWidth(currentWidth - SIDEBAR_RESIZE_STEP),
+				);
+			}
+		};
 
 	const primeWorkspaceDisplay = useCallback(
 		async (workspaceId: string) => {
@@ -996,8 +1040,8 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 							aria-valuemin={MIN_SIDEBAR_WIDTH}
 							aria-valuemax={MAX_SIDEBAR_WIDTH}
 							aria-valuenow={sidebarWidth}
-							onMouseDown={handleResizeStart}
-							onKeyDown={handleResizeKeyDown}
+							onMouseDown={handleResizeStart("sidebar")}
+							onKeyDown={handleResizeKeyDown("sidebar")}
 							className="group absolute inset-y-0 z-30 cursor-ew-resize touch-none outline-none"
 							style={{
 								left: `${sidebarWidth - SIDEBAR_RESIZE_HIT_AREA / 2}px`,
@@ -1006,10 +1050,10 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 						>
 							<span
 								aria-hidden="true"
-								className={`pointer-events-none absolute inset-y-0 left-1/2 -translate-x-1/2 transition-[width,background-color,opacity] duration-150 ${
-									isResizing
-										? "w-[2px] bg-app-foreground/60"
-										: "w-px bg-app-border/0 group-focus-visible:w-[2px] group-focus-visible:bg-app-foreground-soft/40"
+								className={`pointer-events-none absolute inset-y-0 left-1/2 -translate-x-1/2 transition-[width,background-color,box-shadow] ${
+									isSidebarResizing
+										? "w-[2px] bg-app-foreground/80 shadow-[0_0_12px_rgba(250,249,246,0.2)]"
+										: "w-px bg-app-border group-hover:w-[2px] group-hover:bg-app-foreground-soft/75 group-hover:shadow-[0_0_10px_rgba(250,249,246,0.08)] group-focus-visible:w-[2px] group-focus-visible:bg-app-foreground-soft/75"
 								}`}
 							/>
 						</div>
@@ -1141,6 +1185,40 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 							</div>
 							<ChatCacheDebugHud />
 						</section>
+
+						<div
+							role="separator"
+							tabIndex={0}
+							aria-label="Resize inspector sidebar"
+							aria-orientation="vertical"
+							aria-valuemin={MIN_SIDEBAR_WIDTH}
+							aria-valuemax={MAX_SIDEBAR_WIDTH}
+							aria-valuenow={inspectorWidth}
+							onMouseDown={handleResizeStart("inspector")}
+							onKeyDown={handleResizeKeyDown("inspector")}
+							className="group absolute inset-y-0 z-30 cursor-ew-resize touch-none outline-none"
+							style={{
+								right: `${inspectorWidth - SIDEBAR_RESIZE_HIT_AREA / 2}px`,
+								width: `${SIDEBAR_RESIZE_HIT_AREA}px`,
+							}}
+						>
+							<span
+								aria-hidden="true"
+								className={`pointer-events-none absolute inset-y-0 left-1/2 -translate-x-1/2 transition-[width,background-color,box-shadow] ${
+									isInspectorResizing
+										? "w-[2px] bg-app-foreground/80 shadow-[0_0_12px_rgba(250,249,246,0.2)]"
+										: "w-px bg-app-border group-hover:w-[2px] group-hover:bg-app-foreground-soft/75 group-hover:shadow-[0_0_10px_rgba(250,249,246,0.08)] group-focus-visible:w-[2px] group-focus-visible:bg-app-foreground-soft/75"
+								}`}
+							/>
+						</div>
+
+						<aside
+							aria-label="Inspector sidebar"
+							className="relative h-full shrink-0 overflow-hidden bg-app-sidebar"
+							style={{ width: `${inspectorWidth}px` }}
+						>
+							<WorkspaceInspectorSidebar />
+						</aside>
 					</div>
 				</main>
 			)}

--- a/src/components/ai/file-tree.tsx
+++ b/src/components/ai/file-tree.tsx
@@ -1,0 +1,281 @@
+import {
+	ChevronRightIcon,
+	FileIcon,
+	FolderIcon,
+	FolderOpenIcon,
+} from "lucide-react";
+import {
+	createContext,
+	type HTMLAttributes,
+	type ReactNode,
+	useContext,
+	useState,
+} from "react";
+import {
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
+
+interface FileTreeContextType {
+	expandedPaths: Set<string>;
+	togglePath: (path: string) => void;
+	selectedPath?: string;
+	onSelect?: (path: string) => void;
+}
+
+const FileTreeContext = createContext<FileTreeContextType>({
+	expandedPaths: new Set(),
+	togglePath: () => undefined,
+});
+
+export type FileTreeProps = Omit<HTMLAttributes<HTMLDivElement>, "onSelect"> & {
+	expanded?: Set<string>;
+	defaultExpanded?: Set<string>;
+	selectedPath?: string;
+	onSelect?: (path: string) => void;
+	onExpandedChange?: (expanded: Set<string>) => void;
+};
+
+export const FileTree = ({
+	expanded: controlledExpanded,
+	defaultExpanded = new Set(),
+	selectedPath,
+	onSelect,
+	onExpandedChange,
+	className,
+	children,
+	...props
+}: FileTreeProps) => {
+	const [internalExpanded, setInternalExpanded] = useState(defaultExpanded);
+	const expandedPaths = controlledExpanded ?? internalExpanded;
+
+	const togglePath = (path: string) => {
+		const newExpanded = new Set(expandedPaths);
+		if (newExpanded.has(path)) {
+			newExpanded.delete(path);
+		} else {
+			newExpanded.add(path);
+		}
+		setInternalExpanded(newExpanded);
+		onExpandedChange?.(newExpanded);
+	};
+
+	return (
+		<FileTreeContext.Provider
+			value={{ expandedPaths, togglePath, selectedPath, onSelect }}
+		>
+			<div
+				className={cn(
+					"rounded-lg border bg-background font-mono text-sm",
+					className,
+				)}
+				role="tree"
+				{...props}
+			>
+				<div className="p-2">{children}</div>
+			</div>
+		</FileTreeContext.Provider>
+	);
+};
+
+interface FileTreeFolderContextType {
+	path: string;
+	name: string;
+	isExpanded: boolean;
+}
+
+const FileTreeFolderContext = createContext<FileTreeFolderContextType>({
+	path: "",
+	name: "",
+	isExpanded: false,
+});
+
+export type FileTreeFolderProps = HTMLAttributes<HTMLDivElement> & {
+	path: string;
+	name: string;
+};
+
+export const FileTreeFolder = ({
+	path,
+	name,
+	className,
+	children,
+	...props
+}: FileTreeFolderProps) => {
+	const { expandedPaths, togglePath, selectedPath, onSelect } =
+		useContext(FileTreeContext);
+	const isExpanded = expandedPaths.has(path);
+	const isSelected = selectedPath === path;
+
+	return (
+		<FileTreeFolderContext.Provider value={{ path, name, isExpanded }}>
+			<Collapsible onOpenChange={() => togglePath(path)} open={isExpanded}>
+				<div
+					className={cn("", className)}
+					role="treeitem"
+					tabIndex={0}
+					{...props}
+				>
+					<CollapsibleTrigger
+						render={
+							<button
+								className={cn(
+									"flex w-full items-center gap-1 rounded px-2 py-1 text-left transition-colors hover:bg-muted/50",
+									isSelected && "bg-muted",
+								)}
+								onClick={() => onSelect?.(path)}
+								type="button"
+							/>
+						}
+					>
+						<ChevronRightIcon
+							className={cn(
+								"size-4 shrink-0 text-muted-foreground transition-transform",
+								isExpanded && "rotate-90",
+							)}
+						/>
+						<FileTreeIcon>
+							{isExpanded ? (
+								<FolderOpenIcon className="size-4 text-blue-500" />
+							) : (
+								<FolderIcon className="size-4 text-blue-500" />
+							)}
+						</FileTreeIcon>
+						<FileTreeName>{name}</FileTreeName>
+					</CollapsibleTrigger>
+					<CollapsibleContent>
+						<div className="ml-4 border-l pl-2">{children}</div>
+					</CollapsibleContent>
+				</div>
+			</Collapsible>
+		</FileTreeFolderContext.Provider>
+	);
+};
+
+interface FileTreeFileContextType {
+	path: string;
+	name: string;
+}
+
+const FileTreeFileContext = createContext<FileTreeFileContextType>({
+	path: "",
+	name: "",
+});
+
+export type FileTreeFileProps = HTMLAttributes<HTMLDivElement> & {
+	path: string;
+	name: string;
+	icon?: ReactNode;
+};
+
+export const FileTreeFile = ({
+	path,
+	name,
+	icon,
+	className,
+	children,
+	...props
+}: FileTreeFileProps) => {
+	const { selectedPath, onSelect } = useContext(FileTreeContext);
+	const isSelected = selectedPath === path;
+
+	return (
+		<FileTreeFileContext.Provider value={{ path, name }}>
+			<div
+				className={cn(
+					"flex cursor-pointer items-center gap-1 rounded px-2 py-1 transition-colors hover:bg-muted/50",
+					isSelected && "bg-muted",
+					className,
+				)}
+				onClick={() => onSelect?.(path)}
+				onKeyDown={(e) => {
+					if (e.key === "Enter" || e.key === " ") {
+						onSelect?.(path);
+					}
+				}}
+				role="treeitem"
+				tabIndex={0}
+				{...props}
+			>
+				{children ?? (
+					<>
+						<span className="size-4" />
+						<FileTreeIcon>
+							{icon ?? <FileIcon className="size-4 text-muted-foreground" />}
+						</FileTreeIcon>
+						<FileTreeName>{name}</FileTreeName>
+					</>
+				)}
+			</div>
+		</FileTreeFileContext.Provider>
+	);
+};
+
+export type FileTreeIconProps = HTMLAttributes<HTMLSpanElement>;
+
+export const FileTreeIcon = ({
+	className,
+	children,
+	...props
+}: FileTreeIconProps) => (
+	<span className={cn("shrink-0", className)} {...props}>
+		{children}
+	</span>
+);
+
+export type FileTreeNameProps = HTMLAttributes<HTMLSpanElement>;
+
+export const FileTreeName = ({
+	className,
+	children,
+	...props
+}: FileTreeNameProps) => (
+	<span className={cn("truncate", className)} {...props}>
+		{children}
+	</span>
+);
+
+export type FileTreeActionsProps = HTMLAttributes<HTMLDivElement>;
+
+export const FileTreeActions = ({
+	className,
+	children,
+	...props
+}: FileTreeActionsProps) => (
+	<div
+		className={cn("ml-auto flex items-center gap-1", className)}
+		onClick={(e) => e.stopPropagation()}
+		onKeyDown={(e) => e.stopPropagation()}
+		role="group"
+		{...props}
+	>
+		{children}
+	</div>
+);
+
+/** Demo component for preview */
+export default function FileTreeDemo() {
+	const [selected, setSelected] = useState<string>();
+
+	return (
+		<div className="w-full max-w-xs p-4">
+			<FileTree
+				defaultExpanded={new Set(["src", "src/components"])}
+				selectedPath={selected}
+				onSelect={(path: string) => setSelected(path)}
+			>
+				<FileTreeFolder path="src" name="src">
+					<FileTreeFolder path="src/components" name="components">
+						<FileTreeFile path="src/components/Button.tsx" name="Button.tsx" />
+						<FileTreeFile path="src/components/Card.tsx" name="Card.tsx" />
+					</FileTreeFolder>
+					<FileTreeFile path="src/index.ts" name="index.ts" />
+				</FileTreeFolder>
+				<FileTreeFile path="package.json" name="package.json" />
+				<FileTreeFile path="README.md" name="README.md" />
+			</FileTree>
+		</div>
+	);
+}

--- a/src/components/workspace-editor-surface.test.tsx
+++ b/src/components/workspace-editor-surface.test.tsx
@@ -1,0 +1,256 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { EditorSessionState } from "@/lib/editor-session";
+
+const apiMocks = vi.hoisted(() => ({
+	readEditorFile: vi.fn(),
+	writeEditorFile: vi.fn(),
+}));
+
+const runtimeMocks = vi.hoisted(() => {
+	let fileValue = "";
+	let changeHandler: ((value: string) => void) | null = null;
+
+	const fileController = {
+		dispose: vi.fn(),
+		getValue: vi.fn(() => fileValue),
+		onDidChangeModelContent: vi.fn((callback: (value: string) => void) => {
+			changeHandler = callback;
+			return { dispose: vi.fn() };
+		}),
+		revealPosition: vi.fn(),
+		setValue: vi.fn((value: string) => {
+			fileValue = value;
+		}),
+	};
+
+	const diffController = {
+		dispose: vi.fn(),
+		setTexts: vi.fn(),
+	};
+
+	return {
+		createDiffEditor: vi.fn(async () => diffController),
+		createFileEditor: vi.fn(
+			async (options: { content: string; path: string }) => {
+				fileValue = options.content;
+				return fileController;
+			},
+		),
+		diffController,
+		emitFileChange: (value: string) => {
+			fileValue = value;
+			changeHandler?.(value);
+		},
+		fileController,
+		reset() {
+			fileValue = "";
+			changeHandler = null;
+			this.createDiffEditor.mockClear();
+			this.createFileEditor.mockClear();
+			this.diffController.dispose.mockClear();
+			this.diffController.setTexts.mockClear();
+			this.fileController.dispose.mockClear();
+			this.fileController.getValue.mockClear();
+			this.fileController.onDidChangeModelContent.mockClear();
+			this.fileController.revealPosition.mockClear();
+			this.fileController.setValue.mockClear();
+			this.syncVirtualFile.mockClear();
+		},
+		syncVirtualFile: vi.fn(async () => undefined),
+	};
+});
+
+vi.mock("@/lib/api", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/lib/api")>();
+
+	return {
+		...actual,
+		readEditorFile: apiMocks.readEditorFile,
+		writeEditorFile: apiMocks.writeEditorFile,
+	};
+});
+
+vi.mock("@/lib/monaco-runtime", () => ({
+	createDiffEditor: runtimeMocks.createDiffEditor,
+	createFileEditor: runtimeMocks.createFileEditor,
+	syncVirtualFile: runtimeMocks.syncVirtualFile,
+}));
+
+import { WorkspaceEditorSurface } from "./workspace-editor-surface";
+
+function EditorSurfaceHarness({
+	initialSession,
+	onChangeSpy,
+	onError,
+}: {
+	initialSession: EditorSessionState;
+	onChangeSpy: (session: EditorSessionState) => void;
+	onError?: (description: string, title?: string) => void;
+}) {
+	const [session, setSession] = useState(initialSession);
+
+	return (
+		<WorkspaceEditorSurface
+			editorSession={session}
+			workspaceRootPath="/tmp/helmor-workspace"
+			onChangeSession={(next) => {
+				onChangeSpy(next);
+				setSession(next);
+			}}
+			onError={onError}
+			onExit={vi.fn()}
+		/>
+	);
+}
+
+describe("WorkspaceEditorSurface", () => {
+	beforeEach(() => {
+		runtimeMocks.reset();
+		apiMocks.readEditorFile.mockReset();
+		apiMocks.writeEditorFile.mockReset();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it("loads a file, tracks dirty state, and saves it", async () => {
+		const user = userEvent.setup();
+		const onChangeSpy = vi.fn();
+
+		apiMocks.readEditorFile.mockResolvedValue({
+			path: "/tmp/helmor-workspace/src/App.tsx",
+			content: "const value = 1;\n",
+			mtimeMs: 10,
+		});
+		apiMocks.writeEditorFile.mockResolvedValue({
+			path: "/tmp/helmor-workspace/src/App.tsx",
+			mtimeMs: 20,
+		});
+
+		render(
+			<EditorSurfaceHarness
+				initialSession={{
+					kind: "file",
+					path: "/tmp/helmor-workspace/src/App.tsx",
+				}}
+				onChangeSpy={onChangeSpy}
+			/>,
+		);
+
+		await waitFor(() => {
+			expect(apiMocks.readEditorFile).toHaveBeenCalledWith(
+				"/tmp/helmor-workspace/src/App.tsx",
+			);
+			expect(runtimeMocks.createFileEditor).toHaveBeenCalled();
+		});
+
+		runtimeMocks.emitFileChange("const value = 2;\n");
+
+		await waitFor(() => {
+			expect(onChangeSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					dirty: true,
+					kind: "file",
+					modifiedText: "const value = 2;\n",
+				}),
+			);
+		});
+
+		await user.click(screen.getByRole("button", { name: "Save" }));
+
+		await waitFor(() => {
+			expect(apiMocks.writeEditorFile).toHaveBeenCalledWith(
+				"/tmp/helmor-workspace/src/App.tsx",
+				"const value = 2;\n",
+			);
+			expect(runtimeMocks.syncVirtualFile).toHaveBeenCalledWith(
+				"/tmp/helmor-workspace/src/App.tsx",
+				"const value = 2;\n",
+			);
+			const latestCall =
+				onChangeSpy.mock.calls[onChangeSpy.mock.calls.length - 1]?.[0];
+			expect(latestCall).toEqual(
+				expect.objectContaining({
+					dirty: false,
+					kind: "file",
+					originalText: "const value = 2;\n",
+				}),
+			);
+		});
+	});
+
+	it("switches to diff mode and toggles inline review layout", async () => {
+		const user = userEvent.setup();
+		const onChangeSpy = vi.fn();
+
+		render(
+			<EditorSurfaceHarness
+				initialSession={{
+					kind: "file",
+					path: "/tmp/helmor-workspace/src/App.tsx",
+					originalText: "const before = 1;\n",
+					modifiedText: "const before = 2;\n",
+					dirty: true,
+				}}
+				onChangeSpy={onChangeSpy}
+			/>,
+		);
+
+		await waitFor(() => {
+			expect(runtimeMocks.createFileEditor).toHaveBeenCalled();
+		});
+
+		await user.click(
+			(await screen.findAllByRole("button", { name: "Open review mock" }))[0],
+		);
+
+		await waitFor(() => {
+			expect(onChangeSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					kind: "diff",
+					path: "/tmp/helmor-workspace/src/App.tsx",
+				}),
+			);
+			expect(runtimeMocks.createDiffEditor).toHaveBeenCalled();
+		});
+
+		await user.click(screen.getByRole("button", { name: "Inline" }));
+
+		await waitFor(() => {
+			expect(onChangeSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					inline: true,
+					kind: "diff",
+				}),
+			);
+		});
+	});
+
+	it("surfaces read failures without breaking the shell", async () => {
+		const onChangeSpy = vi.fn();
+		const onError = vi.fn();
+
+		apiMocks.readEditorFile.mockRejectedValue(new Error("No such file"));
+
+		render(
+			<EditorSurfaceHarness
+				initialSession={{
+					kind: "file",
+					path: "/tmp/helmor-workspace/src/missing.ts",
+				}}
+				onChangeSpy={onChangeSpy}
+				onError={onError}
+			/>,
+		);
+
+		await waitFor(() => {
+			expect(onError).toHaveBeenCalledWith("No such file", "File open failed");
+			expect(screen.getByText("Editor unavailable")).toBeInTheDocument();
+			expect(screen.getByText("No such file")).toBeInTheDocument();
+		});
+	});
+});

--- a/src/components/workspace-editor-surface.tsx
+++ b/src/components/workspace-editor-surface.tsx
@@ -1,0 +1,521 @@
+import { ArrowLeft, GitCompareArrows, Save } from "lucide-react";
+import {
+	type MutableRefObject,
+	type ReactNode,
+	useCallback,
+	useEffect,
+	useLayoutEffect,
+	useRef,
+	useState,
+} from "react";
+import type { EditorSessionState } from "@/lib/editor-session";
+import { describeUnknownError } from "@/lib/workspace-helpers";
+import { writeEditorFile } from "../lib/api";
+
+type WorkspaceEditorSurfaceProps = {
+	editorSession: EditorSessionState;
+	workspaceRootPath?: string | null;
+	onChangeSession: (session: EditorSessionState) => void;
+	onExit: () => void;
+	onError?: (description: string, title?: string) => void;
+};
+
+type SurfaceStatus =
+	| { kind: "loading" }
+	| { kind: "ready" }
+	| { kind: "error"; message: string };
+
+type MonacoRuntimeModule = typeof import("@/lib/monaco-runtime");
+type FileController = Awaited<
+	ReturnType<MonacoRuntimeModule["createFileEditor"]>
+>;
+type DiffController = Awaited<
+	ReturnType<MonacoRuntimeModule["createDiffEditor"]>
+>;
+
+export function WorkspaceEditorSurface({
+	editorSession,
+	workspaceRootPath: _workspaceRootPath,
+	onChangeSession,
+	onExit,
+	onError,
+}: WorkspaceEditorSurfaceProps) {
+	const editorHostRef = useRef<HTMLDivElement>(null);
+	const fileControllerRef = useRef<FileController | null>(null);
+	const diffControllerRef = useRef<DiffController | null>(null);
+	const changeSubscriptionRef = useRef<{ dispose(): void } | null>(null);
+	const latestSessionRef = useRef(editorSession);
+	const onChangeSessionRef = useRef(onChangeSession);
+	const onErrorRef = useRef(onError);
+	const applyValueRef = useRef(false);
+	const buildRequestIdRef = useRef(0);
+	const [surfaceStatus, setSurfaceStatus] = useState<SurfaceStatus>({
+		kind: "ready",
+	});
+	const [saving, setSaving] = useState(false);
+
+	latestSessionRef.current = editorSession;
+	onChangeSessionRef.current = onChangeSession;
+	onErrorRef.current = onError;
+
+	const canRenderFile =
+		editorSession.kind === "file" &&
+		editorSession.originalText !== undefined &&
+		editorSession.modifiedText !== undefined;
+	const canRenderDiff =
+		editorSession.kind === "diff" &&
+		editorSession.originalText !== undefined &&
+		editorSession.modifiedText !== undefined;
+	const canOpenReview =
+		editorSession.kind === "file" &&
+		editorSession.originalText !== undefined &&
+		editorSession.modifiedText !== undefined;
+	const dirty = Boolean(editorSession.dirty);
+
+	useEffect(() => {
+		if (
+			(editorSession.kind === "file" && canRenderFile) ||
+			(editorSession.kind === "diff" && canRenderDiff)
+		) {
+			return;
+		}
+
+		let cancelled = false;
+
+		void (async () => {
+			try {
+				const { readEditorFile } = await import("@/lib/api");
+				const response = await readEditorFile(editorSession.path);
+
+				if (cancelled) {
+					return;
+				}
+
+				onChangeSessionRef.current({
+					...editorSession,
+					originalText: editorSession.originalText ?? response.content,
+					modifiedText: editorSession.modifiedText ?? response.content,
+					dirty: Boolean(editorSession.dirty),
+					mtimeMs: response.mtimeMs,
+				});
+			} catch (error) {
+				if (cancelled) {
+					return;
+				}
+
+				const message = describeUnknownError(
+					error,
+					"Unable to load the selected file.",
+				);
+				setSurfaceStatus({ kind: "error", message });
+				onErrorRef.current?.(message, "File open failed");
+			}
+		})();
+
+		return () => {
+			cancelled = true;
+		};
+	}, [canRenderDiff, canRenderFile, editorSession]);
+
+	// useLayoutEffect: run model swap BEFORE browser paint to avoid 1-frame flicker
+	useLayoutEffect(() => {
+		const host = editorHostRef.current;
+		if (!host) {
+			return;
+		}
+
+		// ── Fast path: reuse existing file editor on path change ──
+		// Runs even when content isn't loaded yet — switchFile uses Monaco model cache.
+		if (editorSession.kind === "file" && fileControllerRef.current) {
+			const content = editorSession.modifiedText ?? editorSession.originalText;
+			const switched = fileControllerRef.current.switchFile(
+				editorSession.path,
+				content,
+				editorSession.line,
+				editorSession.column,
+			);
+
+			if (switched) {
+				// Sync parent state from cached model when content wasn't in state yet
+				if (content === undefined) {
+					const cachedContent = fileControllerRef.current.getValue();
+					onChangeSessionRef.current({
+						...latestSessionRef.current,
+						originalText: cachedContent,
+						modifiedText: cachedContent,
+						dirty: false,
+					});
+				}
+
+				changeSubscriptionRef.current?.dispose();
+				changeSubscriptionRef.current = null;
+				changeSubscriptionRef.current =
+					fileControllerRef.current.onDidChangeModelContent((value) => {
+						if (applyValueRef.current) {
+							return;
+						}
+						const latest = latestSessionRef.current;
+						const nextDirty = value !== (latest.originalText ?? "");
+						if (
+							value === latest.modifiedText &&
+							nextDirty === Boolean(latest.dirty)
+						) {
+							return;
+						}
+						onChangeSessionRef.current({
+							...latest,
+							kind: "file",
+							modifiedText: value,
+							dirty: nextDirty,
+						});
+					});
+			}
+
+			// Whether switched or not, keep existing editor alive.
+			// If not switched (cache miss, no content), the file-load effect will
+			// fetch content → re-render → this effect runs again with content.
+			return () => {
+				disposeControllers({
+					fileControllerRef,
+					diffControllerRef,
+					changeSubscriptionRef,
+				});
+			};
+		}
+
+		// ── Guard: need content for initial editor creation ──
+		if (!canRenderFile && !canRenderDiff) {
+			return;
+		}
+
+		// ── Slow path: first render or kind change ──
+		const requestId = buildRequestIdRef.current + 1;
+		buildRequestIdRef.current = requestId;
+		let disposed = false;
+
+		disposeControllers({
+			fileControllerRef,
+			diffControllerRef,
+			changeSubscriptionRef,
+		});
+		host.replaceChildren();
+
+		if (editorSession.kind === "file") {
+			void (async () => {
+				try {
+					const { createFileEditor } = await import("@/lib/monaco-runtime");
+					const controller = await createFileEditor({
+						container: host,
+						path: editorSession.path,
+						content:
+							editorSession.modifiedText ?? editorSession.originalText ?? "",
+						line: editorSession.line,
+						column: editorSession.column,
+					});
+
+					if (disposed || requestId !== buildRequestIdRef.current) {
+						controller.dispose();
+						return;
+					}
+
+					fileControllerRef.current = controller;
+					changeSubscriptionRef.current = controller.onDidChangeModelContent(
+						(value) => {
+							if (applyValueRef.current) {
+								return;
+							}
+							const latest = latestSessionRef.current;
+							const nextDirty = value !== (latest.originalText ?? "");
+							if (
+								value === latest.modifiedText &&
+								nextDirty === Boolean(latest.dirty)
+							) {
+								return;
+							}
+							onChangeSessionRef.current({
+								...latest,
+								kind: "file",
+								modifiedText: value,
+								dirty: nextDirty,
+							});
+						},
+					);
+					setSurfaceStatus({ kind: "ready" });
+				} catch (error) {
+					const message = describeUnknownError(
+						error,
+						"Unable to start the editor.",
+					);
+					setSurfaceStatus({ kind: "error", message });
+					onErrorRef.current?.(message, "Editor startup failed");
+				}
+			})();
+		} else {
+			void (async () => {
+				try {
+					const { createDiffEditor } = await import("@/lib/monaco-runtime");
+					const controller = await createDiffEditor({
+						container: host,
+						path: editorSession.path,
+						originalText: editorSession.originalText ?? "",
+						modifiedText: editorSession.modifiedText ?? "",
+						inline: Boolean(editorSession.inline),
+					});
+
+					if (disposed || requestId !== buildRequestIdRef.current) {
+						controller.dispose();
+						return;
+					}
+
+					diffControllerRef.current = controller;
+					setSurfaceStatus({ kind: "ready" });
+				} catch (error) {
+					const message = describeUnknownError(
+						error,
+						"Unable to start the review surface.",
+					);
+					setSurfaceStatus({ kind: "error", message });
+					onErrorRef.current?.(message, "Review surface failed");
+				}
+			})();
+		}
+
+		return () => {
+			disposed = true;
+			disposeControllers({
+				fileControllerRef,
+				diffControllerRef,
+				changeSubscriptionRef,
+			});
+		};
+	}, [canRenderDiff, canRenderFile, editorSession.kind, editorSession.path]);
+
+	useEffect(() => {
+		if (
+			editorSession.kind !== "file" ||
+			!fileControllerRef.current ||
+			editorSession.modifiedText === undefined
+		) {
+			return;
+		}
+
+		applyValueRef.current = true;
+		try {
+			fileControllerRef.current.setValue(editorSession.modifiedText);
+		} finally {
+			applyValueRef.current = false;
+		}
+	}, [editorSession.kind, editorSession.modifiedText]);
+
+	useEffect(() => {
+		if (editorSession.kind !== "file" || !fileControllerRef.current) {
+			return;
+		}
+
+		fileControllerRef.current.revealPosition(
+			editorSession.line,
+			editorSession.column,
+		);
+	}, [editorSession.column, editorSession.kind, editorSession.line]);
+
+	useEffect(() => {
+		if (
+			editorSession.kind !== "diff" ||
+			!diffControllerRef.current ||
+			editorSession.originalText === undefined ||
+			editorSession.modifiedText === undefined
+		) {
+			return;
+		}
+
+		diffControllerRef.current.setTexts({
+			originalText: editorSession.originalText,
+			modifiedText: editorSession.modifiedText,
+			inline: Boolean(editorSession.inline),
+		});
+	}, [
+		editorSession.inline,
+		editorSession.kind,
+		editorSession.modifiedText,
+		editorSession.originalText,
+	]);
+
+	const handleSave = useCallback(async () => {
+		if (editorSession.kind !== "file" || !fileControllerRef.current) {
+			return;
+		}
+
+		const content = fileControllerRef.current.getValue();
+		setSaving(true);
+
+		try {
+			const response = await writeEditorFile(editorSession.path, content);
+			void import("@/lib/monaco-runtime")
+				.then(({ syncVirtualFile }) =>
+					syncVirtualFile(editorSession.path, content),
+				)
+				.catch(() => {
+					// The Tauri write is authoritative; keep the virtual model best-effort.
+				});
+			onChangeSessionRef.current({
+				...latestSessionRef.current,
+				kind: "file",
+				originalText: content,
+				modifiedText: content,
+				dirty: false,
+				mtimeMs: response.mtimeMs,
+			});
+		} catch (error) {
+			const message = describeUnknownError(
+				error,
+				"Unable to save the selected file.",
+			);
+			onErrorRef.current?.(message, "Save failed");
+		} finally {
+			setSaving(false);
+		}
+	}, [editorSession.kind, editorSession.path]);
+
+	const handleOpenReview = useCallback(() => {
+		if (!canOpenReview) {
+			return;
+		}
+
+		onChangeSessionRef.current({
+			...latestSessionRef.current,
+			kind: "diff",
+			inline: false,
+		});
+	}, [canOpenReview]);
+
+	const handleToggleDiffLayout = useCallback(() => {
+		if (editorSession.kind !== "diff") {
+			return;
+		}
+
+		onChangeSessionRef.current({
+			...latestSessionRef.current,
+			inline: !editorSession.inline,
+		});
+	}, [editorSession.inline, editorSession.kind]);
+
+	return (
+		<section
+			aria-label="Workspace editor surface"
+			className="flex h-full min-h-0 flex-col overflow-hidden bg-[#161514] text-[#cccccc]"
+		>
+			<div
+				className="flex h-9 items-center border-b border-[#2b2b2b] pr-3"
+				data-tauri-drag-region
+			>
+				{/* Traffic-light inset: macOS stoplight buttons sit at x=16, ~70px total width */}
+				<div className="w-[86px] shrink-0" data-tauri-drag-region />
+
+				<div className="min-w-0 flex-1" data-tauri-drag-region />
+
+				<div className="flex shrink-0 items-center gap-1">
+					<EditorIconButton onClick={onExit} title="Back to chat">
+						<ArrowLeft className="size-3.5" strokeWidth={1.8} />
+					</EditorIconButton>
+					<EditorIconButton
+						onClick={handleSave}
+						disabled={editorSession.kind !== "file" || !dirty || saving}
+						title={saving ? "Saving..." : "Save"}
+					>
+						<Save className="size-3.5" strokeWidth={1.8} />
+					</EditorIconButton>
+					<EditorIconButton
+						onClick={handleOpenReview}
+						disabled={!canOpenReview || editorSession.kind === "diff"}
+						title="Open review"
+					>
+						<GitCompareArrows className="size-3.5" strokeWidth={1.8} />
+					</EditorIconButton>
+					{editorSession.kind === "diff" && (
+						<EditorIconButton
+							onClick={handleToggleDiffLayout}
+							title={editorSession.inline ? "Side-by-side" : "Inline"}
+						>
+							<GitCompareArrows className="size-3.5" strokeWidth={1.8} />
+						</EditorIconButton>
+					)}
+				</div>
+			</div>
+
+			<div className="relative flex min-h-0 flex-1 bg-[#161514]">
+				<div
+					ref={editorHostRef}
+					aria-label="Editor canvas"
+					className="h-full min-h-0 flex-1"
+				/>
+
+				{surfaceStatus.kind === "error" && (
+					<div className="absolute inset-0 flex items-center justify-center bg-[#161514]">
+						<SurfaceMessage
+							title="Editor unavailable"
+							message={surfaceStatus.message}
+						/>
+					</div>
+				)}
+			</div>
+		</section>
+	);
+}
+
+function EditorIconButton({
+	children,
+	disabled,
+	onClick,
+	title,
+}: {
+	children: ReactNode;
+	disabled?: boolean;
+	onClick: () => void;
+	title?: string;
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			disabled={disabled}
+			title={title}
+			className="inline-flex size-8 items-center justify-center text-[#8f8f8f] transition-colors hover:text-white disabled:cursor-not-allowed disabled:text-[#4a4a4a]"
+		>
+			{children}
+		</button>
+	);
+}
+
+function SurfaceMessage({
+	title,
+	message,
+}: {
+	title: string;
+	message: string;
+}) {
+	return (
+		<div className="max-w-lg rounded-xl border border-[#313131] bg-[#181818] px-5 py-4 text-left shadow-[0_18px_50px_rgba(0,0,0,0.35)]">
+			<p className="text-[11px] uppercase tracking-[0.18em] text-[#8f8f8f]">
+				{title}
+			</p>
+			<p className="mt-2 text-[13px] leading-6 text-[#d4d4d4]">{message}</p>
+		</div>
+	);
+}
+
+function disposeControllers({
+	fileControllerRef,
+	diffControllerRef,
+	changeSubscriptionRef,
+}: {
+	fileControllerRef: MutableRefObject<FileController | null>;
+	diffControllerRef: MutableRefObject<DiffController | null>;
+	changeSubscriptionRef: MutableRefObject<{ dispose(): void } | null>;
+}) {
+	changeSubscriptionRef.current?.dispose();
+	changeSubscriptionRef.current = null;
+	fileControllerRef.current?.dispose();
+	fileControllerRef.current = null;
+	diffControllerRef.current?.dispose();
+	diffControllerRef.current = null;
+}

--- a/src/components/workspace-editor-surface.tsx
+++ b/src/components/workspace-editor-surface.tsx
@@ -287,12 +287,11 @@ export function WorkspaceEditorSurface({
 		}
 
 		return () => {
+			// Only guard against stale async completions — do NOT dispose the
+			// editor here.  The slow path's entry block already calls
+			// disposeControllers before creating a new editor (handles kind
+			// changes), and the separate unmount effect handles final cleanup.
 			disposed = true;
-			disposeControllers({
-				fileControllerRef,
-				diffControllerRef,
-				changeSubscriptionRef,
-			});
 		};
 	}, [canRenderDiff, canRenderFile, editorSession.kind, editorSession.path]);
 

--- a/src/components/workspace-editor-surface.tsx
+++ b/src/components/workspace-editor-surface.tsx
@@ -117,7 +117,21 @@ export function WorkspaceEditorSurface({
 		};
 	}, [canRenderDiff, canRenderFile, editorSession]);
 
-	// useLayoutEffect: run model swap BEFORE browser paint to avoid 1-frame flicker
+	// Dispose editors on unmount (separate from the switching effect so the
+	// fast-path can skip cleanup without leaking on unmount).
+	useEffect(() => {
+		return () => {
+			disposeControllers({
+				fileControllerRef,
+				diffControllerRef,
+				changeSubscriptionRef,
+			});
+		};
+	}, []);
+
+	// useLayoutEffect: run model swap BEFORE browser paint to avoid flicker.
+	// The fast path returns NO cleanup — we keep the editor instance alive across
+	// path changes. Only the slow path (first creation / kind change) disposes.
 	useLayoutEffect(() => {
 		const host = editorHostRef.current;
 		if (!host) {
@@ -171,16 +185,8 @@ export function WorkspaceEditorSurface({
 					});
 			}
 
-			// Whether switched or not, keep existing editor alive.
-			// If not switched (cache miss, no content), the file-load effect will
-			// fetch content → re-render → this effect runs again with content.
-			return () => {
-				disposeControllers({
-					fileControllerRef,
-					diffControllerRef,
-					changeSubscriptionRef,
-				});
-			};
+			// No cleanup — editor stays alive. Unmount cleanup handles disposal.
+			return;
 		}
 
 		// ── Guard: need content for initial editor creation ──

--- a/src/components/workspace-inspector-sidebar.tsx
+++ b/src/components/workspace-inspector-sidebar.tsx
@@ -84,10 +84,10 @@ export function WorkspaceInspectorSidebar({
 				if (cancelled) return;
 				setChanges(response.items);
 
-				// Pre-warm Monaco models so file switches are instant
+				// Cache file contents so switches are instant (no IPC needed)
 				if (response.prefetched.length > 0) {
-					const { preWarmModels } = await import("@/lib/monaco-runtime");
-					await preWarmModels(response.prefetched);
+					const { preWarmFileContents } = await import("@/lib/monaco-runtime");
+					preWarmFileContents(response.prefetched);
 				}
 			})
 			.catch(() => {

--- a/src/components/workspace-inspector-sidebar.tsx
+++ b/src/components/workspace-inspector-sidebar.tsx
@@ -14,19 +14,35 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { flushSync } from "react-dom";
+import { listEditorFilesWithContent } from "@/lib/api";
+import type { InspectorFileItem } from "@/lib/editor-session";
 import { cn } from "@/lib/utils";
 import { Tabs, TabsList, TabsTrigger } from "./ui/tabs";
 
-const DEFAULT_CHANGES_HEIGHT = 120;
-const DEFAULT_ACTIONS_HEIGHT = 200;
+const DEFAULT_CHANGES_RATIO = 0.4;
+const DEFAULT_ACTIONS_RATIO = 0.3;
 const MIN_SECTION_HEIGHT = 48;
 const RESIZE_HIT_AREA = 8;
 
-export function WorkspaceInspectorSidebar() {
+type WorkspaceInspectorSidebarProps = {
+	workspaceRootPath?: string | null;
+	editorMode: boolean;
+	activeEditorPath?: string | null;
+	onOpenEditorFile(path: string): void;
+	onOpenMockReview?: (path: string) => void;
+};
+
+export function WorkspaceInspectorSidebar({
+	workspaceRootPath,
+	editorMode,
+	activeEditorPath,
+	onOpenEditorFile,
+}: WorkspaceInspectorSidebarProps) {
 	const [tabsOpen, setTabsOpen] = useState(true);
 	const [activeTab, setActiveTab] = useState("setup");
-	const [changesHeight, setChangesHeight] = useState(DEFAULT_CHANGES_HEIGHT);
-	const [actionsHeight, setActionsHeight] = useState(DEFAULT_ACTIONS_HEIGHT);
+	const [changesHeight, setChangesHeight] = useState(0);
+	const [actionsHeight, setActionsHeight] = useState(0);
+	const [changes, setChanges] = useState<InspectorFileItem[]>([]);
 	const [resizeState, setResizeState] = useState<{
 		pointerY: number;
 		initialChangesHeight: number;
@@ -34,12 +50,56 @@ export function WorkspaceInspectorSidebar() {
 		target: "actions" | "tabs";
 	} | null>(null);
 
+	const containerRef = useRef<HTMLDivElement>(null);
 	const tabsWrapperRef = useRef<HTMLDivElement>(null);
 	const actionsRef = useRef<HTMLElement>(null);
+
+	// Compute initial section heights from container size (40/30/30 ratio)
+	useEffect(() => {
+		const el = containerRef.current;
+		if (!el || changesHeight > 0) return;
+		// 3 section headers (h-9 = 36px each) + 2 resize handles (~8px each)
+		const overhead = 36 * 3 + 8 * 2;
+		const available = Math.max(0, el.clientHeight - overhead);
+		setChangesHeight(Math.round(available * DEFAULT_CHANGES_RATIO));
+		setActionsHeight(Math.round(available * DEFAULT_ACTIONS_RATIO));
+	}, [changesHeight]);
 
 	const isResizing = resizeState !== null;
 	const isActionsResizing = resizeState?.target === "actions";
 	const isTabsResizing = resizeState?.target === "tabs";
+
+	useEffect(() => {
+		let cancelled = false;
+
+		if (!workspaceRootPath) {
+			setChanges([]);
+			return () => {
+				cancelled = true;
+			};
+		}
+
+		void listEditorFilesWithContent(workspaceRootPath)
+			.then(async (response) => {
+				if (cancelled) return;
+				setChanges(response.items);
+
+				// Pre-warm Monaco models so file switches are instant
+				if (response.prefetched.length > 0) {
+					const { preWarmModels } = await import("@/lib/monaco-runtime");
+					await preWarmModels(response.prefetched);
+				}
+			})
+			.catch(() => {
+				if (!cancelled) {
+					setChanges([]);
+				}
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [workspaceRootPath]);
 
 	const handleToggleTabs = useCallback(() => {
 		const tabsEl = tabsWrapperRef.current;
@@ -152,12 +212,19 @@ export function WorkspaceInspectorSidebar() {
 
 	return (
 		<div
+			ref={containerRef}
 			className={cn(
 				"flex h-full min-h-0 flex-col border-l border-app-border/70 bg-app-sidebar",
 				isResizing && "select-none",
 			)}
 		>
-			<ChangesSection bodyHeight={changesHeight} />
+			<ChangesSection
+				bodyHeight={changesHeight}
+				changes={changes}
+				editorMode={editorMode}
+				activeEditorPath={activeEditorPath}
+				onOpenEditorFile={onOpenEditorFile}
+			/>
 
 			<HorizontalResizeHandle
 				onMouseDown={handleResizeStart("actions")}
@@ -438,7 +505,7 @@ function ActionsSection({
 			)}
 		>
 			<div className="flex h-9 min-w-0 shrink-0 items-center border-b border-app-border/60 bg-app-base/[0.3] px-3">
-				<span className="inline-flex h-9 items-center text-[12px] font-medium tracking-[-0.01em] text-app-foreground-soft">
+				<span className="inline-flex h-9 items-center text-[13px] font-medium tracking-[-0.01em] text-app-foreground-soft">
 					Actions
 				</span>
 			</div>
@@ -535,34 +602,12 @@ function ActionsSection({
 
 // -- Changes section with file tree / flat list toggle --
 
-interface MockChange {
-	path: string;
-	name: string;
-	status: "M" | "A" | "D";
-}
-
-const MOCK_CHANGES: MockChange[] = [
-	{
-		path: "src/components/workspace-inspector-sidebar.tsx",
-		name: "workspace-inspector-sidebar.tsx",
-		status: "M",
-	},
-	{ path: "src/App.tsx", name: "App.tsx", status: "M" },
-	{
-		path: "src/components/ai/file-tree.tsx",
-		name: "file-tree.tsx",
-		status: "A",
-	},
-	{ path: "src/lib/utils.ts", name: "utils.ts", status: "M" },
-	{ path: "src-tauri/src/agents.rs", name: "agents.rs", status: "D" },
-];
-
-function buildTree(changes: MockChange[]) {
+function buildTree(changes: InspectorFileItem[]) {
 	type TreeNode = {
 		name: string;
 		path: string;
 		children: Map<string, TreeNode>;
-		file?: MockChange;
+		file?: InspectorFileItem;
 	};
 
 	const root: TreeNode = { name: "", path: "", children: new Map() };
@@ -592,13 +637,25 @@ function buildTree(changes: MockChange[]) {
 	return root;
 }
 
-const STATUS_COLORS: Record<MockChange["status"], string> = {
+const STATUS_COLORS: Record<InspectorFileItem["status"], string> = {
 	M: "text-yellow-500",
 	A: "text-green-500",
 	D: "text-red-500",
 };
 
-function ChangesSection({ bodyHeight }: { bodyHeight: number }) {
+function ChangesSection({
+	bodyHeight,
+	changes,
+	editorMode,
+	activeEditorPath,
+	onOpenEditorFile,
+}: {
+	bodyHeight: number;
+	changes: InspectorFileItem[];
+	editorMode: boolean;
+	activeEditorPath?: string | null;
+	onOpenEditorFile: (path: string) => void;
+}) {
 	const [treeView, setTreeView] = useState(true);
 
 	return (
@@ -607,7 +664,7 @@ function ChangesSection({ bodyHeight }: { bodyHeight: number }) {
 			className="flex min-h-0 flex-col border-b border-app-border/60 bg-app-sidebar"
 		>
 			<div className="flex h-9 min-w-0 items-center justify-between border-b border-app-border/60 bg-app-base/[0.3] px-3">
-				<span className="inline-flex h-9 items-center text-[12px] font-medium tracking-[-0.01em] text-app-foreground-soft">
+				<span className="inline-flex h-9 items-center text-[13px] font-medium tracking-[-0.01em] text-app-foreground-soft">
 					Changes
 				</span>
 				{treeView ? (
@@ -630,17 +687,43 @@ function ChangesSection({ bodyHeight }: { bodyHeight: number }) {
 				className="overflow-y-auto bg-app-base/[0.16] font-mono text-[11.5px]"
 				style={{ height: `${bodyHeight}px` }}
 			>
-				{treeView ? (
-					<ChangesTreeView changes={MOCK_CHANGES} />
+				{changes.length > 0 ? (
+					treeView ? (
+						<ChangesTreeView
+							changes={changes}
+							editorMode={editorMode}
+							activeEditorPath={activeEditorPath}
+							onOpenEditorFile={onOpenEditorFile}
+						/>
+					) : (
+						<ChangesFlatView
+							changes={changes}
+							editorMode={editorMode}
+							activeEditorPath={activeEditorPath}
+							onOpenEditorFile={onOpenEditorFile}
+						/>
+					)
 				) : (
-					<ChangesFlatView changes={MOCK_CHANGES} />
+					<div className="px-3 py-3 text-[11px] leading-5 text-app-muted">
+						Select a workspace with a root path to open files here.
+					</div>
 				)}
 			</div>
 		</section>
 	);
 }
 
-function ChangesTreeView({ changes }: { changes: MockChange[] }) {
+function ChangesTreeView({
+	changes,
+	editorMode,
+	activeEditorPath,
+	onOpenEditorFile,
+}: {
+	changes: InspectorFileItem[];
+	editorMode: boolean;
+	activeEditorPath?: string | null;
+	onOpenEditorFile: (path: string) => void;
+}) {
 	const tree = buildTree(changes);
 	const [expanded, setExpanded] = useState<Set<string>>(
 		() => new Set(collectFolderPaths(tree)),
@@ -662,6 +745,9 @@ function ChangesTreeView({ changes }: { changes: MockChange[] }) {
 				expanded={expanded}
 				onToggle={toggle}
 				depth={0}
+				editorMode={editorMode}
+				activeEditorPath={activeEditorPath}
+				onOpenEditorFile={onOpenEditorFile}
 			/>
 		</div>
 	);
@@ -683,11 +769,17 @@ function TreeNodeList({
 	expanded,
 	onToggle,
 	depth,
+	editorMode,
+	activeEditorPath,
+	onOpenEditorFile,
 }: {
 	nodes: Map<string, ReturnType<typeof buildTree>>;
 	expanded: Set<string>;
 	onToggle: (path: string) => void;
 	depth: number;
+	editorMode: boolean;
+	activeEditorPath?: string | null;
+	onOpenEditorFile: (path: string) => void;
 }) {
 	const sorted = [...nodes.values()].sort((a, b) => {
 		const aIsFolder = a.children.size > 0 && !a.file;
@@ -742,19 +834,39 @@ function TreeNodeList({
 									expanded={expanded}
 									onToggle={onToggle}
 									depth={depth + 1}
+									editorMode={editorMode}
+									activeEditorPath={activeEditorPath}
+									onOpenEditorFile={onOpenEditorFile}
 								/>
 							)}
 						</div>
 					);
 				}
 
+				const selected = node.file?.absolutePath === activeEditorPath;
+
 				return (
 					<div
 						key={node.path}
-						className="flex cursor-pointer items-center gap-1 py-[1.5px] pr-2 text-app-foreground-soft transition-colors hover:bg-app-foreground/[0.04]"
+						className={cn(
+							"flex cursor-pointer items-center gap-1 py-[1.5px] pr-2 text-app-foreground-soft transition-colors hover:bg-app-foreground/[0.04]",
+							selected &&
+								(editorMode
+									? "bg-app-row-selected text-app-foreground"
+									: "bg-app-foreground/[0.05] text-app-foreground"),
+						)}
 						style={{ paddingLeft: `${depth * 12 + 8 + 14}px` }}
 						role="treeitem"
 						tabIndex={0}
+						onClick={() =>
+							node.file && onOpenEditorFile(node.file.absolutePath)
+						}
+						onKeyDown={(event) => {
+							if ((event.key === "Enter" || event.key === " ") && node.file) {
+								event.preventDefault();
+								onOpenEditorFile(node.file.absolutePath);
+							}
+						}}
 					>
 						<FileIcon
 							className="size-3.5 shrink-0 text-app-muted"
@@ -778,14 +890,38 @@ function TreeNodeList({
 	);
 }
 
-function ChangesFlatView({ changes }: { changes: MockChange[] }) {
+function ChangesFlatView({
+	changes,
+	editorMode,
+	activeEditorPath,
+	onOpenEditorFile,
+}: {
+	changes: InspectorFileItem[];
+	editorMode: boolean;
+	activeEditorPath?: string | null;
+	onOpenEditorFile: (path: string) => void;
+}) {
 	return (
 		<div className="py-0.5">
 			{changes.map((change) => (
 				<div
 					key={change.path}
-					className="flex cursor-pointer items-center gap-1.5 py-[1.5px] pl-2 pr-2 text-app-foreground-soft transition-colors hover:bg-app-foreground/[0.04]"
-					role="listitem"
+					className={cn(
+						"flex cursor-pointer items-center gap-1.5 py-[1.5px] pl-2 pr-2 text-app-foreground-soft transition-colors hover:bg-app-foreground/[0.04]",
+						change.absolutePath === activeEditorPath &&
+							(editorMode
+								? "bg-app-row-selected text-app-foreground"
+								: "bg-app-foreground/[0.05] text-app-foreground"),
+					)}
+					role="button"
+					tabIndex={0}
+					onClick={() => onOpenEditorFile(change.absolutePath)}
+					onKeyDown={(event) => {
+						if (event.key === "Enter" || event.key === " ") {
+							event.preventDefault();
+							onOpenEditorFile(change.absolutePath);
+						}
+					}}
 				>
 					<FileIcon
 						className="size-3.5 shrink-0 text-app-muted"

--- a/src/components/workspace-inspector-sidebar.tsx
+++ b/src/components/workspace-inspector-sidebar.tsx
@@ -1,0 +1,238 @@
+import { ChevronDown } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+import {
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+} from "./ui/collapsible";
+import { Tabs, TabsList, TabsTrigger } from "./ui/tabs";
+
+const DEFAULT_CHANGES_HEIGHT = 120;
+const DEFAULT_ACTIONS_HEIGHT = 120;
+const MIN_SECTION_HEIGHT = 48;
+const RESIZE_HIT_AREA = 8;
+
+export function WorkspaceInspectorSidebar() {
+	const [tabsOpen, setTabsOpen] = useState(true);
+	const [activeTab, setActiveTab] = useState("setup");
+	const [changesHeight, setChangesHeight] = useState(DEFAULT_CHANGES_HEIGHT);
+	const [actionsHeight, setActionsHeight] = useState(DEFAULT_ACTIONS_HEIGHT);
+	const [resizeState, setResizeState] = useState<{
+		pointerY: number;
+		initialChangesHeight: number;
+		initialActionsHeight: number;
+		target: "actions" | "tabs";
+	} | null>(null);
+
+	const isResizing = resizeState !== null;
+	const isActionsResizing = resizeState?.target === "actions";
+	const isTabsResizing = resizeState?.target === "tabs";
+
+	useEffect(() => {
+		if (!resizeState) return;
+
+		const handleMouseMove = (event: globalThis.MouseEvent) => {
+			const deltaY = event.clientY - resizeState.pointerY;
+
+			if (resizeState.target === "actions") {
+				const nextChanges = Math.max(
+					MIN_SECTION_HEIGHT,
+					resizeState.initialChangesHeight + deltaY,
+				);
+				const actualDelta = nextChanges - resizeState.initialChangesHeight;
+				const nextActions = Math.max(
+					MIN_SECTION_HEIGHT,
+					resizeState.initialActionsHeight - actualDelta,
+				);
+				setChangesHeight(nextChanges);
+				setActionsHeight(nextActions);
+			} else {
+				setActionsHeight(
+					Math.max(
+						MIN_SECTION_HEIGHT,
+						resizeState.initialActionsHeight + deltaY,
+					),
+				);
+			}
+		};
+
+		const handleMouseUp = () => {
+			setResizeState(null);
+		};
+
+		const previousCursor = document.body.style.cursor;
+		const previousUserSelect = document.body.style.userSelect;
+		document.body.style.cursor = "ns-resize";
+		document.body.style.userSelect = "none";
+
+		window.addEventListener("mousemove", handleMouseMove);
+		window.addEventListener("mouseup", handleMouseUp);
+
+		return () => {
+			document.body.style.cursor = previousCursor;
+			document.body.style.userSelect = previousUserSelect;
+			window.removeEventListener("mousemove", handleMouseMove);
+			window.removeEventListener("mouseup", handleMouseUp);
+		};
+	}, [resizeState]);
+
+	const handleResizeStart = useCallback(
+		(target: "actions" | "tabs") =>
+			(event: React.MouseEvent<HTMLDivElement>) => {
+				event.preventDefault();
+				setResizeState({
+					pointerY: event.clientY,
+					initialChangesHeight: changesHeight,
+					initialActionsHeight: actionsHeight,
+					target,
+				});
+			},
+		[changesHeight, actionsHeight],
+	);
+
+	return (
+		<div
+			className={cn(
+				"flex h-full min-h-0 flex-col border-l border-app-border/70 bg-app-sidebar",
+				isResizing && "select-none",
+			)}
+		>
+			<StaticSection title="Changes" bodyHeight={changesHeight} />
+
+			<HorizontalResizeHandle
+				onMouseDown={handleResizeStart("actions")}
+				isActive={isActionsResizing}
+			/>
+
+			<StaticSection title="Actions" bodyHeight={actionsHeight} />
+
+			<HorizontalResizeHandle
+				onMouseDown={handleResizeStart("tabs")}
+				isActive={isTabsResizing}
+			/>
+
+			<Collapsible
+				open={tabsOpen}
+				onOpenChange={setTabsOpen}
+				className={cn(
+					"mt-auto flex min-h-0 flex-col",
+					tabsOpen ? "flex-1" : null,
+				)}
+			>
+				<section
+					aria-label="Inspector section Tabs"
+					className={cn(
+						"flex min-h-0 flex-col border-b border-app-border/60 bg-app-sidebar",
+						tabsOpen ? "flex-1" : null,
+					)}
+				>
+					<Tabs
+						value={activeTab}
+						onValueChange={setActiveTab}
+						className="flex min-h-0 flex-1 flex-col gap-0"
+					>
+						<div className="flex h-9 min-w-0 items-center border-b border-app-border/60 bg-app-base/[0.3] pl-1.5 pr-2">
+							<CollapsibleTrigger
+								aria-label="Toggle inspector tabs section"
+								className="group/trigger mr-1 flex size-7 shrink-0 items-center justify-center rounded-md text-app-foreground-soft outline-none transition-colors hover:bg-app-foreground/[0.04]"
+							>
+								<span className="flex size-3.5 items-center justify-center transition-transform group-data-[panel-open]/trigger:rotate-0 group-data-[panel-closed]/trigger:-rotate-90">
+									<ChevronDown className="size-3.5" strokeWidth={1.9} />
+								</span>
+							</CollapsibleTrigger>
+
+							<TabsList
+								variant="line"
+								className="h-9 gap-0 border-none bg-transparent p-0"
+							>
+								<TabsTrigger
+									value="setup"
+									variant="line"
+									className="h-9 w-auto gap-0 px-2.5 text-[12px] font-medium text-app-foreground-soft data-[state=active]:border-app-foreground-soft/80 data-[state=active]:bg-transparent data-[state=active]:text-app-foreground"
+								>
+									Setup
+								</TabsTrigger>
+								<TabsTrigger
+									value="run"
+									variant="line"
+									className="h-9 w-auto gap-0 px-2.5 text-[12px] font-medium text-app-foreground-soft data-[state=active]:border-app-foreground-soft/80 data-[state=active]:bg-transparent data-[state=active]:text-app-foreground"
+								>
+									Run
+								</TabsTrigger>
+							</TabsList>
+						</div>
+
+						{tabsOpen ? (
+							<CollapsibleContent className="flex min-h-0 flex-1 flex-col">
+								<div
+									aria-label="Inspector tabs body"
+									className="min-h-[12rem] flex-1 bg-app-base/[0.16]"
+								/>
+							</CollapsibleContent>
+						) : null}
+					</Tabs>
+				</section>
+			</Collapsible>
+		</div>
+	);
+}
+
+function HorizontalResizeHandle({
+	onMouseDown,
+	isActive,
+}: {
+	onMouseDown: (event: React.MouseEvent<HTMLDivElement>) => void;
+	isActive: boolean;
+}) {
+	return (
+		<div
+			role="separator"
+			aria-orientation="horizontal"
+			aria-valuenow={0}
+			onMouseDown={onMouseDown}
+			className="group relative z-10 cursor-ns-resize touch-none"
+			style={{
+				height: `${RESIZE_HIT_AREA}px`,
+				marginTop: `-${RESIZE_HIT_AREA / 2}px`,
+				marginBottom: `-${RESIZE_HIT_AREA / 2}px`,
+			}}
+		>
+			<span
+				aria-hidden="true"
+				className={`pointer-events-none absolute inset-x-0 top-1/2 -translate-y-1/2 transition-[height,background-color,box-shadow] ${
+					isActive
+						? "h-[2px] bg-app-foreground/80 shadow-[0_0_12px_rgba(250,249,246,0.2)]"
+						: "h-px bg-transparent group-hover:h-[2px] group-hover:bg-app-foreground-soft/75 group-hover:shadow-[0_0_10px_rgba(250,249,246,0.08)]"
+				}`}
+			/>
+		</div>
+	);
+}
+
+function StaticSection({
+	bodyHeight,
+	title,
+}: {
+	bodyHeight: number;
+	title: string;
+}) {
+	return (
+		<section
+			aria-label={`Inspector section ${title}`}
+			className="flex min-h-0 flex-col border-b border-app-border/60 bg-app-sidebar"
+		>
+			<div className="flex h-9 min-w-0 items-center border-b border-app-border/60 bg-app-base/[0.3] px-3">
+				<span className="inline-flex h-9 items-center text-[12px] font-medium tracking-[-0.01em] text-app-foreground-soft">
+					{title}
+				</span>
+			</div>
+
+			<div
+				aria-label={`${title} panel body`}
+				className="bg-app-base/[0.16]"
+				style={{ height: `${bodyHeight}px` }}
+			/>
+		</section>
+	);
+}

--- a/src/components/workspace-inspector-sidebar.tsx
+++ b/src/components/workspace-inspector-sidebar.tsx
@@ -1,15 +1,24 @@
-import { ChevronDown } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
-import { cn } from "@/lib/utils";
+import { MarkGithubIcon } from "@primer/octicons-react";
 import {
-	Collapsible,
-	CollapsibleContent,
-	CollapsibleTrigger,
-} from "./ui/collapsible";
+	ArrowUpRightIcon,
+	CheckIcon,
+	ChevronDown,
+	ChevronRightIcon,
+	CircleIcon,
+	FileIcon,
+	FolderIcon,
+	FolderOpenIcon,
+	ListIcon,
+	ListTreeIcon,
+	TriangleIcon,
+} from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { flushSync } from "react-dom";
+import { cn } from "@/lib/utils";
 import { Tabs, TabsList, TabsTrigger } from "./ui/tabs";
 
 const DEFAULT_CHANGES_HEIGHT = 120;
-const DEFAULT_ACTIONS_HEIGHT = 120;
+const DEFAULT_ACTIONS_HEIGHT = 200;
 const MIN_SECTION_HEIGHT = 48;
 const RESIZE_HIT_AREA = 8;
 
@@ -25,9 +34,59 @@ export function WorkspaceInspectorSidebar() {
 		target: "actions" | "tabs";
 	} | null>(null);
 
+	const tabsWrapperRef = useRef<HTMLDivElement>(null);
+	const actionsRef = useRef<HTMLElement>(null);
+
 	const isResizing = resizeState !== null;
 	const isActionsResizing = resizeState?.target === "actions";
 	const isTabsResizing = resizeState?.target === "tabs";
+
+	const handleToggleTabs = useCallback(() => {
+		const tabsEl = tabsWrapperRef.current;
+		const actionsEl = actionsRef.current;
+		if (!tabsEl) {
+			setTabsOpen((v) => !v);
+			return;
+		}
+
+		const tabsFrom = tabsEl.offsetHeight;
+		const actionsFrom = actionsEl?.offsetHeight ?? 0;
+
+		flushSync(() => setTabsOpen((v) => !v));
+
+		const tabsTo = tabsEl.offsetHeight;
+		const actionsTo = actionsEl?.offsetHeight ?? 0;
+		if (tabsFrom === tabsTo) return;
+
+		const isExpanding = tabsTo > tabsFrom;
+		const opts = { duration: TABS_ANIMATION_MS, easing: TABS_EASING };
+
+		// The element gaining flex-1 needs flex:none during animation,
+		// otherwise flex-grow overrides the animated height.
+		const animateSection = (
+			el: HTMLElement,
+			from: number,
+			to: number,
+			needsFlexOverride: boolean,
+		) => {
+			el.style.overflow = "hidden";
+			if (needsFlexOverride) el.style.flex = "none";
+			const anim = el.animate(
+				[{ height: `${from}px` }, { height: `${to}px` }],
+				opts,
+			);
+			anim.onfinish = anim.oncancel = () => {
+				el.style.overflow = "";
+				if (needsFlexOverride) el.style.flex = "";
+			};
+		};
+
+		// Tabs gains flex-1 when expanding; Actions gains flex-1 when collapsing
+		animateSection(tabsEl, tabsFrom, tabsTo, isExpanding);
+		if (actionsEl && actionsFrom !== actionsTo) {
+			animateSection(actionsEl, actionsFrom, actionsTo, !isExpanding);
+		}
+	}, []);
 
 	useEffect(() => {
 		if (!resizeState) return;
@@ -98,82 +157,113 @@ export function WorkspaceInspectorSidebar() {
 				isResizing && "select-none",
 			)}
 		>
-			<StaticSection title="Changes" bodyHeight={changesHeight} />
+			<ChangesSection bodyHeight={changesHeight} />
 
 			<HorizontalResizeHandle
 				onMouseDown={handleResizeStart("actions")}
 				isActive={isActionsResizing}
 			/>
 
-			<StaticSection title="Actions" bodyHeight={actionsHeight} />
-
-			<HorizontalResizeHandle
-				onMouseDown={handleResizeStart("tabs")}
-				isActive={isTabsResizing}
+			<ActionsSection
+				sectionRef={actionsRef}
+				bodyHeight={actionsHeight}
+				expanded={!tabsOpen}
 			/>
 
-			<Collapsible
+			{tabsOpen && (
+				<HorizontalResizeHandle
+					onMouseDown={handleResizeStart("tabs")}
+					isActive={isTabsResizing}
+				/>
+			)}
+
+			<InspectorTabsSection
+				wrapperRef={tabsWrapperRef}
 				open={tabsOpen}
-				onOpenChange={setTabsOpen}
-				className={cn(
-					"mt-auto flex min-h-0 flex-col",
-					tabsOpen ? "flex-1" : null,
-				)}
+				onToggle={handleToggleTabs}
+				activeTab={activeTab}
+				onTabChange={setActiveTab}
+			/>
+		</div>
+	);
+}
+
+const TABS_ANIMATION_MS = 350;
+const TABS_EASING = "cubic-bezier(0.22, 1, 0.36, 1)";
+
+function InspectorTabsSection({
+	wrapperRef,
+	open,
+	onToggle,
+	activeTab,
+	onTabChange,
+}: {
+	wrapperRef: React.RefObject<HTMLDivElement | null>;
+	open: boolean;
+	onToggle: () => void;
+	activeTab: string;
+	onTabChange: (tab: string) => void;
+}) {
+	return (
+		<div
+			ref={wrapperRef}
+			className={cn("flex min-h-0 flex-col", open && "flex-1")}
+		>
+			<section
+				aria-label="Inspector section Tabs"
+				className="flex min-h-0 flex-1 flex-col border-b border-app-border/60 bg-app-sidebar"
 			>
-				<section
-					aria-label="Inspector section Tabs"
-					className={cn(
-						"flex min-h-0 flex-col border-b border-app-border/60 bg-app-sidebar",
-						tabsOpen ? "flex-1" : null,
-					)}
+				<Tabs
+					value={activeTab}
+					onValueChange={onTabChange}
+					className="flex min-h-0 flex-1 flex-col gap-0"
 				>
-					<Tabs
-						value={activeTab}
-						onValueChange={setActiveTab}
-						className="flex min-h-0 flex-1 flex-col gap-0"
-					>
-						<div className="flex h-9 min-w-0 items-center border-b border-app-border/60 bg-app-base/[0.3] pl-1.5 pr-2">
-							<CollapsibleTrigger
-								aria-label="Toggle inspector tabs section"
-								className="group/trigger mr-1 flex size-7 shrink-0 items-center justify-center rounded-md text-app-foreground-soft outline-none transition-colors hover:bg-app-foreground/[0.04]"
-							>
-								<span className="flex size-3.5 items-center justify-center transition-transform group-data-[panel-open]/trigger:rotate-0 group-data-[panel-closed]/trigger:-rotate-90">
-									<ChevronDown className="size-3.5" strokeWidth={1.9} />
-								</span>
-							</CollapsibleTrigger>
+					<div className="flex h-9 min-w-0 shrink-0 items-center border-b border-app-border/60 bg-app-base/[0.3] pl-1.5 pr-2">
+						<button
+							type="button"
+							aria-label="Toggle inspector tabs section"
+							onClick={onToggle}
+							className="mr-1 flex size-7 shrink-0 items-center justify-center rounded-md text-app-foreground-soft outline-none transition-colors hover:bg-app-foreground/[0.04]"
+						>
+							<ChevronDown
+								className="size-3.5"
+								strokeWidth={1.9}
+								style={{
+									transform: open ? "rotate(0deg)" : "rotate(-90deg)",
+									transition: `transform ${TABS_ANIMATION_MS}ms ${TABS_EASING}`,
+								}}
+							/>
+						</button>
 
-							<TabsList
+						<TabsList
+							variant="line"
+							className="h-9 gap-0 border-none bg-transparent p-0"
+						>
+							<TabsTrigger
+								value="setup"
 								variant="line"
-								className="h-9 gap-0 border-none bg-transparent p-0"
+								className="h-9 w-auto gap-0 px-2.5 text-[12px] font-medium text-app-foreground-soft data-[state=active]:border-app-foreground-soft/80 data-[state=active]:bg-transparent data-[state=active]:text-app-foreground"
 							>
-								<TabsTrigger
-									value="setup"
-									variant="line"
-									className="h-9 w-auto gap-0 px-2.5 text-[12px] font-medium text-app-foreground-soft data-[state=active]:border-app-foreground-soft/80 data-[state=active]:bg-transparent data-[state=active]:text-app-foreground"
-								>
-									Setup
-								</TabsTrigger>
-								<TabsTrigger
-									value="run"
-									variant="line"
-									className="h-9 w-auto gap-0 px-2.5 text-[12px] font-medium text-app-foreground-soft data-[state=active]:border-app-foreground-soft/80 data-[state=active]:bg-transparent data-[state=active]:text-app-foreground"
-								>
-									Run
-								</TabsTrigger>
-							</TabsList>
-						</div>
+								Setup
+							</TabsTrigger>
+							<TabsTrigger
+								value="run"
+								variant="line"
+								className="h-9 w-auto gap-0 px-2.5 text-[12px] font-medium text-app-foreground-soft data-[state=active]:border-app-foreground-soft/80 data-[state=active]:bg-transparent data-[state=active]:text-app-foreground"
+							>
+								Run
+							</TabsTrigger>
+						</TabsList>
+					</div>
 
-						{tabsOpen ? (
-							<CollapsibleContent className="flex min-h-0 flex-1 flex-col">
-								<div
-									aria-label="Inspector tabs body"
-									className="min-h-[12rem] flex-1 bg-app-base/[0.16]"
-								/>
-							</CollapsibleContent>
-						) : null}
-					</Tabs>
-				</section>
-			</Collapsible>
+					{open && (
+						<div
+							aria-label="Inspector tabs body"
+							className="min-h-0 flex-1 bg-app-base/[0.16]"
+						/>
+					)}
+				</Tabs>
+			</section>
 		</div>
 	);
 }
@@ -210,29 +300,511 @@ function HorizontalResizeHandle({
 	);
 }
 
-function StaticSection({
+// -- Actions section --
+
+interface GitStatusItem {
+	label: string;
+	action?: string;
+}
+
+interface DeploymentItem {
+	name: string;
+	provider: "vercel";
+	status: "success" | "pending" | "failure";
+	hasLink?: boolean;
+}
+
+interface CheckItem {
+	name: string;
+	provider: "github" | "vercel";
+	status: "success" | "pending" | "failure";
+	duration?: string;
+	hasLink?: boolean;
+}
+
+const MOCK_GIT_STATUS: GitStatusItem[] = [
+	{ label: "1 uncommitted change", action: "Commit and push" },
+	{ label: "Merge conflicts detected", action: "Resolve" },
+	{ label: "Waiting for PR review" },
+];
+
+const MOCK_DEPLOYMENTS: DeploymentItem[] = [
+	{ name: "marketing", provider: "vercel", status: "success", hasLink: true },
+];
+
+const MOCK_CHECKS: CheckItem[] = [
+	{ name: "changes", provider: "github", status: "success", duration: "12s" },
+	{
+		name: "staging-locked",
+		provider: "github",
+		status: "success",
+		duration: "6s",
+	},
+	{ name: "Deploy to Staging", provider: "github", status: "success" },
+	{
+		name: "Vercel Agent Review",
+		provider: "vercel",
+		status: "success",
+		duration: "1s",
+		hasLink: true,
+	},
+	{
+		name: "Seer Code Review",
+		provider: "github",
+		status: "success",
+		duration: "2m",
+		hasLink: true,
+	},
+	{
+		name: "Vercel Preview Comments",
+		provider: "vercel",
+		status: "success",
+		duration: "0s",
+		hasLink: true,
+	},
+	{
+		name: "Vercel – app",
+		provider: "vercel",
+		status: "success",
+		hasLink: true,
+	},
+	{
+		name: "Vercel – app-emails-preview",
+		provider: "vercel",
+		status: "success",
+		hasLink: true,
+	},
+	{
+		name: "Vercel – design-system",
+		provider: "vercel",
+		status: "success",
+		hasLink: true,
+	},
+	{
+		name: "Vercel – knows",
+		provider: "vercel",
+		status: "success",
+		hasLink: true,
+	},
+	{
+		name: "Vercel – marketing",
+		provider: "vercel",
+		status: "success",
+		hasLink: true,
+	},
+];
+
+function ProviderIcon({ provider }: { provider: "github" | "vercel" }) {
+	if (provider === "vercel") {
+		return (
+			<TriangleIcon
+				className="size-3 shrink-0 fill-current text-app-foreground-soft"
+				strokeWidth={0}
+			/>
+		);
+	}
+	return (
+		<MarkGithubIcon size={12} className="shrink-0 text-app-foreground-soft" />
+	);
+}
+
+function StatusIcon({ status }: { status: "success" | "pending" | "failure" }) {
+	if (status === "success") {
+		return (
+			<CheckIcon className="size-3 shrink-0 text-green-500" strokeWidth={2.2} />
+		);
+	}
+	return (
+		<CircleIcon className="size-3 shrink-0 text-app-muted" strokeWidth={1.5} />
+	);
+}
+
+function ActionsSection({
+	sectionRef,
 	bodyHeight,
-	title,
+	expanded,
 }: {
+	sectionRef?: React.RefObject<HTMLElement | null>;
 	bodyHeight: number;
-	title: string;
+	expanded: boolean;
 }) {
 	return (
 		<section
-			aria-label={`Inspector section ${title}`}
-			className="flex min-h-0 flex-col border-b border-app-border/60 bg-app-sidebar"
+			ref={sectionRef}
+			aria-label="Inspector section Actions"
+			className={cn(
+				"flex min-h-0 flex-col border-b border-app-border/60 bg-app-sidebar",
+				expanded && "flex-1",
+			)}
 		>
-			<div className="flex h-9 min-w-0 items-center border-b border-app-border/60 bg-app-base/[0.3] px-3">
+			<div className="flex h-9 min-w-0 shrink-0 items-center border-b border-app-border/60 bg-app-base/[0.3] px-3">
 				<span className="inline-flex h-9 items-center text-[12px] font-medium tracking-[-0.01em] text-app-foreground-soft">
-					{title}
+					Actions
 				</span>
 			</div>
 
 			<div
-				aria-label={`${title} panel body`}
-				className="bg-app-base/[0.16]"
-				style={{ height: `${bodyHeight}px` }}
-			/>
+				aria-label="Actions panel body"
+				className={cn(
+					"overflow-y-auto bg-app-base/[0.16] text-[11.5px]",
+					expanded && "flex-1",
+				)}
+				style={expanded ? undefined : { height: `${bodyHeight}px` }}
+			>
+				{/* Git status */}
+				<div className="px-2.5 pb-1 pt-2">
+					<span className="text-[10.5px] font-medium tracking-wide text-app-muted">
+						Git status
+					</span>
+				</div>
+				{MOCK_GIT_STATUS.map((item) => (
+					<div
+						key={item.label}
+						className="flex items-center gap-1.5 px-2.5 py-[3px] text-app-foreground-soft transition-colors hover:bg-app-foreground/[0.04]"
+					>
+						<CircleIcon
+							className="size-3 shrink-0 text-app-muted"
+							strokeWidth={1.5}
+						/>
+						<span className="truncate">{item.label}</span>
+						{item.action && (
+							<span className="ml-auto shrink-0 cursor-pointer text-[10.5px] text-app-muted transition-colors hover:text-app-foreground">
+								{item.action}
+							</span>
+						)}
+					</div>
+				))}
+
+				{/* Deployments */}
+				<div className="px-2.5 pb-1 pt-2.5">
+					<span className="text-[10.5px] font-medium tracking-wide text-app-muted">
+						Deployments
+					</span>
+				</div>
+				{MOCK_DEPLOYMENTS.map((item) => (
+					<div
+						key={item.name}
+						className="flex items-center gap-1.5 px-2.5 py-[3px] text-app-foreground-soft transition-colors hover:bg-app-foreground/[0.04]"
+					>
+						<StatusIcon status={item.status} />
+						<ProviderIcon provider={item.provider} />
+						<span className="truncate">{item.name}</span>
+						{item.hasLink && (
+							<ArrowUpRightIcon
+								className="ml-auto size-3 shrink-0 text-app-muted"
+								strokeWidth={1.8}
+							/>
+						)}
+					</div>
+				))}
+
+				{/* Checks */}
+				<div className="px-2.5 pb-1 pt-2.5">
+					<span className="text-[10.5px] font-medium tracking-wide text-app-muted">
+						Checks
+					</span>
+				</div>
+				{MOCK_CHECKS.map((item) => (
+					<div
+						key={item.name}
+						className="flex items-center gap-1.5 px-2.5 py-[3px] text-app-foreground-soft transition-colors hover:bg-app-foreground/[0.04]"
+					>
+						<StatusIcon status={item.status} />
+						<ProviderIcon provider={item.provider} />
+						<span className="truncate">{item.name}</span>
+						{item.duration && (
+							<span className="shrink-0 text-[10.5px] text-app-muted">
+								{item.duration}
+							</span>
+						)}
+						{item.hasLink && (
+							<ArrowUpRightIcon
+								className={cn(
+									"size-3 shrink-0 text-app-muted",
+									!item.duration && "ml-auto",
+								)}
+								strokeWidth={1.8}
+							/>
+						)}
+					</div>
+				))}
+			</div>
 		</section>
+	);
+}
+
+// -- Changes section with file tree / flat list toggle --
+
+interface MockChange {
+	path: string;
+	name: string;
+	status: "M" | "A" | "D";
+}
+
+const MOCK_CHANGES: MockChange[] = [
+	{
+		path: "src/components/workspace-inspector-sidebar.tsx",
+		name: "workspace-inspector-sidebar.tsx",
+		status: "M",
+	},
+	{ path: "src/App.tsx", name: "App.tsx", status: "M" },
+	{
+		path: "src/components/ai/file-tree.tsx",
+		name: "file-tree.tsx",
+		status: "A",
+	},
+	{ path: "src/lib/utils.ts", name: "utils.ts", status: "M" },
+	{ path: "src-tauri/src/agents.rs", name: "agents.rs", status: "D" },
+];
+
+function buildTree(changes: MockChange[]) {
+	type TreeNode = {
+		name: string;
+		path: string;
+		children: Map<string, TreeNode>;
+		file?: MockChange;
+	};
+
+	const root: TreeNode = { name: "", path: "", children: new Map() };
+
+	for (const change of changes) {
+		const parts = change.path.split("/");
+		let current = root;
+		for (let i = 0; i < parts.length - 1; i++) {
+			const part = parts[i];
+			if (!current.children.has(part)) {
+				current.children.set(part, {
+					name: part,
+					path: parts.slice(0, i + 1).join("/"),
+					children: new Map(),
+				});
+			}
+			current = current.children.get(part)!;
+		}
+		current.children.set(change.name, {
+			name: change.name,
+			path: change.path,
+			children: new Map(),
+			file: change,
+		});
+	}
+
+	return root;
+}
+
+const STATUS_COLORS: Record<MockChange["status"], string> = {
+	M: "text-yellow-500",
+	A: "text-green-500",
+	D: "text-red-500",
+};
+
+function ChangesSection({ bodyHeight }: { bodyHeight: number }) {
+	const [treeView, setTreeView] = useState(true);
+
+	return (
+		<section
+			aria-label="Inspector section Changes"
+			className="flex min-h-0 flex-col border-b border-app-border/60 bg-app-sidebar"
+		>
+			<div className="flex h-9 min-w-0 items-center justify-between border-b border-app-border/60 bg-app-base/[0.3] px-3">
+				<span className="inline-flex h-9 items-center text-[12px] font-medium tracking-[-0.01em] text-app-foreground-soft">
+					Changes
+				</span>
+				{treeView ? (
+					<ListIcon
+						className="size-3.5 cursor-pointer text-app-foreground-soft transition-colors hover:text-app-foreground"
+						strokeWidth={1.8}
+						onClick={() => setTreeView(false)}
+					/>
+				) : (
+					<ListTreeIcon
+						className="size-3.5 cursor-pointer text-app-foreground-soft transition-colors hover:text-app-foreground"
+						strokeWidth={1.8}
+						onClick={() => setTreeView(true)}
+					/>
+				)}
+			</div>
+
+			<div
+				aria-label="Changes panel body"
+				className="overflow-y-auto bg-app-base/[0.16] font-mono text-[11.5px]"
+				style={{ height: `${bodyHeight}px` }}
+			>
+				{treeView ? (
+					<ChangesTreeView changes={MOCK_CHANGES} />
+				) : (
+					<ChangesFlatView changes={MOCK_CHANGES} />
+				)}
+			</div>
+		</section>
+	);
+}
+
+function ChangesTreeView({ changes }: { changes: MockChange[] }) {
+	const tree = buildTree(changes);
+	const [expanded, setExpanded] = useState<Set<string>>(
+		() => new Set(collectFolderPaths(tree)),
+	);
+
+	const toggle = (path: string) => {
+		setExpanded((prev) => {
+			const next = new Set(prev);
+			if (next.has(path)) next.delete(path);
+			else next.add(path);
+			return next;
+		});
+	};
+
+	return (
+		<div className="py-0.5">
+			<TreeNodeList
+				nodes={tree.children}
+				expanded={expanded}
+				onToggle={toggle}
+				depth={0}
+			/>
+		</div>
+	);
+}
+
+function collectFolderPaths(node: ReturnType<typeof buildTree>): string[] {
+	const paths: string[] = [];
+	for (const child of node.children.values()) {
+		if (child.children.size > 0 && !child.file) {
+			paths.push(child.path);
+			paths.push(...collectFolderPaths(child));
+		}
+	}
+	return paths;
+}
+
+function TreeNodeList({
+	nodes,
+	expanded,
+	onToggle,
+	depth,
+}: {
+	nodes: Map<string, ReturnType<typeof buildTree>>;
+	expanded: Set<string>;
+	onToggle: (path: string) => void;
+	depth: number;
+}) {
+	const sorted = [...nodes.values()].sort((a, b) => {
+		const aIsFolder = a.children.size > 0 && !a.file;
+		const bIsFolder = b.children.size > 0 && !b.file;
+		if (aIsFolder !== bIsFolder) return aIsFolder ? -1 : 1;
+		return a.name.localeCompare(b.name);
+	});
+
+	return (
+		<>
+			{sorted.map((node) => {
+				const isFolder = node.children.size > 0 && !node.file;
+
+				if (isFolder) {
+					const isOpen = expanded.has(node.path);
+					return (
+						<div key={node.path}>
+							<div
+								className="flex cursor-pointer items-center gap-1 py-[1.5px] pr-2 text-app-foreground-soft transition-colors hover:bg-app-foreground/[0.04]"
+								style={{ paddingLeft: `${depth * 12 + 8}px` }}
+								onClick={() => onToggle(node.path)}
+								onKeyDown={(e) => {
+									if (e.key === "Enter" || e.key === " ") onToggle(node.path);
+								}}
+								tabIndex={0}
+								role="treeitem"
+								aria-expanded={isOpen}
+							>
+								<ChevronRightIcon
+									className={cn(
+										"size-3 shrink-0 transition-transform",
+										isOpen && "rotate-90",
+									)}
+									strokeWidth={1.8}
+								/>
+								{isOpen ? (
+									<FolderOpenIcon
+										className="size-3.5 shrink-0 text-blue-400/80"
+										strokeWidth={1.5}
+									/>
+								) : (
+									<FolderIcon
+										className="size-3.5 shrink-0 text-blue-400/80"
+										strokeWidth={1.5}
+									/>
+								)}
+								<span className="truncate">{node.name}</span>
+							</div>
+							{isOpen && (
+								<TreeNodeList
+									nodes={node.children}
+									expanded={expanded}
+									onToggle={onToggle}
+									depth={depth + 1}
+								/>
+							)}
+						</div>
+					);
+				}
+
+				return (
+					<div
+						key={node.path}
+						className="flex cursor-pointer items-center gap-1 py-[1.5px] pr-2 text-app-foreground-soft transition-colors hover:bg-app-foreground/[0.04]"
+						style={{ paddingLeft: `${depth * 12 + 8 + 14}px` }}
+						role="treeitem"
+						tabIndex={0}
+					>
+						<FileIcon
+							className="size-3.5 shrink-0 text-app-muted"
+							strokeWidth={1.5}
+						/>
+						<span className="truncate">{node.name}</span>
+						{node.file && (
+							<span
+								className={cn(
+									"ml-auto shrink-0 text-[10px] font-semibold",
+									STATUS_COLORS[node.file.status],
+								)}
+							>
+								{node.file.status}
+							</span>
+						)}
+					</div>
+				);
+			})}
+		</>
+	);
+}
+
+function ChangesFlatView({ changes }: { changes: MockChange[] }) {
+	return (
+		<div className="py-0.5">
+			{changes.map((change) => (
+				<div
+					key={change.path}
+					className="flex cursor-pointer items-center gap-1.5 py-[1.5px] pl-2 pr-2 text-app-foreground-soft transition-colors hover:bg-app-foreground/[0.04]"
+					role="listitem"
+				>
+					<FileIcon
+						className="size-3.5 shrink-0 text-app-muted"
+						strokeWidth={1.5}
+					/>
+					<span className="truncate">{change.name}</span>
+					<span className="ml-auto shrink-0 truncate text-[10px] text-app-muted">
+						{change.path.slice(0, change.path.lastIndexOf("/"))}
+					</span>
+					<span
+						className={cn(
+							"shrink-0 text-[10px] font-semibold",
+							STATUS_COLORS[change.status],
+						)}
+					>
+						{change.status}
+					</span>
+				</div>
+			))}
+		</div>
 	);
 }

--- a/src/components/workspace-inspector-sidebar.tsx
+++ b/src/components/workspace-inspector-sidebar.tsx
@@ -14,7 +14,7 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { flushSync } from "react-dom";
-import { listEditorFilesWithContent } from "@/lib/api";
+import { listWorkspaceChangesWithContent } from "@/lib/api";
 import type { InspectorFileItem } from "@/lib/editor-session";
 import { cn } from "@/lib/utils";
 import { Tabs, TabsList, TabsTrigger } from "./ui/tabs";
@@ -79,7 +79,7 @@ export function WorkspaceInspectorSidebar({
 			};
 		}
 
-		void listEditorFilesWithContent(workspaceRootPath)
+		void listWorkspaceChangesWithContent(workspaceRootPath)
 			.then(async (response) => {
 				if (cancelled) return;
 				setChanges(response.items);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,9 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import {
+	buildFallbackInspectorFileItems,
+	type InspectorFileItem,
+} from "./editor-session";
 
 export type GroupTone =
 	| "pinned"
@@ -301,6 +305,35 @@ export type SessionAttachmentRecord = {
 	isLoading: boolean;
 	isDraft: boolean;
 	createdAt: string;
+};
+
+export type EditorFileReadResponse = {
+	path: string;
+	content: string;
+	mtimeMs: number;
+};
+
+export type EditorFileWriteResponse = {
+	path: string;
+	mtimeMs: number;
+};
+
+export type EditorFileStatResponse = {
+	path: string;
+	exists: boolean;
+	isFile: boolean;
+	mtimeMs: number | null;
+	size: number | null;
+};
+
+export type EditorFilePrefetchItem = {
+	absolutePath: string;
+	content: string;
+};
+
+export type EditorFilesWithContentResponse = {
+	items: InspectorFileItem[];
+	prefetched: EditorFilePrefetchItem[];
 };
 
 const DEFAULT_WORKSPACE_GROUPS: WorkspaceGroup[] = [
@@ -798,6 +831,105 @@ export async function openWorkspaceInEditor(
 	const invoke = await getTauriInvoke();
 	if (!invoke) return;
 	await invoke("open_workspace_in_editor", { workspaceId, editor });
+}
+
+export async function readEditorFile(
+	path: string,
+): Promise<EditorFileReadResponse> {
+	const inv = await getTauriInvoke();
+	if (!inv) {
+		throw new Error(
+			"File editing is only available in the Tauri desktop runtime.",
+		);
+	}
+
+	try {
+		return await inv<EditorFileReadResponse>("read_editor_file", { path });
+	} catch (error) {
+		throw new Error(
+			describeInvokeError(error, "Unable to open the selected file."),
+		);
+	}
+}
+
+export async function writeEditorFile(
+	path: string,
+	content: string,
+): Promise<EditorFileWriteResponse> {
+	const inv = await getTauriInvoke();
+	if (!inv) {
+		throw new Error(
+			"File editing is only available in the Tauri desktop runtime.",
+		);
+	}
+
+	try {
+		return await inv<EditorFileWriteResponse>("write_editor_file", {
+			path,
+			content,
+		});
+	} catch (error) {
+		throw new Error(
+			describeInvokeError(error, "Unable to save the selected file."),
+		);
+	}
+}
+
+export async function statEditorFile(
+	path: string,
+): Promise<EditorFileStatResponse> {
+	const inv = await getTauriInvoke();
+	if (!inv) {
+		throw new Error(
+			"File editing is only available in the Tauri desktop runtime.",
+		);
+	}
+
+	try {
+		return await inv<EditorFileStatResponse>("stat_editor_file", { path });
+	} catch (error) {
+		throw new Error(
+			describeInvokeError(error, "Unable to inspect the selected file."),
+		);
+	}
+}
+
+export async function listEditorFiles(
+	workspaceRootPath: string,
+): Promise<InspectorFileItem[]> {
+	const inv = await getTauriInvoke();
+	if (!inv) {
+		return buildFallbackInspectorFileItems(workspaceRootPath);
+	}
+
+	try {
+		return await inv<InspectorFileItem[]>("list_editor_files", {
+			workspaceRootPath,
+		});
+	} catch (error) {
+		throw new Error(describeInvokeError(error, "Unable to list editor files."));
+	}
+}
+
+export async function listEditorFilesWithContent(
+	workspaceRootPath: string,
+): Promise<EditorFilesWithContentResponse> {
+	const inv = await getTauriInvoke();
+	if (!inv) {
+		return {
+			items: buildFallbackInspectorFileItems(workspaceRootPath),
+			prefetched: [],
+		};
+	}
+
+	try {
+		return await inv<EditorFilesWithContentResponse>(
+			"list_editor_files_with_content",
+			{ workspaceRootPath },
+		);
+	} catch (error) {
+		throw new Error(describeInvokeError(error, "Unable to list editor files."));
+	}
 }
 
 export async function permanentlyDeleteWorkspace(

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -932,6 +932,29 @@ export async function listEditorFilesWithContent(
 	}
 }
 
+export async function listWorkspaceChangesWithContent(
+	workspaceRootPath: string,
+): Promise<EditorFilesWithContentResponse> {
+	const inv = await getTauriInvoke();
+	if (!inv) {
+		return {
+			items: buildFallbackInspectorFileItems(workspaceRootPath),
+			prefetched: [],
+		};
+	}
+
+	try {
+		return await inv<EditorFilesWithContentResponse>(
+			"list_workspace_changes_with_content",
+			{ workspaceRootPath },
+		);
+	} catch (error) {
+		throw new Error(
+			describeInvokeError(error, "Unable to list workspace changes."),
+		);
+	}
+}
+
 export async function permanentlyDeleteWorkspace(
 	workspaceId: string,
 ): Promise<void> {

--- a/src/lib/editor-session.ts
+++ b/src/lib/editor-session.ts
@@ -1,0 +1,116 @@
+export type EditorSessionState = {
+	kind: "file" | "diff";
+	path: string;
+	line?: number;
+	column?: number;
+	originalText?: string;
+	modifiedText?: string;
+	inline?: boolean;
+	dirty?: boolean;
+	mtimeMs?: number | null;
+};
+
+export type InspectorFileItem = {
+	path: string;
+	absolutePath: string;
+	name: string;
+	status: "M" | "A" | "D";
+};
+
+const DEFAULT_INSPECTOR_RELATIVE_FILES: Array<{
+	path: string;
+	status: InspectorFileItem["status"];
+}> = [
+	{ path: "src/App.tsx", status: "M" },
+	{
+		path: "src/components/workspace-inspector-sidebar.tsx",
+		status: "M",
+	},
+	{
+		path: "src/components/workspace-panel.tsx",
+		status: "A",
+	},
+	{ path: "src/lib/api.ts", status: "M" },
+	{ path: "src-tauri/src/lib.rs", status: "D" },
+];
+
+export function buildFallbackInspectorFileItems(
+	workspaceRootPath?: string | null,
+): InspectorFileItem[] {
+	if (!workspaceRootPath) {
+		return [];
+	}
+
+	const normalizedRoot = normalizePath(workspaceRootPath);
+
+	return DEFAULT_INSPECTOR_RELATIVE_FILES.map((file) => ({
+		path: file.path,
+		absolutePath: joinPath(normalizedRoot, file.path),
+		name: getBaseName(file.path),
+		status: file.status,
+	}));
+}
+
+export function describeEditorPath(
+	path: string,
+	workspaceRootPath?: string | null,
+): string {
+	const normalizedPath = normalizePath(path);
+	const normalizedRoot = workspaceRootPath
+		? normalizePath(workspaceRootPath)
+		: null;
+
+	if (!normalizedRoot) {
+		return normalizedPath;
+	}
+
+	if (normalizedPath === normalizedRoot) {
+		return ".";
+	}
+
+	const rootWithSlash = normalizedRoot.endsWith("/")
+		? normalizedRoot
+		: `${normalizedRoot}/`;
+
+	if (normalizedPath.startsWith(rootWithSlash)) {
+		return normalizedPath.slice(rootWithSlash.length);
+	}
+
+	return normalizedPath;
+}
+
+export function getBaseName(path: string): string {
+	const normalizedPath = normalizePath(path);
+	const segments = normalizedPath.split("/");
+	return segments[segments.length - 1] ?? normalizedPath;
+}
+
+export function isPathWithinRoot(
+	path: string,
+	workspaceRootPath?: string | null,
+): boolean {
+	if (!workspaceRootPath) {
+		return false;
+	}
+
+	const normalizedPath = normalizePath(path);
+	const normalizedRoot = normalizePath(workspaceRootPath);
+
+	if (normalizedPath === normalizedRoot) {
+		return true;
+	}
+
+	const rootWithSlash = normalizedRoot.endsWith("/")
+		? normalizedRoot
+		: `${normalizedRoot}/`;
+
+	return normalizedPath.startsWith(rootWithSlash);
+}
+
+function joinPath(root: string, relativePath: string): string {
+	return `${root.replace(/\/+$/, "")}/${relativePath.replace(/^\/+/, "")}`;
+}
+
+function normalizePath(path: string): string {
+	return path.replace(/\\/g, "/");
+}

--- a/src/lib/monaco-runtime.ts
+++ b/src/lib/monaco-runtime.ts
@@ -46,6 +46,9 @@ type DiffEditorController = {
 
 let runtimePromise: Promise<MonacoRuntime> | null = null;
 
+/** Content cache for pre-fetched files — avoids IPC on first switch. */
+const fileContentCache = new Map<string, string>();
+
 export async function createFileEditor(options: {
 	container: HTMLElement;
 	path: string;
@@ -56,21 +59,14 @@ export async function createFileEditor(options: {
 	const runtime = await ensureRuntime();
 	const { monaco } = runtime;
 
-	const uri = monaco.Uri.file(options.path);
 	const language = resolveLanguageId(monaco, options.path);
 
-	// Reuse existing model or create a new one
-	let model = monaco.editor.getModel(uri);
-	if (model) {
-		if (model.getValue() !== options.content) {
-			model.setValue(options.content);
-		}
-		if (language && model.getLanguageId() !== language) {
-			monaco.editor.setModelLanguage(model, language);
-		}
-	} else {
-		model = monaco.editor.createModel(options.content, language, uri);
-	}
+	// Single model shared across all file switches — avoids editor.setModel()
+	// which causes a blank frame during the detach→attach cycle.
+	const model = monaco.editor.createModel(options.content, language);
+
+	// Seed content cache for future switches
+	fileContentCache.set(options.path, options.content);
 
 	const editor = monaco.editor.create(options.container, {
 		automaticLayout: true,
@@ -93,7 +89,7 @@ export async function createFileEditor(options: {
 
 	revealEditorPosition(editor, options.line, options.column);
 
-	let currentModel = model;
+	const currentModel = model;
 
 	return {
 		editor,
@@ -119,27 +115,24 @@ export async function createFileEditor(options: {
 			});
 		},
 		switchFile(path: string, content?: string, line?: number, column?: number) {
-			const nextUri = monaco.Uri.file(path);
-			const nextLanguage = resolveLanguageId(monaco, path);
-
-			let nextModel = monaco.editor.getModel(nextUri);
-			if (nextModel) {
-				// Cache hit — reuse existing model, optionally refresh content
-				if (content !== undefined && nextModel.getValue() !== content) {
-					nextModel.setValue(content);
-				}
-				if (nextLanguage && nextModel.getLanguageId() !== nextLanguage) {
-					monaco.editor.setModelLanguage(nextModel, nextLanguage);
-				}
-			} else if (content !== undefined) {
-				nextModel = monaco.editor.createModel(content, nextLanguage, nextUri);
-			} else {
-				// No cached model and no content — caller must load the file first
+			// Resolve content: explicit param → cache → give up
+			const resolvedContent = content ?? fileContentCache.get(path);
+			if (resolvedContent === undefined) {
 				return false;
 			}
 
-			editor.setModel(nextModel);
-			currentModel = nextModel;
+			// In-place update: setValue + setModelLanguage on the SAME model.
+			// Unlike editor.setModel(), this never detaches the DOM → zero blank frames.
+			currentModel.setValue(resolvedContent);
+
+			const nextLanguage = resolveLanguageId(monaco, path);
+			if (nextLanguage && currentModel.getLanguageId() !== nextLanguage) {
+				monaco.editor.setModelLanguage(currentModel, nextLanguage);
+			}
+
+			// Keep cache fresh for future switches back to this file
+			fileContentCache.set(path, resolvedContent);
+
 			revealEditorPosition(editor, line, column);
 			return true;
 		},
@@ -226,27 +219,17 @@ export async function createDiffEditor(options: {
 	};
 }
 
-/** Pre-create Monaco models so future switchFile calls are instant cache hits. */
-export async function preWarmModels(
+/** Cache file contents so future switchFile calls resolve instantly (no IPC). */
+export function preWarmFileContents(
 	files: ReadonlyArray<{ absolutePath: string; content: string }>,
 ) {
-	const { monaco } = await ensureRuntime();
 	for (const file of files) {
-		const uri = monaco.Uri.file(file.absolutePath);
-		if (!monaco.editor.getModel(uri)) {
-			const language = resolveLanguageId(monaco, file.absolutePath);
-			monaco.editor.createModel(file.content, language, uri);
-		}
+		fileContentCache.set(file.absolutePath, file.content);
 	}
 }
 
-export async function syncVirtualFile(path: string, content: string) {
-	const { monaco } = await ensureRuntime();
-	const uri = monaco.Uri.file(path);
-	const model = monaco.editor.getModel(uri);
-	if (model && model.getValue() !== content) {
-		model.setValue(content);
-	}
+export function syncVirtualFile(path: string, content: string) {
+	fileContentCache.set(path, content);
 }
 
 async function ensureRuntime(): Promise<MonacoRuntime> {

--- a/src/lib/monaco-runtime.ts
+++ b/src/lib/monaco-runtime.ts
@@ -1,0 +1,419 @@
+import "monaco-editor/min/vs/editor/editor.main.css";
+import type * as Monaco from "monaco-editor";
+import editorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
+import cssWorker from "monaco-editor/esm/vs/language/css/css.worker?worker";
+import htmlWorker from "monaco-editor/esm/vs/language/html/html.worker?worker";
+import jsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
+import tsWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker";
+
+type MonacoModule = typeof Monaco;
+type StandaloneEditor = Monaco.editor.IStandaloneCodeEditor;
+type StandaloneDiffEditor = Monaco.editor.IStandaloneDiffEditor;
+
+type MonacoRuntime = {
+	monaco: MonacoModule;
+};
+
+type DisposableLike = {
+	dispose(): void;
+};
+
+type FileEditorController = {
+	editor: StandaloneEditor;
+	dispose(): void;
+	getValue(): string;
+	setValue(value: string): void;
+	revealPosition(line?: number, column?: number): void;
+	onDidChangeModelContent(callback: (value: string) => void): DisposableLike;
+	/** Swap the active model. Returns false if no cached model and no content provided. */
+	switchFile(
+		path: string,
+		content?: string,
+		line?: number,
+		column?: number,
+	): boolean;
+};
+
+type DiffEditorController = {
+	editor: StandaloneDiffEditor;
+	dispose(): void;
+	setTexts(options: {
+		originalText: string;
+		modifiedText: string;
+		inline: boolean;
+	}): void;
+};
+
+let runtimePromise: Promise<MonacoRuntime> | null = null;
+
+export async function createFileEditor(options: {
+	container: HTMLElement;
+	path: string;
+	content: string;
+	line?: number;
+	column?: number;
+}): Promise<FileEditorController> {
+	const runtime = await ensureRuntime();
+	const { monaco } = runtime;
+
+	const uri = monaco.Uri.file(options.path);
+	const language = resolveLanguageId(monaco, options.path);
+
+	// Reuse existing model or create a new one
+	let model = monaco.editor.getModel(uri);
+	if (model) {
+		if (model.getValue() !== options.content) {
+			model.setValue(options.content);
+		}
+		if (language && model.getLanguageId() !== language) {
+			monaco.editor.setModelLanguage(model, language);
+		}
+	} else {
+		model = monaco.editor.createModel(options.content, language, uri);
+	}
+
+	const editor = monaco.editor.create(options.container, {
+		automaticLayout: true,
+		bracketPairColorization: { enabled: true },
+		fontFamily:
+			'"SF Mono","Monaco","Cascadia Mono","Roboto Mono","Menlo",monospace',
+		fontLigatures: true,
+		fontSize: 13,
+		lineHeight: 21,
+		minimap: { enabled: false },
+		model,
+		padding: { top: 14, bottom: 24 },
+		renderValidationDecorations: "editable",
+		scrollBeyondLastLine: false,
+		smoothScrolling: true,
+		tabSize: 2,
+		theme: "helmor-editor-dark",
+		wordWrap: "on",
+	});
+
+	revealEditorPosition(editor, options.line, options.column);
+
+	let currentModel = model;
+
+	return {
+		editor,
+		dispose() {
+			editor.dispose();
+		},
+		getValue() {
+			return currentModel.getValue();
+		},
+		setValue(value: string) {
+			if (currentModel.getValue() === value) {
+				return;
+			}
+
+			currentModel.setValue(value);
+		},
+		revealPosition(line?: number, column?: number) {
+			revealEditorPosition(editor, line, column);
+		},
+		onDidChangeModelContent(callback) {
+			return currentModel.onDidChangeContent(() => {
+				callback(currentModel.getValue());
+			});
+		},
+		switchFile(path: string, content?: string, line?: number, column?: number) {
+			const nextUri = monaco.Uri.file(path);
+			const nextLanguage = resolveLanguageId(monaco, path);
+
+			let nextModel = monaco.editor.getModel(nextUri);
+			if (nextModel) {
+				// Cache hit — reuse existing model, optionally refresh content
+				if (content !== undefined && nextModel.getValue() !== content) {
+					nextModel.setValue(content);
+				}
+				if (nextLanguage && nextModel.getLanguageId() !== nextLanguage) {
+					monaco.editor.setModelLanguage(nextModel, nextLanguage);
+				}
+			} else if (content !== undefined) {
+				nextModel = monaco.editor.createModel(content, nextLanguage, nextUri);
+			} else {
+				// No cached model and no content — caller must load the file first
+				return false;
+			}
+
+			editor.setModel(nextModel);
+			currentModel = nextModel;
+			revealEditorPosition(editor, line, column);
+			return true;
+		},
+	};
+}
+
+export async function createDiffEditor(options: {
+	container: HTMLElement;
+	path: string;
+	originalText: string;
+	modifiedText: string;
+	inline: boolean;
+}): Promise<DiffEditorController> {
+	const runtime = await ensureRuntime();
+	const { monaco } = runtime;
+	const language = resolveLanguageId(monaco, options.path);
+
+	const originalUri = monaco.Uri.file(options.path).with({
+		query: "helmor-review=original",
+	});
+	const modifiedUri = monaco.Uri.file(options.path).with({
+		query: "helmor-review=modified",
+	});
+	monaco.editor.getModel(originalUri)?.dispose();
+	monaco.editor.getModel(modifiedUri)?.dispose();
+
+	const originalModel = monaco.editor.createModel(
+		options.originalText,
+		language,
+		originalUri,
+	);
+	const modifiedModel = monaco.editor.createModel(
+		options.modifiedText,
+		language,
+		modifiedUri,
+	);
+
+	const editor = monaco.editor.createDiffEditor(options.container, {
+		automaticLayout: true,
+		enableSplitViewResizing: true,
+		fontFamily:
+			'"SF Mono","Monaco","Cascadia Mono","Roboto Mono","Menlo",monospace',
+		fontLigatures: true,
+		fontSize: 13,
+		hideUnchangedRegions: {
+			enabled: true,
+			contextLineCount: 4,
+			minimumLineCount: 2,
+			revealLineCount: 3,
+		},
+		lineHeight: 21,
+		minimap: { enabled: false },
+		originalEditable: false,
+		padding: { top: 14, bottom: 24 },
+		readOnly: true,
+		renderOverviewRuler: false,
+		renderSideBySide: !options.inline,
+		scrollBeyondLastLine: false,
+		smoothScrolling: true,
+		theme: "helmor-editor-dark",
+	});
+
+	editor.setModel({
+		original: originalModel,
+		modified: modifiedModel,
+	});
+
+	return {
+		editor,
+		dispose() {
+			editor.dispose();
+			originalModel.dispose();
+			modifiedModel.dispose();
+		},
+		setTexts({ originalText, modifiedText, inline }) {
+			if (originalModel.getValue() !== originalText) {
+				originalModel.setValue(originalText);
+			}
+			if (modifiedModel.getValue() !== modifiedText) {
+				modifiedModel.setValue(modifiedText);
+			}
+			editor.updateOptions({ renderSideBySide: !inline });
+		},
+	};
+}
+
+/** Pre-create Monaco models so future switchFile calls are instant cache hits. */
+export async function preWarmModels(
+	files: ReadonlyArray<{ absolutePath: string; content: string }>,
+) {
+	const { monaco } = await ensureRuntime();
+	for (const file of files) {
+		const uri = monaco.Uri.file(file.absolutePath);
+		if (!monaco.editor.getModel(uri)) {
+			const language = resolveLanguageId(monaco, file.absolutePath);
+			monaco.editor.createModel(file.content, language, uri);
+		}
+	}
+}
+
+export async function syncVirtualFile(path: string, content: string) {
+	const { monaco } = await ensureRuntime();
+	const uri = monaco.Uri.file(path);
+	const model = monaco.editor.getModel(uri);
+	if (model && model.getValue() !== content) {
+		model.setValue(content);
+	}
+}
+
+async function ensureRuntime(): Promise<MonacoRuntime> {
+	if (!runtimePromise) {
+		runtimePromise = (async () => {
+			const monaco = await import("monaco-editor");
+
+			installMonacoEnvironment();
+			installEditorTheme(monaco);
+
+			return { monaco };
+		})();
+	}
+
+	return runtimePromise;
+}
+
+function installMonacoEnvironment() {
+	const target = globalThis as typeof globalThis & {
+		MonacoEnvironment?: {
+			getWorker: (_moduleId: string, label: string) => Worker;
+		};
+	};
+
+	if (target.MonacoEnvironment) {
+		return;
+	}
+
+	target.MonacoEnvironment = {
+		getWorker(_moduleId, label) {
+			switch (label) {
+				case "json":
+					return new jsonWorker();
+				case "css":
+				case "scss":
+				case "less":
+					return new cssWorker();
+				case "html":
+				case "handlebars":
+				case "razor":
+					return new htmlWorker();
+				case "typescript":
+				case "javascript":
+					return new tsWorker();
+				default:
+					return new editorWorker();
+			}
+		},
+	};
+}
+
+function installEditorTheme(monaco: MonacoModule) {
+	monaco.editor.defineTheme("helmor-editor-dark", {
+		base: "vs-dark",
+		inherit: true,
+		rules: [
+			{ token: "comment", foreground: "868584" },
+			{ token: "string", foreground: "c9b18f" },
+			{ token: "keyword", foreground: "c5a3a8" },
+			{ token: "number", foreground: "c6b48a" },
+			{ token: "regexp", foreground: "9ea693" },
+			{ token: "type.identifier", foreground: "a9b0c6" },
+			{ token: "identifier", foreground: "faf9f6" },
+			{ token: "delimiter", foreground: "afaeac" },
+		],
+		colors: {
+			"editor.background": "#161514",
+			"editor.foreground": "#FAF9F6",
+			"editor.lineHighlightBackground": "#1f1e1d",
+			"editor.lineHighlightBorder": "#00000000",
+			"editor.selectionBackground": "#353534",
+			"editor.inactiveSelectionBackground": "#2a2928",
+			"editor.wordHighlightBackground": "#35353488",
+			"editor.wordHighlightStrongBackground": "#45454588",
+			"editorCursor.foreground": "#FAF9F6",
+			"editorWhitespace.foreground": "#595755",
+			"editorIndentGuide.background1": "#2b2a29",
+			"editorIndentGuide.activeBackground1": "#4b4946",
+			"editorLineNumber.foreground": "#868584",
+			"editorLineNumber.activeForeground": "#FAF9F6",
+			"editorGutter.background": "#161514",
+			"editorWidget.background": "#1e1d1c",
+			"editorWidget.border": "#343332",
+			"editorSuggestWidget.background": "#1e1d1c",
+			"editorSuggestWidget.border": "#343332",
+			"editorHoverWidget.background": "#1e1d1c",
+			"editorHoverWidget.border": "#343332",
+			"scrollbarSlider.background": "#faf9f626",
+			"scrollbarSlider.hoverBackground": "#faf9f640",
+			"scrollbarSlider.activeBackground": "#faf9f655",
+			"minimap.background": "#161514",
+			"diffEditor.insertedLineBackground": "#2d3a2b66",
+			"diffEditor.insertedTextBackground": "#5a7a5255",
+			"diffEditor.removedLineBackground": "#4a2e2e66",
+			"diffEditor.removedTextBackground": "#8c5e5e55",
+		},
+	});
+	monaco.editor.setTheme("helmor-editor-dark");
+}
+
+function resolveLanguageId(
+	monaco: MonacoModule,
+	path: string,
+): string | undefined {
+	const normalizedPath = path.replace(/\\/g, "/");
+	const fileName = normalizedPath.split("/").pop()?.toLowerCase() ?? "";
+	const extension = fileName.includes(".")
+		? fileName.slice(fileName.lastIndexOf("."))
+		: "";
+
+	const explicitMap: Record<string, string> = {
+		".cjs": "javascript",
+		".css": "css",
+		".go": "go",
+		".html": "html",
+		".java": "java",
+		".js": "javascript",
+		".json": "json",
+		".jsx": "javascript",
+		".md": "markdown",
+		".mjs": "javascript",
+		".py": "python",
+		".rs": "rust",
+		".scss": "scss",
+		".sh": "shell",
+		".sql": "sql",
+		".toml": "ini",
+		".ts": "typescript",
+		".tsx": "typescript",
+		".txt": "plaintext",
+		".yaml": "yaml",
+		".yml": "yaml",
+	};
+
+	if (fileName === "dockerfile") {
+		return "dockerfile";
+	}
+
+	if (fileName.endsWith(".test.tsx") || fileName.endsWith(".spec.tsx")) {
+		return "typescript";
+	}
+
+	if (explicitMap[extension]) {
+		return explicitMap[extension];
+	}
+
+	return monaco.languages.getLanguages().find((language) => {
+		const extensions = language.extensions ?? [];
+		const filenames = language.filenames ?? [];
+		return extensions.includes(extension) || filenames.includes(fileName);
+	})?.id;
+}
+
+function revealEditorPosition(
+	editor: StandaloneEditor,
+	line?: number,
+	column?: number,
+) {
+	if (!line) {
+		return;
+	}
+
+	const position = {
+		lineNumber: Math.max(1, line),
+		column: Math.max(1, column ?? 1),
+	};
+	editor.setPosition(position);
+	editor.revealPositionInCenter(position);
+	editor.focus();
+}


### PR DESCRIPTION
## Summary
- Replace `@codingame/monaco-vscode-api` with vanilla Monaco for the in-app editor surface
- Add `list_workspace_changes` Rust commands that diff current branch against main/master (committed + staged + unstaged + untracked files)
- Implement editor/conversation view mode toggle — inspector sidebar file clicks open files in the in-app editor
- Fix blank frame flash and slow-path cleanup issues during editor file switching

## Test plan
- [ ] Open a workspace, click a file in the inspector sidebar → editor surface opens
- [ ] Switch between files → no blank frame or flickering
- [ ] Toggle back to conversation mode → editor closes cleanly
- [ ] Verify inspector shows only branch-changed files (not all files)
- [ ] Run `pnpm test` — new test files pass