### PR TITLE
feat: improve workspace creation flow

### DIFF
--- a/src-tauri/src/commands/workspace_commands.rs
+++ b/src-tauri/src/commands/workspace_commands.rs
@@ -4,15 +4,25 @@ use crate::{db, git_watcher, workspaces};
 
 use super::common::{run_blocking, CmdResult};
 
+fn notify_workspace_changed_in_background(app: AppHandle) {
+    tauri::async_runtime::spawn(async move {
+        let _ = tauri::async_runtime::spawn_blocking(move || {
+            git_watcher::notify_workspace_changed(&app);
+        })
+        .await;
+    });
+}
+
 #[tauri::command]
 pub async fn create_workspace_from_repo(
     app: AppHandle,
     repo_id: String,
 ) -> CmdResult<workspaces::CreateWorkspaceResponse> {
-    let _lock = db::WORKSPACE_MUTATION_LOCK.lock().await;
-    let result =
-        run_blocking(move || workspaces::create_workspace_from_repo_impl(&repo_id)).await?;
-    git_watcher::notify_workspace_changed(&app);
+    let result = {
+        let _lock = db::WORKSPACE_MUTATION_LOCK.lock().await;
+        run_blocking(move || workspaces::create_workspace_from_repo_impl(&repo_id)).await?
+    };
+    notify_workspace_changed_in_background(app);
     Ok(result)
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -102,7 +102,10 @@ import {
 	useSettings,
 } from "./lib/settings";
 import { useOsNotifications } from "./lib/use-os-notifications";
-import { summaryToArchivedRow } from "./lib/workspace-helpers";
+import {
+	isOptimisticCreatingWorkspaceId,
+	summaryToArchivedRow,
+} from "./lib/workspace-helpers";
 import {
 	type WorkspaceToastOptions,
 	WorkspaceToastProvider,
@@ -464,7 +467,10 @@ function AppShell({
 	);
 	const selectedWorkspaceDetailQuery = useQuery({
 		...workspaceDetailQueryOptions(selectedWorkspaceId ?? "__none__"),
-		enabled: isIdentityConnected && selectedWorkspaceId !== null,
+		enabled:
+			isIdentityConnected &&
+			selectedWorkspaceId !== null &&
+			!isOptimisticCreatingWorkspaceId(selectedWorkspaceId),
 	});
 	const handleOpenSettings = useCallback(() => {
 		onOpenSettings(
@@ -507,7 +513,10 @@ function AppShell({
 	// commit button's resting mode and the "Git · PR #xxx" header badge.
 	const workspacePrQuery = useQuery({
 		...workspacePrQueryOptions(selectedWorkspaceId ?? "__none__"),
-		enabled: isIdentityConnected && selectedWorkspaceId !== null,
+		enabled:
+			isIdentityConnected &&
+			selectedWorkspaceId !== null &&
+			!isOptimisticCreatingWorkspaceId(selectedWorkspaceId),
 	});
 	const workspacePrInfo = workspacePrQuery.data ?? null;
 
@@ -516,13 +525,18 @@ function AppShell({
 	// button's mode derivation — shared cache with inspector's actions.tsx.
 	const workspacePrActionStatusQuery = useQuery({
 		...workspacePrActionStatusQueryOptions(selectedWorkspaceId ?? "__none__"),
-		enabled: isIdentityConnected && selectedWorkspaceId !== null,
+		enabled:
+			isIdentityConnected &&
+			selectedWorkspaceId !== null &&
+			!isOptimisticCreatingWorkspaceId(selectedWorkspaceId),
 	});
 	const workspacePrActionStatus = workspacePrActionStatusQuery.data ?? null;
 
 	const workspaceGitActionStatusQuery = useQuery({
 		...workspaceGitActionStatusQueryOptions(selectedWorkspaceId ?? "__none__"),
-		enabled: selectedWorkspaceId !== null,
+		enabled:
+			selectedWorkspaceId !== null &&
+			!isOptimisticCreatingWorkspaceId(selectedWorkspaceId),
 	});
 	const workspaceGitActionStatus = workspaceGitActionStatusQuery.data ?? null;
 
@@ -822,6 +836,13 @@ function AppShell({
 
 	const primeWorkspaceDisplay = useCallback(
 		async (workspaceId: string) => {
+			if (isOptimisticCreatingWorkspaceId(workspaceId)) {
+				return {
+					workspaceId,
+					sessionId: null,
+				};
+			}
+
 			const [workspaceDetail, workspaceSessions] = await Promise.all([
 				queryClient.ensureQueryData(workspaceDetailQueryOptions(workspaceId)),
 				queryClient.ensureQueryData(workspaceSessionsQueryOptions(workspaceId)),
@@ -868,6 +889,7 @@ function AppShell({
 				null;
 			const hasSessionMessages =
 				sessionId === null ||
+				isOptimisticCreatingWorkspaceId(workspaceId) ||
 				queryClient.getQueryData([
 					...helmorQueryKeys.sessionMessages(sessionId),
 					"thread",
@@ -1036,7 +1058,9 @@ function AppShell({
 			setSelectedSessionId(immediateSessionId);
 
 			if (workspaceId) {
-				triggerWorkspaceFetch(workspaceId);
+				if (!isOptimisticCreatingWorkspaceId(workspaceId)) {
+					triggerWorkspaceFetch(workspaceId);
+				}
 			}
 
 			// Session-level completed dots are cleared reactively via the

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -32,6 +32,7 @@ import {
 	findModelOption,
 	getComposerContextKey,
 	isNewSession,
+	isOptimisticCreatingWorkspaceId,
 	resolveSessionSelectedModelId,
 } from "@/lib/workspace-helpers";
 import type { DeferredToolResponseHandler } from "./deferred-tool";
@@ -138,11 +139,15 @@ export const WorkspaceComposerContainer = memo(
 		const modelSectionsQuery = useQuery(agentModelSectionsQueryOptions());
 		const workspaceDetailQuery = useQuery({
 			...workspaceDetailQueryOptions(displayedWorkspaceId ?? "__none__"),
-			enabled: Boolean(displayedWorkspaceId),
+			enabled:
+				Boolean(displayedWorkspaceId) &&
+				!isOptimisticCreatingWorkspaceId(displayedWorkspaceId),
 		});
 		const sessionsQuery = useQuery({
 			...workspaceSessionsQueryOptions(displayedWorkspaceId ?? "__none__"),
-			enabled: Boolean(displayedWorkspaceId),
+			enabled:
+				Boolean(displayedWorkspaceId) &&
+				!isOptimisticCreatingWorkspaceId(displayedWorkspaceId),
 		});
 
 		const modelSections = modelSectionsQuery.data ?? EMPTY_MODEL_SECTIONS;
@@ -227,6 +232,8 @@ export const WorkspaceComposerContainer = memo(
 			(workspaceDetailQuery.isPending || sessionsQuery.isPending);
 		const composerDisabled =
 			displayedWorkspaceId === null ||
+			isOptimisticCreatingWorkspaceId(displayedWorkspaceId) ||
+			workspaceDetailQuery.data?.state === "initializing" ||
 			workspaceDetailQuery.data?.state === "archived";
 
 		// Auto-close opt-in state comes from settings: `auto_close_action_kinds`

--- a/src/features/navigation/hooks/use-controller.test.tsx
+++ b/src/features/navigation/hooks/use-controller.test.tsx
@@ -314,6 +314,81 @@ describe("useWorkspacesSidebarController archive flow", () => {
 		expect(pushWorkspaceToast).not.toHaveBeenCalled();
 	});
 
+	it("创建 workspace 时先插入 initializing 占位项，再切到真实 workspace", async () => {
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false } },
+		});
+		const onSelectWorkspace = vi.fn();
+		const pushWorkspaceToast = vi.fn();
+		let resolveCreate:
+			| ((value: {
+					createdWorkspaceId: string;
+					selectedWorkspaceId: string;
+					createdState: string;
+					directoryName: string;
+					branch: string;
+			  }) => void)
+			| null = null;
+
+		apiMocks.listRepositories.mockResolvedValue([
+			{
+				id: "repo-1",
+				name: "helmor",
+				defaultBranch: "main",
+				repoInitials: "HE",
+			},
+		]);
+		apiMocks.createWorkspaceFromRepo.mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					resolveCreate = resolve;
+				}),
+		);
+
+		const { result } = renderHook(
+			() =>
+				useWorkspacesSidebarController({
+					selectedWorkspaceId: null,
+					onSelectWorkspace,
+					pushWorkspaceToast,
+				}),
+			{ wrapper: createWrapper(queryClient) },
+		);
+
+		await waitFor(() => {
+			expect(result.current.groups[0]?.rows).toHaveLength(2);
+		});
+
+		act(() => {
+			void result.current.handleCreateWorkspaceFromRepo("repo-1");
+		});
+
+		const optimisticRow = result.current.groups[0]?.rows[0];
+		expect(optimisticRow?.state).toBe("initializing");
+		expect(optimisticRow?.title).toContain("Creating helmor");
+		expect(onSelectWorkspace).toHaveBeenCalledWith(
+			expect.stringMatching(/^creating-workspace:/),
+		);
+
+		await act(async () => {
+			resolveCreate?.({
+				createdWorkspaceId: "ws-created",
+				selectedWorkspaceId: "ws-created",
+				createdState: "ready",
+				directoryName: "vega",
+				branch: "feature/vega",
+			});
+		});
+
+		await waitFor(() => {
+			expect(
+				apiMocks.loadWorkspaceGroups.mock.calls.length,
+			).toBeGreaterThanOrEqual(2);
+		});
+		expect(onSelectWorkspace).toHaveBeenCalledWith("ws-created");
+		expect(pushWorkspaceToast).not.toHaveBeenCalled();
+	});
+
 	it("后台启动立即失败时会回滚乐观更新", async () => {
 		const queryClient = new QueryClient({
 			defaultOptions: { queries: { retry: false } },

--- a/src/features/navigation/hooks/use-controller.ts
+++ b/src/features/navigation/hooks/use-controller.ts
@@ -12,11 +12,14 @@ import {
 	permanentlyDeleteWorkspace,
 	pinWorkspace,
 	prepareArchiveWorkspace,
+	type RepositoryCreateOption,
 	restoreWorkspace,
 	setWorkspaceManualStatus,
 	startArchiveWorkspace,
 	unpinWorkspace,
 	validateRestoreWorkspace,
+	type WorkspaceDetail,
+	type WorkspaceGroup,
 	type WorkspaceRow,
 	type WorkspaceSessionSummary,
 } from "@/lib/api";
@@ -33,10 +36,13 @@ import { useSettings } from "@/lib/settings";
 import {
 	clearWorkspaceUnreadFromGroups,
 	clearWorkspaceUnreadFromSummaries,
+	createOptimisticCreatingWorkspaceDetail,
+	createOptimisticCreatingWorkspaceId,
 	describeUnknownError,
 	findInitialWorkspaceId,
 	findWorkspaceRowById,
 	hasWorkspaceId,
+	isOptimisticCreatingWorkspaceId,
 	rowToWorkspaceSummary,
 	summaryToArchivedRow,
 	workspaceGroupIdFromStatus,
@@ -82,6 +88,17 @@ export function useWorkspacesSidebarController({
 	const [suppressedWorkspaceReadId, setSuppressedWorkspaceReadId] = useState<
 		string | null
 	>(null);
+	const creatingWorkspaceRollbackRef = useRef<
+		Map<
+			string,
+			{
+				row: WorkspaceRow;
+				repoId: string;
+				previousGroups: WorkspaceGroup[] | undefined;
+				previousSelection: string | null;
+			}
+		>
+	>(new Map());
 
 	const archiveRollbackRef = useRef<
 		Map<
@@ -124,19 +141,30 @@ export function useWorkspacesSidebarController({
 
 	const baseGroups = groupsQuery.data ?? [];
 	const baseArchivedSummaries = archivedQuery.data ?? [];
+	const pendingCreatingEntries = Array.from(
+		creatingWorkspaceRollbackRef.current.entries(),
+	);
 	const pendingArchivedEntries = Array.from(
 		archiveRollbackRef.current.entries(),
 	);
 	const pendingArchivedIds = new Set(
 		pendingArchivedEntries.map(([workspaceId]) => workspaceId),
 	);
-	const groups =
+	const groupsWithoutArchived =
 		pendingArchivedIds.size === 0
 			? baseGroups
 			: baseGroups.map((group) => ({
 					...group,
 					rows: group.rows.filter((row) => !pendingArchivedIds.has(row.id)),
 				}));
+	const groups =
+		pendingCreatingEntries.length === 0
+			? groupsWithoutArchived
+			: pendingCreatingEntries.reduce(
+					(currentGroups, [, rollback]) =>
+						insertOptimisticWorkspaceRow(currentGroups, rollback.row),
+					groupsWithoutArchived,
+				);
 	const archivedSummaries =
 		pendingArchivedEntries.length === 0
 			? baseArchivedSummaries
@@ -761,14 +789,93 @@ export function useWorkspacesSidebarController({
 				return;
 			}
 
+			const repository = (repositoriesQuery.data ?? []).find(
+				(item) => item.id === repoId,
+			);
+			if (!repository) {
+				pushWorkspaceToast(
+					"Unable to resolve repository for workspace creation.",
+				);
+				return;
+			}
+
+			const optimisticWorkspaceId = createOptimisticCreatingWorkspaceId(repoId);
+			const optimisticRow = createOptimisticWorkspaceRow(
+				repository,
+				optimisticWorkspaceId,
+			);
+			const previousGroups = queryClient.getQueryData<WorkspaceGroup[]>(
+				helmorQueryKeys.workspaceGroups,
+			);
+			creatingWorkspaceRollbackRef.current.set(optimisticWorkspaceId, {
+				row: optimisticRow,
+				repoId,
+				previousGroups,
+				previousSelection: selectedWorkspaceId,
+			});
+
+			queryClient.setQueryData(
+				helmorQueryKeys.workspaceGroups,
+				(current: WorkspaceGroup[] | undefined) =>
+					insertOptimisticWorkspaceRow(current ?? groups, optimisticRow),
+			);
+			queryClient.setQueryData<WorkspaceDetail | null>(
+				helmorQueryKeys.workspaceDetail(optimisticWorkspaceId),
+				createOptimisticCreatingWorkspaceDetail(optimisticRow, repoId),
+			);
+			queryClient.setQueryData<WorkspaceSessionSummary[]>(
+				helmorQueryKeys.workspaceSessions(optimisticWorkspaceId),
+				[],
+			);
+
 			setCreatingWorkspaceRepoId(repoId);
+			onSelectWorkspace(optimisticWorkspaceId);
 
 			try {
 				const response = await createWorkspaceFromRepo(repoId);
+				creatingWorkspaceRollbackRef.current.delete(optimisticWorkspaceId);
+				queryClient.setQueryData(
+					helmorQueryKeys.workspaceGroups,
+					(current: WorkspaceGroup[] | undefined) =>
+						removeOptimisticWorkspaceRow(
+							current ?? groups,
+							optimisticWorkspaceId,
+						),
+				);
+				queryClient.removeQueries({
+					queryKey: helmorQueryKeys.workspaceDetail(optimisticWorkspaceId),
+					exact: true,
+				});
+				queryClient.removeQueries({
+					queryKey: helmorQueryKeys.workspaceSessions(optimisticWorkspaceId),
+					exact: true,
+				});
 				await refetchNavigation();
 				prefetchWorkspace(response.selectedWorkspaceId);
 				onSelectWorkspace(response.selectedWorkspaceId);
 			} catch (error) {
+				const rollback =
+					creatingWorkspaceRollbackRef.current.get(optimisticWorkspaceId) ??
+					null;
+				creatingWorkspaceRollbackRef.current.delete(optimisticWorkspaceId);
+				queryClient.setQueryData(
+					helmorQueryKeys.workspaceGroups,
+					rollback?.previousGroups ??
+						removeOptimisticWorkspaceRow(groups, optimisticWorkspaceId),
+				);
+				queryClient.removeQueries({
+					queryKey: helmorQueryKeys.workspaceDetail(optimisticWorkspaceId),
+					exact: true,
+				});
+				queryClient.removeQueries({
+					queryKey: helmorQueryKeys.workspaceSessions(optimisticWorkspaceId),
+					exact: true,
+				});
+				if (selectedWorkspaceId === optimisticWorkspaceId) {
+					onSelectWorkspace(
+						rollback?.previousSelection ?? findInitialWorkspaceId(groups),
+					);
+				}
 				pushWorkspaceToast(
 					describeUnknownError(error, "Unable to create workspace."),
 				);
@@ -778,10 +885,14 @@ export function useWorkspacesSidebarController({
 		},
 		[
 			creatingWorkspaceRepoId,
+			groups,
 			onSelectWorkspace,
 			prefetchWorkspace,
 			pushWorkspaceToast,
+			queryClient,
+			repositoriesQuery.data,
 			refetchNavigation,
+			selectedWorkspaceId,
 		],
 	);
 
@@ -1241,4 +1352,70 @@ export function useWorkspacesSidebarController({
 		handleTogglePin,
 		prefetchWorkspace,
 	};
+}
+
+function createOptimisticWorkspaceRow(
+	repository: RepositoryCreateOption,
+	workspaceId: string,
+): WorkspaceRow {
+	return {
+		id: workspaceId,
+		title: `Creating ${repository.name}`,
+		directoryName: workspaceId,
+		repoName: repository.name,
+		repoIconSrc: repository.repoIconSrc ?? null,
+		repoInitials: repository.repoInitials ?? null,
+		state: "initializing",
+		hasUnread: false,
+		workspaceUnread: 0,
+		sessionUnreadTotal: 0,
+		unreadSessionCount: 0,
+		derivedStatus: "in-progress",
+		manualStatus: null,
+		branch: null,
+		activeSessionId: null,
+		activeSessionTitle: null,
+		activeSessionAgentType: null,
+		activeSessionStatus: null,
+		prTitle: null,
+		pinnedAt: null,
+		sessionCount: 0,
+		messageCount: 0,
+		attachmentCount: 0,
+	};
+}
+
+function insertOptimisticWorkspaceRow(
+	groups: WorkspaceGroup[],
+	row: WorkspaceRow,
+): WorkspaceGroup[] {
+	return groups.map((group) =>
+		group.id === "progress"
+			? {
+					...group,
+					rows: group.rows.some((item) => item.id === row.id)
+						? group.rows
+						: [row, ...group.rows],
+				}
+			: group.rows.some((item) => item.id === row.id)
+				? {
+						...group,
+						rows: group.rows.filter((item) => item.id !== row.id),
+					}
+				: group,
+	);
+}
+
+function removeOptimisticWorkspaceRow(
+	groups: WorkspaceGroup[],
+	workspaceId: string,
+): WorkspaceGroup[] {
+	if (!isOptimisticCreatingWorkspaceId(workspaceId)) {
+		return groups;
+	}
+
+	return groups.map((group) => ({
+		...group,
+		rows: group.rows.filter((row) => row.id !== workspaceId),
+	}));
 }

--- a/src/features/navigation/index.test.tsx
+++ b/src/features/navigation/index.test.tsx
@@ -210,6 +210,30 @@ describe("WorkspacesSidebar", () => {
 		expect(onArchiveWorkspace).toHaveBeenCalledWith("workspace-2");
 	});
 
+	it("keeps workspace actions enabled while a new workspace is being created", async () => {
+		const user = userEvent.setup();
+		const onArchiveWorkspace = vi.fn();
+
+		render(
+			<TooltipProvider delayDuration={0}>
+				<WorkspacesSidebar
+					groups={workspaceGroups}
+					archivedRows={[]}
+					onArchiveWorkspace={onArchiveWorkspace}
+					creatingWorkspaceRepoId="repo-1"
+				/>
+			</TooltipProvider>,
+		);
+
+		const [archiveButton] = screen.getAllByRole("button", {
+			name: "Archive workspace",
+		});
+		expect(archiveButton).toBeEnabled();
+
+		await user.click(archiveButton);
+		expect(onArchiveWorkspace).toHaveBeenCalledWith("workspace-1");
+	});
+
 	it("persists section collapse state in localStorage", async () => {
 		const user = userEvent.setup();
 		const collapsedGroups: WorkspaceGroup[] = [

--- a/src/features/navigation/index.tsx
+++ b/src/features/navigation/index.tsx
@@ -414,9 +414,7 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 						markingUnreadWorkspaceId={markingUnreadWorkspaceId}
 						restoringWorkspaceId={restoringWorkspaceId}
 						workspaceActionsDisabled={Boolean(
-							creatingWorkspaceRepoId ||
-								markingUnreadWorkspaceId ||
-								restoringWorkspaceId,
+							markingUnreadWorkspaceId || restoringWorkspaceId,
 						)}
 						{...(item.isArchived
 							? {

--- a/src/features/panel/container.tsx
+++ b/src/features/panel/container.tsx
@@ -21,7 +21,10 @@ import {
 	workspaceSessionsQueryOptions,
 } from "@/lib/query-client";
 import { useSettings } from "@/lib/settings";
-import { resolveSessionDisplayProvider } from "@/lib/workspace-helpers";
+import {
+	isOptimisticCreatingWorkspaceId,
+	resolveSessionDisplayProvider,
+} from "@/lib/workspace-helpers";
 import {
 	WORKSPACE_SCRIPT_PROMPTS,
 	type WorkspaceScriptType,
@@ -78,11 +81,15 @@ export const WorkspacePanelContainer = memo(function WorkspacePanelContainer({
 
 	const detailQuery = useQuery({
 		...workspaceDetailQueryOptions(displayedWorkspaceId ?? "__none__"),
-		enabled: Boolean(displayedWorkspaceId),
+		enabled:
+			Boolean(displayedWorkspaceId) &&
+			!isOptimisticCreatingWorkspaceId(displayedWorkspaceId),
 	});
 	const sessionsQuery = useQuery({
 		...workspaceSessionsQueryOptions(displayedWorkspaceId ?? "__none__"),
-		enabled: Boolean(displayedWorkspaceId),
+		enabled:
+			Boolean(displayedWorkspaceId) &&
+			!isOptimisticCreatingWorkspaceId(displayedWorkspaceId),
 	});
 
 	const workspace = detailQuery.data ?? null;
@@ -114,7 +121,11 @@ export const WorkspacePanelContainer = memo(function WorkspacePanelContainer({
 			return;
 		}
 
-		if (workspace.state === "archived" || sessions.length > 0) {
+		if (
+			workspace.state === "archived" ||
+			workspace.state === "initializing" ||
+			sessions.length > 0
+		) {
 			autoCreatingWorkspaceRef.current.delete(displayedWorkspaceId);
 			return;
 		}

--- a/src/features/panel/index.tsx
+++ b/src/features/panel/index.tsx
@@ -144,6 +144,7 @@ export const WorkspacePanel = memo(function WorkspacePanel({
 					) : (
 						<div className="flex min-h-full flex-1 items-center justify-center px-8">
 							<EmptyState
+								workspaceState={workspace?.state ?? null}
 								hasSession={!!selectedSession}
 								missingScriptTypes={missingScriptTypes}
 								onInitializeScript={onInitializeScript}

--- a/src/features/panel/message-components/empty-state.tsx
+++ b/src/features/panel/message-components/empty-state.tsx
@@ -5,6 +5,7 @@ import {
 	MessageSquareText,
 	Play,
 } from "lucide-react";
+import { HelmorLogoAnimated } from "@/components/helmor-logo-animated";
 import {
 	Empty,
 	EmptyContent,
@@ -38,15 +39,19 @@ const SCRIPT_ACTION_COPY: Record<
 
 export function EmptyState({
 	hasSession,
+	workspaceState = null,
 	missingScriptTypes = [],
 	onInitializeScript,
 }: {
 	hasSession: boolean;
+	workspaceState?: string | null;
 	missingScriptTypes?: WorkspaceScriptType[];
 	onInitializeScript?: (scriptType: WorkspaceScriptType) => void;
 }) {
+	const isCreatingWorkspace = workspaceState === "initializing";
 	const showScriptActions =
 		hasSession &&
+		!isCreatingWorkspace &&
 		missingScriptTypes.length > 0 &&
 		typeof onInitializeScript === "function";
 
@@ -54,15 +59,25 @@ export function EmptyState({
 		<Empty className="max-w-xl">
 			<EmptyHeader>
 				<EmptyMedia className="mb-1 text-muted-foreground [&_svg:not([class*='size-'])]:size-7">
-					<MessageSquareText strokeWidth={1.7} />
+					{isCreatingWorkspace ? (
+						<HelmorLogoAnimated size={28} className="opacity-85" />
+					) : (
+						<MessageSquareText strokeWidth={1.7} />
+					)}
 				</EmptyMedia>
 				<EmptyTitle>
-					{hasSession ? "Nothing here yet" : "No session selected"}
+					{isCreatingWorkspace
+						? "Creating workspace"
+						: hasSession
+							? "Nothing here yet"
+							: "No session selected"}
 				</EmptyTitle>
 				<EmptyDescription>
-					{hasSession
-						? "This session does not have any messages yet."
-						: "Choose a session from the header to inspect its timeline."}
+					{isCreatingWorkspace
+						? "Helmor is still preparing this workspace. Messaging will unlock automatically when setup finishes."
+						: hasSession
+							? "This session does not have any messages yet."
+							: "Choose a session from the header to inspect its timeline."}
 				</EmptyDescription>
 			</EmptyHeader>
 			{showScriptActions ? (

--- a/src/lib/workspace-helpers.ts
+++ b/src/lib/workspace-helpers.ts
@@ -5,11 +5,68 @@ import type {
 	MessagePart,
 	PullRequestInfo,
 	ThreadMessageLike,
+	WorkspaceDetail,
 	WorkspaceGroup,
 	WorkspaceRow,
 	WorkspaceSessionSummary,
 	WorkspaceSummary,
 } from "./api";
+
+export const OPTIMISTIC_CREATING_WORKSPACE_ID_PREFIX = "creating-workspace:";
+
+export function createOptimisticCreatingWorkspaceId(repoId: string): string {
+	return `${OPTIMISTIC_CREATING_WORKSPACE_ID_PREFIX}${repoId}:${crypto.randomUUID()}`;
+}
+
+export function isOptimisticCreatingWorkspaceId(
+	workspaceId: string | null | undefined,
+): boolean {
+	return (
+		typeof workspaceId === "string" &&
+		workspaceId.startsWith(OPTIMISTIC_CREATING_WORKSPACE_ID_PREFIX)
+	);
+}
+
+export function createOptimisticCreatingWorkspaceDetail(
+	row: WorkspaceRow,
+	repoId: string,
+): WorkspaceDetail {
+	return {
+		id: row.id,
+		title: row.title,
+		repoId,
+		repoName: row.repoName ?? "",
+		repoIconSrc: row.repoIconSrc ?? null,
+		repoInitials: row.repoInitials ?? null,
+		remote: null,
+		remoteUrl: null,
+		defaultBranch: null,
+		rootPath: null,
+		directoryName: row.directoryName ?? row.id,
+		state: "initializing",
+		hasUnread: false,
+		workspaceUnread: 0,
+		sessionUnreadTotal: 0,
+		unreadSessionCount: 0,
+		derivedStatus: row.derivedStatus ?? "in-progress",
+		manualStatus: row.manualStatus ?? null,
+		activeSessionId: null,
+		activeSessionTitle: null,
+		activeSessionAgentType: null,
+		activeSessionStatus: null,
+		branch: row.branch ?? null,
+		initializationParentBranch: null,
+		intendedTargetBranch: null,
+		notes: null,
+		pinnedAt: row.pinnedAt ?? null,
+		prTitle: null,
+		prDescription: null,
+		archiveCommit: null,
+		sessionCount: 0,
+		messageCount: 0,
+		attachmentCount: 0,
+	};
+}
 
 export function findInitialWorkspaceId(
 	groups: WorkspaceGroup[],

--- a/src/shell/github-identity-gate.tsx
+++ b/src/shell/github-identity-gate.tsx
@@ -121,7 +121,10 @@ export function GithubIdentityGate({
 							</Button>
 						</div>
 					) : identityState.status === "unconfigured" ? (
-						<div className="mt-10 flex justify-center">
+						<div className="mt-10 flex w-full max-w-xs flex-col items-center gap-4">
+							<p className="text-center text-sm text-muted-foreground">
+								{identityState.message}
+							</p>
 							<Button disabled size="lg">
 								<MarkGithubIcon size={16} data-icon="inline-start" />
 								Continue with GitHub


### PR DESCRIPTION
## What changed
- adds an optimistic `initializing` workspace placeholder when creating a workspace from a repo, then swaps to the real workspace once creation completes
- teaches the app shell, panel, and composer to treat optimistic workspace ids as non-fetchable placeholders so PR/git/session queries do not run too early
- updates the empty state and sidebar behavior so workspace creation feels immediate while other workspace actions remain usable
- moves workspace-change notification off the blocking create path in the Tauri command handler

## Why
Workspace creation previously waited for the backend round trip before the UI showed the new workspace, and parts of the app could start querying against a workspace id that was not ready yet. This change makes creation feel immediate while avoiding premature fetches and keeping the rest of the navigation responsive.

## Test notes
- Added frontend tests for the optimistic workspace creation flow and for keeping workspace actions enabled during creation
- Not run in this session

## Follow-up
- Validate the end-to-end creation flow in the Tauri app to confirm the optimistic placeholder transitions cleanly on slower repositories
