### PR TITLE
fix: prevent sidebar groups from auto-expanding on data refetch

### DIFF
--- a/src/features/navigation/hooks/use-controller.ts
+++ b/src/features/navigation/hooks/use-controller.ts
@@ -210,7 +210,7 @@ export function useWorkspacesSidebarController({
 	}, [queryClient]);
 
 	const invalidateWorkspaceSummary = useCallback(
-		async (workspaceId: string) => {
+		async (workspaceId: string, opts?: { skipSidebarFlush?: boolean }) => {
 			await Promise.all([
 				queryClient.invalidateQueries({
 					queryKey: helmorQueryKeys.workspaceDetail(workspaceId),
@@ -219,7 +219,7 @@ export function useWorkspacesSidebarController({
 					queryKey: helmorQueryKeys.workspaceSessions(workspaceId),
 				}),
 			]);
-			if (sidebarMutationCountRef.current === 0) {
+			if (!opts?.skipSidebarFlush && sidebarMutationCountRef.current === 0) {
 				flushSidebarLists();
 			}
 		},
@@ -298,7 +298,11 @@ export function useWorkspacesSidebarController({
 			);
 
 			void markWorkspaceRead(workspaceId)
-				.then(() => invalidateWorkspaceSummary(workspaceId))
+				.then(() =>
+					invalidateWorkspaceSummary(workspaceId, {
+						skipSidebarFlush: true,
+					}),
+				)
 				.catch((error) => {
 					queryClient.setQueryData(
 						helmorQueryKeys.workspaceGroups,
@@ -427,7 +431,11 @@ export function useWorkspacesSidebarController({
 			}
 
 			void markWorkspaceUnread(workspaceId)
-				.then(() => invalidateWorkspaceSummary(workspaceId))
+				.then(() =>
+					invalidateWorkspaceSummary(workspaceId, {
+						skipSidebarFlush: true,
+					}),
+				)
 				.catch((error) => {
 					queryClient.setQueryData(
 						helmorQueryKeys.workspaceGroups,
@@ -497,7 +505,7 @@ export function useWorkspacesSidebarController({
 
 				return withoutRow.map((group) =>
 					group.id === targetGroupId
-						? { ...group, rows: [...group.rows, updatedRow] }
+						? { ...group, rows: [updatedRow, ...group.rows] }
 						: group,
 				);
 			});
@@ -553,7 +561,7 @@ export function useWorkspacesSidebarController({
 
 				return withoutRow.map((group) =>
 					group.id === targetGroupId
-						? { ...group, rows: [...group.rows, movedRow] }
+						? { ...group, rows: [movedRow, ...group.rows] }
 						: group,
 				);
 			});

--- a/src/features/navigation/index.test.tsx
+++ b/src/features/navigation/index.test.tsx
@@ -165,7 +165,7 @@ describe("WorkspacesSidebar", () => {
 		const virtualList = container.querySelector(
 			'[data-slot="workspace-groups-scroll"] > div',
 		);
-		expect(virtualList).toHaveStyle({ height: "192px" });
+		expect(virtualList).toHaveStyle({ height: "252px" });
 	});
 
 	it("persists section collapse state in localStorage", async () => {
@@ -253,6 +253,177 @@ describe("WorkspacesSidebar", () => {
 		).toBeInTheDocument();
 		expect(
 			within(otherRow).getByLabelText("Interaction required"),
+		).toBeInTheDocument();
+	});
+
+	it("does not auto-expand a collapsed group when groups data refreshes", async () => {
+		const user = userEvent.setup();
+		const groups: WorkspaceGroup[] = [
+			{
+				id: "progress",
+				label: "In Progress",
+				tone: "progress",
+				rows: [workspaceRow],
+			},
+		];
+
+		const { rerender } = render(
+			<TooltipProvider delayDuration={0}>
+				<WorkspacesSidebar
+					groups={groups}
+					archivedRows={[]}
+					selectedWorkspaceId="workspace-1"
+				/>
+			</TooltipProvider>,
+		);
+
+		expect(
+			screen.getByRole("button", { name: "Workspace 1" }),
+		).toBeInTheDocument();
+
+		// Collapse the group
+		await user.click(screen.getByRole("button", { name: /^In Progress/ }));
+		expect(
+			screen.queryByRole("button", { name: "Workspace 1" }),
+		).not.toBeInTheDocument();
+
+		// Simulate a groups refetch (new array reference, same data)
+		rerender(
+			<TooltipProvider delayDuration={0}>
+				<WorkspacesSidebar
+					groups={[...groups.map((g) => ({ ...g, rows: [...g.rows] }))]}
+					archivedRows={[]}
+					selectedWorkspaceId="workspace-1"
+				/>
+			</TooltipProvider>,
+		);
+
+		// Group should stay collapsed
+		expect(
+			screen.queryByRole("button", { name: "Workspace 1" }),
+		).not.toBeInTheDocument();
+	});
+
+	it("does not auto-expand destination group when workspace moves between groups", async () => {
+		const user = userEvent.setup();
+		const ws = { ...workspaceRow, id: "ws-move", title: "Moving WS" };
+		const initialGroups: WorkspaceGroup[] = [
+			{
+				id: "done",
+				label: "Done",
+				tone: "done",
+				rows: [{ ...workspaceRow, id: "ws-completed", title: "Completed WS" }],
+			},
+			{
+				id: "progress",
+				label: "In Progress",
+				tone: "progress",
+				rows: [ws],
+			},
+		];
+
+		const { rerender } = render(
+			<TooltipProvider delayDuration={0}>
+				<WorkspacesSidebar
+					groups={initialGroups}
+					archivedRows={[]}
+					selectedWorkspaceId="ws-move"
+				/>
+			</TooltipProvider>,
+		);
+
+		// Collapse the "Done" group
+		await user.click(screen.getByRole("button", { name: /^Done/ }));
+		expect(
+			screen.queryByRole("button", { name: "Completed WS" }),
+		).not.toBeInTheDocument();
+
+		// Move workspace from progress to done (simulating status change)
+		const afterMoveGroups: WorkspaceGroup[] = [
+			{
+				id: "done",
+				label: "Done",
+				tone: "done",
+				rows: [
+					ws,
+					{ ...workspaceRow, id: "ws-completed", title: "Completed WS" },
+				],
+			},
+			{
+				id: "progress",
+				label: "In Progress",
+				tone: "progress",
+				rows: [],
+			},
+		];
+
+		rerender(
+			<TooltipProvider delayDuration={0}>
+				<WorkspacesSidebar
+					groups={afterMoveGroups}
+					archivedRows={[]}
+					selectedWorkspaceId="ws-move"
+				/>
+			</TooltipProvider>,
+		);
+
+		// "Done" should stay collapsed — the workspace moved there but
+		// selectedWorkspaceId didn't change
+		expect(
+			screen.queryByRole("button", { name: "Moving WS" }),
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: "Completed WS" }),
+		).not.toBeInTheDocument();
+	});
+
+	it("auto-expands a collapsed group when a new workspace is selected in it", async () => {
+		const user = userEvent.setup();
+		const groups: WorkspaceGroup[] = [
+			{
+				id: "done",
+				label: "Done",
+				tone: "done",
+				rows: [{ ...workspaceRow, id: "ws-completed", title: "Completed WS" }],
+			},
+			{
+				id: "progress",
+				label: "In Progress",
+				tone: "progress",
+				rows: [workspaceRow],
+			},
+		];
+
+		const { rerender } = render(
+			<TooltipProvider delayDuration={0}>
+				<WorkspacesSidebar
+					groups={groups}
+					archivedRows={[]}
+					selectedWorkspaceId="workspace-1"
+				/>
+			</TooltipProvider>,
+		);
+
+		// Collapse "Done"
+		await user.click(screen.getByRole("button", { name: /^Done/ }));
+		expect(
+			screen.queryByRole("button", { name: "Completed WS" }),
+		).not.toBeInTheDocument();
+
+		// Select a workspace inside the collapsed "Done" group
+		rerender(
+			<TooltipProvider delayDuration={0}>
+				<WorkspacesSidebar
+					groups={groups}
+					archivedRows={[]}
+					selectedWorkspaceId="ws-completed"
+				/>
+			</TooltipProvider>,
+		);
+
+		// Group should expand because selectedWorkspaceId changed
+		expect(
+			screen.getByRole("button", { name: "Completed WS" }),
 		).toBeInTheDocument();
 	});
 

--- a/src/features/navigation/index.tsx
+++ b/src/features/navigation/index.tsx
@@ -67,15 +67,14 @@ type VirtualItem =
 	| { kind: "group-gap"; size: number }
 	| { kind: "bottom-padding" };
 
-const HEADER_HEIGHT = 34; // tighter header + minimal gap below
-const EMPTY_HEADER_HEIGHT = 24; // tighter header for empty groups
+const HEADER_HEIGHT = 34; // unified header height for all groups
 const ROW_HEIGHT = 32; // 30px (h-7.5) + 2px gap
 const GROUP_GAP = 8; // tighter gap between populated groups
 const EMPTY_GROUP_GAP = 8; // tighter spacing around empty groups
 const BOTTOM_PADDING = 8;
 
-function getGroupHeaderHeight(hasRows: boolean) {
-	return hasRows ? HEADER_HEIGHT : EMPTY_HEADER_HEIGHT;
+function getGroupHeaderHeight(_hasRows: boolean) {
+	return HEADER_HEIGHT;
 }
 
 function getGroupGapSize(previousHasRows: boolean, nextHasRows: boolean) {
@@ -171,7 +170,19 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 		writeStoredSectionOpenState(sectionOpenState);
 	}, [sectionOpenState]);
 
+	// Auto-expand the group containing the selected workspace, but ONLY when
+	// the selection actually changes — not on every groups refetch (window
+	// focus, invalidation, status change). Without this guard, collapsed
+	// groups reopen whenever their data refreshes.
+	const lastAutoExpandedIdRef = useRef<string | null>(null);
 	useEffect(() => {
+		if (
+			!selectedWorkspaceId ||
+			selectedWorkspaceId === lastAutoExpandedIdRef.current
+		) {
+			return;
+		}
+
 		const selectedSectionId = findSelectedSectionId(
 			selectedWorkspaceId,
 			groups,
@@ -182,6 +193,7 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 			return;
 		}
 
+		lastAutoExpandedIdRef.current = selectedWorkspaceId;
 		setSectionOpenState((current) =>
 			current[selectedSectionId]
 				? current
@@ -348,7 +360,7 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 						type="button"
 						className={cn(
 							"group/trigger flex w-full select-none items-center justify-between rounded-lg px-2 text-[13px] font-semibold tracking-[-0.01em] text-foreground hover:bg-accent/60",
-							isEmptyGroup ? "py-0.5" : "py-1",
+							"py-1",
 							item.canCollapse ? "cursor-pointer" : "cursor-default",
 						)}
 						data-empty-group={isEmptyGroup ? "true" : "false"}

--- a/src/features/navigation/row-item.tsx
+++ b/src/features/navigation/row-item.tsx
@@ -125,8 +125,6 @@ export const WorkspaceRowItem = memo(
 			manualStatus: row.manualStatus,
 			derivedStatus: row.derivedStatus,
 		});
-		const actionOverlayWidthClassName =
-			isRestoreAction && onDeleteWorkspace ? "w-16" : "w-9";
 		const statusDotLabel = isInteractionRequired
 			? "Interaction required"
 			: isCompleted
@@ -216,26 +214,54 @@ export const WorkspaceRowItem = memo(
 				{hasActionHandler ? (
 					<span
 						className={cn(
-							"pointer-events-none absolute inset-y-0 right-0 z-10 flex items-center justify-end opacity-0 group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100",
-							actionOverlayWidthClassName,
-							isBusy && "pointer-events-auto opacity-100",
+							"shrink-0 flex items-center gap-0.5 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100",
+							isBusy && "opacity-100",
 						)}
 					>
-						<span className="absolute inset-y-0 right-0 w-full rounded-r-md bg-[linear-gradient(to_right,transparent_0%,var(--sidebar)_38%,var(--sidebar)_100%)]" />
-						<span className="relative z-10 flex items-center gap-0.5 pr-1">
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<Button
+									aria-label={actionLabel}
+									disabled={Boolean(workspaceActionsDisabled)}
+									onClick={(event) => {
+										event.stopPropagation();
+										if (workspaceActionsDisabled) return;
+										if (isRestoreAction) {
+											onRestoreWorkspace?.(row.id);
+										} else {
+											onArchiveWorkspace?.(row.id);
+										}
+									}}
+									variant="ghost"
+									size="icon-xs"
+									className={cn(
+										"size-5 rounded-md p-0 text-muted-foreground",
+										workspaceActionsDisabled
+											? "cursor-not-allowed opacity-60"
+											: "cursor-pointer hover:text-foreground",
+									)}
+								>
+									{actionIcon}
+								</Button>
+							</TooltipTrigger>
+							<TooltipContent
+								side="top"
+								sideOffset={8}
+								className="flex h-[22px] items-center rounded-md px-1.5 text-[11px] leading-none"
+							>
+								<span>{actionLabel}</span>
+							</TooltipContent>
+						</Tooltip>
+						{isRestoreAction && onDeleteWorkspace ? (
 							<Tooltip>
 								<TooltipTrigger asChild>
 									<Button
-										aria-label={actionLabel}
+										aria-label="Delete permanently"
 										disabled={Boolean(workspaceActionsDisabled)}
 										onClick={(event) => {
 											event.stopPropagation();
 											if (workspaceActionsDisabled) return;
-											if (isRestoreAction) {
-												onRestoreWorkspace?.(row.id);
-											} else {
-												onArchiveWorkspace?.(row.id);
-											}
+											onDeleteWorkspace(row.id);
 										}}
 										variant="ghost"
 										size="icon-xs"
@@ -243,10 +269,10 @@ export const WorkspaceRowItem = memo(
 											"size-5 rounded-md p-0 text-muted-foreground",
 											workspaceActionsDisabled
 												? "cursor-not-allowed opacity-60"
-												: "cursor-pointer hover:text-foreground",
+												: "cursor-pointer hover:text-destructive",
 										)}
 									>
-										{actionIcon}
+										<Trash2 className="size-3.5" strokeWidth={2.1} />
 									</Button>
 								</TooltipTrigger>
 								<TooltipContent
@@ -254,42 +280,10 @@ export const WorkspaceRowItem = memo(
 									sideOffset={8}
 									className="flex h-[22px] items-center rounded-md px-1.5 text-[11px] leading-none"
 								>
-									<span>{actionLabel}</span>
+									<span>Delete permanently</span>
 								</TooltipContent>
 							</Tooltip>
-							{isRestoreAction && onDeleteWorkspace ? (
-								<Tooltip>
-									<TooltipTrigger asChild>
-										<Button
-											aria-label="Delete permanently"
-											disabled={Boolean(workspaceActionsDisabled)}
-											onClick={(event) => {
-												event.stopPropagation();
-												if (workspaceActionsDisabled) return;
-												onDeleteWorkspace(row.id);
-											}}
-											variant="ghost"
-											size="icon-xs"
-											className={cn(
-												"size-5 rounded-md p-0 text-muted-foreground",
-												workspaceActionsDisabled
-													? "cursor-not-allowed opacity-60"
-													: "cursor-pointer hover:text-destructive",
-											)}
-										>
-											<Trash2 className="size-3.5" strokeWidth={2.1} />
-										</Button>
-									</TooltipTrigger>
-									<TooltipContent
-										side="top"
-										sideOffset={8}
-										className="flex h-[22px] items-center rounded-md px-1.5 text-[11px] leading-none"
-									>
-										<span>Delete permanently</span>
-									</TooltipContent>
-								</Tooltip>
-							) : null}
-						</span>
+						) : null}
 					</span>
 				) : null}
 			</div>


### PR DESCRIPTION
## Summary

- **Fix collapsed groups reopening on data refetch:** Auto-expand logic now only triggers when `selectedWorkspaceId` actually changes, not on every query invalidation (window focus, mark-read, status change). Uses a ref to track the last auto-expanded ID.
- **Fix workspace sort order on group move:** Moved/restored workspaces are prepended to the target group instead of appended, so they appear at the top.
- **Skip sidebar flush on mark-read/unread:** Passes `skipSidebarFlush: true` to `invalidateWorkspaceSummary` during read-state toggling, preventing unnecessary list re-sorting.
- **Clean up row action buttons:** Replaced the absolute-positioned gradient overlay with inline flex layout — simpler markup, no visual artifacts.
- **Unify group header heights:** Removed the smaller `EMPTY_HEADER_HEIGHT` constant; all groups now use the same header height for consistent spacing.

## Test plan

- [x] 3 new tests covering collapse/expand edge cases:
  - Collapsed group stays collapsed on data refresh
  - Collapsed destination group stays collapsed when workspace moves into it
  - Auto-expands collapsed group only when a new workspace is selected in it
- [ ] Manual: collapse a group → switch tabs/refocus → confirm it stays collapsed
- [ ] Manual: mark a workspace read/unread → confirm sidebar order doesn't jump

🤖 Generated with [Claude Code](https://claude.com/claude-code)