### PR TITLE
fix: collapse apply_patch file results

### DIFF
--- a/src/features/composer/index.test.tsx
+++ b/src/features/composer/index.test.tsx
@@ -330,7 +330,7 @@ describe("WorkspaceComposer", () => {
 		expect(screen.queryByLabelText("Fast mode")).not.toBeInTheDocument();
 	});
 
-	it("renders the fast mode lottie overlay inside the lightning button", () => {
+	it("renders the fast mode lottie overlay inside the lightning button when enabled", () => {
 		const queryClient = createHelmorQueryClient();
 
 		render(
@@ -364,9 +364,51 @@ describe("WorkspaceComposer", () => {
 		const overlay = fastModeButton.querySelector(
 			"[data-testid='fast-mode-lottie-icon']",
 		);
+		const zapIcon = fastModeButton.querySelector("svg");
 
 		expect(overlay).not.toBeNull();
 		expect(overlay).toHaveClass("absolute", "inset-[-5px]", "z-10");
+		expect(zapIcon).not.toHaveClass("opacity-55");
+	});
+
+	it("only dims the fast mode lightning icon when disabled", () => {
+		const queryClient = createHelmorQueryClient();
+
+		render(
+			<TooltipProvider delayDuration={0}>
+				<QueryClientProvider client={queryClient}>
+					<WorkspaceComposer
+						contextKey="session:session-1"
+						onSubmit={vi.fn()}
+						disabled={false}
+						submitDisabled={false}
+						sending={false}
+						selectedModelId="opus-1m"
+						modelSections={MODEL_SECTIONS}
+						onSelectModel={vi.fn()}
+						provider="claude"
+						effortLevel="high"
+						onSelectEffort={vi.fn()}
+						permissionMode="acceptEdits"
+						onChangePermissionMode={vi.fn()}
+						fastMode={false}
+						onChangeFastMode={vi.fn()}
+						restoreImages={[]}
+						restoreFiles={[]}
+						restoreCustomTags={[]}
+					/>
+				</QueryClientProvider>
+			</TooltipProvider>,
+		);
+
+		const fastModeButton = screen.getByRole("button", { name: "Fast mode" });
+		const overlay = fastModeButton.querySelector(
+			"[data-testid='fast-mode-lottie-icon']",
+		);
+		const zapIcon = fastModeButton.querySelector("svg");
+
+		expect(overlay).toBeNull();
+		expect(zapIcon).toHaveClass("opacity-55");
 	});
 
 	it("shows a hover preview for inserted image badges", async () => {

--- a/src/features/composer/index.tsx
+++ b/src/features/composer/index.tsx
@@ -556,15 +556,23 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 														fastMode
 															? "text-amber-500 hover:bg-amber-500/10 hover:text-amber-500"
 															: "text-muted-foreground",
+														toolbarDisabled
+															? "cursor-not-allowed opacity-45 hover:bg-transparent hover:text-muted-foreground"
+															: null,
 													)}
 													onClick={() => onChangeFastMode(!fastMode)}
 												>
 													<span className="relative block size-[14px]">
 														<Zap
-															className="absolute inset-0 z-0 size-[14px] opacity-55"
+															className={cn(
+																"absolute inset-0 z-0 size-[14px]",
+																fastMode ? null : "opacity-55",
+															)}
 															strokeWidth={1.8}
 														/>
-														<FastModeLottieIcon className="absolute inset-[-5px] z-10 drop-shadow-[0_0_4px_rgba(245,158,11,0.5)]" />
+														{fastMode ? (
+															<FastModeLottieIcon className="absolute inset-[-5px] z-10 drop-shadow-[0_0_4px_rgba(245,158,11,0.5)]" />
+														) : null}
 													</span>
 												</ComposerButton>
 											</TooltipTrigger>

--- a/src/features/panel/message-components/edit-diff.tsx
+++ b/src/features/panel/message-components/edit-diff.tsx
@@ -57,7 +57,12 @@ export function EditDiffTrigger({
 				{icon}
 				<span className="min-w-0 truncate">{file}</span>
 				{diffAdd != null || diffDel != null ? (
-					<span className="ml-auto flex shrink-0 items-center gap-1 text-[11px]">
+					<span
+						className={cn(
+							"flex shrink-0 items-center gap-1 text-[11px]",
+							variant === "row" ? "" : "ml-auto",
+						)}
+					>
 						{diffAdd != null ? (
 							<span className="text-chart-2">+{diffAdd}</span>
 						) : null}

--- a/src/features/panel/message-components/tool-call.test.tsx
+++ b/src/features/panel/message-components/tool-call.test.tsx
@@ -1,0 +1,37 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { AssistantToolCall } from "./tool-call";
+
+describe("AssistantToolCall apply_patch", () => {
+	it("collapses multi-file edits instead of showing generic patch text", () => {
+		const { container } = render(
+			<AssistantToolCall
+				toolName="apply_patch"
+				args={{
+					changes: [
+						{ path: "/src/request-parser.ts", diff: "+line one" },
+						{ path: "/src/data_dir.rs", diff: "+line two" },
+						{ path: "/src/App.tsx", diff: "+line three" },
+					],
+				}}
+				result="Patch applied"
+			/>,
+		);
+
+		expect(screen.queryByText("Patch applied")).not.toBeInTheDocument();
+		expect(screen.getByText("request-parser.ts")).toBeInTheDocument();
+		expect(screen.getByText("data_dir.rs")).toBeInTheDocument();
+		expect(screen.getByText("App.tsx")).toBeInTheDocument();
+
+		const details = container.querySelector(
+			"details",
+		) as HTMLDetailsElement | null;
+		expect(details).not.toBeNull();
+		details!.open = false;
+		fireEvent(details!, new Event("toggle"));
+
+		expect(screen.queryByText("request-parser.ts")).not.toBeInTheDocument();
+		expect(screen.queryByText("data_dir.rs")).not.toBeInTheDocument();
+		expect(screen.queryByText("App.tsx")).not.toBeInTheDocument();
+	});
+});

--- a/src/features/panel/message-components/tool-call.tsx
+++ b/src/features/panel/message-components/tool-call.tsx
@@ -95,6 +95,11 @@ export const AssistantToolCall = memo(function AssistantToolCall({
 	const unifiedDiff =
 		isApplyPatch && typeof info.rawDiff === "string" ? info.rawDiff : null;
 	const hasDiff = oldStr != null || newStr != null || unifiedDiff != null;
+	const hasFiles = (info.files?.length ?? 0) > 0;
+	const suppressGenericPatchResult =
+		isApplyPatch &&
+		hasFiles &&
+		(result === "Patch applied" || result === "Patch failed");
 
 	const resultStr = useMemo(
 		() =>
@@ -106,13 +111,21 @@ export const AssistantToolCall = memo(function AssistantToolCall({
 		[result],
 	);
 	const hasChildren = (childParts?.length ?? 0) > 0;
-	const resultText = hasChildren ? null : (info.body ?? resultStr);
+	const resultText =
+		hasChildren || suppressGenericPatchResult ? null : (info.body ?? resultStr);
 	const hasOutput = resultText != null && resultText.length > 5;
+	const canExpand = hasOutput || hasFiles;
 	const isLiveTool = isLiveStreamingStatus(streamingStatus);
-	const [isOpen, setIsOpen] = useState(isLiveTool);
+	const [isOpen, setIsOpen] = useState(isLiveTool || hasFiles);
 	useEffect(() => {
-		if (!isLiveTool) setIsOpen(false);
-	}, [isLiveTool]);
+		if (isLiveTool) {
+			setIsOpen(true);
+			return;
+		}
+		if (!canExpand) {
+			setIsOpen(false);
+		}
+	}, [canExpand, isLiveTool]);
 
 	const statusIndicator = isLiveTool ? (
 		<LoaderCircle
@@ -157,7 +170,9 @@ export const AssistantToolCall = memo(function AssistantToolCall({
 					</>
 				)
 			) : null}
-			{!hasDiff && (info.diffAdd != null || info.diffDel != null) ? (
+			{!hasDiff &&
+			!hasFiles &&
+			(info.diffAdd != null || info.diffDel != null) ? (
 				<span className="flex items-center gap-1 text-[11px]">
 					{info.diffAdd != null ? (
 						<span className="text-chart-2">+{info.diffAdd}</span>
@@ -192,8 +207,6 @@ export const AssistantToolCall = memo(function AssistantToolCall({
 		);
 	}
 
-	const hasFiles = (info.files?.length ?? 0) > 0;
-
 	if (compact) {
 		const detail = info.file ?? info.command ?? info.detail ?? null;
 		return (
@@ -219,11 +232,11 @@ export const AssistantToolCall = memo(function AssistantToolCall({
 				<summary
 					className={cn(
 						"flex max-w-full items-center gap-1.5 py-0.5 text-[12px] text-muted-foreground [&::-webkit-details-marker]:hidden",
-						hasOutput ? "cursor-pointer" : "cursor-default",
+						canExpand ? "cursor-pointer" : "cursor-default",
 					)}
 				>
 					{toolLine}
-					{hasOutput ? (
+					{canExpand ? (
 						<span className="shrink-0 cursor-pointer text-muted-foreground/40 hover:text-muted-foreground">
 							<svg
 								className="size-2.5 group-open/out:rotate-90"
@@ -241,70 +254,76 @@ export const AssistantToolCall = memo(function AssistantToolCall({
 						</span>
 					) : null}
 				</summary>
-				{hasOutput && (isLiveTool || isOpen) ? (
-					<div className="max-h-[16rem] overflow-auto rounded-md bg-accent/35 text-[11px] leading-5">
-						{info.fullCommand ? (
-							<div className="border-b border-border/20 px-2 py-1.5">
-								<span className="mr-1.5 text-chart-3/70">$</span>
-								<code className="font-mono text-muted-foreground">
-									{info.fullCommand}
-								</code>
+				{canExpand && (isLiveTool || isOpen) ? (
+					<div className="flex flex-col gap-1">
+						{hasOutput ? (
+							<div className="max-h-[16rem] overflow-auto rounded-md bg-accent/35 text-[11px] leading-5">
+								{info.fullCommand ? (
+									<div className="border-b border-border/20 px-2 py-1.5">
+										<span className="mr-1.5 text-chart-3/70">$</span>
+										<code className="font-mono text-muted-foreground">
+											{info.fullCommand}
+										</code>
+									</div>
+								) : null}
+								<pre className="whitespace-pre-wrap break-words p-1.5 text-muted-foreground/80">
+									{resultText!.slice(0, 2000)}
+									{resultText!.length > 2000 ? "…" : ""}
+								</pre>
 							</div>
 						) : null}
-						<pre className="whitespace-pre-wrap break-words p-1.5 text-muted-foreground/80">
-							{resultText!.slice(0, 2000)}
-							{resultText!.length > 2000 ? "…" : ""}
-						</pre>
+						{hasFiles ? (
+							<div className="ml-5 flex flex-col gap-0.5 border-l border-border/30 pl-3">
+								{info.files!.map((f, i) =>
+									f.rawDiff ? (
+										<EditDiffTrigger
+											key={`${f.name}-${i}`}
+											file={f.name}
+											diffAdd={f.diffAdd}
+											diffDel={f.diffDel}
+											oldStr={null}
+											newStr={null}
+											unifiedDiff={f.rawDiff}
+											variant="row"
+											icon={
+												<img
+													src={getMaterialFileIcon(f.name)}
+													alt=""
+													className="size-3.5 shrink-0"
+												/>
+											}
+										/>
+									) : (
+										<div
+											key={`${f.name}-${i}`}
+											className="flex max-w-full items-center gap-1.5 rounded-md px-2 py-1 text-[12px] leading-4 text-muted-foreground transition-colors hover:bg-accent/60"
+										>
+											<img
+												src={getMaterialFileIcon(f.name)}
+												alt=""
+												className="size-3.5 shrink-0"
+											/>
+											<span className="min-w-0 truncate">{f.name}</span>
+											{f.diffAdd != null || f.diffDel != null ? (
+												<span className="flex shrink-0 items-center gap-1 text-[11px]">
+													{f.diffAdd != null ? (
+														<span className="text-chart-2">+{f.diffAdd}</span>
+													) : null}
+													{f.diffDel != null ? (
+														<span className="text-destructive">
+															-{f.diffDel}
+														</span>
+													) : null}
+												</span>
+											) : null}
+										</div>
+									),
+								)}
+							</div>
+						) : null}
 					</div>
 				) : null}
 			</details>
-			{hasFiles ? (
-				<div className="ml-5 flex flex-col gap-0.5 border-l border-border/30 pl-3">
-					{info.files!.map((f, i) =>
-						f.rawDiff ? (
-							<EditDiffTrigger
-								key={`${f.name}-${i}`}
-								file={f.name}
-								diffAdd={f.diffAdd}
-								diffDel={f.diffDel}
-								oldStr={null}
-								newStr={null}
-								unifiedDiff={f.rawDiff}
-								variant="row"
-								icon={
-									<img
-										src={getMaterialFileIcon(f.name)}
-										alt=""
-										className="size-3.5 shrink-0"
-									/>
-								}
-							/>
-						) : (
-							<div
-								key={`${f.name}-${i}`}
-								className="flex max-w-full items-center gap-1.5 rounded-md px-2 py-1 text-[12px] leading-4 text-muted-foreground transition-colors hover:bg-accent/60"
-							>
-								<img
-									src={getMaterialFileIcon(f.name)}
-									alt=""
-									className="size-3.5 shrink-0"
-								/>
-								<span className="min-w-0 truncate">{f.name}</span>
-								{f.diffAdd != null || f.diffDel != null ? (
-									<span className="ml-auto flex shrink-0 items-center gap-1 text-[11px]">
-										{f.diffAdd != null ? (
-											<span className="text-chart-2">+{f.diffAdd}</span>
-										) : null}
-										{f.diffDel != null ? (
-											<span className="text-destructive">-{f.diffDel}</span>
-										) : null}
-									</span>
-								) : null}
-							</div>
-						),
-					)}
-				</div>
-			) : null}
 			{isError === true ? <ToolCallErrorRow result={result} /> : null}
 		</>
 	);


### PR DESCRIPTION
## What changed
- suppress generic `Patch applied` / `Patch failed` text when an `apply_patch` tool call already includes per-file results
- keep tool-call file rows inside the expandable details block so multi-file patch output can be collapsed cleanly
- adjust `EditDiffTrigger` row layout so file diff counts align correctly in the nested file list
- add a frontend test covering the collapsed multi-file `apply_patch` rendering

## Why
- the previous rendering duplicated patch feedback and left file rows visible even after collapsing the tool call, which made multi-file edit results noisy and inconsistent

## Test notes
- `pnpm vitest run src/features/panel/message-components/tool-call.test.tsx`

## Follow-up
- no additional follow-up identified