### PR TITLE
Fix archived workspace root access

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -482,14 +482,18 @@ function AppShell({
 		selectedWorkspaceDetailQuery.data?.repoId,
 		selectedWorkspaceId,
 	]);
-	const workspaceRootPath =
-		selectedWorkspaceDetailQuery.data?.rootPath ??
+	const selectedWorkspaceDetail =
+		selectedWorkspaceDetailQuery.data ??
 		(selectedWorkspaceId
 			? queryClient.getQueryData<WorkspaceDetail | null>(
 					helmorQueryKeys.workspaceDetail(selectedWorkspaceId),
-				)?.rootPath
+				)
 			: null) ??
 		null;
+	const workspaceRootPath =
+		selectedWorkspaceDetail?.state === "archived"
+			? null
+			: (selectedWorkspaceDetail?.rootPath ?? null);
 
 	// Cmd+Shift+C to copy current workspace path
 	useEffect(() => {
@@ -536,7 +540,8 @@ function AppShell({
 		...workspaceGitActionStatusQueryOptions(selectedWorkspaceId ?? "__none__"),
 		enabled:
 			selectedWorkspaceId !== null &&
-			!isOptimisticCreatingWorkspaceId(selectedWorkspaceId),
+			!isOptimisticCreatingWorkspaceId(selectedWorkspaceId) &&
+			selectedWorkspaceDetail?.state !== "archived",
 	});
 	const workspaceGitActionStatus = workspaceGitActionStatusQuery.data ?? null;
 

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -333,7 +333,10 @@ export const WorkspaceComposerContainer = memo(
 			],
 		);
 
-		const workingDirectory = workspaceDetailQuery.data?.rootPath ?? null;
+		const workingDirectory =
+			workspaceDetailQuery.data?.state === "archived"
+				? null
+				: (workspaceDetailQuery.data?.rootPath ?? null);
 
 		// Narrow `provider` (which can be the loosely-typed agentType from a
 		// historical session) to a real AgentProvider before keying the


### PR DESCRIPTION
## What changed
- derive the selected workspace detail before computing `workspaceRootPath`
- treat archived workspaces as having no working directory/root path
- skip workspace git action status queries for archived workspaces
- stop the composer from passing an archived workspace root path as the working directory

## Why
Archived workspaces should not behave like active checked-out repositories. This change avoids trying to read or act on a root path for archived workspaces, which prevents invalid workspace-root and git-status behavior.

## Follow-up / test notes
- Tests not run in this pass
- Change is limited to archived-workspace handling in the frontend