### PR TITLE
fix: preserve setup/run terminal scroll state across tab switches

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -244,6 +244,21 @@ body {
 	background: transparent;
 }
 
+/* xterm: custom scrollbar shape to match app style */
+.xterm .xterm-scrollable-element > .scrollbar {
+	width: 8px !important;
+}
+
+.xterm .xterm-scrollable-element > .scrollbar > .slider {
+	border-radius: 999px !important;
+	left: 2px !important;
+	width: calc(100% - 4px) !important;
+}
+
+.xterm .xterm-scrollable-element > .shadow.top {
+	display: none !important;
+}
+
 .scrollbar-none {
 	scrollbar-width: none;
 }

--- a/src/components/terminal-output.tsx
+++ b/src/components/terminal-output.tsx
@@ -14,17 +14,25 @@ export type TerminalHandle = {
 	dispose: () => void;
 };
 
-/** Read --terminal-* CSS variables and build an xterm ITheme. */
+/** Read --terminal-* and --foreground CSS variables and build an xterm ITheme. */
 function resolveTerminalTheme(): ITheme {
 	const s = getComputedStyle(document.documentElement);
 	const v = (suffix: string) =>
 		s.getPropertyValue(`--terminal-${suffix}`).trim();
+
+	// Match the app's global scrollbar colors (foreground @ 18%/30%/40%).
+	const fg = s.getPropertyValue("--foreground").trim();
+	const mix = (pct: number) =>
+		`color-mix(in oklch, ${fg} ${pct}%, transparent)`;
 
 	return {
 		background: v("background"),
 		foreground: v("foreground"),
 		cursor: v("cursor"),
 		selectionBackground: v("selection"),
+		scrollbarSliderBackground: mix(18),
+		scrollbarSliderHoverBackground: mix(30),
+		scrollbarSliderActiveBackground: mix(40),
 		black: v("black"),
 		red: v("red"),
 		green: v("green"),
@@ -128,7 +136,7 @@ export function TerminalOutput({
 			style={{
 				width: "100%",
 				height: "100%",
-				padding: 12,
+				padding: "12px 2px 12px 12px",
 				backgroundColor: "var(--terminal-background)",
 			}}
 		>

--- a/src/features/inspector/layout.tsx
+++ b/src/features/inspector/layout.tsx
@@ -111,7 +111,7 @@ export function InspectorTabsSection({
 					{open && (
 						<div
 							aria-label="Inspector tabs body"
-							className="flex min-h-0 flex-1 flex-col bg-sidebar"
+							className="relative flex min-h-0 flex-1 flex-col bg-sidebar"
 						>
 							{children}
 						</div>

--- a/src/features/inspector/sections/run.tsx
+++ b/src/features/inspector/sections/run.tsx
@@ -37,7 +37,6 @@ export function RunTab({
 	const [status, setStatus] = useState<ScriptStatus>("idle");
 	const [hasRun, setHasRun] = useState(false);
 
-	// Attach to store on mount / when workspaceId changes; replay buffered output.
 	useEffect(() => {
 		if (!workspaceId) return;
 
@@ -49,15 +48,18 @@ export function RunTab({
 		if (existing) {
 			setHasRun(true);
 			setStatus(existing.status);
-			requestAnimationFrame(() => {
-				termRef.current?.clear();
-				for (const chunk of existing.chunks) {
-					termRef.current?.write(chunk);
-				}
-			});
+			const replay = () => {
+				const t = termRef.current;
+				if (!t) return;
+				t.clear();
+				for (const chunk of existing.chunks) t.write(chunk);
+			};
+			if (termRef.current) replay();
+			else requestAnimationFrame(replay);
 		} else {
 			setHasRun(false);
 			setStatus("idle");
+			termRef.current?.clear();
 		}
 
 		return () => detach(workspaceId, "run");
@@ -86,10 +88,38 @@ export function RunTab({
 
 	const hasScript = !!runScript?.trim();
 
-	// Empty state: no script configured
-	if (!hasScript && !hasRun) {
-		return (
-			<TabsContent value="run" className="flex-1 min-h-0">
+	return (
+		<TabsContent
+			value="run"
+			forceMount
+			className="relative flex min-h-0 flex-1 flex-col data-[state=inactive]:invisible data-[state=inactive]:absolute data-[state=inactive]:inset-0 data-[state=inactive]:pointer-events-none"
+		>
+			{hasRun ? (
+				<>
+					<div className="min-h-0 flex-1">
+						<TerminalOutput terminalRef={termRef} className="h-full" />
+					</div>
+
+					{(status === "running" || status === "exited") && (
+						<div className="absolute bottom-3 right-4">
+							<Button
+								variant={status === "running" ? "destructive" : "secondary"}
+								size="sm"
+								className="border border-border/40 text-[12px] shadow-sm backdrop-blur-sm transition-none"
+								onClick={status === "running" ? handleStop : handleRun}
+								disabled={status === "exited" && !hasScript}
+							>
+								{status === "running" ? (
+									<Square className="size-3" strokeWidth={2} />
+								) : (
+									<RotateCcw className="size-3" strokeWidth={2} />
+								)}
+								{status === "running" ? "Stop" : "Rerun"}
+							</Button>
+						</div>
+					)}
+				</>
+			) : !hasScript ? (
 				<div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
 					<Button
 						variant="outline"
@@ -104,14 +134,7 @@ export function RunTab({
 						Run tests or a development server to test changes in this workspace.
 					</p>
 				</div>
-			</TabsContent>
-		);
-	}
-
-	// Ready state before first run
-	if (!hasRun) {
-		return (
-			<TabsContent value="run" className="flex-1 min-h-0">
+			) : (
 				<div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
 					<p className="text-[13px] text-muted-foreground">
 						No run script output
@@ -127,35 +150,6 @@ export function RunTab({
 					>
 						<Play className="size-3" strokeWidth={2} />
 						Run
-					</Button>
-				</div>
-			</TabsContent>
-		);
-	}
-
-	return (
-		<TabsContent value="run" className="relative flex min-h-0 flex-1 flex-col">
-			{/* Terminal */}
-			<div className="min-h-0 flex-1">
-				<TerminalOutput terminalRef={termRef} className="h-full" />
-			</div>
-
-			{/* Floating action button */}
-			{(status === "running" || status === "exited") && (
-				<div className="absolute bottom-3 right-3">
-					<Button
-						variant={status === "running" ? "destructive" : "secondary"}
-						size="sm"
-						className="text-[12px] transition-none"
-						onClick={status === "running" ? handleStop : handleRun}
-						disabled={status === "exited" && !hasScript}
-					>
-						{status === "running" ? (
-							<Square className="size-3" strokeWidth={2} />
-						) : (
-							<RotateCcw className="size-3" strokeWidth={2} />
-						)}
-						{status === "running" ? "Stop" : "Rerun"}
 					</Button>
 				</div>
 			)}

--- a/src/features/inspector/sections/setup.tsx
+++ b/src/features/inspector/sections/setup.tsx
@@ -43,7 +43,6 @@ export function SetupTab({
 
 	const hasScript = !!setupScript?.trim();
 
-	// Attach to store on mount / when workspaceId changes; replay buffered output.
 	useEffect(() => {
 		if (!workspaceId) return;
 
@@ -51,7 +50,6 @@ export function SetupTab({
 			onChunk: (data) => termRef.current?.write(data),
 			onStatusChange: (s) => {
 				setStatus(s);
-				// Invalidate workspace detail when setup completes successfully.
 				if (s === "exited") {
 					const state = getScriptState(workspaceId, "setup");
 					if (state?.exitCode === 0) {
@@ -66,17 +64,21 @@ export function SetupTab({
 		if (existing) {
 			setHasRun(true);
 			setStatus(existing.status);
-			requestAnimationFrame(() => {
-				termRef.current?.clear();
-				for (const chunk of existing.chunks) {
-					termRef.current?.write(chunk);
-				}
-			});
+			const replay = () => {
+				const t = termRef.current;
+				if (!t) return;
+				t.clear();
+				for (const chunk of existing.chunks) t.write(chunk);
+			};
+			// Terminal already mounted → replay now; otherwise wait one frame
+			// for React to flush setHasRun(true) and mount the terminal.
+			if (termRef.current) replay();
+			else requestAnimationFrame(replay);
 		} else {
 			setHasRun(false);
 			setStatus("idle");
-			// Reset auto-run guard for this new workspace.
 			hasAutoRunRef.current = false;
+			termRef.current?.clear();
 		}
 
 		return () => detach(workspaceId, "setup");
@@ -124,10 +126,38 @@ export function SetupTab({
 		}
 	}, [workspaceState, scriptsLoaded, hasScript, workspaceId, queryClient]);
 
-	// Empty state: no script configured
-	if (!hasScript && !hasRun) {
-		return (
-			<TabsContent value="setup" className="flex-1 min-h-0">
+	return (
+		<TabsContent
+			value="setup"
+			forceMount
+			className="relative flex min-h-0 flex-1 flex-col data-[state=inactive]:invisible data-[state=inactive]:absolute data-[state=inactive]:inset-0 data-[state=inactive]:pointer-events-none"
+		>
+			{hasRun ? (
+				<>
+					<div className="min-h-0 flex-1">
+						<TerminalOutput terminalRef={termRef} className="h-full" />
+					</div>
+
+					{(status === "running" || status === "exited") && (
+						<div className="absolute bottom-3 right-4">
+							<Button
+								variant={status === "running" ? "destructive" : "secondary"}
+								size="sm"
+								className="border border-border/40 text-[12px] shadow-sm backdrop-blur-sm transition-none"
+								onClick={status === "running" ? handleStop : handleRun}
+								disabled={status === "exited" && !hasScript}
+							>
+								{status === "running" ? (
+									<Square className="size-3" strokeWidth={2} />
+								) : (
+									<RotateCcw className="size-3" strokeWidth={2} />
+								)}
+								{status === "running" ? "Stop" : "Rerun setup"}
+							</Button>
+						</div>
+					)}
+				</>
+			) : !hasScript ? (
 				<div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
 					<p className="text-[13px] font-medium text-muted-foreground">
 						No setup script configured
@@ -145,14 +175,7 @@ export function SetupTab({
 						Open settings
 					</Button>
 				</div>
-			</TabsContent>
-		);
-	}
-
-	// Ready state before first run
-	if (!hasRun) {
-		return (
-			<TabsContent value="setup" className="flex-1 min-h-0">
+			) : (
 				<div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
 					<p className="text-[13px] text-muted-foreground">
 						No setup script output
@@ -168,38 +191,6 @@ export function SetupTab({
 					>
 						<Play className="size-3" strokeWidth={2} />
 						Run setup
-					</Button>
-				</div>
-			</TabsContent>
-		);
-	}
-
-	return (
-		<TabsContent
-			value="setup"
-			className="relative flex min-h-0 flex-1 flex-col"
-		>
-			{/* Terminal */}
-			<div className="min-h-0 flex-1">
-				<TerminalOutput terminalRef={termRef} className="h-full" />
-			</div>
-
-			{/* Floating action button */}
-			{(status === "running" || status === "exited") && (
-				<div className="absolute bottom-3 right-3">
-					<Button
-						variant={status === "running" ? "destructive" : "secondary"}
-						size="sm"
-						className="text-[12px] transition-none"
-						onClick={status === "running" ? handleStop : handleRun}
-						disabled={status === "exited" && !hasScript}
-					>
-						{status === "running" ? (
-							<Square className="size-3" strokeWidth={2} />
-						) : (
-							<RotateCcw className="size-3" strokeWidth={2} />
-						)}
-						{status === "running" ? "Stop" : "Rerun setup"}
 					</Button>
 				</div>
 			)}


### PR DESCRIPTION
## Summary

- **forceMount + visibility toggling** on Setup/Run `TabsContent` so xterm terminal instances stay mounted when switching inspector tabs — prevents scroll position and buffered output from being destroyed.
- **Fix terminal replay timing**: replay buffered chunks synchronously when the terminal ref is already available; fall back to `requestAnimationFrame` only when it isn't mounted yet. Also clear the terminal when switching to a workspace with no prior output.
- **Style xterm scrollbar** to match the app's global scrollbar: rounded pill shape, theme-aware foreground colors via `color-mix`, hide the top shadow, and reduce right padding to keep the scrollbar flush.
- **Polish floating action button**: add `border`, `shadow-sm`, `backdrop-blur-sm` for better contrast over terminal output; nudge position from `right-3` → `right-4`.

## Why

Switching between the Setup/Run/Changes tabs was remounting the xterm terminal, losing scroll position and all buffered output. The scrollbar also looked inconsistent with the rest of the app.

## Test plan

- [ ] Switch between Setup, Run, and Changes tabs — terminal output and scroll position should be preserved
- [ ] Run a script, scroll up, switch tabs, switch back — scroll position retained
- [ ] Switch workspaces — terminal clears correctly for workspaces with no prior output
- [ ] Verify scrollbar appearance matches the app's global scrollbar style (rounded, themed)
- [ ] Floating action button (Stop / Rerun) visible and usable over terminal content

🤖 Generated with [Claude Code](https://claude.com/claude-code)