### PR TITLE
fix: use relative timestamps in system messages

### DIFF
--- a/src/features/panel/message-components/system-message.tsx
+++ b/src/features/panel/message-components/system-message.tsx
@@ -1,4 +1,4 @@
-import { format } from "date-fns";
+import { formatDistanceToNow } from "date-fns";
 import {
 	AlertCircle,
 	AlertTriangle,
@@ -145,9 +145,12 @@ function MessageTimestamp({ createdAt }: { createdAt?: string }) {
 	const date = new Date(createdAt);
 	if (Number.isNaN(date.getTime())) return null;
 	return (
-		<span className="ml-auto shrink-0 text-[11px] tabular-nums text-muted-foreground/50">
-			{format(date, "HH:mm")}
-		</span>
+		<>
+			<span className="mx-1 text-[11px] text-muted-foreground/40">·</span>
+			<span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
+				{formatDistanceToNow(date, { addSuffix: true })}
+			</span>
+		</>
 	);
 }
 

--- a/src/features/panel/message-components/system-message.tsx
+++ b/src/features/panel/message-components/system-message.tsx
@@ -146,7 +146,7 @@ function MessageTimestamp({ createdAt }: { createdAt?: string }) {
 	if (Number.isNaN(date.getTime())) return null;
 	return (
 		<>
-			<span className="mx-1 text-[11px] text-muted-foreground/40">·</span>
+			<span className="mx-0.5 text-[11px] text-muted-foreground/60">•</span>
 			<span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
 				{formatDistanceToNow(date, { addSuffix: true })}
 			</span>
@@ -177,8 +177,8 @@ export function ChatSystemMessage({ message }: { message: RenderedMessage }) {
 					return null;
 				})}
 			</div>
-			<CopyMessageButton />
 			<MessageTimestamp createdAt={message.createdAt} />
+			<CopyMessageButton />
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary

- Replaced absolute `HH:mm` timestamps in system messages with relative time (e.g. "5 minutes ago") using `formatDistanceToNow` from date-fns.
- Adjusted layout: swapped `ml-auto` alignment for a dot separator (`·`) and inline placement, with slightly stronger text contrast (`text-muted-foreground` instead of `text-muted-foreground/50`).

## Why

Relative timestamps are more intuitive at a glance — users can immediately tell how recent a system message is without mental math. The dot separator visually groups the timestamp with adjacent content instead of pushing it to the far right.

## Test plan

- [ ] Verify system messages display relative timestamps (e.g. "2 minutes ago", "about 1 hour ago")
- [ ] Confirm timestamps update or remain correct on session reload
- [ ] Check edge cases: missing `createdAt`, invalid date strings (should render nothing)