### PR TITLE
refactor: extract BranchPickerPopover, fix dropdown/popover scroll bleed

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1687,19 +1687,21 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 										{!sidebarCollapsed && (
 											<aside
 												aria-label="Workspace sidebar"
-												className="relative h-full shrink-0 overflow-hidden bg-sidebar"
+												className="relative flex h-full shrink-0 flex-col overflow-hidden bg-sidebar"
 												style={{ width: `${sidebarWidth}px` }}
 											>
-												<WorkspacesSidebarContainer
-													selectedWorkspaceId={selectedWorkspaceId}
-													sendingWorkspaceIds={sendingWorkspaceIds}
-													completedWorkspaceIds={completedWorkspaceIds}
-													interactionRequiredWorkspaceIds={
-														interactionRequiredWorkspaceIds
-													}
-													onSelectWorkspace={handleSelectWorkspace}
-													pushWorkspaceToast={pushWorkspaceToast}
-												/>
+												<div className="min-h-0 flex-1">
+													<WorkspacesSidebarContainer
+														selectedWorkspaceId={selectedWorkspaceId}
+														sendingWorkspaceIds={sendingWorkspaceIds}
+														completedWorkspaceIds={completedWorkspaceIds}
+														interactionRequiredWorkspaceIds={
+															interactionRequiredWorkspaceIds
+														}
+														onSelectWorkspace={handleSelectWorkspace}
+														pushWorkspaceToast={pushWorkspaceToast}
+													/>
+												</div>
 												<Button
 													aria-label="Collapse sidebar"
 													onClick={() => setSidebarCollapsed(true)}
@@ -1712,7 +1714,7 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 														strokeWidth={1.8}
 													/>
 												</Button>
-												<div className="absolute inset-x-3 bottom-3 z-20 flex items-center justify-between">
+												<div className="flex shrink-0 items-center justify-between px-3 pb-3 pt-1">
 													<SettingsButton onClick={onOpenSettings} />
 													{githubIdentityState.status === "connected" ? (
 														<GithubStatusMenu

--- a/src/components/branch-picker.tsx
+++ b/src/components/branch-picker.tsx
@@ -1,0 +1,102 @@
+import { LoaderCircle } from "lucide-react";
+import { useState } from "react";
+import {
+	Command,
+	CommandEmpty,
+	CommandInput,
+	CommandItem,
+	CommandList,
+} from "@/components/ui/command";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+// Scoped thin scrollbar: 3px, sits in the right padding gap.
+// Uses high-specificity selector to override the global 8px scrollbar.
+const scrollbarStyle = `
+.branch-picker [data-slot="command-list"]::-webkit-scrollbar { width: 3px; background: transparent; }
+.branch-picker [data-slot="command-list"]::-webkit-scrollbar-track { background: transparent; }
+.branch-picker [data-slot="command-list"]::-webkit-scrollbar-thumb { border-radius: 999px; background: color-mix(in oklch, var(--foreground) 18%, transparent); }
+.branch-picker [data-slot="command-list"] { scrollbar-width: thin; }
+`;
+
+/**
+ * Shared branch picker popover used in both the workspace header
+ * and repository settings. Renders a searchable list of branches.
+ *
+ * Pass the trigger element as `children` — it will be wrapped in
+ * a `PopoverTrigger`.
+ */
+export function BranchPickerPopover({
+	currentBranch,
+	branches,
+	loading,
+	onOpen,
+	onSelect,
+	align = "start",
+	children,
+}: {
+	currentBranch: string;
+	branches: string[];
+	loading: boolean;
+	onOpen: () => void;
+	onSelect: (branch: string) => void;
+	align?: "start" | "center" | "end";
+	children: React.ReactNode;
+}) {
+	const [open, setOpen] = useState(false);
+
+	return (
+		<Popover
+			open={open}
+			onOpenChange={(next: boolean) => {
+				setOpen(next);
+				if (next) onOpen();
+			}}
+		>
+			<PopoverTrigger asChild>{children}</PopoverTrigger>
+			<PopoverContent align={align} className="w-[260px] p-0">
+				<style>{scrollbarStyle}</style>
+				<Command className="branch-picker rounded-lg! p-1">
+					<CommandInput placeholder="Search branches..." />
+					<CommandList className="max-h-52 px-1" style={{ marginRight: -3 }}>
+						{loading && branches.length === 0 ? (
+							<div className="flex items-center justify-center gap-2 py-5 text-[12px] text-muted-foreground">
+								<LoaderCircle
+									className="size-3.5 animate-spin"
+									strokeWidth={2}
+								/>
+								Loading branches...
+							</div>
+						) : null}
+						<CommandEmpty>No branches found</CommandEmpty>
+						{branches.map((branch) => (
+							<CommandItem
+								key={branch}
+								value={branch}
+								data-checked={branch === currentBranch ? "true" : undefined}
+								onSelect={() => {
+									onSelect(branch);
+									setOpen(false);
+								}}
+								className="rounded-lg text-[12px]"
+							>
+								<span
+									className={cn(
+										"min-w-0 flex-1 truncate",
+										branch === currentBranch && "font-semibold",
+									)}
+								>
+									{branch}
+								</span>
+							</CommandItem>
+						))}
+					</CommandList>
+				</Command>
+			</PopoverContent>
+		</Popover>
+	);
+}

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -67,7 +67,7 @@ function CommandInput({
 	...props
 }: React.ComponentProps<typeof CommandPrimitive.Input>) {
 	return (
-		<div data-slot="command-input-wrapper" className="p-1 pb-0">
+		<div data-slot="command-input-wrapper" className="p-1">
 			<InputGroup className="h-8! rounded-lg! border-input/30 bg-input/30 shadow-none! *:data-[slot=input-group-addon]:pl-2!">
 				<CommandPrimitive.Input
 					data-slot="command-input"

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -40,6 +40,7 @@ function DropdownMenuContent({
 				data-slot="dropdown-menu-content"
 				sideOffset={sideOffset}
 				align={align}
+				onWheel={(e) => e.stopPropagation()}
 				className={cn(
 					"z-50 max-h-(--radix-dropdown-menu-content-available-height) w-(--radix-dropdown-menu-trigger-width) min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:overflow-hidden data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
 					className,

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -29,6 +29,9 @@ function PopoverContent({
 				data-slot="popover-content"
 				align={align}
 				sideOffset={sideOffset}
+				// Prevent react-remove-scroll (used by Dialog) from blocking
+				// wheel events — the portal renders outside the Dialog DOM tree.
+				onWheel={(e) => e.stopPropagation()}
 				className={cn(
 					"z-50 flex w-72 origin-(--radix-popover-content-transform-origin) flex-col gap-2.5 rounded-lg bg-popover p-2.5 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
 					className,

--- a/src/features/navigation/index.tsx
+++ b/src/features/navigation/index.tsx
@@ -72,7 +72,7 @@ const EMPTY_HEADER_HEIGHT = 24; // tighter header for empty groups
 const ROW_HEIGHT = 32; // 30px (h-7.5) + 2px gap
 const GROUP_GAP = 8; // tighter gap between populated groups
 const EMPTY_GROUP_GAP = 8; // tighter spacing around empty groups
-const BOTTOM_PADDING = 24; // pb-6
+const BOTTOM_PADDING = 8;
 
 function getGroupHeaderHeight(hasRows: boolean) {
 	return hasRows ? HEADER_HEIGHT : EMPTY_HEADER_HEIGHT;
@@ -447,7 +447,7 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 	);
 
 	return (
-		<div className="flex h-full min-h-0 flex-col overflow-hidden pb-4">
+		<div className="flex h-full min-h-0 flex-col overflow-hidden">
 			<div
 				data-slot="window-safe-top"
 				className="flex h-9 shrink-0 items-center pr-3"

--- a/src/features/panel/header.tsx
+++ b/src/features/panel/header.tsx
@@ -8,7 +8,6 @@ import {
 	Copy,
 	GitBranch,
 	History,
-	LoaderCircle,
 	Pencil,
 	Plus,
 	RotateCcw,
@@ -16,15 +15,10 @@ import {
 	X,
 } from "lucide-react";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { BranchPickerPopover } from "@/components/branch-picker";
 import { HelmorThinkingIndicator } from "@/components/helmor-thinking-indicator";
 import { ClaudeIcon, OpenAIIcon } from "@/components/icons";
 import { Button } from "@/components/ui/button";
-import {
-	Command,
-	CommandEmpty,
-	CommandItem,
-	CommandList,
-} from "@/components/ui/command";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -32,11 +26,6 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { HyperText } from "@/components/ui/hyper-text";
 import { Input } from "@/components/ui/input";
-import {
-	Popover,
-	PopoverContent,
-	PopoverTrigger,
-} from "@/components/ui/popover";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
 	Tooltip,
@@ -781,6 +770,7 @@ function displaySessionTitle(session: WorkspaceSessionSummary): string {
 	return "Untitled";
 }
 
+// BranchPicker: thin wrapper around shared BranchPickerPopover with header trigger styling.
 function BranchPicker({
 	currentBranch,
 	displayRemote,
@@ -796,68 +786,25 @@ function BranchPicker({
 	onOpen: () => void;
 	onSelect: (branch: string) => void;
 }) {
-	const [open, setOpen] = useState(false);
-
 	return (
-		<Popover
-			open={open}
-			onOpenChange={(next: boolean) => {
-				setOpen(next);
-				if (next) {
-					onOpen();
-				}
-			}}
+		<BranchPickerPopover
+			currentBranch={currentBranch}
+			branches={branches}
+			loading={loading}
+			onOpen={onOpen}
+			onSelect={onSelect}
 		>
-			<PopoverTrigger asChild>
-				<Button
-					type="button"
-					variant="ghost"
-					size="xs"
-					className="h-6 max-w-[180px] gap-1 rounded-md px-1.5 text-[13px] font-medium text-muted-foreground hover:text-foreground"
-				>
-					<span className="truncate">
-						{displayRemote}/{currentBranch}
-					</span>
-					<ChevronDown data-icon="inline-end" strokeWidth={2} />
-				</Button>
-			</PopoverTrigger>
-			<PopoverContent align="start" className="w-[260px] p-0">
-				<Command className="rounded-lg! p-0.5">
-					<CommandList className="max-h-52">
-						{loading && branches.length === 0 ? (
-							<div className="flex items-center justify-center gap-2 py-5 text-[12px] text-muted-foreground">
-								<LoaderCircle
-									className="size-3.5 animate-spin"
-									strokeWidth={2}
-								/>
-								Loading branches...
-							</div>
-						) : null}
-						<CommandEmpty>No branches found</CommandEmpty>
-						{branches.map((branch) => (
-							<CommandItem
-								key={branch}
-								value={branch}
-								data-checked={branch === currentBranch ? "true" : undefined}
-								onSelect={() => {
-									onSelect(branch);
-									setOpen(false);
-								}}
-								className="rounded-lg text-[12px]"
-							>
-								<span
-									className={cn(
-										"min-w-0 flex-1 truncate",
-										branch === currentBranch && "font-semibold",
-									)}
-								>
-									{branch}
-								</span>
-							</CommandItem>
-						))}
-					</CommandList>
-				</Command>
-			</PopoverContent>
-		</Popover>
+			<Button
+				type="button"
+				variant="ghost"
+				size="xs"
+				className="h-6 max-w-[180px] gap-1 rounded-md px-1.5 text-[13px] font-medium text-muted-foreground hover:text-foreground"
+			>
+				<span className="truncate">
+					{displayRemote}/{currentBranch}
+				</span>
+				<ChevronDown data-icon="inline-end" strokeWidth={2} />
+			</Button>
+		</BranchPickerPopover>
 	);
 }

--- a/src/features/settings/panels/repository-settings.tsx
+++ b/src/features/settings/panels/repository-settings.tsx
@@ -1,18 +1,11 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import {
-	Check,
-	ChevronDown,
-	GitBranch,
-	Loader2,
-	LoaderCircle,
-	Trash2,
-} from "lucide-react";
+import { Check, ChevronDown, GitBranch, Loader2, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { BranchPickerPopover } from "@/components/branch-picker";
 import { Button } from "@/components/ui/button";
 import {
 	Command,
 	CommandEmpty,
-	CommandInput,
 	CommandItem,
 	CommandList,
 } from "@/components/ui/command";
@@ -58,7 +51,6 @@ export function RepositorySettingsPanel({
 }) {
 	const [branches, setBranches] = useState<string[]>([]);
 	const [loading, setLoading] = useState(false);
-	const [open, setOpen] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 
 	const currentBranch = repo.defaultBranch ?? "main";
@@ -82,7 +74,6 @@ export function RepositorySettingsPanel({
 	const handleSelect = useCallback(
 		(branch: string) => {
 			if (branch === currentBranch) return;
-			setOpen(false);
 			setError(null);
 			void updateRepositoryDefaultBranch(repo.id, branch).then(
 				onRepoSettingsChanged,
@@ -200,14 +191,17 @@ export function RepositorySettingsPanel({
 					Each workspace is an isolated copy of your codebase.
 				</div>
 				<div className="mt-3">
-					<Popover
-						open={open}
-						onOpenChange={(next: boolean) => {
-							setOpen(next);
-							if (next) handleOpen();
-						}}
+					<BranchPickerPopover
+						currentBranch={currentBranch}
+						branches={branches}
+						loading={loading}
+						onOpen={handleOpen}
+						onSelect={handleSelect}
 					>
-						<PopoverTrigger className="inline-flex cursor-pointer items-center gap-1 rounded-lg border border-app-border/40 bg-app-base/30 px-3 py-2 text-[13px] font-medium text-app-foreground transition-colors hover:border-app-border-strong">
+						<button
+							type="button"
+							className="inline-flex cursor-pointer items-center gap-1 rounded-lg border border-app-border/40 bg-app-base/30 px-3 py-2 text-[13px] font-medium text-app-foreground transition-colors hover:border-app-border-strong"
+						>
 							<GitBranch
 								className="size-3.5 text-app-foreground-soft"
 								strokeWidth={1.8}
@@ -219,45 +213,8 @@ export function RepositorySettingsPanel({
 								className="size-3 shrink-0 text-app-muted"
 								strokeWidth={2}
 							/>
-						</PopoverTrigger>
-						<PopoverContent align="start" className="w-[280px] p-0">
-							<Command className="rounded-lg! p-0.5">
-								<CommandInput placeholder="Search branches..." />
-								<CommandList className="max-h-52">
-									{loading && branches.length === 0 ? (
-										<div className="flex items-center justify-center gap-2 py-5 text-[12px] text-app-muted">
-											<LoaderCircle
-												className="size-3.5 animate-spin"
-												strokeWidth={2}
-											/>
-											Loading branches...
-										</div>
-									) : null}
-									<CommandEmpty>No branches found</CommandEmpty>
-									{branches.map((branch) => (
-										<CommandItem
-											key={branch}
-											value={branch}
-											onSelect={() => handleSelect(branch)}
-											className="flex items-center justify-between gap-2 px-1.5 py-1 text-[12px]"
-										>
-											<span
-												className={cn(
-													"truncate",
-													branch === currentBranch && "font-semibold",
-												)}
-											>
-												{branch}
-											</span>
-											{branch === currentBranch && (
-												<Check className="size-3.5 shrink-0" strokeWidth={2} />
-											)}
-										</CommandItem>
-									))}
-								</CommandList>
-							</Command>
-						</PopoverContent>
-					</Popover>
+						</button>
+					</BranchPickerPopover>
 					{error && <p className="mt-2 text-[12px] text-red-400/90">{error}</p>}
 				</div>
 			</div>


### PR DESCRIPTION
## Summary
- **Extract `BranchPickerPopover`** (`src/components/branch-picker.tsx`): the branch-picking UI was duplicated between the workspace header and repository settings. Now both consumers share one component, each passing its own trigger element as `children`.
- **Fix scroll bleed in dropdowns & popovers**: add `onWheel` `stopPropagation` to `DropdownMenuContent` and `PopoverContent` so scrolling inside a portal overlay doesn't propagate to the parent scroll container (e.g. Dialog with `react-remove-scroll`).
- **Fix sidebar layout**: convert the sidebar `<aside>` from overflow-hidden absolute-positioned bottom bar to a proper flex column so the settings/github row never overlaps workspace list items. Tighten bottom padding accordingly.
- **Command input padding**: remove asymmetric `pb-0` so the search field has even spacing inside the popover.

## Why
- Duplicated branch picker logic made changes error-prone — a style or behavior fix had to be applied twice.
- Wheel events propagating out of dropdown/popover menus caused the underlying page to scroll unexpectedly.
- The sidebar bottom bar (settings + GitHub status) could overlap the last workspace row when the list was long enough.

## Test plan
- [ ] Open a workspace → click the branch picker in the header → scroll the branch list → confirm the page behind doesn't scroll
- [ ] Open Settings → Repository Settings → click the default-branch picker → same scroll isolation check
- [ ] Resize the window short enough for the sidebar workspace list to scroll → confirm the bottom settings bar doesn't overlap workspace items
- [ ] Search branches in both pickers → verify filter + selection still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)