### PR TITLE
Add workspace script setup actions to panel empty states

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1314,14 +1314,15 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 
 		try {
 			const { sessionId } = await createSession(workspaceId);
+			const cachedWorkspace =
+				queryClient.getQueryData<WorkspaceDetail | null>(
+					helmorQueryKeys.workspaceDetail(workspaceId),
+				) ?? null;
 			seedNewSessionInCache({
 				queryClient,
 				workspaceId,
 				sessionId,
-				workspace:
-					queryClient.getQueryData<WorkspaceDetail | null>(
-						helmorQueryKeys.workspaceDetail(workspaceId),
-					) ?? null,
+				workspace: cachedWorkspace,
 				existingSessions:
 					queryClient.getQueryData<WorkspaceSessionSummary[]>(
 						helmorQueryKeys.workspaceSessions(workspaceId),
@@ -1330,6 +1331,16 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 			handleSelectSession(sessionId);
 
 			void Promise.all([
+				...(cachedWorkspace
+					? [
+							queryClient.invalidateQueries({
+								queryKey: helmorQueryKeys.repoScripts(
+									cachedWorkspace.repoId,
+									workspaceId,
+								),
+							}),
+						]
+					: []),
 				queryClient.invalidateQueries({
 					queryKey: helmorQueryKeys.workspaceDetail(workspaceId),
 				}),
@@ -1866,6 +1877,9 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 												pendingInsertRequests={pendingComposerInserts}
 												onPendingInsertRequestsConsumed={
 													handlePendingComposerInsertsConsumed
+												}
+												onQueuePendingPromptForSession={
+													queuePendingPromptForSession
 												}
 												headerLeading={
 													sidebarCollapsed ? (

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -282,9 +282,22 @@ export const WorkspaceComposerContainer = memo(
 					try {
 						const { sessionId: newSessionId } =
 							await createSession(displayedWorkspaceId);
-						await queryClient.invalidateQueries({
-							queryKey: helmorQueryKeys.workspaceSessions(displayedWorkspaceId),
-						});
+						await Promise.all([
+							queryClient.invalidateQueries({
+								queryKey:
+									helmorQueryKeys.workspaceSessions(displayedWorkspaceId),
+							}),
+							...(workspaceDetailQuery.data?.repoId
+								? [
+										queryClient.invalidateQueries({
+											queryKey: helmorQueryKeys.repoScripts(
+												workspaceDetailQuery.data.repoId,
+												displayedWorkspaceId,
+											),
+										}),
+									]
+								: []),
+						]);
 						onSwitchSession?.(newSessionId);
 						const newContextKey = getComposerContextKey(
 							displayedWorkspaceId,
@@ -309,6 +322,7 @@ export const WorkspaceComposerContainer = memo(
 				onSelectModel,
 				onSwitchSession,
 				queryClient,
+				workspaceDetailQuery.data?.repoId,
 			],
 		);
 

--- a/src/features/conversation/index.tsx
+++ b/src/features/conversation/index.tsx
@@ -54,6 +54,12 @@ type WorkspaceConversationContainerProps = {
 	onPendingPromptConsumed?: () => void;
 	pendingInsertRequests?: ResolvedComposerInsertRequest[];
 	onPendingInsertRequestsConsumed?: (ids: string[]) => void;
+	onQueuePendingPromptForSession?: (request: {
+		sessionId: string;
+		prompt: string;
+		modelId?: string | null;
+		permissionMode?: string | null;
+	}) => void;
 };
 
 export const WorkspaceConversationContainer = memo(
@@ -78,6 +84,7 @@ export const WorkspaceConversationContainer = memo(
 		onPendingPromptConsumed,
 		pendingInsertRequests = [],
 		onPendingInsertRequestsConsumed,
+		onQueuePendingPromptForSession,
 	}: WorkspaceConversationContainerProps) {
 		const [composerModelSelections, setComposerModelSelections] = useState<
 			Record<string, string>
@@ -226,6 +233,7 @@ export const WorkspaceConversationContainer = memo(
 					workspacePrInfo={workspacePrInfo}
 					onSelectSession={onSelectSession}
 					onResolveDisplayedSession={onResolveDisplayedSession}
+					onQueuePendingPromptForSession={onQueuePendingPromptForSession}
 					headerActions={headerActions}
 					headerLeading={headerLeading}
 				/>

--- a/src/features/panel/container.test.tsx
+++ b/src/features/panel/container.test.tsx
@@ -7,6 +7,7 @@ import { renderWithProviders } from "@/test/render-with-providers";
 
 const apiMocks = vi.hoisted(() => ({
 	createSession: vi.fn(),
+	loadRepoScripts: vi.fn(),
 	loadWorkspaceDetail: vi.fn(),
 	loadWorkspaceSessions: vi.fn(),
 	loadSessionMessages: vi.fn(),
@@ -21,6 +22,7 @@ vi.mock("@/lib/api", async (importOriginal) => {
 	return {
 		...actual,
 		createSession: apiMocks.createSession,
+		loadRepoScripts: apiMocks.loadRepoScripts,
 		loadWorkspaceDetail: apiMocks.loadWorkspaceDetail,
 		loadWorkspaceSessions: apiMocks.loadWorkspaceSessions,
 		loadSessionMessages: apiMocks.loadSessionThreadMessages,
@@ -252,11 +254,20 @@ describe("WorkspacePanelContainer loading semantics", () => {
 	beforeEach(() => {
 		panelRenderSpy.mockReset();
 		apiMocks.createSession.mockReset();
+		apiMocks.loadRepoScripts.mockReset();
 		apiMocks.loadWorkspaceDetail.mockReset();
 		apiMocks.loadWorkspaceSessions.mockReset();
 		apiMocks.loadSessionThreadMessages.mockReset();
 
 		apiMocks.createSession.mockResolvedValue({ sessionId: "session-created" });
+		apiMocks.loadRepoScripts.mockResolvedValue({
+			setupScript: "pnpm install",
+			runScript: "pnpm dev",
+			archiveScript: "true",
+			setupFromProject: false,
+			runFromProject: false,
+			archiveFromProject: false,
+		});
 		apiMocks.loadWorkspaceDetail.mockImplementation((workspaceId?: string) =>
 			Promise.resolve(createWorkspaceDetail(workspaceId)),
 		);
@@ -408,6 +419,33 @@ describe("WorkspacePanelContainer loading semantics", () => {
 				resumeSessionAt: null,
 				isHidden: false,
 				isCompacting: false,
+				active: true,
+			},
+		]);
+		apiMocks.loadWorkspaceSessions.mockResolvedValue([
+			{
+				id: "session-new",
+				workspaceId: "workspace-1",
+				title: "Untitled",
+				agentType: null,
+				status: "idle",
+				model: null,
+				permissionMode: "default",
+				providerSessionId: null,
+				effortLevel: null,
+				unreadCount: 0,
+				contextTokenCount: 0,
+				contextUsedPercent: null,
+				thinkingEnabled: true,
+				fastMode: false,
+				agentPersonality: null,
+				createdAt: "2026-04-05T00:00:00Z",
+				updatedAt: "2026-04-05T00:00:00Z",
+				lastUserMessageAt: null,
+				resumeSessionAt: null,
+				isHidden: false,
+				isCompacting: false,
+				actionKind: null,
 				active: true,
 			},
 		]);

--- a/src/features/panel/container.tsx
+++ b/src/features/panel/container.tsx
@@ -4,11 +4,16 @@ import type {
 	AgentModelSection,
 	AgentProvider,
 	PullRequestInfo,
+	RepoScripts,
 	ThreadMessageLike,
 	WorkspaceDetail,
 	WorkspaceSessionSummary,
 } from "@/lib/api";
-import { createSession, generateSessionTitle } from "@/lib/api";
+import {
+	createSession,
+	generateSessionTitle,
+	loadRepoScripts,
+} from "@/lib/api";
 import {
 	helmorQueryKeys,
 	sessionThreadMessagesQueryOptions,
@@ -17,6 +22,10 @@ import {
 } from "@/lib/query-client";
 import { useSettings } from "@/lib/settings";
 import { resolveSessionDisplayProvider } from "@/lib/workspace-helpers";
+import {
+	WORKSPACE_SCRIPT_PROMPTS,
+	type WorkspaceScriptType,
+} from "@/lib/workspace-script-actions";
 import { WorkspacePanel } from "./index";
 
 const EMPTY_MESSAGES: ThreadMessageLike[] = [];
@@ -35,6 +44,12 @@ type WorkspacePanelContainerProps = {
 	workspacePrInfo?: PullRequestInfo | null;
 	onSelectSession: (sessionId: string | null) => void;
 	onResolveDisplayedSession: (sessionId: string | null) => void;
+	onQueuePendingPromptForSession?: (request: {
+		sessionId: string;
+		prompt: string;
+		modelId?: string | null;
+		permissionMode?: string | null;
+	}) => void;
 	headerActions?: React.ReactNode;
 	headerLeading?: React.ReactNode;
 };
@@ -53,6 +68,7 @@ export const WorkspacePanelContainer = memo(function WorkspacePanelContainer({
 	workspacePrInfo = null,
 	onSelectSession,
 	onResolveDisplayedSession,
+	onQueuePendingPromptForSession,
 	headerActions,
 	headerLeading,
 }: WorkspacePanelContainerProps) {
@@ -253,6 +269,15 @@ export const WorkspacePanelContainer = memo(function WorkspacePanelContainer({
 	const messagesQuery = useQuery({
 		...sessionThreadMessagesQueryOptions(threadSessionId ?? "__none__"),
 		enabled: Boolean(threadSessionId),
+	});
+	const repoScriptsQuery = useQuery({
+		queryKey: helmorQueryKeys.repoScripts(
+			workspace?.repoId ?? "__none__",
+			displayedWorkspaceId,
+		),
+		queryFn: () => loadRepoScripts(workspace!.repoId, displayedWorkspaceId),
+		enabled: Boolean(workspace?.repoId && displayedWorkspaceId),
+		staleTime: 0,
 	});
 
 	const messages = messagesQuery.data ?? EMPTY_MESSAGES;
@@ -483,6 +508,44 @@ export const WorkspacePanelContainer = memo(function WorkspacePanelContainer({
 		void invalidateWorkspaceQueries();
 	}, [invalidateWorkspaceQueries]);
 	const selectedSessionIdForPanel = selectedSessionId ?? threadSessionId;
+	const selectedSession =
+		sessions.find((session) => session.id === selectedSessionIdForPanel) ??
+		null;
+	const missingScriptTypes = useMemo<WorkspaceScriptType[]>(() => {
+		if (!selectedSession) {
+			return [];
+		}
+
+		const scripts: RepoScripts | undefined = repoScriptsQuery.data;
+		if (!scripts) {
+			return [];
+		}
+
+		const missing: WorkspaceScriptType[] = [];
+		if (!scripts.setupScript?.trim()) {
+			missing.push("setup");
+		}
+		if (!scripts.runScript?.trim()) {
+			missing.push("run");
+		}
+		if (!scripts.archiveScript?.trim()) {
+			missing.push("archive");
+		}
+		return missing;
+	}, [repoScriptsQuery.data, selectedSession]);
+	const handleInitializeScript = useCallback(
+		(scriptType: WorkspaceScriptType) => {
+			if (!selectedSessionIdForPanel || !onQueuePendingPromptForSession) {
+				return;
+			}
+
+			onQueuePendingPromptForSession({
+				sessionId: selectedSessionIdForPanel,
+				prompt: WORKSPACE_SCRIPT_PROMPTS[scriptType],
+			});
+		},
+		[onQueuePendingPromptForSession, selectedSessionIdForPanel],
+	);
 
 	return (
 		<WorkspacePanel
@@ -506,6 +569,8 @@ export const WorkspacePanelContainer = memo(function WorkspacePanelContainer({
 			onWorkspaceChanged={handleWorkspaceChanged}
 			headerActions={headerActions}
 			headerLeading={headerLeading}
+			missingScriptTypes={missingScriptTypes}
+			onInitializeScript={handleInitializeScript}
 			prInfo={workspacePrInfo}
 		/>
 	);

--- a/src/features/panel/header.tsx
+++ b/src/features/panel/header.tsx
@@ -198,6 +198,9 @@ export const WorkspacePanelHeader = memo(function WorkspacePanelHeader({
 				createdAt: new Date().toISOString(),
 			});
 
+			void queryClient.invalidateQueries({
+				queryKey: helmorQueryKeys.repoScripts(workspace.repoId, workspace.id),
+			});
 			onSessionsChanged?.();
 			onSelectSession?.(result.sessionId);
 		} catch (error) {

--- a/src/features/panel/index.test.tsx
+++ b/src/features/panel/index.test.tsx
@@ -271,6 +271,77 @@ describe("WorkspacePanel", () => {
 		);
 	});
 
+	it("renders only the missing workspace script actions in the empty state", () => {
+		render(
+			<TooltipProvider delayDuration={0}>
+				<QueryClientProvider client={createHelmorQueryClient()}>
+					<WorkspacePanel
+						workspace={WORKSPACE}
+						sessions={SESSIONS}
+						selectedSessionId="session-1"
+						sessionPanes={[
+							{
+								sessionId: "session-1",
+								messages: [],
+								sending: false,
+								hasLoaded: true,
+								presentationState: "presented",
+							},
+						]}
+						missingScriptTypes={["setup", "archive"]}
+						onInitializeScript={vi.fn()}
+						sending={false}
+					/>
+				</QueryClientProvider>
+			</TooltipProvider>,
+		);
+
+		expect(
+			screen.getByRole("button", { name: /Create setup script/i }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: /Create archive script/i }),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: /Create run script/i }),
+		).toBeNull();
+	});
+
+	it("calls the initialize handler when a missing script action is clicked", async () => {
+		const user = userEvent.setup();
+		const onInitializeScript = vi.fn();
+
+		render(
+			<TooltipProvider delayDuration={0}>
+				<QueryClientProvider client={createHelmorQueryClient()}>
+					<WorkspacePanel
+						workspace={WORKSPACE}
+						sessions={SESSIONS}
+						selectedSessionId="session-1"
+						sessionPanes={[
+							{
+								sessionId: "session-1",
+								messages: [],
+								sending: false,
+								hasLoaded: true,
+								presentationState: "presented",
+							},
+						]}
+						missingScriptTypes={["run"]}
+						onInitializeScript={onInitializeScript}
+						sending={false}
+					/>
+				</QueryClientProvider>
+			</TooltipProvider>,
+		);
+
+		await user.click(
+			screen.getByRole("button", { name: /Create run script/i }),
+		);
+
+		expect(onInitializeScript).toHaveBeenCalledWith("run");
+	});
+
 	it("shows a yellow dot for sessions waiting on user interaction", () => {
 		const sessions = [
 			SESSIONS[0],

--- a/src/features/panel/index.tsx
+++ b/src/features/panel/index.tsx
@@ -7,6 +7,7 @@ import type {
 	WorkspaceSessionSummary,
 } from "@/lib/api";
 import { HelmorProfiler } from "@/lib/dev-react-profiler";
+import type { WorkspaceScriptType } from "@/lib/workspace-script-actions";
 import { WorkspacePanelHeader } from "./header";
 import { EmptyState, preloadStreamdown } from "./message-components";
 import {
@@ -44,6 +45,8 @@ type WorkspacePanelProps = {
 	onWorkspaceChanged?: () => void;
 	headerActions?: ReactNode;
 	headerLeading?: ReactNode;
+	missingScriptTypes?: WorkspaceScriptType[];
+	onInitializeScript?: (scriptType: WorkspaceScriptType) => void;
 };
 
 export const WorkspacePanel = memo(function WorkspacePanel({
@@ -69,6 +72,8 @@ export const WorkspacePanel = memo(function WorkspacePanel({
 	onWorkspaceChanged,
 	headerActions,
 	headerLeading,
+	missingScriptTypes = [],
+	onInitializeScript,
 }: WorkspacePanelProps) {
 	const selectedSession =
 		sessions.find((session) => session.id === selectedSessionId) ?? null;
@@ -131,12 +136,18 @@ export const WorkspacePanel = memo(function WorkspacePanel({
 						<ActiveThreadViewport
 							hasSession={!!selectedSession}
 							pane={activePane}
+							missingScriptTypes={missingScriptTypes}
+							onInitializeScript={onInitializeScript}
 						/>
 					) : loadingWorkspace || loadingSession ? (
 						<ConversationColdPlaceholder />
 					) : (
 						<div className="flex min-h-full flex-1 items-center justify-center px-8">
-							<EmptyState hasSession={!!selectedSession} />
+							<EmptyState
+								hasSession={!!selectedSession}
+								missingScriptTypes={missingScriptTypes}
+								onInitializeScript={onInitializeScript}
+							/>
 						</div>
 					)}
 				</div>

--- a/src/features/panel/message-components/empty-state.tsx
+++ b/src/features/panel/message-components/empty-state.tsx
@@ -1,17 +1,59 @@
-import { MessageSquareText } from "lucide-react";
+import {
+	Archive,
+	Hammer,
+	type LucideIcon,
+	MessageSquareText,
+	Play,
+} from "lucide-react";
 import {
 	Empty,
+	EmptyContent,
 	EmptyDescription,
 	EmptyHeader,
 	EmptyMedia,
 	EmptyTitle,
 } from "@/components/ui/empty";
+import type { WorkspaceScriptType } from "@/lib/workspace-script-actions";
 
-export function EmptyState({ hasSession }: { hasSession: boolean }) {
+const SCRIPT_ACTION_COPY: Record<
+	WorkspaceScriptType,
+	{ title: string; description: string; icon: LucideIcon }
+> = {
+	setup: {
+		title: "Create setup script",
+		description: "Bootstrap dependencies after a workspace is created.",
+		icon: Hammer,
+	},
+	run: {
+		title: "Create run script",
+		description: "Default command launched with Cmd+R.",
+		icon: Play,
+	},
+	archive: {
+		title: "Create archive script",
+		description: "Light cleanup or handoff before archiving.",
+		icon: Archive,
+	},
+};
+
+export function EmptyState({
+	hasSession,
+	missingScriptTypes = [],
+	onInitializeScript,
+}: {
+	hasSession: boolean;
+	missingScriptTypes?: WorkspaceScriptType[];
+	onInitializeScript?: (scriptType: WorkspaceScriptType) => void;
+}) {
+	const showScriptActions =
+		hasSession &&
+		missingScriptTypes.length > 0 &&
+		typeof onInitializeScript === "function";
+
 	return (
-		<Empty className="max-w-sm">
+		<Empty className="max-w-xl">
 			<EmptyHeader>
-				<EmptyMedia className="mb-1 text-app-foreground-soft/72 [&_svg:not([class*='size-'])]:size-7">
+				<EmptyMedia className="mb-1 text-muted-foreground [&_svg:not([class*='size-'])]:size-7">
 					<MessageSquareText strokeWidth={1.7} />
 				</EmptyMedia>
 				<EmptyTitle>
@@ -23,6 +65,40 @@ export function EmptyState({ hasSession }: { hasSession: boolean }) {
 						: "Choose a session from the header to inspect its timeline."}
 				</EmptyDescription>
 			</EmptyHeader>
+			{showScriptActions ? (
+				<EmptyContent className="mt-4 max-w-[22.25rem] items-stretch gap-2">
+					{missingScriptTypes.map((scriptType) => {
+						const item = SCRIPT_ACTION_COPY[scriptType];
+						const Icon = item.icon;
+
+						return (
+							<button
+								key={scriptType}
+								type="button"
+								onClick={() => onInitializeScript(scriptType)}
+								className="group flex w-full cursor-pointer items-center gap-2.5 rounded-lg border border-border/70 bg-background px-2.5 py-2 text-left transition-[background-color,border-color] hover:border-border hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
+							>
+								<span className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground/75 transition-colors group-hover:text-foreground">
+									<Icon className="size-5" strokeWidth={1.75} />
+								</span>
+								<span className="flex min-w-0 flex-1 flex-col">
+									<span className="block text-[12.5px] font-medium leading-[1.4] tracking-[-0.005em] text-foreground">
+										{item.title}
+									</span>
+									<span className="mt-0.5 block text-[11.5px] leading-[1.5] text-muted-foreground">
+										{item.description}
+									</span>
+								</span>
+							</button>
+						);
+					})}
+					<p className="mt-2 w-full text-center text-[11.5px] leading-[1.55] text-muted-foreground">
+						<span className="font-medium text-foreground/80">Tips:</span>{" "}
+						Configuring these scripts upgrades your dev loop — click any item
+						and let AI set it up for you.
+					</p>
+				</EmptyContent>
+			) : null}
 		</Empty>
 	);
 }

--- a/src/features/panel/session-close.ts
+++ b/src/features/panel/session-close.ts
@@ -50,6 +50,9 @@ export async function closeWorkspaceSession({
 				replacementSessionId,
 				now,
 			);
+			void queryClient.invalidateQueries({
+				queryKey: helmorQueryKeys.repoScripts(workspace.repoId, workspace.id),
+			});
 
 			queryClient.setQueryData(
 				helmorQueryKeys.workspaceDetail(workspace.id),

--- a/src/features/panel/thread-viewport.tsx
+++ b/src/features/panel/thread-viewport.tsx
@@ -20,6 +20,7 @@ import { estimateThreadRowHeights } from "@/lib/message-layout-estimator";
 import { measureSync } from "@/lib/perf-marks";
 import { hasUnresolvedPlanReview } from "@/lib/plan-review";
 import { useSettings } from "@/lib/settings";
+import type { WorkspaceScriptType } from "@/lib/workspace-script-actions";
 import { EmptyState, MemoConversationMessage } from "./message-components";
 
 export type PresentedSessionPane = {
@@ -46,9 +47,13 @@ const PROGRESSIVE_VIEWPORT_FOOTER_HEIGHT = 20;
 export function ActiveThreadViewport({
 	hasSession,
 	pane,
+	missingScriptTypes = [],
+	onInitializeScript,
 }: {
 	hasSession: boolean;
 	pane: PresentedSessionPane;
+	missingScriptTypes?: WorkspaceScriptType[];
+	onInitializeScript?: (scriptType: WorkspaceScriptType) => void;
 }) {
 	const stackRef = useRef<HTMLDivElement | null>(null);
 	const [widthBucket, setWidthBucket] = useState(0);
@@ -94,6 +99,8 @@ export function ActiveThreadViewport({
 					hasSession={hasSession}
 					layoutCacheKey={getSessionLayoutCacheKey(pane.sessionId, widthBucket)}
 					messages={pane.messages}
+					missingScriptTypes={missingScriptTypes}
+					onInitializeScript={onInitializeScript}
 					paneWidth={paneWidth}
 					sessionId={pane.sessionId}
 					sending={pane.sending}
@@ -107,6 +114,8 @@ function ChatThread({
 	layoutCacheKey,
 	messages,
 	hasSession,
+	missingScriptTypes,
+	onInitializeScript,
 	paneWidth,
 	sessionId,
 	sending,
@@ -114,6 +123,8 @@ function ChatThread({
 	layoutCacheKey: string;
 	messages: ThreadMessageLike[];
 	hasSession: boolean;
+	missingScriptTypes: WorkspaceScriptType[];
+	onInitializeScript?: (scriptType: WorkspaceScriptType) => void;
 	paneWidth: number;
 	sessionId: string;
 	sending: boolean;
@@ -210,6 +221,8 @@ function ChatThread({
 				hasSession={hasSession}
 				itemContent={itemContent}
 				layoutCacheKey={layoutCacheKey}
+				missingScriptTypes={missingScriptTypes}
+				onInitializeScript={onInitializeScript}
 				paneWidth={paneWidth}
 				pinTailRows={pinTailRows}
 				scrollRef={handleScrollRef}
@@ -244,6 +257,8 @@ function ConversationViewport({
 	hasSession,
 	itemContent,
 	layoutCacheKey,
+	missingScriptTypes,
+	onInitializeScript,
 	paneWidth,
 	pinTailRows,
 	scrollRef,
@@ -260,6 +275,8 @@ function ConversationViewport({
 	hasSession: boolean;
 	itemContent: (index: number, message: RenderedMessage) => ReactNode;
 	layoutCacheKey: string;
+	missingScriptTypes: WorkspaceScriptType[];
+	onInitializeScript?: (scriptType: WorkspaceScriptType) => void;
 	paneWidth: number;
 	pinTailRows: boolean;
 	scrollRef: React.RefCallback<HTMLElement>;
@@ -287,7 +304,11 @@ function ConversationViewport({
 			: ConversationFooterSpacer;
 	const EmptyPlaceholder: ThreadViewportSlot = () => (
 		<div className="flex min-h-full flex-1 items-center justify-center px-8">
-			<EmptyState hasSession={hasSession} />
+			<EmptyState
+				hasSession={hasSession}
+				missingScriptTypes={missingScriptTypes}
+				onInitializeScript={onInitializeScript}
+			/>
 		</div>
 	);
 

--- a/src/lib/query-client.ts
+++ b/src/lib/query-client.ts
@@ -50,6 +50,8 @@ export const helmorQueryKeys = {
 		["workspaceGitActionStatus", workspaceId] as const,
 	workspacePrActionStatus: (workspaceId: string) =>
 		["workspacePrActionStatus", workspaceId] as const,
+	repoScripts: (repoId: string, workspaceId: string | null) =>
+		["repoScripts", repoId, workspaceId ?? ""] as const,
 	autoCloseActionKinds: ["autoCloseActionKinds"] as const,
 	autoCloseOptInAsked: ["autoCloseOptInAsked"] as const,
 	slashCommands: (

--- a/src/lib/workspace-script-actions.ts
+++ b/src/lib/workspace-script-actions.ts
@@ -1,0 +1,143 @@
+export type WorkspaceScriptType = "setup" | "run" | "archive";
+
+export const WORKSPACE_SCRIPT_PROMPTS: Record<WorkspaceScriptType, string> = {
+	setup: `Please help me initialize the Helmor setup script for this workspace and write the final result into the current workspace's helmor.json.
+
+Context:
+- This setup script runs automatically right after a new workspace is created.
+- Its job is to prepare this worktree so I can start working.
+- It should be used for dependency install, bootstrap, codegen, hooks setup, or filling in local config that the new worktree is missing.
+- It should not start a dev server, enter watch mode, or become a long-running process.
+
+Rules:
+1. Inspect the repository first before asking questions.
+2. Your goal is to actually create or update scripts.setup in helmor.json, not just give advice.
+3. This is a worktree-based workspace. Use the environment variables correctly:
+   - HELMOR_ROOT_PATH: the original repository root, not this workspace worktree path.
+   - HELMOR_WORKSPACE_PATH: the current workspace's worktree path, and the directory where the script runs.
+   - HELMOR_WORKSPACE_NAME: the current workspace name.
+   - HELMOR_DEFAULT_BRANCH: the repository default branch.
+4. If helmor.json does not exist but conductor.json exists, first copy conductor.json to helmor.json, then continue working only on helmor.json.
+5. If the migrated helmor.json already contains scripts.setup, stop and tell me the migration is complete.
+6. Keep setup minimal and idempotent.
+7. Do not hardcode absolute local paths.
+8. Ask at most 3 rounds of questions, and only when they materially change the script design.
+
+What to inspect:
+- helmor.json, conductor.json
+- README and developer docs
+- package.json, lockfiles, workspace config, Cargo.toml, pyproject.toml, go.mod, Gemfile
+- Makefile, justfile
+- .env*, .env.example, .env.local*
+- .gitignore
+- git status --short --ignored
+
+Pay special attention to ignored or untracked local files that a fresh worktree may be missing. If some of them are likely required, identify them clearly before deciding whether setup should copy them from HELMOR_ROOT_PATH into HELMOR_WORKSPACE_PATH.
+
+Your flow:
+1. Inspect silently first.
+2. Tell me:
+   - where you plan to write the setup script
+   - what command(s) you plan to use
+   - why
+   - which local files look like likely migration candidates
+3. Only ask concise blocking questions if needed.
+4. Then create or update helmor.json.
+5. End with a short summary:
+   - which file you changed
+   - the final scripts.setup
+   - any local files that still need confirmation
+   - your key assumptions`,
+	run: `Please help me initialize the Helmor run script for this workspace and write the final result into the current workspace's helmor.json.
+
+Context:
+- This run script executes when I press Cmd+R.
+- Its job is to give this workspace a practical default command for daily work.
+- There may not be a single obvious answer, so you should inspect first and then let me choose from the best candidates.
+
+Rules:
+1. Inspect the repository first before asking questions.
+2. Your goal is to actually create or update scripts.run in helmor.json, not just give advice.
+3. This is a worktree-based workspace. Use the environment variables correctly:
+   - HELMOR_ROOT_PATH: the original repository root.
+   - HELMOR_WORKSPACE_PATH: the current workspace's worktree path, and the directory where the script runs.
+   - HELMOR_WORKSPACE_NAME: the current workspace name.
+   - HELMOR_DEFAULT_BRANCH: the repository default branch.
+4. If helmor.json does not exist but conductor.json exists, first copy conductor.json to helmor.json, then continue working only on helmor.json.
+5. If the migrated helmor.json already contains scripts.run, stop and tell me the migration is complete.
+6. Do not overfit this run script to the current task, a single test file, or a one-off command.
+7. Do not quietly choose a heavy, destructive, or highly opinionated command when multiple reasonable defaults exist.
+8. Ask at most 3 rounds of questions, and only when they materially change the choice.
+
+What to inspect:
+- helmor.json, conductor.json
+- README and developer docs
+- package.json, workspace config, Cargo.toml
+- Makefile, justfile
+- docker-compose files
+- existing dev / start / test / serve / worker commands
+
+Your flow:
+1. Inspect silently first.
+2. Find the best 2 to 5 run candidates.
+3. Show me the candidates in a concise list. For each one, explain:
+   - what it likely does
+   - who or what workflow it suits
+   - why it could be a good Cmd+R default
+4. Give me your recommended default.
+5. Ask me to choose, ideally so I can answer with A / B / C.
+6. After I choose, create or update helmor.json.
+7. End with a short summary:
+   - which file you changed
+   - the final scripts.run
+   - why it fits Cmd+R
+   - how I can switch to another candidate later`,
+	archive: `Please help me initialize the Helmor archive script for this workspace and write the final result into the current workspace's helmor.json.
+
+Context:
+- This archive script runs when this workspace is archived.
+- Its job is to do light, safe, clearly-scoped cleanup or save a small amount of context before archive.
+- It should not perform dangerous deletion or take over workspace lifecycle management.
+
+Rules:
+1. Inspect the repository and workspace context first before asking questions.
+2. Your goal is to actually create or update scripts.archive in helmor.json, not just give advice.
+3. This is a worktree-based workspace. Use the environment variables correctly:
+   - HELMOR_ROOT_PATH: the original repository root.
+   - HELMOR_WORKSPACE_PATH: the current workspace's worktree path, and the directory where the script runs.
+   - HELMOR_WORKSPACE_NAME: the current workspace name.
+   - HELMOR_DEFAULT_BRANCH: the repository default branch.
+4. If helmor.json does not exist but conductor.json exists, first copy conductor.json to helmor.json, then continue working only on helmor.json.
+5. If the migrated helmor.json already contains scripts.archive, stop and tell me the migration is complete.
+6. Default to conservative behavior.
+7. Ask at most 3 rounds of questions, and only when they materially change the script design.
+8. Without my explicit confirmation, do not write any destructive action such as deleting databases, volumes, caches, build outputs, secrets, logs, screenshots, files outside the workspace, remote resources, or broad rm -rf / git clean behavior.
+
+What to inspect:
+- helmor.json, conductor.json
+- README and developer docs
+- package.json, Cargo.toml
+- Makefile, justfile
+- docker-compose files
+- .env*
+- .gitignore
+- anything suggesting local services, containers, exports, or archive context
+
+Your flow:
+1. Inspect silently first.
+2. Tell me:
+   - where you plan to write the archive script
+   - which candidate archive actions you found
+   - which ones are safe by default
+   - which ones need confirmation
+   - which ones are too risky to write by default
+3. Only ask concise blocking questions if needed.
+4. Then create or update helmor.json.
+5. End with a short summary:
+   - which file you changed
+   - the final scripts.archive
+   - which higher-risk actions you intentionally left out
+   - your key assumptions
+
+If this project does not appear to need an automated archive script, say so clearly and choose the smallest safe result instead of inventing risky behavior.`,
+};


### PR DESCRIPTION
## What changed
- add shared workspace script prompt templates for setup, run, and archive initialization flows
- load repo script configuration in the panel container and detect which script slots are still missing for the selected session
- surface contextual empty-state actions that let users trigger AI setup for only the missing scripts, and thread those handlers through the conversation/panel stack
- invalidate repo script queries when new sessions are created or sessions are auto-closed so the empty-state actions stay in sync
- add panel/container tests covering the missing-script rendering and action dispatch behavior

## Why
Users with a fresh workspace session had no direct way to initialize the workspace scripts Helmor expects. This change exposes the missing script setup paths directly in the empty state so the first-run workflow is discoverable and can be completed in place.

## Follow-up / test notes
- automated tests were not run manually for this PR
- commit hooks ran Biome formatting/checks on the staged frontend files during commit