### PR TITLE
feat: Cmd+R shortcut to trigger run script

### DIFF
--- a/helmor.json
+++ b/helmor.json
@@ -1,5 +1,6 @@
 {
 	"scripts": {
-		"setup": "cp \"$HELMOR_ROOT_PATH/.env.local\" \"$HELMOR_WORKSPACE_PATH/.env.local\"\ncp -r \"$HELMOR_ROOT_PATH/sidecar/dist\" \"$HELMOR_WORKSPACE_PATH/sidecar/dist\"\npnpm install"
+		"setup": "cp \"$HELMOR_ROOT_PATH/.env.local\" \"$HELMOR_WORKSPACE_PATH/.env.local\"\ncp -r \"$HELMOR_ROOT_PATH/sidecar/dist\" \"$HELMOR_WORKSPACE_PATH/sidecar/dist\"\npnpm install",
+		"run": "pnpm run dev:analyze"
 	}
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1517,6 +1517,34 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 		};
 	}, [handleCreateSession, isIdentityConnected, workspaceViewMode]);
 
+	// Cmd+R to run the configured run script
+	useEffect(() => {
+		if (!isIdentityConnected) {
+			return;
+		}
+
+		const handleWindowKeyDown = (event: globalThis.KeyboardEvent) => {
+			if (
+				!event.metaKey ||
+				event.altKey ||
+				event.ctrlKey ||
+				event.shiftKey ||
+				event.key.toLowerCase() !== "r"
+			) {
+				return;
+			}
+
+			event.preventDefault();
+			window.dispatchEvent(new Event("helmor:run-script"));
+		};
+
+		window.addEventListener("keydown", handleWindowKeyDown, true);
+
+		return () => {
+			window.removeEventListener("keydown", handleWindowKeyDown, true);
+		};
+	}, [isIdentityConnected]);
+
 	const handleInsertIntoComposer = useCallback(
 		(request: ComposerInsertRequest) => {
 			const resolvedTarget = resolveComposerInsertTarget(request.target, {

--- a/src/features/inspector/hooks/use-inspector.ts
+++ b/src/features/inspector/hooks/use-inspector.ts
@@ -38,6 +38,7 @@ export function useWorkspaceInspectorSidebar({
 }: UseWorkspaceInspectorSidebarArgs) {
 	const [tabsOpen, setTabsOpen] = useState(false);
 	const [activeTab, setActiveTab] = useState("setup");
+	const [pendingRunScript, setPendingRunScript] = useState(false);
 
 	// Auto-open the setup tab when workspace needs setup.
 	useEffect(() => {
@@ -46,6 +47,17 @@ export function useWorkspaceInspectorSidebar({
 			setActiveTab("setup");
 		}
 	}, [workspaceState]);
+
+	// Listen for Cmd+R "run script" shortcut event.
+	useEffect(() => {
+		const handler = () => {
+			setTabsOpen(true);
+			setActiveTab("run");
+			setPendingRunScript(true);
+		};
+		window.addEventListener("helmor:run-script", handler);
+		return () => window.removeEventListener("helmor:run-script", handler);
+	}, []);
 	const [changesHeight, setChangesHeight] = useState(0);
 	const [actionsHeight, setActionsHeight] = useState(0);
 	const [resizeState, setResizeState] = useState<ResizeState | null>(null);
@@ -278,12 +290,18 @@ export function useWorkspaceInspectorSidebar({
 		[actionsHeight, changesHeight],
 	);
 
+	const clearPendingRunScript = useCallback(
+		() => setPendingRunScript(false),
+		[],
+	);
+
 	return {
 		actionsHeight,
 		actionsRef,
 		activeTab,
 		changes,
 		changesHeight,
+		clearPendingRunScript,
 		containerRef,
 		flashingPaths,
 		handleResizeStart,
@@ -291,6 +309,7 @@ export function useWorkspaceInspectorSidebar({
 		isActionsResizing,
 		isResizing,
 		isTabsResizing,
+		pendingRunScript,
 		repoScripts,
 		scriptsLoaded,
 		setActiveTab,

--- a/src/features/inspector/index.tsx
+++ b/src/features/inspector/index.tsx
@@ -51,6 +51,7 @@ export function WorkspaceInspectorSidebar({
 		activeTab,
 		changes,
 		changesHeight,
+		clearPendingRunScript,
 		containerRef,
 		flashingPaths,
 		handleResizeStart,
@@ -58,6 +59,7 @@ export function WorkspaceInspectorSidebar({
 		isActionsResizing,
 		isResizing,
 		isTabsResizing,
+		pendingRunScript,
 		repoScripts,
 		scriptsLoaded,
 		setActiveTab,
@@ -141,6 +143,8 @@ export function WorkspaceInspectorSidebar({
 					workspaceId={workspaceId ?? null}
 					runScript={repoScripts?.runScript ?? null}
 					isActive={activeTab === "run"}
+					pendingRun={pendingRunScript}
+					onPendingRunHandled={clearPendingRunScript}
 					onOpenSettings={handleOpenSettings}
 				/>
 			</InspectorTabsSection>

--- a/src/features/inspector/layout.tsx
+++ b/src/features/inspector/layout.tsx
@@ -69,20 +69,22 @@ export function InspectorTabsSection({
 					onValueChange={onTabChange}
 					className={cn("flex min-h-0 flex-col gap-0", open && "flex-1")}
 				>
-					<div className={cn(INSPECTOR_SECTION_HEADER_CLASS, "relative z-10")}>
+					<div
+						className={cn(INSPECTOR_SECTION_HEADER_CLASS, "relative z-10 pt-0")}
+					>
 						<TabsList
 							variant="line"
-							className="h-9 gap-4 border-none bg-transparent p-0"
+							className="h-8 gap-4 border-none bg-transparent p-0"
 						>
 							<TabsTrigger
 								value="setup"
-								className="h-9 w-auto gap-0 border-transparent px-0 text-[12px] font-medium text-muted-foreground focus-visible:border-transparent focus-visible:ring-0 focus-visible:outline-none data-[state=active]:bg-transparent data-[state=active]:text-foreground"
+								className="h-8 w-auto gap-0 border-transparent px-0 text-[12px] font-medium text-muted-foreground after:bottom-[-1px] focus-visible:border-transparent focus-visible:ring-0 focus-visible:outline-none data-[state=active]:bg-transparent data-[state=active]:text-foreground"
 							>
 								Setup
 							</TabsTrigger>
 							<TabsTrigger
 								value="run"
-								className="h-9 w-auto gap-0 border-transparent px-0 text-[12px] font-medium text-muted-foreground focus-visible:border-transparent focus-visible:ring-0 focus-visible:outline-none data-[state=active]:bg-transparent data-[state=active]:text-foreground"
+								className="h-8 w-auto gap-0 border-transparent px-0 text-[12px] font-medium text-muted-foreground after:bottom-[-1px] focus-visible:border-transparent focus-visible:ring-0 focus-visible:outline-none data-[state=active]:bg-transparent data-[state=active]:text-foreground"
 							>
 								Run
 							</TabsTrigger>

--- a/src/features/inspector/sections/run.tsx
+++ b/src/features/inspector/sections/run.tsx
@@ -15,6 +15,8 @@ type RunTabProps = {
 	workspaceId: string | null;
 	runScript: string | null;
 	isActive: boolean;
+	pendingRun?: boolean;
+	onPendingRunHandled?: () => void;
 	onOpenSettings: () => void;
 };
 
@@ -23,6 +25,8 @@ export function RunTab({
 	workspaceId,
 	runScript,
 	isActive,
+	pendingRun,
+	onPendingRunHandled,
 	onOpenSettings,
 }: RunTabProps) {
 	const termRef = useRef<TerminalHandle | null>(null);
@@ -73,6 +77,14 @@ export function RunTab({
 		if (!repoId) return;
 		void stopRepoScript(repoId, "run", workspaceId);
 	}, [repoId, workspaceId]);
+
+	// Handle pending run request from Cmd+R shortcut.
+	useEffect(() => {
+		if (pendingRun && isActive && repoId && runScript?.trim()) {
+			onPendingRunHandled?.();
+			handleRun();
+		}
+	}, [pendingRun, isActive, repoId, runScript, handleRun, onPendingRunHandled]);
 
 	const hasScript = !!runScript?.trim();
 


### PR DESCRIPTION
## Summary

- Adds a global **Cmd+R** keyboard shortcut that instantly opens the inspector's **Run** tab and auto-executes the configured run script.
- Tightens the inspector tab header styling (height h-9 → h-8, aligned active-tab underline).

## How it works

1. `App.tsx` registers a capture-phase `keydown` listener for `Cmd+R` (meta-only, no other modifiers). It `preventDefault()`s the browser reload and dispatches a custom `helmor:run-script` window event.
2. `useWorkspaceInspectorSidebar` listens for that event, opens the tabs panel, switches to the "run" tab, and sets a `pendingRunScript` flag.
3. `RunTab` consumes the flag via a `useEffect` — when the tab is active and a run script is configured, it calls `handleRun()` and clears the flag.

## Changed files

| File | Change |
|---|---|
| `src/App.tsx` | Global Cmd+R keydown handler |
| `src/features/inspector/hooks/use-inspector.ts` | `pendingRunScript` state + event wiring |
| `src/features/inspector/index.tsx` | Pass pending-run props to RunTab |
| `src/features/inspector/sections/run.tsx` | Auto-run effect on pending flag |
| `src/features/inspector/layout.tsx` | Tab header height & underline alignment |

## Test plan

- [ ] Press **Cmd+R** with a run script configured → inspector opens to Run tab and script executes
- [ ] Press **Cmd+R** without a run script → inspector opens to Run tab, nothing crashes
- [ ] Press **Cmd+R** when not connected (no identity) → shortcut is ignored
- [ ] Verify browser reload is fully suppressed (no page refresh)
- [ ] Confirm tab header looks correct at the new h-8 height