### PR TITLE
feat: commit button enhancements, keyboard shortcuts, UX polish & backend hardening

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Helmor</title>
     <script>
-      ;(function() {
+      ;(() => {
         var t = localStorage.getItem('helmor-theme') || 'system'
         var dark = t === 'dark' || (t === 'system' && window.matchMedia('(prefers-color-scheme:dark)').matches)
         if (dark) document.documentElement.classList.add('dark')

--- a/src-tauri/src/.agents.rs.pending-snap
+++ b/src-tauri/src/.agents.rs.pending-snap
@@ -20,3 +20,4 @@
 {"run_id":"1776136704-285314000","line":869,"new":null,"old":null}
 {"run_id":"1776137058-307695000","line":869,"new":null,"old":null}
 {"run_id":"1776138392-488788000","line":869,"new":null,"old":null}
+{"run_id":"1776140072-678757000","line":869,"new":null,"old":null}

--- a/src-tauri/src/agents/.streaming.rs.pending-snap
+++ b/src-tauri/src/agents/.streaming.rs.pending-snap
@@ -20,3 +20,4 @@
 {"run_id":"1776136704-285314000","line":819,"new":null,"old":null}
 {"run_id":"1776137058-307695000","line":819,"new":null,"old":null}
 {"run_id":"1776138392-488788000","line":819,"new":null,"old":null}
+{"run_id":"1776140072-678757000","line":819,"new":null,"old":null}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -82,7 +82,9 @@ import {
 	helmorQueryPersister,
 	sessionThreadMessagesQueryOptions,
 	workspaceDetailQueryOptions,
+	workspaceGitActionStatusQueryOptions,
 	workspaceGroupsQueryOptions,
+	workspacePrActionStatusQueryOptions,
 	workspacePrQueryOptions,
 	workspaceSessionsQueryOptions,
 } from "./lib/query-client";
@@ -442,6 +444,21 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 		enabled: isIdentityConnected && selectedWorkspaceId !== null,
 	});
 	const workspacePrInfo = workspacePrQuery.data ?? null;
+
+	// PR action status (mergeable, reviewDecision, checks) and local git
+	// status (uncommittedCount, conflictCount). These drive the commit
+	// button's mode derivation — shared cache with inspector's actions.tsx.
+	const workspacePrActionStatusQuery = useQuery({
+		...workspacePrActionStatusQueryOptions(selectedWorkspaceId ?? "__none__"),
+		enabled: isIdentityConnected && selectedWorkspaceId !== null,
+	});
+	const workspacePrActionStatus = workspacePrActionStatusQuery.data ?? null;
+
+	const workspaceGitActionStatusQuery = useQuery({
+		...workspaceGitActionStatusQueryOptions(selectedWorkspaceId ?? "__none__"),
+		enabled: selectedWorkspaceId !== null,
+	});
+	const workspaceGitActionStatus = workspaceGitActionStatusQuery.data ?? null;
 
 	// Reactively transition workspace sidebar status when the PR query
 	// detects a state change. Handles PRs created/merged/closed externally.
@@ -1089,6 +1106,8 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 		selectedWorkspaceIdRef,
 		workspaceManualStatus: selectedWorkspaceManualStatus,
 		workspacePrInfo,
+		workspacePrActionStatus,
+		workspaceGitActionStatus,
 		sendingSessionIds,
 		onSelectSession: handleSelectSession,
 	});

--- a/src/features/commit/hooks/use-commit-lifecycle.ts
+++ b/src/features/commit/hooks/use-commit-lifecycle.ts
@@ -17,7 +17,13 @@ import {
 	type PullRequestInfo,
 	setWorkspaceManualStatus,
 	type WorkspaceDetail,
+	type WorkspaceGitActionStatus,
+	type WorkspacePrActionStatus,
 } from "@/lib/api";
+import {
+	deriveCommitButtonMode,
+	deriveCommitButtonState,
+} from "@/lib/commit-button-logic";
 import { COMMIT_BUTTON_PROMPTS } from "@/lib/commit-button-prompts";
 import { helmorQueryKeys } from "@/lib/query-client";
 import type { CommitButtonState, WorkspaceCommitButtonMode } from "../button";
@@ -43,6 +49,8 @@ export function useWorkspaceCommitLifecycle({
 	selectedWorkspaceIdRef,
 	workspaceManualStatus,
 	workspacePrInfo,
+	workspacePrActionStatus,
+	workspaceGitActionStatus,
 	sendingSessionIds,
 	onSelectSession,
 }: {
@@ -51,6 +59,8 @@ export function useWorkspaceCommitLifecycle({
 	selectedWorkspaceIdRef: MutableRefObject<string | null>;
 	workspaceManualStatus: string | null;
 	workspacePrInfo: PullRequestInfo | null;
+	workspacePrActionStatus: WorkspacePrActionStatus | null;
+	workspaceGitActionStatus: WorkspaceGitActionStatus | null;
 	sendingSessionIds: Set<string>;
 	onSelectSession: (sessionId: string | null) => void;
 }) {
@@ -58,6 +68,11 @@ export function useWorkspaceCommitLifecycle({
 		useState<PendingPromptForSession | null>(null);
 	const [commitLifecycle, setCommitLifecycle] =
 		useState<CommitLifecycle | null>(null);
+
+	// Keep a stable ref so the merge-validation guard in the callback can
+	// read the latest value without adding it to the dependency array.
+	const prActionStatusRef = useRef(workspacePrActionStatus);
+	prActionStatusRef.current = workspacePrActionStatus;
 
 	const handleInspectorCommitAction = useCallback(
 		async (mode: WorkspaceCommitButtonMode) => {
@@ -70,6 +85,27 @@ export function useWorkspaceCommitLifecycle({
 			console.log("[commitButton] begin", { mode, workspaceId });
 
 			if (mode === "merge" || mode === "closed") {
+				// ── Merge pre-validation ─────────────────────────────────
+				if (mode === "merge") {
+					const currentMergeable = prActionStatusRef.current?.mergeable;
+					if (currentMergeable === "CONFLICTING") {
+						console.warn(
+							"[commitButton] merge blocked: PR has merge conflicts",
+						);
+						return;
+					}
+					if (currentMergeable === "UNKNOWN") {
+						console.warn(
+							"[commitButton] merge blocked: mergeable status still computing, please wait",
+						);
+						// Trigger a refresh so the status resolves sooner
+						void queryClient.invalidateQueries({
+							queryKey: helmorQueryKeys.workspacePrActionStatus(workspaceId),
+						});
+						return;
+					}
+				}
+
 				const currentPr = queryClient.getQueryData<PullRequestInfo | null>(
 					helmorQueryKeys.workspacePr(workspaceId),
 				);
@@ -322,36 +358,26 @@ export function useWorkspaceCommitLifecycle({
 			? commitLifecycle
 			: null;
 
-	const commitButtonMode = useMemo<WorkspaceCommitButtonMode>(() => {
-		if (activeLifecycle) {
-			if (activeLifecycle.phase === "done" && activeLifecycle.prInfo) {
-				return activeLifecycle.prInfo.isMerged ? "merged" : "merge";
-			}
-			return activeLifecycle.mode;
-		}
+	const commitButtonMode = useMemo<WorkspaceCommitButtonMode>(
+		() =>
+			deriveCommitButtonMode(
+				activeLifecycle,
+				workspacePrInfo,
+				workspacePrActionStatus,
+				workspaceGitActionStatus,
+			),
+		[
+			activeLifecycle,
+			workspacePrInfo,
+			workspacePrActionStatus,
+			workspaceGitActionStatus,
+		],
+	);
 
-		if (workspacePrInfo) {
-			if (workspacePrInfo.isMerged) return "merged";
-			if (workspacePrInfo.state === "OPEN") return "merge";
-			if (workspacePrInfo.state === "CLOSED") return "create-pr";
-		}
-
-		return "create-pr";
-	}, [activeLifecycle, workspacePrInfo]);
-
-	const commitButtonState = useMemo<CommitButtonState>(() => {
-		if (!activeLifecycle) return "idle";
-		switch (activeLifecycle.phase) {
-			case "creating":
-			case "streaming":
-			case "verifying":
-				return "busy";
-			case "done":
-				return "done";
-			case "error":
-				return "error";
-		}
-	}, [activeLifecycle]);
+	const commitButtonState = useMemo<CommitButtonState>(
+		() => deriveCommitButtonState(activeLifecycle, workspacePrActionStatus),
+		[activeLifecycle, workspacePrActionStatus],
+	);
 
 	return {
 		commitButtonMode,

--- a/src/lib/commit-button-logic.test.ts
+++ b/src/lib/commit-button-logic.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import type { PullRequestInfo } from "./api";
+import type {
+	PullRequestInfo,
+	WorkspaceGitActionStatus,
+	WorkspacePrActionStatus,
+} from "./api";
 import {
 	type CommitLifecycle,
 	deriveCommitButtonMode,
@@ -33,6 +37,31 @@ function makeLifecycle(
 	};
 }
 
+function makePrActionStatus(
+	overrides: Partial<WorkspacePrActionStatus> = {},
+): WorkspacePrActionStatus {
+	return {
+		pr: null,
+		reviewDecision: null,
+		mergeable: null,
+		deployments: [],
+		checks: [],
+		remoteState: "ok",
+		message: null,
+		...overrides,
+	};
+}
+
+function makeGitActionStatus(
+	overrides: Partial<WorkspaceGitActionStatus> = {},
+): WorkspaceGitActionStatus {
+	return {
+		uncommittedCount: 0,
+		conflictCount: 0,
+		...overrides,
+	};
+}
+
 // ── deriveCommitButtonMode ───────────────────────────────────────────
 
 describe("deriveCommitButtonMode", () => {
@@ -41,7 +70,7 @@ describe("deriveCommitButtonMode", () => {
 			expect(deriveCommitButtonMode(null, null)).toBe("create-pr");
 		});
 
-		it("returns merge when PR is OPEN", () => {
+		it("returns merge when PR is OPEN and no blocking conditions", () => {
 			expect(deriveCommitButtonMode(null, makePr({ state: "OPEN" }))).toBe(
 				"merge",
 			);
@@ -56,13 +85,175 @@ describe("deriveCommitButtonMode", () => {
 			).toBe("merged");
 		});
 
-		it("returns create-pr when PR is CLOSED (not merged)", () => {
+		it("returns open-pr when PR is CLOSED (not merged)", () => {
 			expect(
 				deriveCommitButtonMode(
 					null,
 					makePr({ state: "CLOSED", isMerged: false }),
 				),
-			).toBe("create-pr");
+			).toBe("open-pr");
+		});
+	});
+
+	describe("resolve-conflicts priority", () => {
+		it("returns resolve-conflicts when mergeable is CONFLICTING", () => {
+			expect(
+				deriveCommitButtonMode(
+					null,
+					makePr({ state: "OPEN" }),
+					makePrActionStatus({ mergeable: "CONFLICTING" }),
+				),
+			).toBe("resolve-conflicts");
+		});
+
+		it("returns resolve-conflicts when local conflictCount > 0", () => {
+			expect(
+				deriveCommitButtonMode(
+					null,
+					makePr({ state: "OPEN" }),
+					makePrActionStatus(),
+					makeGitActionStatus({ conflictCount: 3 }),
+				),
+			).toBe("resolve-conflicts");
+		});
+
+		it("conflicts take precedence over uncommitted changes", () => {
+			expect(
+				deriveCommitButtonMode(
+					null,
+					makePr({ state: "OPEN" }),
+					makePrActionStatus({ mergeable: "CONFLICTING" }),
+					makeGitActionStatus({ uncommittedCount: 5 }),
+				),
+			).toBe("resolve-conflicts");
+		});
+
+		it("conflicts take precedence over failing checks", () => {
+			expect(
+				deriveCommitButtonMode(
+					null,
+					makePr({ state: "OPEN" }),
+					makePrActionStatus({
+						mergeable: "CONFLICTING",
+						checks: [
+							{
+								id: "ci-1",
+								name: "build",
+								provider: "github",
+								status: "failure",
+							},
+						],
+					}),
+				),
+			).toBe("resolve-conflicts");
+		});
+	});
+
+	describe("commit-and-push priority", () => {
+		it("returns commit-and-push when uncommittedCount > 0 and no conflicts", () => {
+			expect(
+				deriveCommitButtonMode(
+					null,
+					makePr({ state: "OPEN" }),
+					makePrActionStatus({ mergeable: "MERGEABLE" }),
+					makeGitActionStatus({ uncommittedCount: 2 }),
+				),
+			).toBe("commit-and-push");
+		});
+
+		it("uncommitted changes take precedence over failing checks", () => {
+			expect(
+				deriveCommitButtonMode(
+					null,
+					makePr({ state: "OPEN" }),
+					makePrActionStatus({
+						mergeable: "MERGEABLE",
+						checks: [
+							{
+								id: "ci-1",
+								name: "build",
+								provider: "github",
+								status: "failure",
+							},
+						],
+					}),
+					makeGitActionStatus({ uncommittedCount: 1 }),
+				),
+			).toBe("commit-and-push");
+		});
+	});
+
+	describe("fix CI priority", () => {
+		it("returns fix when a check has failure status", () => {
+			expect(
+				deriveCommitButtonMode(
+					null,
+					makePr({ state: "OPEN" }),
+					makePrActionStatus({
+						checks: [
+							{
+								id: "ci-1",
+								name: "build",
+								provider: "github",
+								status: "failure",
+							},
+						],
+					}),
+					makeGitActionStatus(),
+				),
+			).toBe("fix");
+		});
+
+		it("returns merge when all checks pass", () => {
+			expect(
+				deriveCommitButtonMode(
+					null,
+					makePr({ state: "OPEN" }),
+					makePrActionStatus({
+						checks: [
+							{
+								id: "ci-1",
+								name: "build",
+								provider: "github",
+								status: "success",
+							},
+						],
+					}),
+					makeGitActionStatus(),
+				),
+			).toBe("merge");
+		});
+
+		it("returns merge when checks are pending (not failure)", () => {
+			expect(
+				deriveCommitButtonMode(
+					null,
+					makePr({ state: "OPEN" }),
+					makePrActionStatus({
+						checks: [
+							{
+								id: "ci-1",
+								name: "build",
+								provider: "github",
+								status: "pending",
+							},
+						],
+					}),
+					makeGitActionStatus(),
+				),
+			).toBe("merge");
+		});
+	});
+
+	describe("backward compatibility (no action status args)", () => {
+		it("returns merge when PR is OPEN with only 2 args", () => {
+			expect(deriveCommitButtonMode(null, makePr({ state: "OPEN" }))).toBe(
+				"merge",
+			);
+		});
+
+		it("returns create-pr with no args", () => {
+			expect(deriveCommitButtonMode(null, null)).toBe("create-pr");
 		});
 	});
 
@@ -129,11 +320,13 @@ describe("deriveCommitButtonMode", () => {
 			).toBe("create-pr");
 		});
 
-		it("lifecycle takes priority over PR query", () => {
+		it("lifecycle takes priority over PR query and action statuses", () => {
 			expect(
 				deriveCommitButtonMode(
 					makeLifecycle({ mode: "create-pr", phase: "streaming" }),
 					makePr({ state: "OPEN" }),
+					makePrActionStatus({ mergeable: "CONFLICTING" }),
+					makeGitActionStatus({ uncommittedCount: 5 }),
 				),
 			).toBe("create-pr");
 		});
@@ -144,6 +337,28 @@ describe("deriveCommitButtonMode", () => {
 
 describe("deriveCommitButtonState", () => {
 	it("returns idle when no lifecycle", () => {
+		expect(deriveCommitButtonState(null)).toBe("idle");
+	});
+
+	it("returns disabled when mergeable is UNKNOWN", () => {
+		expect(
+			deriveCommitButtonState(
+				null,
+				makePrActionStatus({ mergeable: "UNKNOWN" }),
+			),
+		).toBe("disabled");
+	});
+
+	it("returns idle when mergeable is MERGEABLE", () => {
+		expect(
+			deriveCommitButtonState(
+				null,
+				makePrActionStatus({ mergeable: "MERGEABLE" }),
+			),
+		).toBe("idle");
+	});
+
+	it("returns idle when no prActionStatus", () => {
 		expect(deriveCommitButtonState(null)).toBe("idle");
 	});
 
@@ -175,6 +390,15 @@ describe("deriveCommitButtonState", () => {
 		expect(deriveCommitButtonState(makeLifecycle({ phase: "error" }))).toBe(
 			"error",
 		);
+	});
+
+	it("lifecycle takes priority over UNKNOWN mergeable", () => {
+		expect(
+			deriveCommitButtonState(
+				makeLifecycle({ phase: "streaming" }),
+				makePrActionStatus({ mergeable: "UNKNOWN" }),
+			),
+		).toBe("busy");
 	});
 });
 

--- a/src/lib/commit-button-logic.ts
+++ b/src/lib/commit-button-logic.ts
@@ -2,7 +2,11 @@ import type {
 	CommitButtonState,
 	WorkspaceCommitButtonMode,
 } from "@/features/commit/button";
-import type { PullRequestInfo } from "./api";
+import type {
+	PullRequestInfo,
+	WorkspaceGitActionStatus,
+	WorkspacePrActionStatus,
+} from "./api";
 
 /**
  * The shape of the commit button lifecycle tracked by App.tsx.
@@ -16,37 +20,80 @@ export type CommitLifecycle = {
 } | null;
 
 /**
- * Derive the commit button's visible mode from the lifecycle + PR query.
+ * Derive the commit button's visible mode from the lifecycle + PR query +
+ * action statuses.
  *
- * During an active lifecycle, the mode follows the lifecycle. At rest, the
- * mode is derived from the persistent PR query so the button reflects the
- * real GitHub state across page reloads.
+ * During an active lifecycle the mode follows the lifecycle. At rest the
+ * mode is derived from the persistent queries so the button reflects the
+ * real GitHub / local-git state across page reloads.
+ *
+ * Priority order when PR is OPEN (highest wins):
+ *   1. resolve-conflicts  — conflicts block everything
+ *   2. commit-and-push    — local changes need pushing first
+ *   3. fix                — CI needs fixing before merge
+ *   4. merge              — ready to merge
  */
 export function deriveCommitButtonMode(
 	lifecycle: CommitLifecycle,
 	prInfo: PullRequestInfo | null,
+	prActionStatus?: WorkspacePrActionStatus | null,
+	gitActionStatus?: WorkspaceGitActionStatus | null,
 ): WorkspaceCommitButtonMode {
+	// ── Active lifecycle takes priority ──────────────────────────────
 	if (lifecycle) {
 		if (lifecycle.phase === "done" && lifecycle.prInfo) {
 			return lifecycle.prInfo.isMerged ? "merged" : "merge";
 		}
 		return lifecycle.mode;
 	}
+
+	// ── Resting state — derive from persistent queries ──────────────
 	if (prInfo) {
 		if (prInfo.isMerged) return "merged";
-		if (prInfo.state === "OPEN") return "merge";
-		if (prInfo.state === "CLOSED") return "create-pr";
+
+		if (prInfo.state === "OPEN") {
+			// 1. Conflicts block everything
+			const hasConflict =
+				prActionStatus?.mergeable === "CONFLICTING" ||
+				(gitActionStatus?.conflictCount ?? 0) > 0;
+			if (hasConflict) return "resolve-conflicts";
+
+			// 2. Local uncommitted changes need pushing first
+			if ((gitActionStatus?.uncommittedCount ?? 0) > 0) {
+				return "commit-and-push";
+			}
+
+			// 3. Any failing CI check → show Fix CI
+			const hasFailingCheck = prActionStatus?.checks?.some(
+				(c) => c.status === "failure",
+			);
+			if (hasFailingCheck) return "fix";
+
+			// 4. Ready to merge
+			return "merge";
+		}
+
+		// PR closed (not merged) → offer to reopen
+		if (prInfo.state === "CLOSED") return "open-pr";
 	}
+
 	return "create-pr";
 }
 
 /**
- * Derive the commit button's visible state from the lifecycle.
+ * Derive the commit button's visible state from the lifecycle + action
+ * status. Returns `"disabled"` while GitHub is still computing the
+ * mergeable status so the user can't click Merge prematurely.
  */
 export function deriveCommitButtonState(
 	lifecycle: CommitLifecycle,
+	prActionStatus?: WorkspacePrActionStatus | null,
 ): CommitButtonState {
-	if (!lifecycle) return "idle";
+	if (!lifecycle) {
+		// GitHub is still computing mergeable — disable the button
+		if (prActionStatus?.mergeable === "UNKNOWN") return "disabled";
+		return "idle";
+	}
 	switch (lifecycle.phase) {
 		case "creating":
 		case "streaming":


### PR DESCRIPTION
## Summary

Rolls up several features, fixes, and refactors made across the frontend, Rust backend, and sidecar since the last merge to `main`.

### Features
- **Commit button v2** — shows conflict, uncommitted-changes, and CI-failure states with contextual actions (`commit-button-logic.ts`, 234+ new test lines)
- **Keyboard shortcuts** — `Cmd+R` triggers the run script from anywhere; `Cmd+Shift+C` copies the active workspace path
- **Delete repository with cascade** — backend support for repo deletion including sessions/messages/workspaces (`repos.rs`, `schema.rs`, `repository_commands.rs`)
- **Run script** — `helmor.json` gains a `run` script; inspector shows a Run section
- **HelmorThinkingIndicator** — shared spinner component replaces ad-hoc inline spinners

### Fixes
- Scoped commit lifecycle to the active workspace (was leaking across workspaces)
- Relative timestamps in system messages for better readability
- System message footer reordered; dot separator visibility improved
- `tsconfig` lib bumped to ES2022 to resolve `Array.at()` type error
- Flaky test suite stabilized (mock timers, setup file)

### Refactors & Chores
- Sidebar group spacing tightened for denser navigation
- `cursor-pointer` enforced on all interactive UI elements (button, command, context-menu, dropdown, sidebar)
- Workspace name pool expanded to 120 celestial names
- Error handling and logging improvements across sidecar + backend (`claude-session-manager.ts`, `sidecar.rs`, `shell_env.rs`)
- Pending-snap markers updated

## Changed files

46 files changed, **+1 221 / −275**

## Test plan

- [x] `pnpm run test` — all three suites (frontend / sidecar / Rust) should pass
- [ ] Manual: open app → verify commit button shows correct state for clean / dirty / conflicted repos
- [ ] Manual: `Cmd+R` triggers run script; `Cmd+Shift+C` copies workspace path to clipboard
- [ ] Manual: delete a repository from settings → confirm cascade removes sessions & workspaces
- [ ] Manual: system messages show relative timestamps ("2 min ago") instead of absolute