### PR TITLE
fix: force inline display on HyperText in navigation row item

### DIFF
--- a/src/features/navigation/row-item.tsx
+++ b/src/features/navigation/row-item.tsx
@@ -199,6 +199,7 @@ export const WorkspaceRowItem = memo(
 					>
 						<HyperText
 							text={row.branch ? humanizeBranch(row.branch) : row.title}
+							className="inline"
 						/>
 					</span>
 					{showStatusDot ? (


### PR DESCRIPTION
## Summary

- **fix: update git status messages for clarity in inspector actions** — improves wording of git status messages shown in the inspector panel.
- **fix: force inline display on HyperText in navigation row item** — adds `className="inline"` to the `<HyperText>` component inside the sidebar workspace row, fixing a layout/truncation issue caused by the component's default block-level rendering.

## Why

The `HyperText` animation component defaults to block-level display, which disrupts the `truncate` (overflow-hidden + text-ellipsis) behavior of its parent `<span>` in the sidebar navigation row. Forcing `display: inline` keeps the text in flow so truncation works as expected.

## Changes

| File | Change |
|---|---|
| `src/features/navigation/row-item.tsx` | Add `className="inline"` to `<HyperText>` |

## Test plan

- [ ] Open the sidebar with workspaces that have long branch names
- [ ] Verify branch names truncate correctly with ellipsis instead of overflowing
- [ ] Verify the HyperText hover animation still works