### PR TITLE
Fix inspector setup/run panel overflow

### DIFF
--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -26,6 +26,7 @@ import {
 	workspaceSessionsQueryOptions,
 } from "@/lib/query-client";
 import { useSettings } from "@/lib/settings";
+import { cn } from "@/lib/utils";
 import {
 	clampEffortToModel,
 	findModelOption,
@@ -454,7 +455,10 @@ export const WorkspaceComposerContainer = memo(
 			<div className="flex flex-col">
 				{isActionSession ? (
 					<ActionRow
-						className="relative z-10 mx-auto -mb-px w-[90%] rounded-t-[14px] border-b-0"
+						className={cn(
+							"relative z-10 mx-auto -mb-px w-[90%] rounded-t-[14px] border-b-0",
+							autoCloseEnabled ? "border-primary/40" : "border-secondary/80",
+						)}
 						overlay={
 							autoCloseEnabled ? (
 								<>

--- a/src/features/inspector/index.tsx
+++ b/src/features/inspector/index.tsx
@@ -135,6 +135,7 @@ export function WorkspaceInspectorSidebar({
 					workspaceState={workspaceState ?? null}
 					setupScript={repoScripts?.setupScript ?? null}
 					scriptsLoaded={scriptsLoaded}
+					isActive={activeTab === "setup"}
 					onOpenSettings={handleOpenSettings}
 				/>
 				<RunTab

--- a/src/features/inspector/layout.tsx
+++ b/src/features/inspector/layout.tsx
@@ -1,6 +1,5 @@
 import { ChevronDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import type { WorkspaceCommitButtonMode } from "@/features/commit/button";
 import { cn } from "@/lib/utils";
 
@@ -13,6 +12,8 @@ export const INSPECTOR_SECTION_HEADER_CLASS =
 	"flex h-8 min-w-0 shrink-0 items-center justify-between border-b border-border/60 bg-muted/25 px-3";
 export const INSPECTOR_SECTION_TITLE_CLASS =
 	"text-[13px] leading-8 font-medium tracking-[-0.01em] text-muted-foreground";
+const INSPECTOR_TAB_BUTTON_CLASS =
+	"relative inline-flex h-full cursor-pointer items-center justify-center px-0 text-[12px] font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-0";
 
 export function getGitSectionHeaderHighlightClass(
 	mode: WorkspaceCommitButtonMode,
@@ -64,38 +65,70 @@ export function InspectorTabsSection({
 					open && "flex-1",
 				)}
 			>
-				<Tabs
-					value={activeTab}
-					onValueChange={onTabChange}
-					className={cn("flex min-h-0 flex-col gap-0", open && "flex-1")}
-				>
+				<div className={cn("flex min-h-0 flex-col gap-0", open && "flex-1")}>
 					<div
-						className={cn(INSPECTOR_SECTION_HEADER_CLASS, "relative z-10 pt-0")}
+						className={cn(
+							INSPECTOR_SECTION_HEADER_CLASS,
+							"relative z-10 items-stretch pt-0",
+						)}
 					>
-						<TabsList
-							variant="line"
-							className="h-8 gap-4 border-none bg-transparent p-0"
+						<div
+							role="tablist"
+							aria-orientation="horizontal"
+							className="flex h-full self-stretch items-stretch gap-4"
 						>
-							<TabsTrigger
-								value="setup"
-								className="h-8 w-auto gap-0 border-transparent px-0 text-[12px] font-medium text-muted-foreground after:bottom-[-1px] focus-visible:border-transparent focus-visible:ring-0 focus-visible:outline-none data-[state=active]:bg-transparent data-[state=active]:text-foreground"
+							<button
+								type="button"
+								role="tab"
+								id="inspector-tab-setup"
+								aria-controls="inspector-panel-setup"
+								aria-selected={activeTab === "setup"}
+								tabIndex={activeTab === "setup" ? 0 : -1}
+								className={cn(
+									INSPECTOR_TAB_BUTTON_CLASS,
+									activeTab === "setup" && "text-foreground",
+								)}
+								onClick={() => onTabChange("setup")}
 							>
 								Setup
-							</TabsTrigger>
-							<TabsTrigger
-								value="run"
-								className="h-8 w-auto gap-0 border-transparent px-0 text-[12px] font-medium text-muted-foreground after:bottom-[-1px] focus-visible:border-transparent focus-visible:ring-0 focus-visible:outline-none data-[state=active]:bg-transparent data-[state=active]:text-foreground"
+								<span
+									aria-hidden="true"
+									className={cn(
+										"pointer-events-none absolute inset-x-0 bottom-0 h-0.5 bg-foreground opacity-0 transition-opacity",
+										activeTab === "setup" && "opacity-100",
+									)}
+								/>
+							</button>
+							<button
+								type="button"
+								role="tab"
+								id="inspector-tab-run"
+								aria-controls="inspector-panel-run"
+								aria-selected={activeTab === "run"}
+								tabIndex={activeTab === "run" ? 0 : -1}
+								className={cn(
+									INSPECTOR_TAB_BUTTON_CLASS,
+									activeTab === "run" && "text-foreground",
+								)}
+								onClick={() => onTabChange("run")}
 							>
 								Run
-							</TabsTrigger>
-						</TabsList>
+								<span
+									aria-hidden="true"
+									className={cn(
+										"pointer-events-none absolute inset-x-0 bottom-0 h-0.5 bg-foreground opacity-0 transition-opacity",
+										activeTab === "run" && "opacity-100",
+									)}
+								/>
+							</button>
+						</div>
 						<Button
 							type="button"
 							aria-label="Toggle inspector tabs section"
 							onClick={onToggle}
 							variant="ghost"
 							size="icon-sm"
-							className="ml-auto shrink-0 text-muted-foreground hover:bg-accent/60 hover:text-foreground"
+							className="ml-auto shrink-0 self-center text-muted-foreground hover:bg-accent/60 hover:text-foreground"
 						>
 							<ChevronDown
 								className="size-3.5"
@@ -116,7 +149,7 @@ export function InspectorTabsSection({
 							{children}
 						</div>
 					)}
-				</Tabs>
+				</div>
 			</section>
 		</div>
 	);

--- a/src/features/inspector/sections/run.tsx
+++ b/src/features/inspector/sections/run.tsx
@@ -5,7 +5,7 @@ import {
 	TerminalOutput,
 } from "@/components/terminal-output";
 import { Button } from "@/components/ui/button";
-import { TabsContent } from "@/components/ui/tabs";
+import { cn } from "@/lib/utils";
 import {
 	attach,
 	detach,
@@ -89,10 +89,15 @@ export function RunTab({
 	const hasScript = !!runScript?.trim();
 
 	return (
-		<TabsContent
-			value="run"
-			forceMount
-			className="relative flex min-h-0 flex-1 flex-col data-[state=inactive]:invisible data-[state=inactive]:opacity-0 data-[state=inactive]:absolute data-[state=inactive]:inset-0 data-[state=inactive]:pointer-events-none"
+		<div
+			id="inspector-panel-run"
+			role="tabpanel"
+			aria-labelledby="inspector-tab-run"
+			hidden={!isActive}
+			className={cn(
+				"relative flex min-h-0 flex-1 flex-col",
+				!isActive && "pointer-events-none absolute inset-0 invisible opacity-0",
+			)}
 		>
 			{hasRun ? (
 				<>
@@ -153,6 +158,6 @@ export function RunTab({
 					</Button>
 				</div>
 			)}
-		</TabsContent>
+		</div>
 	);
 }

--- a/src/features/inspector/sections/setup.tsx
+++ b/src/features/inspector/sections/setup.tsx
@@ -6,9 +6,9 @@ import {
 	TerminalOutput,
 } from "@/components/terminal-output";
 import { Button } from "@/components/ui/button";
-import { TabsContent } from "@/components/ui/tabs";
 import { completeWorkspaceSetup } from "@/lib/api";
 import { helmorQueryKeys } from "@/lib/query-client";
+import { cn } from "@/lib/utils";
 import {
 	attach,
 	detach,
@@ -24,6 +24,7 @@ type SetupTabProps = {
 	workspaceState: string | null;
 	setupScript: string | null;
 	scriptsLoaded: boolean;
+	isActive: boolean;
 	onOpenSettings: () => void;
 };
 
@@ -33,6 +34,7 @@ export function SetupTab({
 	workspaceState,
 	setupScript,
 	scriptsLoaded,
+	isActive,
 	onOpenSettings,
 }: SetupTabProps) {
 	const termRef = useRef<TerminalHandle | null>(null);
@@ -127,10 +129,15 @@ export function SetupTab({
 	}, [workspaceState, scriptsLoaded, hasScript, workspaceId, queryClient]);
 
 	return (
-		<TabsContent
-			value="setup"
-			forceMount
-			className="relative flex min-h-0 flex-1 flex-col data-[state=inactive]:invisible data-[state=inactive]:opacity-0 data-[state=inactive]:absolute data-[state=inactive]:inset-0 data-[state=inactive]:pointer-events-none"
+		<div
+			id="inspector-panel-setup"
+			role="tabpanel"
+			aria-labelledby="inspector-tab-setup"
+			hidden={!isActive}
+			className={cn(
+				"relative flex min-h-0 flex-1 flex-col",
+				!isActive && "pointer-events-none absolute inset-0 invisible opacity-0",
+			)}
 		>
 			{hasRun ? (
 				<>
@@ -194,6 +201,6 @@ export function SetupTab({
 					</Button>
 				</div>
 			)}
-		</TabsContent>
+		</div>
 	);
 }


### PR DESCRIPTION
## What changed
- replace the shared tabs primitive in the inspector header with explicit tab buttons and panel wiring
- pass active-state props into the setup and run panels so inactive content can be hidden and overlaid cleanly
- keep the existing setup/run terminal behavior while preventing inactive panels from affecting layout

## Why
The setup and run inspector panes were leaking into layout when inactive, which caused overflow and visibility issues. This change makes the tab state explicit so only the active panel participates visually while preserving accessibility attributes.

## Follow-up / test notes
- Tests not run in this workspace
- No backend or persistence changes