### PR TITLE
Fix commit flow auto-close after action session completion

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -344,6 +344,12 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 	const [completedSessions, setCompletedSessions] = useState<
 		Map<string, string>
 	>(() => new Map());
+	// Tracks sessions that have reached a terminal "done" event at least once.
+	// This is separate from `completedSessions`, which only drives away-from-tab
+	// UI badges and intentionally excludes the currently-viewed session.
+	const [settledSessionIds, setSettledSessionIds] = useState<Set<string>>(
+		() => new Set(),
+	);
 	const [interactionRequiredSessions, setInteractionRequiredSessions] =
 		useState<Map<string, string>>(() => new Map());
 	const completedSessionIds = useMemo(
@@ -1151,7 +1157,7 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 		workspacePrInfo,
 		workspacePrActionStatus,
 		workspaceGitActionStatus,
-		completedSessionIds,
+		completedSessionIds: settledSessionIds,
 		interactionRequiredSessionIds,
 		sendingSessionIds,
 		onSelectSession: handleSelectSession,
@@ -1159,6 +1165,13 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 
 	const handleSessionCompleted = useCallback(
 		(sessionId: string, workspaceId: string) => {
+			setSettledSessionIds((prev) => {
+				if (prev.has(sessionId)) return prev;
+				const next = new Set(prev);
+				next.add(sessionId);
+				return next;
+			});
+
 			const isCurrentSession = sessionId === selectedSessionIdRef.current;
 			// Green dot only for sessions the user isn't viewing
 			if (!isCurrentSession) {

--- a/src/features/commit/hooks/use-commit-lifecycle.test.tsx
+++ b/src/features/commit/hooks/use-commit-lifecycle.test.tsx
@@ -1,0 +1,185 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+	PullRequestInfo,
+	WorkspaceGitActionStatus,
+	WorkspacePrActionStatus,
+} from "@/lib/api";
+import { helmorQueryKeys } from "@/lib/query-client";
+import { useWorkspaceCommitLifecycle } from "./use-commit-lifecycle";
+
+const apiMocks = vi.hoisted(() => ({
+	closeWorkspacePr: vi.fn(),
+	createSession: vi.fn(),
+	hideSession: vi.fn(),
+	loadAutoCloseActionKinds: vi.fn(),
+	lookupWorkspacePr: vi.fn(),
+	mergeWorkspacePr: vi.fn(),
+	setWorkspaceManualStatus: vi.fn(),
+}));
+
+vi.mock("@/lib/api", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/lib/api")>();
+
+	return {
+		...actual,
+		closeWorkspacePr: apiMocks.closeWorkspacePr,
+		createSession: apiMocks.createSession,
+		hideSession: apiMocks.hideSession,
+		loadAutoCloseActionKinds: apiMocks.loadAutoCloseActionKinds,
+		lookupWorkspacePr: apiMocks.lookupWorkspacePr,
+		mergeWorkspacePr: apiMocks.mergeWorkspacePr,
+		setWorkspaceManualStatus: apiMocks.setWorkspaceManualStatus,
+	};
+});
+
+const EMPTY_GIT_ACTION_STATUS: WorkspaceGitActionStatus = {
+	uncommittedCount: 0,
+	conflictCount: 0,
+	syncTargetBranch: "main",
+	syncStatus: "upToDate",
+	behindTargetCount: 0,
+};
+
+const EMPTY_PR_ACTION_STATUS: WorkspacePrActionStatus = {
+	pr: null,
+	reviewDecision: null,
+	mergeable: null,
+	deployments: [],
+	checks: [],
+	remoteState: "unavailable",
+	message: null,
+};
+
+function createWrapper(queryClient: QueryClient) {
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+	};
+}
+
+describe("useWorkspaceCommitLifecycle", () => {
+	beforeEach(() => {
+		apiMocks.closeWorkspacePr.mockReset();
+		apiMocks.createSession.mockReset();
+		apiMocks.hideSession.mockReset();
+		apiMocks.loadAutoCloseActionKinds.mockReset();
+		apiMocks.lookupWorkspacePr.mockReset();
+		apiMocks.mergeWorkspacePr.mockReset();
+		apiMocks.setWorkspaceManualStatus.mockReset();
+
+		apiMocks.createSession.mockResolvedValue({ sessionId: "session-action" });
+		apiMocks.loadAutoCloseActionKinds.mockResolvedValue(["create-pr"]);
+		apiMocks.setWorkspaceManualStatus.mockResolvedValue(undefined);
+		apiMocks.lookupWorkspacePr.mockResolvedValue({
+			number: 53,
+			title: "Fix overflow",
+			url: "https://github.com/example/repo/pull/53",
+			state: "OPEN",
+			isDraft: false,
+			isMerged: false,
+		} satisfies PullRequestInfo);
+		apiMocks.hideSession.mockResolvedValue(undefined);
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("verifies and auto-closes an action session once it has completed", async () => {
+		const queryClient = new QueryClient({
+			defaultOptions: {
+				queries: {
+					retry: false,
+				},
+			},
+		});
+		queryClient.setQueryData(helmorQueryKeys.workspaceDetail("workspace-1"), {
+			id: "workspace-1",
+			activeSessionId: "session-after-close",
+		});
+
+		const selectedWorkspaceIdRef = { current: "workspace-1" };
+		const onSelectSession = vi.fn();
+
+		const { result, rerender } = renderHook(
+			({
+				completedSessionIds,
+				interactionRequiredSessionIds,
+				sendingSessionIds,
+			}: {
+				completedSessionIds: Set<string>;
+				interactionRequiredSessionIds: Set<string>;
+				sendingSessionIds: Set<string>;
+			}) =>
+				useWorkspaceCommitLifecycle({
+					queryClient,
+					selectedWorkspaceId: "workspace-1",
+					selectedWorkspaceIdRef,
+					workspaceManualStatus: null,
+					workspacePrInfo: null,
+					workspacePrActionStatus: EMPTY_PR_ACTION_STATUS,
+					workspaceGitActionStatus: EMPTY_GIT_ACTION_STATUS,
+					completedSessionIds,
+					interactionRequiredSessionIds,
+					sendingSessionIds,
+					onSelectSession,
+				}),
+			{
+				initialProps: {
+					completedSessionIds: new Set<string>(),
+					interactionRequiredSessionIds: new Set<string>(),
+					sendingSessionIds: new Set<string>(),
+				},
+				wrapper: createWrapper(queryClient),
+			},
+		);
+
+		await act(async () => {
+			await result.current.handleInspectorCommitAction("create-pr");
+		});
+
+		expect(apiMocks.createSession).toHaveBeenCalledWith("workspace-1", {
+			actionKind: "create-pr",
+		});
+		expect(result.current.pendingPromptForSession).toMatchObject({
+			sessionId: "session-action",
+		});
+		expect(onSelectSession).toHaveBeenCalledWith("session-action");
+
+		act(() => {
+			result.current.handlePendingPromptConsumed();
+		});
+
+		rerender({
+			completedSessionIds: new Set<string>(),
+			interactionRequiredSessionIds: new Set<string>(),
+			sendingSessionIds: new Set(["session-action"]),
+		});
+
+		rerender({
+			completedSessionIds: new Set(["session-action"]),
+			interactionRequiredSessionIds: new Set<string>(),
+			sendingSessionIds: new Set<string>(),
+		});
+
+		await waitFor(() => {
+			expect(apiMocks.lookupWorkspacePr).toHaveBeenCalledWith("workspace-1");
+		});
+		await waitFor(() => {
+			expect(apiMocks.setWorkspaceManualStatus).toHaveBeenCalledWith(
+				"workspace-1",
+				"review",
+			);
+		});
+		await waitFor(() => {
+			expect(apiMocks.hideSession).toHaveBeenCalledWith("session-action");
+		});
+		await waitFor(() => {
+			expect(onSelectSession).toHaveBeenCalledWith("session-after-close");
+		});
+	});
+});


### PR DESCRIPTION
## What changed
- track session IDs that have reached a terminal done state separately from the away-from-tab completion badge state
- pass the settled session set into the commit lifecycle so action sessions are still recognized as completed even when the user is viewing them
- add a focused hook test covering create-PR auto-close, status refresh, session hiding, and session reselection

## Why this changed
The commit lifecycle was reusing the completion badge state, which intentionally excludes the currently selected session. That meant an action session could finish while open in the panel and never be treated as completed by the auto-close flow.

## Follow-up / test notes
- Verified with `pnpm vitest run src/features/commit/hooks/use-commit-lifecycle.test.tsx`
- No broader frontend or Rust suites were run for this PR