### PR TITLE
perf: speed up Rust dev builds with sccache and profile tuning

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"dev:cli": "cd src-tauri && cargo run --bin helmor-cli --",
 		"dev:cli:build": "cd src-tauri && cargo build --bin helmor-cli",
 		"dev:cli:install": "cd src-tauri && cargo build --bin helmor-cli && cp target/debug/helmor-cli /usr/local/bin/helmor && cp ../sidecar/dist/helmor-sidecar /usr/local/bin/helmor-sidecar && echo 'Installed helmor + helmor-sidecar to /usr/local/bin/'",
-		"postinstall": "cd sidecar && bun install",
+		"postinstall": "cd sidecar && bun install && node -e \"const{execSync}=require('child_process');try{execSync('sccache --version',{stdio:'pipe'})}catch{console.error('\\n\\x1b[33m⚠  sccache is not installed.\\x1b[0m Rust builds will be slower without cross-worktree compilation cache.\\n\\n  Install it:\\n\\n    brew install sccache\\n');process.exit(1)}\"",
 		"prepare": "husky"
 	},
 	"dependencies": {

--- a/src-tauri/.cargo/config.toml
+++ b/src-tauri/.cargo/config.toml
@@ -1,0 +1,5 @@
+[build]
+rustc-wrapper = "sccache"
+
+[target.aarch64-apple-darwin]
+rustflags = ["-C", "link-arg=-Wl,-no_deduplicate"]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -61,3 +61,25 @@ path = "src/bin/gen_pipeline_fixture.rs"
 [dev-dependencies]
 insta = { version = "1", features = ["yaml", "glob"] }
 tempfile = "3"
+
+# ---------------------------------------------------------------------------
+# Dev profile: optimised for fastest compilation, not runtime performance.
+# sccache is the cross-worktree cache; incremental is disabled because the
+# two are mutually exclusive.
+# ---------------------------------------------------------------------------
+[profile.dev]
+debug = "line-tables-only"   # keep backtraces, skip 80% of debug info
+split-debuginfo = "unpacked" # skip dsymutil merge (macOS default, explicit)
+opt-level = 0
+codegen-units = 256          # max intra-crate parallelism
+incremental = false          # required for sccache compatibility
+
+[profile.dev.package."*"]
+debug = false                # deps don't need debug info at all
+opt-level = 0
+codegen-units = 256
+
+[profile.dev.build-override]
+debug = false                # build scripts & proc-macros: fastest possible
+opt-level = 0
+codegen-units = 256

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -10,7 +10,12 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
     for env_path in candidate_env_paths() {
-        println!("cargo:rerun-if-changed={}", env_path.display());
+        // Only watch files that exist. Watching a missing file makes Cargo
+        // treat the fingerprint as permanently stale, which forces a full
+        // recompile of the crate on every single `cargo build` invocation.
+        if env_path.exists() {
+            println!("cargo:rerun-if-changed={}", env_path.display());
+        }
         load_env_var(&env_path, GITHUB_CLIENT_ID_KEY);
         load_env_var(&env_path, GITHUB_CLIENT_SECRET_KEY);
     }


### PR DESCRIPTION
## Summary

- **sccache integration**: Add `.cargo/config.toml` to enable `sccache` as `rustc-wrapper`, giving cross-worktree compilation caching so parallel Claude Code agents (each in their own git worktree) share cached artifacts.
- **Dev profile tuning** (`Cargo.toml`): `debug = "line-tables-only"`, `codegen-units = 256`, `incremental = false` (required for sccache), and stripped debug info for dependencies — optimises for compile speed over runtime perf.
- **Linker flag**: Skip `ld -no_deduplicate` on aarch64-apple-darwin for faster linking.
- **build.rs fix**: Only emit `cargo:rerun-if-changed` for env files that actually exist. Watching a missing file made Cargo treat the fingerprint as permanently stale, forcing a full recompile on every invocation.
- **postinstall check**: Warn (and fail) if `sccache` is not installed, so contributors know to `brew install sccache`.

## Why

Rust dev builds in Helmor take a long time, especially when multiple worktree-based agents compile concurrently. `sccache` provides a shared on-disk cache that eliminates redundant compilation across worktrees. The profile tweaks further reduce wall-clock time by trading debug fidelity and runtime performance for faster `rustc` invocations.

## Test plan

- [x] `pnpm install` on a machine **without** sccache → prints warning and exits 1
- [x] `pnpm install` on a machine **with** sccache → succeeds silently
- [x] `pnpm run dev` compiles successfully with the new profile settings
- [x] `cargo test` passes in `src-tauri/`
- [ ] Verify cache hits: run `sccache -s` before and after a rebuild to confirm hit rate