### PR TITLE
refactor: reduce sidebar group spacing for denser navigation

### DIFF
--- a/src/features/navigation/index.test.tsx
+++ b/src/features/navigation/index.test.tsx
@@ -161,7 +161,7 @@ describe("WorkspacesSidebar", () => {
 		const virtualList = container.querySelector(
 			'[data-slot="workspace-groups-scroll"] > div',
 		);
-		expect(virtualList).toHaveStyle({ height: "244px" });
+		expect(virtualList).toHaveStyle({ height: "208px" });
 	});
 
 	it("persists section collapse state in localStorage", async () => {

--- a/src/features/navigation/index.tsx
+++ b/src/features/navigation/index.tsx
@@ -67,10 +67,10 @@ type VirtualItem =
 	| { kind: "group-gap"; size: number }
 	| { kind: "bottom-padding" };
 
-const HEADER_HEIGHT = 42; // 36px content + 6px gap below
-const EMPTY_HEADER_HEIGHT = 30; // tighter header for empty groups
+const HEADER_HEIGHT = 34; // tighter header + minimal gap below
+const EMPTY_HEADER_HEIGHT = 24; // tighter header for empty groups
 const ROW_HEIGHT = 32; // 30px (h-7.5) + 2px gap
-const GROUP_GAP = 16; // gap-4
+const GROUP_GAP = 8; // tighter gap between populated groups
 const EMPTY_GROUP_GAP = 8; // tighter spacing around empty groups
 const BOTTOM_PADDING = 24; // pb-6
 
@@ -348,7 +348,7 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 						type="button"
 						className={cn(
 							"group/trigger flex w-full select-none items-center justify-between rounded-lg px-2 text-[13px] font-semibold tracking-[-0.01em] text-foreground hover:bg-accent/60",
-							isEmptyGroup ? "py-1" : "py-1.5",
+							isEmptyGroup ? "py-0.5" : "py-1",
 							item.canCollapse ? "cursor-pointer" : "cursor-default",
 						)}
 						data-empty-group={isEmptyGroup ? "true" : "false"}


### PR DESCRIPTION
## Summary

- **Tightened header heights**: `HEADER_HEIGHT` 42→34, `EMPTY_HEADER_HEIGHT` 30→24 — less dead space above each group.
- **Reduced group gap**: `GROUP_GAP` 16→8 — populated groups sit closer together, matching the existing `EMPTY_GROUP_GAP`.
- **Smaller vertical padding** on group trigger buttons (`py-1.5`→`py-1`, `py-1`→`py-0.5`) for a more compact feel.
- **Updated snapshot assertion** in `index.test.tsx` to reflect the new virtual-list height (244→208 px).

## Why

The sidebar had generous vertical spacing that pushed workspace groups out of view on shorter screens. This tightens the layout so more groups are visible without scrolling, improving scannability while keeping the same visual hierarchy.

## Test plan

- [x] `pnpm run test:frontend` — virtual-list height assertion updated and passing
- [ ] Manual: verify sidebar appearance in `pnpm run dev` — groups should be visibly more compact with no clipping or overlap