### PR TITLE
fix: remove opacity transition from workspace hover actions

### DIFF
--- a/src/features/navigation/index.test.tsx
+++ b/src/features/navigation/index.test.tsx
@@ -255,4 +255,24 @@ describe("WorkspacesSidebar", () => {
 			within(otherRow).getByLabelText("Interaction required"),
 		).toBeInTheDocument();
 	});
+
+	it("shows workspace hover actions without an opacity transition", () => {
+		render(
+			<TooltipProvider delayDuration={0}>
+				<WorkspacesSidebar
+					groups={workspaceGroups}
+					archivedRows={[]}
+					onArchiveWorkspace={vi.fn()}
+				/>
+			</TooltipProvider>,
+		);
+
+		const actionButton = screen.getByRole("button", {
+			name: "Archive workspace",
+		});
+		const actionOverlay = actionButton.parentElement?.parentElement;
+
+		expect(actionOverlay).not.toBeNull();
+		expect(actionOverlay).not.toHaveClass("transition-opacity");
+	});
 });

--- a/src/features/navigation/row-item.tsx
+++ b/src/features/navigation/row-item.tsx
@@ -215,7 +215,7 @@ export const WorkspaceRowItem = memo(
 				{hasActionHandler ? (
 					<span
 						className={cn(
-							"pointer-events-none absolute inset-y-0 right-0 z-10 flex items-center justify-end opacity-0 transition-opacity duration-150 group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100",
+							"pointer-events-none absolute inset-y-0 right-0 z-10 flex items-center justify-end opacity-0 group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100",
 							actionOverlayWidthClassName,
 							isBusy && "pointer-events-auto opacity-100",
 						)}


### PR DESCRIPTION
## Summary

- Removed `transition-opacity duration-150` from the sidebar workspace-row action overlay in `row-item.tsx`
- The CSS transition caused a visible flicker / delayed appearance when hovering workspace rows; actions now appear instantly
- Added a regression test asserting the overlay never carries the `transition-opacity` class

## Why

The 150 ms opacity fade on hover actions felt sluggish and produced a noticeable flicker in the Tauri webview. Removing the transition makes the interaction feel instant and eliminates the visual artifact.

## Test plan

- [x] New unit test: `shows workspace hover actions without an opacity transition`
- [ ] Manual: hover workspace rows in sidebar — actions should appear immediately with no fade
- [ ] `pnpm run test:frontend` passes