### PR TITLE
feat: session shortcuts, git worktree support, condensed empty groups

### DIFF
--- a/sidecar/src/claude-session-manager.ts
+++ b/sidecar/src/claude-session-manager.ts
@@ -18,6 +18,7 @@ import {
 } from "@anthropic-ai/claude-agent-sdk";
 import { isAbortError } from "./abort.js";
 import type { SidecarEmitter } from "./emitter.js";
+import { resolveGitAccessDirectories } from "./git-access.js";
 import { parseImageRefs } from "./images.js";
 import { logger } from "./logger.js";
 import type {
@@ -358,6 +359,7 @@ export class ClaudeSessionManager implements SessionManager {
 			effortLevel,
 		} = params;
 		const abortController = new AbortController();
+		const additionalDirectories = await resolveGitAccessDirectories(cwd);
 
 		const { text, imagePaths } = parseImageRefs(prompt);
 		const promptValue: string | AsyncIterable<SDKUserMessage> =
@@ -374,6 +376,7 @@ export class ClaudeSessionManager implements SessionManager {
 				pathToClaudeCodeExecutable: CLAUDE_CLI_PATH,
 				...executableOptions(),
 				cwd: cwd || undefined,
+				...(additionalDirectories.length > 0 ? { additionalDirectories } : {}),
 				model: model || undefined,
 				...(resume ? { resume } : {}),
 				permissionMode: parsePermissionMode(permissionMode),

--- a/sidecar/src/codex-session-manager.ts
+++ b/sidecar/src/codex-session-manager.ts
@@ -31,6 +31,7 @@ function newCodex(): Codex {
 
 import { scanCodexSkills } from "./codex-skill-scanner.js";
 import type { SidecarEmitter } from "./emitter.js";
+import { resolveGitAccessDirectories } from "./git-access.js";
 import { parseImageRefs } from "./images.js";
 import { logger } from "./logger.js";
 import type {
@@ -106,9 +107,11 @@ export class CodexSessionManager implements SessionManager {
 		try {
 			const codex = newCodex();
 			const effort = parseEffort(effortLevel);
+			const additionalDirectories = await resolveGitAccessDirectories(cwd);
 			const threadOpts: ThreadOptions = {
 				...(model ? { model } : {}),
 				...(cwd ? { workingDirectory: cwd } : {}),
+				...(additionalDirectories.length > 0 ? { additionalDirectories } : {}),
 				skipGitRepoCheck: true,
 				...(effort ? { modelReasoningEffort: effort } : {}),
 				...(permissionMode === "plan"

--- a/sidecar/src/git-access.ts
+++ b/sidecar/src/git-access.ts
@@ -1,0 +1,72 @@
+import { readFile, stat } from "node:fs/promises";
+import { join, resolve } from "node:path";
+
+async function existingDirectory(path: string): Promise<string | null> {
+	try {
+		const info = await stat(path);
+		return info.isDirectory() ? path : null;
+	} catch {
+		return null;
+	}
+}
+
+async function readWorktreeGitdir(cwd: string): Promise<string | null> {
+	try {
+		const pointer = await readFile(join(cwd, ".git"), "utf-8");
+		const match = pointer.match(/^gitdir:\s*(.+)\s*$/m);
+		if (!match?.[1]) {
+			return null;
+		}
+		return resolve(cwd, match[1].trim());
+	} catch {
+		return null;
+	}
+}
+
+async function readCommonDir(gitDir: string): Promise<string | null> {
+	try {
+		const pointer = await readFile(join(gitDir, "commondir"), "utf-8");
+		return resolve(gitDir, pointer.trim());
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Worktrees store mutable git metadata outside the workspace directory:
+ *
+ * - `.git` inside the worktree is a pointer file, not a directory.
+ * - The actual worktree gitdir lives under `<repo>/.git/worktrees/<name>`.
+ * - Shared refs/objects/hooks live under the worktree's `commondir`.
+ *
+ * Sandboxed agents need both directories whitelisted or `git commit` /
+ * `git push` will fail even though the worktree itself is writable.
+ */
+export async function resolveGitAccessDirectories(
+	cwd: string | undefined,
+): Promise<string[]> {
+	if (!cwd) {
+		return [];
+	}
+
+	const gitDirPath = await readWorktreeGitdir(cwd);
+	if (!gitDirPath) {
+		return [];
+	}
+
+	const gitDir = await existingDirectory(gitDirPath);
+	if (!gitDir) {
+		return [];
+	}
+
+	const directories = new Set<string>([gitDir]);
+	const commonDirPath = await readCommonDir(gitDir);
+	if (commonDirPath) {
+		const commonDir = await existingDirectory(commonDirPath);
+		if (commonDir) {
+			directories.add(commonDir);
+		}
+	}
+
+	return Array.from(directories);
+}

--- a/sidecar/test/claude-session-manager.test.ts
+++ b/sidecar/test/claude-session-manager.test.ts
@@ -8,8 +8,15 @@
  * `id` field so what we replay matches raw SDK output.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { createSidecarEmitter, type SidecarEmitter } from "../src/emitter.js";
 
@@ -37,10 +44,13 @@ type MockQueryImpl = (options: {
 }) => AsyncIterable<unknown>;
 
 let mockQueryImpl: MockQueryImpl = () => emptyAsyncIterable();
+let lastQueryArgs: unknown = null;
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
-	query: (options: { abortController?: AbortController }) =>
-		mockQueryImpl(options),
+	query: (options: unknown) => {
+		lastQueryArgs = options;
+		return mockQueryImpl(options as Parameters<MockQueryImpl>[0]);
+	},
 }));
 
 // Dynamic import AFTER the mock is registered so the manager picks up the
@@ -60,6 +70,20 @@ const CLAUDE_FIXTURE_ROOT = resolve(
 	import.meta.dir,
 	"../../src-tauri/tests/fixtures/streams/claude",
 );
+
+const tempRoots: string[] = [];
+
+function makeTempDir(prefix: string): string {
+	const dir = mkdtempSync(resolve(tmpdir(), prefix));
+	tempRoots.push(dir);
+	return dir;
+}
+
+afterEach(() => {
+	for (const dir of tempRoots.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
 
 interface FixtureEvent {
 	readonly [key: string]: unknown;
@@ -132,6 +156,7 @@ describe("ClaudeSessionManager.sendMessage", () => {
 
 	beforeEach(() => {
 		captured = [];
+		lastQueryArgs = null;
 		emitter = createSidecarEmitter((event) => {
 			captured.push(event as Record<string, unknown>);
 		});
@@ -282,6 +307,40 @@ describe("ClaudeSessionManager.sendMessage", () => {
 		expect(captured).toHaveLength(1);
 		expect(captured.some((e) => e.type === "end")).toBe(false);
 		expect(captured.some((e) => e.type === "aborted")).toBe(false);
+	});
+
+	test("adds worktree git metadata directories to Claude query options", async () => {
+		const workspaceDir = makeTempDir("helmor-claude-worktree-");
+		const repoRoot = makeTempDir("helmor-claude-repo-");
+		const gitCommonDir = resolve(repoRoot, ".git");
+		const gitDir = resolve(gitCommonDir, "worktrees", "alnitak");
+
+		mkdirSync(gitDir, { recursive: true });
+		writeFileSync(resolve(workspaceDir, ".git"), `gitdir: ${gitDir}\n`);
+		writeFileSync(resolve(gitDir, "commondir"), "../../\n");
+
+		mockQueryImpl = () => asyncIterableFrom([{ type: "result", result: "ok" }]);
+
+		await manager.sendMessage(
+			"REQ-WORKTREE",
+			{
+				sessionId: "s-worktree",
+				prompt: "commit the changes",
+				model: "opus-1m",
+				cwd: workspaceDir,
+				resume: undefined,
+				permissionMode: "bypassPermissions",
+				effortLevel: undefined,
+			},
+			emitter,
+		);
+
+		expect(lastQueryArgs).toMatchObject({
+			options: {
+				cwd: workspaceDir,
+				additionalDirectories: [gitDir, gitCommonDir],
+			},
+		});
 	});
 
 	test("suppresses deferred tool_use passthrough while keeping the deferred control event", async () => {

--- a/sidecar/test/codex-session-manager.test.ts
+++ b/sidecar/test/codex-session-manager.test.ts
@@ -9,8 +9,15 @@
  * emitted.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { createSidecarEmitter, type SidecarEmitter } from "../src/emitter.js";
 
@@ -71,6 +78,20 @@ const CODEX_FIXTURE_ROOT = resolve(
 	import.meta.dir,
 	"../../src-tauri/tests/fixtures/streams/codex",
 );
+
+const tempRoots: string[] = [];
+
+function makeTempDir(prefix: string): string {
+	const dir = mkdtempSync(resolve(tmpdir(), prefix));
+	tempRoots.push(dir);
+	return dir;
+}
+
+afterEach(() => {
+	for (const dir of tempRoots.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
 
 function loadCodexFixture(fixtureName: string): CodexEvent[] {
 	const raw = readFileSync(resolve(CODEX_FIXTURE_ROOT, fixtureName), "utf-8");
@@ -306,6 +327,37 @@ describe("CodexSessionManager.sendMessage", () => {
 		expect(lastRunInput).toContain("Plan mode is enabled.");
 		expect(lastRunInput).toContain("produce a concrete plan only");
 		expect(lastRunInput).toContain("User request:");
+	});
+
+	test("adds worktree git metadata directories to thread options", async () => {
+		mockEvents = [{ type: "thread.started" }, { type: "turn.completed" }];
+		const workspaceDir = makeTempDir("helmor-codex-worktree-");
+		const repoRoot = makeTempDir("helmor-codex-repo-");
+		const gitCommonDir = resolve(repoRoot, ".git");
+		const gitDir = resolve(gitCommonDir, "worktrees", "alnitak");
+
+		mkdirSync(gitDir, { recursive: true });
+		writeFileSync(resolve(workspaceDir, ".git"), `gitdir: ${gitDir}\n`);
+		writeFileSync(resolve(gitDir, "commondir"), "../../\n");
+
+		await manager.sendMessage(
+			"REQ-WORKTREE",
+			{
+				sessionId: "s-worktree",
+				prompt: "commit the changes",
+				model: "gpt-5.4",
+				cwd: workspaceDir,
+				resume: undefined,
+				permissionMode: "bypassPermissions",
+				effortLevel: undefined,
+			},
+			emitter,
+		);
+
+		expect(lastThreadOptions).toMatchObject({
+			workingDirectory: workspaceDir,
+			additionalDirectories: [gitDir, gitCommonDir],
+		});
 	});
 });
 

--- a/sidecar/test/git-access.test.ts
+++ b/sidecar/test/git-access.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveGitAccessDirectories } from "../src/git-access.js";
+
+const tempRoots: string[] = [];
+
+function makeTempDir(prefix: string): string {
+	const dir = mkdtempSync(join(tmpdir(), prefix));
+	tempRoots.push(dir);
+	return dir;
+}
+
+afterEach(() => {
+	for (const dir of tempRoots.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe("resolveGitAccessDirectories", () => {
+	test("returns no extra directories for undefined cwd", async () => {
+		await expect(resolveGitAccessDirectories(undefined)).resolves.toEqual([]);
+	});
+
+	test("returns no extra directories for a regular repository", async () => {
+		const workspaceDir = makeTempDir("helmor-git-access-");
+		mkdirSync(join(workspaceDir, ".git"));
+
+		await expect(resolveGitAccessDirectories(workspaceDir)).resolves.toEqual(
+			[],
+		);
+	});
+
+	test("returns gitdir and commondir for a worktree pointer", async () => {
+		const workspaceDir = makeTempDir("helmor-worktree-");
+		const repoRoot = makeTempDir("helmor-repo-");
+		const gitCommonDir = join(repoRoot, ".git");
+		const gitDir = join(gitCommonDir, "worktrees", "alnitak");
+
+		mkdirSync(gitDir, { recursive: true });
+		writeFileSync(join(workspaceDir, ".git"), `gitdir: ${gitDir}\n`);
+		writeFileSync(join(gitDir, "commondir"), "../../\n");
+
+		await expect(resolveGitAccessDirectories(workspaceDir)).resolves.toEqual([
+			gitDir,
+			gitCommonDir,
+		]);
+	});
+});

--- a/src/App.shortcuts.test.tsx
+++ b/src/App.shortcuts.test.tsx
@@ -9,6 +9,9 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const apiMocks = vi.hoisted(() => ({
+	createSession: vi.fn(),
+	deleteSession: vi.fn(),
+	hideSession: vi.fn(),
 	loadWorkspaceGroups: vi.fn(),
 	loadArchivedWorkspaces: vi.fn(),
 	loadAgentModelSections: vi.fn(),
@@ -17,9 +20,30 @@ const apiMocks = vi.hoisted(() => ({
 	loadSessionThreadMessages: vi.fn(),
 }));
 
+const windowApiMocks = vi.hoisted(() => ({
+	onCloseRequested: vi.fn(),
+	closeRequestedHandler: null as
+		| ((event: { preventDefault: () => void }) => void | Promise<void>)
+		| null,
+}));
+
 vi.mock("./App.css", () => ({}));
 vi.mock("@tauri-apps/plugin-dialog", () => ({
 	open: vi.fn(),
+}));
+vi.mock("@tauri-apps/api/window", () => ({
+	getCurrentWindow: () => ({
+		onCloseRequested: windowApiMocks.onCloseRequested.mockImplementation(
+			async (handler: typeof windowApiMocks.closeRequestedHandler) => {
+				windowApiMocks.closeRequestedHandler = handler;
+				return () => {
+					if (windowApiMocks.closeRequestedHandler === handler) {
+						windowApiMocks.closeRequestedHandler = null;
+					}
+				};
+			},
+		),
+	}),
 }));
 
 vi.mock("./lib/api", async (importOriginal) => {
@@ -27,6 +51,9 @@ vi.mock("./lib/api", async (importOriginal) => {
 
 	return {
 		...actual,
+		createSession: apiMocks.createSession,
+		deleteSession: apiMocks.deleteSession,
+		hideSession: apiMocks.hideSession,
 		loadWorkspaceGroups: apiMocks.loadWorkspaceGroups,
 		loadArchivedWorkspaces: apiMocks.loadArchivedWorkspaces,
 		loadAgentModelSections: apiMocks.loadAgentModelSections,
@@ -48,59 +75,130 @@ const WORKSPACE_IDS = {
 } as const;
 
 type WorkspaceFixtureId = (typeof WORKSPACE_IDS)[keyof typeof WORKSPACE_IDS];
-
-const SESSION_FIXTURES: Record<
-	WorkspaceFixtureId,
-	readonly {
-		id: string;
-		title: string;
-		active: boolean;
-	}[]
-> = {
-	[WORKSPACE_IDS.done]: [
-		{
-			id: "session-done-1",
-			title: "Done session 1",
-			active: true,
-		},
-		{
-			id: "session-done-2",
-			title: "Done session 2",
-			active: false,
-		},
-	],
-	[WORKSPACE_IDS.review]: [
-		{
-			id: "session-review-1",
-			title: "Review session 1",
-			active: true,
-		},
-	],
-	[WORKSPACE_IDS.progress]: [
-		{
-			id: "session-progress-1",
-			title: "Progress session 1",
-			active: true,
-		},
-	],
-	[WORKSPACE_IDS.archived1]: [
-		{
-			id: "session-archived-1",
-			title: "Archived session 1",
-			active: true,
-		},
-	],
-	[WORKSPACE_IDS.archived2]: [
-		{
-			id: "session-archived-2",
-			title: "Archived session 2",
-			active: true,
-		},
-	],
+type SessionFixture = {
+	id: string;
+	title: string;
+	active: boolean;
 };
 
+const SESSION_FIXTURES: Record<WorkspaceFixtureId, readonly SessionFixture[]> =
+	{
+		[WORKSPACE_IDS.done]: [
+			{
+				id: "session-done-1",
+				title: "Done session 1",
+				active: true,
+			},
+			{
+				id: "session-done-2",
+				title: "Done session 2",
+				active: false,
+			},
+		],
+		[WORKSPACE_IDS.review]: [
+			{
+				id: "session-review-1",
+				title: "Review session 1",
+				active: true,
+			},
+		],
+		[WORKSPACE_IDS.progress]: [
+			{
+				id: "session-progress-1",
+				title: "Progress session 1",
+				active: true,
+			},
+		],
+		[WORKSPACE_IDS.archived1]: [
+			{
+				id: "session-archived-1",
+				title: "Archived session 1",
+				active: true,
+			},
+		],
+		[WORKSPACE_IDS.archived2]: [
+			{
+				id: "session-archived-2",
+				title: "Archived session 2",
+				active: true,
+			},
+		],
+	};
+
+let runtimeSessionFixtures: Record<WorkspaceFixtureId, SessionFixture[]> =
+	createRuntimeSessionFixtures();
+
+function createRuntimeSessionFixtures(): Record<
+	WorkspaceFixtureId,
+	SessionFixture[]
+> {
+	return Object.fromEntries(
+		Object.entries(SESSION_FIXTURES).map(([workspaceId, sessions]) => [
+			workspaceId,
+			sessions.map((session) => ({ ...session })),
+		]),
+	) as Record<WorkspaceFixtureId, SessionFixture[]>;
+}
+
+function addSessionFixture(workspaceId: WorkspaceFixtureId, sessionId: string) {
+	runtimeSessionFixtures[workspaceId] = [
+		...runtimeSessionFixtures[workspaceId].map((session) => ({
+			...session,
+			active: false,
+		})),
+		{
+			id: sessionId,
+			title: "Untitled",
+			active: true,
+		},
+	];
+}
+
+function closeSessionFixture(sessionId: string): WorkspaceFixtureId | null {
+	for (const workspaceId of Object.keys(
+		runtimeSessionFixtures,
+	) as WorkspaceFixtureId[]) {
+		const sessions = runtimeSessionFixtures[workspaceId];
+		const removedIndex = sessions.findIndex(
+			(session) => session.id === sessionId,
+		);
+		if (removedIndex === -1) {
+			continue;
+		}
+
+		const removedWasActive = sessions[removedIndex]?.active ?? false;
+		const remainingSessions = sessions.filter(
+			(session) => session.id !== sessionId,
+		);
+		const nextActiveId =
+			remainingSessions.length === 0
+				? null
+				: removedWasActive
+					? ((
+							remainingSessions[removedIndex] ??
+							remainingSessions[removedIndex - 1] ??
+							remainingSessions[0]
+						)?.id ?? null)
+					: ((
+							remainingSessions.find((session) => session.active) ??
+							remainingSessions[0]
+						)?.id ?? null);
+
+		runtimeSessionFixtures[workspaceId] = remainingSessions.map((session) => ({
+			...session,
+			active: session.id === nextActiveId,
+		}));
+
+		return workspaceId;
+	}
+
+	return null;
+}
+
 function createWorkspaceDetail(workspaceId: WorkspaceFixtureId) {
-	const primarySession = SESSION_FIXTURES[workspaceId][0];
+	const sessions = runtimeSessionFixtures[workspaceId];
+	const primarySession =
+		sessions.find((session) => session.active) ?? sessions[0];
 	const archived = workspaceId.startsWith("workspace-archived");
 
 	return {
@@ -116,10 +214,10 @@ function createWorkspaceDetail(workspaceId: WorkspaceFixtureId) {
 		unreadSessionCount: 0,
 		derivedStatus: archived ? "archived" : "progress",
 		manualStatus: null,
-		activeSessionId: primarySession.id,
-		activeSessionTitle: primarySession.title,
+		activeSessionId: primarySession?.id ?? null,
+		activeSessionTitle: primarySession?.title ?? null,
 		activeSessionAgentType: "claude",
-		activeSessionStatus: "idle",
+		activeSessionStatus: primarySession ? "idle" : null,
 		branch: archived ? "archive/main" : "main",
 		initializationParentBranch: "main",
 		intendedTargetBranch: "main",
@@ -128,14 +226,14 @@ function createWorkspaceDetail(workspaceId: WorkspaceFixtureId) {
 		prTitle: null,
 		prDescription: null,
 		archiveCommit: null,
-		sessionCount: SESSION_FIXTURES[workspaceId].length,
+		sessionCount: sessions.length,
 		messageCount: 0,
 		attachmentCount: 0,
 	};
 }
 
 function createWorkspaceSessions(workspaceId: WorkspaceFixtureId) {
-	return SESSION_FIXTURES[workspaceId].map((session) => ({
+	return runtimeSessionFixtures[workspaceId].map((session) => ({
 		id: session.id,
 		workspaceId,
 		title: session.title,
@@ -191,6 +289,16 @@ function pressGlobalShortcut(
 	});
 }
 
+function pressCreateSessionShortcut(
+	options?: Parameters<typeof fireEvent.keyDown>[1],
+) {
+	fireEvent.keyDown(window, {
+		key: "t",
+		metaKey: true,
+		...options,
+	});
+}
+
 async function renderAppReady() {
 	render(<App />);
 
@@ -202,12 +310,29 @@ async function renderAppReady() {
 
 describe("App global navigation shortcuts", () => {
 	beforeEach(() => {
+		runtimeSessionFixtures = createRuntimeSessionFixtures();
+		apiMocks.createSession.mockReset();
+		apiMocks.deleteSession.mockReset();
+		apiMocks.hideSession.mockReset();
 		apiMocks.loadWorkspaceGroups.mockReset();
 		apiMocks.loadArchivedWorkspaces.mockReset();
 		apiMocks.loadAgentModelSections.mockReset();
 		apiMocks.loadWorkspaceDetail.mockReset();
 		apiMocks.loadWorkspaceSessions.mockReset();
 		apiMocks.loadSessionThreadMessages.mockReset();
+		windowApiMocks.onCloseRequested.mockClear();
+		windowApiMocks.closeRequestedHandler = null;
+		apiMocks.createSession.mockImplementation(async (workspaceId: string) => {
+			const nextSessionId = `${workspaceId}-session-new`;
+			addSessionFixture(workspaceId as WorkspaceFixtureId, nextSessionId);
+			return { sessionId: nextSessionId };
+		});
+		apiMocks.deleteSession.mockImplementation(async (sessionId: string) => {
+			closeSessionFixture(sessionId);
+		});
+		apiMocks.hideSession.mockImplementation(async (sessionId: string) => {
+			closeSessionFixture(sessionId);
+		});
 
 		apiMocks.loadWorkspaceGroups.mockResolvedValue([
 			{
@@ -335,6 +460,27 @@ describe("App global navigation shortcuts", () => {
 
 		await waitFor(() => {
 			expectSelectedSession("Done session 2");
+		});
+	});
+
+	it("creates a new session on Command+T", async () => {
+		await renderAppReady();
+
+		apiMocks.createSession.mockImplementationOnce(
+			async (workspaceId: string) => {
+				addSessionFixture(
+					workspaceId as WorkspaceFixtureId,
+					"session-done-new",
+				);
+				return { sessionId: "session-done-new" };
+			},
+		);
+
+		pressCreateSessionShortcut();
+
+		await waitFor(() => {
+			expect(apiMocks.createSession).toHaveBeenCalledWith(WORKSPACE_IDS.done);
+			expectSelectedSession("Untitled");
 		});
 	});
 
@@ -483,5 +629,29 @@ describe("App global navigation shortcuts", () => {
 		expect(apiMocks.loadSessionThreadMessages).not.toHaveBeenCalledWith(
 			"session-done-2",
 		);
+	});
+
+	it("closes the current session on Command+W and swallows the follow-up window close", async () => {
+		await renderAppReady();
+
+		await waitFor(() => {
+			expect(windowApiMocks.closeRequestedHandler).not.toBeNull();
+		});
+
+		fireEvent.keyDown(window, {
+			key: "w",
+			metaKey: true,
+		});
+
+		await waitFor(() => {
+			expectSelectedSession("Done session 2");
+		});
+		expect(apiMocks.hideSession).toHaveBeenCalledWith("session-done-1");
+		expect(apiMocks.deleteSession).not.toHaveBeenCalled();
+
+		const preventDefault = vi.fn();
+		await windowApiMocks.closeRequestedHandler?.({ preventDefault });
+
+		expect(preventDefault).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import "./App.css";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
 	Check,
 	ChevronDown,
@@ -32,6 +33,8 @@ import { WorkspaceConversationContainer } from "@/features/conversation";
 import { WorkspaceEditorSurface } from "@/features/editor";
 import { WorkspaceInspectorSidebar } from "@/features/inspector";
 import { WorkspacesSidebarContainer } from "@/features/navigation/container";
+import { seedNewSessionInCache } from "@/features/panel/session-cache";
+import { closeWorkspaceSession } from "@/features/panel/session-close";
 import { SettingsButton, SettingsDialog } from "@/features/settings";
 import { EditorIcon } from "@/shell/editor-icon";
 import { GithubIdentityGate } from "@/shell/github-identity-gate";
@@ -49,6 +52,7 @@ import {
 } from "@/shell/layout";
 import {
 	type ConductorWorkspace,
+	createSession,
 	type DetectedEditor,
 	detectInstalledEditors,
 	drainPendingCliSends,
@@ -199,6 +203,10 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 	const warmedWorkspaceIdsRef = useRef<Set<string>>(new Set());
 	const selectedWorkspaceIdRef = useRef<string | null>(null);
 	const selectedSessionIdRef = useRef<string | null>(null);
+	const sessionCloseShortcutRequestedAtRef = useRef(0);
+	const workspaceViewModeRef = useRef<"conversation" | "editor">(
+		"conversation",
+	);
 	const sessionSelectionHistoryByWorkspaceRef = useRef<
 		Record<string, string[]>
 	>({});
@@ -497,6 +505,10 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 	useEffect(() => {
 		selectedSessionIdRef.current = selectedSessionId;
 	}, [selectedSessionId]);
+
+	useEffect(() => {
+		workspaceViewModeRef.current = workspaceViewMode;
+	}, [workspaceViewMode]);
 
 	// Persist last workspace/session for restore-on-launch
 	useEffect(() => {
@@ -1111,6 +1123,123 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 		[notify, queryClient],
 	);
 
+	const getCloseableCurrentSession = useCallback(() => {
+		if (workspaceViewModeRef.current !== "conversation") {
+			return null;
+		}
+
+		const workspaceId = selectedWorkspaceIdRef.current;
+		const sessionId = selectedSessionIdRef.current;
+		if (!workspaceId || !sessionId) {
+			return null;
+		}
+
+		const workspace = queryClient.getQueryData<WorkspaceDetail | null>(
+			helmorQueryKeys.workspaceDetail(workspaceId),
+		);
+		const sessions =
+			queryClient.getQueryData<WorkspaceSessionSummary[]>(
+				helmorQueryKeys.workspaceSessions(workspaceId),
+			) ?? [];
+		if (!workspace || !sessions.some((session) => session.id === sessionId)) {
+			return null;
+		}
+
+		return {
+			workspaceId,
+			sessionId,
+			workspace,
+			sessions,
+		};
+	}, [queryClient]);
+
+	const handleCloseSelectedSession = useCallback(async () => {
+		const currentSession = getCloseableCurrentSession();
+		if (!currentSession) {
+			return false;
+		}
+
+		await closeWorkspaceSession({
+			queryClient,
+			workspace: currentSession.workspace,
+			sessions: currentSession.sessions,
+			sessionId: currentSession.sessionId,
+			onSelectSession: handleSelectSession,
+			onSessionsChanged: () => {
+				void Promise.all([
+					queryClient.invalidateQueries({
+						queryKey: helmorQueryKeys.workspaceDetail(
+							currentSession.workspaceId,
+						),
+					}),
+					queryClient.invalidateQueries({
+						queryKey: helmorQueryKeys.workspaceSessions(
+							currentSession.workspaceId,
+						),
+					}),
+					queryClient.invalidateQueries({
+						queryKey: helmorQueryKeys.workspaceGroups,
+					}),
+					queryClient.invalidateQueries({
+						queryKey: [
+							...helmorQueryKeys.sessionMessages(currentSession.sessionId),
+							"thread",
+						],
+					}),
+				]);
+			},
+			pushToast: pushWorkspaceToast,
+		});
+		return true;
+	}, [
+		getCloseableCurrentSession,
+		handleSelectSession,
+		pushWorkspaceToast,
+		queryClient,
+	]);
+
+	const handleCreateSession = useCallback(async () => {
+		const workspaceId = selectedWorkspaceIdRef.current;
+		if (!workspaceId) {
+			return;
+		}
+
+		try {
+			const { sessionId } = await createSession(workspaceId);
+			seedNewSessionInCache({
+				queryClient,
+				workspaceId,
+				sessionId,
+				workspace:
+					queryClient.getQueryData<WorkspaceDetail | null>(
+						helmorQueryKeys.workspaceDetail(workspaceId),
+					) ?? null,
+				existingSessions:
+					queryClient.getQueryData<WorkspaceSessionSummary[]>(
+						helmorQueryKeys.workspaceSessions(workspaceId),
+					) ?? [],
+			});
+			handleSelectSession(sessionId);
+
+			void Promise.all([
+				queryClient.invalidateQueries({
+					queryKey: helmorQueryKeys.workspaceDetail(workspaceId),
+				}),
+				queryClient.invalidateQueries({
+					queryKey: helmorQueryKeys.workspaceSessions(workspaceId),
+				}),
+				queryClient.invalidateQueries({
+					queryKey: helmorQueryKeys.workspaceGroups,
+				}),
+			]);
+		} catch (error) {
+			pushWorkspaceToast(
+				error instanceof Error ? error.message : String(error),
+				"Unable to create session",
+			);
+		}
+	}, [handleSelectSession, pushWorkspaceToast, queryClient]);
+
 	const handleNavigateSessions = useCallback(
 		(offset: -1 | 1) => {
 			const workspaceId = selectedWorkspaceIdRef.current;
@@ -1246,6 +1375,34 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 	]);
 
 	useEffect(() => {
+		let disposed = false;
+		let unlisten: (() => void) | undefined;
+
+		void getCurrentWindow()
+			.onCloseRequested(async (event) => {
+				if (Date.now() - sessionCloseShortcutRequestedAtRef.current > 1_000) {
+					return;
+				}
+
+				sessionCloseShortcutRequestedAtRef.current = 0;
+				event.preventDefault();
+			})
+			.then((fn) => {
+				if (disposed) {
+					fn();
+					return;
+				}
+
+				unlisten = fn;
+			});
+
+		return () => {
+			disposed = true;
+			unlisten?.();
+		};
+	}, []);
+
+	useEffect(() => {
 		if (!isIdentityConnected || workspaceViewMode === "editor") {
 			return;
 		}
@@ -1295,6 +1452,70 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 		isIdentityConnected,
 		workspaceViewMode,
 	]);
+
+	useEffect(() => {
+		if (!isIdentityConnected || workspaceViewMode === "editor") {
+			return;
+		}
+
+		const handleWindowKeyDown = (event: globalThis.KeyboardEvent) => {
+			if (
+				!event.metaKey ||
+				event.altKey ||
+				event.ctrlKey ||
+				event.shiftKey ||
+				event.key.toLowerCase() !== "w"
+			) {
+				return;
+			}
+
+			if (!getCloseableCurrentSession()) {
+				return;
+			}
+
+			sessionCloseShortcutRequestedAtRef.current = Date.now();
+			event.preventDefault();
+			void handleCloseSelectedSession();
+		};
+
+		window.addEventListener("keydown", handleWindowKeyDown, true);
+
+		return () => {
+			window.removeEventListener("keydown", handleWindowKeyDown, true);
+		};
+	}, [
+		getCloseableCurrentSession,
+		handleCloseSelectedSession,
+		isIdentityConnected,
+		workspaceViewMode,
+	]);
+
+	useEffect(() => {
+		if (!isIdentityConnected || workspaceViewMode === "editor") {
+			return;
+		}
+
+		const handleWindowKeyDown = (event: globalThis.KeyboardEvent) => {
+			if (
+				!event.metaKey ||
+				event.altKey ||
+				event.ctrlKey ||
+				event.shiftKey ||
+				event.key.toLowerCase() !== "t"
+			) {
+				return;
+			}
+
+			event.preventDefault();
+			void handleCreateSession();
+		};
+
+		window.addEventListener("keydown", handleWindowKeyDown, true);
+
+		return () => {
+			window.removeEventListener("keydown", handleWindowKeyDown, true);
+		};
+	}, [handleCreateSession, isIdentityConnected, workspaceViewMode]);
 
 	const handleInsertIntoComposer = useCallback(
 		(request: ComposerInsertRequest) => {

--- a/src/features/navigation/index.test.tsx
+++ b/src/features/navigation/index.test.tsx
@@ -134,6 +134,36 @@ describe("WorkspacesSidebar", () => {
 		).not.toBeInTheDocument();
 	});
 
+	it("keeps empty groups visible with condensed spacing", () => {
+		const emptyGroups: WorkspaceGroup[] = [
+			{ id: "done", label: "Done", tone: "done", rows: [] },
+			{ id: "review", label: "In review", tone: "review", rows: [] },
+			{ id: "progress", label: "In progress", tone: "progress", rows: [] },
+			{ id: "backlog", label: "Backlog", tone: "backlog", rows: [] },
+			{ id: "canceled", label: "Canceled", tone: "canceled", rows: [] },
+		];
+
+		const { container } = render(
+			<TooltipProvider delayDuration={0}>
+				<WorkspacesSidebar groups={emptyGroups} archivedRows={[]} />
+			</TooltipProvider>,
+		);
+
+		expect(screen.getByRole("button", { name: "Done" })).toHaveAttribute(
+			"data-empty-group",
+			"true",
+		);
+		expect(screen.getByRole("button", { name: "Archived" })).toHaveAttribute(
+			"data-empty-group",
+			"true",
+		);
+
+		const virtualList = container.querySelector(
+			'[data-slot="workspace-groups-scroll"] > div',
+		);
+		expect(virtualList).toHaveStyle({ height: "244px" });
+	});
+
 	it("persists section collapse state in localStorage", async () => {
 		const user = userEvent.setup();
 		const collapsedGroups: WorkspaceGroup[] = [

--- a/src/features/navigation/index.tsx
+++ b/src/features/navigation/index.tsx
@@ -64,13 +64,23 @@ type VirtualItem =
 			canCollapse: boolean;
 	  }
 	| { kind: "row"; groupId: string; row: WorkspaceRow; isArchived: boolean }
-	| { kind: "group-gap" }
+	| { kind: "group-gap"; size: number }
 	| { kind: "bottom-padding" };
 
 const HEADER_HEIGHT = 42; // 36px content + 6px gap below
+const EMPTY_HEADER_HEIGHT = 30; // tighter header for empty groups
 const ROW_HEIGHT = 32; // 30px (h-7.5) + 2px gap
 const GROUP_GAP = 16; // gap-4
+const EMPTY_GROUP_GAP = 8; // tighter spacing around empty groups
 const BOTTOM_PADDING = 24; // pb-6
+
+function getGroupHeaderHeight(hasRows: boolean) {
+	return hasRows ? HEADER_HEIGHT : EMPTY_HEADER_HEIGHT;
+}
+
+function getGroupGapSize(previousHasRows: boolean, nextHasRows: boolean) {
+	return previousHasRows && nextHasRows ? GROUP_GAP : EMPTY_GROUP_GAP;
+}
 
 // ---------------------------------------------------------------------------
 // Component
@@ -187,8 +197,18 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 		);
 
 		for (let gi = 0; gi < visibleGroups.length; gi++) {
-			if (gi > 0) items.push({ kind: "group-gap" });
 			const group = visibleGroups[gi];
+			if (gi > 0) {
+				const previousGroup = visibleGroups[gi - 1];
+				items.push({
+					kind: "group-gap",
+					size: getGroupGapSize(
+						previousGroup.rows.length > 0,
+						group.rows.length > 0,
+					),
+				});
+			}
+
 			const canCollapse = group.rows.length > 0;
 			items.push({
 				kind: "group-header",
@@ -210,7 +230,14 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 		}
 
 		// Archived section
-		items.push({ kind: "group-gap" });
+		const previousGroup = visibleGroups.at(-1);
+		items.push({
+			kind: "group-gap",
+			size: getGroupGapSize(
+				previousGroup?.rows.length > 0,
+				archivedRows.length > 0,
+			),
+		});
 		items.push({
 			kind: "group-header",
 			groupId: ARCHIVED_SECTION_ID,
@@ -243,13 +270,14 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 		count: flatItems.length,
 		getScrollElement: () => scrollContainerRef.current,
 		estimateSize: (index) => {
-			switch (flatItems[index].kind) {
+			const item = flatItems[index];
+			switch (item.kind) {
 				case "group-header":
-					return HEADER_HEIGHT;
+					return getGroupHeaderHeight(item.group.rows.length > 0);
 				case "row":
 					return ROW_HEIGHT;
 				case "group-gap":
-					return GROUP_GAP;
+					return item.size;
 				case "bottom-padding":
 					return BOTTOM_PADDING;
 			}
@@ -313,14 +341,17 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 						? (sectionOpenState[item.groupId] ?? false)
 						: (sectionOpenState[item.groupId] ?? true);
 				const isArchived = item.groupId === ARCHIVED_SECTION_ID;
+				const isEmptyGroup = item.group.rows.length === 0;
 
 				return (
 					<button
 						type="button"
 						className={cn(
-							"group/trigger flex w-full select-none items-center justify-between rounded-lg px-2 py-1.5 text-[13px] font-semibold tracking-[-0.01em] text-foreground hover:bg-accent/60",
+							"group/trigger flex w-full select-none items-center justify-between rounded-lg px-2 text-[13px] font-semibold tracking-[-0.01em] text-foreground hover:bg-accent/60",
+							isEmptyGroup ? "py-1" : "py-1.5",
 							item.canCollapse ? "cursor-pointer" : "cursor-default",
 						)}
+						data-empty-group={isEmptyGroup ? "true" : "false"}
 						disabled={!item.canCollapse}
 						onClick={() => toggleSection(item.groupId)}
 					>

--- a/src/features/panel/header.tsx
+++ b/src/features/panel/header.tsx
@@ -45,7 +45,6 @@ import {
 import {
 	createSession,
 	deleteSession,
-	hideSession,
 	listRemoteBranches,
 	loadHiddenSessions,
 	type PullRequestInfo,
@@ -61,10 +60,11 @@ import { helmorQueryKeys } from "@/lib/query-client";
 import { cn } from "@/lib/utils";
 import {
 	getWorkspaceBranchTone,
-	isNewSession,
 	type WorkspaceBranchTone,
 } from "@/lib/workspace-helpers";
 import { useWorkspaceToast } from "@/lib/workspace-toast-context";
+import { seedNewSessionInCache } from "./session-cache";
+import { closeWorkspaceSession } from "./session-close";
 
 type WorkspacePanelHeaderProps = {
 	workspace: WorkspaceDetail | null;
@@ -198,60 +198,14 @@ export const WorkspacePanelHeader = memo(function WorkspacePanelHeader({
 		}
 		try {
 			const result = await createSession(workspace.id);
-			const now = new Date().toISOString();
-			const optimisticSession = buildOptimisticSession(
-				workspace.id,
-				result.sessionId,
-				now,
-			);
-
-			queryClient.setQueryData(
-				helmorQueryKeys.workspaceDetail(workspace.id),
-				(current: WorkspaceDetail | null | undefined) => {
-					const base = current ?? workspace;
-					if (!base) {
-						return base;
-					}
-
-					return {
-						...base,
-						activeSessionId: result.sessionId,
-						activeSessionTitle: "Untitled",
-						activeSessionAgentType: null,
-						activeSessionStatus: "idle",
-						sessionCount:
-							base.activeSessionId === result.sessionId
-								? base.sessionCount
-								: base.sessionCount + 1,
-					};
-				},
-			);
-			queryClient.setQueryData(
-				helmorQueryKeys.workspaceSessions(workspace.id),
-				(current: WorkspaceSessionSummary[] | undefined) => {
-					const existingSessions = current ?? sessions;
-					if (
-						existingSessions.some((session) => session.id === result.sessionId)
-					) {
-						return existingSessions.map((session) => ({
-							...session,
-							active: session.id === result.sessionId,
-						}));
-					}
-
-					return [
-						...existingSessions.map((session) => ({
-							...session,
-							active: false,
-						})),
-						optimisticSession,
-					];
-				},
-			);
-			queryClient.setQueryData(
-				[...helmorQueryKeys.sessionMessages(result.sessionId), "thread"],
-				[],
-			);
+			seedNewSessionInCache({
+				queryClient,
+				workspaceId: workspace.id,
+				sessionId: result.sessionId,
+				workspace,
+				existingSessions: sessions,
+				createdAt: new Date().toISOString(),
+			});
 
 			onSessionsChanged?.();
 			onSelectSession?.(result.sessionId);
@@ -267,72 +221,15 @@ export const WorkspacePanelHeader = memo(function WorkspacePanelHeader({
 				return;
 			}
 
-			const targetSession = sessions.find((s) => s.id === sessionId) ?? null;
-			const isEmptySession = isNewSession(targetSession);
-			const isClosingLastVisibleSession = sessions.length === 1;
-
-			try {
-				if (isClosingLastVisibleSession) {
-					const { sessionId: replacementSessionId } = await createSession(
-						workspace.id,
-					);
-					const now = new Date().toISOString();
-					const optimisticSession = buildOptimisticSession(
-						workspace.id,
-						replacementSessionId,
-						now,
-					);
-
-					queryClient.setQueryData(
-						helmorQueryKeys.workspaceDetail(workspace.id),
-						(current: WorkspaceDetail | null | undefined) => {
-							const base = current ?? workspace;
-							if (!base) {
-								return base;
-							}
-
-							return {
-								...base,
-								activeSessionId: replacementSessionId,
-								activeSessionTitle: "Untitled",
-								activeSessionAgentType: null,
-								activeSessionStatus: "idle",
-								sessionCount: Math.max(1, base.sessionCount),
-							};
-						},
-					);
-					queryClient.setQueryData(
-						helmorQueryKeys.workspaceSessions(workspace.id),
-						() => [optimisticSession],
-					);
-					queryClient.setQueryData(
-						[
-							...helmorQueryKeys.sessionMessages(replacementSessionId),
-							"thread",
-						],
-						[],
-					);
-
-					onSelectSession?.(replacementSessionId);
-				}
-
-				// New sessions (never had any messages) are deleted outright
-				// instead of being hidden, so they don't clutter the history list.
-				if (isEmptySession) {
-					await deleteSession(sessionId);
-				} else {
-					await hideSession(sessionId);
-				}
-				onSessionsChanged?.();
-			} catch (error) {
-				console.error("Failed to close session:", error);
-				onSessionsChanged?.();
-				pushToast(
-					error instanceof Error ? error.message : String(error),
-					"Unable to close session",
-					"destructive",
-				);
-			}
+			await closeWorkspaceSession({
+				queryClient,
+				workspace,
+				sessions,
+				sessionId,
+				onSelectSession,
+				onSessionsChanged,
+				pushToast,
+			});
 		},
 		[
 			onSelectSession,
@@ -886,38 +783,6 @@ function displaySessionTitle(session: WorkspaceSessionSummary): string {
 		return session.title;
 	}
 	return "Untitled";
-}
-
-function buildOptimisticSession(
-	workspaceId: string,
-	sessionId: string,
-	createdAt: string,
-): WorkspaceSessionSummary {
-	return {
-		id: sessionId,
-		workspaceId,
-		title: "Untitled",
-		agentType: null,
-		status: "idle",
-		model: null,
-		permissionMode: "default",
-		providerSessionId: null,
-		effortLevel: null,
-		unreadCount: 0,
-		contextTokenCount: 0,
-		contextUsedPercent: null,
-		thinkingEnabled: true,
-		fastMode: false,
-		agentPersonality: null,
-		createdAt,
-		updatedAt: createdAt,
-		lastUserMessageAt: null,
-		resumeSessionAt: null,
-		isHidden: false,
-		isCompacting: false,
-		actionKind: null,
-		active: true,
-	};
 }
 
 function BranchPicker({

--- a/src/features/panel/session-cache.ts
+++ b/src/features/panel/session-cache.ts
@@ -1,0 +1,107 @@
+import type { QueryClient } from "@tanstack/react-query";
+import type { WorkspaceDetail, WorkspaceSessionSummary } from "@/lib/api";
+import { helmorQueryKeys } from "@/lib/query-client";
+
+export function buildOptimisticSession(
+	workspaceId: string,
+	sessionId: string,
+	createdAt: string,
+): WorkspaceSessionSummary {
+	return {
+		id: sessionId,
+		workspaceId,
+		title: "Untitled",
+		agentType: null,
+		status: "idle",
+		model: null,
+		permissionMode: "default",
+		providerSessionId: null,
+		effortLevel: null,
+		unreadCount: 0,
+		contextTokenCount: 0,
+		contextUsedPercent: null,
+		thinkingEnabled: true,
+		fastMode: false,
+		agentPersonality: null,
+		createdAt,
+		updatedAt: createdAt,
+		lastUserMessageAt: null,
+		resumeSessionAt: null,
+		isHidden: false,
+		isCompacting: false,
+		actionKind: null,
+		active: true,
+	};
+}
+
+type SeedNewSessionInCacheOptions = {
+	queryClient: QueryClient;
+	workspaceId: string;
+	sessionId: string;
+	workspace?: WorkspaceDetail | null;
+	existingSessions?: WorkspaceSessionSummary[];
+	createdAt?: string;
+};
+
+export function seedNewSessionInCache({
+	queryClient,
+	workspaceId,
+	sessionId,
+	workspace = null,
+	existingSessions,
+	createdAt = new Date().toISOString(),
+}: SeedNewSessionInCacheOptions): WorkspaceSessionSummary {
+	const optimisticSession = buildOptimisticSession(
+		workspaceId,
+		sessionId,
+		createdAt,
+	);
+
+	queryClient.setQueryData(
+		helmorQueryKeys.workspaceDetail(workspaceId),
+		(current: WorkspaceDetail | null | undefined) => {
+			const base = current ?? workspace;
+			if (!base) {
+				return current;
+			}
+
+			return {
+				...base,
+				activeSessionId: sessionId,
+				activeSessionTitle: "Untitled",
+				activeSessionAgentType: null,
+				activeSessionStatus: "idle",
+				sessionCount:
+					base.activeSessionId === sessionId
+						? base.sessionCount
+						: base.sessionCount + 1,
+			};
+		},
+	);
+	queryClient.setQueryData(
+		helmorQueryKeys.workspaceSessions(workspaceId),
+		(current: WorkspaceSessionSummary[] | undefined) => {
+			const resolvedSessions = current ?? existingSessions ?? [];
+			if (resolvedSessions.some((session) => session.id === sessionId)) {
+				return resolvedSessions.map((session) => ({
+					...session,
+					active: session.id === sessionId,
+				}));
+			}
+
+			return [
+				...resolvedSessions.map((session) => ({
+					...session,
+					active: false,
+				})),
+				optimisticSession,
+			];
+		},
+	);
+	queryClient.setQueryData(
+		[...helmorQueryKeys.sessionMessages(sessionId), "thread"],
+		[],
+	);
+
+	return optimisticSession;
+}

--- a/src/features/panel/session-close.ts
+++ b/src/features/panel/session-close.ts
@@ -1,0 +1,103 @@
+import type { QueryClient } from "@tanstack/react-query";
+import {
+	createSession,
+	deleteSession,
+	hideSession,
+	type WorkspaceDetail,
+	type WorkspaceSessionSummary,
+} from "@/lib/api";
+import { helmorQueryKeys } from "@/lib/query-client";
+import { isNewSession } from "@/lib/workspace-helpers";
+import type { PushWorkspaceToast } from "@/lib/workspace-toast-context";
+import { buildOptimisticSession } from "./session-cache";
+
+type CloseWorkspaceSessionOptions = {
+	queryClient: QueryClient;
+	workspace: WorkspaceDetail;
+	sessions: WorkspaceSessionSummary[];
+	sessionId: string;
+	onSelectSession?: (sessionId: string) => void;
+	onSessionsChanged?: () => void;
+	pushToast?: PushWorkspaceToast;
+};
+
+export async function closeWorkspaceSession({
+	queryClient,
+	workspace,
+	sessions,
+	sessionId,
+	onSelectSession,
+	onSessionsChanged,
+	pushToast,
+}: CloseWorkspaceSessionOptions): Promise<boolean> {
+	const targetSession =
+		sessions.find((session) => session.id === sessionId) ?? null;
+	if (!targetSession) {
+		return false;
+	}
+
+	const isEmptySession = isNewSession(targetSession);
+	const isClosingLastVisibleSession = sessions.length === 1;
+
+	try {
+		if (isClosingLastVisibleSession) {
+			const { sessionId: replacementSessionId } = await createSession(
+				workspace.id,
+			);
+			const now = new Date().toISOString();
+			const optimisticSession = buildOptimisticSession(
+				workspace.id,
+				replacementSessionId,
+				now,
+			);
+
+			queryClient.setQueryData(
+				helmorQueryKeys.workspaceDetail(workspace.id),
+				(current: WorkspaceDetail | null | undefined) => {
+					const base = current ?? workspace;
+					if (!base) {
+						return base;
+					}
+
+					return {
+						...base,
+						activeSessionId: replacementSessionId,
+						activeSessionTitle: "Untitled",
+						activeSessionAgentType: null,
+						activeSessionStatus: "idle",
+						sessionCount: Math.max(1, base.sessionCount),
+					};
+				},
+			);
+			queryClient.setQueryData(
+				helmorQueryKeys.workspaceSessions(workspace.id),
+				() => [optimisticSession],
+			);
+			queryClient.setQueryData(
+				[...helmorQueryKeys.sessionMessages(replacementSessionId), "thread"],
+				[],
+			);
+
+			onSelectSession?.(replacementSessionId);
+		}
+
+		// New sessions (never had any messages) are deleted outright instead of
+		// being hidden, so they don't clutter the history list.
+		if (isEmptySession) {
+			await deleteSession(sessionId);
+		} else {
+			await hideSession(sessionId);
+		}
+		onSessionsChanged?.();
+		return true;
+	} catch (error) {
+		console.error("Failed to close session:", error);
+		onSessionsChanged?.();
+		pushToast?.(
+			error instanceof Error ? error.message : String(error),
+			"Unable to close session",
+			"destructive",
+		);
+		return false;
+	}
+}


### PR DESCRIPTION
## Summary
- **Cmd+T / Cmd+W session shortcuts**: Cmd+T creates a new session in the current workspace; Cmd+W closes the active session (with window-close interception to prevent Tauri from quitting the app)
- **Git worktree `additionalDirectories`**: Claude and Codex sidecars now resolve worktree git metadata paths so agents can access shared `.git` data in worktree setups
- **Condensed empty sidebar groups**: Empty groups render with tighter spacing and smaller headers for a cleaner sidebar
- **Session logic extraction**: Moved session cache seeding and close logic from `header.tsx` into dedicated `session-cache.ts` and `session-close.ts` modules

## Test plan
- [ ] Verify Cmd+T creates a new session and selects it
- [ ] Verify Cmd+W closes the current session and selects the adjacent one
- [ ] Verify Cmd+W does not close the Tauri window
- [ ] Verify git worktree workspaces pass `additionalDirectories` to agent SDKs
- [ ] Verify empty sidebar groups display with condensed spacing
- [ ] Run `pnpm run test` — all three suites (frontend, sidecar, rust) pass