### PR TITLE
feat: add flat/tree view toggle for inspector changes sections

### DIFF
--- a/src/features/inspector/sections/changes.tsx
+++ b/src/features/inspector/sections/changes.tsx
@@ -7,6 +7,8 @@ import {
 import {
 	ChevronRightIcon,
 	GitBranchIcon,
+	ListIcon,
+	ListTreeIcon,
 	LoaderCircleIcon,
 	MinusIcon,
 	PlusIcon,
@@ -73,7 +75,8 @@ export function ChangesSection({
 	prInfo,
 }: ChangesSectionProps) {
 	const queryClient = useQueryClient();
-	const [treeView] = useState(true);
+	const [changesTreeView, setChangesTreeView] = useState(true);
+	const [branchDiffTreeView, setBranchDiffTreeView] = useState(true);
 	const [changesOpen, setChangesOpen] = useState(true);
 	const [stagedOpen, setStagedOpen] = useState(true);
 	const [branchDiffOpen, setBranchDiffOpen] = useState(true);
@@ -255,7 +258,8 @@ export function ChangesSection({
 								open={stagedOpen}
 								onToggle={() => setStagedOpen((current) => !current)}
 								changes={stagedChanges}
-								treeView={treeView}
+								treeView={changesTreeView}
+								onToggleTreeView={() => setChangesTreeView((v) => !v)}
 								action="unstage"
 								onStageAction={unstageFile}
 								onBatchAction={unstageAll}
@@ -272,7 +276,8 @@ export function ChangesSection({
 								open={changesOpen}
 								onToggle={() => setChangesOpen((current) => !current)}
 								changes={unstagedChanges}
-								treeView={treeView}
+								treeView={changesTreeView}
+								onToggleTreeView={() => setChangesTreeView((v) => !v)}
 								action="stage"
 								onStageAction={stageFile}
 								onBatchAction={stageAll}
@@ -295,7 +300,8 @@ export function ChangesSection({
 						open={branchDiffOpen}
 						onToggle={() => setBranchDiffOpen((current) => !current)}
 						changes={committedChanges}
-						treeView={treeView}
+						treeView={branchDiffTreeView}
+						onToggleTreeView={() => setBranchDiffTreeView((v) => !v)}
 						editorMode={editorMode}
 						activeEditorPath={activeEditorPath}
 						onOpenEditorFile={onOpenEditorFile}
@@ -322,6 +328,7 @@ function ChangesGroup({
 	onToggle,
 	changes,
 	treeView,
+	onToggleTreeView,
 	action,
 	onStageAction,
 	onBatchAction,
@@ -337,6 +344,7 @@ function ChangesGroup({
 	onToggle: () => void;
 	changes: InspectorFileItem[];
 	treeView: boolean;
+	onToggleTreeView: () => void;
 	action: StageActionKind;
 	onStageAction: (path: string) => void;
 	onBatchAction?: () => void;
@@ -355,7 +363,7 @@ function ChangesGroup({
 					size="xs"
 					onClick={onToggle}
 					aria-expanded={open}
-					className="h-auto min-w-0 flex-1 justify-start gap-1 rounded-none px-0 text-left hover:bg-transparent hover:text-foreground aria-expanded:bg-transparent aria-expanded:text-foreground"
+					className="h-auto min-w-0 flex-1 justify-start gap-1 rounded-none px-0 text-left hover:bg-transparent hover:text-foreground dark:hover:bg-transparent aria-expanded:bg-transparent aria-expanded:text-foreground"
 				>
 					<ChevronRightIcon
 						data-icon="inline-start"
@@ -367,13 +375,14 @@ function ChangesGroup({
 					/>
 					<span className="truncate">{label}</span>
 				</Button>
+				<ViewToggleButton treeView={treeView} onToggle={onToggleTreeView} />
 				{onBatchAction && (
 					<RowIconButton
 						aria-label={
 							action === "stage" ? "Stage all changes" : "Unstage all changes"
 						}
 						onClick={onBatchAction}
-						className="opacity-0 transition-opacity group-hover/header:opacity-100 focus-visible:opacity-100"
+						className="text-transparent hover:bg-transparent group-hover/header:text-muted-foreground group-hover/header:hover:text-foreground"
 					>
 						{action === "stage" ? (
 							<PlusIcon className="size-3.5" strokeWidth={2} />
@@ -429,6 +438,7 @@ function BranchDiffSection({
 	onToggle,
 	changes,
 	treeView,
+	onToggleTreeView,
 	editorMode,
 	activeEditorPath,
 	onOpenEditorFile,
@@ -442,6 +452,7 @@ function BranchDiffSection({
 	onToggle: () => void;
 	changes: InspectorFileItem[];
 	treeView: boolean;
+	onToggleTreeView: () => void;
 	editorMode: boolean;
 	activeEditorPath?: string | null;
 	onOpenEditorFile: (path: string, options?: DiffOpenOptions) => void;
@@ -470,7 +481,7 @@ function BranchDiffSection({
 					size="xs"
 					onClick={onToggle}
 					aria-expanded={open}
-					className="h-auto min-w-0 flex-1 justify-start gap-1 rounded-none px-0 text-left hover:bg-transparent hover:text-foreground aria-expanded:bg-transparent aria-expanded:text-foreground"
+					className="h-auto min-w-0 flex-1 justify-start gap-1 rounded-none px-0 text-left hover:bg-transparent hover:text-foreground dark:hover:bg-transparent aria-expanded:bg-transparent aria-expanded:text-foreground"
 				>
 					<ChevronRightIcon
 						data-icon="inline-start"
@@ -490,6 +501,7 @@ function BranchDiffSection({
 						<span className="min-w-0 truncate">{targetLabel}</span>
 					</span>
 				</Button>
+				<ViewToggleButton treeView={treeView} onToggle={onToggleTreeView} />
 				<Badge
 					variant="secondary"
 					className="h-4 min-w-[16px] justify-center rounded-full px-1 text-[9.5px] leading-none"
@@ -834,20 +846,24 @@ function ChangesFlatView({
 						alt=""
 						className="size-4 shrink-0"
 					/>
-					<ShinyFlash active={flashingPaths.has(change.path)}>
-						{change.name}
-					</ShinyFlash>
-					<span
-						className={cn(
-							"ml-auto shrink-0 truncate text-[10px] text-muted-foreground",
-							hasAction && "group-hover/row:hidden",
-						)}
-					>
-						{change.path.slice(0, change.path.lastIndexOf("/"))}
+					<span className="min-w-0 max-w-[60%] truncate">
+						<ShinyFlash active={flashingPaths.has(change.path)}>
+							{change.name}
+						</ShinyFlash>
 					</span>
 					<span
 						className={cn(
-							"flex shrink-0 items-center gap-1.5",
+							"min-w-0 flex-1 truncate text-right text-[10px] text-muted-foreground",
+							hasAction && "group-hover/row:hidden",
+						)}
+					>
+						{change.path.includes("/")
+							? change.path.slice(0, change.path.lastIndexOf("/"))
+							: ""}
+					</span>
+					<span
+						className={cn(
+							"flex shrink-0 items-center gap-1 tabular-nums",
 							hasAction && "group-hover/row:hidden",
 						)}
 					>
@@ -997,6 +1013,28 @@ function RowIconButton({
 	);
 }
 
+function ViewToggleButton({
+	treeView,
+	onToggle,
+}: {
+	treeView: boolean;
+	onToggle: () => void;
+}) {
+	return (
+		<RowIconButton
+			aria-label={treeView ? "Switch to list view" : "Switch to tree view"}
+			onClick={onToggle}
+			className="text-transparent hover:bg-transparent group-hover/header:text-muted-foreground group-hover/header:hover:text-foreground"
+		>
+			{treeView ? (
+				<ListIcon className="size-3.5" strokeWidth={1.8} />
+			) : (
+				<ListTreeIcon className="size-3.5" strokeWidth={1.8} />
+			)}
+		</RowIconButton>
+	);
+}
+
 function LineStats({
 	insertions,
 	deletions,
@@ -1009,7 +1047,7 @@ function LineStats({
 	}
 
 	return (
-		<span className="flex shrink-0 items-center gap-1 text-[10px]">
+		<span className="flex shrink-0 items-center gap-1 text-[10px] tabular-nums">
 			{insertions > 0 && (
 				<span className="text-chart-2">
 					+<NumberTicker value={insertions} className="text-chart-2" />


### PR DESCRIPTION
## Summary

- Add a **list/tree view toggle button** to each changes group header (staged, unstaged, branch diff), allowing users to switch between flat file list and tree view independently per section.
- Separate tree-view state: changes (staged + unstaged) share one toggle, branch diff has its own.
- Polish flat-view layout: truncate long filenames, hide empty parent paths for root-level files, use `tabular-nums` for line stats.
- Fix dark-mode hover background on section header buttons (`dark:hover:bg-transparent`).
- Batch action button visibility uses text color instead of opacity for smoother appearance.

## Test plan

- [ ] Toggle between flat/tree view in staged, unstaged, and branch diff sections — each should persist independently
- [ ] Verify toggle icon flips between `ListIcon` (→ flat) and `ListTreeIcon` (→ tree)
- [ ] Check long file paths truncate properly in flat view
- [ ] Confirm dark mode: header buttons have no background flash on hover
- [ ] Verify batch stage/unstage buttons remain visible on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)