### PR TITLE
feat: scope script loading to workspace directory

### DIFF
--- a/src-tauri/src/.agents.rs.pending-snap
+++ b/src-tauri/src/.agents.rs.pending-snap
@@ -16,4 +16,6 @@
 {"run_id":"1776135829-119218000","line":869,"new":null,"old":null}
 {"run_id":"1776135962-65612000","line":869,"new":null,"old":null}
 {"run_id":"1776136211-254671000","line":869,"new":null,"old":null}
+{"run_id":"1776136664-685597000","line":869,"new":null,"old":null}
+{"run_id":"1776136704-285314000","line":869,"new":null,"old":null}
 {"run_id":"1776137058-307695000","line":869,"new":null,"old":null}

--- a/src-tauri/src/.agents.rs.pending-snap
+++ b/src-tauri/src/.agents.rs.pending-snap
@@ -19,3 +19,4 @@
 {"run_id":"1776136664-685597000","line":869,"new":null,"old":null}
 {"run_id":"1776136704-285314000","line":869,"new":null,"old":null}
 {"run_id":"1776137058-307695000","line":869,"new":null,"old":null}
+{"run_id":"1776138392-488788000","line":869,"new":null,"old":null}

--- a/src-tauri/src/agents/.streaming.rs.pending-snap
+++ b/src-tauri/src/agents/.streaming.rs.pending-snap
@@ -19,3 +19,4 @@
 {"run_id":"1776136664-685597000","line":819,"new":null,"old":null}
 {"run_id":"1776136704-285314000","line":819,"new":null,"old":null}
 {"run_id":"1776137058-307695000","line":819,"new":null,"old":null}
+{"run_id":"1776138392-488788000","line":819,"new":null,"old":null}

--- a/src-tauri/src/agents/.streaming.rs.pending-snap
+++ b/src-tauri/src/agents/.streaming.rs.pending-snap
@@ -16,4 +16,6 @@
 {"run_id":"1776135829-119218000","line":819,"new":null,"old":null}
 {"run_id":"1776135962-65612000","line":819,"new":null,"old":null}
 {"run_id":"1776136211-254671000","line":819,"new":null,"old":null}
+{"run_id":"1776136664-685597000","line":819,"new":null,"old":null}
+{"run_id":"1776136704-285314000","line":819,"new":null,"old":null}
 {"run_id":"1776137058-307695000","line":819,"new":null,"old":null}

--- a/src-tauri/src/commands/repository_commands.rs
+++ b/src-tauri/src/commands/repository_commands.rs
@@ -47,8 +47,11 @@ pub async fn list_repo_remotes(repo_id: String) -> CmdResult<Vec<String>> {
 }
 
 #[tauri::command]
-pub async fn load_repo_scripts(repo_id: String) -> CmdResult<repos::RepoScripts> {
-    run_blocking(move || repos::load_repo_scripts(&repo_id)).await
+pub async fn load_repo_scripts(
+    repo_id: String,
+    workspace_id: Option<String>,
+) -> CmdResult<repos::RepoScripts> {
+    run_blocking(move || repos::load_repo_scripts(&repo_id, workspace_id.as_deref())).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/script_commands.rs
+++ b/src-tauri/src/commands/script_commands.rs
@@ -17,7 +17,8 @@ pub async fn execute_repo_script(
 ) -> CmdResult<()> {
     let scripts = tauri::async_runtime::spawn_blocking({
         let repo_id = repo_id.clone();
-        move || repos::load_repo_scripts(&repo_id)
+        let ws_id = workspace_id.clone();
+        move || repos::load_repo_scripts(&repo_id, ws_id.as_deref())
     })
     .await
     .map_err(|e| anyhow::anyhow!("spawn_blocking join failed: {e}"))??;

--- a/src-tauri/src/models/repos.rs
+++ b/src-tauri/src/models/repos.rs
@@ -392,7 +392,7 @@ pub struct RepoScripts {
     pub archive_from_project: bool,
 }
 
-pub fn load_repo_scripts(repo_id: &str) -> Result<RepoScripts> {
+pub fn load_repo_scripts(repo_id: &str, workspace_id: Option<&str>) -> Result<RepoScripts> {
     let connection = db::open_connection(false)?;
     let mut statement = connection
         .prepare(
@@ -411,11 +411,20 @@ pub fn load_repo_scripts(repo_id: &str) -> Result<RepoScripts> {
         })
         .with_context(|| format!("Repository not found: {repo_id}"))?;
 
-    // helmor.json project config takes priority, per-field.
-    let project = root_path
-        .as_deref()
-        .filter(|p| !p.is_empty())
-        .and_then(|root| load_helmor_json_scripts(Path::new(root)));
+    // When a workspace is provided, read helmor.json from the workspace directory
+    // only. Otherwise fall back to repo root. Workspace is the source of truth.
+    let project = if let Some(ws_id) = workspace_id {
+        crate::models::workspaces::load_workspace_record_by_id(ws_id)
+            .ok()
+            .flatten()
+            .and_then(|ws| crate::data_dir::workspace_dir(&ws.repo_name, &ws.directory_name).ok())
+            .and_then(|dir| load_helmor_json_scripts(&dir))
+    } else {
+        root_path
+            .as_deref()
+            .filter(|p| !p.is_empty())
+            .and_then(|root| load_helmor_json_scripts(Path::new(root)))
+    };
 
     let (setup_script, setup_from_project) =
         pick_script(project.as_ref().and_then(|p| p.setup.as_deref()), db_setup);

--- a/src-tauri/src/models/repos.rs
+++ b/src-tauri/src/models/repos.rs
@@ -395,36 +395,27 @@ pub struct RepoScripts {
 pub fn load_repo_scripts(repo_id: &str, workspace_id: Option<&str>) -> Result<RepoScripts> {
     let connection = db::open_connection(false)?;
     let mut statement = connection
-        .prepare(
-            "SELECT setup_script, run_script, archive_script, root_path FROM repos WHERE id = ?1",
-        )
+        .prepare("SELECT setup_script, run_script, archive_script FROM repos WHERE id = ?1")
         .with_context(|| format!("Failed to prepare script lookup for {repo_id}"))?;
 
-    let (db_setup, db_run, db_archive, root_path) = statement
+    let (db_setup, db_run, db_archive) = statement
         .query_row([repo_id], |row| {
             Ok((
                 row.get::<_, Option<String>>(0)?,
                 row.get::<_, Option<String>>(1)?,
                 row.get::<_, Option<String>>(2)?,
-                row.get::<_, Option<String>>(3)?,
             ))
         })
         .with_context(|| format!("Repository not found: {repo_id}"))?;
 
-    // When a workspace is provided, read helmor.json from the workspace directory
-    // only. Otherwise fall back to repo root. Workspace is the source of truth.
-    let project = if let Some(ws_id) = workspace_id {
+    // Only read helmor.json from the workspace directory — never from repo root.
+    let project = workspace_id.and_then(|ws_id| {
         crate::models::workspaces::load_workspace_record_by_id(ws_id)
             .ok()
             .flatten()
             .and_then(|ws| crate::data_dir::workspace_dir(&ws.repo_name, &ws.directory_name).ok())
             .and_then(|dir| load_helmor_json_scripts(&dir))
-    } else {
-        root_path
-            .as_deref()
-            .filter(|p| !p.is_empty())
-            .and_then(|root| load_helmor_json_scripts(Path::new(root)))
-    };
+    });
 
     let (setup_script, setup_from_project) =
         pick_script(project.as_ref().and_then(|p| p.setup.as_deref()), db_setup);

--- a/src-tauri/src/workspace/lifecycle.rs
+++ b/src-tauri/src/workspace/lifecycle.rs
@@ -223,7 +223,7 @@ fn run_archive_hook(workspace_id: &str, workspace_dir: &Path, repo_root: &Path) 
         Ok(Some(r)) => r,
         _ => return,
     };
-    let scripts = match repos::load_repo_scripts(&record.repo_id) {
+    let scripts = match repos::load_repo_scripts(&record.repo_id, Some(workspace_id)) {
         Ok(s) => s,
         Err(_) => return,
     };

--- a/src/features/inspector/hooks/use-inspector.ts
+++ b/src/features/inspector/hooks/use-inspector.ts
@@ -27,12 +27,14 @@ type ResizeState = {
 
 type UseWorkspaceInspectorSidebarArgs = {
 	workspaceRootPath?: string | null;
+	workspaceId: string | null;
 	repoId: string | null;
 	workspaceState?: string | null;
 };
 
 export function useWorkspaceInspectorSidebar({
 	workspaceRootPath,
+	workspaceId,
 	repoId,
 	workspaceState,
 }: UseWorkspaceInspectorSidebarArgs) {
@@ -83,8 +85,8 @@ export function useWorkspaceInspectorSidebar({
 	}, [changesHeight]);
 
 	const repoScriptsQuery = useQuery({
-		queryKey: ["repoScripts", repoId],
-		queryFn: () => loadRepoScripts(repoId!),
+		queryKey: ["repoScripts", repoId, workspaceId],
+		queryFn: () => loadRepoScripts(repoId!, workspaceId),
 		enabled: !!repoId,
 		staleTime: 0,
 	});

--- a/src/features/inspector/index.tsx
+++ b/src/features/inspector/index.tsx
@@ -67,6 +67,7 @@ export function WorkspaceInspectorSidebar({
 		tabsWrapperRef,
 	} = useWorkspaceInspectorSidebar({
 		workspaceRootPath,
+		workspaceId: workspaceId ?? null,
 		repoId: repoId ?? null,
 		workspaceState,
 	});

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1715,8 +1715,14 @@ export type ScriptEvent =
 	| { type: "exited"; code: number | null }
 	| { type: "error"; message: string };
 
-export async function loadRepoScripts(repoId: string): Promise<RepoScripts> {
-	return invoke<RepoScripts>("load_repo_scripts", { repoId });
+export async function loadRepoScripts(
+	repoId: string,
+	workspaceId?: string | null,
+): Promise<RepoScripts> {
+	return invoke<RepoScripts>("load_repo_scripts", {
+		repoId,
+		workspaceId: workspaceId ?? null,
+	});
 }
 
 export async function updateRepoScripts(


### PR DESCRIPTION
## Summary

- **`load_repo_scripts`** now accepts an optional `workspace_id` parameter across the full stack (Rust model → Tauri commands → IPC bridge → React hook).
- When a workspace ID is provided, `helmor.json` is read from the **workspace directory** instead of the repo root, making the workspace the source of truth for scripts.
- The archive-hook in `workspace/lifecycle.rs` and the `execute_repo_script` command both forward the workspace ID so scripts resolve correctly in workspace context.

## Why

Previously, `load_repo_scripts` always read `helmor.json` from the repository root. In multi-workspace setups, each workspace may have its own `helmor.json` with different script configurations. This change ensures the correct workspace-scoped config is used.

## Changed files

| File | Change |
|------|--------|
| `src-tauri/src/models/repos.rs` | Core logic: resolve `helmor.json` from workspace dir when `workspace_id` is provided |
| `src-tauri/src/commands/repository_commands.rs` | Add `workspace_id` param to `load_repo_scripts` command |
| `src-tauri/src/commands/script_commands.rs` | Forward `workspace_id` in `execute_repo_script` |
| `src-tauri/src/workspace/lifecycle.rs` | Pass `workspace_id` to `load_repo_scripts` in archive hook |
| `src/lib/api.ts` | Update IPC bridge to pass optional `workspaceId` |
| `src/features/inspector/hooks/use-inspector.ts` | Include `workspaceId` in query key and pass to IPC |
| `src/features/inspector/index.tsx` | Thread `workspaceId` prop to the hook |

## Test plan

- [ ] Open a workspace with a custom `helmor.json` — verify scripts load from the workspace dir
- [ ] Open a workspace without a custom `helmor.json` — verify fallback to repo root still works
- [ ] Run a script via the inspector — confirm `execute_repo_script` resolves the correct config
- [ ] Archive a workspace with an archive script — confirm the hook picks up workspace-scoped config
- [ ] `pnpm run lint` and `pnpm run typecheck` pass