### PR TITLE
fix: update Tauri app identifier and commit lifecycle test mock

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Helmor",
 	"version": "0.1.0",
-	"identifier": "build.helmor.app",
+	"identifier": "ai.helmor.desktop",
 	"build": {
 		"beforeDevCommand": "pnpm exec vite",
 		"devUrl": "http://localhost:1420",

--- a/src/features/commit/hooks/use-commit-lifecycle.test.tsx
+++ b/src/features/commit/hooks/use-commit-lifecycle.test.tsx
@@ -79,7 +79,6 @@ describe("useWorkspaceCommitLifecycle", () => {
 			title: "Fix overflow",
 			url: "https://github.com/example/repo/pull/53",
 			state: "OPEN",
-			isDraft: false,
 			isMerged: false,
 		} satisfies PullRequestInfo);
 		apiMocks.hideSession.mockResolvedValue(undefined);


### PR DESCRIPTION
## What changed
- changed the Tauri application identifier from `build.helmor.app` to `ai.helmor.desktop`
- removed the stale `isDraft` field from the `PullRequestInfo` mock in the commit lifecycle hook test

## Why it changed
- the desktop bundle identifier needs to match the intended application identity
- the test mock should reflect the current pull request shape used by the app

## Follow-up / test notes
- no additional test run was performed beyond the repository's commit-time Biome hook
- branch contains only the two tracked changes above