### PR TITLE
feat: add direct workspace push action

### DIFF
--- a/src-tauri/src/commands/tests/branch_switch.rs
+++ b/src-tauri/src/commands/tests/branch_switch.rs
@@ -351,3 +351,121 @@ fn sync_workspace_target_branch_reports_conflict() {
         "merge conflict should remain visible"
     );
 }
+
+#[test]
+fn push_workspace_to_remote_publishes_unpublished_branch() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let harness = BranchSwitchTestHarness::new();
+
+    let result = workspaces::push_workspace_to_remote(&harness.workspace_id).unwrap();
+
+    assert_eq!(result.target_ref, "origin/test/switch-branch");
+    assert_eq!(result.head_commit, harness.workspace_head());
+    assert!(
+        git_ops::verify_remote_ref_exists(&harness.workspace_dir(), "origin", "test/switch-branch")
+            .unwrap(),
+        "push should create the same-name remote branch"
+    );
+    let status =
+        git_ops::workspace_action_status(&harness.workspace_dir(), Some("origin"), Some("main"))
+            .unwrap();
+    assert_eq!(
+        status.remote_tracking_ref.as_deref(),
+        Some("origin/test/switch-branch")
+    );
+    assert_eq!(status.push_status, git_ops::WorkspacePushStatus::Published);
+}
+
+#[test]
+fn push_workspace_to_remote_updates_existing_remote_branch() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let harness = BranchSwitchTestHarness::new();
+    workspaces::push_workspace_to_remote(&harness.workspace_id).unwrap();
+    harness.commit_in_workspace("push.txt", "second push", "second push");
+
+    let result = workspaces::push_workspace_to_remote(&harness.workspace_id).unwrap();
+
+    assert_eq!(result.target_ref, "origin/test/switch-branch");
+    assert_eq!(result.head_commit, harness.workspace_head());
+    assert_eq!(
+        git_ops::remote_ref_sha(&harness.workspace_dir(), "origin", "test/switch-branch").unwrap(),
+        harness.workspace_head()
+    );
+}
+
+#[test]
+fn push_workspace_to_remote_allows_uncommitted_changes() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let harness = BranchSwitchTestHarness::new();
+    workspaces::push_workspace_to_remote(&harness.workspace_id).unwrap();
+    harness.commit_in_workspace("push.txt", "second push", "second push");
+    harness.dirty_tracked_file();
+
+    let result = workspaces::push_workspace_to_remote(&harness.workspace_id).unwrap();
+
+    assert_eq!(result.target_ref, "origin/test/switch-branch");
+    assert_eq!(result.head_commit, harness.workspace_head());
+    assert_eq!(
+        git_ops::remote_ref_sha(&harness.workspace_dir(), "origin", "test/switch-branch").unwrap(),
+        harness.workspace_head()
+    );
+    let readme = fs::read_to_string(harness.workspace_dir().join("README.md")).unwrap();
+    assert_eq!(readme, "user edits");
+}
+
+#[test]
+fn push_workspace_to_remote_preserves_existing_different_upstream() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let harness = BranchSwitchTestHarness::new();
+    git_ops::run_git(
+        [
+            "-C",
+            harness.workspace_dir().to_str().unwrap(),
+            "push",
+            "--set-upstream",
+            "origin",
+            "HEAD:refs/heads/test/custom-remote-branch",
+        ],
+        None,
+    )
+    .unwrap();
+    harness.commit_in_workspace("push.txt", "second push", "second push");
+
+    let result = workspaces::push_workspace_to_remote(&harness.workspace_id).unwrap();
+
+    assert_eq!(result.target_ref, "origin/test/custom-remote-branch");
+    assert_eq!(result.head_commit, harness.workspace_head());
+    let status =
+        git_ops::workspace_action_status(&harness.workspace_dir(), Some("origin"), Some("main"))
+            .unwrap();
+    assert_eq!(
+        status.remote_tracking_ref.as_deref(),
+        Some("origin/test/custom-remote-branch")
+    );
+    assert_eq!(
+        git_ops::remote_ref_sha(
+            &harness.workspace_dir(),
+            "origin",
+            "test/custom-remote-branch"
+        )
+        .unwrap(),
+        harness.workspace_head()
+    );
+    assert!(
+        !git_ops::verify_remote_ref_exists(
+            &harness.workspace_dir(),
+            "origin",
+            "test/switch-branch"
+        )
+        .unwrap(),
+        "push should keep using the configured upstream instead of creating a same-name branch"
+    );
+}

--- a/src-tauri/src/commands/workspace_commands.rs
+++ b/src-tauri/src/commands/workspace_commands.rs
@@ -154,6 +154,15 @@ pub async fn sync_workspace_with_target_branch(
 }
 
 #[tauri::command]
+pub async fn push_workspace_to_remote(
+    workspace_id: String,
+) -> CmdResult<workspaces::PushWorkspaceToRemoteResponse> {
+    let ws_lock = db::workspace_mutation_lock(&workspace_id);
+    let _lock = ws_lock.lock().await;
+    run_blocking(move || workspaces::push_workspace_to_remote(&workspace_id)).await
+}
+
+#[tauri::command]
 pub async fn restore_workspace(
     app: AppHandle,
     workspace_id: String,

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -20,6 +20,13 @@ pub struct WorkspaceGitActionStatus {
     pub behind_target_count: u32,
     pub remote_tracking_ref: Option<String>,
     pub ahead_of_remote_count: u32,
+    pub push_status: WorkspacePushStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PushBranchResult {
+    pub branch: String,
+    pub target_ref: String,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
@@ -27,6 +34,14 @@ pub struct WorkspaceGitActionStatus {
 pub enum WorkspaceSyncStatus {
     UpToDate,
     Behind,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum WorkspacePushStatus {
+    Published,
+    Unpublished,
     Unknown,
 }
 
@@ -552,6 +567,37 @@ pub fn current_workspace_head_commit(workspace_dir: &Path) -> Result<String> {
     Ok(commit)
 }
 
+pub fn current_branch_name(workspace_dir: &Path) -> Result<String> {
+    let workspace_dir = workspace_dir.display().to_string();
+    let branch = run_git(
+        ["-C", workspace_dir.as_str(), "branch", "--show-current"],
+        None,
+    )
+    .with_context(|| format!("Failed to resolve current branch for {}", workspace_dir))?;
+
+    let branch = branch.trim();
+    if branch.is_empty() {
+        bail!("Workspace {} is not on a branch", workspace_dir);
+    }
+
+    Ok(branch.to_string())
+}
+
+pub fn current_upstream_ref_name(workspace_dir: &Path) -> Option<String> {
+    current_upstream_ref(workspace_dir)
+}
+
+fn upstream_push_ref(upstream_ref: &str) -> Option<String> {
+    let branch = if let Some(branch) = upstream_ref.strip_prefix("refs/remotes/") {
+        let (_, branch) = branch.split_once('/')?;
+        branch
+    } else {
+        let (_, branch) = upstream_ref.split_once('/')?;
+        branch
+    };
+    Some(format!("HEAD:refs/heads/{branch}"))
+}
+
 pub fn default_branch_ref(remote: &str, default_branch: &str) -> String {
     format!("refs/remotes/{remote}/{default_branch}")
 }
@@ -629,11 +675,12 @@ pub fn workspace_action_status(
         .map(ToOwned::to_owned);
     let (sync_status, behind_target_count) =
         workspace_sync_status(workspace_dir, remote, sync_target_branch.as_deref());
-    let remote_tracking_ref = current_upstream_ref(workspace_dir);
+    let remote_tracking_ref = resolve_remote_tracking_ref(workspace_dir, remote);
     let ahead_of_remote_count = remote_tracking_ref
         .as_deref()
         .and_then(|upstream| commits_ahead_of(workspace_dir, upstream).ok())
         .unwrap_or(0);
+    let push_status = resolve_push_status(workspace_dir, remote, remote_tracking_ref.as_deref());
 
     Ok(WorkspaceGitActionStatus {
         uncommitted_count,
@@ -643,6 +690,7 @@ pub fn workspace_action_status(
         behind_target_count,
         remote_tracking_ref,
         ahead_of_remote_count,
+        push_status,
     })
 }
 
@@ -690,6 +738,84 @@ fn current_upstream_ref(workspace_dir: &Path) -> Option<String> {
     .ok()
     .map(|value| value.trim().to_string())
     .filter(|value| !value.is_empty())
+}
+
+fn resolve_remote_tracking_ref(workspace_dir: &Path, remote: Option<&str>) -> Option<String> {
+    if let Some(upstream) = current_upstream_ref(workspace_dir) {
+        return Some(upstream);
+    }
+
+    let remote = remote.map(str::trim).filter(|value| !value.is_empty())?;
+    let branch = current_branch_name(workspace_dir).ok()?;
+    verify_remote_ref_exists(workspace_dir, remote, &branch)
+        .ok()
+        .filter(|exists| *exists)
+        .map(|_| format!("{remote}/{branch}"))
+}
+
+fn resolve_push_status(
+    workspace_dir: &Path,
+    remote: Option<&str>,
+    remote_tracking_ref: Option<&str>,
+) -> WorkspacePushStatus {
+    if remote_tracking_ref.is_some() {
+        return WorkspacePushStatus::Published;
+    }
+
+    let Some(_remote) = remote.map(str::trim).filter(|value| !value.is_empty()) else {
+        return WorkspacePushStatus::Unknown;
+    };
+    if current_branch_name(workspace_dir).is_err() {
+        return WorkspacePushStatus::Unknown;
+    }
+
+    WorkspacePushStatus::Unpublished
+}
+
+pub fn push_current_branch(workspace_dir: &Path, remote: &str) -> Result<PushBranchResult> {
+    let branch = current_branch_name(workspace_dir)?;
+    let workspace_dir = workspace_dir.display().to_string();
+    let upstream = current_upstream_ref(Path::new(&workspace_dir));
+
+    if let Some(target_ref) = upstream {
+        let push_ref = upstream_push_ref(&target_ref)
+            .with_context(|| format!("Unsupported upstream ref for push: {target_ref}"))?;
+        return run_git_with_timeout(
+            [
+                "-C",
+                workspace_dir.as_str(),
+                "push",
+                remote,
+                push_ref.as_str(),
+            ],
+            None,
+            GIT_NETWORK_TIMEOUT,
+        )
+        .map(|_| PushBranchResult {
+            branch: branch.clone(),
+            target_ref,
+        })
+        .with_context(|| format!("Failed to push branch {branch} to its upstream"));
+    }
+
+    let push_ref = format!("HEAD:refs/heads/{branch}");
+    run_git_with_timeout(
+        [
+            "-C",
+            workspace_dir.as_str(),
+            "push",
+            "--set-upstream",
+            remote,
+            push_ref.as_str(),
+        ],
+        None,
+        GIT_NETWORK_TIMEOUT,
+    )
+    .map(|_| PushBranchResult {
+        branch: branch.clone(),
+        target_ref: format!("{remote}/{branch}"),
+    })
+    .with_context(|| format!("Failed to push branch {branch} to {remote}"))
 }
 
 /// Counts how many commits are reachable from HEAD but not from `base_ref`.
@@ -909,6 +1035,7 @@ mod tests {
         assert_eq!(status.behind_target_count, 0);
         assert_eq!(status.remote_tracking_ref, None);
         assert_eq!(status.ahead_of_remote_count, 0);
+        assert_eq!(status.push_status, WorkspacePushStatus::Unknown);
     }
 
     #[test]
@@ -959,6 +1086,7 @@ mod tests {
         assert_eq!(status.behind_target_count, 1);
         assert_eq!(status.remote_tracking_ref.as_deref(), Some("origin/main"));
         assert_eq!(status.ahead_of_remote_count, 0);
+        assert_eq!(status.push_status, WorkspacePushStatus::Published);
     }
 
     #[test]
@@ -972,6 +1100,7 @@ mod tests {
         assert_eq!(status.behind_target_count, 0);
         assert_eq!(status.remote_tracking_ref.as_deref(), Some("origin/main"));
         assert_eq!(status.ahead_of_remote_count, 0);
+        assert_eq!(status.push_status, WorkspacePushStatus::Published);
     }
 
     #[test]
@@ -985,6 +1114,64 @@ mod tests {
 
         assert_eq!(status.remote_tracking_ref.as_deref(), Some("origin/main"));
         assert_eq!(status.ahead_of_remote_count, 1);
+        assert_eq!(status.push_status, WorkspacePushStatus::Published);
+    }
+
+    #[test]
+    fn workspace_action_status_reports_unpublished_branch_without_upstream() {
+        let (_origin, clone) = init_repo_with_remote();
+        run(clone.path(), &["checkout", "-b", "feature/unpublished"]);
+
+        let status = workspace_action_status(clone.path(), Some("origin"), Some("main")).unwrap();
+
+        assert_eq!(status.remote_tracking_ref, None);
+        assert_eq!(status.ahead_of_remote_count, 0);
+        assert_eq!(status.push_status, WorkspacePushStatus::Unpublished);
+    }
+
+    #[test]
+    fn push_current_branch_sets_upstream_when_missing() {
+        let (_origin, clone) = init_repo_with_remote();
+        run(clone.path(), &["checkout", "-b", "feature/push-same-name"]);
+
+        let result = push_current_branch(clone.path(), "origin").unwrap();
+
+        assert_eq!(result.branch, "feature/push-same-name");
+        assert_eq!(result.target_ref, "origin/feature/push-same-name");
+        assert!(has_upstream(clone.path(), "feature/push-same-name"));
+        assert!(verify_remote_ref_exists(clone.path(), "origin", &result.branch).unwrap());
+    }
+
+    #[test]
+    fn push_current_branch_preserves_existing_differently_named_upstream() {
+        let (_origin, clone) = init_repo_with_remote();
+        run(clone.path(), &["checkout", "-b", "feature/local-name"]);
+        run(
+            clone.path(),
+            &[
+                "push",
+                "--set-upstream",
+                "origin",
+                "HEAD:refs/heads/feature/remote-name",
+            ],
+        );
+        std::fs::write(clone.path().join("follow-up.txt"), "next\n").unwrap();
+        run(clone.path(), &["add", "follow-up.txt"]);
+        run(clone.path(), &["commit", "-m", "follow up"]);
+
+        let result = push_current_branch(clone.path(), "origin").unwrap();
+
+        assert_eq!(result.branch, "feature/local-name");
+        assert_eq!(result.target_ref, "origin/feature/remote-name");
+        assert_eq!(
+            current_upstream_ref(clone.path()).as_deref(),
+            Some("origin/feature/remote-name")
+        );
+        assert_eq!(
+            remote_ref_sha(clone.path(), "origin", "feature/remote-name").unwrap(),
+            current_workspace_head_commit(clone.path()).unwrap()
+        );
+        assert!(!verify_remote_ref_exists(clone.path(), "origin", "feature/local-name").unwrap());
     }
 
     /// Clone a repo so we have a real `origin` remote with tracking refs.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -245,6 +245,7 @@ pub fn run() {
             commands::workspace_commands::rename_workspace_branch,
             commands::workspace_commands::update_intended_target_branch,
             commands::workspace_commands::prefetch_remote_refs,
+            commands::workspace_commands::push_workspace_to_remote,
             commands::workspace_commands::sync_workspace_with_target_branch,
             commands::workspace_commands::mark_workspace_read,
             commands::workspace_commands::mark_workspace_unread,

--- a/src-tauri/src/workspace/branching.rs
+++ b/src-tauri/src/workspace/branching.rs
@@ -325,6 +325,13 @@ pub struct SyncWorkspaceTargetResponse {
     pub target_branch: String,
 }
 
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PushWorkspaceToRemoteResponse {
+    pub target_ref: String,
+    pub head_commit: String,
+}
+
 pub fn prefetch_remote_refs(
     workspace_id: Option<&str>,
     repo_id: Option<&str>,
@@ -439,6 +446,43 @@ pub fn sync_workspace_with_target_branch(
             }
         }
     }
+}
+
+pub fn push_workspace_to_remote(workspace_id: &str) -> Result<PushWorkspaceToRemoteResponse> {
+    let record = workspace_models::load_workspace_record_by_id(workspace_id)?
+        .with_context(|| format!("Workspace not found: {workspace_id}"))?;
+    if record.state != "ready" {
+        bail!("Cannot push branch: workspace is not in ready state");
+    }
+
+    let remote = record
+        .remote
+        .clone()
+        .unwrap_or_else(|| "origin".to_string());
+    let workspace_dir = crate::data_dir::workspace_dir(&record.repo_name, &record.directory_name)?;
+    if !workspace_dir.is_dir() {
+        bail!("Workspace directory is missing for {workspace_id}");
+    }
+
+    let current_status = git_ops::workspace_action_status(
+        &workspace_dir,
+        Some(&remote),
+        record
+            .intended_target_branch
+            .as_deref()
+            .or(record.default_branch.as_deref()),
+    )?;
+    if current_status.conflict_count > 0 {
+        bail!("Cannot push branch while merge conflicts are present");
+    }
+
+    let push_result = git_ops::push_current_branch(&workspace_dir, &remote)?;
+    let head_commit = git_ops::current_workspace_head_commit(&workspace_dir)?;
+
+    Ok(PushWorkspaceToRemoteResponse {
+        target_ref: push_result.target_ref,
+        head_commit,
+    })
 }
 
 pub(crate) fn clear_prefetch_rate_limit(workspace_id: &str) {

--- a/src-tauri/src/workspace/workspaces.rs
+++ b/src-tauri/src/workspace/workspaces.rs
@@ -13,8 +13,9 @@ pub use super::archive::{
 };
 pub use super::branching::{
     _reset_prefetch_rate_limit, list_remote_branches, prefetch_remote_refs,
-    refresh_remote_and_realign, rename_workspace_branch, sync_workspace_with_target_branch,
-    update_intended_target_branch, update_intended_target_branch_local, PrefetchRemoteRefsResponse,
+    push_workspace_to_remote, refresh_remote_and_realign, rename_workspace_branch,
+    sync_workspace_with_target_branch, update_intended_target_branch,
+    update_intended_target_branch_local, PrefetchRemoteRefsResponse, PushWorkspaceToRemoteResponse,
     SyncWorkspaceTargetOutcome, SyncWorkspaceTargetResponse, UpdateIntendedTargetBranchInternal,
     UpdateIntendedTargetBranchResponse,
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1161,6 +1161,7 @@ function AppShell({ onOpenSettings }: { onOpenSettings: () => void }) {
 		interactionRequiredSessionIds,
 		sendingSessionIds,
 		onSelectSession: handleSelectSession,
+		pushToast: pushWorkspaceToast,
 	});
 
 	const handleSessionCompleted = useCallback(

--- a/src/features/commit/hooks/use-commit-lifecycle.test.tsx
+++ b/src/features/commit/hooks/use-commit-lifecycle.test.tsx
@@ -17,6 +17,7 @@ const apiMocks = vi.hoisted(() => ({
 	loadAutoCloseActionKinds: vi.fn(),
 	lookupWorkspacePr: vi.fn(),
 	mergeWorkspacePr: vi.fn(),
+	pushWorkspaceToRemote: vi.fn(),
 	setWorkspaceManualStatus: vi.fn(),
 }));
 
@@ -31,6 +32,7 @@ vi.mock("@/lib/api", async (importOriginal) => {
 		loadAutoCloseActionKinds: apiMocks.loadAutoCloseActionKinds,
 		lookupWorkspacePr: apiMocks.lookupWorkspacePr,
 		mergeWorkspacePr: apiMocks.mergeWorkspacePr,
+		pushWorkspaceToRemote: apiMocks.pushWorkspaceToRemote,
 		setWorkspaceManualStatus: apiMocks.setWorkspaceManualStatus,
 	};
 });
@@ -43,6 +45,7 @@ const EMPTY_GIT_ACTION_STATUS: WorkspaceGitActionStatus = {
 	behindTargetCount: 0,
 	remoteTrackingRef: null,
 	aheadOfRemoteCount: 0,
+	pushStatus: "unknown",
 };
 
 const EMPTY_PR_ACTION_STATUS: WorkspacePrActionStatus = {
@@ -71,6 +74,7 @@ describe("useWorkspaceCommitLifecycle", () => {
 		apiMocks.loadAutoCloseActionKinds.mockReset();
 		apiMocks.lookupWorkspacePr.mockReset();
 		apiMocks.mergeWorkspacePr.mockReset();
+		apiMocks.pushWorkspaceToRemote.mockReset();
 		apiMocks.setWorkspaceManualStatus.mockReset();
 
 		apiMocks.createSession.mockResolvedValue({ sessionId: "session-action" });
@@ -83,6 +87,10 @@ describe("useWorkspaceCommitLifecycle", () => {
 			state: "OPEN",
 			isMerged: false,
 		} satisfies PullRequestInfo);
+		apiMocks.pushWorkspaceToRemote.mockResolvedValue({
+			targetRef: "origin/feature/test",
+			headCommit: "abc123",
+		});
 		apiMocks.hideSession.mockResolvedValue(undefined);
 	});
 
@@ -190,6 +198,225 @@ describe("useWorkspaceCommitLifecycle", () => {
 		});
 		await waitFor(() => {
 			expect(onSelectSession).toHaveBeenCalledWith("session-after-close");
+		});
+	});
+
+	it("pushes directly without creating an action session", async () => {
+		const queryClient = new QueryClient({
+			defaultOptions: {
+				queries: {
+					retry: false,
+				},
+			},
+		});
+		const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries");
+		const onSelectSession = vi.fn();
+		const pushToast = vi.fn();
+
+		const { result } = renderHook(
+			() =>
+				useWorkspaceCommitLifecycle({
+					queryClient,
+					selectedWorkspaceId: "workspace-1",
+					selectedWorkspaceIdRef: { current: "workspace-1" },
+					workspaceManualStatus: null,
+					workspacePrInfo: null,
+					workspacePrActionStatus: EMPTY_PR_ACTION_STATUS,
+					workspaceGitActionStatus: {
+						...EMPTY_GIT_ACTION_STATUS,
+						pushStatus: "unpublished",
+					},
+					completedSessionIds: new Set<string>(),
+					interactionRequiredSessionIds: new Set<string>(),
+					sendingSessionIds: new Set<string>(),
+					onSelectSession,
+					pushToast,
+				}),
+			{
+				wrapper: createWrapper(queryClient),
+			},
+		);
+
+		await act(async () => {
+			await result.current.handleInspectorCommitAction("push");
+		});
+
+		expect(apiMocks.pushWorkspaceToRemote).toHaveBeenCalledWith("workspace-1");
+		expect(apiMocks.createSession).not.toHaveBeenCalled();
+		expect(result.current.pendingPromptForSession).toBeNull();
+		expect(onSelectSession).not.toHaveBeenCalled();
+
+		await waitFor(() => {
+			expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+				queryKey: helmorQueryKeys.workspaceGitActionStatus("workspace-1"),
+			});
+			expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+				queryKey: helmorQueryKeys.workspacePr("workspace-1"),
+			});
+			expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+				queryKey: helmorQueryKeys.workspacePrActionStatus("workspace-1"),
+			});
+			expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+				queryKey: helmorQueryKeys.workspaceDetail("workspace-1"),
+			});
+			expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+				queryKey: helmorQueryKeys.workspaceGroups,
+			});
+			expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+				queryKey: ["workspaceChanges"],
+			});
+		});
+		expect(pushToast).not.toHaveBeenCalled();
+	});
+
+	it("shows a destructive workspace toast when push fails", async () => {
+		const queryClient = new QueryClient({
+			defaultOptions: {
+				queries: {
+					retry: false,
+				},
+			},
+		});
+		const pushToast = vi.fn();
+		apiMocks.pushWorkspaceToRemote.mockRejectedValueOnce(
+			new Error(
+				"Cannot push branch while the workspace has uncommitted changes",
+			),
+		);
+
+		const { result } = renderHook(
+			() =>
+				useWorkspaceCommitLifecycle({
+					queryClient,
+					selectedWorkspaceId: "workspace-1",
+					selectedWorkspaceIdRef: { current: "workspace-1" },
+					workspaceManualStatus: null,
+					workspacePrInfo: null,
+					workspacePrActionStatus: EMPTY_PR_ACTION_STATUS,
+					workspaceGitActionStatus: {
+						...EMPTY_GIT_ACTION_STATUS,
+						pushStatus: "unpublished",
+					},
+					completedSessionIds: new Set<string>(),
+					interactionRequiredSessionIds: new Set<string>(),
+					sendingSessionIds: new Set<string>(),
+					onSelectSession: vi.fn(),
+					pushToast,
+				}),
+			{
+				wrapper: createWrapper(queryClient),
+			},
+		);
+
+		await act(async () => {
+			await result.current.handleInspectorCommitAction("push");
+		});
+
+		expect(pushToast).toHaveBeenCalledWith(
+			"Cannot push branch while the workspace has uncommitted changes",
+			"Push failed",
+			"destructive",
+		);
+	});
+
+	it("shows a destructive workspace toast when an action session fails to start", async () => {
+		const queryClient = new QueryClient({
+			defaultOptions: {
+				queries: {
+					retry: false,
+				},
+			},
+		});
+		const pushToast = vi.fn();
+		apiMocks.createSession.mockRejectedValueOnce(
+			new Error("Unable to create action session"),
+		);
+
+		const { result } = renderHook(
+			() =>
+				useWorkspaceCommitLifecycle({
+					queryClient,
+					selectedWorkspaceId: "workspace-1",
+					selectedWorkspaceIdRef: { current: "workspace-1" },
+					workspaceManualStatus: null,
+					workspacePrInfo: null,
+					workspacePrActionStatus: EMPTY_PR_ACTION_STATUS,
+					workspaceGitActionStatus: EMPTY_GIT_ACTION_STATUS,
+					completedSessionIds: new Set<string>(),
+					interactionRequiredSessionIds: new Set<string>(),
+					sendingSessionIds: new Set<string>(),
+					onSelectSession: vi.fn(),
+					pushToast,
+				}),
+			{
+				wrapper: createWrapper(queryClient),
+			},
+		);
+
+		await act(async () => {
+			await result.current.handleInspectorCommitAction("create-pr");
+		});
+
+		expect(pushToast).toHaveBeenCalledWith(
+			"Unable to create action session",
+			"Create PR failed",
+			"destructive",
+		);
+	});
+
+	it("shows a destructive workspace toast when merge fails", async () => {
+		const queryClient = new QueryClient({
+			defaultOptions: {
+				queries: {
+					retry: false,
+				},
+			},
+		});
+		const pushToast = vi.fn();
+		apiMocks.mergeWorkspacePr.mockRejectedValueOnce(
+			new Error("GitHub merge failed"),
+		);
+
+		const { result } = renderHook(
+			() =>
+				useWorkspaceCommitLifecycle({
+					queryClient,
+					selectedWorkspaceId: "workspace-1",
+					selectedWorkspaceIdRef: { current: "workspace-1" },
+					workspaceManualStatus: null,
+					workspacePrInfo: {
+						number: 53,
+						title: "Fix overflow",
+						url: "https://github.com/example/repo/pull/53",
+						state: "OPEN",
+						isMerged: false,
+					},
+					workspacePrActionStatus: {
+						...EMPTY_PR_ACTION_STATUS,
+						mergeable: "MERGEABLE",
+					},
+					workspaceGitActionStatus: EMPTY_GIT_ACTION_STATUS,
+					completedSessionIds: new Set<string>(),
+					interactionRequiredSessionIds: new Set<string>(),
+					sendingSessionIds: new Set<string>(),
+					onSelectSession: vi.fn(),
+					pushToast,
+				}),
+			{
+				wrapper: createWrapper(queryClient),
+			},
+		);
+
+		await act(async () => {
+			await result.current.handleInspectorCommitAction("merge");
+		});
+
+		await waitFor(() => {
+			expect(pushToast).toHaveBeenCalledWith(
+				"GitHub merge failed",
+				"Merge failed",
+				"destructive",
+			);
 		});
 	});
 });

--- a/src/features/commit/hooks/use-commit-lifecycle.ts
+++ b/src/features/commit/hooks/use-commit-lifecycle.ts
@@ -15,6 +15,7 @@ import {
 	lookupWorkspacePr,
 	mergeWorkspacePr,
 	type PullRequestInfo,
+	pushWorkspaceToRemote,
 	setWorkspaceManualStatus,
 	type WorkspaceDetail,
 	type WorkspaceGitActionStatus,
@@ -26,7 +27,41 @@ import {
 } from "@/lib/commit-button-logic";
 import { COMMIT_BUTTON_PROMPTS } from "@/lib/commit-button-prompts";
 import { helmorQueryKeys } from "@/lib/query-client";
+import type { PushWorkspaceToast } from "@/lib/workspace-toast-context";
 import type { CommitButtonState, WorkspaceCommitButtonMode } from "../button";
+
+function isActionSessionMode(
+	mode: WorkspaceCommitButtonMode,
+): mode is keyof typeof COMMIT_BUTTON_PROMPTS {
+	return mode in COMMIT_BUTTON_PROMPTS;
+}
+
+function getActionFailureTitle(mode: WorkspaceCommitButtonMode): string {
+	switch (mode) {
+		case "create-pr":
+			return "Create PR failed";
+		case "commit-and-push":
+			return "Commit and push failed";
+		case "push":
+			return "Push failed";
+		case "fix":
+			return "Fix CI failed";
+		case "resolve-conflicts":
+			return "Resolve conflicts failed";
+		case "merge":
+			return "Merge failed";
+		case "open-pr":
+			return "Open PR failed";
+		case "closed":
+			return "Close PR failed";
+		default:
+			return "Action failed";
+	}
+}
+
+function getErrorMessage(error: unknown, fallback: string): string {
+	return error instanceof Error ? error.message : fallback;
+}
 
 type CommitLifecycle = {
 	workspaceId: string;
@@ -55,6 +90,7 @@ export function useWorkspaceCommitLifecycle({
 	interactionRequiredSessionIds,
 	sendingSessionIds,
 	onSelectSession,
+	pushToast,
 }: {
 	queryClient: QueryClient;
 	selectedWorkspaceId: string | null;
@@ -67,6 +103,7 @@ export function useWorkspaceCommitLifecycle({
 	interactionRequiredSessionIds: Set<string>;
 	sendingSessionIds: Set<string>;
 	onSelectSession: (sessionId: string | null) => void;
+	pushToast?: PushWorkspaceToast;
 }) {
 	const [pendingPromptForSession, setPendingPromptForSession] =
 		useState<PendingPromptForSession | null>(null);
@@ -81,10 +118,19 @@ export function useWorkspaceCommitLifecycle({
 	const refreshWorkspaceRemoteStatus = useCallback(
 		(workspaceId: string) => {
 			void queryClient.invalidateQueries({
+				queryKey: helmorQueryKeys.workspaceGitActionStatus(workspaceId),
+			});
+			void queryClient.invalidateQueries({
 				queryKey: helmorQueryKeys.workspacePr(workspaceId),
 			});
 			void queryClient.invalidateQueries({
 				queryKey: helmorQueryKeys.workspacePrActionStatus(workspaceId),
+			});
+			void queryClient.invalidateQueries({
+				queryKey: helmorQueryKeys.workspaceDetail(workspaceId),
+			});
+			void queryClient.invalidateQueries({
+				queryKey: helmorQueryKeys.workspaceGroups,
 			});
 		},
 		[queryClient],
@@ -109,11 +155,21 @@ export function useWorkspaceCommitLifecycle({
 						console.warn(
 							"[commitButton] merge blocked: PR has merge conflicts",
 						);
+						pushToast?.(
+							"PR has merge conflicts and cannot be merged yet.",
+							"Merge blocked",
+							"destructive",
+						);
 						return;
 					}
 					if (currentMergeable === "UNKNOWN") {
 						console.warn(
 							"[commitButton] merge blocked: mergeable status still computing, please wait",
+						);
+						pushToast?.(
+							"Mergeability is still being calculated. Please wait and try again.",
+							"Merge blocked",
+							"destructive",
 						);
 						// Trigger a refresh so the status resolves sooner
 						void queryClient.invalidateQueries({
@@ -165,6 +221,11 @@ export function useWorkspaceCommitLifecycle({
 						);
 					} catch (error) {
 						console.error(`[commitButton] ${mode} failed:`, error);
+						pushToast?.(
+							getErrorMessage(error, "Unable to complete action."),
+							getActionFailureTitle(mode),
+							"destructive",
+						);
 						queryClient.setQueryData(
 							helmorQueryKeys.workspacePr(workspaceId),
 							currentPr,
@@ -185,14 +246,6 @@ export function useWorkspaceCommitLifecycle({
 				return;
 			}
 
-			const prompt = COMMIT_BUTTON_PROMPTS[mode];
-			if (!prompt) {
-				console.warn(
-					`[commitButton] action ignored: no prompt for mode ${mode}`,
-				);
-				return;
-			}
-
 			setCommitLifecycle({
 				workspaceId,
 				trackedSessionId: null,
@@ -200,6 +253,32 @@ export function useWorkspaceCommitLifecycle({
 				phase: "creating",
 				prInfo: null,
 			});
+
+			if (mode === "push") {
+				try {
+					await pushWorkspaceToRemote(workspaceId);
+					setCommitLifecycle((current) =>
+						current ? { ...current, phase: "done" } : current,
+					);
+				} catch (error) {
+					console.error("[commitButton] Failed to push branch:", error);
+					const message = getErrorMessage(error, "Unable to push branch.");
+					pushToast?.(message, "Push failed", "destructive");
+					setCommitLifecycle((current) =>
+						current ? { ...current, phase: "error" } : current,
+					);
+				}
+				return;
+			}
+
+			if (!isActionSessionMode(mode)) {
+				console.warn(
+					`[commitButton] action ignored: no prompt for mode ${mode}`,
+				);
+				setCommitLifecycle(null);
+				return;
+			}
+			const prompt = COMMIT_BUTTON_PROMPTS[mode];
 
 			try {
 				const { sessionId } = await createSession(workspaceId, {
@@ -221,6 +300,11 @@ export function useWorkspaceCommitLifecycle({
 				onSelectSession(sessionId);
 			} catch (error) {
 				console.error("[commitButton] Failed to start session:", error);
+				pushToast?.(
+					getErrorMessage(error, "Unable to start action."),
+					getActionFailureTitle(mode),
+					"destructive",
+				);
 				setCommitLifecycle((current) =>
 					current ? { ...current, phase: "error" } : current,
 				);
@@ -228,6 +312,7 @@ export function useWorkspaceCommitLifecycle({
 		},
 		[
 			onSelectSession,
+			pushToast,
 			queryClient,
 			selectedWorkspaceIdRef,
 			workspaceManualStatus,
@@ -327,6 +412,11 @@ export function useWorkspaceCommitLifecycle({
 				refreshWorkspaceRemoteStatus(workspaceId);
 			} catch (error) {
 				console.error("[commitButton] PR lookup failed:", error);
+				pushToast?.(
+					getErrorMessage(error, "Unable to verify action result."),
+					getActionFailureTitle(current.mode),
+					"destructive",
+				);
 				setCommitLifecycle((prev) =>
 					prev && prev.workspaceId === workspaceId
 						? { ...prev, phase: "error" }
@@ -337,6 +427,7 @@ export function useWorkspaceCommitLifecycle({
 	}, [
 		completedSessionIds,
 		interactionRequiredSessionIds,
+		pushToast,
 		refreshWorkspaceRemoteStatus,
 		sendingSessionIds,
 	]);

--- a/src/features/inspector/index.test.tsx
+++ b/src/features/inspector/index.test.tsx
@@ -48,6 +48,7 @@ function cleanGitStatus(): WorkspaceGitActionStatus {
 		behindTargetCount: 0,
 		remoteTrackingRef: "refs/remotes/origin/main",
 		aheadOfRemoteCount: 0,
+		pushStatus: "published",
 	};
 }
 
@@ -231,6 +232,28 @@ describe("WorkspaceInspectorSidebar Actions section", () => {
 		expect(onCommitAction).toHaveBeenCalledWith("push");
 	});
 
+	it("shows push when the branch has not been published yet", async () => {
+		const user = userEvent.setup();
+		const onCommitAction = vi.fn();
+		apiMocks.loadWorkspaceGitActionStatus.mockResolvedValue({
+			uncommittedCount: 0,
+			conflictCount: 0,
+			syncTargetBranch: "main",
+			syncStatus: "upToDate",
+			behindTargetCount: 0,
+			remoteTrackingRef: null,
+			aheadOfRemoteCount: 0,
+			pushStatus: "unpublished",
+		});
+
+		renderInspector({ onCommitAction });
+
+		await screen.findByText("Branch not published to remote");
+		await user.click(screen.getByRole("button", { name: "Push" }));
+
+		expect(onCommitAction).toHaveBeenCalledWith("push");
+	});
+
 	it("prioritizes actionable git rows ahead of passed checks", async () => {
 		apiMocks.loadWorkspaceGitActionStatus.mockResolvedValue({
 			uncommittedCount: 0,
@@ -314,6 +337,101 @@ describe("WorkspaceInspectorSidebar Actions section", () => {
 		expect(
 			await screen.findByRole("button", { name: "Commit and push" }),
 		).toBeDisabled();
+	});
+
+	it("shows a neutral loading spinner on push while the push lifecycle is busy", async () => {
+		apiMocks.loadWorkspaceGitActionStatus.mockResolvedValue({
+			uncommittedCount: 0,
+			conflictCount: 0,
+			syncTargetBranch: "main",
+			syncStatus: "upToDate",
+			behindTargetCount: 0,
+			remoteTrackingRef: "refs/remotes/origin/dohooo/short-reply-setting",
+			aheadOfRemoteCount: 2,
+			pushStatus: "published",
+		});
+
+		renderInspector({
+			commitButtonMode: "push",
+			commitButtonState: "busy",
+		});
+
+		const actions = screen.getByLabelText("Inspector section Actions");
+		const pushButton = await within(actions).findByRole("button", {
+			name: "Pushing",
+		});
+		expect(pushButton).toBeDisabled();
+		expect(pushButton).toHaveAttribute("aria-busy", "true");
+		expect(
+			pushButton.querySelector(".animate-spin.text-current"),
+		).toBeInTheDocument();
+		expect(pushButton).not.toHaveTextContent("Push");
+	});
+
+	it("shows a neutral loading spinner on commit-and-push while that lifecycle is busy", async () => {
+		apiMocks.loadWorkspaceGitActionStatus.mockResolvedValue({
+			uncommittedCount: 2,
+			conflictCount: 0,
+			syncTargetBranch: "main",
+			syncStatus: "upToDate",
+			behindTargetCount: 0,
+			pushStatus: "published",
+		});
+
+		renderInspector({
+			commitButtonMode: "commit-and-push",
+			commitButtonState: "busy",
+		});
+
+		const actions = screen.getByLabelText("Inspector section Actions");
+		const commitButton = await within(actions).findByRole("button", {
+			name: "Committing",
+		});
+		expect(commitButton).toBeDisabled();
+		expect(commitButton).toHaveAttribute("aria-busy", "true");
+		expect(
+			commitButton.querySelector(".animate-spin.text-current"),
+		).toBeInTheDocument();
+		expect(commitButton).not.toHaveTextContent("Commit and push");
+	});
+
+	it("shows a neutral loading spinner on pull while sync is pending", async () => {
+		const user = userEvent.setup();
+		let resolveSync = (_value: {
+			outcome: "updated";
+			targetBranch: string;
+		}) => {};
+		apiMocks.loadWorkspaceGitActionStatus.mockResolvedValue({
+			uncommittedCount: 0,
+			conflictCount: 0,
+			syncTargetBranch: "main",
+			syncStatus: "behind",
+			behindTargetCount: 2,
+			pushStatus: "published",
+		});
+		apiMocks.syncWorkspaceWithTargetBranch.mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					resolveSync = resolve;
+				}),
+		);
+
+		renderInspector();
+
+		await user.click(await screen.findByRole("button", { name: "Pull" }));
+
+		const actions = screen.getByLabelText("Inspector section Actions");
+		const pullButton = await within(actions).findByRole("button", {
+			name: "Pulling",
+		});
+		expect(pullButton).toBeDisabled();
+		expect(pullButton).toHaveAttribute("aria-busy", "true");
+		expect(
+			pullButton.querySelector(".animate-spin.text-current"),
+		).toBeInTheDocument();
+		expect(pullButton).not.toHaveTextContent("Pull");
+
+		resolveSync({ outcome: "updated", targetBranch: "main" });
 	});
 
 	it("renders running and failed remote status colors with accessible labels", async () => {

--- a/src/features/inspector/index.tsx
+++ b/src/features/inspector/index.tsx
@@ -114,6 +114,7 @@ export function WorkspaceInspectorSidebar({
 				bodyHeight={actionsHeight}
 				expanded={!tabsOpen}
 				onCommitAction={onCommitAction}
+				commitButtonMode={commitButtonMode}
 				commitButtonState={commitButtonState}
 				prInfo={prInfo ?? null}
 			/>

--- a/src/features/inspector/sections/actions.tsx
+++ b/src/features/inspector/sections/actions.tsx
@@ -1,7 +1,12 @@
 import { MarkGithubIcon } from "@primer/octicons-react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { ArrowUpRightIcon, CheckIcon, TriangleIcon } from "lucide-react";
+import {
+	ArrowUpRightIcon,
+	CheckIcon,
+	LoaderCircleIcon,
+	TriangleIcon,
+} from "lucide-react";
 import { useCallback, useState } from "react";
 import { toast } from "sonner";
 import {
@@ -46,6 +51,21 @@ interface GitStatusItem {
 	};
 }
 
+function loadingActionLabel(label: string): string {
+	switch (label) {
+		case "Push":
+			return "Pushing";
+		case "Pull":
+			return "Pulling";
+		case "Resolve":
+			return "Resolving";
+		case "Commit and push":
+			return "Committing";
+		default:
+			return "Loading";
+	}
+}
+
 const EMPTY_GIT_ACTION_STATUS: WorkspaceGitActionStatus = {
 	uncommittedCount: 0,
 	conflictCount: 0,
@@ -54,6 +74,7 @@ const EMPTY_GIT_ACTION_STATUS: WorkspaceGitActionStatus = {
 	behindTargetCount: 0,
 	remoteTrackingRef: null,
 	aheadOfRemoteCount: 0,
+	pushStatus: "unknown",
 };
 
 const EMPTY_PR_ACTION_STATUS: WorkspacePrActionStatus = {
@@ -73,6 +94,7 @@ type ActionsSectionProps = {
 	bodyHeight: number;
 	expanded: boolean;
 	onCommitAction?: (mode: WorkspaceCommitButtonMode) => Promise<void>;
+	commitButtonMode?: WorkspaceCommitButtonMode;
 	commitButtonState?: CommitButtonState;
 	prInfo: PullRequestInfo | null;
 };
@@ -84,6 +106,7 @@ export function ActionsSection({
 	bodyHeight,
 	expanded,
 	onCommitAction,
+	commitButtonMode,
 	commitButtonState,
 	prInfo,
 }: ActionsSectionProps) {
@@ -203,6 +226,13 @@ export function ActionsSection({
 				</div>
 				{gitRows.map((item) => {
 					const action = item.action;
+					const isCommitActionBusy =
+						action?.kind === "commit" &&
+						action.mode != null &&
+						commitButtonMode === action.mode &&
+						commitButtonState === "busy";
+					const isSyncActionBusy = action?.kind === "sync" && syncPending;
+					const isActionBusy = isCommitActionBusy || isSyncActionBusy;
 					return (
 						<div
 							key={item.label}
@@ -230,10 +260,21 @@ export function ActionsSection({
 									disabled={
 										action.kind === "commit" ? actionDisabled : syncPending
 									}
+									aria-busy={isActionBusy ? true : undefined}
+									aria-label={
+										isActionBusy ? loadingActionLabel(action.label) : undefined
+									}
 								>
-									{action.kind === "sync" && syncPending
-										? "Pulling..."
-										: action.label}
+									<span className="inline-flex items-center gap-1">
+										{isActionBusy ? (
+											<LoaderCircleIcon
+												aria-hidden="true"
+												className="size-3 animate-spin text-current opacity-70"
+												strokeWidth={2}
+											/>
+										) : null}
+										{isActionBusy ? null : action.label}
+									</span>
 								</button>
 							)}
 						</div>
@@ -387,12 +428,9 @@ function buildGitRows(
 						mode: "commit-and-push",
 					},
 				},
-		(gitStatus.aheadOfRemoteCount ?? 0) > 0
+		gitStatus.pushStatus === "unpublished"
 			? {
-					label:
-						gitStatus.aheadOfRemoteCount === 1
-							? `1 commit ahead of ${gitStatus.remoteTrackingRef ?? "upstream"}`
-							: `${gitStatus.aheadOfRemoteCount} commits ahead of ${gitStatus.remoteTrackingRef ?? "upstream"}`,
+					label: "Branch not published to remote",
 					status: "pending",
 					action: {
 						label: "Push",
@@ -400,10 +438,23 @@ function buildGitRows(
 						mode: "push",
 					},
 				}
-			: {
-					label: "Branch fully pushed",
-					status: "success",
-				},
+			: (gitStatus.aheadOfRemoteCount ?? 0) > 0
+				? {
+						label:
+							gitStatus.aheadOfRemoteCount === 1
+								? `1 commit ahead of ${gitStatus.remoteTrackingRef ?? "upstream"}`
+								: `${gitStatus.aheadOfRemoteCount} commits ahead of ${gitStatus.remoteTrackingRef ?? "upstream"}`,
+						status: "pending",
+						action: {
+							label: "Push",
+							kind: "commit",
+							mode: "push",
+						},
+					}
+				: {
+						label: "Branch fully pushed",
+						status: "success",
+					},
 		conflictCount > 0
 			? {
 					label: "Merge conflicts detected",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -981,6 +981,7 @@ export type PullRequestInfo = {
 export type ActionStatusKind = "success" | "pending" | "running" | "failure";
 export type ActionProvider = "github" | "vercel" | "unknown";
 export type WorkspaceGitSyncStatus = "upToDate" | "behind" | "unknown";
+export type WorkspacePushStatus = "published" | "unpublished" | "unknown";
 
 export type WorkspaceGitActionStatus = {
 	uncommittedCount: number;
@@ -990,6 +991,7 @@ export type WorkspaceGitActionStatus = {
 	behindTargetCount: number;
 	remoteTrackingRef?: string | null;
 	aheadOfRemoteCount: number;
+	pushStatus?: WorkspacePushStatus;
 };
 
 export type SyncWorkspaceTargetOutcome =
@@ -1000,6 +1002,11 @@ export type SyncWorkspaceTargetOutcome =
 export type SyncWorkspaceTargetResponse = {
 	outcome: SyncWorkspaceTargetOutcome;
 	targetBranch: string;
+};
+
+export type PushWorkspaceToRemoteResponse = {
+	targetRef: string;
+	headCommit: string;
 };
 
 export type WorkspacePrActionItem = {
@@ -1070,6 +1077,19 @@ export async function syncWorkspaceWithTargetBranch(
 		throw new Error(
 			describeInvokeError(error, "Unable to pull target branch updates."),
 		);
+	}
+}
+
+export async function pushWorkspaceToRemote(
+	workspaceId: string,
+): Promise<PushWorkspaceToRemoteResponse> {
+	try {
+		return await invoke<PushWorkspaceToRemoteResponse>(
+			"push_workspace_to_remote",
+			{ workspaceId },
+		);
+	} catch (error) {
+		throw new Error(describeInvokeError(error, "Unable to push branch."));
 	}
 }
 

--- a/src/lib/commit-button-logic.test.ts
+++ b/src/lib/commit-button-logic.test.ts
@@ -63,6 +63,7 @@ function makeGitActionStatus(
 		behindTargetCount: 0,
 		remoteTrackingRef: "refs/remotes/origin/main",
 		aheadOfRemoteCount: 0,
+		pushStatus: "published",
 		...overrides,
 	};
 }
@@ -189,6 +190,17 @@ describe("deriveCommitButtonMode", () => {
 	});
 
 	describe("push priority", () => {
+		it("returns push when the branch has not been published yet", () => {
+			expect(
+				deriveCommitButtonMode(
+					null,
+					makePr({ state: "OPEN" }),
+					makePrActionStatus({ mergeable: "MERGEABLE" }),
+					makeGitActionStatus({ pushStatus: "unpublished" }),
+				),
+			).toBe("push");
+		});
+
 		it("returns push when local branch is ahead of remote", () => {
 			expect(
 				deriveCommitButtonMode(

--- a/src/lib/commit-button-logic.ts
+++ b/src/lib/commit-button-logic.ts
@@ -65,7 +65,10 @@ export function deriveCommitButtonMode(
 			}
 
 			// 3. Local commits ahead of origin need pushing before CI / merge
-			if ((gitActionStatus?.aheadOfRemoteCount ?? 0) > 0) {
+			if (
+				gitActionStatus?.pushStatus === "unpublished" ||
+				(gitActionStatus?.aheadOfRemoteCount ?? 0) > 0
+			) {
 				return "push";
 			}
 

--- a/src/lib/commit-button-prompts.ts
+++ b/src/lib/commit-button-prompts.ts
@@ -1,21 +1,21 @@
 import type { WorkspaceCommitButtonMode } from "@/features/commit/button";
 
+type ActionSessionMode = Exclude<
+	WorkspaceCommitButtonMode,
+	"push" | "merge" | "closed" | "merged"
+>;
+
 /**
- * Full prompt templates dispatched to a freshly created session when the
- * inspector commit button is clicked. Keyed by the
- * {@link WorkspaceCommitButtonMode} that fired the action.
+ * Prompt templates for commit-button modes that still execute through an
+ * action session.
  *
  * These aren't terse starter messages — each one is a self-contained
  * instruction set the agent can execute without further clarification. We
  * dispatch them as the user message so they appear in the transcript and
  * the post-stream verifier has something concrete to check against.
- *
- * Modes not backed by a real action (`merged`) use short
- * placeholders so the dispatch contract stays exhaustive.
  */
-export const COMMIT_BUTTON_PROMPTS: Record<WorkspaceCommitButtonMode, string> =
-	{
-		"create-pr": `Create a pull request for the uncommitted work in this workspace.
+export const COMMIT_BUTTON_PROMPTS: Record<ActionSessionMode, string> = {
+	"create-pr": `Create a pull request for the uncommitted work in this workspace.
 
 Do the following, in order:
 1. Run \`git status\` and \`git diff\` to survey what's changed.
@@ -27,7 +27,7 @@ Do the following, in order:
 
 Don't stop to ask for confirmation — execute each step automatically. If you hit an unrecoverable error (e.g. merge conflict, pre-push hook failure), report it clearly so I can intervene.`,
 
-		"commit-and-push": `Commit and push all uncommitted work in this workspace.
+	"commit-and-push": `Commit and push all uncommitted work in this workspace.
 
 Do the following, in order:
 1. Run \`git status\` and \`git diff\` to survey what's changed.
@@ -38,17 +38,7 @@ Do the following, in order:
 
 Don't stop to ask for confirmation — execute each step automatically. If a pre-commit / pre-push hook fails, report the failure and stop without force-pushing.`,
 
-		push: `Push the current branch to its remote.
-
-Do the following, in order:
-1. Run \`git status\` to confirm the worktree is clean.
-2. Inspect the current branch and upstream tracking ref (\`git branch -vv\` or equivalent) so you know exactly what will be pushed.
-3. Push the current branch to its configured upstream with \`git push\`.
-4. Report the pushed ref and resulting HEAD commit SHA.
-
-Don't stop to ask for confirmation — execute each step automatically. If the push is rejected or a pre-push hook fails, report the failure clearly and stop without force-pushing.`,
-
-		fix: `CI is failing on the current branch. Diagnose and fix it.
+	fix: `CI is failing on the current branch. Diagnose and fix it.
 
 Do the following, in order:
 1. Use \`gh run list\` / \`gh run view\` to inspect the most recent failing run for this branch. Read the logs for each failing job.
@@ -57,7 +47,7 @@ Do the following, in order:
 4. Commit the fix with a clear \`fix(ci): …\` message and push to the same branch so CI re-runs.
 5. Report what was broken, what you changed, and whether the re-run is passing.`,
 
-		"resolve-conflicts": `This branch has merge conflicts with its target branch. Resolve them.
+	"resolve-conflicts": `This branch has merge conflicts with its target branch. Resolve them.
 
 Do the following, in order:
 1. Identify the target branch (usually \`main\` or \`master\` — check the repo's default branch).
@@ -69,24 +59,10 @@ Do the following, in order:
 
 If a conflict is too ambiguous to resolve automatically, stop and ask.`,
 
-		merge: `Merge this pull request into its base branch.
-
-Do the following:
-1. Confirm CI is green and all required reviews have been collected (\`gh pr checks\`, \`gh pr view\`).
-2. Merge using the repository's standard strategy (merge commit unless the repo convention says otherwise).
-3. Report the merge commit SHA and confirm the PR is closed.
-
-If CI is red or required reviews are missing, do NOT merge — report what's blocking and stop.`,
-
-		"open-pr": `Reopen the closed pull request for this branch and leave a short comment explaining why it's being reopened.
+	"open-pr": `Reopen the closed pull request for this branch and leave a short comment explaining why it's being reopened.
 
 Use \`gh pr reopen\` + \`gh pr comment\`. Report the PR URL when done.`,
-
-		merged: "This pull request has already been merged. No action required.",
-
-		closed:
-			"This pull request has been closed without merging. No action required.",
-	};
+};
 
 /**
  * Human-readable name for an action kind. Used in tooltips, toasts, and

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -119,6 +119,9 @@ vi.mock("@tauri-apps/api/core", () => ({
 					syncTargetBranch: null,
 					syncStatus: "unknown",
 					behindTargetCount: 0,
+					aheadOfRemoteCount: 0,
+					remoteTrackingRef: null,
+					pushStatus: "unknown",
 				};
 			case "get_workspace_pr_action_status":
 				return {


### PR DESCRIPTION
## What changed
- add a backend `push_workspace_to_remote` command and git helpers to publish unpublished workspace branches or update their existing upstream
- include `pushStatus` in workspace git status so the UI can distinguish unpublished branches from already-published branches that are merely ahead
- wire the inspector commit flow to execute push directly for push-only actions, show clearer busy/error states, and cover the behavior with frontend and Rust tests

## Why
The inspector previously treated push as an action-session flow and could not clearly represent a branch that had never been published. This makes branch publishing a first-class workspace action and gives the UI enough state to present the right action immediately.

## Test notes
- pre-commit hooks ran during `git commit`
- `biome check --write --error-on-warnings --no-errors-on-unmatched --files-ignore-unknown=true --config-path=./biome.json`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --all`
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
- no additional test suite was run manually in this session