### PR TITLE
refactor: polish code block UI and move file icon into diff trigger

### DIFF
--- a/src/components/ai/code-block.tsx
+++ b/src/components/ai/code-block.tsx
@@ -140,6 +140,15 @@ export const CodeBlock = ({
 		};
 	}, [code, resolvedLanguage, showLineNumbers]);
 
+	const codePadding = isPlain
+		? "[&>pre]:p-3.5"
+		: "[&>pre]:px-3.5 [&>pre]:pb-3.5 [&>pre]:pt-1";
+	const wrapClasses = wrapLines
+		? "overflow-x-hidden overflow-y-hidden [&>pre]:whitespace-pre-wrap [&>pre]:break-words [&_code]:whitespace-pre-wrap [&_code]:break-words"
+		: "overflow-x-auto overflow-y-hidden [&>pre]:min-w-full";
+	const codeBase =
+		"[&>pre]:m-0 [&>pre]:bg-transparent! [&>pre]:text-[12px] [&>pre]:leading-5 [&>pre]:text-foreground! [&_code]:font-mono [&_code]:text-[12px]";
+
 	return (
 		<CodeBlockContext.Provider value={{ code }}>
 			<div
@@ -152,29 +161,30 @@ export const CodeBlock = ({
 				{...props}
 			>
 				{isPlain ? null : (
-					<div className="flex items-center justify-between gap-2 border-b border-border/60 px-3 py-2">
-						<span className="truncate font-mono text-[10.5px] tracking-wide text-muted-foreground uppercase">
-							{language || "code"}
-						</span>
-						<div className="flex items-center gap-1">{children}</div>
+					<div className="flex items-center justify-between gap-2 px-3 pt-1.5">
+						{language ? (
+							<span className="truncate font-mono text-[10px] leading-none tracking-wide text-muted-foreground/50 uppercase select-none">
+								{language}
+							</span>
+						) : (
+							<span />
+						)}
+						<div className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+							{children}
+						</div>
 					</div>
 				)}
 				<div className="relative">
 					<div
-						className={cn(
-							"px-0 py-0 dark:hidden [&>pre]:m-0 [&>pre]:bg-transparent! [&>pre]:p-3.5 [&>pre]:text-[12px] [&>pre]:leading-5 [&>pre]:text-foreground! [&_code]:font-mono [&_code]:text-[12px]",
-							wrapLines
-								? "overflow-x-hidden overflow-y-hidden [&>pre]:whitespace-pre-wrap [&>pre]:break-words [&_code]:whitespace-pre-wrap [&_code]:break-words"
-								: "overflow-x-auto overflow-y-hidden [&>pre]:min-w-full",
-						)}
+						className={cn(codeBase, codePadding, wrapClasses, "dark:hidden")}
 						dangerouslySetInnerHTML={{ __html: lightHtml }}
 					/>
 					<div
 						className={cn(
-							"hidden px-0 py-0 dark:block [&>pre]:m-0 [&>pre]:bg-transparent! [&>pre]:p-3.5 [&>pre]:text-[12px] [&>pre]:leading-5 [&>pre]:text-foreground! [&_code]:font-mono [&_code]:text-[12px]",
-							wrapLines
-								? "overflow-x-hidden overflow-y-hidden [&>pre]:whitespace-pre-wrap [&>pre]:break-words [&_code]:whitespace-pre-wrap [&_code]:break-words"
-								: "overflow-x-auto overflow-y-hidden [&>pre]:min-w-full",
+							codeBase,
+							codePadding,
+							wrapClasses,
+							"hidden dark:block",
 						)}
 						dangerouslySetInnerHTML={{ __html: darkHtml }}
 					/>
@@ -212,7 +222,7 @@ export const CodeBlockCopyButton = ({
 	return (
 		<Button
 			className={cn(
-				"h-7 w-7 rounded-md border border-border/60 bg-background/70 text-muted-foreground hover:bg-accent/60 hover:text-foreground",
+				"h-6 w-6 rounded-md text-muted-foreground/50 hover:bg-accent/60 hover:text-foreground",
 				className,
 			)}
 			onClick={() => {

--- a/src/features/panel/message-components/edit-diff.tsx
+++ b/src/features/panel/message-components/edit-diff.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { type ReactNode, useCallback, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { Separator } from "@/components/ui/separator";
 
@@ -8,12 +8,14 @@ export function EditDiffTrigger({
 	diffDel,
 	oldStr,
 	newStr,
+	icon,
 }: {
 	file: string;
 	diffAdd?: number;
 	diffDel?: number;
 	oldStr: string | null;
 	newStr: string | null;
+	icon?: ReactNode;
 }) {
 	const triggerRef = useRef<HTMLSpanElement>(null);
 	const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -41,6 +43,7 @@ export function EditDiffTrigger({
 				onMouseLeave={hideDelayed}
 				className="inline-flex cursor-default items-center gap-1.5 rounded border border-border/60 px-1.5 py-0.5 transition-colors hover:border-muted-foreground/40 hover:bg-accent/40"
 			>
+				{icon}
 				<span className="truncate text-muted-foreground">{file}</span>
 				{diffAdd != null || diffDel != null ? (
 					<span className="flex items-center gap-1 text-[11px]">

--- a/src/features/panel/message-components/tool-call.tsx
+++ b/src/features/panel/message-components/tool-call.tsx
@@ -126,24 +126,31 @@ export const AssistantToolCall = memo(function AssistantToolCall({
 				{info.action}
 			</span>
 			{info.file ? (
-				<>
-					<img
-						src={getMaterialFileIcon(info.file)}
-						alt=""
-						className="size-4 shrink-0"
+				hasDiff ? (
+					<EditDiffTrigger
+						file={info.file}
+						diffAdd={info.diffAdd}
+						diffDel={info.diffDel}
+						oldStr={oldStr}
+						newStr={newStr}
+						icon={
+							<img
+								src={getMaterialFileIcon(info.file)}
+								alt=""
+								className="size-4 shrink-0"
+							/>
+						}
 					/>
-					{hasDiff ? (
-						<EditDiffTrigger
-							file={info.file}
-							diffAdd={info.diffAdd}
-							diffDel={info.diffDel}
-							oldStr={oldStr}
-							newStr={newStr}
+				) : (
+					<>
+						<img
+							src={getMaterialFileIcon(info.file)}
+							alt=""
+							className="size-4 shrink-0"
 						/>
-					) : (
 						<span className="truncate text-muted-foreground">{info.file}</span>
-					)}
-				</>
+					</>
+				)
 			) : null}
 			{!hasDiff && (info.diffAdd != null || info.diffDel != null) ? (
 				<span className="flex items-center gap-1 text-[11px]">


### PR DESCRIPTION
## Summary

- **Code block styling cleanup**: extracted repeated Tailwind class strings (`codeBase`, `codePadding`, `wrapClasses`) into variables to eliminate duplication between the light/dark theme containers.
- **Header redesign**: removed the bottom border from the code block header, made the language label subtler (`text-muted-foreground/50`, smaller font), and added hover-reveal for action buttons (copy, etc.).
- **Smaller copy button**: reduced from `h-7 w-7` to `h-6 w-6`, lighter default color.
- **File icon inside diff trigger**: added an `icon` prop to `EditDiffTrigger` so the tool-call component can nest the material file icon *inside* the badge instead of rendering it separately. This keeps the icon visually grouped with the filename when hovering a diff.

## Why

The code block header felt heavy — the border and always-visible action buttons added visual noise during streaming. Extracting the duplicated class strings also makes future style tweaks single-point changes. Moving the file icon into the diff trigger badge improves visual cohesion in tool-call messages.

## Test plan

- [ ] Verify code blocks render correctly in both light and dark mode
- [ ] Confirm action buttons (copy) appear on hover and hide otherwise
- [ ] Check tool-call messages with file edits show the file icon inside the diff badge
- [ ] Confirm tool-call messages without diffs still show the file icon normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)