### PR TITLE
fix: show git HEAD content as original side in diff preview

### DIFF
--- a/src-tauri/src/commands/editor_commands.rs
+++ b/src-tauri/src/commands/editor_commands.rs
@@ -10,6 +10,15 @@ pub async fn read_editor_file(path: String) -> CmdResult<editor_files::EditorFil
 }
 
 #[tauri::command]
+pub async fn read_file_git_original(
+    workspace_root_path: String,
+    file_path: String,
+) -> CmdResult<Option<String>> {
+    run_blocking(move || editor_files::read_file_git_original(&workspace_root_path, &file_path))
+        .await
+}
+
+#[tauri::command]
 pub async fn list_editor_files(
     workspace_root_path: String,
 ) -> CmdResult<Vec<editor_files::EditorFileListItem>> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -262,6 +262,7 @@ pub fn run() {
             commands::github_commands::close_workspace_pr,
             commands::system_commands::drain_pending_cli_sends,
             commands::editor_commands::read_editor_file,
+            commands::editor_commands::read_file_git_original,
             commands::workspace_commands::set_workspace_manual_status,
             commands::system_commands::detect_installed_editors,
             commands::system_commands::open_workspace_in_editor,

--- a/src-tauri/src/workspace/files/editor.rs
+++ b/src-tauri/src/workspace/files/editor.rs
@@ -19,6 +19,32 @@ use super::{
 const MAX_EDITOR_FILE_ITEMS: usize = 24;
 const MAX_PREFETCH_BYTES: u64 = 1_048_576;
 
+/// Read the git HEAD version of a file. Returns `None` for new/untracked files.
+pub fn read_file_git_original(
+    workspace_root_path: &str,
+    file_path: &str,
+) -> Result<Option<String>> {
+    let workspace_root = Path::new(workspace_root_path);
+    if !workspace_root.is_absolute() || !workspace_root.is_dir() {
+        bail!(
+            "Workspace root is not a valid directory: {}",
+            workspace_root.display()
+        );
+    }
+
+    let abs = Path::new(file_path);
+    let relative = abs
+        .strip_prefix(workspace_root)
+        .with_context(|| format!("{file_path} is not inside {workspace_root_path}"))?;
+    let relative_str = relative.to_string_lossy().replace('\\', "/");
+
+    let git_path = format!("HEAD:{relative_str}");
+    match crate::git_ops::run_git(["show", &git_path], Some(workspace_root)) {
+        Ok(content) => Ok(Some(content)),
+        Err(_) => Ok(None), // file doesn't exist in HEAD (new/untracked)
+    }
+}
+
 pub fn read_editor_file(path: &str) -> Result<EditorFileReadResponse> {
     let resolved_path = resolve_allowed_path(Path::new(path), true)?;
     let metadata = fs::metadata(&resolved_path)

--- a/src-tauri/src/workspace/files/mod.rs
+++ b/src-tauri/src/workspace/files/mod.rs
@@ -9,7 +9,7 @@ pub use changes::{
 };
 pub use editor::{
     list_editor_files, list_editor_files_with_content, list_workspace_files, read_editor_file,
-    stat_editor_file, write_editor_file,
+    read_file_git_original, stat_editor_file, write_editor_file,
 };
 pub use types::{
     EditorFileListItem, EditorFilePrefetchItem, EditorFileReadResponse, EditorFileStatResponse,

--- a/src/features/editor/index.tsx
+++ b/src/features/editor/index.tsx
@@ -39,7 +39,7 @@ type DiffController = Awaited<
 
 export function WorkspaceEditorSurface({
 	editorSession,
-	workspaceRootPath: _workspaceRootPath,
+	workspaceRootPath,
 	onChangeSession,
 	onExit,
 	onError,
@@ -81,8 +81,15 @@ export function WorkspaceEditorSurface({
 
 		void (async () => {
 			try {
-				const { readEditorFile } = await import("@/lib/api");
-				const response = await readEditorFile(editorSession.path);
+				const api = await import("@/lib/api");
+				const isDiff = editorSession.kind === "diff";
+
+				const [response, gitOriginal] = await Promise.all([
+					api.readEditorFile(editorSession.path),
+					isDiff && workspaceRootPath
+						? api.readFileGitOriginal(workspaceRootPath, editorSession.path)
+						: Promise.resolve(null),
+				]);
 
 				if (cancelled) {
 					return;
@@ -90,7 +97,9 @@ export function WorkspaceEditorSurface({
 
 				onChangeSessionRef.current({
 					...editorSession,
-					originalText: editorSession.originalText ?? response.content,
+					originalText:
+						editorSession.originalText ??
+						(isDiff ? (gitOriginal ?? "") : response.content),
 					modifiedText: editorSession.modifiedText ?? response.content,
 					dirty: Boolean(editorSession.dirty),
 					mtimeMs: response.mtimeMs,
@@ -112,7 +121,7 @@ export function WorkspaceEditorSurface({
 		return () => {
 			cancelled = true;
 		};
-	}, [canRenderDiff, canRenderFile, editorSession]);
+	}, [canRenderDiff, canRenderFile, editorSession, workspaceRootPath]);
 
 	// Dispose editors on unmount (separate from the switching effect so the
 	// fast-path can skip cleanup without leaking on unmount).

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -868,6 +868,16 @@ export async function readEditorFile(
 	}
 }
 
+export async function readFileGitOriginal(
+	workspaceRootPath: string,
+	filePath: string,
+): Promise<string | null> {
+	return await invoke<string | null>("read_file_git_original", {
+		workspaceRootPath,
+		filePath,
+	});
+}
+
 export async function writeEditorFile(
 	path: string,
 	content: string,


### PR DESCRIPTION
## Summary

- **Problem:** The diff editor used the current file content for *both* the original and modified panes, so diffs always appeared empty.
- **Fix:** Added a new `read_file_git_original` Tauri command that runs `git show HEAD:<path>` to retrieve the committed version of a file. The editor surface now fetches this as the original side when opening a diff view.
- **Scope:** New Rust command + IPC binding + frontend wiring. No schema or pipeline changes.

## Changes

| File | What |
|---|---|
| `src-tauri/src/workspace/files/editor.rs` | New `read_file_git_original()` — runs `git show HEAD:<relative_path>`, returns `None` for untracked files |
| `src-tauri/src/commands/editor_commands.rs` | Tauri command wrapper |
| `src-tauri/src/lib.rs` | Register the new command |
| `src-tauri/src/workspace/files/mod.rs` | Re-export |
| `src/lib/api.ts` | `readFileGitOriginal()` IPC bridge function |
| `src/features/editor/index.tsx` | Fetch git original in parallel when `kind === "diff"`, use it as `originalText` |

## Test plan

- [ ] Open a file that has unstaged changes → diff view should show the HEAD version on the left and working copy on the right
- [ ] Open a newly created (untracked) file in diff mode → left pane should be empty, right pane shows file content
- [ ] Open a file with no changes → both sides should be identical
- [ ] Verify clippy + biome pass (pre-commit hook ran successfully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)