### PR TITLE
feat: auto-resize oversized images before Claude API handoff

### DIFF
--- a/sidecar/src/claude-session-manager.ts
+++ b/sidecar/src/claude-session-manager.ts
@@ -3,7 +3,6 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { readFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { basename, extname } from "node:path";
 import {
@@ -19,6 +18,7 @@ import {
 import { isAbortError } from "./abort.js";
 import type { SidecarEmitter } from "./emitter.js";
 import { resolveGitAccessDirectories } from "./git-access.js";
+import { readImageWithResize } from "./image-resize.js";
 import { parseImageRefs } from "./images.js";
 import { errorDetails, logger } from "./logger.js";
 import type {
@@ -230,13 +230,13 @@ async function buildUserMessageWithImages(
 
 	for (const imgPath of imagePaths) {
 		try {
-			const data = await readFile(imgPath);
+			const { buffer } = await readImageWithResize(imgPath);
 			content.push({
 				type: "image",
 				source: {
 					type: "base64",
 					media_type: extToMediaType(imgPath),
-					data: data.toString("base64"),
+					data: buffer.toString("base64"),
 				},
 			});
 		} catch (err) {

--- a/sidecar/src/image-resize.ts
+++ b/sidecar/src/image-resize.ts
@@ -1,0 +1,180 @@
+/**
+ * Zero-dependency image dimension detection and resizing.
+ *
+ * Parses PNG / JPEG / GIF headers to read pixel dimensions, then uses
+ * platform-native tools (`sips` on macOS, `magick`/`convert` on Linux) to
+ * downscale oversized images.  This avoids depending on sharp / libvips
+ * native bindings that are unavailable in the Tauri app bundle.
+ */
+
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, unlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { extname, join } from "node:path";
+import { promisify } from "node:util";
+import { logger } from "./logger.js";
+
+const execFileAsync = promisify(execFile);
+
+/** Claude API hard limit — images must fit within this box. */
+const MAX_DIMENSION = 2000;
+
+interface ImageDimensions {
+	width: number;
+	height: number;
+}
+
+// ---------------------------------------------------------------------------
+// Header parsing — pure TypeScript, no native deps
+// ---------------------------------------------------------------------------
+
+function parseDimensions(buf: Buffer): ImageDimensions | null {
+	if (buf.length < 10) return null;
+
+	// PNG: 8-byte signature (\x89PNG\r\n\x1a\n) + IHDR
+	if (
+		buf[0] === 0x89 &&
+		buf[1] === 0x50 &&
+		buf[2] === 0x4e &&
+		buf[3] === 0x47 &&
+		buf.length >= 24
+	) {
+		return { width: buf.readUInt32BE(16), height: buf.readUInt32BE(20) };
+	}
+
+	// JPEG: SOI (0xFFD8), then scan for SOF markers
+	if (buf[0] === 0xff && buf[1] === 0xd8) {
+		let offset = 2;
+		while (offset + 9 < buf.length) {
+			if (buf[offset] !== 0xff) {
+				offset++;
+				continue;
+			}
+			const marker = buf[offset + 1]!;
+			// SOF0–SOF15 (0xC0–0xCF), excluding DHT (0xC4) and JPG ext (0xC8)
+			if (
+				marker >= 0xc0 &&
+				marker <= 0xcf &&
+				marker !== 0xc4 &&
+				marker !== 0xc8
+			) {
+				return {
+					height: buf.readUInt16BE(offset + 5),
+					width: buf.readUInt16BE(offset + 7),
+				};
+			}
+			if (offset + 3 >= buf.length) break;
+			offset += 2 + buf.readUInt16BE(offset + 2);
+		}
+	}
+
+	// GIF: "GIF87a" / "GIF89a"
+	if (buf[0] === 0x47 && buf[1] === 0x49 && buf[2] === 0x46) {
+		return { width: buf.readUInt16LE(6), height: buf.readUInt16LE(8) };
+	}
+
+	return null;
+}
+
+// ---------------------------------------------------------------------------
+// Platform-native resize
+// ---------------------------------------------------------------------------
+
+async function resizeWithSips(input: string, output: string): Promise<boolean> {
+	try {
+		await execFileAsync("sips", [
+			"--resampleHeightWidthMax",
+			String(MAX_DIMENSION),
+			input,
+			"--out",
+			output,
+		]);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function resizeWithConvert(
+	input: string,
+	output: string,
+): Promise<boolean> {
+	for (const cmd of ["magick", "convert"]) {
+		try {
+			await execFileAsync(cmd, [
+				input,
+				"-resize",
+				`${MAX_DIMENSION}x${MAX_DIMENSION}>`,
+				output,
+			]);
+			return true;
+		} catch {}
+	}
+	return false;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface ResizedImage {
+	/** Image data (original if within limits, resized otherwise). */
+	buffer: Buffer;
+	/** Whether the image was actually resized. */
+	resized: boolean;
+}
+
+/**
+ * Read an image from disk and, if either dimension exceeds `MAX_DIMENSION`,
+ * downscale it using platform-native tools.  Returns the (possibly resized)
+ * image buffer ready for base64 encoding.
+ */
+export async function readImageWithResize(
+	filePath: string,
+): Promise<ResizedImage> {
+	const original = await readFile(filePath);
+	const dims = parseDimensions(original);
+
+	if (!dims) {
+		// Unrecognized format — pass through unchanged.
+		return { buffer: original, resized: false };
+	}
+
+	if (dims.width <= MAX_DIMENSION && dims.height <= MAX_DIMENSION) {
+		return { buffer: original, resized: false };
+	}
+
+	logger.info("Image exceeds 2000px limit, resizing before SDK handoff", {
+		path: filePath,
+		width: dims.width,
+		height: dims.height,
+	});
+
+	const ext = extname(filePath) || ".png";
+	const tmpDir = await mkdtemp(join(tmpdir(), "helmor-img-"));
+	const tmpPath = join(tmpDir, `resized${ext}`);
+
+	const ok =
+		process.platform === "darwin"
+			? await resizeWithSips(filePath, tmpPath)
+			: await resizeWithConvert(filePath, tmpPath);
+
+	if (!ok) {
+		logger.error("Resize failed, forwarding original image", {
+			path: filePath,
+		});
+		return { buffer: original, resized: false };
+	}
+
+	try {
+		const resized = await readFile(tmpPath);
+		logger.info("Image resized successfully", {
+			path: filePath,
+			originalBytes: original.length,
+			resizedBytes: resized.length,
+		});
+		return { buffer: resized, resized: true };
+	} finally {
+		unlink(tmpPath).catch(() => {});
+	}
+}


### PR DESCRIPTION
## Summary

- **New module `sidecar/src/image-resize.ts`**: Zero-dependency image dimension detection (PNG/JPEG/GIF header parsing) and platform-native downscaling (`sips` on macOS, `magick`/`convert` on Linux). Images exceeding the Claude API 2000 px limit are resized in a temp file before base64 encoding.
- **Updated `sidecar/src/claude-session-manager.ts`**: Replaced the raw `readFile` call in `buildUserMessageWithImages` with `readImageWithResize`, so oversized screenshots/photos are automatically shrunk before being sent to the SDK.

## Why

The Claude API rejects (or silently degrades) images whose width or height exceeds 2000 px. Users pasting high-res screenshots would hit this limit. This change transparently resizes on the fly without adding any native npm dependencies — it shells out to tools already available on macOS and Linux.

## Test plan

- [ ] Attach a >2000 px PNG/JPEG screenshot in a prompt — verify the sidecar log shows "Image resized successfully" and the message reaches Claude without error.
- [ ] Attach a small (<2000 px) image — verify no resize occurs (log should be silent, image sent as-is).
- [ ] Attach an unsupported format (e.g. WebP) — verify it falls through unchanged (no crash).
- [ ] Run `pnpm run test:sidecar` to confirm no regressions.