### PR TITLE
refactor: replace inline spinner with HelmorThinkingIndicator component

### DIFF
--- a/src/components/helmor-thinking-indicator.tsx
+++ b/src/components/helmor-thinking-indicator.tsx
@@ -1,0 +1,26 @@
+import { HelmorLogoAnimated } from "@/components/helmor-logo-animated";
+import { cn } from "@/lib/utils";
+
+type HelmorThinkingIndicatorProps = {
+	size?: number | string;
+	className?: string;
+};
+
+export function HelmorThinkingIndicator({
+	size = 14,
+	className,
+}: HelmorThinkingIndicatorProps) {
+	return (
+		<span
+			aria-hidden="true"
+			data-slot="helmor-thinking-indicator"
+			className={cn(
+				"inline-flex shrink-0 items-center justify-center",
+				className,
+			)}
+			style={{ width: size, height: size }}
+		>
+			<HelmorLogoAnimated size={size} className="shrink-0 opacity-80" />
+		</span>
+	);
+}

--- a/src/features/navigation/index.test.tsx
+++ b/src/features/navigation/index.test.tsx
@@ -47,7 +47,7 @@ afterEach(() => {
 });
 
 describe("WorkspacesSidebar", () => {
-	it("updates the row icon immediately when a workspace enters sending state", () => {
+	it("shows the Helmor thinking indicator when a workspace enters sending state", () => {
 		const { rerender } = render(
 			<TooltipProvider delayDuration={0}>
 				<WorkspacesSidebar
@@ -60,7 +60,9 @@ describe("WorkspacesSidebar", () => {
 		);
 
 		const initialRow = screen.getByRole("button", { name: "Workspace 1" });
-		expect(initialRow.querySelector(".animate-spin")).toBeNull();
+		expect(
+			initialRow.querySelector('[data-slot="helmor-thinking-indicator"]'),
+		).toBeNull();
 
 		rerender(
 			<TooltipProvider delayDuration={0}>
@@ -74,7 +76,9 @@ describe("WorkspacesSidebar", () => {
 		);
 
 		const updatedRow = screen.getByRole("button", { name: "Workspace 1" });
-		expect(updatedRow.querySelector(".animate-spin")).not.toBeNull();
+		expect(
+			updatedRow.querySelector('[data-slot="helmor-thinking-indicator"]'),
+		).not.toBeNull();
 	});
 
 	it("opens the repository picker and creates a workspace from the selected repository", async () => {

--- a/src/features/navigation/row-item.tsx
+++ b/src/features/navigation/row-item.tsx
@@ -10,6 +10,7 @@ import {
 	Trash2,
 } from "lucide-react";
 import { memo, useEffect } from "react";
+import { HelmorThinkingIndicator } from "@/components/helmor-thinking-indicator";
 import { Button } from "@/components/ui/button";
 import {
 	ContextMenu,
@@ -174,10 +175,7 @@ export const WorkspaceRowItem = memo(
 						title={row.title}
 					/>
 					{isSending && !isInteractionRequired ? (
-						<span className="relative flex size-[13px] shrink-0 items-center justify-center">
-							<span className="absolute inset-0 animate-spin rounded-full border border-transparent border-t-[var(--workspace-sidebar-status-progress)]" />
-							<span className="size-1 rounded-full bg-[var(--workspace-sidebar-status-progress)]" />
-						</span>
+						<HelmorThinkingIndicator size={13} />
 					) : (
 						<GitBranch
 							className={cn(

--- a/src/features/panel/header.tsx
+++ b/src/features/panel/header.tsx
@@ -16,6 +16,7 @@ import {
 	X,
 } from "lucide-react";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { HelmorThinkingIndicator } from "@/components/helmor-thinking-indicator";
 import { ClaudeIcon, OpenAIIcon } from "@/components/icons";
 import { Button } from "@/components/ui/button";
 import {
@@ -765,12 +766,7 @@ function SessionProviderIcon({
 	active: boolean;
 }) {
 	if (active) {
-		return (
-			<span className="relative flex size-3.5 shrink-0 items-center justify-center">
-				<span className="absolute inset-0 animate-spin rounded-full border border-transparent border-t-chart-2" />
-				<span className="size-1.5 rounded-full bg-chart-2" />
-			</span>
-		);
+		return <HelmorThinkingIndicator size={14} />;
 	}
 	if (agentType === "codex") {
 		return <OpenAIIcon className="size-3 shrink-0 text-muted-foreground" />;

--- a/src/features/panel/index.test.tsx
+++ b/src/features/panel/index.test.tsx
@@ -315,4 +315,28 @@ describe("WorkspacePanel", () => {
 			),
 		).toBe(true);
 	});
+
+	it("shows the Helmor thinking indicator for the active sending session", () => {
+		render(
+			<TooltipProvider delayDuration={0}>
+				<QueryClientProvider client={createHelmorQueryClient()}>
+					<WorkspacePanel
+						workspace={WORKSPACE}
+						sessions={SESSIONS}
+						selectedSessionId="session-1"
+						sessionPanes={[]}
+						sending
+					/>
+				</QueryClientProvider>
+			</TooltipProvider>,
+		);
+
+		const activeSessions = screen.getAllByRole("tab", { name: "Session 1" });
+		expect(
+			activeSessions.some(
+				(tab) =>
+					tab.querySelector('[data-slot="helmor-thinking-indicator"]') !== null,
+			),
+		).toBe(true);
+	});
 });

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,6 +1,14 @@
 import "@testing-library/jest-dom/vitest";
 import { vi } from "vitest";
 
+vi.mock("lottie-web/build/player/lottie_svg", () => ({
+	default: {
+		loadAnimation: vi.fn(() => ({
+			destroy: vi.fn(),
+		})),
+	},
+}));
+
 // @tanstack/react-virtual requires a layout engine to determine visible items.
 // jsdom has none, so mock the virtualizer to render all items unconditionally.
 vi.mock("@tanstack/react-virtual", () => ({
@@ -137,6 +145,19 @@ if (
 	// JSDOM does not provide ResizeObserver.
 	window.ResizeObserver = ResizeObserverMock as typeof ResizeObserver;
 	globalThis.ResizeObserver = ResizeObserverMock as typeof ResizeObserver;
+}
+
+if (typeof window !== "undefined" && typeof window.matchMedia === "undefined") {
+	window.matchMedia = ((query: string) => ({
+		matches: query.includes("dark"),
+		media: query,
+		onchange: null,
+		addListener: () => {},
+		removeListener: () => {},
+		addEventListener: () => {},
+		removeEventListener: () => {},
+		dispatchEvent: () => false,
+	})) as typeof window.matchMedia;
 }
 
 if (typeof HTMLCanvasElement !== "undefined") {


### PR DESCRIPTION
## Summary

- **Extracted** the duplicated CSS spinner markup (border-spin + center dot) from `navigation/row-item.tsx` and `panel/header.tsx` into a new shared `HelmorThinkingIndicator` component (`src/components/helmor-thinking-indicator.tsx`).
- The new component wraps `HelmorLogoAnimated` (Lottie-based Helmor logo) and exposes a `data-slot="helmor-thinking-indicator"` attribute for easy test targeting.
- **Updated tests** in `navigation/index.test.tsx` and `panel/index.test.tsx` to assert on the new `data-slot` attribute instead of `.animate-spin`.
- **Added test mocks** in `src/test/setup.ts`: `lottie-web` module mock and `window.matchMedia` polyfill, both required by the animated logo dependency.

## Why

The spinning indicator was copy-pasted across two features with slightly different styling. Centralizing it into a branded component:
1. Eliminates duplication and drift between the two spinner variants.
2. Replaces the generic CSS spinner with the animated Helmor logo for a more polished, branded feel.
3. Makes tests more resilient by querying a semantic `data-slot` instead of a Tailwind class name.

## Test plan

- [x] `pnpm run test:frontend` — existing + new tests pass with the lottie-web and matchMedia mocks
- [ ] Visual QA: confirm the Helmor logo animates in the sidebar row when a workspace is sending
- [ ] Visual QA: confirm the Helmor logo animates in the panel header for the active session tab