### PR TITLE
Allow pull to continue while chat streaming

### DIFF
--- a/src/features/inspector/index.test.tsx
+++ b/src/features/inspector/index.test.tsx
@@ -304,7 +304,42 @@ describe("WorkspaceInspectorSidebar Actions section", () => {
 		});
 	});
 
-	it("shows a workspace toast instead of queueing when the current chat is still streaming", async () => {
+	it("still attempts pull while the current chat is streaming when no AI follow-up is needed", async () => {
+		const user = userEvent.setup();
+		const onQueuePendingPromptForSession = vi.fn();
+		const pushToast = vi.fn() as PushWorkspaceToast;
+		apiMocks.syncWorkspaceWithTargetBranch.mockResolvedValue({
+			outcome: "updated",
+			targetBranch: "main",
+			conflictedFiles: [],
+		});
+		apiMocks.loadWorkspaceGitActionStatus.mockResolvedValue({
+			uncommittedCount: 0,
+			conflictCount: 0,
+			syncTargetBranch: "main",
+			syncStatus: "behind",
+			behindTargetCount: 2,
+		});
+
+		renderInspector({
+			onQueuePendingPromptForSession,
+			pushToast,
+			sendingSessionIds: new Set(["session-1"]),
+		});
+
+		await screen.findByText("2 commits behind nathan/main");
+		await user.click(screen.getByRole("button", { name: "Pull" }));
+
+		await waitFor(() => {
+			expect(apiMocks.syncWorkspaceWithTargetBranch).toHaveBeenCalledWith(
+				"workspace-1",
+			);
+		});
+		expect(pushToast).not.toHaveBeenCalled();
+		expect(onQueuePendingPromptForSession).not.toHaveBeenCalled();
+	});
+
+	it("shows a workspace toast instead of queueing when pull needs AI follow-up and the current chat is still streaming", async () => {
 		const user = userEvent.setup();
 		const onQueuePendingPromptForSession = vi.fn();
 		const pushToast = vi.fn() as PushWorkspaceToast;
@@ -336,7 +371,9 @@ describe("WorkspaceInspectorSidebar Actions section", () => {
 				"AI is still responding",
 			);
 		});
-		expect(apiMocks.syncWorkspaceWithTargetBranch).not.toHaveBeenCalled();
+		expect(apiMocks.syncWorkspaceWithTargetBranch).toHaveBeenCalledWith(
+			"workspace-1",
+		);
 		expect(onQueuePendingPromptForSession).not.toHaveBeenCalled();
 	});
 

--- a/src/features/inspector/sections/actions.tsx
+++ b/src/features/inspector/sections/actions.tsx
@@ -199,13 +199,6 @@ export function ActionsSection({
 		if (!workspaceId || syncPending) {
 			return;
 		}
-		if (currentSessionId && sendingSessionIds?.has(currentSessionId)) {
-			pushToast?.(
-				"AI is still responding in the current chat. Wait for that reply to finish, then retry Pull so Helmor can send the merge task in this conversation.",
-				"AI is still responding",
-			);
-			return;
-		}
 
 		setSyncPending(true);
 		try {


### PR DESCRIPTION
## What changed
- remove the early guard that blocked the inspector Pull action whenever the current chat was still streaming
- keep the follow-up handling in place so we only show the workspace toast when pull needs an AI merge/conflict task and the current chat is still busy
- update inspector tests to cover both the no-follow-up path and the follow-up-blocked path

## Why
- pulling can complete without any AI follow-up, so blocking the action just because a chat response is in flight prevented a valid workspace sync path
- the UI should only defer Pull when Helmor actually needs to queue an AI task into the active conversation

## Test notes
- `pnpm vitest run src/features/inspector/index.test.tsx`