### PR TITLE
fix: hide completed/unread status dot on the active session tab

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1119,14 +1119,17 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 
 	const handleSessionCompleted = useCallback(
 		(sessionId: string, workspaceId: string) => {
-			setCompletedSessions((prev) => {
-				const next = new Map(prev);
-				next.set(sessionId, workspaceId);
-				return next;
-			});
-			// Skip notification only when the user is actively viewing this session
-			if (document.hasFocus() && sessionId === selectedSessionIdRef.current)
-				return;
+			const isCurrentSession = sessionId === selectedSessionIdRef.current;
+			// Green dot only for sessions the user isn't viewing
+			if (!isCurrentSession) {
+				setCompletedSessions((prev) => {
+					const next = new Map(prev);
+					next.set(sessionId, workspaceId);
+					return next;
+				});
+			}
+			// OS notification: skip when user is focused on this session
+			if (document.hasFocus() && isCurrentSession) return;
 			const name =
 				queryClient.getQueryData<WorkspaceDetail | null>(
 					helmorQueryKeys.workspaceDetail(workspaceId),

--- a/src/features/panel/header.tsx
+++ b/src/features/panel/header.tsx
@@ -527,7 +527,8 @@ export const WorkspacePanelHeader = memo(function WorkspacePanelHeader({
 										const isActive =
 											isActivelySending && !isInteractionRequired;
 										const hasStatusDot =
-											isInteractionRequired || hasUnread || isCompleted;
+											isInteractionRequired ||
+											(!selected && (hasUnread || isCompleted));
 										const isEditing = editingSessionId === session.id;
 
 										return (


### PR DESCRIPTION
## Summary

- **Problem:** The green "completed" dot and unread indicator were appearing on the session tab the user was already viewing, which is visually noisy and misleading.
- **Fix in `App.tsx`:** The `handleSessionCompleted` callback now skips adding to `completedSessions` when the completed session is the one currently selected — the dot is only set for background sessions.
- **Fix in `header.tsx`:** The `hasStatusDot` flag now excludes `hasUnread` and `isCompleted` for the currently selected tab. `isInteractionRequired` still shows regardless of selection.

## Test plan

- [ ] Open multiple sessions in a workspace
- [ ] Run a task in a background session — verify the green dot appears on its tab
- [ ] Switch to that session — verify the dot clears
- [ ] Run a task in the currently viewed session — verify no dot appears while you're watching it
- [ ] Verify OS notifications still fire for background completions

🤖 Generated with [Claude Code](https://claude.com/claude-code)