### PR TITLE
feat: pull-from-target-branch sync in inspector actions

### DIFF
--- a/src-tauri/src/commands/editor_commands.rs
+++ b/src-tauri/src/commands/editor_commands.rs
@@ -81,7 +81,12 @@ pub async fn get_workspace_git_action_status(
             .with_context(|| format!("Workspace not found: {workspace_id}"))?;
         let workspace_dir =
             crate::data_dir::workspace_dir(&record.repo_name, &record.directory_name)?;
-        git_ops::workspace_action_status(&workspace_dir)
+        let remote = record.remote.as_deref();
+        let target_branch = record
+            .intended_target_branch
+            .as_deref()
+            .or(record.default_branch.as_deref());
+        git_ops::workspace_action_status(&workspace_dir, remote, target_branch)
     })
     .await
 }

--- a/src-tauri/src/commands/tests/branch_switch.rs
+++ b/src-tauri/src/commands/tests/branch_switch.rs
@@ -290,3 +290,64 @@ fn prefetch_remote_refs_rate_limit() {
     let third = workspaces::prefetch_remote_refs(Some(&harness.workspace_id), None).unwrap();
     assert!(third.fetched, "rate limiter should re-enable after reset");
 }
+
+#[test]
+fn sync_workspace_target_branch_reports_already_up_to_date() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let harness = BranchSwitchTestHarness::new();
+
+    let result = workspaces::sync_workspace_with_target_branch(&harness.workspace_id).unwrap();
+
+    assert_eq!(
+        result.outcome,
+        workspaces::SyncWorkspaceTargetOutcome::AlreadyUpToDate
+    );
+    assert_eq!(result.target_branch, "main");
+}
+
+#[test]
+fn sync_workspace_target_branch_merges_latest_target() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let harness = BranchSwitchTestHarness::new();
+    harness.commit_in_workspace("feature.txt", "local work", "local commit");
+    harness.upstream_advance("main", "main2.txt", "fresh", "advance main");
+
+    let result = workspaces::sync_workspace_with_target_branch(&harness.workspace_id).unwrap();
+
+    assert_eq!(
+        result.outcome,
+        workspaces::SyncWorkspaceTargetOutcome::Updated
+    );
+    let merged_main = fs::read_to_string(harness.workspace_dir().join("main2.txt")).unwrap();
+    let merged_feature = fs::read_to_string(harness.workspace_dir().join("feature.txt")).unwrap();
+    assert_eq!(merged_main, "fresh");
+    assert_eq!(merged_feature, "local work");
+}
+
+#[test]
+fn sync_workspace_target_branch_reports_conflict() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let harness = BranchSwitchTestHarness::new();
+    harness.commit_in_workspace("README.md", "workspace change", "workspace change");
+    harness.upstream_advance("main", "README.md", "upstream change", "advance readme");
+
+    let result = workspaces::sync_workspace_with_target_branch(&harness.workspace_id).unwrap();
+
+    assert_eq!(
+        result.outcome,
+        workspaces::SyncWorkspaceTargetOutcome::Conflict
+    );
+    let status =
+        git_ops::workspace_action_status(&harness.workspace_dir(), Some("origin"), Some("main"))
+            .unwrap();
+    assert!(
+        status.conflict_count > 0,
+        "merge conflict should remain visible"
+    );
+}

--- a/src-tauri/src/commands/workspace_commands.rs
+++ b/src-tauri/src/commands/workspace_commands.rs
@@ -132,6 +132,15 @@ pub async fn prefetch_remote_refs(
 }
 
 #[tauri::command]
+pub async fn sync_workspace_with_target_branch(
+    workspace_id: String,
+) -> CmdResult<workspaces::SyncWorkspaceTargetResponse> {
+    let ws_lock = db::workspace_mutation_lock(&workspace_id);
+    let _lock = ws_lock.lock().await;
+    run_blocking(move || workspaces::sync_workspace_with_target_branch(&workspace_id)).await
+}
+
+#[tauri::command]
 pub async fn restore_workspace(
     app: AppHandle,
     workspace_id: String,

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -15,6 +15,17 @@ use std::{
 pub struct WorkspaceGitActionStatus {
     pub uncommitted_count: usize,
     pub conflict_count: usize,
+    pub sync_target_branch: Option<String>,
+    pub sync_status: WorkspaceSyncStatus,
+    pub behind_target_count: u32,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum WorkspaceSyncStatus {
+    UpToDate,
+    Behind,
+    Unknown,
 }
 
 /// Hard upper bound on any `git` command that touches the network. Long
@@ -582,7 +593,11 @@ pub fn working_tree_clean(workspace_dir: &Path) -> Result<bool> {
 /// This is intentionally local-only: it never fetches or contacts a remote, so
 /// the Actions panel can poll it frequently without hanging on credentials or
 /// network.
-pub fn workspace_action_status(workspace_dir: &Path) -> Result<WorkspaceGitActionStatus> {
+pub fn workspace_action_status(
+    workspace_dir: &Path,
+    remote: Option<&str>,
+    target_branch: Option<&str>,
+) -> Result<WorkspaceGitActionStatus> {
     let workspace_dir_arg = workspace_dir.display().to_string();
     let status_output = run_git(
         [
@@ -606,11 +621,48 @@ pub fn workspace_action_status(workspace_dir: &Path) -> Result<WorkspaceGitActio
     let conflict_output =
         run_git(["-C", workspace_dir_arg.as_str(), "ls-files", "-u"], None).unwrap_or_default();
     let conflict_count = parse_unmerged_paths(&conflict_output).len();
+    let sync_target_branch = target_branch
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned);
+    let (sync_status, behind_target_count) =
+        workspace_sync_status(workspace_dir, remote, sync_target_branch.as_deref());
 
     Ok(WorkspaceGitActionStatus {
         uncommitted_count,
         conflict_count,
+        sync_target_branch,
+        sync_status,
+        behind_target_count,
     })
+}
+
+fn workspace_sync_status(
+    workspace_dir: &Path,
+    remote: Option<&str>,
+    target_branch: Option<&str>,
+) -> (WorkspaceSyncStatus, u32) {
+    let Some(remote) = remote.map(str::trim).filter(|value| !value.is_empty()) else {
+        return (WorkspaceSyncStatus::Unknown, 0);
+    };
+    let Some(target_branch) = target_branch
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return (WorkspaceSyncStatus::Unknown, 0);
+    };
+
+    let target_ref = format!("refs/remotes/{remote}/{target_branch}");
+    let exists = verify_remote_ref_exists(workspace_dir, remote, target_branch).unwrap_or(false);
+    if !exists {
+        return (WorkspaceSyncStatus::Unknown, 0);
+    }
+
+    match commits_behind(workspace_dir, &target_ref) {
+        Ok(count) if count > 0 => (WorkspaceSyncStatus::Behind, count),
+        Ok(_) => (WorkspaceSyncStatus::UpToDate, 0),
+        Err(_) => (WorkspaceSyncStatus::Unknown, 0),
+    }
 }
 
 /// Counts how many commits are reachable from HEAD but not from `base_ref`.
@@ -632,6 +684,34 @@ pub fn commits_ahead_of(workspace_dir: &Path, base_ref: &str) -> Result<u32> {
     .with_context(|| {
         format!(
             "Failed to count commits ahead of {} in {}",
+            base_ref, workspace_dir
+        )
+    })?;
+
+    output
+        .trim()
+        .parse::<u32>()
+        .with_context(|| format!("Unexpected rev-list count output: {}", output))
+}
+
+/// Counts how many commits are reachable from `base_ref` but not from HEAD.
+/// Returns 0 if HEAD already contains everything in `base_ref`.
+pub fn commits_behind(workspace_dir: &Path, base_ref: &str) -> Result<u32> {
+    let workspace_dir = workspace_dir.display().to_string();
+    let range = format!("HEAD..{base_ref}");
+    let output = run_git(
+        [
+            "-C",
+            workspace_dir.as_str(),
+            "rev-list",
+            "--count",
+            range.as_str(),
+        ],
+        None,
+    )
+    .with_context(|| {
+        format!(
+            "Failed to count commits behind {} in {}",
             base_ref, workspace_dir
         )
     })?;
@@ -734,6 +814,22 @@ pub fn remote_ref_sha(workspace_dir: &Path, remote: &str, branch: &str) -> Resul
     Ok(sha.trim().to_string())
 }
 
+pub fn merge_ref_no_edit(workspace_dir: &Path, target_ref: &str) -> Result<()> {
+    let workspace_dir = workspace_dir.display().to_string();
+    run_git(
+        [
+            "-C",
+            workspace_dir.as_str(),
+            "merge",
+            "--no-edit",
+            target_ref,
+        ],
+        None,
+    )
+    .map(|_| ())
+    .with_context(|| format!("Failed to merge {target_ref} into {workspace_dir}"))
+}
+
 /// Hard-reset the currently checked-out branch in the workspace to `target_ref`.
 /// Caller is responsible for ensuring this is safe (clean tree, no user commits).
 pub fn reset_current_branch_hard(workspace_dir: &Path, target_ref: &str) -> Result<()> {
@@ -767,6 +863,7 @@ mod tests {
         run(dir.path(), &["checkout", "-b", "main"]);
         run(dir.path(), &["config", "user.email", "helmor@example.com"]);
         run(dir.path(), &["config", "user.name", "Helmor Test"]);
+        run(dir.path(), &["config", "commit.gpgsign", "false"]);
         std::fs::write(dir.path().join("file.txt"), "base\n").unwrap();
         run(dir.path(), &["add", "file.txt"]);
         run(dir.path(), &["commit", "-m", "initial"]);
@@ -777,10 +874,12 @@ mod tests {
     fn workspace_action_status_reports_clean_repo() {
         let dir = init_repo();
 
-        let status = workspace_action_status(dir.path()).unwrap();
+        let status = workspace_action_status(dir.path(), None, None).unwrap();
 
         assert_eq!(status.uncommitted_count, 0);
         assert_eq!(status.conflict_count, 0);
+        assert_eq!(status.sync_status, WorkspaceSyncStatus::Unknown);
+        assert_eq!(status.behind_target_count, 0);
     }
 
     #[test]
@@ -789,7 +888,7 @@ mod tests {
         std::fs::write(dir.path().join("file.txt"), "changed\n").unwrap();
         std::fs::write(dir.path().join("new.txt"), "new\n").unwrap();
 
-        let status = workspace_action_status(dir.path()).unwrap();
+        let status = workspace_action_status(dir.path(), None, None).unwrap();
 
         assert_eq!(status.uncommitted_count, 2);
         assert_eq!(status.conflict_count, 0);
@@ -809,10 +908,37 @@ mod tests {
         let merge_result = run_git(["merge", "main"], Some(dir.path()));
         assert!(merge_result.is_err(), "merge should conflict");
 
-        let status = workspace_action_status(dir.path()).unwrap();
+        let status = workspace_action_status(dir.path(), None, None).unwrap();
 
         assert_eq!(status.conflict_count, 1);
         assert!(status.uncommitted_count >= 1);
+    }
+
+    #[test]
+    fn workspace_action_status_reports_behind_target_branch() {
+        let (origin, clone) = init_repo_with_remote();
+        run(origin.path(), &["checkout", "main"]);
+        std::fs::write(origin.path().join("remote.txt"), "fresh\n").unwrap();
+        run(origin.path(), &["add", "remote.txt"]);
+        run(origin.path(), &["commit", "-m", "advance main"]);
+        fetch_remote_branch(clone.path(), "origin", "main").unwrap();
+
+        let status = workspace_action_status(clone.path(), Some("origin"), Some("main")).unwrap();
+
+        assert_eq!(status.sync_target_branch.as_deref(), Some("main"));
+        assert_eq!(status.sync_status, WorkspaceSyncStatus::Behind);
+        assert_eq!(status.behind_target_count, 1);
+    }
+
+    #[test]
+    fn workspace_action_status_reports_up_to_date_target_branch() {
+        let (_origin, clone) = init_repo_with_remote();
+
+        let status = workspace_action_status(clone.path(), Some("origin"), Some("main")).unwrap();
+
+        assert_eq!(status.sync_target_branch.as_deref(), Some("main"));
+        assert_eq!(status.sync_status, WorkspaceSyncStatus::UpToDate);
+        assert_eq!(status.behind_target_count, 0);
     }
 
     /// Clone a repo so we have a real `origin` remote with tracking refs.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -241,6 +241,7 @@ pub fn run() {
             commands::workspace_commands::rename_workspace_branch,
             commands::workspace_commands::update_intended_target_branch,
             commands::workspace_commands::prefetch_remote_refs,
+            commands::workspace_commands::sync_workspace_with_target_branch,
             commands::workspace_commands::mark_workspace_read,
             commands::workspace_commands::mark_workspace_unread,
             commands::workspace_commands::pin_workspace,

--- a/src-tauri/src/workspace/branching.rs
+++ b/src-tauri/src/workspace/branching.rs
@@ -310,6 +310,21 @@ pub struct PrefetchRemoteRefsResponse {
     pub fetched: bool,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum SyncWorkspaceTargetOutcome {
+    Updated,
+    AlreadyUpToDate,
+    Conflict,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncWorkspaceTargetResponse {
+    pub outcome: SyncWorkspaceTargetOutcome,
+    pub target_branch: String,
+}
+
 pub fn prefetch_remote_refs(
     workspace_id: Option<&str>,
     repo_id: Option<&str>,
@@ -351,6 +366,79 @@ pub fn prefetch_remote_refs(
     }
 
     Ok(PrefetchRemoteRefsResponse { fetched: true })
+}
+
+pub fn sync_workspace_with_target_branch(
+    workspace_id: &str,
+) -> Result<SyncWorkspaceTargetResponse> {
+    let record = workspace_models::load_workspace_record_by_id(workspace_id)?
+        .with_context(|| format!("Workspace not found: {workspace_id}"))?;
+    if record.state != "ready" {
+        bail!("Cannot sync target branch: workspace is not in ready state");
+    }
+
+    let target_branch = record
+        .intended_target_branch
+        .clone()
+        .or(record.default_branch.clone())
+        .unwrap_or_else(|| "main".to_string());
+    let remote = record
+        .remote
+        .clone()
+        .unwrap_or_else(|| "origin".to_string());
+    let workspace_dir = crate::data_dir::workspace_dir(&record.repo_name, &record.directory_name)?;
+    if !workspace_dir.is_dir() {
+        bail!("Workspace directory is missing for {workspace_id}");
+    }
+
+    let current_status =
+        git_ops::workspace_action_status(&workspace_dir, Some(&remote), Some(&target_branch))?;
+    if current_status.conflict_count > 0 {
+        return Ok(SyncWorkspaceTargetResponse {
+            outcome: SyncWorkspaceTargetOutcome::Conflict,
+            target_branch,
+        });
+    }
+    if current_status.uncommitted_count > 0 {
+        bail!("Cannot pull updates while the workspace has uncommitted changes");
+    }
+
+    git_ops::fetch_remote_branch(&workspace_dir, &remote, &target_branch)?;
+    let behind_count = git_ops::commits_behind(
+        &workspace_dir,
+        &format!("refs/remotes/{remote}/{target_branch}"),
+    )?;
+    if behind_count == 0 {
+        return Ok(SyncWorkspaceTargetResponse {
+            outcome: SyncWorkspaceTargetOutcome::AlreadyUpToDate,
+            target_branch,
+        });
+    }
+
+    match git_ops::merge_ref_no_edit(
+        &workspace_dir,
+        &format!("refs/remotes/{remote}/{target_branch}"),
+    ) {
+        Ok(()) => Ok(SyncWorkspaceTargetResponse {
+            outcome: SyncWorkspaceTargetOutcome::Updated,
+            target_branch,
+        }),
+        Err(error) => {
+            let merge_status = git_ops::workspace_action_status(
+                &workspace_dir,
+                Some(&remote),
+                Some(&target_branch),
+            )?;
+            if merge_status.conflict_count > 0 {
+                Ok(SyncWorkspaceTargetResponse {
+                    outcome: SyncWorkspaceTargetOutcome::Conflict,
+                    target_branch,
+                })
+            } else {
+                Err(error)
+            }
+        }
+    }
 }
 
 pub(crate) fn clear_prefetch_rate_limit(workspace_id: &str) {

--- a/src-tauri/src/workspace/workspaces.rs
+++ b/src-tauri/src/workspace/workspaces.rs
@@ -9,9 +9,10 @@ use crate::{
 
 pub use super::branching::{
     _reset_prefetch_rate_limit, list_remote_branches, prefetch_remote_refs,
-    refresh_remote_and_realign, rename_workspace_branch, update_intended_target_branch,
-    update_intended_target_branch_local, PrefetchRemoteRefsResponse,
-    UpdateIntendedTargetBranchInternal, UpdateIntendedTargetBranchResponse,
+    refresh_remote_and_realign, rename_workspace_branch, sync_workspace_with_target_branch,
+    update_intended_target_branch, update_intended_target_branch_local, PrefetchRemoteRefsResponse,
+    SyncWorkspaceTargetOutcome, SyncWorkspaceTargetResponse, UpdateIntendedTargetBranchInternal,
+    UpdateIntendedTargetBranchResponse,
 };
 pub use super::lifecycle::{
     archive_workspace_impl, create_workspace_from_repo_impl, restore_workspace_impl,

--- a/src/features/inspector/index.test.tsx
+++ b/src/features/inspector/index.test.tsx
@@ -15,6 +15,7 @@ const apiMocks = vi.hoisted(() => ({
 	getWorkspacePrCheckInsertText: vi.fn(),
 	loadWorkspaceGitActionStatus: vi.fn(),
 	loadWorkspacePrActionStatus: vi.fn(),
+	syncWorkspaceWithTargetBranch: vi.fn(),
 }));
 
 const openerMocks = vi.hoisted(() => ({
@@ -34,11 +35,18 @@ vi.mock("@/lib/api", async (importOriginal) => {
 		listWorkspaceChangesWithContent: apiMocks.listWorkspaceChangesWithContent,
 		loadWorkspaceGitActionStatus: apiMocks.loadWorkspaceGitActionStatus,
 		loadWorkspacePrActionStatus: apiMocks.loadWorkspacePrActionStatus,
+		syncWorkspaceWithTargetBranch: apiMocks.syncWorkspaceWithTargetBranch,
 	};
 });
 
 function cleanGitStatus(): WorkspaceGitActionStatus {
-	return { uncommittedCount: 0, conflictCount: 0 };
+	return {
+		uncommittedCount: 0,
+		conflictCount: 0,
+		syncTargetBranch: "main",
+		syncStatus: "upToDate",
+		behindTargetCount: 0,
+	};
 }
 
 function emptyPrStatus(
@@ -78,6 +86,7 @@ describe("WorkspaceInspectorSidebar Actions section", () => {
 		apiMocks.getWorkspacePrCheckInsertText.mockReset();
 		apiMocks.loadWorkspaceGitActionStatus.mockReset();
 		apiMocks.loadWorkspacePrActionStatus.mockReset();
+		apiMocks.syncWorkspaceWithTargetBranch.mockReset();
 		openerMocks.openUrl.mockReset();
 
 		apiMocks.listWorkspaceChangesWithContent.mockResolvedValue({
@@ -89,6 +98,10 @@ describe("WorkspaceInspectorSidebar Actions section", () => {
 		);
 		apiMocks.loadWorkspaceGitActionStatus.mockResolvedValue(cleanGitStatus());
 		apiMocks.loadWorkspacePrActionStatus.mockResolvedValue(emptyPrStatus());
+		apiMocks.syncWorkspaceWithTargetBranch.mockResolvedValue({
+			outcome: "updated",
+			targetBranch: "main",
+		});
 	});
 
 	afterEach(() => {
@@ -112,10 +125,12 @@ describe("WorkspaceInspectorSidebar Actions section", () => {
 	it("shows clean git rows with passed status icons", async () => {
 		renderInspector();
 
-		await screen.findByText("No uncommitted changes");
+		await screen.findByText("No updates from main");
 
 		const actions = screen.getByLabelText("Inspector section Actions");
-		expect(within(actions).getByText("No merge conflicts")).toBeInTheDocument();
+		expect(
+			within(actions).getByText("No updates from main"),
+		).toBeInTheDocument();
 		expect(
 			within(actions).getByText("Waiting for PR review"),
 		).toBeInTheDocument();
@@ -128,6 +143,9 @@ describe("WorkspaceInspectorSidebar Actions section", () => {
 		apiMocks.loadWorkspaceGitActionStatus.mockResolvedValue({
 			uncommittedCount: 2,
 			conflictCount: 1,
+			syncTargetBranch: "main",
+			syncStatus: "behind",
+			behindTargetCount: 2,
 		});
 
 		renderInspector({ onCommitAction });
@@ -140,10 +158,52 @@ describe("WorkspaceInspectorSidebar Actions section", () => {
 		expect(onCommitAction).toHaveBeenCalledWith("resolve-conflicts");
 	});
 
+	it("shows pull when target branch is behind and triggers sync action", async () => {
+		const user = userEvent.setup();
+		apiMocks.loadWorkspaceGitActionStatus.mockResolvedValue({
+			uncommittedCount: 0,
+			conflictCount: 0,
+			syncTargetBranch: "main",
+			syncStatus: "behind",
+			behindTargetCount: 2,
+		});
+
+		renderInspector();
+
+		await screen.findByText("2 updates available from main");
+		await user.click(screen.getByRole("button", { name: "Pull" }));
+
+		await waitFor(() => {
+			expect(apiMocks.syncWorkspaceWithTargetBranch).toHaveBeenCalledWith(
+				"workspace-1",
+			);
+		});
+	});
+
+	it("hides pull when conflicts are present even if target is behind", async () => {
+		apiMocks.loadWorkspaceGitActionStatus.mockResolvedValue({
+			uncommittedCount: 0,
+			conflictCount: 1,
+			syncTargetBranch: "main",
+			syncStatus: "behind",
+			behindTargetCount: 3,
+		});
+
+		renderInspector();
+
+		await screen.findByText("Merge conflicts detected");
+		expect(
+			screen.queryByRole("button", { name: "Pull" }),
+		).not.toBeInTheDocument();
+	});
+
 	it("disables git row actions while the commit lifecycle is busy", async () => {
 		apiMocks.loadWorkspaceGitActionStatus.mockResolvedValue({
 			uncommittedCount: 1,
 			conflictCount: 0,
+			syncTargetBranch: "main",
+			syncStatus: "upToDate",
+			behindTargetCount: 0,
 		});
 
 		renderInspector({ commitButtonState: "busy" });

--- a/src/features/inspector/sections/actions.tsx
+++ b/src/features/inspector/sections/actions.tsx
@@ -1,8 +1,9 @@
 import { MarkGithubIcon } from "@primer/octicons-react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { ArrowUpRightIcon, CheckIcon, TriangleIcon } from "lucide-react";
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
 import {
 	AppendContextButton,
 	type AppendContextPayloadResult,
@@ -17,12 +18,14 @@ import {
 	type ActionStatusKind,
 	getWorkspacePrCheckInsertText,
 	type PullRequestInfo,
+	syncWorkspaceWithTargetBranch,
 	type WorkspaceGitActionStatus,
 	type WorkspacePrActionItem,
 	type WorkspacePrActionStatus,
 } from "@/lib/api";
 import { buildComposerPreviewPayload } from "@/lib/composer-insert";
 import {
+	helmorQueryKeys,
 	workspaceGitActionStatusQueryOptions,
 	workspacePrActionStatusQueryOptions,
 } from "@/lib/query-client";
@@ -37,13 +40,17 @@ interface GitStatusItem {
 	status: ActionStatusKind;
 	action?: {
 		label: string;
-		mode: WorkspaceCommitButtonMode;
+		kind: "commit" | "sync";
+		mode?: WorkspaceCommitButtonMode;
 	};
 }
 
 const EMPTY_GIT_ACTION_STATUS: WorkspaceGitActionStatus = {
 	uncommittedCount: 0,
 	conflictCount: 0,
+	syncTargetBranch: null,
+	syncStatus: "unknown",
+	behindTargetCount: 0,
 };
 
 const EMPTY_PR_ACTION_STATUS: WorkspacePrActionStatus = {
@@ -75,6 +82,8 @@ export function ActionsSection({
 	commitButtonState,
 	prInfo,
 }: ActionsSectionProps) {
+	const queryClient = useQueryClient();
+	const [syncPending, setSyncPending] = useState(false);
 	const gitStatusQuery = useQuery({
 		...workspaceGitActionStatusQueryOptions(workspaceId ?? "__none__"),
 		enabled: workspaceId !== null,
@@ -87,6 +96,50 @@ export function ActionsSection({
 	const prStatus = prStatusQuery.data ?? EMPTY_PR_ACTION_STATUS;
 	const gitRows = buildGitStatusRows(gitStatus, prStatus, prInfo);
 	const actionDisabled = commitButtonState === "busy";
+	const handleSync = useCallback(async () => {
+		if (!workspaceId || syncPending) {
+			return;
+		}
+
+		setSyncPending(true);
+		try {
+			const result = await syncWorkspaceWithTargetBranch(workspaceId);
+			const target = result.targetBranch;
+			if (result.outcome === "updated") {
+				toast.success(`Pulled latest from ${target}`);
+			} else if (result.outcome === "alreadyUpToDate") {
+				toast(`Already up to date with ${target}`);
+			} else {
+				toast.error(`Conflicts detected while pulling ${target}`);
+			}
+		} catch (error) {
+			const message =
+				error instanceof Error
+					? error.message
+					: "Unable to pull target updates.";
+			toast.error(message);
+		} finally {
+			await Promise.all([
+				queryClient.invalidateQueries({
+					queryKey: helmorQueryKeys.workspaceGitActionStatus(workspaceId),
+				}),
+				queryClient.invalidateQueries({
+					queryKey: helmorQueryKeys.workspacePr(workspaceId),
+				}),
+				queryClient.invalidateQueries({
+					queryKey: helmorQueryKeys.workspacePrActionStatus(workspaceId),
+				}),
+				queryClient.invalidateQueries({
+					queryKey: helmorQueryKeys.workspaceDetail(workspaceId),
+				}),
+				queryClient.invalidateQueries({
+					queryKey: helmorQueryKeys.workspaceGroups,
+				}),
+				queryClient.invalidateQueries({ queryKey: ["workspaceChanges"] }),
+			]);
+			setSyncPending(false);
+		}
+	}, [queryClient, syncPending, workspaceId]);
 	const handleInsertCheck = useCallback(
 		async (item: WorkspacePrActionItem) => {
 			if (!workspaceId) {
@@ -146,16 +199,27 @@ export function ActionsSection({
 							{action && (
 								<button
 									type="button"
-									disabled={actionDisabled}
 									onClick={() => {
-										if (actionDisabled) {
+										if (
+											(action.kind === "commit" && actionDisabled) ||
+											(action.kind === "sync" && syncPending)
+										) {
 											return;
 										}
-										void onCommitAction?.(action.mode);
+										if (action.kind === "sync") {
+											void handleSync();
+											return;
+										}
+										void onCommitAction?.(action.mode!);
 									}}
 									className="ml-auto shrink-0 cursor-pointer text-[10.5px] text-primary transition-colors hover:text-primary/80 disabled:cursor-not-allowed disabled:opacity-50"
+									disabled={
+										action.kind === "commit" ? actionDisabled : syncPending
+									}
 								>
-									{action.label}
+									{action.kind === "sync" && syncPending
+										? "Pulling..."
+										: action.label}
 								</button>
 							)}
 						</div>
@@ -263,6 +327,8 @@ function buildGitStatusRows(
 	const conflictCount = gitStatus.conflictCount;
 	const hasMergeConflict =
 		conflictCount > 0 || prStatus.mergeable === "CONFLICTING";
+	const syncTargetBranch =
+		gitStatus.syncTargetBranch?.trim() || "target branch";
 	const pr = prStatus.pr ?? prInfo;
 	const isMerged = pr?.isMerged ?? false;
 
@@ -280,6 +346,7 @@ function buildGitStatusRows(
 					status: "pending",
 					action: {
 						label: "Commit and push",
+						kind: "commit",
 						mode: "commit-and-push",
 					},
 				},
@@ -289,13 +356,31 @@ function buildGitStatusRows(
 					status: "failure",
 					action: {
 						label: "Resolve",
+						kind: "commit",
 						mode: "resolve-conflicts",
 					},
 				}
-			: {
-					label: "No merge conflicts",
-					status: "success",
-				},
+			: gitStatus.syncStatus === "behind"
+				? {
+						label:
+							gitStatus.behindTargetCount === 1
+								? `1 update available from ${syncTargetBranch}`
+								: `${gitStatus.behindTargetCount} updates available from ${syncTargetBranch}`,
+						status: "pending",
+						action: {
+							label: "Pull",
+							kind: "sync",
+						},
+					}
+				: gitStatus.syncStatus === "upToDate"
+					? {
+							label: `No updates from ${syncTargetBranch}`,
+							status: "success",
+						}
+					: {
+							label: "Sync status unavailable",
+							status: "pending",
+						},
 	];
 
 	if (isMerged || prStatus.reviewDecision === "APPROVED") {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1014,10 +1014,24 @@ export type PullRequestInfo = {
 
 export type ActionStatusKind = "success" | "pending" | "running" | "failure";
 export type ActionProvider = "github" | "vercel" | "unknown";
+export type WorkspaceGitSyncStatus = "upToDate" | "behind" | "unknown";
 
 export type WorkspaceGitActionStatus = {
 	uncommittedCount: number;
 	conflictCount: number;
+	syncTargetBranch?: string | null;
+	syncStatus: WorkspaceGitSyncStatus;
+	behindTargetCount: number;
+};
+
+export type SyncWorkspaceTargetOutcome =
+	| "updated"
+	| "alreadyUpToDate"
+	| "conflict";
+
+export type SyncWorkspaceTargetResponse = {
+	outcome: SyncWorkspaceTargetOutcome;
+	targetBranch: string;
 };
 
 export type WorkspacePrActionItem = {
@@ -1072,6 +1086,21 @@ export async function loadWorkspaceGitActionStatus(
 	} catch (error) {
 		throw new Error(
 			describeInvokeError(error, "Unable to load workspace Git status."),
+		);
+	}
+}
+
+export async function syncWorkspaceWithTargetBranch(
+	workspaceId: string,
+): Promise<SyncWorkspaceTargetResponse> {
+	try {
+		return await invoke<SyncWorkspaceTargetResponse>(
+			"sync_workspace_with_target_branch",
+			{ workspaceId },
+		);
+	} catch (error) {
+		throw new Error(
+			describeInvokeError(error, "Unable to pull target branch updates."),
 		);
 	}
 }

--- a/src/lib/commit-button-logic.test.ts
+++ b/src/lib/commit-button-logic.test.ts
@@ -58,6 +58,9 @@ function makeGitActionStatus(
 	return {
 		uncommittedCount: 0,
 		conflictCount: 0,
+		syncTargetBranch: "main",
+		syncStatus: "upToDate",
+		behindTargetCount: 0,
 		...overrides,
 	};
 }

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -107,7 +107,13 @@ vi.mock("@tauri-apps/api/core", () => ({
 			case "lookup_workspace_pr":
 				return null;
 			case "get_workspace_git_action_status":
-				return { uncommittedCount: 0, conflictCount: 0 };
+				return {
+					uncommittedCount: 0,
+					conflictCount: 0,
+					syncTargetBranch: null,
+					syncStatus: "unknown",
+					behindTargetCount: 0,
+				};
 			case "get_workspace_pr_action_status":
 				return {
 					pr: null,


### PR DESCRIPTION
## Summary

- **New Tauri command** `sync_workspace_with_target_branch` — fetches the remote target branch and merges it into the workspace, handling three outcomes: `Updated`, `AlreadyUpToDate`, and `Conflict`.
- **Expanded `workspace_action_status`** to report `syncStatus` (upToDate / behind / unknown) and `behindTargetCount`, using a new `commits_behind` helper in `git/ops.rs`.
- **Inspector Actions panel** now replaces the old "No merge conflicts" row with a dynamic sync-status row:
  - ✅ "No updates from main" when up to date
  - ⏳ "N updates available from main" + **Pull** button when behind
  - Shows "Pulling…" spinner state, toast feedback on success/conflict/error, and invalidates all relevant queries afterward.
- Conflict-aware: Pull button is hidden when merge conflicts are already present; the command itself bails if there are uncommitted changes.

## Test plan

- [x] 3 new Rust integration tests in `branch_switch.rs` (already-up-to-date, merge-success, conflict)
- [x] 2 new unit tests in `git/ops.rs` (behind-target, up-to-date-target)
- [x] 2 new React tests in `inspector/index.test.tsx` (pull triggers sync, pull hidden during conflicts)
- [x] Updated test helpers in `commit-button-logic.test.ts` and `test/setup.ts` to match new shape
- [x] Pre-commit hooks pass (biome, clippy, cargo fmt)