### PR TITLE
fix: scope commit lifecycle to the active workspace

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1067,6 +1067,7 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 		queuePendingPromptForSession,
 	} = useWorkspaceCommitLifecycle({
 		queryClient,
+		selectedWorkspaceId,
 		selectedWorkspaceIdRef,
 		workspaceManualStatus: selectedWorkspaceManualStatus,
 		workspacePrInfo,

--- a/src/features/commit/hooks/use-commit-lifecycle.ts
+++ b/src/features/commit/hooks/use-commit-lifecycle.ts
@@ -39,6 +39,7 @@ export type PendingPromptForSession = {
 
 export function useWorkspaceCommitLifecycle({
 	queryClient,
+	selectedWorkspaceId,
 	selectedWorkspaceIdRef,
 	workspaceManualStatus,
 	workspacePrInfo,
@@ -46,6 +47,7 @@ export function useWorkspaceCommitLifecycle({
 	onSelectSession,
 }: {
 	queryClient: QueryClient;
+	selectedWorkspaceId: string | null;
 	selectedWorkspaceIdRef: MutableRefObject<string | null>;
 	workspaceManualStatus: string | null;
 	workspacePrInfo: PullRequestInfo | null;
@@ -314,12 +316,18 @@ export function useWorkspaceCommitLifecycle({
 		return () => window.clearTimeout(timeoutId);
 	}, [commitLifecycle, onSelectSession, queryClient]);
 
+	// Only honour the lifecycle if it belongs to the currently-selected workspace.
+	const activeLifecycle =
+		commitLifecycle && commitLifecycle.workspaceId === selectedWorkspaceId
+			? commitLifecycle
+			: null;
+
 	const commitButtonMode = useMemo<WorkspaceCommitButtonMode>(() => {
-		if (commitLifecycle) {
-			if (commitLifecycle.phase === "done" && commitLifecycle.prInfo) {
-				return commitLifecycle.prInfo.isMerged ? "merged" : "merge";
+		if (activeLifecycle) {
+			if (activeLifecycle.phase === "done" && activeLifecycle.prInfo) {
+				return activeLifecycle.prInfo.isMerged ? "merged" : "merge";
 			}
-			return commitLifecycle.mode;
+			return activeLifecycle.mode;
 		}
 
 		if (workspacePrInfo) {
@@ -329,11 +337,11 @@ export function useWorkspaceCommitLifecycle({
 		}
 
 		return "create-pr";
-	}, [commitLifecycle, workspacePrInfo]);
+	}, [activeLifecycle, workspacePrInfo]);
 
 	const commitButtonState = useMemo<CommitButtonState>(() => {
-		if (!commitLifecycle) return "idle";
-		switch (commitLifecycle.phase) {
+		if (!activeLifecycle) return "idle";
+		switch (activeLifecycle.phase) {
 			case "creating":
 			case "streaming":
 			case "verifying":
@@ -343,7 +351,7 @@ export function useWorkspaceCommitLifecycle({
 			case "error":
 				return "error";
 		}
-	}, [commitLifecycle]);
+	}, [activeLifecycle]);
 
 	return {
 		commitButtonMode,


### PR DESCRIPTION
## Summary

- The commit button's mode (`create-pr` / `merge` / `merged`) and state (`idle` / `running` / `error`) were derived from a **global** `commitLifecycle` object that could belong to any workspace.
- When the user switched workspaces, stale lifecycle state from the previous workspace leaked into the commit button UI — e.g. showing "merge" when the new workspace had no PR at all.
- This PR adds `selectedWorkspaceId` to `useWorkspaceCommitLifecycle` and gates all derived values behind a workspace-id equality check (`activeLifecycle`), so the button always reflects the currently-selected workspace.

## Changes

| File | What |
|------|------|
| `src/App.tsx` | Pass `selectedWorkspaceId` into the hook |
| `src/features/commit/hooks/use-commit-lifecycle.ts` | Accept `selectedWorkspaceId`, derive `activeLifecycle`, use it in `commitButtonMode` / `commitButtonState` |

## Test plan

- [ ] Select workspace A → start a commit lifecycle → switch to workspace B → verify the commit button resets to `create-pr` / `idle`
- [ ] Switch back to workspace A → verify the in-progress lifecycle is still shown correctly
- [ ] Complete a PR in workspace A → switch away and back → verify "merge" / "merged" state persists correctly