### PR TITLE
fix: improve notification triggers for interaction and completion events

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1114,12 +1114,14 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 
 	const handleSessionCompleted = useCallback(
 		(sessionId: string, workspaceId: string) => {
-			if (sessionId === selectedSessionIdRef.current) return;
 			setCompletedSessions((prev) => {
 				const next = new Map(prev);
 				next.set(sessionId, workspaceId);
 				return next;
 			});
+			// Skip notification only when the user is actively viewing this session
+			if (document.hasFocus() && sessionId === selectedSessionIdRef.current)
+				return;
 			const name =
 				queryClient.getQueryData<WorkspaceDetail | null>(
 					helmorQueryKeys.workspaceDetail(workspaceId),
@@ -1129,8 +1131,28 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 		[notify, queryClient],
 	);
 
+	const lastInteractionCountsRef = useRef<Map<string, number>>(new Map());
 	const handleInteractionSessionsChange = useCallback(
-		(nextMap: Map<string, string>) => {
+		(nextMap: Map<string, string>, counts: Map<string, number>) => {
+			// Notify for new sessions or sessions with increased interaction count
+			for (const [sessionId, workspaceId] of nextMap) {
+				const count = counts.get(sessionId) ?? 0;
+				const prev = lastInteractionCountsRef.current.get(sessionId) ?? 0;
+				if (count > prev) {
+					const name =
+						queryClient.getQueryData<WorkspaceDetail | null>(
+							helmorQueryKeys.workspaceDetail(workspaceId),
+						)?.title ?? "Workspace";
+					notify({ title: "Input needed", body: name });
+				}
+			}
+			// Track counts (only for sessions still in the map)
+			const nextCounts = new Map<string, number>();
+			for (const [sessionId] of nextMap) {
+				nextCounts.set(sessionId, counts.get(sessionId) ?? 0);
+			}
+			lastInteractionCountsRef.current = nextCounts;
+
 			setInteractionRequiredSessions((current) => {
 				if (current.size === nextMap.size) {
 					let unchanged = true;
@@ -1140,21 +1162,8 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 							break;
 						}
 					}
-					if (unchanged) {
-						return current;
-					}
+					if (unchanged) return current;
 				}
-
-				for (const [sessionId, workspaceId] of nextMap) {
-					if (!current.has(sessionId)) {
-						const name =
-							queryClient.getQueryData<WorkspaceDetail | null>(
-								helmorQueryKeys.workspaceDetail(workspaceId),
-							)?.title ?? "Workspace";
-						notify({ title: "Input needed", body: name });
-					}
-				}
-
 				return new Map(nextMap);
 			});
 		},

--- a/src/features/conversation/hooks/use-streaming.test.tsx
+++ b/src/features/conversation/hooks/use-streaming.test.tsx
@@ -147,7 +147,7 @@ describe("useConversationStreaming", () => {
 					displayedSelectedModelId: MODEL.id,
 					displayedSessionId,
 					displayedWorkspaceId,
-					onInteractionSessionsChange: (sessionWorkspaceMap) => {
+					onInteractionSessionsChange: (sessionWorkspaceMap, _counts) => {
 						interactionSnapshots.push(new Map(sessionWorkspaceMap));
 					},
 					selectionPending: false,
@@ -385,7 +385,7 @@ describe("useConversationStreaming", () => {
 					displayedSelectedModelId: MODEL.id,
 					displayedSessionId: "session-1",
 					displayedWorkspaceId: "workspace-1",
-					onInteractionSessionsChange: (sessionWorkspaceMap) => {
+					onInteractionSessionsChange: (sessionWorkspaceMap, _counts) => {
 						interactionSnapshots.push(new Map(sessionWorkspaceMap));
 					},
 					selectionPending: false,

--- a/src/features/conversation/hooks/use-streaming.ts
+++ b/src/features/conversation/hooks/use-streaming.ts
@@ -82,6 +82,7 @@ type UseConversationStreamingArgs = {
 	onSendingSessionsChange?: (sessionIds: Set<string>) => void;
 	onInteractionSessionsChange?: (
 		sessionWorkspaceMap: Map<string, string>,
+		interactionCounts: Map<string, number>,
 	) => void;
 	onSessionCompleted?: (sessionId: string, workspaceId: string) => void;
 };
@@ -178,6 +179,12 @@ export function useConversationStreaming({
 	}, [sendingContextKeys, sendingSessionIds]);
 	useLayoutEffect(() => {
 		const interactionSessions = new Map<string, string>();
+		const interactionCounts = new Map<string, number>();
+
+		const resolveWorkspace = (contextKey: string): string | null =>
+			interactionWorkspaceByContext[contextKey] ??
+			sendingWorkspaceMapRef.current.get(contextKey) ??
+			null;
 
 		for (const [contextKey, permissions] of Object.entries(
 			pendingPermissionsByContext,
@@ -185,11 +192,14 @@ export function useConversationStreaming({
 			if (permissions.length === 0 || !contextKey.startsWith("session:")) {
 				continue;
 			}
-			const workspaceId = interactionWorkspaceByContext[contextKey];
-			if (!workspaceId) {
-				continue;
-			}
-			interactionSessions.set(contextKey.slice(8), workspaceId);
+			const workspaceId = resolveWorkspace(contextKey);
+			if (!workspaceId) continue;
+			const sessionId = contextKey.slice(8);
+			interactionSessions.set(sessionId, workspaceId);
+			interactionCounts.set(
+				sessionId,
+				(interactionCounts.get(sessionId) ?? 0) + permissions.length,
+			);
 		}
 
 		for (const [contextKey, deferred] of Object.entries(
@@ -198,11 +208,14 @@ export function useConversationStreaming({
 			if (!deferred || !contextKey.startsWith("session:")) {
 				continue;
 			}
-			const workspaceId = interactionWorkspaceByContext[contextKey];
-			if (!workspaceId) {
-				continue;
-			}
-			interactionSessions.set(contextKey.slice(8), workspaceId);
+			const workspaceId = resolveWorkspace(contextKey);
+			if (!workspaceId) continue;
+			const sessionId = contextKey.slice(8);
+			interactionSessions.set(sessionId, workspaceId);
+			interactionCounts.set(
+				sessionId,
+				(interactionCounts.get(sessionId) ?? 0) + 1,
+			);
 		}
 
 		for (const [contextKey, elicitation] of Object.entries(
@@ -211,25 +224,34 @@ export function useConversationStreaming({
 			if (!elicitation || !contextKey.startsWith("session:")) {
 				continue;
 			}
-			const workspaceId = interactionWorkspaceByContext[contextKey];
-			if (!workspaceId) {
-				continue;
-			}
-			interactionSessions.set(contextKey.slice(8), workspaceId);
+			const workspaceId = resolveWorkspace(contextKey);
+			if (!workspaceId) continue;
+			const sessionId = contextKey.slice(8);
+			interactionSessions.set(sessionId, workspaceId);
+			interactionCounts.set(
+				sessionId,
+				(interactionCounts.get(sessionId) ?? 0) + 1,
+			);
 		}
 
 		for (const [contextKey, active] of Object.entries(planReviewByContext)) {
 			if (!active || !contextKey.startsWith("session:")) {
 				continue;
 			}
-			const workspaceId = interactionWorkspaceByContext[contextKey];
-			if (!workspaceId) {
-				continue;
-			}
-			interactionSessions.set(contextKey.slice(8), workspaceId);
+			const workspaceId = resolveWorkspace(contextKey);
+			if (!workspaceId) continue;
+			const sessionId = contextKey.slice(8);
+			interactionSessions.set(sessionId, workspaceId);
+			interactionCounts.set(
+				sessionId,
+				(interactionCounts.get(sessionId) ?? 0) + 1,
+			);
 		}
 
-		onInteractionSessionsChangeRef.current?.(interactionSessions);
+		onInteractionSessionsChangeRef.current?.(
+			interactionSessions,
+			interactionCounts,
+		);
 	}, [
 		interactionWorkspaceByContext,
 		pendingElicitationByContext,

--- a/src/features/conversation/index.tsx
+++ b/src/features/conversation/index.tsx
@@ -33,6 +33,7 @@ type WorkspaceConversationContainerProps = {
 	onSendingSessionsChange?: (sessionIds: Set<string>) => void;
 	onInteractionSessionsChange?: (
 		sessionWorkspaceMap: Map<string, string>,
+		interactionCounts: Map<string, number>,
 	) => void;
 	completedSessionIds?: Set<string>;
 	interactionRequiredSessionIds?: Set<string>;

--- a/src/lib/use-os-notifications.ts
+++ b/src/lib/use-os-notifications.ts
@@ -5,8 +5,7 @@ type NotifyFn = (opts: { title: string; body: string }) => void;
 
 /** Sends native OS notifications, gated by the `notifications` setting. */
 export function useOsNotifications(settings: AppSettings): NotifyFn {
-	const permissionCheckedRef = useRef(false);
-	const permissionGrantedRef = useRef(false);
+	const permissionRequestedRef = useRef(false);
 
 	return useCallback(
 		({ title, body }: { title: string; body: string }) => {
@@ -17,20 +16,18 @@ export function useOsNotifications(settings: AppSettings): NotifyFn {
 					const { isPermissionGranted, requestPermission, sendNotification } =
 						await import("@tauri-apps/plugin-notification");
 
-					if (!permissionCheckedRef.current) {
-						permissionCheckedRef.current = true;
-						let granted = await isPermissionGranted();
-						if (!granted) {
-							const result = await requestPermission();
-							granted = result === "granted";
-						}
-						permissionGrantedRef.current = granted;
+					let granted = await isPermissionGranted();
+					if (!granted) {
+						// Only pop the OS permission dialog once per session
+						if (permissionRequestedRef.current) return;
+						permissionRequestedRef.current = true;
+						granted = (await requestPermission()) === "granted";
 					}
 
-					if (!permissionGrantedRef.current) return;
+					if (!granted) return;
 					sendNotification({ title, body });
-				} catch {
-					// non-Tauri env or permission denied
+				} catch (err) {
+					console.warn("[os-notification] failed to send:", err);
 				}
 			})();
 		},


### PR DESCRIPTION
## Summary
- **Interaction notifications now fire on count changes**, not just when a session first appears in the interaction map. Previously, if a session already had one pending permission and gained a second, no notification was sent. Now we track per-session interaction counts and notify whenever the count increases.
- **Completion notifications fire even for the active session** when the window is not focused. Previously, `handleSessionCompleted` early-returned for the selected session regardless of focus, so a user Alt-Tabbed away would miss the notification. The `completedSessions` state is now always updated; only the OS notification is gated by `document.hasFocus() && isSelectedSession`.
- **Workspace resolution fallback**: `resolveWorkspace` now also checks `sendingWorkspaceMapRef`, so interaction notifications work even when `interactionWorkspaceByContext` hasn't been populated yet.
- **OS notification permission**: `useOsNotifications` now re-checks `isPermissionGranted()` on every call (cheap) but only pops the native permission dialog once per session, fixing a bug where a previously-denied-then-granted permission was never picked up.

## Test plan
- [ ] Verify "Input needed" notification fires when a background session requests a new permission
- [ ] Verify "Input needed" fires again if a second permission arrives on the same session
- [ ] Verify "Session completed" notification fires when viewing a different session or when window is unfocused
- [ ] Verify no duplicate notification when actively viewing the completing session with the window focused
- [ ] Existing `use-streaming.test.tsx` tests pass (`pnpm run test:frontend`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)