### PR TITLE
refactor: move quit confirmation from native Rust dialog to React

### DIFF
--- a/src-tauri/src/commands/system_commands.rs
+++ b/src-tauri/src/commands/system_commands.rs
@@ -269,6 +269,50 @@ fn base64_decode(input: &str) -> anyhow::Result<Vec<u8>> {
 }
 
 // ---------------------------------------------------------------------------
+// Graceful quit (called from the frontend quit-confirmation dialog)
+// ---------------------------------------------------------------------------
+
+/// Shut down git watchers, abort active streams (when `force`), tear down
+/// the sidecar cooperatively, then exit. Git watchers go first to stop new
+/// events from arriving while we drain.
+#[tauri::command]
+pub async fn request_quit(app: tauri::AppHandle, force: bool) {
+    tracing::info!(force, "request_quit invoked from frontend");
+
+    // 1. Stop filesystem watchers so no new events arrive.
+    app.state::<git_watcher::GitWatcherManager>().shutdown();
+
+    // 2. If tasks are in flight, gracefully stop every active stream.
+    if force {
+        let sidecar = app.state::<sidecar::ManagedSidecar>();
+        let active = app.state::<agents::ActiveStreams>();
+        agents::abort_all_active_streams_blocking(
+            &sidecar,
+            &active,
+            std::time::Duration::from_millis(1500),
+        );
+    }
+
+    // 3. Cooperative sidecar teardown: shutdown RPC → SIGTERM → SIGKILL.
+    let sidecar = app.state::<sidecar::ManagedSidecar>();
+    let (cooperative, escalation) = if force {
+        (
+            std::time::Duration::from_millis(2000),
+            std::time::Duration::from_millis(500),
+        )
+    } else {
+        (
+            std::time::Duration::from_millis(500),
+            std::time::Duration::from_millis(200),
+        )
+    };
+    sidecar.shutdown(cooperative, escalation);
+
+    // 4. Done — terminate the process.
+    app.exit(0);
+}
+
+// ---------------------------------------------------------------------------
 // Dev-only: nuclear data reset
 // ---------------------------------------------------------------------------
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,18 +28,8 @@ pub use workspace::files as editor_files;
 pub use workspace::helpers;
 pub use workspace::workspaces;
 
-use std::sync::atomic::{AtomicBool, Ordering};
 use tauri::path::BaseDirectory;
 use tauri::Manager;
-use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
-
-/// Set once the user has confirmed quitting. Short-circuits the
-/// `CloseRequested` handler on the second pass so it skips the dialog.
-static SHUTDOWN_CONFIRMED: AtomicBool = AtomicBool::new(false);
-
-/// Set while the shutdown confirmation dialog is on screen. Prevents
-/// stacking duplicates from rapid-fire `CloseRequested` events.
-static SHUTDOWN_DIALOG_OPEN: AtomicBool = AtomicBool::new(false);
 
 /// Initialise the database schema (call once at startup).
 pub fn schema_init(conn: &rusqlite::Connection) {
@@ -276,6 +266,7 @@ pub fn run() {
             commands::conductor_commands::list_conductor_workspaces,
             commands::conductor_commands::import_conductor_workspaces,
             commands::system_commands::save_pasted_image,
+            commands::system_commands::request_quit,
             commands::system_commands::dev_reset_all_data,
             commands::settings_commands::update_app_settings,
             commands::session_commands::update_session_settings,
@@ -288,105 +279,9 @@ pub fn run() {
         .build(tauri::generate_context!())
         .expect("error while building tauri application");
 
-    // Hook `WindowEvent::CloseRequested` — not `ExitRequested`, which only
-    // fires after all windows are destroyed. The dialog is dispatched via
-    // the async `show(callback)` form; `blocking_show()` would freeze the
-    // app when called from the main thread.
-    app.run(|app_handle, event| {
-        let tauri::RunEvent::WindowEvent {
-            label,
-            event: tauri::WindowEvent::CloseRequested { api, .. },
-            ..
-        } = &event
-        else {
-            return;
-        };
-
-        // Second pass after the user confirmed — don't re-prompt.
-        if SHUTDOWN_CONFIRMED.load(Ordering::Acquire) {
-            tracing::debug!(window = %label, "CloseRequested — confirmed, letting through");
-            return;
-        }
-
-        let active = app_handle.state::<agents::ActiveStreams>();
-        let count = active.len();
-        tracing::info!(window = %label, count, "CloseRequested");
-
-        if count == 0 {
-            // Stop git filesystem watchers before tearing down the sidecar.
-            app_handle
-                .state::<git_watcher::GitWatcherManager>()
-                .shutdown();
-
-            // No active streams, but still shut down the sidecar cooperatively
-            // so Bun and any child CLIs get a chance to exit cleanly instead of
-            // being SIGKILL'd by the Drop impl.
-            let sidecar = app_handle.state::<sidecar::ManagedSidecar>();
-            sidecar.shutdown(
-                std::time::Duration::from_millis(500),
-                std::time::Duration::from_millis(200),
-            );
-            return;
-        }
-
-        // Streams in flight — keep the window open and ask the user.
-        api.prevent_close();
-
-        // Guard against duplicate dialogs from rapid-fire CloseRequested
-        // events (multiple windows, double Cmd+Q, etc.).
-        if SHUTDOWN_DIALOG_OPEN.swap(true, Ordering::AcqRel) {
-            tracing::debug!("Shutdown dialog already on screen, swallowing duplicate");
-            return;
-        }
-
-        let app_handle_clone = app_handle.clone();
-        let message = if count == 1 {
-            "There is 1 task in progress. Quitting now will cancel it.".to_string()
-        } else {
-            format!("There are {count} tasks in progress. Quitting now will cancel them.")
-        };
-
-        tracing::info!("Showing shutdown confirmation dialog");
-        app_handle
-            .dialog()
-            .message(message)
-            .title("Quit Helmor?")
-            .buttons(MessageDialogButtons::OkCancelCustom(
-                "Quit anyway".to_string(),
-                "Cancel".to_string(),
-            ))
-            .show(move |confirmed| {
-                SHUTDOWN_DIALOG_OPEN.store(false, Ordering::Release);
-
-                if !confirmed {
-                    tracing::info!("Shutdown cancelled by user");
-                    return;
-                }
-
-                tracing::info!("User confirmed shutdown — aborting active streams");
-                app_handle_clone
-                    .state::<git_watcher::GitWatcherManager>()
-                    .shutdown();
-                // We're on a worker thread now, so the blocking helpers are
-                // safe to call.
-                let sidecar = app_handle_clone.state::<sidecar::ManagedSidecar>();
-                let active = app_handle_clone.state::<agents::ActiveStreams>();
-                agents::abort_all_active_streams_blocking(
-                    &sidecar,
-                    &active,
-                    std::time::Duration::from_millis(1500),
-                );
-                // Cooperative sidecar teardown — let bun close every live
-                // SDK Query so the spawned claude-code / codex CLIs get a
-                // chance to exit on their own. Ladder: shutdown RPC (2s) →
-                // SIGTERM (500ms) → SIGKILL via Drop.
-                sidecar.shutdown(
-                    std::time::Duration::from_millis(2000),
-                    std::time::Duration::from_millis(500),
-                );
-                SHUTDOWN_CONFIRMED.store(true, Ordering::Release);
-                tracing::info!("Shutdown cleanup done, calling exit(0)");
-                app_handle_clone.exit(0);
-            });
-    });
+    // The frontend's onCloseRequested always calls preventDefault(), so
+    // the JS layer never destroys the window on its own.  All quit logic
+    // lives in the `request_quit` Tauri command (called from the frontend
+    // quit-confirmation dialog).  Nothing to do here.
+    app.run(|_app_handle, _event| {});
 }

--- a/src/App.shortcuts.test.tsx
+++ b/src/App.shortcuts.test.tsx
@@ -61,6 +61,7 @@ vi.mock("./lib/api", async (importOriginal) => {
 		loadWorkspaceSessions: apiMocks.loadWorkspaceSessions,
 		loadSessionMessages: apiMocks.loadSessionThreadMessages,
 		loadSessionThreadMessages: apiMocks.loadSessionThreadMessages,
+		requestQuit: vi.fn(),
 	};
 });
 
@@ -649,6 +650,7 @@ describe("App global navigation shortcuts", () => {
 		expect(apiMocks.hideSession).toHaveBeenCalledWith("session-done-1");
 		expect(apiMocks.deleteSession).not.toHaveBeenCalled();
 
+		// QuitConfirmDialog always prevents the JS-layer close.
 		const preventDefault = vi.fn();
 		await windowApiMocks.closeRequestedHandler?.({ preventDefault });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import "./App.css";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client";
-import { getCurrentWindow } from "@tauri-apps/api/window";
+
 import {
 	Check,
 	ChevronDown,
@@ -18,6 +18,7 @@ import {
 } from "react";
 import { toast } from "sonner";
 import { ConductorOnboarding } from "@/components/conductor-onboarding";
+import { QuitConfirmDialog } from "@/components/quit-confirm-dialog";
 import { SplashScreen } from "@/components/splash-screen";
 import { Button } from "@/components/ui/button";
 import {
@@ -205,7 +206,7 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 	const warmedWorkspaceIdsRef = useRef<Set<string>>(new Set());
 	const selectedWorkspaceIdRef = useRef<string | null>(null);
 	const selectedSessionIdRef = useRef<string | null>(null);
-	const sessionCloseShortcutRequestedAtRef = useRef(0);
+
 	const workspaceViewModeRef = useRef<"conversation" | "editor">(
 		"conversation",
 	);
@@ -1429,33 +1430,8 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 		queuePendingPromptForSession,
 	]);
 
-	useEffect(() => {
-		let disposed = false;
-		let unlisten: (() => void) | undefined;
-
-		void getCurrentWindow()
-			.onCloseRequested(async (event) => {
-				if (Date.now() - sessionCloseShortcutRequestedAtRef.current > 1_000) {
-					return;
-				}
-
-				sessionCloseShortcutRequestedAtRef.current = 0;
-				event.preventDefault();
-			})
-			.then((fn) => {
-				if (disposed) {
-					fn();
-					return;
-				}
-
-				unlisten = fn;
-			});
-
-		return () => {
-			disposed = true;
-			unlisten?.();
-		};
-	}, []);
+	// Close-confirmation is handled by <QuitConfirmDialog /> which registers
+	// its own onCloseRequested listener.  No need for a separate hook here.
 
 	useEffect(() => {
 		if (!isIdentityConnected || workspaceViewMode === "editor") {
@@ -1528,7 +1504,6 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 				return;
 			}
 
-			sessionCloseShortcutRequestedAtRef.current = Date.now();
 			event.preventDefault();
 			void handleCloseSelectedSession();
 		};
@@ -2020,6 +1995,7 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 					/>
 				</ComposerInsertProvider>
 			</WorkspaceToastProvider>
+			<QuitConfirmDialog sendingSessionIds={sendingSessionIds} />
 		</TooltipProvider>
 	);
 }

--- a/src/components/quit-confirm-dialog.tsx
+++ b/src/components/quit-confirm-dialog.tsx
@@ -1,0 +1,65 @@
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { requestQuit } from "@/lib/api";
+
+export function QuitConfirmDialog({
+	sendingSessionIds,
+}: {
+	sendingSessionIds: Set<string>;
+}) {
+	const [open, setOpen] = useState(false);
+	const sendingRef = useRef(sendingSessionIds);
+	sendingRef.current = sendingSessionIds;
+
+	const handleQuit = useCallback(async (force: boolean) => {
+		setOpen(false);
+		await requestQuit(force);
+	}, []);
+
+	useEffect(() => {
+		let disposed = false;
+		let unlisten: (() => void) | undefined;
+
+		void getCurrentWindow()
+			.onCloseRequested(async (event) => {
+				event.preventDefault();
+
+				if (sendingRef.current.size === 0) {
+					await requestQuit(false);
+					return;
+				}
+
+				setOpen(true);
+			})
+			.then((fn) => {
+				if (disposed) {
+					fn();
+					return;
+				}
+				unlisten = fn;
+			});
+
+		return () => {
+			disposed = true;
+			unlisten?.();
+		};
+	}, []);
+
+	const count = sendingSessionIds.size;
+
+	return (
+		<ConfirmDialog
+			open={open}
+			onOpenChange={setOpen}
+			title="Quit Helmor?"
+			description={
+				count === 1
+					? "There is 1 task in progress. Quitting now will cancel it."
+					: `There are ${count} tasks in progress. Quitting now will cancel them.`
+			}
+			confirmLabel="Quit anyway"
+			onConfirm={() => void handleQuit(true)}
+		/>
+	);
+}

--- a/src/components/ui/confirm-dialog.tsx
+++ b/src/components/ui/confirm-dialog.tsx
@@ -1,0 +1,60 @@
+import type { ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogTitle,
+} from "@/components/ui/dialog";
+
+export function ConfirmDialog({
+	open,
+	onOpenChange,
+	title,
+	description,
+	confirmLabel = "Confirm",
+	cancelLabel = "Cancel",
+	onConfirm,
+	loading = false,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	title: string;
+	description: ReactNode;
+	confirmLabel?: string;
+	cancelLabel?: string;
+	onConfirm: () => void;
+	loading?: boolean;
+}) {
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent
+				className="max-w-[320px] gap-0 p-4"
+				showCloseButton={false}
+			>
+				<DialogTitle className="text-[13px] font-semibold">{title}</DialogTitle>
+				<DialogDescription className="mt-1.5 text-[12px] leading-relaxed text-muted-foreground">
+					{description}
+				</DialogDescription>
+				<div className="mt-3 flex justify-end gap-2">
+					<Button
+						variant="outline"
+						size="sm"
+						onClick={() => onOpenChange(false)}
+						disabled={loading}
+					>
+						{cancelLabel}
+					</Button>
+					<Button
+						variant="destructive"
+						size="sm"
+						onClick={onConfirm}
+						disabled={loading}
+					>
+						{confirmLabel}
+					</Button>
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/src/features/settings/panels/dev-tools.tsx
+++ b/src/features/settings/panels/dev-tools.tsx
@@ -1,13 +1,7 @@
-import { AlertTriangle, Loader2, Trash2 } from "lucide-react";
+import { Loader2, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
-import {
-	Dialog,
-	DialogContent,
-	DialogDescription,
-	DialogFooter,
-	DialogTitle,
-} from "@/components/ui/dialog";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { devResetAllData, loadDataInfo } from "@/lib/api";
 
 export function DevToolsPanel() {
@@ -85,55 +79,22 @@ export function DevToolsPanel() {
 				)}
 			</div>
 
-			{/* Confirmation dialog */}
-			<Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
-				<DialogContent className="max-w-sm">
-					<div className="flex items-center gap-3">
-						<div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-destructive/10">
-							<AlertTriangle
-								className="size-5 text-destructive"
-								strokeWidth={1.8}
-							/>
-						</div>
-						<div>
-							<DialogTitle className="text-[14px] font-semibold">
-								Confirm Reset
-							</DialogTitle>
-							<DialogDescription className="mt-1 text-[12px] text-muted-foreground">
-								This will permanently delete{" "}
-								<strong>all workspaces, sessions, and repositories</strong> from
-								the development database. This action cannot be undone. You can
-								re-import from Conductor afterwards.
-							</DialogDescription>
-						</div>
-					</div>
-					<DialogFooter className="mt-4">
-						<Button
-							variant="outline"
-							size="sm"
-							onClick={() => setConfirmOpen(false)}
-							disabled={resetting}
-						>
-							Cancel
-						</Button>
-						<Button
-							variant="destructive"
-							size="sm"
-							onClick={() => void handleReset()}
-							disabled={resetting}
-						>
-							{resetting ? (
-								<>
-									<Loader2 className="mr-1.5 size-3.5 animate-spin" />
-									Resetting...
-								</>
-							) : (
-								"Delete Everything"
-							)}
-						</Button>
-					</DialogFooter>
-				</DialogContent>
-			</Dialog>
+			<ConfirmDialog
+				open={confirmOpen}
+				onOpenChange={setConfirmOpen}
+				title="Confirm Reset"
+				description={
+					<>
+						This will permanently delete{" "}
+						<strong>all workspaces, sessions, and repositories</strong> from the
+						development database. This action cannot be undone. You can
+						re-import from Conductor afterwards.
+					</>
+				}
+				confirmLabel={resetting ? "Resetting..." : "Delete Everything"}
+				onConfirm={() => void handleReset()}
+				loading={resetting}
+			/>
 		</div>
 	);
 }

--- a/src/features/settings/panels/repository-settings.tsx
+++ b/src/features/settings/panels/repository-settings.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Check, ChevronDown, GitBranch, Loader2, Trash2 } from "lucide-react";
+import { Check, ChevronDown, GitBranch, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { BranchPickerPopover } from "@/components/branch-picker";
 import { Button } from "@/components/ui/button";
@@ -9,12 +9,7 @@ import {
 	CommandItem,
 	CommandList,
 } from "@/components/ui/command";
-import {
-	Dialog,
-	DialogContent,
-	DialogDescription,
-	DialogTitle,
-} from "@/components/ui/dialog";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import {
 	Popover,
 	PopoverContent,
@@ -448,44 +443,22 @@ function DeleteRepoSection({
 				)}
 			</div>
 
-			<Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
-				<DialogContent className="max-w-[320px] gap-0 p-4">
-					<DialogTitle className="text-[13px] font-semibold">
-						Delete {repo.name}?
-					</DialogTitle>
-					<DialogDescription className="mt-1.5 text-[12px] leading-relaxed text-muted-foreground">
+			<ConfirmDialog
+				open={confirmOpen}
+				onOpenChange={setConfirmOpen}
+				title={`Delete ${repo.name}?`}
+				description={
+					<>
 						This will permanently delete all workspaces, sessions, and messages
 						associated with{" "}
 						<strong className="text-foreground/80">{repo.name}</strong>. This
 						cannot be undone.
-					</DialogDescription>
-					<div className="mt-3 flex justify-end gap-2">
-						<Button
-							variant="outline"
-							size="sm"
-							onClick={() => setConfirmOpen(false)}
-							disabled={deleting}
-						>
-							Cancel
-						</Button>
-						<Button
-							variant="destructive"
-							size="sm"
-							onClick={() => void handleDelete()}
-							disabled={deleting}
-						>
-							{deleting ? (
-								<>
-									<Loader2 className="mr-1.5 size-3.5 animate-spin" />
-									Deleting...
-								</>
-							) : (
-								"Delete"
-							)}
-						</Button>
-					</div>
-				</DialogContent>
-			</Dialog>
+					</>
+				}
+				confirmLabel={deleting ? "Deleting..." : "Delete"}
+				onConfirm={() => void handleDelete()}
+				loading={deleting}
+			/>
 		</>
 	);
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -539,6 +539,10 @@ export type DevResetResult = {
 	directoriesRemoved: string[];
 };
 
+export async function requestQuit(force: boolean): Promise<void> {
+	return await invoke("request_quit", { force });
+}
+
 export async function devResetAllData(): Promise<DevResetResult> {
 	return await invoke<DevResetResult>("dev_reset_all_data");
 }


### PR DESCRIPTION
## Summary

- **Move quit-confirmation from Rust-side native OS dialog to a React-rendered `<QuitConfirmDialog />`** — gives consistent in-app UX instead of a platform-native message box, and keeps all UI logic in the frontend layer.
- **Extract a reusable `<ConfirmDialog />` component** (`src/components/ui/confirm-dialog.tsx`) and deduplicate the inline dialog markup previously repeated in `dev-tools.tsx` and `repository-settings.tsx`.
- **Add `request_quit` Tauri command** in `system_commands.rs` — handles graceful shutdown (git watchers → abort active streams → sidecar teardown → `app.exit(0)`), callable from the frontend dialog.
- **Simplify `lib.rs`** by removing ~100 lines of `CloseRequested` event handling, `AtomicBool` guards, and `tauri_plugin_dialog` usage — the `app.run()` callback is now a no-op since the frontend owns the quit flow.

## Test plan

- [ ] With no active tasks: close the window → app quits immediately (no dialog)
- [ ] With active tasks: close the window → in-app confirmation dialog appears → "Cancel" keeps the app open, "Quit anyway" shuts down gracefully
- [ ] Cmd+Q behaviour unchanged
- [ ] Settings → Dev Tools → "Reset All Data" confirmation dialog still works
- [ ] Settings → Repository → "Delete" confirmation dialog still works
- [ ] Existing shortcut tests pass (`pnpm run test:frontend`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)