### PR TITLE
fix: sync archive updates with git watchers

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,7 +36,7 @@ reqwest = { version = "0.12", default-features = false, features = ["blocking", 
 rusqlite = { version = "0.31", features = ["bundled", "backup"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tauri = { version = "2", features = ["protocol-asset"] }
+tauri = { version = "2", features = ["protocol-asset", "test"] }
 tauri-plugin-deep-link = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-mcp-bridge = "0.11.0"

--- a/src-tauri/src/commands/tests/archive_restore.rs
+++ b/src-tauri/src/commands/tests/archive_restore.rs
@@ -1,4 +1,10 @@
 use super::support::*;
+use std::thread;
+use std::time::{Duration, Instant};
+use tauri::{
+    test::{mock_builder, mock_context, noop_assets},
+    Manager,
+};
 
 #[test]
 fn restore_workspace_recreates_worktree_and_context() {
@@ -302,6 +308,58 @@ fn archive_workspace_cleans_up_when_db_update_fails() {
         )
         .unwrap();
     assert_eq!(state, "ready");
+}
+
+#[test]
+fn start_archive_workspace_syncs_git_fetchers_after_success() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let harness = ArchiveTestHarness::new(true);
+    let connection = Connection::open(crate::data_dir::db_path().unwrap()).unwrap();
+    connection
+        .execute("UPDATE repos SET remote = 'origin' WHERE id = 'repo-1'", [])
+        .unwrap();
+    drop(connection);
+
+    let app = mock_builder()
+        .manage(workspaces::ArchiveJobManager::new())
+        .manage(crate::git_watcher::GitWatcherManager::new())
+        .build(mock_context(noop_assets()))
+        .unwrap();
+    let app_handle = app.handle().clone();
+    let watcher_manager = app_handle.state::<crate::git_watcher::GitWatcherManager>();
+
+    watcher_manager.sync_from_db(app_handle.clone()).unwrap();
+    assert_eq!(watcher_manager.fetcher_count(), 1);
+
+    let archive_manager = app_handle.state::<workspaces::ArchiveJobManager>();
+    archive_manager.prepare(&harness.workspace_id).unwrap();
+    workspaces::start_archive_workspace(&app_handle, &harness.workspace_id).unwrap();
+
+    let deadline = Instant::now() + Duration::from_secs(3);
+    loop {
+        let connection = Connection::open(crate::data_dir::db_path().unwrap()).unwrap();
+        let state: String = connection
+            .query_row(
+                "SELECT state FROM workspaces WHERE id = ?1",
+                [&harness.workspace_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        drop(connection);
+
+        if state == "archived" && watcher_manager.fetcher_count() == 0 {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "Timed out waiting for archive success to sync git fetchers",
+        );
+        thread::sleep(Duration::from_millis(20));
+    }
+
+    watcher_manager.shutdown();
 }
 
 #[test]

--- a/src-tauri/src/git/watcher.rs
+++ b/src-tauri/src/git/watcher.rs
@@ -14,7 +14,7 @@ use anyhow::{bail, Context, Result};
 use notify::RecursiveMode;
 use notify_debouncer_full::{new_debouncer, Debouncer, RecommendedCache};
 use serde::Serialize;
-use tauri::{AppHandle, Emitter, Manager};
+use tauri::{AppHandle, Emitter, Manager, Runtime};
 
 use crate::{git_ops, models::db};
 
@@ -103,7 +103,7 @@ impl GitWatcherManager {
     }
 
     /// Sync watchers and auto-fetchers with the current DB state.
-    pub fn sync_from_db(&self, app: AppHandle) -> Result<()> {
+    pub fn sync_from_db<R: Runtime>(&self, app: AppHandle<R>) -> Result<()> {
         let workspaces = load_watchable_workspaces()?;
         let ready: Vec<&WatchableWorkspace> =
             workspaces.iter().filter(|w| w.state == "ready").collect();
@@ -238,6 +238,14 @@ impl GitWatcherManager {
             }
         }
     }
+
+    #[cfg(test)]
+    pub(crate) fn fetcher_count(&self) -> usize {
+        self.fetchers
+            .lock()
+            .map(|fetchers| fetchers.len())
+            .unwrap_or(0)
+    }
 }
 
 // -- Gitdir resolution --
@@ -297,7 +305,10 @@ fn read_head_branch(gitdir: &Path) -> Option<String> {
 
 // -- Watcher setup --
 
-fn start_watcher(app: &AppHandle, ws: &WatchableWorkspace) -> Result<WorkspaceWatcher> {
+fn start_watcher<R: Runtime>(
+    app: &AppHandle<R>,
+    ws: &WatchableWorkspace,
+) -> Result<WorkspaceWatcher> {
     let workspace_dir = crate::data_dir::workspace_dir(&ws.repo_name, &ws.directory_name)?;
     if !workspace_dir.is_dir() {
         bail!("Workspace directory missing: {}", workspace_dir.display());
@@ -569,7 +580,7 @@ fn sleep_interruptible(cancel: &AtomicBool, duration: Duration) -> bool {
 
 /// Detect branch name change from HEAD, update DB if needed, emit event.
 fn handle_head_change(
-    app: &AppHandle,
+    app: &AppHandle<impl Runtime>,
     workspace_id: &str,
     gitdir: &Path,
     last_branch: &Mutex<Option<String>>,
@@ -666,7 +677,7 @@ fn load_watchable_workspaces() -> Result<Vec<WatchableWorkspace>> {
 }
 
 /// Called from workspace lifecycle commands to keep watchers in sync.
-pub fn notify_workspace_changed(app: &AppHandle) {
+pub fn notify_workspace_changed<R: Runtime>(app: &AppHandle<R>) {
     let manager = app.state::<GitWatcherManager>();
     if let Err(e) = manager.sync_from_db(app.clone()) {
         tracing::warn!("Failed to sync git watchers after workspace change: {e:#}");

--- a/src-tauri/src/workspace/archive.rs
+++ b/src-tauri/src/workspace/archive.rs
@@ -3,7 +3,7 @@ use std::sync::Mutex;
 
 use anyhow::{bail, Context, Result};
 use serde::Serialize;
-use tauri::{AppHandle, Emitter, Manager};
+use tauri::{AppHandle, Emitter, Manager, Runtime};
 
 use crate::git_watcher;
 
@@ -97,7 +97,7 @@ impl ArchiveJobManager {
     }
 }
 
-pub fn start_archive_workspace(app: &AppHandle, workspace_id: &str) -> Result<()> {
+pub fn start_archive_workspace<R: Runtime>(app: &AppHandle<R>, workspace_id: &str) -> Result<()> {
     let manager = app.state::<ArchiveJobManager>();
     let plan = manager.start_prepared(workspace_id)?;
     let app_handle = app.clone();
@@ -113,6 +113,7 @@ pub fn start_archive_workspace(app: &AppHandle, workspace_id: &str) -> Result<()
 
         match result {
             Ok(Ok(_)) => {
+                git_watcher::notify_workspace_changed(&app_handle);
                 let _ = app_handle.emit(
                     ARCHIVE_EXECUTION_SUCCEEDED_EVENT,
                     ArchiveExecutionSucceededPayload {

--- a/src/features/navigation/hooks/use-controller.test.tsx
+++ b/src/features/navigation/hooks/use-controller.test.tsx
@@ -429,11 +429,19 @@ describe("useWorkspacesSidebarController archive flow", () => {
 			defaultOptions: { queries: { retry: false } },
 		});
 		let resolveStart: (() => void) | null = null;
+		let archivedFromServer: WorkspaceSummary[] = [];
+		let groupsFromServer = workspaceGroups;
 		apiMocks.startArchiveWorkspace.mockImplementation(
 			() =>
 				new Promise<void>((resolve) => {
 					resolveStart = resolve;
 				}),
+		);
+		apiMocks.loadWorkspaceGroups.mockImplementation(
+			async () => groupsFromServer,
+		);
+		apiMocks.loadArchivedWorkspaces.mockImplementation(
+			async () => archivedFromServer,
 		);
 
 		const { result } = renderHook(
@@ -461,15 +469,11 @@ describe("useWorkspacesSidebarController archive flow", () => {
 		});
 
 		act(() => {
+			groupsFromServer = [
+				{ ...workspaceGroups[0], rows: [workspaceGroups[0].rows[1]] },
+			];
+			archivedFromServer = [makeArchivedSummary("ws-1")];
 			apiMocks.emitArchiveSucceeded({ workspaceId: "ws-1" });
-			queryClient.setQueryData(
-				["workspaceGroups"],
-				[{ ...workspaceGroups[0], rows: [workspaceGroups[0].rows[1]] }],
-			);
-			queryClient.setQueryData(
-				["archivedWorkspaces"],
-				[makeArchivedSummary("ws-1")],
-			);
 		});
 
 		await waitFor(() => {
@@ -478,6 +482,8 @@ describe("useWorkspacesSidebarController archive flow", () => {
 			]);
 		});
 		expect(result.current.archivedRows.map((row) => row.id)).toEqual(["ws-1"]);
+		expect(apiMocks.loadWorkspaceGroups).toHaveBeenCalledTimes(2);
+		expect(apiMocks.loadArchivedWorkspaces).toHaveBeenCalledTimes(2);
 
 		act(() => {
 			resolveStart?.();

--- a/src/features/navigation/hooks/use-controller.ts
+++ b/src/features/navigation/hooks/use-controller.ts
@@ -266,6 +266,12 @@ export function useWorkspacesSidebarController({
 				return;
 			}
 			archiveRollbackRef.current.delete(payload.workspaceId);
+			void queryClient.invalidateQueries({
+				queryKey: helmorQueryKeys.workspaceGroups,
+			});
+			void queryClient.invalidateQueries({
+				queryKey: helmorQueryKeys.archivedWorkspaces,
+			});
 		}).then((cleanup) => {
 			if (disposed) {
 				cleanup();
@@ -279,7 +285,7 @@ export function useWorkspacesSidebarController({
 			unlistenFailure?.();
 			unlistenSuccess?.();
 		};
-	}, [rollbackArchivedWorkspace]);
+	}, [queryClient, rollbackArchivedWorkspace]);
 
 	useEffect(() => {
 		if (


### PR DESCRIPTION
## What changed
- notify the Rust git watcher manager after archive execution succeeds so watcher and auto-fetcher state matches the archived workspace state
- make the watcher/archive APIs generic over Tauri runtimes and add a test-only fetcher count helper for coverage
- invalidate sidebar workspace and archived-workspace queries after archive success instead of relying on optimistic cache mutation alone
- add backend and frontend tests covering watcher sync and archive success refresh behavior
- enable the Tauri `test` feature needed by the new Rust test harness usage

## Why
Archiving a workspace could leave git watcher state and sidebar data out of sync after a successful archive. This change makes the archive success path refresh both backend watcher state and frontend query state so the UI reflects the archived workspace reliably.

## Test notes
- pre-commit hook ran `biome check --write --error-on-warnings --no-errors-on-unmatched --files-ignore-unknown=true --config-path=./biome.json`
- pre-commit hook ran `cargo fmt --manifest-path src-tauri/Cargo.toml --all`
- pre-commit hook ran `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
- no additional test suites were run manually in this session
