### PR TITLE
refactor: consolidate per-level log files into single file per component

### DIFF
--- a/sidecar/src/logger.ts
+++ b/sidecar/src/logger.ts
@@ -1,7 +1,7 @@
 /**
  * Structured JSON logger for the sidecar process.
  *
- * - NDJSON to three level-specific files (inclusive routing).
+ * - NDJSON to a single file per day: `sidecar.YYYY-MM-DD.jsonl`.
  * - Dev stderr matches Rust tracing-subscriber's default format so both
  *   processes produce visually identical terminal output.
  * - stdout is NEVER touched — it is the exclusive JSON protocol channel.
@@ -69,11 +69,7 @@ export function errorDetails(err: unknown): Record<string, unknown> {
 
 class Logger {
 	private minLevel: number;
-	private files: Record<Level, WriteStream | undefined> = {
-		debug: undefined,
-		info: undefined,
-		error: undefined,
-	};
+	private file: WriteStream | undefined;
 	private devStderr: boolean;
 
 	constructor() {
@@ -91,10 +87,9 @@ class Logger {
 		if (logDir) {
 			mkdirSync(logDir, { recursive: true });
 			const today = localTs().slice(0, 10);
-			const path = (lvl: string) => `${logDir}/sidecar-${lvl}.${today}.jsonl`;
-			this.files.debug = createWriteStream(path("debug"), { flags: "a" });
-			this.files.info = createWriteStream(path("info"), { flags: "a" });
-			this.files.error = createWriteStream(path("error"), { flags: "a" });
+			this.file = createWriteStream(`${logDir}/sidecar.${today}.jsonl`, {
+				flags: "a",
+			});
 		}
 	}
 
@@ -119,9 +114,8 @@ class Logger {
 				: {};
 		const type = String(evt.type ?? "unknown");
 
-		// Full event → JSONL debug file
 		const line = `${JSON.stringify({ ts, level: "debug", source: "sidecar", msg: "sdk_event", requestId, type, event })}\n`;
-		this.files.debug?.write(line);
+		this.file?.write(line);
 
 		if (this.devStderr) {
 			const { label, color } = LEVEL_FMT.debug;
@@ -141,11 +135,7 @@ class Logger {
 
 		const ts = localTs();
 		const line = `${JSON.stringify({ ts, level, source: "sidecar", msg, ...data })}\n`;
-
-		// Inclusive file routing
-		this.files.debug?.write(line);
-		if (LEVELS[level] >= LEVELS.info) this.files.info?.write(line);
-		if (LEVELS[level] >= LEVELS.error) this.files.error?.write(line);
+		this.file?.write(line);
 
 		// Human-readable stderr matching Rust tracing format
 		if (this.devStderr) {

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -1,6 +1,6 @@
 //! Structured JSON logging with daily rotation.
 //!
-//! Files: `rust-{error,info,debug}.YYYY-MM-DD.jsonl` under the data-dir `logs/` folder.
+//! Single file per component: `rust.YYYY-MM-DD.jsonl` under the data-dir `logs/` folder.
 //! Dev builds also print human-readable output to stderr.
 //! Old log files are gzip-compressed on startup; files older than 7 days are purged.
 //!
@@ -19,8 +19,8 @@ use tracing_subscriber::{
 
 /// Set up the global tracing subscriber.
 ///
-/// Dev:  stderr (human-readable) + three JSONL files at `debug` level.
-/// Prod: three JSONL files only, default `info` (override via `HELMOR_LOG`).
+/// Dev:  stderr (human-readable) + JSONL file at `debug` level.
+/// Prod: JSONL file only, default `info` (override via `HELMOR_LOG`).
 pub fn init(logs_dir: &Path) -> Result<()> {
     let is_dev = crate::data_dir::is_dev();
     let level = resolve_level(is_dev);
@@ -56,9 +56,7 @@ pub fn init(logs_dir: &Path) -> Result<()> {
     });
 
     tracing_subscriber::registry()
-        .with(file_layer!("rust-error", LevelFilter::ERROR))
-        .with(file_layer!("rust-info", LevelFilter::INFO))
-        .with(file_layer!("rust-debug", level))
+        .with(file_layer!("rust", level))
         .with(stderr_layer)
         .init();
 


### PR DESCRIPTION
## Summary

- **Rust backend** (`logging.rs`): Replace three tracing file layers (`rust-error`, `rust-info`, `rust-debug`) with a single `rust.YYYY-MM-DD.jsonl` file.
- **Sidecar** (`logger.ts`): Replace three `WriteStream`s (`sidecar-{debug,info,error}`) with a single `sidecar.YYYY-MM-DD.jsonl` file.

## Why

The per-level file routing (inclusive: debug gets everything, info gets info+error, error gets error-only) tripled open file handles and disk writes with no practical benefit — logs are almost always searched with `grep`/`jq` across all levels anyway. A single file per component per day is simpler to manage, rotate, and compress.

## Test plan

- [ ] `pnpm run dev` — verify `~/helmor-dev/logs/` produces `rust.YYYY-MM-DD.jsonl` and `sidecar.YYYY-MM-DD.jsonl` (no per-level files)
- [ ] Confirm log entries contain the `level` field for filtering
- [ ] `pnpm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)