### PR TITLE
fix: preserve script output across workspace switches

### DIFF
--- a/src/features/inspector/index.tsx
+++ b/src/features/inspector/index.tsx
@@ -129,17 +129,14 @@ export function WorkspaceInspectorSidebar({
 				onTabChange={setActiveTab}
 			>
 				<SetupTab
-					key={`setup-${workspaceId ?? "none"}`}
 					repoId={repoId ?? null}
 					workspaceId={workspaceId ?? null}
 					workspaceState={workspaceState ?? null}
 					setupScript={repoScripts?.setupScript ?? null}
 					scriptsLoaded={scriptsLoaded}
-					isActive={activeTab === "setup"}
 					onOpenSettings={handleOpenSettings}
 				/>
 				<RunTab
-					key={`run-${workspaceId ?? "none"}`}
 					repoId={repoId ?? null}
 					workspaceId={workspaceId ?? null}
 					runScript={repoScripts?.runScript ?? null}

--- a/src/features/inspector/script-store.ts
+++ b/src/features/inspector/script-store.ts
@@ -1,0 +1,116 @@
+import { executeRepoScript, type ScriptEvent, stopRepoScript } from "@/lib/api";
+
+export type ScriptStatus = "idle" | "running" | "exited";
+
+type Listener = {
+	onChunk: (data: string) => void;
+	onStatusChange: (status: ScriptStatus) => void;
+};
+
+type ScriptEntry = {
+	chunks: string[];
+	status: ScriptStatus;
+	exitCode: number | null;
+	listener: Listener | null;
+};
+
+/** Module-level store — survives React mount/unmount cycles. */
+const entries = new Map<string, ScriptEntry>();
+
+function key(workspaceId: string, scriptType: string) {
+	return `${workspaceId}:${scriptType}`;
+}
+
+export function getScriptState(workspaceId: string, scriptType: string) {
+	return entries.get(key(workspaceId, scriptType)) ?? null;
+}
+
+export function startScript(
+	repoId: string,
+	scriptType: "setup" | "run",
+	workspaceId: string,
+) {
+	const k = key(workspaceId, scriptType);
+
+	// If there's already a running entry, its output will be replaced.
+	const entry: ScriptEntry = {
+		chunks: [],
+		status: "running",
+		exitCode: null,
+		listener: entries.get(k)?.listener ?? null,
+	};
+	entries.set(k, entry);
+
+	entry.listener?.onStatusChange("running");
+
+	executeRepoScript(
+		repoId,
+		scriptType,
+		(event: ScriptEvent) => {
+			// Guard: entry may have been replaced by a new run.
+			if (entries.get(k) !== entry) return;
+
+			switch (event.type) {
+				case "started":
+					break;
+				case "stdout":
+				case "stderr":
+					entry.chunks.push(event.data);
+					entry.listener?.onChunk(event.data);
+					break;
+				case "exited":
+					entry.status = "exited";
+					entry.exitCode = event.code;
+					entry.listener?.onStatusChange("exited");
+					break;
+				case "error": {
+					const msg = `\r\n\x1b[31m${event.message}\x1b[0m\r\n`;
+					entry.chunks.push(msg);
+					entry.status = "exited";
+					entry.listener?.onChunk(msg);
+					entry.listener?.onStatusChange("exited");
+					break;
+				}
+			}
+		},
+		workspaceId,
+	).catch((err) => {
+		if (entries.get(k) !== entry) return;
+		const msg = `\r\n\x1b[31mFailed to start: ${err}\x1b[0m\r\n`;
+		entry.chunks.push(msg);
+		entry.status = "exited";
+		entry.listener?.onChunk(msg);
+		entry.listener?.onStatusChange("exited");
+	});
+}
+
+export function stopScript(
+	repoId: string,
+	scriptType: "setup" | "run",
+	workspaceId: string,
+) {
+	void stopRepoScript(repoId, scriptType, workspaceId);
+}
+
+/** Attach a live listener. Returns current state for replay, or null. */
+export function attach(
+	workspaceId: string,
+	scriptType: string,
+	listener: Listener,
+): ScriptEntry | null {
+	const k = key(workspaceId, scriptType);
+	const entry = entries.get(k);
+	if (entry) {
+		entry.listener = listener;
+		return entry;
+	}
+	return null;
+}
+
+/** Detach the live listener (entry stays alive). */
+export function detach(workspaceId: string, scriptType: string) {
+	const entry = entries.get(key(workspaceId, scriptType));
+	if (entry) {
+		entry.listener = null;
+	}
+}

--- a/src/features/inspector/sections/run.tsx
+++ b/src/features/inspector/sections/run.tsx
@@ -6,9 +6,13 @@ import {
 } from "@/components/terminal-output";
 import { Button } from "@/components/ui/button";
 import { TabsContent } from "@/components/ui/tabs";
-import { executeRepoScript, stopRepoScript } from "@/lib/api";
-
-type ScriptStatus = "idle" | "running" | "exited";
+import {
+	attach,
+	detach,
+	type ScriptStatus,
+	startScript,
+	stopScript,
+} from "../script-store";
 
 type RunTabProps = {
 	repoId: string | null;
@@ -33,49 +37,44 @@ export function RunTab({
 	const [status, setStatus] = useState<ScriptStatus>("idle");
 	const [hasRun, setHasRun] = useState(false);
 
-	// Reset to initial state when tab deactivates (avoids stale empty terminal).
+	// Attach to store on mount / when workspaceId changes; replay buffered output.
 	useEffect(() => {
-		if (!isActive && status !== "running") {
+		if (!workspaceId) return;
+
+		const existing = attach(workspaceId, "run", {
+			onChunk: (data) => termRef.current?.write(data),
+			onStatusChange: setStatus,
+		});
+
+		if (existing) {
+			setHasRun(true);
+			setStatus(existing.status);
+			// Replay buffered chunks into a fresh terminal on next frame
+			// (terminal mounts asynchronously).
+			requestAnimationFrame(() => {
+				for (const chunk of existing.chunks) {
+					termRef.current?.write(chunk);
+				}
+			});
+		} else {
 			setHasRun(false);
 			setStatus("idle");
 		}
-	}, [isActive, status]);
+
+		return () => detach(workspaceId, "run");
+	}, [workspaceId]);
 
 	const handleRun = useCallback(() => {
-		if (!repoId) return;
+		if (!repoId || !workspaceId) return;
 		termRef.current?.clear();
 		setStatus("running");
 		setHasRun(true);
-		executeRepoScript(
-			repoId,
-			"run",
-			(event) => {
-				switch (event.type) {
-					case "started":
-						break;
-					case "stdout":
-					case "stderr":
-						termRef.current?.write(event.data);
-						break;
-					case "exited":
-						setStatus("exited");
-						break;
-					case "error":
-						termRef.current?.write(`\r\n\x1b[31m${event.message}\x1b[0m\r\n`);
-						setStatus("exited");
-						break;
-				}
-			},
-			workspaceId,
-		).catch((err) => {
-			termRef.current?.write(`\r\n\x1b[31mFailed to start: ${err}\x1b[0m\r\n`);
-			setStatus("exited");
-		});
+		startScript(repoId, "run", workspaceId);
 	}, [repoId, workspaceId]);
 
 	const handleStop = useCallback(() => {
-		if (!repoId) return;
-		void stopRepoScript(repoId, "run", workspaceId);
+		if (!repoId || !workspaceId) return;
+		stopScript(repoId, "run", workspaceId);
 	}, [repoId, workspaceId]);
 
 	// Handle pending run request from Cmd+R shortcut.

--- a/src/features/inspector/sections/setup.tsx
+++ b/src/features/inspector/sections/setup.tsx
@@ -7,14 +7,16 @@ import {
 } from "@/components/terminal-output";
 import { Button } from "@/components/ui/button";
 import { TabsContent } from "@/components/ui/tabs";
-import {
-	completeWorkspaceSetup,
-	executeRepoScript,
-	stopRepoScript,
-} from "@/lib/api";
+import { completeWorkspaceSetup } from "@/lib/api";
 import { helmorQueryKeys } from "@/lib/query-client";
-
-type ScriptStatus = "idle" | "running" | "exited";
+import {
+	attach,
+	detach,
+	getScriptState,
+	type ScriptStatus,
+	startScript,
+	stopScript,
+} from "../script-store";
 
 type SetupTabProps = {
 	repoId: string | null;
@@ -22,7 +24,6 @@ type SetupTabProps = {
 	workspaceState: string | null;
 	setupScript: string | null;
 	scriptsLoaded: boolean;
-	isActive: boolean;
 	onOpenSettings: () => void;
 };
 
@@ -32,7 +33,6 @@ export function SetupTab({
 	workspaceState,
 	setupScript,
 	scriptsLoaded,
-	isActive,
 	onOpenSettings,
 }: SetupTabProps) {
 	const termRef = useRef<TerminalHandle | null>(null);
@@ -43,58 +43,58 @@ export function SetupTab({
 
 	const hasScript = !!setupScript?.trim();
 
-	// Reset to initial state when tab deactivates (avoids stale empty terminal).
+	// Attach to store on mount / when workspaceId changes; replay buffered output.
 	useEffect(() => {
-		if (!isActive && status !== "running") {
+		if (!workspaceId) return;
+
+		const existing = attach(workspaceId, "setup", {
+			onChunk: (data) => termRef.current?.write(data),
+			onStatusChange: (s) => {
+				setStatus(s);
+				// Invalidate workspace detail when setup completes successfully.
+				if (s === "exited") {
+					const state = getScriptState(workspaceId, "setup");
+					if (state?.exitCode === 0) {
+						queryClient.invalidateQueries({
+							queryKey: helmorQueryKeys.workspaceDetail(workspaceId),
+						});
+					}
+				}
+			},
+		});
+
+		if (existing) {
+			setHasRun(true);
+			setStatus(existing.status);
+			requestAnimationFrame(() => {
+				for (const chunk of existing.chunks) {
+					termRef.current?.write(chunk);
+				}
+			});
+		} else {
 			setHasRun(false);
 			setStatus("idle");
+			// Reset auto-run guard for this new workspace.
+			hasAutoRunRef.current = false;
 		}
-	}, [isActive, status]);
+
+		return () => detach(workspaceId, "setup");
+	}, [workspaceId, queryClient]);
 
 	const handleRun = useCallback(() => {
-		if (!repoId) return;
+		if (!repoId || !workspaceId) return;
 		termRef.current?.clear();
 		setStatus("running");
 		setHasRun(true);
-		executeRepoScript(
-			repoId,
-			"setup",
-			(event) => {
-				switch (event.type) {
-					case "started":
-						break;
-					case "stdout":
-					case "stderr":
-						termRef.current?.write(event.data);
-						break;
-					case "exited":
-						setStatus("exited");
-						if (event.code === 0 && workspaceId) {
-							queryClient.invalidateQueries({
-								queryKey: helmorQueryKeys.workspaceDetail(workspaceId),
-							});
-						}
-						break;
-					case "error":
-						termRef.current?.write(`\r\n\x1b[31m${event.message}\x1b[0m\r\n`);
-						setStatus("exited");
-						break;
-				}
-			},
-			workspaceId,
-		).catch((err) => {
-			termRef.current?.write(`\r\n\x1b[31mFailed to start: ${err}\x1b[0m\r\n`);
-			setStatus("exited");
-		});
-	}, [repoId, workspaceId, queryClient]);
+		startScript(repoId, "setup", workspaceId);
+	}, [repoId, workspaceId]);
 
 	const handleStop = useCallback(() => {
-		if (!repoId) return;
-		void stopRepoScript(repoId, "setup", workspaceId);
+		if (!repoId || !workspaceId) return;
+		stopScript(repoId, "setup", workspaceId);
 	}, [repoId, workspaceId]);
 
 	// Auto-run setup when workspace is pending and script is available.
-	// Ref guard prevents re-triggering after tab-switch resets.
 	useEffect(() => {
 		if (
 			workspaceState === "setup_pending" &&
@@ -108,7 +108,6 @@ export function SetupTab({
 	}, [workspaceState, hasScript, status, handleRun]);
 
 	// Auto-complete if workspace is pending but no script is configured.
-	// Wait until scriptsLoaded to distinguish "still loading" from "no script".
 	useEffect(() => {
 		if (
 			workspaceState === "setup_pending" &&


### PR DESCRIPTION
## Summary

- **Problem**: Setup/Run tab terminal output was lost when switching workspaces because React component unmount destroyed all in-flight script state (chunks, status).
- **Fix**: Extract script execution lifecycle into a module-level store (`script-store.ts`) that lives outside the React tree. Components attach/detach listeners on mount/unmount and replay buffered chunks when re-mounting.
- Removed the `key` prop hack and `isActive` prop that were trying to work around the stale-state issue — no longer needed.

## What changed

| File | Change |
|---|---|
| `script-store.ts` | **New** — module-level Map store. `startScript` / `stopScript` manage execution; `attach` / `detach` manage listeners; chunks buffer survives unmount. |
| `sections/run.tsx` | Refactored to use store. `useEffect` attaches on mount, replays existing chunks, detaches on cleanup. |
| `sections/setup.tsx` | Same pattern. Also wires `exitCode` check for workspace-detail invalidation via store state. |
| `index.tsx` | Removed per-workspace `key` props and `isActive` prop — no longer needed. |

## Test plan

- [ ] Start a setup/run script, switch to a different workspace tab, switch back — terminal output should still be visible
- [ ] Start a long-running script, switch away mid-stream, switch back — should see all output including what arrived while away
- [ ] Re-run a script on the same workspace — terminal clears and shows fresh output
- [ ] Auto-run setup on a `setup_pending` workspace still works
- [ ] Verify no memory leaks: entries Map doesn't grow unbounded (one entry per workspace×scriptType)

🤖 Generated with [Claude Code](https://claude.com/claude-code)