### PR TITLE
feat(panel): refine empty-state tips section

### DIFF
--- a/src/features/panel/message-components/empty-state.tsx
+++ b/src/features/panel/message-components/empty-state.tsx
@@ -1,6 +1,7 @@
 import {
 	Archive,
 	Hammer,
+	Lightbulb,
 	type LucideIcon,
 	MessageSquareText,
 	Play,
@@ -66,7 +67,17 @@ export function EmptyState({
 				</EmptyDescription>
 			</EmptyHeader>
 			{showScriptActions ? (
-				<EmptyContent className="mt-4 max-w-[22.25rem] items-stretch gap-2">
+				<div
+					aria-hidden="true"
+					className="flex w-full max-w-[24rem] items-center gap-2"
+				>
+					<span className="h-px flex-1 bg-muted-foreground/12" />
+					<span className="size-[3px] rounded-full bg-muted-foreground/12" />
+					<span className="h-px flex-1 bg-muted-foreground/12" />
+				</div>
+			) : null}
+			{showScriptActions ? (
+				<EmptyContent className="mt-1 max-w-[22.25rem] items-stretch gap-2">
 					{missingScriptTypes.map((scriptType) => {
 						const item = SCRIPT_ACTION_COPY[scriptType];
 						const Icon = item.icon;
@@ -92,10 +103,16 @@ export function EmptyState({
 							</button>
 						);
 					})}
-					<p className="mt-2 w-full text-center text-[11.5px] leading-[1.55] text-muted-foreground">
-						<span className="font-medium text-foreground/80">Tips:</span>{" "}
-						Configuring these scripts upgrades your dev loop — click any item
-						and let AI set it up for you.
+					<p className="mt-2 flex w-full items-center justify-center gap-1.5 whitespace-nowrap text-[11.5px] leading-[1.55] text-muted-foreground">
+						<Lightbulb
+							className="size-3 text-foreground/80"
+							fill="currentColor"
+							strokeWidth={1.5}
+						/>
+						<span>
+							<span className="font-medium text-foreground/80">Tips:</span>{" "}
+							Configuring these scripts upgrades your dev loop.
+						</span>
 					</p>
 				</EmptyContent>
 			) : null}


### PR DESCRIPTION
## Summary

Polish the empty-state layout in the chat panel so the tips line reads as a single, clearly-anchored hint instead of a wrap-prone paragraph.

- Add a thin dotted divider between the empty-state header and the script action cards to separate "what this is" from "what you can do".
- Collapse the tips copy into one line ("Configuring these scripts upgrades your dev loop.") and prefix it with a filled `Lightbulb` icon for visual anchoring.
- Tighten vertical rhythm (`mt-4` → `mt-1` on `EmptyContent`) now that the divider provides the separation.

## Why

The previous tips paragraph wrapped to two lines and competed with the header copy for attention. Shortening the text and introducing a divider + icon gives the panel a clearer hierarchy: header → divider → actions → tip.

## Files

- `src/features/panel/message-components/empty-state.tsx`

## Test plan

- [ ] `pnpm run dev` — open a workspace with no scripts configured and confirm the empty state shows: header, dotted divider, script cards, and a single-line tip with a lightbulb icon.
- [ ] Confirm the tip never wraps at the default panel width (`max-w-[22.25rem]`).
- [ ] `pnpm run lint` and `pnpm run typecheck` pass.