### PR TITLE
refactor: simplify action row active state styling

### DIFF
--- a/src/components/action-row.tsx
+++ b/src/components/action-row.tsx
@@ -20,7 +20,7 @@ export function ActionRow({
 	return (
 		<div
 			className={cn(
-				"relative flex items-center justify-between overflow-hidden border border-border/40 bg-background px-3 pb-1 pt-1.5",
+				"relative flex items-center justify-between overflow-hidden border border-primary/40 bg-background px-3 pb-1 pt-1.5",
 				className,
 			)}
 		>
@@ -43,31 +43,16 @@ export function ActionRowButton({
 	children,
 	...props
 }: ActionRowButtonProps) {
-	if (active) {
-		return (
-			<Button
-				type="button"
-				size="sm"
-				className={cn(
-					"h-7 cursor-pointer gap-1 rounded-[3px] border-transparent bg-foreground px-2.5 text-[12px] leading-none tracking-[0.02em] text-background shadow-none transition-colors hover:bg-[color-mix(in_oklch,var(--foreground)_90%,black_10%)] hover:text-background disabled:cursor-not-allowed disabled:border-border/50 disabled:bg-muted disabled:text-muted-foreground disabled:opacity-100",
-					className,
-				)}
-				{...props}
-			>
-				{children}
-			</Button>
-		);
-	}
+	const buttonColorClass =
+		"h-7 cursor-pointer gap-1 rounded-[3px] px-2.5 text-[12px] leading-none tracking-[0.02em] disabled:cursor-not-allowed disabled:opacity-60";
 
 	return (
 		<Button
 			type="button"
 			variant="outline"
 			size="sm"
-			className={cn(
-				"h-7 cursor-pointer gap-1 rounded-[3px] px-2.5 text-[12px] leading-none tracking-[0.02em] disabled:cursor-not-allowed disabled:opacity-60",
-				className,
-			)}
+			className={cn(buttonColorClass, className)}
+			aria-pressed={active}
 			{...props}
 		>
 			{children}

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -459,18 +459,14 @@ export const WorkspaceComposerContainer = memo(
 			<div className="flex flex-col">
 				{isActionSession ? (
 					<ActionRow
-						className="relative z-10 mx-auto -mb-px w-[90%] rounded-t-[14px]"
+						className="relative z-10 mx-auto -mb-px w-[90%] rounded-t-[14px] border-b-0"
 						overlay={
 							autoCloseEnabled ? (
 								<>
 									<ShineBorder
 										borderWidth={1}
 										duration={8}
-										shineColor={[
-											"oklch(0.88 0.08 98)",
-											"oklch(0.84 0.1 92)",
-											"oklch(0.8 0.09 84)",
-										]}
+										shineColor="var(--primary)"
 									/>
 									<div className="pointer-events-none absolute inset-x-px bottom-0 z-[1] h-[2px] bg-background" />
 								</>
@@ -507,11 +503,6 @@ export const WorkspaceComposerContainer = memo(
 								onClick={() => {
 									void handleToggleAutoClose();
 								}}
-								className={
-									autoCloseEnabled
-										? "border-[color:oklch(0.76_0.17_88_/_0.45)] bg-[color:oklch(0.76_0.17_88_/_0.12)] text-[color:oklch(0.84_0.11_96)] hover:bg-[color:oklch(0.76_0.17_88_/_0.16)] hover:text-[color:oklch(0.9_0.08_96)]"
-										: undefined
-								}
 							>
 								<TimerReset
 									className="size-[13px] shrink-0"


### PR DESCRIPTION
## What changed
- Refined `ActionRow` border styling to use the primary border token for clearer prominence.
- Simplified `ActionRowButton` active-state rendering so active and inactive states share the same base button while relying on `aria-pressed` and existing visual semantics.
- Simplified the action-row auto-close button treatment in the composer overlay: removed custom active color classes and switched shine border color to the design tokenized primary color.

## Why this changed
- Aligns the action row visual treatment with current token-driven styling and avoids unnecessary class branching for active/inactive variants.
- Reduces style complexity while preserving the same interactions (`aria-pressed`, disable state, click behavior), improving maintainability and visual consistency.

## Notes / tests
- Commit was made with pre-commit formatting hooks in the repo, so TS/TSX formatting was auto-normalized during commit.
- No additional runtime tests were run in this pass.
