### PR TITLE
refactor(inspector): drop auto-open on setup_pending and widen default tabs body

### DIFF
--- a/src/features/inspector/hooks/use-inspector.ts
+++ b/src/features/inspector/hooks/use-inspector.ts
@@ -11,7 +11,12 @@ import { flushSync } from "react-dom";
 import { loadRepoScripts, type RepoScripts } from "@/lib/api";
 import type { InspectorFileItem } from "@/lib/editor-session";
 import { workspaceChangesQueryOptions } from "@/lib/query-client";
-import { MIN_SECTION_HEIGHT, TABS_ANIMATION_MS, TABS_EASING } from "../layout";
+import {
+	DEFAULT_TABS_BODY_HEIGHT,
+	MIN_SECTION_HEIGHT,
+	TABS_ANIMATION_MS,
+	TABS_EASING,
+} from "../layout";
 
 const DEFAULT_CHANGES_RATIO = 0.6;
 const DEFAULT_ACTIONS_RATIO = 0.4;
@@ -29,26 +34,16 @@ type UseWorkspaceInspectorSidebarArgs = {
 	workspaceRootPath?: string | null;
 	workspaceId: string | null;
 	repoId: string | null;
-	workspaceState?: string | null;
 };
 
 export function useWorkspaceInspectorSidebar({
 	workspaceRootPath,
 	workspaceId,
 	repoId,
-	workspaceState,
 }: UseWorkspaceInspectorSidebarArgs) {
 	const [tabsOpen, setTabsOpen] = useState(false);
 	const [activeTab, setActiveTab] = useState("setup");
 	const [pendingRunScript, setPendingRunScript] = useState(false);
-
-	// Auto-open the setup tab when workspace needs setup.
-	useEffect(() => {
-		if (workspaceState === "setup_pending") {
-			setTabsOpen(true);
-			setActiveTab("setup");
-		}
-	}, [workspaceState]);
 
 	// Listen for Cmd+R "run script" shortcut event.
 	useEffect(() => {
@@ -78,7 +73,7 @@ export function useWorkspaceInspectorSidebar({
 		const available = Math.max(0, element.clientHeight - overhead);
 		const resizableAvailable = Math.max(
 			MIN_SECTION_HEIGHT * 2,
-			available - MIN_SECTION_HEIGHT,
+			available - DEFAULT_TABS_BODY_HEIGHT,
 		);
 		setChangesHeight(Math.round(resizableAvailable * DEFAULT_CHANGES_RATIO));
 		setActionsHeight(Math.round(resizableAvailable * DEFAULT_ACTIONS_RATIO));

--- a/src/features/inspector/index.tsx
+++ b/src/features/inspector/index.tsx
@@ -86,7 +86,6 @@ export function WorkspaceInspectorSidebar({
 		workspaceRootPath,
 		workspaceId: workspaceId ?? null,
 		repoId: repoId ?? null,
-		workspaceState,
 	});
 
 	const handleOpenSettings = onOpenSettings ?? (() => {});

--- a/src/features/inspector/layout.tsx
+++ b/src/features/inspector/layout.tsx
@@ -4,6 +4,10 @@ import type { WorkspaceCommitButtonMode } from "@/features/commit/button";
 import { cn } from "@/lib/utils";
 
 export const MIN_SECTION_HEIGHT = 48;
+// Default body height reserved for the tabs section when first expanded.
+// Larger than MIN_SECTION_HEIGHT so the Setup/Run panel opens with enough
+// room to comfortably show its empty/idle state.
+export const DEFAULT_TABS_BODY_HEIGHT = 128;
 export const RESIZE_HIT_AREA = 10;
 export const TABS_ANIMATION_MS = 350;
 export const TABS_EASING = "cubic-bezier(0.22, 1, 0.36, 1)";


### PR DESCRIPTION
## Summary

- Stop auto-opening the Setup tab when `workspaceState === "setup_pending"`. Users found the forced expansion intrusive, so the Inspector now preserves whatever tabs state the user last chose.
- Drop the now-unused `workspaceState` argument from `useWorkspaceInspectorSidebar`.
- Introduce `DEFAULT_TABS_BODY_HEIGHT = 128` and use it (instead of `MIN_SECTION_HEIGHT`) when computing the initial height split. The tabs section now opens with enough room to comfortably show Setup/Run's idle/empty state without looking cramped.

## Why

The auto-open behaviour was triggered on every workspace that happened to be in `setup_pending`, even when the user had deliberately closed the Inspector tabs. Removing it keeps the Inspector's open/closed state user-driven. The larger default body height fixes a long-standing layout glitch where the first expansion of the tabs showed a truncated Setup panel.

## Test plan

- [ ] Open a workspace in `setup_pending` with the Inspector tabs collapsed — confirm the tabs stay collapsed.
- [ ] Manually expand the tabs — confirm the Setup panel has roughly 128px of body height and renders its idle state cleanly.
- [ ] Drag the resize handle — confirm min-height constraints still apply and both sections can still be resized.
- [ ] `pnpm run typecheck` and `pnpm run lint` pass.