### PR TITLE
feat(signin): refresh identity gate with logo, banner, and typing tagline

### DIFF
--- a/src/components/ui/typing-animation.tsx
+++ b/src/components/ui/typing-animation.tsx
@@ -1,0 +1,77 @@
+import { memo, useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+
+/** One segment of styled text revealed together as part of the typing flow. */
+export type TypingSegment = {
+	text: string;
+	className?: string;
+};
+
+type TypingAnimationProps = {
+	/**
+	 * Text to reveal character by character. Pass a plain string for a single
+	 * style, or an array of segments to style portions (e.g. bold) of the line
+	 * while keeping a single continuous typing flow.
+	 */
+	text: string | TypingSegment[];
+	/** Ms between each character. Default 60. */
+	duration?: number;
+	/** Ms before typing starts after mount. Default 0. */
+	delay?: number;
+	className?: string;
+};
+
+/** Typewriter reveal effect inspired by magicui.design/docs/components/typing-animation. */
+export const TypingAnimation = memo(function TypingAnimation({
+	text,
+	duration = 60,
+	delay = 0,
+	className,
+}: TypingAnimationProps) {
+	const segments: TypingSegment[] = Array.isArray(text) ? text : [{ text }];
+	const fullText = segments.map((s) => s.text).join("");
+
+	const [revealed, setRevealed] = useState(0);
+
+	useEffect(() => {
+		setRevealed(0);
+
+		let interval: number | null = null;
+		const start = window.setTimeout(() => {
+			interval = window.setInterval(() => {
+				setRevealed((prev) => {
+					if (prev >= fullText.length) {
+						if (interval !== null) window.clearInterval(interval);
+						return prev;
+					}
+					return prev + 1;
+				});
+			}, duration);
+		}, delay);
+
+		return () => {
+			window.clearTimeout(start);
+			if (interval !== null) window.clearInterval(interval);
+		};
+	}, [fullText, duration, delay]);
+
+	let consumed = 0;
+	return (
+		<span className={cn("inline-block", className)}>
+			{segments.map((seg, idx) => {
+				const segStart = consumed;
+				consumed += seg.text.length;
+				const revealedInSeg = Math.max(
+					0,
+					Math.min(revealed - segStart, seg.text.length),
+				);
+				if (revealedInSeg === 0) return null;
+				return (
+					<span key={idx} className={seg.className}>
+						{seg.text.slice(0, revealedInSeg)}
+					</span>
+				);
+			})}
+		</span>
+	);
+});

--- a/src/shell/github-identity-gate.tsx
+++ b/src/shell/github-identity-gate.tsx
@@ -2,7 +2,10 @@ import { MarkGithubIcon } from "@primer/octicons-react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { Check, Copy, RefreshCw } from "lucide-react";
 import { useCallback, useState } from "react";
+import helmorLogoSrc from "@/assets/helmor-logo.png";
+import bannerHtml from "@/assets/render-banner.html?raw";
 import { Button } from "@/components/ui/button";
+import { TypingAnimation } from "@/components/ui/typing-animation";
 import type { GithubIdentityState } from "./types";
 
 export function GithubIdentityGate({
@@ -17,31 +20,6 @@ export function GithubIdentityGate({
 	onCancelGithubConnect: () => void;
 }) {
 	const [codeCopied, setCodeCopied] = useState(false);
-
-	const title =
-		identityState.status === "checking"
-			? "Checking GitHub connection"
-			: identityState.status === "awaiting-redirect"
-				? "Waiting for GitHub authorization"
-				: identityState.status === "pending"
-					? "Finish sign-in on GitHub"
-					: identityState.status === "unconfigured"
-						? "GitHub account connection is not configured"
-						: identityState.status === "error"
-							? "GitHub connection failed"
-							: "Sign in with GitHub";
-	const description =
-		identityState.status === "checking"
-			? "Helmor is restoring your last GitHub account session."
-			: identityState.status === "awaiting-redirect"
-				? "Complete the sign-in in your browser. Helmor will update automatically."
-				: identityState.status === "pending"
-					? "Copy the code below, then you'll be redirected to GitHub to authorize."
-					: identityState.status === "unconfigured"
-						? identityState.message
-						: identityState.status === "error"
-							? identityState.message
-							: "GitHub account connection is required before Helmor loads your workspaces.";
 
 	const handleCopyCodeThenRedirect = useCallback(async () => {
 		if (identityState.status !== "pending" || codeCopied) {
@@ -74,6 +52,13 @@ export function GithubIdentityGate({
 			aria-label="GitHub identity gate"
 			className="relative h-screen overflow-hidden bg-background font-sans text-foreground antialiased"
 		>
+			<iframe
+				title="Helmor branding animation"
+				srcDoc={bannerHtml}
+				aria-hidden
+				tabIndex={-1}
+				className="pointer-events-none absolute inset-0 z-0 h-full w-full border-0 bg-transparent opacity-[0.02]"
+			/>
 			<div
 				aria-label="GitHub identity gate drag region"
 				className="absolute inset-x-0 top-0 z-10 flex h-11 items-center"
@@ -82,88 +67,77 @@ export function GithubIdentityGate({
 				<div data-tauri-drag-region className="h-full flex-1" />
 			</div>
 
-			<div className="relative flex h-full items-center justify-center px-6">
-				<div className="w-full max-w-[31rem]">
-					<h1 className="text-center text-[40px] leading-[1.04] tracking-[-0.04em] text-foreground">
-						{title}
-					</h1>
-					<p className="mx-auto mt-4 max-w-[31rem] text-center text-[16px] leading-7 text-muted-foreground">
-						{description}
-					</p>
+			<div className="relative z-10 flex h-full items-center justify-center px-6">
+				<div className="flex w-full max-w-md flex-col items-center">
+					<img
+						src={helmorLogoSrc}
+						alt="Helmor"
+						draggable={false}
+						className="size-18 rounded-[11px] opacity-90"
+					/>
 
 					{identityState.status === "awaiting-redirect" ? (
-						<div className="mt-8 flex flex-col items-center gap-4">
-							<div className="inline-flex items-center gap-2 text-[14px] text-muted-foreground">
+						<div className="mt-10 flex flex-col items-center gap-3">
+							<div className="inline-flex items-center gap-2 text-sm text-muted-foreground">
 								<RefreshCw className="size-4 animate-spin" strokeWidth={1.8} />
 								Waiting for authorization
 							</div>
-							<Button
-								variant="ghost"
-								onClick={onCancelGithubConnect}
-								className="rounded-full px-4 text-[14px] text-muted-foreground hover:text-foreground"
-							>
+							<Button variant="ghost" size="sm" onClick={onCancelGithubConnect}>
 								Cancel
 							</Button>
 						</div>
 					) : identityState.status === "pending" ? (
-						<div className="mt-8 flex flex-col items-center gap-5">
+						<div className="mt-10 flex w-full max-w-xs flex-col items-center gap-4">
 							<Button
-								variant="ghost"
+								variant="outline"
+								size="lg"
 								onClick={() => {
 									void handleCopyCodeThenRedirect();
 								}}
 								disabled={codeCopied}
-								className="relative h-auto rounded-2xl px-5 py-3 hover:bg-accent/60"
 								aria-label="Copy one-time code"
 								title="Copy one-time code"
+								className="h-auto w-full justify-center gap-3 py-4"
 							>
-								<span className="font-mono text-[30px] tracking-[0.18em] text-foreground">
+								<span className="font-mono text-2xl font-medium tracking-[0.25em] text-foreground">
 									{identityState.flow.userCode}
 								</span>
-								<span className="absolute -right-6 top-1/2 flex -translate-y-1/2 items-center justify-center">
-									{codeCopied ? (
-										<Check
-											className="size-4 text-green-400"
-											strokeWidth={2.5}
-										/>
-									) : (
-										<Copy
-											className="size-4 text-foreground/40"
-											strokeWidth={1.8}
-										/>
-									)}
-								</span>
+								{codeCopied ? (
+									<Check
+										data-icon="inline-end"
+										className="size-4 text-emerald-500"
+										strokeWidth={2.5}
+									/>
+								) : (
+									<Copy
+										data-icon="inline-end"
+										className="size-4 text-muted-foreground"
+										strokeWidth={1.8}
+									/>
+								)}
 							</Button>
-							<div className="flex flex-wrap items-center justify-center gap-3">
-								<Button
-									variant="ghost"
-									onClick={onCancelGithubConnect}
-									className="rounded-full px-4 text-[14px] text-muted-foreground hover:text-foreground"
-								>
-									Cancel
-								</Button>
-							</div>
+							<Button variant="ghost" size="sm" onClick={onCancelGithubConnect}>
+								Cancel
+							</Button>
 						</div>
 					) : identityState.status === "unconfigured" ? (
-						<div className="mt-8 flex justify-center">
-							<Button
-								disabled
-								className="rounded-full px-4 text-[14px] opacity-70"
-							>
+						<div className="mt-10 flex justify-center">
+							<Button disabled size="lg">
 								<MarkGithubIcon size={16} data-icon="inline-start" />
 								Continue with GitHub
 							</Button>
 						</div>
 					) : identityState.status === "checking" ? (
-						<div className="mt-8 inline-flex w-full items-center justify-center gap-2 text-[14px] text-muted-foreground">
+						<div className="mt-10 inline-flex items-center justify-center gap-2 text-sm text-muted-foreground">
 							<RefreshCw className="size-4 animate-spin" strokeWidth={1.8} />
 							Restoring your last session
 						</div>
 					) : (
-						<div className="mt-8 flex justify-center">
+						<div className="mt-10 flex justify-center">
 							<Button
 								onClick={onConnectGithub}
-								className="rounded-full px-4 text-[14px]"
+								size="lg"
+								className="hover:bg-primary/90"
 							>
 								<MarkGithubIcon size={16} data-icon="inline-start" />
 								{identityState.status === "error"
@@ -174,6 +148,31 @@ export function GithubIdentityGate({
 					)}
 				</div>
 			</div>
+
+			<figure className="absolute inset-x-0 bottom-16 z-10 flex items-baseline justify-center gap-2 px-6">
+				<span
+					aria-hidden
+					className="font-serif text-3xl leading-none text-muted-foreground/40"
+				>
+					&ldquo;
+				</span>
+				<blockquote className="whitespace-nowrap font-serif text-lg italic leading-snug text-foreground/70">
+					<TypingAnimation
+						text={[
+							{ text: "AI made me 10x. " },
+							{
+								text: "Helmor",
+								className: "font-bold text-foreground",
+							},
+							{
+								text: " takes me 100x. Goodbye, handcrafted code. 👋",
+							},
+						]}
+						duration={55}
+						delay={400}
+					/>
+				</blockquote>
+			</figure>
 		</main>
 	);
 }


### PR DESCRIPTION
## Summary
- Reworks the GitHub identity gate: drops the heavy title/description block in favor of a centered Helmor logo, a subtle full-bleed `render-banner.html` iframe, and a typewriter tagline (`"AI made me 10x. Helmor takes me 100x."`) anchored at the bottom.
- Standardizes the gate buttons on shadcn `size`/`variant` props instead of hand-tuned class strings — aligns with the rest of the shell and makes the code/copy affordances consistent across states (`checking` / `pending` / `awaiting-redirect` / `unconfigured` / `error` / default).
- Adds a reusable `TypingAnimation` component under `src/components/ui/` that supports styled segments so portions of the text (e.g. bold "Helmor") can be emphasized while keeping a single continuous reveal.

## Why
The previous gate felt verbose and state-heavy: five copy variants for what is effectively a single "sign in" surface. This shifts the first-run impression toward the product identity (logo + motion + tagline) and relies on button state for status, instead of title copy. It also unlocks `TypingAnimation` for future marketing/onboarding surfaces.

## Test plan
- [ ] `pnpm run dev` — launch with no configured GitHub account and confirm the `unconfigured`, `checking`, default (`Sign in`), `pending` (one-time code + copy affordance), `awaiting-redirect`, and `error` states all render correctly with the new layout.
- [ ] Verify the banner iframe stays non-interactive (`pointer-events-none`, `aria-hidden`, `tabIndex=-1`) and does not steal focus from the copy-code button.
- [ ] Verify the typing tagline reveals smoothly, respects the `delay`/`duration` props, and cleans up timers on unmount (cancel mid-type by navigating away).
- [ ] `pnpm run lint` and `pnpm run typecheck` both pass.