### PR TITLE
feat: add Cmd+Shift+C shortcut to copy workspace path

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -417,6 +417,24 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 			: null) ??
 		null;
 
+	// Cmd+Shift+C to copy current workspace path
+	useEffect(() => {
+		const handler = (e: KeyboardEvent) => {
+			if (e.metaKey && e.shiftKey && e.key.toLowerCase() === "c") {
+				if (!workspaceRootPath) return;
+				e.preventDefault();
+				void navigator.clipboard.writeText(workspaceRootPath).then(() => {
+					toast.success("Path copied", {
+						description: workspaceRootPath,
+						duration: 2000,
+					});
+				});
+			}
+		};
+		window.addEventListener("keydown", handler, true);
+		return () => window.removeEventListener("keydown", handler, true);
+	}, [workspaceRootPath]);
+
 	// Persistent PR state for the current workspace's branch. Drives the
 	// commit button's resting mode and the "Git · PR #xxx" header badge.
 	const workspacePrQuery = useQuery({


### PR DESCRIPTION
## Summary

- Adds a **Cmd+Shift+C** keyboard shortcut inside `AppShell` that copies the current workspace root path to the system clipboard.
- Shows a `toast.success` notification with the copied path for 2 seconds.
- The shortcut is no-op when no workspace is selected.

## Why

Quick access to the workspace path is a common need when switching between Helmor and the terminal. This saves users from navigating to settings or manually locating the path.

## Test plan

- [ ] Open a workspace, press **Cmd+Shift+C** → toast appears, clipboard contains the workspace path.
- [ ] With no workspace selected, press **Cmd+Shift+C** → nothing happens (no error).
- [ ] Verify the shortcut does not conflict with existing keybindings (Cmd+Shift+C is not used elsewhere).