### PR TITLE
feat: make workspace archiving asynchronous

### DIFF
--- a/src-tauri/src/commands/tests/archive_restore.rs
+++ b/src-tauri/src/commands/tests/archive_restore.rs
@@ -87,6 +87,56 @@ fn archive_workspace_moves_context_and_removes_worktree() {
 }
 
 #[test]
+fn prepare_archive_plan_is_read_only() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let harness = ArchiveTestHarness::new(true);
+
+    let _plan = workspaces::prepare_archive_plan(&harness.workspace_id).unwrap();
+
+    assert!(harness.workspace_dir().exists());
+    assert!(!harness.archived_context_dir().exists());
+
+    let connection = Connection::open(crate::data_dir::db_path().unwrap()).unwrap();
+    let state: String = connection
+        .query_row(
+            "SELECT state FROM workspaces WHERE id = ?1",
+            [&harness.workspace_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(state, "ready");
+}
+
+#[test]
+fn archive_workspace_allows_setup_pending_state() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let harness = ArchiveTestHarness::new(true);
+    harness.set_state("setup_pending");
+
+    let response = workspaces::archive_workspace_impl(&harness.workspace_id).unwrap();
+
+    assert_eq!(response.archived_state, "archived");
+    assert!(!harness.workspace_dir().exists());
+}
+
+#[test]
+fn archive_workspace_rejects_initializing_state() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let harness = ArchiveTestHarness::new(true);
+    harness.set_state("initializing");
+
+    let error = workspaces::prepare_archive_plan(&harness.workspace_id).unwrap_err();
+
+    assert!(error.to_string().contains("not archive-ready"));
+}
+
+#[test]
 fn restore_workspace_cleans_up_existing_target_directory() {
     let _guard = TEST_LOCK
         .lock()

--- a/src-tauri/src/commands/tests/support.rs
+++ b/src-tauri/src/commands/tests/support.rs
@@ -219,6 +219,16 @@ impl ArchiveTestHarness {
             .display()
             .to_string()
     }
+
+    pub(crate) fn set_state(&self, state: &str) {
+        let connection = Connection::open(crate::data_dir::db_path().unwrap()).unwrap();
+        connection
+            .execute(
+                "UPDATE workspaces SET state = ?2 WHERE id = ?1",
+                (&self.workspace_id, state),
+            )
+            .unwrap();
+    }
 }
 
 pub(crate) struct CreateTestHarness {

--- a/src-tauri/src/commands/workspace_commands.rs
+++ b/src-tauri/src/commands/workspace_commands.rs
@@ -177,24 +177,35 @@ pub async fn validate_restore_workspace(
 }
 
 #[tauri::command]
-pub async fn archive_workspace(
+pub async fn prepare_archive_workspace(
     app: AppHandle,
     workspace_id: String,
-) -> CmdResult<workspaces::ArchiveWorkspaceResponse> {
-    let ws_lock = db::workspace_mutation_lock(&workspace_id);
-    let _lock = ws_lock.lock().await;
-    // Stop the git watcher BEFORE removing the worktree to avoid race
-    // conditions between the watcher's debouncer and directory deletion.
-    let manager = app.state::<git_watcher::GitWatcherManager>();
-    manager.unwatch(&workspace_id);
-    let result = run_blocking(move || workspaces::archive_workspace_impl(&workspace_id)).await?;
-    git_watcher::notify_workspace_changed(&app);
-    Ok(result)
+) -> CmdResult<workspaces::PrepareArchiveWorkspaceResponse> {
+    let app_handle = app.clone();
+    run_blocking(move || {
+        let manager = app_handle.state::<workspaces::ArchiveJobManager>();
+        manager.prepare(&workspace_id)
+    })
+    .await
 }
 
 #[tauri::command]
-pub async fn validate_archive_workspace(workspace_id: String) -> CmdResult<()> {
-    run_blocking(move || workspaces::validate_archive_workspace(&workspace_id)).await
+pub async fn start_archive_workspace(app: AppHandle, workspace_id: String) -> CmdResult<()> {
+    workspaces::start_archive_workspace(&app, &workspace_id)?;
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn validate_archive_workspace(
+    workspace_id: String,
+) -> CmdResult<workspaces::PrepareArchiveWorkspaceResponse> {
+    run_blocking(move || {
+        workspaces::validate_archive_workspace(&workspace_id)?;
+        Ok(workspaces::PrepareArchiveWorkspaceResponse {
+            workspace_id: workspace_id.clone(),
+        })
+    })
+    .await
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -114,6 +114,7 @@ pub fn run() {
         .manage(sidecar::ManagedSidecar::new())
         .manage(agents::ActiveStreams::new())
         .manage(agents::SlashCommandCache::new())
+        .manage(workspace::archive::ArchiveJobManager::new())
         .manage(git_watcher::GitWatcherManager::new())
         .manage(workspace::scripts::ScriptProcessManager::new())
         .setup(|app| {
@@ -200,7 +201,8 @@ pub fn run() {
             agents::respond_to_elicitation_request,
             agents::generate_session_title,
             agents::list_slash_commands,
-            commands::workspace_commands::archive_workspace,
+            commands::workspace_commands::prepare_archive_workspace,
+            commands::workspace_commands::start_archive_workspace,
             commands::workspace_commands::validate_archive_workspace,
             commands::workspace_commands::validate_restore_workspace,
             commands::github_commands::cancel_github_identity_connect,

--- a/src-tauri/src/models/workspaces.rs
+++ b/src-tauri/src/models/workspaces.rs
@@ -322,7 +322,7 @@ pub(crate) fn update_archived_workspace_state(
             SET state = 'archived',
                 archive_commit = ?2,
                 updated_at = datetime('now')
-            WHERE id = ?1 AND state = 'ready'
+            WHERE id = ?1 AND state IN ('ready', 'setup_pending')
             "#,
             (workspace_id, archive_commit),
         )

--- a/src-tauri/src/workspace/archive.rs
+++ b/src-tauri/src/workspace/archive.rs
@@ -1,0 +1,153 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::Mutex;
+
+use anyhow::{bail, Context, Result};
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, Manager};
+
+use crate::git_watcher;
+
+use super::lifecycle::{execute_archive_plan, prepare_archive_plan, ArchivePreparedPlan};
+
+pub const ARCHIVE_EXECUTION_FAILED_EVENT: &str = "archive-execution-failed";
+pub const ARCHIVE_EXECUTION_SUCCEEDED_EVENT: &str = "archive-execution-succeeded";
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PrepareArchiveWorkspaceResponse {
+    pub workspace_id: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchiveExecutionFailedPayload {
+    pub workspace_id: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchiveExecutionSucceededPayload {
+    pub workspace_id: String,
+}
+
+#[derive(Default)]
+struct ArchiveJobState {
+    prepared: HashMap<String, ArchivePreparedPlan>,
+    running: HashSet<String>,
+}
+
+pub struct ArchiveJobManager {
+    state: Mutex<ArchiveJobState>,
+}
+
+impl Default for ArchiveJobManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ArchiveJobManager {
+    pub fn new() -> Self {
+        Self {
+            state: Mutex::new(ArchiveJobState::default()),
+        }
+    }
+
+    pub fn prepare(&self, workspace_id: &str) -> Result<PrepareArchiveWorkspaceResponse> {
+        let plan = prepare_archive_plan(workspace_id)?;
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| anyhow::anyhow!("archive job lock poisoned"))?;
+
+        if state.running.contains(workspace_id) {
+            bail!("Archive already in progress: {workspace_id}");
+        }
+
+        state.prepared.insert(workspace_id.to_string(), plan);
+
+        Ok(PrepareArchiveWorkspaceResponse {
+            workspace_id: workspace_id.to_string(),
+        })
+    }
+
+    fn start_prepared(&self, workspace_id: &str) -> Result<ArchivePreparedPlan> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| anyhow::anyhow!("archive job lock poisoned"))?;
+
+        if state.running.contains(workspace_id) {
+            bail!("Archive already in progress: {workspace_id}");
+        }
+
+        let plan = state
+            .prepared
+            .remove(workspace_id)
+            .with_context(|| format!("Archive preflight is missing for {workspace_id}"))?;
+        state.running.insert(workspace_id.to_string());
+        Ok(plan)
+    }
+
+    fn finish(&self, workspace_id: &str) {
+        if let Ok(mut state) = self.state.lock() {
+            state.running.remove(workspace_id);
+        }
+    }
+}
+
+pub fn start_archive_workspace(app: &AppHandle, workspace_id: &str) -> Result<()> {
+    let manager = app.state::<ArchiveJobManager>();
+    let plan = manager.start_prepared(workspace_id)?;
+    let app_handle = app.clone();
+    let workspace_id = workspace_id.to_string();
+
+    tauri::async_runtime::spawn(async move {
+        app_handle
+            .state::<git_watcher::GitWatcherManager>()
+            .unwatch(&workspace_id);
+
+        let result =
+            tauri::async_runtime::spawn_blocking(move || execute_archive_plan(&plan)).await;
+
+        match result {
+            Ok(Ok(_)) => {
+                let _ = app_handle.emit(
+                    ARCHIVE_EXECUTION_SUCCEEDED_EVENT,
+                    ArchiveExecutionSucceededPayload {
+                        workspace_id: workspace_id.clone(),
+                    },
+                );
+            }
+            Ok(Err(error)) => {
+                tracing::error!(workspace_id, error = %error, "Archive execution failed");
+                git_watcher::notify_workspace_changed(&app_handle);
+                let _ = app_handle.emit(
+                    ARCHIVE_EXECUTION_FAILED_EVENT,
+                    ArchiveExecutionFailedPayload {
+                        workspace_id: workspace_id.clone(),
+                        message: format!("{error:#}"),
+                    },
+                );
+            }
+            Err(error) => {
+                tracing::error!(workspace_id, error = %error, "Archive execution task crashed");
+                git_watcher::notify_workspace_changed(&app_handle);
+                let _ = app_handle.emit(
+                    ARCHIVE_EXECUTION_FAILED_EVENT,
+                    ArchiveExecutionFailedPayload {
+                        workspace_id: workspace_id.clone(),
+                        message: format!("Archive task failed: {error}"),
+                    },
+                );
+            }
+        }
+
+        app_handle
+            .state::<ArchiveJobManager>()
+            .finish(&workspace_id);
+    });
+
+    Ok(())
+}

--- a/src-tauri/src/workspace/lifecycle.rs
+++ b/src-tauri/src/workspace/lifecycle.rs
@@ -181,12 +181,17 @@ pub fn create_workspace_from_repo_impl(repo_id: &str) -> Result<CreateWorkspaceR
     }
 }
 
-struct ArchivePreflightData {
+#[derive(Debug, Clone)]
+pub struct ArchivePreparedPlan {
+    pub workspace_id: String,
     repo_root: PathBuf,
     branch: String,
     workspace_dir: PathBuf,
     archived_context_dir: PathBuf,
-    archive_commit: String,
+}
+
+fn is_archive_eligible_state(state: &str) -> bool {
+    matches!(state, "ready" | "setup_pending")
 }
 
 /// Best-effort archive hook: load the repo's archive_script and run it
@@ -245,12 +250,15 @@ fn run_archive_hook(workspace_id: &str, workspace_dir: &Path, repo_root: &Path) 
     }
 }
 
-fn archive_workspace_preflight(workspace_id: &str) -> Result<ArchivePreflightData> {
+pub fn prepare_archive_plan(workspace_id: &str) -> Result<ArchivePreparedPlan> {
     let record = workspace_models::load_workspace_record_by_id(workspace_id)?
         .with_context(|| format!("Workspace not found: {workspace_id}"))?;
 
-    if record.state != "ready" {
-        bail!("Workspace is not ready: {workspace_id}");
+    if !is_archive_eligible_state(&record.state) {
+        bail!(
+            "Workspace is not archive-ready: {workspace_id} (state: {})",
+            record.state
+        );
     }
 
     let repo_root = helpers::non_empty(&record.root_path)
@@ -277,33 +285,42 @@ fn archive_workspace_preflight(workspace_id: &str) -> Result<ArchivePreflightDat
         );
     }
 
-    let archive_commit = git_ops::current_workspace_head_commit(&workspace_dir)?;
-    git_ops::verify_commit_exists(&repo_root, &archive_commit)?;
-
-    Ok(ArchivePreflightData {
+    Ok(ArchivePreparedPlan {
+        workspace_id: workspace_id.to_string(),
         repo_root,
         branch,
         workspace_dir,
         archived_context_dir,
-        archive_commit,
     })
 }
 
 pub fn validate_archive_workspace(workspace_id: &str) -> Result<()> {
-    archive_workspace_preflight(workspace_id).map(|_| ())
+    prepare_archive_plan(workspace_id).map(|_| ())
 }
 
 pub fn archive_workspace_impl(workspace_id: &str) -> Result<ArchiveWorkspaceResponse> {
-    let ArchivePreflightData {
-        repo_root,
-        branch,
-        workspace_dir,
-        archived_context_dir,
-        archive_commit,
-    } = archive_workspace_preflight(workspace_id)?;
+    let plan = prepare_archive_plan(workspace_id)?;
+    execute_archive_plan(&plan)
+}
+
+pub fn execute_archive_plan(plan: &ArchivePreparedPlan) -> Result<ArchiveWorkspaceResponse> {
+    let repo_root = &plan.repo_root;
+    let branch = &plan.branch;
+    let workspace_dir = &plan.workspace_dir;
+    let archived_context_dir = &plan.archived_context_dir;
+    let workspace_id = &plan.workspace_id;
+    let timing = std::time::Instant::now();
+    let archive_commit = git_ops::current_workspace_head_commit(workspace_dir)?;
+    git_ops::verify_commit_exists(repo_root, &archive_commit)?;
 
     // Run archive script (best-effort, don't block archive on script failure).
-    run_archive_hook(workspace_id, &workspace_dir, &repo_root);
+    let hook_started = std::time::Instant::now();
+    run_archive_hook(workspace_id, workspace_dir, repo_root);
+    tracing::info!(
+        workspace_id,
+        elapsed_ms = hook_started.elapsed().as_millis(),
+        "Archive hook finished"
+    );
 
     fs::create_dir_all(archived_context_dir.parent().with_context(|| {
         format!(
@@ -319,13 +336,25 @@ pub fn archive_workspace_impl(workspace_id: &str) -> Result<ArchiveWorkspaceResp
     })?;
 
     let workspace_context_dir = workspace_dir.join(".context");
-    let staged_archive_dir = helpers::staged_archive_context_dir(&archived_context_dir);
+    let staged_archive_dir = helpers::staged_archive_context_dir(archived_context_dir);
+    let context_copy_started = std::time::Instant::now();
     create_staged_archive_context(&workspace_context_dir, &staged_archive_dir)?;
+    tracing::info!(
+        workspace_id,
+        elapsed_ms = context_copy_started.elapsed().as_millis(),
+        "Archive context staging finished"
+    );
 
-    if let Err(error) = git_ops::remove_worktree(&repo_root, &workspace_dir) {
+    let remove_worktree_started = std::time::Instant::now();
+    if let Err(error) = git_ops::remove_worktree(repo_root, workspace_dir) {
         let _ = fs::remove_dir_all(&staged_archive_dir);
         return Err(error);
     }
+    tracing::info!(
+        workspace_id,
+        elapsed_ms = remove_worktree_started.elapsed().as_millis(),
+        "Archive worktree removal finished"
+    );
 
     git_ops::run_git(
         [
@@ -333,21 +362,21 @@ pub fn archive_workspace_impl(workspace_id: &str) -> Result<ArchiveWorkspaceResp
             &repo_root.display().to_string(),
             "branch",
             "-D",
-            &branch,
+            branch,
         ],
         None,
     )
     .ok();
 
-    if let Err(error) = fs::rename(&staged_archive_dir, &archived_context_dir) {
+    if let Err(error) = fs::rename(&staged_archive_dir, archived_context_dir) {
         cleanup_failed_archive(
-            &repo_root,
-            &workspace_dir,
+            repo_root,
+            workspace_dir,
             &workspace_context_dir,
-            &branch,
+            branch,
             &archive_commit,
             &staged_archive_dir,
-            &archived_context_dir,
+            archived_context_dir,
         );
         bail!(
             "Failed to move archived context into {}: {error}",
@@ -359,16 +388,22 @@ pub fn archive_workspace_impl(workspace_id: &str) -> Result<ArchiveWorkspaceResp
         workspace_models::update_archived_workspace_state(workspace_id, &archive_commit)
     {
         cleanup_failed_archive(
-            &repo_root,
-            &workspace_dir,
+            repo_root,
+            workspace_dir,
             &workspace_context_dir,
-            &branch,
+            branch,
             &archive_commit,
             &staged_archive_dir,
-            &archived_context_dir,
+            archived_context_dir,
         );
         return Err(error);
     }
+
+    tracing::info!(
+        workspace_id,
+        elapsed_ms = timing.elapsed().as_millis(),
+        "Archive execution finished"
+    );
 
     Ok(ArchiveWorkspaceResponse {
         archived_workspace_id: workspace_id.to_string(),

--- a/src-tauri/src/workspace/mod.rs
+++ b/src-tauri/src/workspace/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod archive;
 pub(crate) mod branching;
 pub mod files;
 pub mod helpers;

--- a/src-tauri/src/workspace/workspaces.rs
+++ b/src-tauri/src/workspace/workspaces.rs
@@ -7,6 +7,10 @@ use crate::{
     sessions,
 };
 
+pub use super::archive::{
+    start_archive_workspace, ArchiveExecutionFailedPayload, ArchiveExecutionSucceededPayload,
+    ArchiveJobManager, PrepareArchiveWorkspaceResponse,
+};
 pub use super::branching::{
     _reset_prefetch_rate_limit, list_remote_branches, prefetch_remote_refs,
     refresh_remote_and_realign, rename_workspace_branch, sync_workspace_with_target_branch,
@@ -15,10 +19,10 @@ pub use super::branching::{
     UpdateIntendedTargetBranchResponse,
 };
 pub use super::lifecycle::{
-    archive_workspace_impl, create_workspace_from_repo_impl, restore_workspace_impl,
-    validate_archive_workspace, validate_restore_workspace, ArchiveWorkspaceResponse, BranchRename,
-    CreateWorkspaceResponse, RestoreWorkspaceResponse, TargetBranchConflict,
-    ValidateRestoreResponse,
+    archive_workspace_impl, create_workspace_from_repo_impl, prepare_archive_plan,
+    restore_workspace_impl, validate_archive_workspace, validate_restore_workspace,
+    ArchivePreparedPlan, ArchiveWorkspaceResponse, BranchRename, CreateWorkspaceResponse,
+    RestoreWorkspaceResponse, TargetBranchConflict, ValidateRestoreResponse,
 };
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -611,7 +611,7 @@ describe("App", () => {
 				]}
 				archivedRows={[]}
 				onArchiveWorkspace={onArchiveWorkspace}
-				archivingWorkspaceId="ready-workspace"
+				archivingWorkspaceIds={new Set(["ready-workspace"])}
 			/>,
 		);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2019,6 +2019,9 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 										workspaceBranch={
 											selectedWorkspaceDetailQuery.data?.branch ?? null
 										}
+										workspaceRemote={
+											selectedWorkspaceDetailQuery.data?.remote ?? null
+										}
 										workspaceTargetBranch={(() => {
 											const d = selectedWorkspaceDetailQuery.data;
 											const target =

--- a/src/features/inspector/index.test.tsx
+++ b/src/features/inspector/index.test.tsx
@@ -73,6 +73,7 @@ function renderInspector(
 			workspaceRootPath="/tmp/workspace"
 			workspaceBranch="feature/actions"
 			workspaceTargetBranch="main"
+			workspaceRemote="origin"
 			editorMode={false}
 			onOpenEditorFile={vi.fn()}
 			{...props}
@@ -125,11 +126,11 @@ describe("WorkspaceInspectorSidebar Actions section", () => {
 	it("shows clean git rows with passed status icons", async () => {
 		renderInspector();
 
-		await screen.findByText("Up to date with main");
+		await screen.findByText("Up to date with origin/main");
 
 		const actions = screen.getByLabelText("Inspector section Actions");
 		expect(
-			within(actions).getByText("Up to date with main"),
+			within(actions).getByText("Up to date with origin/main"),
 		).toBeInTheDocument();
 		expect(
 			within(actions).getByText("Waiting for PR review"),
@@ -170,7 +171,7 @@ describe("WorkspaceInspectorSidebar Actions section", () => {
 
 		renderInspector();
 
-		await screen.findByText("2 commits behind main");
+		await screen.findByText("2 commits behind origin/main");
 		await user.click(screen.getByRole("button", { name: "Pull" }));
 
 		await waitFor(() => {
@@ -332,6 +333,7 @@ describe("WorkspaceInspectorSidebar Actions section", () => {
 					workspaceRootPath="/tmp/workspace"
 					workspaceBranch="feature/actions"
 					workspaceTargetBranch="main"
+					workspaceRemote="origin"
 					editorMode={false}
 					onOpenEditorFile={vi.fn()}
 				/>
@@ -372,5 +374,19 @@ describe("WorkspaceInspectorSidebar Actions section", () => {
 			],
 			behavior: "append",
 		});
+	});
+
+	it("uses the workspace remote when formatting sync target labels", async () => {
+		apiMocks.loadWorkspaceGitActionStatus.mockResolvedValue({
+			uncommittedCount: 0,
+			conflictCount: 0,
+			syncTargetBranch: "main",
+			syncStatus: "upToDate",
+			behindTargetCount: 0,
+		});
+
+		renderInspector({ workspaceRemote: "upstream" });
+
+		await screen.findByText("Up to date with upstream/main");
 	});
 });

--- a/src/features/inspector/index.tsx
+++ b/src/features/inspector/index.tsx
@@ -17,6 +17,7 @@ type WorkspaceInspectorSidebarProps = {
 	workspaceRootPath?: string | null;
 	workspaceBranch?: string | null;
 	workspaceTargetBranch?: string | null;
+	workspaceRemote?: string | null;
 	workspaceState?: string | null;
 	repoId?: string | null;
 	editorMode: boolean;
@@ -35,6 +36,7 @@ export function WorkspaceInspectorSidebar({
 	workspaceRootPath,
 	workspaceBranch,
 	workspaceTargetBranch,
+	workspaceRemote,
 	workspaceState,
 	repoId,
 	editorMode,
@@ -107,6 +109,7 @@ export function WorkspaceInspectorSidebar({
 
 			<ActionsSection
 				workspaceId={workspaceId ?? null}
+				workspaceRemote={workspaceRemote ?? null}
 				sectionRef={actionsRef}
 				bodyHeight={actionsHeight}
 				expanded={!tabsOpen}

--- a/src/features/inspector/sections/actions.tsx
+++ b/src/features/inspector/sections/actions.tsx
@@ -65,6 +65,7 @@ const EMPTY_PR_ACTION_STATUS: WorkspacePrActionStatus = {
 
 type ActionsSectionProps = {
 	workspaceId: string | null;
+	workspaceRemote?: string | null;
 	sectionRef?: React.RefObject<HTMLElement | null>;
 	bodyHeight: number;
 	expanded: boolean;
@@ -75,6 +76,7 @@ type ActionsSectionProps = {
 
 export function ActionsSection({
 	workspaceId,
+	workspaceRemote,
 	sectionRef,
 	bodyHeight,
 	expanded,
@@ -94,7 +96,7 @@ export function ActionsSection({
 	});
 	const gitStatus = gitStatusQuery.data ?? EMPTY_GIT_ACTION_STATUS;
 	const prStatus = prStatusQuery.data ?? EMPTY_PR_ACTION_STATUS;
-	const gitRows = buildGitRows(gitStatus);
+	const gitRows = buildGitRows(gitStatus, workspaceRemote);
 	const reviewRows = buildReviewRows(prStatus, prInfo);
 	const actionDisabled = commitButtonState === "busy";
 	const handleSync = useCallback(async () => {
@@ -338,11 +340,16 @@ function StatusIcon({ status }: { status: ActionStatusKind }) {
 	);
 }
 
-function buildGitRows(gitStatus: WorkspaceGitActionStatus): GitStatusItem[] {
+function buildGitRows(
+	gitStatus: WorkspaceGitActionStatus,
+	workspaceRemote?: string | null,
+): GitStatusItem[] {
 	const uncommittedCount = gitStatus.uncommittedCount;
 	const conflictCount = gitStatus.conflictCount;
-	const syncTargetBranch =
-		gitStatus.syncTargetBranch?.trim() || "target branch";
+	const syncTargetBranch = formatSyncTargetRef(
+		workspaceRemote,
+		gitStatus.syncTargetBranch,
+	);
 
 	return [
 		uncommittedCount === 0
@@ -394,6 +401,21 @@ function buildGitRows(gitStatus: WorkspaceGitActionStatus): GitStatusItem[] {
 							status: "pending",
 						},
 	];
+}
+
+function formatSyncTargetRef(
+	workspaceRemote?: string | null,
+	syncTargetBranch?: string | null,
+): string {
+	const branch = syncTargetBranch?.trim();
+	if (!branch) {
+		return "target branch";
+	}
+	if (branch.includes("/")) {
+		return branch;
+	}
+	const remote = workspaceRemote?.trim() || "origin";
+	return `${remote}/${branch}`;
 }
 
 function buildReviewRows(

--- a/src/features/navigation/container.tsx
+++ b/src/features/navigation/container.tsx
@@ -32,6 +32,7 @@ export const WorkspacesSidebarContainer = memo(
 	}: WorkspacesSidebarContainerProps) {
 		const {
 			addingRepository,
+			archivingWorkspaceIds,
 			archivedRows,
 			availableRepositories,
 			creatingWorkspaceRepoId,
@@ -58,6 +59,7 @@ export const WorkspacesSidebarContainer = memo(
 				archivedRows={archivedRows}
 				availableRepositories={availableRepositories}
 				addingRepository={addingRepository}
+				archivingWorkspaceIds={archivingWorkspaceIds}
 				selectedWorkspaceId={selectedWorkspaceId}
 				sendingWorkspaceIds={sendingWorkspaceIds}
 				completedWorkspaceIds={completedWorkspaceIds}

--- a/src/features/navigation/hooks/use-controller.test.tsx
+++ b/src/features/navigation/hooks/use-controller.test.tsx
@@ -1,0 +1,486 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+	ArchiveExecutionFailedPayload,
+	ArchiveExecutionSucceededPayload,
+	PrepareArchiveWorkspaceResponse,
+	WorkspaceDetail,
+	WorkspaceGroup,
+	WorkspaceSessionSummary,
+	WorkspaceSummary,
+} from "@/lib/api";
+import { DEFAULT_SETTINGS, SettingsContext } from "@/lib/settings";
+import { useWorkspacesSidebarController } from "./use-controller";
+
+const apiMocks = vi.hoisted(() => {
+	let archiveFailedListener:
+		| ((payload: ArchiveExecutionFailedPayload) => void)
+		| null = null;
+	let archiveSucceededListener:
+		| ((payload: ArchiveExecutionSucceededPayload) => void)
+		| null = null;
+
+	return {
+		addRepositoryFromLocalPath: vi.fn(),
+		createWorkspaceFromRepo: vi.fn(),
+		listRepositories: vi.fn(),
+		loadAddRepositoryDefaults: vi.fn(),
+		loadArchivedWorkspaces: vi.fn(),
+		loadSessionThreadMessages: vi.fn(),
+		loadWorkspaceDetail: vi.fn(),
+		loadWorkspaceGroups: vi.fn(),
+		loadWorkspaceSessions: vi.fn(),
+		markWorkspaceRead: vi.fn(),
+		markWorkspaceUnread: vi.fn(),
+		permanentlyDeleteWorkspace: vi.fn(),
+		pinWorkspace: vi.fn(),
+		prepareArchiveWorkspace: vi.fn(),
+		restoreWorkspace: vi.fn(),
+		setWorkspaceManualStatus: vi.fn(),
+		startArchiveWorkspace: vi.fn(),
+		unpinWorkspace: vi.fn(),
+		validateRestoreWorkspace: vi.fn(),
+		listenArchiveExecutionFailed: vi.fn(async (callback) => {
+			archiveFailedListener = callback;
+			return () => {
+				if (archiveFailedListener === callback) {
+					archiveFailedListener = null;
+				}
+			};
+		}),
+		listenArchiveExecutionSucceeded: vi.fn(async (callback) => {
+			archiveSucceededListener = callback;
+			return () => {
+				if (archiveSucceededListener === callback) {
+					archiveSucceededListener = null;
+				}
+			};
+		}),
+		emitArchiveFailed(payload: ArchiveExecutionFailedPayload) {
+			archiveFailedListener?.(payload);
+		},
+		emitArchiveSucceeded(payload: ArchiveExecutionSucceededPayload) {
+			archiveSucceededListener?.(payload);
+		},
+	};
+});
+
+vi.mock("@/lib/api", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/lib/api")>();
+
+	return {
+		...actual,
+		addRepositoryFromLocalPath: apiMocks.addRepositoryFromLocalPath,
+		createWorkspaceFromRepo: apiMocks.createWorkspaceFromRepo,
+		listRepositories: apiMocks.listRepositories,
+		loadAddRepositoryDefaults: apiMocks.loadAddRepositoryDefaults,
+		loadArchivedWorkspaces: apiMocks.loadArchivedWorkspaces,
+		loadSessionThreadMessages: apiMocks.loadSessionThreadMessages,
+		loadWorkspaceDetail: apiMocks.loadWorkspaceDetail,
+		loadWorkspaceGroups: apiMocks.loadWorkspaceGroups,
+		loadWorkspaceSessions: apiMocks.loadWorkspaceSessions,
+		listenArchiveExecutionFailed: apiMocks.listenArchiveExecutionFailed,
+		listenArchiveExecutionSucceeded: apiMocks.listenArchiveExecutionSucceeded,
+		markWorkspaceRead: apiMocks.markWorkspaceRead,
+		markWorkspaceUnread: apiMocks.markWorkspaceUnread,
+		permanentlyDeleteWorkspace: apiMocks.permanentlyDeleteWorkspace,
+		pinWorkspace: apiMocks.pinWorkspace,
+		prepareArchiveWorkspace: apiMocks.prepareArchiveWorkspace,
+		restoreWorkspace: apiMocks.restoreWorkspace,
+		setWorkspaceManualStatus: apiMocks.setWorkspaceManualStatus,
+		startArchiveWorkspace: apiMocks.startArchiveWorkspace,
+		unpinWorkspace: apiMocks.unpinWorkspace,
+		validateRestoreWorkspace: apiMocks.validateRestoreWorkspace,
+	};
+});
+
+const workspaceGroups: WorkspaceGroup[] = [
+	{
+		id: "progress",
+		label: "In progress",
+		tone: "progress",
+		rows: [
+			{
+				id: "ws-1",
+				title: "Workspace 1",
+				repoName: "helmor",
+				repoInitials: "HE",
+				state: "ready",
+				manualStatus: null,
+				derivedStatus: "in-progress",
+				hasUnread: false,
+				workspaceUnread: 0,
+				sessionUnreadTotal: 0,
+				unreadSessionCount: 0,
+				activeSessionId: null,
+				activeSessionTitle: null,
+				activeSessionAgentType: null,
+				activeSessionStatus: null,
+				branch: "feature/ws-1",
+				prTitle: null,
+				pinnedAt: null,
+				sessionCount: 0,
+				messageCount: 0,
+				attachmentCount: 0,
+			},
+			{
+				id: "ws-2",
+				title: "Workspace 2",
+				repoName: "helmor",
+				repoInitials: "HE",
+				state: "ready",
+				manualStatus: null,
+				derivedStatus: "in-progress",
+				hasUnread: false,
+				workspaceUnread: 0,
+				sessionUnreadTotal: 0,
+				unreadSessionCount: 0,
+				activeSessionId: null,
+				activeSessionTitle: null,
+				activeSessionAgentType: null,
+				activeSessionStatus: null,
+				branch: "feature/ws-2",
+				prTitle: null,
+				pinnedAt: null,
+				sessionCount: 0,
+				messageCount: 0,
+				attachmentCount: 0,
+			},
+		],
+	},
+];
+
+function makeArchivedSummary(id: string): WorkspaceSummary {
+	return {
+		id,
+		title: `Archived ${id}`,
+		directoryName: id,
+		repoName: "helmor",
+		repoInitials: "HE",
+		state: "archived",
+		hasUnread: false,
+		workspaceUnread: 0,
+		sessionUnreadTotal: 0,
+		unreadSessionCount: 0,
+		derivedStatus: "in-progress",
+		manualStatus: null,
+		branch: `feature/${id}`,
+		activeSessionId: null,
+		activeSessionTitle: null,
+		activeSessionAgentType: null,
+		activeSessionStatus: null,
+		prTitle: null,
+		sessionCount: 0,
+		messageCount: 0,
+		attachmentCount: 0,
+	};
+}
+
+function makeWorkspaceDetail(id: string): WorkspaceDetail {
+	return {
+		id,
+		title: `Workspace ${id}`,
+		repoId: "repo-1",
+		repoName: "helmor",
+		repoInitials: "HE",
+		repoIconSrc: null,
+		remote: "origin",
+		remoteUrl: null,
+		defaultBranch: "main",
+		rootPath: `/tmp/${id}`,
+		directoryName: id,
+		state: "ready",
+		hasUnread: false,
+		workspaceUnread: 0,
+		sessionUnreadTotal: 0,
+		unreadSessionCount: 0,
+		derivedStatus: "in-progress",
+		manualStatus: null,
+		activeSessionId: null,
+		activeSessionTitle: null,
+		activeSessionAgentType: null,
+		activeSessionStatus: null,
+		branch: `feature/${id}`,
+		initializationParentBranch: "main",
+		intendedTargetBranch: "main",
+		notes: null,
+		pinnedAt: null,
+		prTitle: null,
+		prDescription: null,
+		archiveCommit: null,
+		sessionCount: 0,
+		messageCount: 0,
+		attachmentCount: 0,
+	};
+}
+
+const emptySessions: WorkspaceSessionSummary[] = [];
+
+function createWrapper(queryClient: QueryClient) {
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return (
+			<SettingsContext.Provider
+				value={{
+					settings: DEFAULT_SETTINGS,
+					updateSettings: () => {},
+				}}
+			>
+				<QueryClientProvider client={queryClient}>
+					{children}
+				</QueryClientProvider>
+			</SettingsContext.Provider>
+		);
+	};
+}
+
+describe("useWorkspacesSidebarController archive flow", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		apiMocks.loadWorkspaceGroups.mockResolvedValue(workspaceGroups);
+		apiMocks.loadArchivedWorkspaces.mockResolvedValue([]);
+		apiMocks.listRepositories.mockResolvedValue([]);
+		apiMocks.loadAddRepositoryDefaults.mockResolvedValue({
+			lastCloneDirectory: null,
+		});
+		apiMocks.loadWorkspaceDetail.mockImplementation(async (id: string) =>
+			makeWorkspaceDetail(id),
+		);
+		apiMocks.loadWorkspaceSessions.mockResolvedValue(emptySessions);
+		apiMocks.loadSessionThreadMessages.mockResolvedValue([]);
+		apiMocks.prepareArchiveWorkspace.mockImplementation(
+			async (
+				workspaceId: string,
+			): Promise<PrepareArchiveWorkspaceResponse> => ({
+				workspaceId,
+			}),
+		);
+		apiMocks.startArchiveWorkspace.mockResolvedValue(undefined);
+		apiMocks.validateRestoreWorkspace.mockResolvedValue({
+			targetBranchConflict: null,
+		});
+		apiMocks.restoreWorkspace.mockResolvedValue({
+			restoredWorkspaceId: "ws-1",
+			restoredState: "ready",
+			selectedWorkspaceId: "ws-1",
+			branchRename: null,
+		});
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("preflight 成功后立即乐观移动 workspace，并切到下一个 workspace", async () => {
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false } },
+		});
+		const onSelectWorkspace = vi.fn();
+		const pushWorkspaceToast = vi.fn();
+
+		const { result } = renderHook(
+			() =>
+				useWorkspacesSidebarController({
+					selectedWorkspaceId: "ws-1",
+					onSelectWorkspace,
+					pushWorkspaceToast,
+				}),
+			{ wrapper: createWrapper(queryClient) },
+		);
+
+		await waitFor(() => {
+			expect(result.current.groups[0]?.rows).toHaveLength(2);
+		});
+
+		act(() => {
+			result.current.handleArchiveWorkspace("ws-1");
+		});
+
+		await waitFor(() => {
+			expect(apiMocks.prepareArchiveWorkspace).toHaveBeenCalledWith("ws-1");
+		});
+		await waitFor(() => {
+			expect(apiMocks.startArchiveWorkspace).toHaveBeenCalledWith("ws-1");
+		});
+		await waitFor(() => {
+			expect(result.current.groups[0]?.rows.map((row) => row.id)).toEqual([
+				"ws-2",
+			]);
+		});
+		expect(result.current.archivedRows.map((row) => row.id)).toContain("ws-1");
+		expect(onSelectWorkspace).toHaveBeenCalledWith("ws-2");
+		expect(pushWorkspaceToast).not.toHaveBeenCalled();
+	});
+
+	it("后台启动立即失败时会回滚乐观更新", async () => {
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false } },
+		});
+		const pushWorkspaceToast = vi.fn();
+		apiMocks.startArchiveWorkspace.mockRejectedValueOnce(new Error("boom"));
+
+		const { result } = renderHook(
+			() =>
+				useWorkspacesSidebarController({
+					selectedWorkspaceId: null,
+					onSelectWorkspace: vi.fn(),
+					pushWorkspaceToast,
+				}),
+			{ wrapper: createWrapper(queryClient) },
+		);
+
+		await waitFor(() => {
+			expect(result.current.groups[0]?.rows).toHaveLength(2);
+		});
+
+		act(() => {
+			result.current.handleArchiveWorkspace("ws-1");
+		});
+
+		await waitFor(() => {
+			expect(apiMocks.startArchiveWorkspace).toHaveBeenCalledWith("ws-1");
+		});
+		await waitFor(() => {
+			expect(result.current.groups[0]?.rows.map((row) => row.id)).toEqual([
+				"ws-1",
+				"ws-2",
+			]);
+		});
+		expect(result.current.archivedRows).toHaveLength(0);
+		expect(pushWorkspaceToast).toHaveBeenCalled();
+	});
+
+	it("后台未完成时，stale refetch 不会把 workspace 拉回 live 列表；失败事件会回滚", async () => {
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false } },
+		});
+		const pushWorkspaceToast = vi.fn();
+		let resolveStart: (() => void) | null = null;
+		apiMocks.startArchiveWorkspace.mockImplementation(
+			() =>
+				new Promise<void>((resolve) => {
+					resolveStart = resolve;
+				}),
+		);
+
+		const { result } = renderHook(
+			() =>
+				useWorkspacesSidebarController({
+					selectedWorkspaceId: null,
+					onSelectWorkspace: vi.fn(),
+					pushWorkspaceToast,
+				}),
+			{ wrapper: createWrapper(queryClient) },
+		);
+
+		await waitFor(() => {
+			expect(result.current.groups[0]?.rows.map((row) => row.id)).toEqual([
+				"ws-1",
+				"ws-2",
+			]);
+		});
+
+		act(() => {
+			result.current.handleArchiveWorkspace("ws-1");
+		});
+
+		await waitFor(() => {
+			expect(result.current.archivedRows.map((row) => row.id)).toContain(
+				"ws-1",
+			);
+		});
+
+		act(() => {
+			queryClient.setQueryData(["workspaceGroups"], workspaceGroups);
+			queryClient.setQueryData(["archivedWorkspaces"], []);
+		});
+
+		await waitFor(() => {
+			expect(result.current.groups[0]?.rows.map((row) => row.id)).toEqual([
+				"ws-2",
+			]);
+		});
+		expect(result.current.archivedRows.map((row) => row.id)).toContain("ws-1");
+
+		act(() => {
+			apiMocks.emitArchiveFailed({
+				workspaceId: "ws-1",
+				message: "archive failed later",
+			});
+		});
+
+		await waitFor(() => {
+			expect(result.current.groups[0]?.rows.map((row) => row.id)).toEqual([
+				"ws-1",
+				"ws-2",
+			]);
+		});
+		expect(result.current.archivedRows).toHaveLength(0);
+		expect(pushWorkspaceToast).toHaveBeenCalled();
+
+		act(() => {
+			resolveStart?.();
+		});
+	});
+
+	it("成功事件后，后续服务端刷新会以真实 archived 数据为准", async () => {
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false } },
+		});
+		let resolveStart: (() => void) | null = null;
+		apiMocks.startArchiveWorkspace.mockImplementation(
+			() =>
+				new Promise<void>((resolve) => {
+					resolveStart = resolve;
+				}),
+		);
+
+		const { result } = renderHook(
+			() =>
+				useWorkspacesSidebarController({
+					selectedWorkspaceId: null,
+					onSelectWorkspace: vi.fn(),
+					pushWorkspaceToast: vi.fn(),
+				}),
+			{ wrapper: createWrapper(queryClient) },
+		);
+
+		await waitFor(() => {
+			expect(result.current.groups[0]?.rows).toHaveLength(2);
+		});
+
+		act(() => {
+			result.current.handleArchiveWorkspace("ws-1");
+		});
+
+		await waitFor(() => {
+			expect(result.current.archivedRows.map((row) => row.id)).toContain(
+				"ws-1",
+			);
+		});
+
+		act(() => {
+			apiMocks.emitArchiveSucceeded({ workspaceId: "ws-1" });
+			queryClient.setQueryData(
+				["workspaceGroups"],
+				[{ ...workspaceGroups[0], rows: [workspaceGroups[0].rows[1]] }],
+			);
+			queryClient.setQueryData(
+				["archivedWorkspaces"],
+				[makeArchivedSummary("ws-1")],
+			);
+		});
+
+		await waitFor(() => {
+			expect(result.current.groups[0]?.rows.map((row) => row.id)).toEqual([
+				"ws-2",
+			]);
+		});
+		expect(result.current.archivedRows.map((row) => row.id)).toEqual(["ws-1"]);
+
+		act(() => {
+			resolveStart?.();
+		});
+	});
+});

--- a/src/features/navigation/hooks/use-controller.ts
+++ b/src/features/navigation/hooks/use-controller.ts
@@ -3,18 +3,21 @@ import { open } from "@tauri-apps/plugin-dialog";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
 	addRepositoryFromLocalPath,
-	archiveWorkspace,
 	createWorkspaceFromRepo,
+	listenArchiveExecutionFailed,
+	listenArchiveExecutionSucceeded,
 	loadAddRepositoryDefaults,
 	markWorkspaceRead,
 	markWorkspaceUnread,
 	permanentlyDeleteWorkspace,
 	pinWorkspace,
+	prepareArchiveWorkspace,
 	restoreWorkspace,
 	setWorkspaceManualStatus,
+	startArchiveWorkspace,
 	unpinWorkspace,
-	validateArchiveWorkspace,
 	validateRestoreWorkspace,
+	type WorkspaceRow,
 	type WorkspaceSessionSummary,
 } from "@/lib/api";
 import {
@@ -70,6 +73,9 @@ export function useWorkspacesSidebarController({
 	const [creatingWorkspaceRepoId, setCreatingWorkspaceRepoId] = useState<
 		string | null
 	>(null);
+	const [archivingWorkspaceIds, setArchivingWorkspaceIds] = useState<
+		Set<string>
+	>(() => new Set());
 	const [markingReadWorkspaceId, setMarkingReadWorkspaceId] = useState<
 		string | null
 	>(null);
@@ -77,6 +83,16 @@ export function useWorkspacesSidebarController({
 		string | null
 	>(null);
 
+	const archiveRollbackRef = useRef<
+		Map<
+			string,
+			{
+				row: WorkspaceRow;
+				sourceGroupId: string;
+				sourceIndex: number;
+			}
+		>
+	>(new Map());
 	const sidebarMutationCountRef = useRef(0);
 
 	const flushSidebarLists = useCallback(() => {
@@ -106,12 +122,164 @@ export function useWorkspacesSidebarController({
 	const archivedQuery = useQuery(archivedWorkspacesQueryOptions());
 	const repositoriesQuery = useQuery(repositoriesQueryOptions());
 
-	const groups = groupsQuery.data ?? [];
-	const archivedSummaries = archivedQuery.data ?? [];
+	const baseGroups = groupsQuery.data ?? [];
+	const baseArchivedSummaries = archivedQuery.data ?? [];
+	const pendingArchivedEntries = Array.from(
+		archiveRollbackRef.current.entries(),
+	);
+	const pendingArchivedIds = new Set(
+		pendingArchivedEntries.map(([workspaceId]) => workspaceId),
+	);
+	const groups =
+		pendingArchivedIds.size === 0
+			? baseGroups
+			: baseGroups.map((group) => ({
+					...group,
+					rows: group.rows.filter((row) => !pendingArchivedIds.has(row.id)),
+				}));
+	const archivedSummaries =
+		pendingArchivedEntries.length === 0
+			? baseArchivedSummaries
+			: [
+					...pendingArchivedEntries
+						.filter(
+							([workspaceId]) =>
+								!baseArchivedSummaries.some(
+									(summary) => summary.id === workspaceId,
+								),
+						)
+						.map(([, rollback]) =>
+							rowToWorkspaceSummary(rollback.row, {
+								state: "archived",
+							}),
+						),
+					...baseArchivedSummaries,
+				];
 	const archivedRows = useMemo(
 		() => archivedSummaries.map(summaryToArchivedRow),
 		[archivedSummaries],
 	);
+
+	const updateArchivingWorkspaceId = useCallback(
+		(workspaceId: string, active: boolean) => {
+			setArchivingWorkspaceIds((current) => {
+				const next = new Set(current);
+				if (active) {
+					next.add(workspaceId);
+				} else {
+					next.delete(workspaceId);
+				}
+				return next;
+			});
+		},
+		[],
+	);
+
+	const rollbackArchivedWorkspace = useCallback(
+		(workspaceId: string, error: unknown, fallbackMessage: string) => {
+			updateArchivingWorkspaceId(workspaceId, false);
+			const rollback = archiveRollbackRef.current.get(workspaceId);
+			archiveRollbackRef.current.delete(workspaceId);
+
+			if (!rollback) {
+				flushSidebarLists();
+				pushWorkspaceToast(
+					describeUnknownError(error, fallbackMessage),
+					"Archive failed",
+					"destructive",
+				);
+				return;
+			}
+
+			queryClient.setQueryData(helmorQueryKeys.archivedWorkspaces, (current) =>
+				Array.isArray(current)
+					? (current as typeof archivedSummaries).filter(
+							(summary) => summary.id !== workspaceId,
+						)
+					: current,
+			);
+
+			queryClient.setQueryData(helmorQueryKeys.workspaceGroups, (current) => {
+				if (!Array.isArray(current)) {
+					return current;
+				}
+				return (current as typeof groups).map((group) => {
+					if (group.id !== rollback.sourceGroupId) {
+						return group;
+					}
+					if (group.rows.some((row) => row.id === workspaceId)) {
+						return group;
+					}
+					const nextRows = [...group.rows];
+					const insertAt = Math.min(
+						Math.max(rollback.sourceIndex, 0),
+						nextRows.length,
+					);
+					nextRows.splice(insertAt, 0, rollback.row);
+					return {
+						...group,
+						rows: nextRows,
+					};
+				});
+			});
+
+			pushWorkspaceToast(
+				describeUnknownError(error, fallbackMessage),
+				"Archive failed",
+				"destructive",
+			);
+		},
+		[
+			archivedSummaries,
+			flushSidebarLists,
+			groups,
+			pushWorkspaceToast,
+			queryClient,
+			updateArchivingWorkspaceId,
+		],
+	);
+
+	useEffect(() => {
+		let disposed = false;
+		let unlistenFailure: (() => void) | undefined;
+		let unlistenSuccess: (() => void) | undefined;
+
+		void listenArchiveExecutionFailed((payload) => {
+			if (disposed) {
+				return;
+			}
+			rollbackArchivedWorkspace(
+				payload.workspaceId,
+				new Error(payload.message),
+				"Unable to archive workspace.",
+			);
+		}).then((cleanup) => {
+			if (disposed) {
+				cleanup();
+				return;
+			}
+			unlistenFailure = cleanup;
+		});
+
+		void listenArchiveExecutionSucceeded((payload) => {
+			if (disposed) {
+				return;
+			}
+			archiveRollbackRef.current.delete(payload.workspaceId);
+		}).then((cleanup) => {
+			if (disposed) {
+				cleanup();
+				return;
+			}
+			unlistenSuccess = cleanup;
+		});
+
+		return () => {
+			disposed = true;
+			unlistenFailure?.();
+			unlistenSuccess?.();
+		};
+	}, [rollbackArchivedWorkspace]);
 
 	useEffect(() => {
 		if (
@@ -769,26 +937,30 @@ export function useWorkspacesSidebarController({
 	const handleArchiveWorkspace = useCallback(
 		(workspaceId: string) => {
 			void (async () => {
+				if (archivingWorkspaceIds.has(workspaceId)) {
+					return;
+				}
+
+				updateArchivingWorkspaceId(workspaceId, true);
+
 				try {
-					await validateArchiveWorkspace(workspaceId);
+					await prepareArchiveWorkspace(workspaceId);
 				} catch (error) {
-					pushPermanentDeleteRecoveryToast(
-						workspaceId,
+					updateArchivingWorkspaceId(workspaceId, false);
+					pushWorkspaceToast(
+						describeUnknownError(error, "Unable to archive workspace."),
 						"Archive failed",
-						error,
-						"Unable to archive workspace.",
+						"destructive",
 					);
 					return;
 				}
 
-				const previousGroups = queryClient.getQueryData(
-					helmorQueryKeys.workspaceGroups,
-				);
-				const previousArchived = queryClient.getQueryData(
-					helmorQueryKeys.archivedWorkspaces,
-				);
+				const previousGroups =
+					queryClient.getQueryData(helmorQueryKeys.workspaceGroups) ?? groups;
 
-				let movedRow: (typeof groups)[number]["rows"][number] | null = null;
+				let movedRow: WorkspaceRow | null = null;
+				let sourceGroupId: string | null = null;
+				let sourceIndex = -1;
 				const optimisticGroups = Array.isArray(previousGroups)
 					? (previousGroups as typeof groups).map((group) => {
 							const index = group.rows.findIndex(
@@ -798,6 +970,8 @@ export function useWorkspacesSidebarController({
 								return group;
 							}
 							movedRow = group.rows[index];
+							sourceGroupId = group.id;
+							sourceIndex = index;
 							return {
 								...group,
 								rows: [
@@ -808,18 +982,18 @@ export function useWorkspacesSidebarController({
 						})
 					: undefined;
 
-				if (!movedRow || !optimisticGroups) {
-					beginSidebarMutation();
-					void archiveWorkspace(workspaceId)
-						.catch((error) => {
-							pushPermanentDeleteRecoveryToast(
-								workspaceId,
-								"Archive failed",
-								error,
-								"Unable to archive workspace.",
-							);
-						})
-						.finally(endSidebarMutation);
+				if (
+					!movedRow ||
+					!optimisticGroups ||
+					sourceGroupId === null ||
+					sourceIndex < 0
+				) {
+					updateArchivingWorkspaceId(workspaceId, false);
+					pushWorkspaceToast(
+						"Unable to find workspace in the sidebar cache.",
+						"Archive failed",
+						"destructive",
+					);
 					return;
 				}
 
@@ -830,6 +1004,11 @@ export function useWorkspacesSidebarController({
 
 				const archivedPlaceholder = rowToWorkspaceSummary(movedRow, {
 					state: "archived",
+				});
+				archiveRollbackRef.current.set(workspaceId, {
+					row: movedRow,
+					sourceGroupId,
+					sourceIndex,
 				});
 				queryClient.setQueryData(
 					helmorQueryKeys.archivedWorkspaces,
@@ -857,35 +1036,29 @@ export function useWorkspacesSidebarController({
 					onSelectWorkspace(nextWorkspaceId);
 				}
 
-				beginSidebarMutation();
-				void archiveWorkspace(workspaceId)
+				void startArchiveWorkspace(workspaceId)
 					.catch((error) => {
-						queryClient.setQueryData(
-							helmorQueryKeys.workspaceGroups,
-							previousGroups,
-						);
-						queryClient.setQueryData(
-							helmorQueryKeys.archivedWorkspaces,
-							previousArchived,
-						);
-						pushPermanentDeleteRecoveryToast(
+						rollbackArchivedWorkspace(
 							workspaceId,
-							"Archive failed",
 							error,
 							"Unable to archive workspace.",
 						);
 					})
-					.finally(endSidebarMutation);
+					.finally(() => {
+						updateArchivingWorkspaceId(workspaceId, false);
+					});
 			})();
 		},
 		[
-			beginSidebarMutation,
-			endSidebarMutation,
+			archivingWorkspaceIds,
+			groups,
 			onSelectWorkspace,
 			prefetchWorkspace,
-			pushPermanentDeleteRecoveryToast,
+			pushWorkspaceToast,
 			queryClient,
+			rollbackArchivedWorkspace,
 			selectedWorkspaceId,
+			updateArchivingWorkspaceId,
 		],
 	);
 
@@ -1039,6 +1212,7 @@ export function useWorkspacesSidebarController({
 
 	return {
 		addingRepository,
+		archivingWorkspaceIds,
 		archivedRows,
 		availableRepositories: repositoriesQuery.data ?? [],
 		creatingWorkspaceRepoId,

--- a/src/features/navigation/index.test.tsx
+++ b/src/features/navigation/index.test.tsx
@@ -168,6 +168,48 @@ describe("WorkspacesSidebar", () => {
 		expect(virtualList).toHaveStyle({ height: "252px" });
 	});
 
+	it("only disables the row whose workspace id is in archivingWorkspaceIds", async () => {
+		const user = userEvent.setup();
+		const onArchiveWorkspace = vi.fn();
+		const groups: WorkspaceGroup[] = [
+			{
+				id: "progress",
+				label: "In Progress",
+				tone: "progress",
+				rows: [
+					workspaceRow,
+					{
+						...workspaceRow,
+						id: "workspace-2",
+						title: "Workspace 2",
+					},
+				],
+			},
+		];
+
+		render(
+			<TooltipProvider delayDuration={0}>
+				<WorkspacesSidebar
+					groups={groups}
+					archivedRows={[]}
+					onArchiveWorkspace={onArchiveWorkspace}
+					archivingWorkspaceIds={new Set(["workspace-1"])}
+				/>
+			</TooltipProvider>,
+		);
+
+		const archiveButtons = screen.getAllByRole("button", {
+			name: "Archive workspace",
+		});
+
+		expect(archiveButtons).toHaveLength(2);
+		expect(archiveButtons[0]).toBeDisabled();
+		expect(archiveButtons[1]).toBeEnabled();
+
+		await user.click(archiveButtons[1]);
+		expect(onArchiveWorkspace).toHaveBeenCalledWith("workspace-2");
+	});
+
 	it("persists section collapse state in localStorage", async () => {
 		const user = userEvent.setup();
 		const collapsedGroups: WorkspaceGroup[] = [

--- a/src/features/navigation/index.tsx
+++ b/src/features/navigation/index.tsx
@@ -105,7 +105,7 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 	onDeleteWorkspace,
 	onTogglePin,
 	onSetManualStatus,
-	archivingWorkspaceId,
+	archivingWorkspaceIds,
 	markingUnreadWorkspaceId,
 	restoringWorkspaceId,
 }: {
@@ -128,7 +128,7 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 	onDeleteWorkspace?: (workspaceId: string) => void;
 	onTogglePin?: (workspaceId: string, currentlyPinned: boolean) => void;
 	onSetManualStatus?: (workspaceId: string, status: string | null) => void;
-	archivingWorkspaceId?: string | null;
+	archivingWorkspaceIds?: Set<string>;
 	markingUnreadWorkspaceId?: string | null;
 	restoringWorkspaceId?: string | null;
 }) {
@@ -323,10 +323,7 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 	}, [selectedWorkspaceId, sectionOpenState, flatItems, virtualizer]);
 
 	const workspaceActionsBusy = Boolean(
-		addingRepository ||
-			archivingWorkspaceId ||
-			markingUnreadWorkspaceId ||
-			restoringWorkspaceId,
+		addingRepository || markingUnreadWorkspaceId || restoringWorkspaceId,
 	);
 	const createBusy = Boolean(creatingWorkspaceRepoId);
 	const addRepositoryBusy = Boolean(addingRepository);
@@ -417,12 +414,11 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 						onMarkWorkspaceUnread={onMarkWorkspaceUnread}
 						onTogglePin={onTogglePin}
 						onSetManualStatus={onSetManualStatus}
-						archivingWorkspaceId={archivingWorkspaceId}
+						archivingWorkspaceIds={archivingWorkspaceIds}
 						markingUnreadWorkspaceId={markingUnreadWorkspaceId}
 						restoringWorkspaceId={restoringWorkspaceId}
 						workspaceActionsDisabled={Boolean(
 							creatingWorkspaceRepoId ||
-								archivingWorkspaceId ||
 								markingUnreadWorkspaceId ||
 								restoringWorkspaceId,
 						)}
@@ -451,7 +447,7 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 			onDeleteWorkspace,
 			onTogglePin,
 			onSetManualStatus,
-			archivingWorkspaceId,
+			archivingWorkspaceIds,
 			markingUnreadWorkspaceId,
 			restoringWorkspaceId,
 			creatingWorkspaceRepoId,

--- a/src/features/navigation/row-item.tsx
+++ b/src/features/navigation/row-item.tsx
@@ -70,7 +70,7 @@ export type WorkspaceRowItemProps = {
 	onDeleteWorkspace?: (workspaceId: string) => void;
 	onTogglePin?: (workspaceId: string, currentlyPinned: boolean) => void;
 	onSetManualStatus?: (workspaceId: string, status: string | null) => void;
-	archivingWorkspaceId?: string | null;
+	archivingWorkspaceIds?: Set<string>;
 	markingUnreadWorkspaceId?: string | null;
 	restoringWorkspaceId?: string | null;
 	workspaceActionsDisabled?: boolean;
@@ -92,7 +92,7 @@ export const WorkspaceRowItem = memo(
 		onDeleteWorkspace,
 		onTogglePin,
 		onSetManualStatus,
-		archivingWorkspaceId,
+		archivingWorkspaceIds,
 		markingUnreadWorkspaceId,
 		restoringWorkspaceId,
 		workspaceActionsDisabled,
@@ -102,7 +102,7 @@ export const WorkspaceRowItem = memo(
 		});
 		const actionLabel =
 			row.state === "archived" ? "Restore workspace" : "Archive workspace";
-		const isArchiving = archivingWorkspaceId === row.id;
+		const isArchiving = archivingWorkspaceIds?.has(row.id) ?? false;
 		const isMarkingUnread = markingUnreadWorkspaceId === row.id;
 		const isRestoring = restoringWorkspaceId === row.id;
 		const isRestoreAction = row.state === "archived";
@@ -222,10 +222,10 @@ export const WorkspaceRowItem = memo(
 							<TooltipTrigger asChild>
 								<Button
 									aria-label={actionLabel}
-									disabled={Boolean(workspaceActionsDisabled)}
+									disabled={Boolean(workspaceActionsDisabled || isBusy)}
 									onClick={(event) => {
 										event.stopPropagation();
-										if (workspaceActionsDisabled) return;
+										if (workspaceActionsDisabled || isBusy) return;
 										if (isRestoreAction) {
 											onRestoreWorkspace?.(row.id);
 										} else {
@@ -257,10 +257,10 @@ export const WorkspaceRowItem = memo(
 								<TooltipTrigger asChild>
 									<Button
 										aria-label="Delete permanently"
-										disabled={Boolean(workspaceActionsDisabled)}
+										disabled={Boolean(workspaceActionsDisabled || isBusy)}
 										onClick={(event) => {
 											event.stopPropagation();
-											if (workspaceActionsDisabled) return;
+											if (workspaceActionsDisabled || isBusy) return;
 											onDeleteWorkspace(row.id);
 										}}
 										variant="ghost"
@@ -368,7 +368,7 @@ export const WorkspaceRowItem = memo(
 			previous.isSending === next.isSending &&
 			previous.isCompleted === next.isCompleted &&
 			previous.isInteractionRequired === next.isInteractionRequired &&
-			previous.archivingWorkspaceId === next.archivingWorkspaceId &&
+			previous.archivingWorkspaceIds === next.archivingWorkspaceIds &&
 			previous.markingUnreadWorkspaceId === next.markingUnreadWorkspaceId &&
 			previous.restoringWorkspaceId === next.restoringWorkspaceId &&
 			previous.workspaceActionsDisabled === next.workspaceActionsDisabled

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -280,6 +280,19 @@ export type ArchiveWorkspaceResponse = {
 	archivedState: string;
 };
 
+export type PrepareArchiveWorkspaceResponse = {
+	workspaceId: string;
+};
+
+export type ArchiveExecutionFailedPayload = {
+	workspaceId: string;
+	message: string;
+};
+
+export type ArchiveExecutionSucceededPayload = {
+	workspaceId: string;
+};
+
 export type CreateWorkspaceResponse = {
 	createdWorkspaceId: string;
 	selectedWorkspaceId: string;
@@ -732,21 +745,44 @@ export async function validateRestoreWorkspace(
 	});
 }
 
-export async function archiveWorkspace(
+export async function prepareArchiveWorkspace(
 	workspaceId: string,
-): Promise<ArchiveWorkspaceResponse> {
-	return invoke<ArchiveWorkspaceResponse>("archive_workspace", {
+): Promise<PrepareArchiveWorkspaceResponse> {
+	return invoke<PrepareArchiveWorkspaceResponse>("prepare_archive_workspace", {
 		workspaceId,
 	});
 }
 
-/**
- * Read-only preflight for archive — see `validateRestoreWorkspace`.
- */
-export async function validateArchiveWorkspace(
+export async function startArchiveWorkspace(
 	workspaceId: string,
 ): Promise<void> {
-	await invoke<void>("validate_archive_workspace", { workspaceId });
+	await invoke<void>("start_archive_workspace", { workspaceId });
+}
+
+export async function validateArchiveWorkspace(
+	workspaceId: string,
+): Promise<PrepareArchiveWorkspaceResponse> {
+	return invoke<PrepareArchiveWorkspaceResponse>("validate_archive_workspace", {
+		workspaceId,
+	});
+}
+
+export async function listenArchiveExecutionFailed(
+	callback: (payload: ArchiveExecutionFailedPayload) => void,
+): Promise<UnlistenFn> {
+	return listen<ArchiveExecutionFailedPayload>(
+		"archive-execution-failed",
+		(event) => callback(event.payload),
+	);
+}
+
+export async function listenArchiveExecutionSucceeded(
+	callback: (payload: ArchiveExecutionSucceededPayload) => void,
+): Promise<UnlistenFn> {
+	return listen<ArchiveExecutionSucceededPayload>(
+		"archive-execution-succeeded",
+		(event) => callback(event.payload),
+	);
 }
 
 export type DetectedEditor = {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,4 +1,5 @@
 import "@testing-library/jest-dom/vitest";
+import { createElement, type SVGProps } from "react";
 import { vi } from "vitest";
 
 vi.mock("lottie-web/build/player/lottie_svg", () => ({
@@ -7,6 +8,11 @@ vi.mock("lottie-web/build/player/lottie_svg", () => ({
 			destroy: vi.fn(),
 		})),
 	},
+}));
+
+vi.mock("@lobehub/icons", () => ({
+	Github: (props: SVGProps<SVGSVGElement>) =>
+		createElement("svg", { ...props, "data-testid": "mock-github-icon" }),
 }));
 
 // @tanstack/react-virtual requires a layout engine to determine visible items.


### PR DESCRIPTION
## What changed
- split workspace archiving into a read-only prepare step and an async start step on the Tauri side
- added an archive job manager plus success/failure events so the frontend can optimistically move archived workspaces and roll back if execution fails
- updated sidebar and inspector UI to track archiving per workspace, keep stale refetches from reintroducing pending archives, and format sync target labels with the workspace remote
- added frontend and Rust test coverage for the new archive behavior and archive eligibility states

## Why
- archiving could fail after the UI had already transitioned, and the old single-step flow did not give the frontend a clean way to manage optimistic state or recover from late failures
- separating preflight from execution lets the UI validate first, start the backend job explicitly, and handle success/failure events without losing list consistency

## Test notes
- pre-commit hooks passed: biome check, cargo fmt, cargo clippy -- -D warnings
- full test suites were not run in this PR flow

## Follow-up
- verify the end-to-end archive UX in a running Tauri dev session, especially delayed failures from archive hooks or worktree removal