### PR TITLE
feat: progressive loading for slash commands

### DIFF
--- a/src-tauri/src/.agents.rs.pending-snap
+++ b/src-tauri/src/.agents.rs.pending-snap
@@ -22,3 +22,4 @@
 {"run_id":"1776138392-488788000","line":869,"new":null,"old":null}
 {"run_id":"1776140072-678757000","line":869,"new":null,"old":null}
 {"run_id":"1776134234-237119000","line":872,"new":null,"old":null}
+{"run_id":"1776141131-705180000","line":872,"new":null,"old":null}

--- a/src-tauri/src/.agents.rs.pending-snap
+++ b/src-tauri/src/.agents.rs.pending-snap
@@ -21,3 +21,4 @@
 {"run_id":"1776137058-307695000","line":869,"new":null,"old":null}
 {"run_id":"1776138392-488788000","line":869,"new":null,"old":null}
 {"run_id":"1776140072-678757000","line":869,"new":null,"old":null}
+{"run_id":"1776134234-237119000","line":872,"new":null,"old":null}

--- a/src-tauri/src/agents.rs
+++ b/src-tauri/src/agents.rs
@@ -8,6 +8,7 @@ use crate::error::CommandError;
 mod catalog;
 mod persistence;
 mod queries;
+mod slash_commands;
 mod streaming;
 mod support;
 
@@ -16,8 +17,9 @@ pub use self::catalog::{
 };
 pub use self::queries::{
     GenerateSessionTitleRequest, GenerateSessionTitleResponse, ListSlashCommandsRequest,
-    SlashCommandEntry,
+    SlashCommandEntry, SlashCommandsResponse,
 };
+pub use self::slash_commands::SlashCommandCache;
 pub use self::streaming::{
     abort_all_active_streams_blocking, bridge_elicitation_request_event, ActiveStreams,
 };
@@ -373,9 +375,10 @@ pub async fn generate_session_title(
 pub async fn list_slash_commands(
     app: AppHandle,
     sidecar: tauri::State<'_, crate::sidecar::ManagedSidecar>,
+    cache: tauri::State<'_, SlashCommandCache>,
     request: ListSlashCommandsRequest,
-) -> CmdResult<Vec<SlashCommandEntry>> {
-    queries::list_slash_commands(app, sidecar, request).await
+) -> CmdResult<SlashCommandsResponse> {
+    queries::list_slash_commands(app, sidecar, cache, request).await
 }
 
 #[cfg(test)]

--- a/src-tauri/src/agents/.streaming.rs.pending-snap
+++ b/src-tauri/src/agents/.streaming.rs.pending-snap
@@ -22,3 +22,4 @@
 {"run_id":"1776138392-488788000","line":819,"new":null,"old":null}
 {"run_id":"1776140072-678757000","line":819,"new":null,"old":null}
 {"run_id":"1776134234-237119000","line":819,"new":null,"old":null}
+{"run_id":"1776141131-705180000","line":819,"new":null,"old":null}

--- a/src-tauri/src/agents/.streaming.rs.pending-snap
+++ b/src-tauri/src/agents/.streaming.rs.pending-snap
@@ -21,3 +21,4 @@
 {"run_id":"1776137058-307695000","line":819,"new":null,"old":null}
 {"run_id":"1776138392-488788000","line":819,"new":null,"old":null}
 {"run_id":"1776140072-678757000","line":819,"new":null,"old":null}
+{"run_id":"1776134234-237119000","line":819,"new":null,"old":null}

--- a/src-tauri/src/agents/queries.rs
+++ b/src-tauri/src/agents/queries.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tauri::{AppHandle, Manager};
+use tauri::{AppHandle, Emitter, Manager};
 use uuid::Uuid;
 
 use super::CmdResult;
@@ -259,10 +259,71 @@ pub struct SlashCommandEntry {
     pub source: String,
 }
 
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SlashCommandsResponse {
+    pub commands: Vec<SlashCommandEntry>,
+    /// `false` while the background sidecar refresh is still in flight
+    /// (the commands shown are from a local disk scan only).
+    pub is_complete: bool,
+}
+
 pub async fn list_slash_commands(
     app: AppHandle,
     sidecar: tauri::State<'_, crate::sidecar::ManagedSidecar>,
+    cache: tauri::State<'_, super::slash_commands::SlashCommandCache>,
     request: ListSlashCommandsRequest,
+) -> CmdResult<SlashCommandsResponse> {
+    let cache_key = (
+        request.provider.clone(),
+        request.working_directory.clone().unwrap_or_default(),
+        request.model_id.clone().unwrap_or_default(),
+    );
+
+    // Non-claude providers (e.g. Codex): the sidecar scan is already fast
+    // (pure filesystem, no MCP wait), so fall through to the blocking path.
+    if request.provider != "claude" {
+        let commands = fetch_from_sidecar(&sidecar, &request)?;
+        return Ok(SlashCommandsResponse {
+            commands,
+            is_complete: true,
+        });
+    }
+
+    // --- Claude provider: progressive loading ---
+
+    // 1. Check cache
+    if let Some((commands, is_complete)) = cache.get(&cache_key) {
+        // Cache hit — return immediately.  Spawn a background refresh to
+        // keep the cache fresh (stale-while-revalidate).
+        if is_complete {
+            spawn_background_refresh(&app, &cache, &request, cache_key);
+        }
+        return Ok(SlashCommandsResponse {
+            commands,
+            is_complete,
+        });
+    }
+
+    // 2. Cache miss — scan local skills from disk (fast, < 5 ms)
+    let local = super::slash_commands::scan_local_commands(request.working_directory.as_deref());
+    cache.set(cache_key.clone(), local.clone(), false);
+
+    // 3. Spawn background sidecar refresh
+    spawn_background_refresh(&app, &cache, &request, cache_key);
+
+    Ok(SlashCommandsResponse {
+        commands: local,
+        is_complete: false,
+    })
+}
+
+/// Run the sidecar `listSlashCommands` call synchronously (blocking the
+/// current async task).  Used for the non-claude fast path and by the
+/// background refresh thread.
+fn fetch_from_sidecar(
+    sidecar: &crate::sidecar::ManagedSidecar,
+    request: &ListSlashCommandsRequest,
 ) -> CmdResult<Vec<SlashCommandEntry>> {
     let request_id = Uuid::new_v4().to_string();
 
@@ -287,89 +348,125 @@ pub async fn list_slash_commands(
         return Err(anyhow::anyhow!("Sidecar send failed: {e}").into());
     }
 
-    let result: CmdResult<Vec<SlashCommandEntry>> = tauri::async_runtime::spawn_blocking({
-        let rid = request_id.clone();
-        move || {
-            let sidecar_state: tauri::State<'_, crate::sidecar::ManagedSidecar> = app.state();
-            let mut commands: Vec<SlashCommandEntry> = Vec::new();
-            let mut error: Option<String> = None;
-            let timeout = std::time::Duration::from_secs(10);
+    let mut commands: Vec<SlashCommandEntry> = Vec::new();
+    let mut error: Option<String> = None;
+    let timeout = std::time::Duration::from_secs(10);
 
-            loop {
-                match rx.recv_timeout(timeout) {
-                    Ok(event) => match event.event_type() {
-                        "slashCommandsListed" => {
-                            if let Some(entries) =
-                                event.raw.get("commands").and_then(Value::as_array)
-                            {
-                                for entry in entries {
-                                    let Some(name) = entry.get("name").and_then(Value::as_str)
-                                    else {
-                                        continue;
-                                    };
-                                    let description = entry
-                                        .get("description")
-                                        .and_then(Value::as_str)
-                                        .unwrap_or("")
-                                        .to_string();
-                                    let argument_hint = entry
-                                        .get("argumentHint")
-                                        .and_then(Value::as_str)
-                                        .filter(|hint| !hint.is_empty())
-                                        .map(str::to_string);
-                                    let source = entry
-                                        .get("source")
-                                        .and_then(Value::as_str)
-                                        .unwrap_or("builtin")
-                                        .to_string();
-                                    commands.push(SlashCommandEntry {
-                                        name: name.to_string(),
-                                        description,
-                                        argument_hint,
-                                        source,
-                                    });
-                                }
-                            }
-                            break;
+    loop {
+        match rx.recv_timeout(timeout) {
+            Ok(event) => match event.event_type() {
+                "slashCommandsListed" => {
+                    if let Some(entries) = event.raw.get("commands").and_then(Value::as_array) {
+                        for entry in entries {
+                            let Some(name) = entry.get("name").and_then(Value::as_str) else {
+                                continue;
+                            };
+                            let description = entry
+                                .get("description")
+                                .and_then(Value::as_str)
+                                .unwrap_or("")
+                                .to_string();
+                            let argument_hint = entry
+                                .get("argumentHint")
+                                .and_then(Value::as_str)
+                                .filter(|hint| !hint.is_empty())
+                                .map(str::to_string);
+                            let source = entry
+                                .get("source")
+                                .and_then(Value::as_str)
+                                .unwrap_or("builtin")
+                                .to_string();
+                            commands.push(SlashCommandEntry {
+                                name: name.to_string(),
+                                description,
+                                argument_hint,
+                                source,
+                            });
                         }
-                        "error" => {
-                            error = Some(
-                                event
-                                    .raw
-                                    .get("message")
-                                    .and_then(Value::as_str)
-                                    .unwrap_or("Unknown error")
-                                    .to_string(),
-                            );
-                            break;
-                        }
-                        _ => {}
-                    },
-                    Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-                        error = Some("listSlashCommands timed out after 10s".to_string());
-                        break;
                     }
-                    Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-                        error = Some(
-                            "Sidecar disconnected while waiting for slash commands".to_string(),
-                        );
-                        break;
+                    break;
+                }
+                "error" => {
+                    error = Some(
+                        event
+                            .raw
+                            .get("message")
+                            .and_then(Value::as_str)
+                            .unwrap_or("Unknown error")
+                            .to_string(),
+                    );
+                    break;
+                }
+                _ => {}
+            },
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                error = Some("listSlashCommands timed out after 10s".to_string());
+                break;
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                error = Some("Sidecar disconnected while waiting for slash commands".to_string());
+                break;
+            }
+        }
+    }
+
+    sidecar.unsubscribe(&request_id);
+    if let Some(message) = error {
+        Err(anyhow::anyhow!("listSlashCommands failed: {message}").into())
+    } else {
+        Ok(commands)
+    }
+}
+
+/// Fire-and-forget background thread that fetches the full command list from
+/// the sidecar and updates the cache + emits a Tauri event on success.
+fn spawn_background_refresh(
+    app: &AppHandle,
+    cache: &super::slash_commands::SlashCommandCache,
+    request: &ListSlashCommandsRequest,
+    cache_key: (String, String, String),
+) {
+    if !cache.try_start_refresh() {
+        return; // another refresh already in flight
+    }
+
+    let app = app.clone();
+    let request = request.clone();
+
+    std::thread::Builder::new()
+        .name("slash-cmd-refresh".into())
+        .spawn(move || {
+            let sidecar_state: tauri::State<'_, crate::sidecar::ManagedSidecar> = app.state();
+            let cache_state: tauri::State<'_, super::slash_commands::SlashCommandCache> =
+                app.state();
+
+            match fetch_from_sidecar(&sidecar_state, &request) {
+                Ok(commands) => {
+                    tracing::debug!(
+                        count = commands.len(),
+                        "Background slash command refresh succeeded"
+                    );
+                    cache_state.set(cache_key, commands, true);
+
+                    // Notify the frontend so it can invalidate its React Query cache.
+                    let payload = serde_json::json!({
+                        "provider": request.provider,
+                        "cwd": request.working_directory.as_deref().unwrap_or(""),
+                        "model": request.model_id.as_deref().unwrap_or(""),
+                    });
+                    if let Err(e) = app.emit("slash-commands-refreshed", payload) {
+                        tracing::warn!("Failed to emit slash-commands-refreshed: {e}");
                     }
+                }
+                Err(e) => {
+                    // Don't clear the cache — stale local data is better than nothing.
+                    tracing::warn!("Background slash command refresh failed: {e:?}");
                 }
             }
 
-            sidecar_state.unsubscribe(&rid);
-            if let Some(message) = error {
-                Err(anyhow::anyhow!("listSlashCommands failed: {message}").into())
-            } else {
-                Ok(commands)
-            }
-        }
-    })
-    .await
-    .map_err(|e| anyhow::anyhow!("listSlashCommands task failed: {e}"))?;
-
-    result
+            cache_state.finish_refresh();
+        })
+        .ok();
 }
 
 fn open_write_connection() -> Result<rusqlite::Connection> {

--- a/src-tauri/src/agents/slash_commands.rs
+++ b/src-tauri/src/agents/slash_commands.rs
@@ -88,9 +88,16 @@ impl SlashCommandCache {
 // Local skill/command scanner
 // ---------------------------------------------------------------------------
 
-/// Scan `~/.claude/skills/` and `~/.claude/commands/` (and optionally
-/// project-level commands) for slash command entries.  Returns results
-/// sorted by name.
+/// Scan skills and commands from disk following the Claude Code precedence:
+///
+///   1. Personal skills  — `~/.claude/skills/<name>/SKILL.md`
+///   2. Project skills   — `<cwd>/.claude/skills/<name>/SKILL.md`
+///   3. Personal commands — `~/.claude/commands/<name>.md`
+///   4. Project commands  — `<cwd>/.claude/commands/<name>.md`
+///
+/// Dedup by name (first occurrence wins), so higher-priority locations
+/// shadow lower ones.  Skills always shadow same-named commands because
+/// they are scanned first.
 pub fn scan_local_commands(working_directory: Option<&str>) -> Vec<SlashCommandEntry> {
     let Some(home) = std::env::var_os("HOME").map(PathBuf::from) else {
         return Vec::new();
@@ -100,13 +107,20 @@ pub fn scan_local_commands(working_directory: Option<&str>) -> Vec<SlashCommandE
     let mut entries = Vec::new();
     let mut seen = std::collections::HashSet::new();
 
-    // 1. ~/.claude/skills/*/SKILL.md
+    // 1. Personal skills — ~/.claude/skills/*/SKILL.md (highest priority)
     scan_skills_dir(&claude_dir.join("skills"), &mut entries, &mut seen);
 
-    // 2. ~/.claude/commands/*.md
+    // 2. Project skills — <cwd>/.claude/skills/*/SKILL.md
+    if let Some(cwd) = working_directory {
+        let project_skills = Path::new(cwd).join(".claude").join("skills");
+        scan_skills_dir(&project_skills, &mut entries, &mut seen);
+    }
+
+    // 3. Personal commands — ~/.claude/commands/*.md
+    //    (same-named skills from steps 1–2 take precedence via `seen` set)
     scan_commands_dir(&claude_dir.join("commands"), &mut entries, &mut seen);
 
-    // 3. <cwd>/.claude/commands/*.md (project-level)
+    // 4. Project commands — <cwd>/.claude/commands/*.md (lowest priority)
     if let Some(cwd) = working_directory {
         let project_cmds = Path::new(cwd).join(".claude").join("commands");
         scan_commands_dir(&project_cmds, &mut entries, &mut seen);

--- a/src-tauri/src/agents/slash_commands.rs
+++ b/src-tauri/src/agents/slash_commands.rs
@@ -1,0 +1,385 @@
+//! Slash command cache and local skill/command scanner.
+//!
+//! Provides two capabilities:
+//!
+//! 1. **Local scanning**: reads `~/.claude/skills/` and `~/.claude/commands/`
+//!    directly from disk, returning results in < 5 ms with no sidecar round-trip.
+//!
+//! 2. **In-memory cache**: stores the last successful full result (from the
+//!    sidecar/SDK) per `(provider, cwd, model)` key so subsequent `/` presses
+//!    resolve instantly.
+//!
+//! Together these enable progressive loading: the user sees local skills
+//! immediately while the full SDK result loads in the background.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::RwLock;
+
+use serde::Serialize;
+
+use super::queries::SlashCommandEntry;
+
+// ---------------------------------------------------------------------------
+// Cache
+// ---------------------------------------------------------------------------
+
+type CacheKey = (String, String, String); // (provider, cwd, model)
+
+struct CachedResult {
+    commands: Vec<SlashCommandEntry>,
+    is_complete: bool,
+}
+
+pub struct SlashCommandCache {
+    entries: RwLock<HashMap<CacheKey, CachedResult>>,
+    /// Prevents concurrent background sidecar refreshes.
+    refreshing: AtomicBool,
+}
+
+impl Default for SlashCommandCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SlashCommandCache {
+    pub fn new() -> Self {
+        Self {
+            entries: RwLock::new(HashMap::new()),
+            refreshing: AtomicBool::new(false),
+        }
+    }
+
+    pub fn get(&self, key: &CacheKey) -> Option<(Vec<SlashCommandEntry>, bool)> {
+        self.entries
+            .read()
+            .ok()?
+            .get(key)
+            .map(|c| (c.commands.clone(), c.is_complete))
+    }
+
+    pub fn set(&self, key: CacheKey, commands: Vec<SlashCommandEntry>, is_complete: bool) {
+        if let Ok(mut map) = self.entries.write() {
+            map.insert(
+                key,
+                CachedResult {
+                    commands,
+                    is_complete,
+                },
+            );
+        }
+    }
+
+    /// Try to claim the refresh lock.  Returns `true` if this caller won.
+    pub fn try_start_refresh(&self) -> bool {
+        self.refreshing
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+    }
+
+    pub fn finish_refresh(&self) {
+        self.refreshing.store(false, Ordering::SeqCst);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Local skill/command scanner
+// ---------------------------------------------------------------------------
+
+/// Scan `~/.claude/skills/` and `~/.claude/commands/` (and optionally
+/// project-level commands) for slash command entries.  Returns results
+/// sorted by name.
+pub fn scan_local_commands(working_directory: Option<&str>) -> Vec<SlashCommandEntry> {
+    let Some(home) = std::env::var_os("HOME").map(PathBuf::from) else {
+        return Vec::new();
+    };
+
+    let claude_dir = home.join(".claude");
+    let mut entries = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+
+    // 1. ~/.claude/skills/*/SKILL.md
+    scan_skills_dir(&claude_dir.join("skills"), &mut entries, &mut seen);
+
+    // 2. ~/.claude/commands/*.md
+    scan_commands_dir(&claude_dir.join("commands"), &mut entries, &mut seen);
+
+    // 3. <cwd>/.claude/commands/*.md (project-level)
+    if let Some(cwd) = working_directory {
+        let project_cmds = Path::new(cwd).join(".claude").join("commands");
+        scan_commands_dir(&project_cmds, &mut entries, &mut seen);
+    }
+
+    entries.sort_by(|a, b| a.name.cmp(&b.name));
+    entries
+}
+
+/// Read `<dir>/<name>/SKILL.md` for every subdirectory.
+fn scan_skills_dir(
+    dir: &Path,
+    out: &mut Vec<SlashCommandEntry>,
+    seen: &mut std::collections::HashSet<String>,
+) {
+    let Ok(read_dir) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in read_dir.flatten() {
+        // Follow symlinks: metadata() traverses symlinks, symlink_metadata() does not.
+        let Ok(meta) = entry.metadata() else {
+            continue;
+        };
+        if !meta.is_dir() {
+            continue;
+        }
+        let skill_file = entry.path().join("SKILL.md");
+        let Ok(content) = std::fs::read_to_string(&skill_file) else {
+            continue;
+        };
+        if let Some(fm) = parse_frontmatter(&content) {
+            if seen.insert(fm.name.clone()) {
+                out.push(SlashCommandEntry {
+                    name: fm.name,
+                    description: fm.description,
+                    argument_hint: fm.argument_hint,
+                    source: "skill".to_string(),
+                });
+            }
+        }
+    }
+}
+
+/// Read `<dir>/*.md` files (skip `.bak` etc.).  Name is inferred from filename.
+fn scan_commands_dir(
+    dir: &Path,
+    out: &mut Vec<SlashCommandEntry>,
+    seen: &mut std::collections::HashSet<String>,
+) {
+    let Ok(read_dir) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in read_dir.flatten() {
+        let path = entry.path();
+        let ext = path.extension().and_then(|e| e.to_str());
+        if ext != Some("md") {
+            continue;
+        }
+        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let fm = parse_frontmatter(&content);
+        let name = fm
+            .as_ref()
+            .and_then(|f| {
+                if f.name.is_empty() {
+                    None
+                } else {
+                    Some(f.name.clone())
+                }
+            })
+            .unwrap_or_else(|| stem.to_string());
+        let description = fm
+            .as_ref()
+            .map(|f| f.description.clone())
+            .unwrap_or_default();
+        let argument_hint = fm.as_ref().and_then(|f| f.argument_hint.clone());
+
+        if seen.insert(name.clone()) {
+            out.push(SlashCommandEntry {
+                name,
+                description,
+                argument_hint,
+                source: "skill".to_string(),
+            });
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// YAML frontmatter parser (no external crate)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ParsedFrontmatter {
+    pub name: String,
+    pub description: String,
+    pub argument_hint: Option<String>,
+}
+
+/// Extract `name`, `description`, and `argument-hint` from YAML frontmatter
+/// delimited by `---`.  Handles simple scalars, quoted values, and block
+/// scalars (`|` / `>`).
+pub fn parse_frontmatter(content: &str) -> Option<ParsedFrontmatter> {
+    let content = content.trim_start();
+    if !content.starts_with("---") {
+        return None;
+    }
+    let after_open = &content[3..];
+    let close_idx = after_open.find("\n---")?;
+    let block = &after_open[..close_idx];
+
+    let mut name = None;
+    let mut description = None;
+    let mut argument_hint = None;
+
+    let lines: Vec<&str> = block.lines().collect();
+    let mut i = 0;
+    while i < lines.len() {
+        let line = lines[i];
+
+        if let Some(val) = strip_key(line, "name:") {
+            name = Some(unquote(val));
+        } else if let Some(val) = strip_key(line, "description:") {
+            description = Some(collect_value(val, &lines, &mut i));
+        } else if let Some(val) = strip_key(line, "argument-hint:") {
+            argument_hint = Some(collect_value(val, &lines, &mut i));
+        }
+        i += 1;
+    }
+
+    let name = name.filter(|n| !n.is_empty())?;
+    let description = description.unwrap_or_default();
+    if description.is_empty() {
+        return None;
+    }
+
+    Some(ParsedFrontmatter {
+        name,
+        description,
+        argument_hint: argument_hint.filter(|h| !h.is_empty()),
+    })
+}
+
+/// Strip a YAML key prefix (e.g. `"description:"`) and return the remainder trimmed.
+fn strip_key<'a>(line: &'a str, key: &str) -> Option<&'a str> {
+    let trimmed = line.trim_start();
+    trimmed.strip_prefix(key).map(str::trim)
+}
+
+/// If `val` is a block scalar indicator (`|` or `>`), collect indented
+/// continuation lines.  Otherwise return the inline value (unquoted).
+fn collect_value(val: &str, lines: &[&str], i: &mut usize) -> String {
+    let val = val.trim();
+    if val == "|" || val == ">" {
+        let fold = val == ">";
+        let mut parts = Vec::new();
+        while *i + 1 < lines.len() {
+            let next = lines[*i + 1];
+            if next.is_empty() || next.starts_with(' ') || next.starts_with('\t') {
+                parts.push(next.trim());
+                *i += 1;
+            } else {
+                break;
+            }
+        }
+        if fold {
+            parts.join(" ")
+        } else {
+            parts.join("\n")
+        }
+    } else {
+        unquote(val)
+    }
+}
+
+/// Strip surrounding quotes (`"` or `'`) from a YAML scalar value.
+fn unquote(val: &str) -> String {
+    let val = val.trim();
+    if (val.starts_with('"') && val.ends_with('"'))
+        || (val.starts_with('\'') && val.ends_with('\''))
+    {
+        val[1..val.len() - 1].to_string()
+    } else {
+        val.to_string()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_simple_frontmatter() {
+        let input = r#"---
+name: find-skills
+description: Helps users discover and install agent skills.
+---
+body text
+"#;
+        let fm = parse_frontmatter(input).unwrap();
+        assert_eq!(fm.name, "find-skills");
+        assert_eq!(
+            fm.description,
+            "Helps users discover and install agent skills."
+        );
+        assert!(fm.argument_hint.is_none());
+    }
+
+    #[test]
+    fn parse_block_scalar_description() {
+        let input = "---\nname: investigate\ndescription: |\n  Systematic debugging.\n  Four phases.\n---\n";
+        let fm = parse_frontmatter(input).unwrap();
+        assert_eq!(fm.name, "investigate");
+        assert_eq!(fm.description, "Systematic debugging.\nFour phases.");
+    }
+
+    #[test]
+    fn parse_folded_scalar_description() {
+        let input = "---\nname: review\ndescription: >\n  First line.\n  Second line.\n---\n";
+        let fm = parse_frontmatter(input).unwrap();
+        assert_eq!(fm.name, "review");
+        assert_eq!(fm.description, "First line. Second line.");
+    }
+
+    #[test]
+    fn parse_quoted_values() {
+        let input = "---\nname: \"my-skill\"\ndescription: 'A cool skill'\n---\n";
+        let fm = parse_frontmatter(input).unwrap();
+        assert_eq!(fm.name, "my-skill");
+        assert_eq!(fm.description, "A cool skill");
+    }
+
+    #[test]
+    fn parse_command_with_argument_hint() {
+        let input = "---\ndescription: Polish code\nargument-hint: [base-branch]\n---\n";
+        // Commands may have no `name` — parse_frontmatter returns None.
+        let fm = parse_frontmatter(input);
+        assert!(fm.is_none());
+    }
+
+    #[test]
+    fn parse_command_with_name_and_hint() {
+        let input =
+            "---\nname: polish\ndescription: Polish code\nargument-hint: [base-branch]\n---\n";
+        let fm = parse_frontmatter(input).unwrap();
+        assert_eq!(fm.name, "polish");
+        assert_eq!(fm.argument_hint, Some("[base-branch]".to_string()));
+    }
+
+    #[test]
+    fn missing_frontmatter_returns_none() {
+        assert!(parse_frontmatter("no frontmatter here").is_none());
+    }
+
+    #[test]
+    fn missing_description_returns_none() {
+        let input = "---\nname: test\n---\n";
+        assert!(parse_frontmatter(input).is_none());
+    }
+
+    #[test]
+    fn scan_local_commands_returns_empty_for_nonexistent() {
+        // With a bogus HOME, nothing should be found and it should not panic.
+        std::env::set_var("HOME", "/tmp/helmor-test-nonexistent-dir");
+        let result = scan_local_commands(None);
+        assert!(result.is_empty());
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -120,6 +120,7 @@ pub fn run() {
         .manage(auth::GithubIdentityFlowRuntime::default())
         .manage(sidecar::ManagedSidecar::new())
         .manage(agents::ActiveStreams::new())
+        .manage(agents::SlashCommandCache::new())
         .manage(git_watcher::GitWatcherManager::new())
         .manage(workspace::scripts::ScriptProcessManager::new())
         .setup(|app| {

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -12,7 +12,11 @@ import type {
 	AgentProvider,
 	SlashCommandEntry,
 } from "@/lib/api";
-import { createSession, saveAutoCloseActionKinds } from "@/lib/api";
+import {
+	createSession,
+	listenSlashCommandsRefreshed,
+	saveAutoCloseActionKinds,
+} from "@/lib/api";
 import { describeActionKind } from "@/lib/commit-button-prompts";
 import type {
 	ComposerCustomTag,
@@ -294,7 +298,9 @@ export const WorkspaceComposerContainer = memo(
 			),
 			enabled: Boolean(workingDirectory),
 		});
-		const slashCommands = slashCommandsQuery.data ?? EMPTY_SLASH_COMMANDS;
+		const slashCommandsResponse = slashCommandsQuery.data;
+		const slashCommands =
+			slashCommandsResponse?.commands ?? EMPTY_SLASH_COMMANDS;
 		// Pending only (`isPending`) covers the very first fetch with no data
 		// yet; once we have data, `isFetching` covers background refetches but
 		// users don't need a spinner for those — the cached list is fine.
@@ -304,9 +310,40 @@ export const WorkspaceComposerContainer = memo(
 			!slashCommandsQuery.isError;
 		const slashCommandsError =
 			Boolean(workingDirectory) && slashCommandsQuery.isError;
+		// True when local skills are shown but the full list is still loading
+		// in the background via the sidecar.
+		const slashCommandsRefreshing =
+			slashCommandsResponse != null && !slashCommandsResponse.isComplete;
 		const refetchSlashCommands = useCallback(() => {
 			void slashCommandsQuery.refetch();
 		}, [slashCommandsQuery]);
+
+		// Listen for background sidecar refresh completion → invalidate query
+		// so the popup updates with the full list (including built-in commands).
+		useEffect(() => {
+			let disposed = false;
+			let unlisten: (() => void) | undefined;
+			void listenSlashCommandsRefreshed(() => {
+				if (disposed) return;
+				void queryClient.invalidateQueries({
+					queryKey: helmorQueryKeys.slashCommands(
+						slashProvider,
+						workingDirectory,
+						selectedModelId,
+					),
+				});
+			}).then((fn) => {
+				if (disposed) {
+					fn();
+					return;
+				}
+				unlisten = fn;
+			});
+			return () => {
+				disposed = true;
+				unlisten?.();
+			};
+		}, [queryClient, slashProvider, workingDirectory, selectedModelId]);
 		const handleComposerSubmit = useCallback(
 			(
 				prompt: string,
@@ -525,6 +562,7 @@ export const WorkspaceComposerContainer = memo(
 					slashCommands={slashCommands}
 					slashCommandsLoading={slashCommandsLoading}
 					slashCommandsError={slashCommandsError}
+					slashCommandsRefreshing={slashCommandsRefreshing}
 					onRetrySlashCommands={refetchSlashCommands}
 					workspaceRootPath={workingDirectory}
 				/>

--- a/src/features/composer/editor/plugins/slash-command-plugin.tsx
+++ b/src/features/composer/editor/plugins/slash-command-plugin.tsx
@@ -92,6 +92,7 @@ export function SlashCommandPlugin({
 	commands,
 	isLoading = false,
 	isError = false,
+	isRefreshing = false,
 	onRetry,
 }: {
 	commands: readonly SlashCommandEntry[];
@@ -99,6 +100,8 @@ export function SlashCommandPlugin({
 	isLoading?: boolean;
 	/** True when the query rejected (sidecar timeout, missing CLI, etc). */
 	isError?: boolean;
+	/** True when local skills are shown but the full list is still loading. */
+	isRefreshing?: boolean;
 	/** Click handler for the "retry" row in the error state. */
 	onRetry?: () => void;
 }) {
@@ -271,6 +274,12 @@ export function SlashCommandPlugin({
 										})}
 									</CommandGroup>
 								) : null}
+								{hasOptions && isRefreshing && (
+									<div className="flex items-center gap-2 border-t border-border/40 px-3 py-1.5 text-[12px] text-muted-foreground">
+										<Loader2 className="size-3 shrink-0 animate-spin" />
+										<span>Loading more commands…</span>
+									</div>
+								)}
 							</CommandList>
 						</Command>
 					</div>,

--- a/src/features/composer/index.tsx
+++ b/src/features/composer/index.tsx
@@ -93,6 +93,7 @@ type WorkspaceComposerProps = {
 	slashCommands?: readonly SlashCommandEntry[];
 	slashCommandsLoading?: boolean;
 	slashCommandsError?: boolean;
+	slashCommandsRefreshing?: boolean;
 	onRetrySlashCommands?: () => void;
 	workspaceRootPath?: string | null;
 	pendingElicitation?: PendingElicitation | null;
@@ -149,6 +150,7 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 	slashCommands = EMPTY_SLASH_COMMANDS,
 	slashCommandsLoading = false,
 	slashCommandsError = false,
+	slashCommandsRefreshing = false,
 	onRetrySlashCommands,
 	workspaceRootPath = null,
 	pendingElicitation = null,
@@ -432,6 +434,7 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 							commands={slashCommands}
 							isLoading={slashCommandsLoading}
 							isError={slashCommandsError}
+							isRefreshing={slashCommandsRefreshing}
 							onRetry={onRetrySlashCommands}
 						/>
 						<FileMentionPlugin workspaceRootPath={workspaceRootPath} />

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -620,19 +620,29 @@ export type SlashCommandEntry = {
 	source: "builtin" | "skill";
 };
 
+export type SlashCommandsResponse = {
+	commands: SlashCommandEntry[];
+	/** `false` while the background sidecar refresh is still in flight. */
+	isComplete: boolean;
+};
+
 /**
  * Fetch the slash commands the composer popup should display for the given
- * provider + workspace. The Rust side dispatches to the sidecar which uses
- * either the Claude SDK control protocol or a Codex skill-directory scan,
- * but the frontend gets the same shape either way.
+ * provider + workspace.
+ *
+ * The Rust backend returns local skills instantly from a disk scan and
+ * fetches the full list (including built-in commands) from the sidecar in
+ * the background.  When `isComplete` is `false`, a background refresh is
+ * still in flight — listen for the `slash-commands-refreshed` event and
+ * invalidate the query when it fires.
  */
 export async function listSlashCommands(input: {
 	provider: AgentProvider;
 	workingDirectory?: string | null;
 	modelId?: string | null;
-}): Promise<SlashCommandEntry[]> {
+}): Promise<SlashCommandsResponse> {
 	try {
-		return await invoke<SlashCommandEntry[]>("list_slash_commands", {
+		return await invoke<SlashCommandsResponse>("list_slash_commands", {
 			request: {
 				provider: input.provider,
 				workingDirectory: input.workingDirectory ?? null,
@@ -644,6 +654,12 @@ export async function listSlashCommands(input: {
 			describeInvokeError(error, "Unable to load slash commands."),
 		);
 	}
+}
+
+export async function listenSlashCommandsRefreshed(
+	callback: () => void,
+): Promise<UnlistenFn> {
+	return listen("slash-commands-refreshed", () => callback());
 }
 
 export async function loadWorkspaceDetail(

--- a/src/lib/query-client.ts
+++ b/src/lib/query-client.ts
@@ -201,16 +201,14 @@ export function slashCommandsQueryOptions(
 		// Slash commands rarely change within a workspace; cache aggressively.
 		staleTime: 5 * 60_000,
 		gcTime: DEFAULT_GC_TIME,
-		// Retry on transient sidecar failures (cold-start `claude-code`,
-		// control-protocol timeouts). Without this a single timeout would
-		// lock the popup empty until the staleTime window expires, which
-		// the user perceives as "/ doesn't open the menu anymore". Errors
-		// are surfaced through `isError` so the popup can show a retry
-		// affordance instead of silently failing.
-		retry: 2,
-		retryDelay: (attempt) => Math.min(1_000 * 2 ** attempt, 4_000),
+		// The Rust backend always succeeds now (returns local skills from
+		// disk even if the sidecar is unreachable), so retries are no longer
+		// necessary. The background sidecar refresh handles recovery by
+		// emitting a `slash-commands-refreshed` event which triggers a
+		// query invalidation.
+		retry: 0,
 		// Refetch on mount so re-opening a workspace tab gets a fresh shot
-		// at recovery without waiting out staleTime.
+		// at upgrading a partial cache to a complete one.
 		refetchOnMount: "always",
 	});
 }


### PR DESCRIPTION
## Summary

- **Instant local results**: Slash command popup now shows local skills from `~/.claude/skills/` and `~/.claude/commands/` immediately via a fast disk scan (< 5 ms), eliminating the 1–10 s wait for the sidecar round-trip on first `/` press.
- **Background sidecar refresh**: The full command list (including built-in commands) loads in the background via a dedicated thread. On completion, a `slash-commands-refreshed` Tauri event fires to update the frontend.
- **In-memory cache with stale-while-revalidate**: `SlashCommandCache` stores results per `(provider, cwd, model)` key. Subsequent presses are instant; a background refresh keeps the cache fresh.

## What changed

| Area | Files | Change |
|------|-------|--------|
| Rust – new module | `agents/slash_commands.rs` | `SlashCommandCache` + `scan_local_commands()` + YAML frontmatter parser with tests |
| Rust – queries | `agents/queries.rs` | Progressive loading flow: cache check → local scan → background sidecar refresh |
| Rust – wiring | `agents.rs`, `lib.rs` | Register `SlashCommandCache` as managed state, expose new types |
| Frontend – API | `lib/api.ts` | New `SlashCommandsResponse` type with `isComplete` flag; `listenSlashCommandsRefreshed()` helper |
| Frontend – query | `lib/query-client.ts` | Remove retry logic (backend always succeeds with local data); keep `refetchOnMount: "always"` |
| Frontend – composer | `container.tsx`, `index.tsx` | Listen for refresh event → invalidate query; pass `slashCommandsRefreshing` prop |
| Frontend – plugin | `slash-command-plugin.tsx` | Show "Loading more commands…" spinner while background refresh is in flight |

## How it works

```
User presses "/"
  → Frontend calls list_slash_commands
  → Rust checks SlashCommandCache
    → Cache hit (complete): return immediately, spawn background refresh
    → Cache miss: scan_local_commands() from disk (< 5ms), cache partial result
      → Spawn background thread: sidecar listSlashCommands
      → On success: update cache (is_complete=true), emit event
      → Frontend receives event → invalidates React Query → popup updates
```

## Test plan

- [ ] Rust unit tests pass: `cd src-tauri && cargo test -- slash_commands`
- [ ] Frontend type-checks: `pnpm run typecheck`
- [ ] Full test suite: `pnpm run test`
- [ ] Manual: open composer, type `/` — local skills appear instantly, then built-in commands appear after ~1–2 s with a brief "Loading more commands…" spinner
- [ ] Manual: second `/` press in same workspace is instant (cache hit)
- [ ] Manual: non-Claude providers (Codex) still get the full list synchronously