### PR TITLE
fix: stabilize workspace sidebar transitions

### DIFF
--- a/src/features/navigation/hooks/use-controller.test.tsx
+++ b/src/features/navigation/hooks/use-controller.test.tsx
@@ -11,6 +11,7 @@ import type {
 	WorkspaceSessionSummary,
 	WorkspaceSummary,
 } from "@/lib/api";
+import { helmorQueryKeys } from "@/lib/query-client";
 import { DEFAULT_SETTINGS, SettingsContext } from "@/lib/settings";
 import { useWorkspacesSidebarController } from "./use-controller";
 
@@ -314,6 +315,82 @@ describe("useWorkspacesSidebarController archive flow", () => {
 		expect(pushWorkspaceToast).not.toHaveBeenCalled();
 	});
 
+	it("连续 archive 时会按当前 sidebar 位置向下顺延，而不是跳到 archived", async () => {
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false } },
+		});
+		const onSelectWorkspace = vi.fn();
+		const pushWorkspaceToast = vi.fn();
+
+		apiMocks.loadWorkspaceGroups.mockResolvedValue([
+			{
+				id: "progress",
+				label: "In progress",
+				tone: "progress",
+				rows: [
+					{
+						...workspaceGroups[0].rows[0],
+						id: "ws-1",
+						title: "Workspace 1",
+					},
+					{
+						...workspaceGroups[0].rows[0],
+						id: "ws-2",
+						title: "Workspace 2",
+					},
+					{
+						...workspaceGroups[0].rows[0],
+						id: "ws-3",
+						title: "Workspace 3",
+					},
+				],
+			},
+		]);
+		apiMocks.loadArchivedWorkspaces.mockResolvedValue([
+			makeArchivedSummary("arch-1"),
+		]);
+
+		const { result, rerender } = renderHook(
+			({ selectedWorkspaceId }: { selectedWorkspaceId: string | null }) =>
+				useWorkspacesSidebarController({
+					selectedWorkspaceId,
+					onSelectWorkspace,
+					pushWorkspaceToast,
+				}),
+			{
+				initialProps: { selectedWorkspaceId: "ws-1" },
+				wrapper: createWrapper(queryClient),
+			},
+		);
+
+		await waitFor(() => {
+			expect(result.current.groups[0]?.rows.map((row) => row.id)).toEqual([
+				"ws-1",
+				"ws-2",
+				"ws-3",
+			]);
+		});
+
+		act(() => {
+			result.current.handleArchiveWorkspace("ws-1");
+		});
+
+		await waitFor(() => {
+			expect(onSelectWorkspace).toHaveBeenLastCalledWith("ws-2");
+		});
+
+		rerender({ selectedWorkspaceId: "ws-2" });
+
+		act(() => {
+			result.current.handleArchiveWorkspace("ws-2");
+		});
+
+		await waitFor(() => {
+			expect(onSelectWorkspace).toHaveBeenLastCalledWith("ws-3");
+		});
+		expect(pushWorkspaceToast).not.toHaveBeenCalled();
+	});
+
 	it("创建 workspace 时先插入 initializing 占位项，再切到真实 workspace", async () => {
 		const queryClient = new QueryClient({
 			defaultOptions: { queries: { retry: false } },
@@ -387,6 +464,181 @@ describe("useWorkspacesSidebarController archive flow", () => {
 		});
 		expect(onSelectWorkspace).toHaveBeenCalledWith("ws-created");
 		expect(pushWorkspaceToast).not.toHaveBeenCalled();
+	});
+
+	it("创建成功后会直接把 optimistic row 升级成真实 workspace，避免 sidebar 真空期", async () => {
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false } },
+		});
+		const onSelectWorkspace = vi.fn();
+		let resolveCreate:
+			| ((value: {
+					createdWorkspaceId: string;
+					selectedWorkspaceId: string;
+					createdState: string;
+					directoryName: string;
+					branch: string;
+			  }) => void)
+			| null = null;
+
+		apiMocks.listRepositories.mockResolvedValue([
+			{
+				id: "repo-1",
+				name: "helmor",
+				defaultBranch: "main",
+				repoInitials: "HE",
+			},
+		]);
+		apiMocks.createWorkspaceFromRepo.mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					resolveCreate = resolve;
+				}),
+		);
+
+		const { result } = renderHook(
+			() =>
+				useWorkspacesSidebarController({
+					selectedWorkspaceId: null,
+					onSelectWorkspace,
+					pushWorkspaceToast: vi.fn(),
+				}),
+			{ wrapper: createWrapper(queryClient) },
+		);
+
+		await waitFor(() => {
+			expect(result.current.groups[0]?.rows.map((row) => row.id)).toEqual([
+				"ws-1",
+				"ws-2",
+			]);
+		});
+
+		act(() => {
+			void result.current.handleCreateWorkspaceFromRepo("repo-1");
+		});
+
+		await waitFor(() => {
+			expect(result.current.groups[0]?.rows[0]?.id).toMatch(
+				/^creating-workspace:/,
+			);
+		});
+
+		await act(async () => {
+			resolveCreate?.({
+				createdWorkspaceId: "ws-created",
+				selectedWorkspaceId: "ws-created",
+				createdState: "initializing",
+				directoryName: "caspian-helmor",
+				branch: "caspian/helmor",
+			});
+		});
+
+		await waitFor(() => {
+			expect(result.current.groups[0]?.rows[0]?.id).toBe("ws-created");
+		});
+
+		expect(
+			queryClient.getQueryData(helmorQueryKeys.workspaceDetail("ws-created")),
+		).toMatchObject({
+			id: "ws-created",
+			directoryName: "caspian-helmor",
+			branch: "caspian/helmor",
+		});
+		expect(
+			queryClient.getQueryData(helmorQueryKeys.workspaceSessions("ws-created")),
+		).toEqual([]);
+		expect(onSelectWorkspace).toHaveBeenCalledWith("ws-created");
+	});
+
+	it("创建成功时如果真实 workspace 已经进了 cache，也不会和 optimistic 升级项并存", async () => {
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false } },
+		});
+		let resolveCreate:
+			| ((value: {
+					createdWorkspaceId: string;
+					selectedWorkspaceId: string;
+					createdState: string;
+					directoryName: string;
+					branch: string;
+			  }) => void)
+			| null = null;
+
+		apiMocks.listRepositories.mockResolvedValue([
+			{
+				id: "repo-1",
+				name: "helmor",
+				defaultBranch: "main",
+				repoInitials: "HE",
+			},
+		]);
+		apiMocks.createWorkspaceFromRepo.mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					resolveCreate = resolve;
+				}),
+		);
+
+		const { result } = renderHook(
+			() =>
+				useWorkspacesSidebarController({
+					selectedWorkspaceId: null,
+					onSelectWorkspace: vi.fn(),
+					pushWorkspaceToast: vi.fn(),
+				}),
+			{ wrapper: createWrapper(queryClient) },
+		);
+
+		await waitFor(() => {
+			expect(result.current.groups[0]?.rows.map((row) => row.id)).toEqual([
+				"ws-1",
+				"ws-2",
+			]);
+		});
+
+		act(() => {
+			void result.current.handleCreateWorkspaceFromRepo("repo-1");
+		});
+
+		await waitFor(() => {
+			expect(result.current.groups[0]?.rows[0]?.id).toMatch(
+				/^creating-workspace:/,
+			);
+		});
+
+		act(() => {
+			queryClient.setQueryData(helmorQueryKeys.workspaceGroups, [
+				{
+					...workspaceGroups[0],
+					rows: [
+						{
+							...workspaceGroups[0].rows[0],
+							id: "ws-created",
+							title: "Workspace created",
+							state: "initializing",
+							branch: "caspian/helmor",
+						},
+						...workspaceGroups[0].rows,
+					],
+				},
+			]);
+		});
+
+		await act(async () => {
+			resolveCreate?.({
+				createdWorkspaceId: "ws-created",
+				selectedWorkspaceId: "ws-created",
+				createdState: "initializing",
+				directoryName: "caspian-helmor",
+				branch: "caspian/helmor",
+			});
+		});
+
+		await waitFor(() => {
+			expect(
+				result.current.groups[0]?.rows.filter((row) => row.id === "ws-created"),
+			).toHaveLength(1);
+		});
 	});
 
 	it("后台启动立即失败时会回滚乐观更新", async () => {
@@ -560,6 +812,72 @@ describe("useWorkspacesSidebarController archive flow", () => {
 		expect(result.current.archivedRows.map((row) => row.id)).toEqual(["ws-1"]);
 		expect(apiMocks.loadWorkspaceGroups).toHaveBeenCalledTimes(2);
 		expect(apiMocks.loadArchivedWorkspaces).toHaveBeenCalledTimes(2);
+
+		act(() => {
+			resolveStart?.();
+		});
+	});
+
+	it("成功事件先到、服务端快照未切换时，也不会把同一 workspace 同时渲染到 live 和 archived", async () => {
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false } },
+		});
+		let resolveStart: (() => void) | null = null;
+		apiMocks.startArchiveWorkspace.mockImplementation(
+			() =>
+				new Promise<void>((resolve) => {
+					resolveStart = resolve;
+				}),
+		);
+
+		const { result } = renderHook(
+			() =>
+				useWorkspacesSidebarController({
+					selectedWorkspaceId: null,
+					onSelectWorkspace: vi.fn(),
+					pushWorkspaceToast: vi.fn(),
+				}),
+			{ wrapper: createWrapper(queryClient) },
+		);
+
+		await waitFor(() => {
+			expect(result.current.groups[0]?.rows.map((row) => row.id)).toEqual([
+				"ws-1",
+				"ws-2",
+			]);
+		});
+
+		act(() => {
+			result.current.handleArchiveWorkspace("ws-1");
+		});
+
+		await waitFor(() => {
+			expect(result.current.groups[0]?.rows.map((row) => row.id)).toEqual([
+				"ws-2",
+			]);
+			expect(result.current.archivedRows.map((row) => row.id)).toEqual([
+				"ws-1",
+			]);
+		});
+
+		act(() => {
+			apiMocks.emitArchiveSucceeded({ workspaceId: "ws-1" });
+		});
+
+		await waitFor(() => {
+			expect(result.current.groups[0]?.rows.map((row) => row.id)).toEqual([
+				"ws-2",
+			]);
+			expect(result.current.archivedRows.map((row) => row.id)).toEqual([
+				"ws-1",
+			]);
+		});
+
+		const occurrences = [
+			...result.current.groups.flatMap((group) => group.rows),
+			...result.current.archivedRows,
+		].filter((row) => row.id === "ws-1");
+		expect(occurrences).toHaveLength(1);
 
 		act(() => {
 			resolveStart?.();

--- a/src/features/navigation/hooks/use-controller.ts
+++ b/src/features/navigation/hooks/use-controller.ts
@@ -40,13 +40,20 @@ import {
 	createOptimisticCreatingWorkspaceId,
 	describeUnknownError,
 	findInitialWorkspaceId,
+	findReplacementWorkspaceIdAfterRemoval,
 	findWorkspaceRowById,
 	hasWorkspaceId,
-	isOptimisticCreatingWorkspaceId,
 	rowToWorkspaceSummary,
 	summaryToArchivedRow,
 	workspaceGroupIdFromStatus,
 } from "@/lib/workspace-helpers";
+import {
+	type PendingArchiveEntry,
+	type PendingCreationEntry,
+	projectSidebarLists,
+	shouldReconcilePendingArchive,
+	shouldReconcilePendingCreation,
+} from "../sidebar-projection";
 
 type WorkspaceToastVariant = "default" | "destructive";
 
@@ -88,28 +95,19 @@ export function useWorkspacesSidebarController({
 	const [suppressedWorkspaceReadId, setSuppressedWorkspaceReadId] = useState<
 		string | null
 	>(null);
-	const creatingWorkspaceRollbackRef = useRef<
+	const [pendingArchives, setPendingArchives] = useState<
+		Map<string, PendingArchiveEntry>
+	>(() => new Map());
+	const [pendingCreations, setPendingCreations] = useState<
 		Map<
 			string,
 			{
-				row: WorkspaceRow;
-				repoId: string;
+				entry: PendingCreationEntry;
 				previousGroups: WorkspaceGroup[] | undefined;
 				previousSelection: string | null;
 			}
 		>
-	>(new Map());
-
-	const archiveRollbackRef = useRef<
-		Map<
-			string,
-			{
-				row: WorkspaceRow;
-				sourceGroupId: string;
-				sourceIndex: number;
-			}
-		>
-	>(new Map());
+	>(() => new Map());
 	const sidebarMutationCountRef = useRef(0);
 
 	const flushSidebarLists = useCallback(() => {
@@ -141,51 +139,32 @@ export function useWorkspacesSidebarController({
 
 	const baseGroups = groupsQuery.data ?? [];
 	const baseArchivedSummaries = archivedQuery.data ?? [];
-	const pendingCreatingEntries = Array.from(
-		creatingWorkspaceRollbackRef.current.entries(),
+	const projectedSidebar = useMemo(
+		() =>
+			projectSidebarLists({
+				baseGroups,
+				baseArchivedSummaries,
+				pendingArchives,
+				pendingCreations: new Map(
+					Array.from(pendingCreations.entries()).map(
+						([workspaceId, pendingCreation]) => [
+							workspaceId,
+							pendingCreation.entry,
+						],
+					),
+				),
+			}),
+		[baseArchivedSummaries, baseGroups, pendingArchives, pendingCreations],
 	);
-	const pendingArchivedEntries = Array.from(
-		archiveRollbackRef.current.entries(),
+	const groups = projectedSidebar.groups;
+	const archivedSummaries = useMemo(
+		() =>
+			projectedSidebar.archivedRows.map((row) => rowToWorkspaceSummary(row)),
+		[projectedSidebar.archivedRows],
 	);
-	const pendingArchivedIds = new Set(
-		pendingArchivedEntries.map(([workspaceId]) => workspaceId),
-	);
-	const groupsWithoutArchived =
-		pendingArchivedIds.size === 0
-			? baseGroups
-			: baseGroups.map((group) => ({
-					...group,
-					rows: group.rows.filter((row) => !pendingArchivedIds.has(row.id)),
-				}));
-	const groups =
-		pendingCreatingEntries.length === 0
-			? groupsWithoutArchived
-			: pendingCreatingEntries.reduce(
-					(currentGroups, [, rollback]) =>
-						insertOptimisticWorkspaceRow(currentGroups, rollback.row),
-					groupsWithoutArchived,
-				);
-	const archivedSummaries =
-		pendingArchivedEntries.length === 0
-			? baseArchivedSummaries
-			: [
-					...pendingArchivedEntries
-						.filter(
-							([workspaceId]) =>
-								!baseArchivedSummaries.some(
-									(summary) => summary.id === workspaceId,
-								),
-						)
-						.map(([, rollback]) =>
-							rowToWorkspaceSummary(rollback.row, {
-								state: "archived",
-							}),
-						),
-					...baseArchivedSummaries,
-				];
 	const archivedRows = useMemo(
-		() => archivedSummaries.map(summaryToArchivedRow),
-		[archivedSummaries],
+		() => projectedSidebar.archivedRows,
+		[projectedSidebar.archivedRows],
 	);
 
 	const updateArchivingWorkspaceId = useCallback(
@@ -206,8 +185,17 @@ export function useWorkspacesSidebarController({
 	const rollbackArchivedWorkspace = useCallback(
 		(workspaceId: string, error: unknown, fallbackMessage: string) => {
 			updateArchivingWorkspaceId(workspaceId, false);
-			const rollback = archiveRollbackRef.current.get(workspaceId);
-			archiveRollbackRef.current.delete(workspaceId);
+			let rollback: PendingArchiveEntry | null = null;
+			setPendingArchives((current) => {
+				const existing = current.get(workspaceId) ?? null;
+				if (!existing) {
+					return current;
+				}
+				rollback = existing;
+				const next = new Map(current);
+				next.delete(workspaceId);
+				return next;
+			});
 
 			if (!rollback) {
 				flushSidebarLists();
@@ -219,52 +207,13 @@ export function useWorkspacesSidebarController({
 				return;
 			}
 
-			queryClient.setQueryData(helmorQueryKeys.archivedWorkspaces, (current) =>
-				Array.isArray(current)
-					? (current as typeof archivedSummaries).filter(
-							(summary) => summary.id !== workspaceId,
-						)
-					: current,
-			);
-
-			queryClient.setQueryData(helmorQueryKeys.workspaceGroups, (current) => {
-				if (!Array.isArray(current)) {
-					return current;
-				}
-				return (current as typeof groups).map((group) => {
-					if (group.id !== rollback.sourceGroupId) {
-						return group;
-					}
-					if (group.rows.some((row) => row.id === workspaceId)) {
-						return group;
-					}
-					const nextRows = [...group.rows];
-					const insertAt = Math.min(
-						Math.max(rollback.sourceIndex, 0),
-						nextRows.length,
-					);
-					nextRows.splice(insertAt, 0, rollback.row);
-					return {
-						...group,
-						rows: nextRows,
-					};
-				});
-			});
-
 			pushWorkspaceToast(
 				describeUnknownError(error, fallbackMessage),
 				"Archive failed",
 				"destructive",
 			);
 		},
-		[
-			archivedSummaries,
-			flushSidebarLists,
-			groups,
-			pushWorkspaceToast,
-			queryClient,
-			updateArchivingWorkspaceId,
-		],
+		[flushSidebarLists, pushWorkspaceToast, updateArchivingWorkspaceId],
 	);
 
 	useEffect(() => {
@@ -293,7 +242,19 @@ export function useWorkspacesSidebarController({
 			if (disposed) {
 				return;
 			}
-			archiveRollbackRef.current.delete(payload.workspaceId);
+			setPendingArchives((current) => {
+				const existing = current.get(payload.workspaceId);
+				if (!existing || existing.stage === "confirmed") {
+					return current;
+				}
+				const next = new Map(current);
+				next.set(payload.workspaceId, {
+					...existing,
+					stage: "confirmed",
+					sortTimestamp: Date.now(),
+				});
+				return next;
+			});
 			void queryClient.invalidateQueries({
 				queryKey: helmorQueryKeys.workspaceGroups,
 			});
@@ -314,6 +275,65 @@ export function useWorkspacesSidebarController({
 			unlistenSuccess?.();
 		};
 	}, [queryClient, rollbackArchivedWorkspace]);
+
+	useEffect(() => {
+		if (pendingArchives.size === 0) {
+			return;
+		}
+
+		const resolvedIds: string[] = [];
+		for (const [workspaceId, pendingArchive] of pendingArchives) {
+			if (
+				pendingArchive.stage === "confirmed" &&
+				shouldReconcilePendingArchive(
+					workspaceId,
+					baseGroups,
+					baseArchivedSummaries,
+				)
+			) {
+				resolvedIds.push(workspaceId);
+			}
+		}
+
+		if (resolvedIds.length === 0) {
+			return;
+		}
+
+		setPendingArchives((current) => {
+			let changed = false;
+			const next = new Map(current);
+			for (const workspaceId of resolvedIds) {
+				changed = next.delete(workspaceId) || changed;
+			}
+			return changed ? next : current;
+		});
+	}, [baseArchivedSummaries, baseGroups, pendingArchives]);
+
+	useEffect(() => {
+		if (pendingCreations.size === 0) {
+			return;
+		}
+
+		const resolvedIds: string[] = [];
+		for (const [workspaceId, pendingCreation] of pendingCreations) {
+			if (shouldReconcilePendingCreation(pendingCreation.entry, baseGroups)) {
+				resolvedIds.push(workspaceId);
+			}
+		}
+
+		if (resolvedIds.length === 0) {
+			return;
+		}
+
+		setPendingCreations((current) => {
+			let changed = false;
+			const next = new Map(current);
+			for (const workspaceId of resolvedIds) {
+				changed = next.delete(workspaceId) || changed;
+			}
+			return changed ? next : current;
+		});
+	}, [baseGroups, pendingCreations]);
 
 	useEffect(() => {
 		if (
@@ -807,18 +827,21 @@ export function useWorkspacesSidebarController({
 			const previousGroups = queryClient.getQueryData<WorkspaceGroup[]>(
 				helmorQueryKeys.workspaceGroups,
 			);
-			creatingWorkspaceRollbackRef.current.set(optimisticWorkspaceId, {
-				row: optimisticRow,
-				repoId,
-				previousGroups,
-				previousSelection: selectedWorkspaceId,
+			setPendingCreations((current) => {
+				const next = new Map(current);
+				next.set(optimisticWorkspaceId, {
+					entry: {
+						repoId,
+						row: optimisticRow,
+						stage: "creating",
+						resolvedWorkspaceId: null,
+					},
+					previousGroups,
+					previousSelection: selectedWorkspaceId,
+				});
+				return next;
 			});
 
-			queryClient.setQueryData(
-				helmorQueryKeys.workspaceGroups,
-				(current: WorkspaceGroup[] | undefined) =>
-					insertOptimisticWorkspaceRow(current ?? groups, optimisticRow),
-			);
 			queryClient.setQueryData<WorkspaceDetail | null>(
 				helmorQueryKeys.workspaceDetail(optimisticWorkspaceId),
 				createOptimisticCreatingWorkspaceDetail(optimisticRow, repoId),
@@ -833,14 +856,39 @@ export function useWorkspacesSidebarController({
 
 			try {
 				const response = await createWorkspaceFromRepo(repoId);
-				creatingWorkspaceRollbackRef.current.delete(optimisticWorkspaceId);
-				queryClient.setQueryData(
-					helmorQueryKeys.workspaceGroups,
-					(current: WorkspaceGroup[] | undefined) =>
-						removeOptimisticWorkspaceRow(
-							current ?? groups,
-							optimisticWorkspaceId,
+				const resolvedOptimisticRow = createResolvedWorkspaceRow(
+					optimisticRow,
+					response,
+				);
+				setPendingCreations((current) => {
+					const pendingCreation = current.get(optimisticWorkspaceId);
+					if (!pendingCreation) {
+						return current;
+					}
+					const next = new Map(current);
+					next.set(optimisticWorkspaceId, {
+						...pendingCreation,
+						entry: {
+							...pendingCreation.entry,
+							row: resolvedOptimisticRow,
+							stage: "confirmed",
+							resolvedWorkspaceId: response.selectedWorkspaceId,
+						},
+					});
+					return next;
+				});
+				queryClient.setQueryData<WorkspaceDetail | null>(
+					helmorQueryKeys.workspaceDetail(response.selectedWorkspaceId),
+					(current) =>
+						current ??
+						createOptimisticResolvedWorkspaceDetail(
+							resolvedOptimisticRow,
+							repoId,
 						),
+				);
+				queryClient.setQueryData<WorkspaceSessionSummary[]>(
+					helmorQueryKeys.workspaceSessions(response.selectedWorkspaceId),
+					(current) => current ?? [],
 				);
 				queryClient.removeQueries({
 					queryKey: helmorQueryKeys.workspaceDetail(optimisticWorkspaceId),
@@ -850,19 +898,31 @@ export function useWorkspacesSidebarController({
 					queryKey: helmorQueryKeys.workspaceSessions(optimisticWorkspaceId),
 					exact: true,
 				});
-				await refetchNavigation();
-				prefetchWorkspace(response.selectedWorkspaceId);
 				onSelectWorkspace(response.selectedWorkspaceId);
+				prefetchWorkspace(response.selectedWorkspaceId);
+				void refetchNavigation();
 			} catch (error) {
-				const rollback =
-					creatingWorkspaceRollbackRef.current.get(optimisticWorkspaceId) ??
-					null;
-				creatingWorkspaceRollbackRef.current.delete(optimisticWorkspaceId);
-				queryClient.setQueryData(
-					helmorQueryKeys.workspaceGroups,
-					rollback?.previousGroups ??
-						removeOptimisticWorkspaceRow(groups, optimisticWorkspaceId),
-				);
+				let rollback: {
+					entry: PendingCreationEntry;
+					previousGroups: WorkspaceGroup[] | undefined;
+					previousSelection: string | null;
+				} | null = null;
+				setPendingCreations((current) => {
+					const pendingCreation = current.get(optimisticWorkspaceId) ?? null;
+					if (!pendingCreation) {
+						return current;
+					}
+					rollback = pendingCreation;
+					const next = new Map(current);
+					next.delete(optimisticWorkspaceId);
+					return next;
+				});
+				if (rollback?.previousGroups) {
+					queryClient.setQueryData(
+						helmorQueryKeys.workspaceGroups,
+						rollback.previousGroups,
+					);
+				}
 				queryClient.removeQueries({
 					queryKey: helmorQueryKeys.workspaceDetail(optimisticWorkspaceId),
 					exact: true,
@@ -946,7 +1006,14 @@ export function useWorkspacesSidebarController({
 	const handleDeleteWorkspace = useCallback(
 		(workspaceId: string) => {
 			const wasSelected = selectedWorkspaceId === workspaceId;
-			archiveRollbackRef.current.delete(workspaceId);
+			setPendingArchives((current) => {
+				if (!current.has(workspaceId)) {
+					return current;
+				}
+				const next = new Map(current);
+				next.delete(workspaceId);
+				return next;
+			});
 			const previousGroups = queryClient.getQueryData(
 				helmorQueryKeys.workspaceGroups,
 			);
@@ -1121,39 +1188,54 @@ export function useWorkspacesSidebarController({
 					return;
 				}
 
+				const sortTimestamp = Date.now();
+				const pendingArchive: PendingArchiveEntry = {
+					row: {
+						...movedRow,
+						state: "archived",
+					},
+					sourceGroupId,
+					sourceIndex,
+					stage: "running",
+					sortTimestamp,
+				};
+				setPendingArchives((current) => {
+					const next = new Map(current);
+					next.set(workspaceId, pendingArchive);
+					return next;
+				});
+
 				queryClient.setQueryData(
 					helmorQueryKeys.workspaceGroups,
 					optimisticGroups,
 				);
 
-				const archivedPlaceholder = rowToWorkspaceSummary(movedRow, {
-					state: "archived",
+				const optimisticArchived = projectSidebarLists({
+					baseGroups: optimisticGroups,
+					baseArchivedSummaries,
+					pendingArchives: new Map([
+						...pendingArchives,
+						[workspaceId, pendingArchive],
+					]),
+					pendingCreations: new Map(
+						Array.from(pendingCreations.entries()).map(
+							([optimisticWorkspaceId, pendingCreation]) => [
+								optimisticWorkspaceId,
+								pendingCreation.entry,
+							],
+						),
+					),
 				});
-				archiveRollbackRef.current.set(workspaceId, {
-					row: movedRow,
-					sourceGroupId,
-					sourceIndex,
-				});
-				queryClient.setQueryData(
-					helmorQueryKeys.archivedWorkspaces,
-					(current) =>
-						Array.isArray(current)
-							? [archivedPlaceholder, ...(current as typeof archivedSummaries)]
-							: [archivedPlaceholder],
-				);
-
-				const optimisticArchived =
-					(queryClient.getQueryData(
-						helmorQueryKeys.archivedWorkspaces,
-					) as typeof archivedSummaries) ?? [];
 				const shouldNavigate =
 					!selectedWorkspaceId || selectedWorkspaceId === workspaceId;
 				if (shouldNavigate) {
-					const nextWorkspaceId =
-						findInitialWorkspaceId(optimisticGroups) ??
-						optimisticArchived.find((summary) => summary.id !== workspaceId)
-							?.id ??
-						null;
+					const nextWorkspaceId = findReplacementWorkspaceIdAfterRemoval({
+						currentGroups: groups,
+						currentArchivedRows: archivedRows,
+						nextGroups: optimisticGroups,
+						nextArchivedRows: optimisticArchived.archivedRows,
+						removedWorkspaceId: workspaceId,
+					});
 					if (nextWorkspaceId) {
 						prefetchWorkspace(nextWorkspaceId);
 					}
@@ -1175,8 +1257,10 @@ export function useWorkspacesSidebarController({
 		},
 		[
 			archivingWorkspaceIds,
+			baseArchivedSummaries,
 			groups,
 			onSelectWorkspace,
+			pendingArchives,
 			prefetchWorkspace,
 			pushWorkspaceToast,
 			queryClient,
@@ -1290,6 +1374,7 @@ export function useWorkspacesSidebarController({
 			endSidebarMutation,
 			notifyBranchRename,
 			onSelectWorkspace,
+			pendingCreations,
 			prefetchWorkspace,
 			pushPermanentDeleteRecoveryToast,
 			queryClient,
@@ -1385,37 +1470,35 @@ function createOptimisticWorkspaceRow(
 	};
 }
 
-function insertOptimisticWorkspaceRow(
-	groups: WorkspaceGroup[],
+function createResolvedWorkspaceRow(
 	row: WorkspaceRow,
-): WorkspaceGroup[] {
-	return groups.map((group) =>
-		group.id === "progress"
-			? {
-					...group,
-					rows: group.rows.some((item) => item.id === row.id)
-						? group.rows
-						: [row, ...group.rows],
-				}
-			: group.rows.some((item) => item.id === row.id)
-				? {
-						...group,
-						rows: group.rows.filter((item) => item.id !== row.id),
-					}
-				: group,
-	);
+	response: {
+		selectedWorkspaceId: string;
+		createdState: string;
+		directoryName: string;
+		branch: string;
+	},
+): WorkspaceRow {
+	return {
+		...row,
+		id: response.selectedWorkspaceId,
+		title: row.repoName ? `${row.repoName} workspace` : row.title,
+		directoryName: response.directoryName,
+		state: response.createdState,
+		branch: response.branch,
+	};
 }
 
-function removeOptimisticWorkspaceRow(
-	groups: WorkspaceGroup[],
-	workspaceId: string,
-): WorkspaceGroup[] {
-	if (!isOptimisticCreatingWorkspaceId(workspaceId)) {
-		return groups;
-	}
-
-	return groups.map((group) => ({
-		...group,
-		rows: group.rows.filter((row) => row.id !== workspaceId),
-	}));
+function createOptimisticResolvedWorkspaceDetail(
+	row: WorkspaceRow,
+	repoId: string,
+): WorkspaceDetail {
+	return {
+		...createOptimisticCreatingWorkspaceDetail(row, repoId),
+		id: row.id,
+		title: row.title,
+		directoryName: row.directoryName ?? row.id,
+		state: row.state ?? "initializing",
+		branch: row.branch ?? null,
+	};
 }

--- a/src/features/navigation/index.tsx
+++ b/src/features/navigation/index.tsx
@@ -296,7 +296,7 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 				case "group-header":
 					return `header-${item.groupId}`;
 				case "row":
-					return `row-${item.row.id}`;
+					return `row-${item.groupId}-${item.row.id}`;
 				case "group-gap":
 					return `gap-${index}`;
 				case "bottom-padding":

--- a/src/features/navigation/sidebar-projection.test.ts
+++ b/src/features/navigation/sidebar-projection.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from "vitest";
+import type { WorkspaceGroup, WorkspaceSummary } from "@/lib/api";
+import {
+	type PendingArchiveEntry,
+	type PendingCreationEntry,
+	projectSidebarLists,
+	shouldReconcilePendingArchive,
+	shouldReconcilePendingCreation,
+} from "./sidebar-projection";
+
+const liveGroups: WorkspaceGroup[] = [
+	{
+		id: "progress",
+		label: "In progress",
+		tone: "progress",
+		rows: [
+			{
+				id: "ws-1",
+				title: "Workspace 1",
+				state: "ready",
+				derivedStatus: "in-progress",
+			},
+			{
+				id: "ws-2",
+				title: "Workspace 2",
+				state: "ready",
+				derivedStatus: "in-progress",
+			},
+		],
+	},
+];
+
+function makeArchivedSummary(id: string): WorkspaceSummary {
+	return {
+		id,
+		title: `Archived ${id}`,
+		directoryName: id,
+		repoName: "helmor",
+		state: "archived",
+		hasUnread: false,
+		workspaceUnread: 0,
+		sessionUnreadTotal: 0,
+		unreadSessionCount: 0,
+		derivedStatus: "in-progress",
+		manualStatus: null,
+		branch: null,
+		activeSessionId: null,
+		activeSessionTitle: null,
+		activeSessionAgentType: null,
+		activeSessionStatus: null,
+		prTitle: null,
+		sessionCount: 0,
+		messageCount: 0,
+		attachmentCount: 0,
+	};
+}
+
+function makePendingArchive(
+	workspaceId: string,
+	sortTimestamp: number,
+): PendingArchiveEntry {
+	return {
+		row: {
+			id: workspaceId,
+			title: `Workspace ${workspaceId}`,
+			state: "archived",
+			derivedStatus: "in-progress",
+		},
+		sourceGroupId: "progress",
+		sourceIndex: 0,
+		stage: "running",
+		sortTimestamp,
+	};
+}
+
+function makePendingCreation(
+	workspaceId: string,
+	resolvedWorkspaceId: string | null = null,
+): PendingCreationEntry {
+	return {
+		repoId: "repo-1",
+		row: {
+			id: resolvedWorkspaceId ?? workspaceId,
+			title: "Creating helmor",
+			state: "initializing",
+			derivedStatus: "in-progress",
+		},
+		stage: resolvedWorkspaceId ? "confirmed" : "creating",
+		resolvedWorkspaceId,
+	};
+}
+
+describe("projectSidebarLists", () => {
+	it("keeps a pending archived workspace out of live groups even before server reconciliation", () => {
+		const projected = projectSidebarLists({
+			baseGroups: liveGroups,
+			baseArchivedSummaries: [],
+			pendingArchives: new Map([["ws-1", makePendingArchive("ws-1", 100)]]),
+			pendingCreations: new Map(),
+		});
+
+		expect(projected.groups[0]?.rows.map((row) => row.id)).toEqual(["ws-2"]);
+		expect(projected.archivedRows.map((row) => row.id)).toEqual(["ws-1"]);
+	});
+
+	it("dedupes a workspace once the server snapshot also contains it in archived", () => {
+		const projected = projectSidebarLists({
+			baseGroups: liveGroups,
+			baseArchivedSummaries: [makeArchivedSummary("ws-1")],
+			pendingArchives: new Map([["ws-1", makePendingArchive("ws-1", 100)]]),
+			pendingCreations: new Map(),
+		});
+
+		expect(projected.groups[0]?.rows.map((row) => row.id)).toEqual(["ws-2"]);
+		expect(projected.archivedRows.map((row) => row.id)).toEqual(["ws-1"]);
+	});
+
+	it("sorts optimistic archived placeholders by their latest archive timestamp", () => {
+		const projected = projectSidebarLists({
+			baseGroups: liveGroups,
+			baseArchivedSummaries: [],
+			pendingArchives: new Map([
+				["ws-1", makePendingArchive("ws-1", 100)],
+				["ws-2", makePendingArchive("ws-2", 200)],
+			]),
+			pendingCreations: new Map(),
+		});
+
+		expect(projected.archivedRows.map((row) => row.id)).toEqual([
+			"ws-2",
+			"ws-1",
+		]);
+	});
+
+	it("shows a pending creation as a single projected row even after the real workspace appears", () => {
+		const projected = projectSidebarLists({
+			baseGroups: [
+				{
+					...liveGroups[0],
+					rows: [
+						{
+							id: "ws-created",
+							title: "Workspace created",
+							state: "initializing",
+							derivedStatus: "in-progress",
+						},
+						...liveGroups[0].rows,
+					],
+				},
+			],
+			baseArchivedSummaries: [],
+			pendingArchives: new Map(),
+			pendingCreations: new Map([
+				[
+					"creating-workspace:repo-1:1",
+					makePendingCreation("creating-workspace:repo-1:1", "ws-created"),
+				],
+			]),
+		});
+
+		expect(
+			projected.groups[0]?.rows.filter((row) => row.id === "ws-created"),
+		).toHaveLength(1);
+	});
+});
+
+describe("shouldReconcilePendingArchive", () => {
+	it("waits until the workspace leaves live groups and appears in archived", () => {
+		expect(
+			shouldReconcilePendingArchive("ws-1", liveGroups, [
+				makeArchivedSummary("ws-1"),
+			]),
+		).toBe(false);
+		expect(
+			shouldReconcilePendingArchive(
+				"ws-1",
+				[{ ...liveGroups[0], rows: [] }],
+				[],
+			),
+		).toBe(false);
+		expect(
+			shouldReconcilePendingArchive(
+				"ws-1",
+				[{ ...liveGroups[0], rows: [] }],
+				[makeArchivedSummary("ws-1")],
+			),
+		).toBe(true);
+	});
+});
+
+describe("shouldReconcilePendingCreation", () => {
+	it("waits until the confirmed workspace appears in live groups", () => {
+		expect(
+			shouldReconcilePendingCreation(
+				makePendingCreation("creating-workspace:repo-1:1"),
+				liveGroups,
+			),
+		).toBe(false);
+		expect(
+			shouldReconcilePendingCreation(
+				makePendingCreation("creating-workspace:repo-1:1", "ws-created"),
+				liveGroups,
+			),
+		).toBe(false);
+		expect(
+			shouldReconcilePendingCreation(
+				makePendingCreation("creating-workspace:repo-1:1", "ws-created"),
+				[
+					{
+						...liveGroups[0],
+						rows: [
+							{
+								id: "ws-created",
+								title: "Workspace created",
+								state: "initializing",
+								derivedStatus: "in-progress",
+							},
+						],
+					},
+				],
+			),
+		).toBe(true);
+	});
+});

--- a/src/features/navigation/sidebar-projection.ts
+++ b/src/features/navigation/sidebar-projection.ts
@@ -1,0 +1,137 @@
+import type { WorkspaceGroup, WorkspaceRow, WorkspaceSummary } from "@/lib/api";
+import { summaryToArchivedRow } from "@/lib/workspace-helpers";
+
+export type PendingArchiveEntry = {
+	row: WorkspaceRow;
+	sourceGroupId: string;
+	sourceIndex: number;
+	stage: "preparing" | "running" | "confirmed";
+	sortTimestamp: number;
+};
+
+export type PendingCreationEntry = {
+	repoId: string;
+	row: WorkspaceRow;
+	stage: "creating" | "confirmed";
+	resolvedWorkspaceId: string | null;
+};
+
+type ProjectedArchivedRow = {
+	row: WorkspaceRow;
+	sortTimestamp: number;
+};
+
+export function projectSidebarLists({
+	baseGroups,
+	baseArchivedSummaries,
+	pendingArchives,
+	pendingCreations,
+}: {
+	baseGroups: WorkspaceGroup[];
+	baseArchivedSummaries: WorkspaceSummary[];
+	pendingArchives: ReadonlyMap<string, PendingArchiveEntry>;
+	pendingCreations: ReadonlyMap<string, PendingCreationEntry>;
+}): {
+	groups: WorkspaceGroup[];
+	archivedRows: WorkspaceRow[];
+} {
+	const hiddenLiveIds = new Set(pendingArchives.keys());
+	for (const [optimisticWorkspaceId, pendingCreation] of pendingCreations) {
+		hiddenLiveIds.add(optimisticWorkspaceId);
+		if (pendingCreation.resolvedWorkspaceId) {
+			hiddenLiveIds.add(pendingCreation.resolvedWorkspaceId);
+		}
+	}
+	const groups =
+		hiddenLiveIds.size === 0
+			? baseGroups
+			: baseGroups.map((group) => ({
+					...group,
+					rows: group.rows.filter((row) => !hiddenLiveIds.has(row.id)),
+				}));
+
+	const liveGroups = Array.from(pendingCreations.values()).reduce(
+		(currentGroups, pendingCreation) =>
+			insertPendingCreationRow(currentGroups, pendingCreation.row),
+		groups,
+	);
+
+	const archivedById = new Map<string, ProjectedArchivedRow>();
+	for (let index = 0; index < baseArchivedSummaries.length; index += 1) {
+		const summary = baseArchivedSummaries[index];
+		archivedById.set(summary.id, {
+			row: summaryToArchivedRow(summary),
+			// Keep the server ordering stable while allowing newer optimistic
+			// placeholders to sit above previously archived rows.
+			sortTimestamp: -index,
+		});
+	}
+
+	for (const [workspaceId, pendingArchive] of pendingArchives) {
+		if (archivedById.has(workspaceId)) {
+			continue;
+		}
+
+		archivedById.set(workspaceId, {
+			row: {
+				...pendingArchive.row,
+				state: "archived",
+			},
+			sortTimestamp: pendingArchive.sortTimestamp,
+		});
+	}
+
+	const archivedRows = Array.from(archivedById.values())
+		.sort((left, right) => right.sortTimestamp - left.sortTimestamp)
+		.map((entry) => entry.row);
+
+	return {
+		groups: liveGroups,
+		archivedRows,
+	};
+}
+
+export function shouldReconcilePendingArchive(
+	workspaceId: string,
+	baseGroups: WorkspaceGroup[],
+	baseArchivedSummaries: WorkspaceSummary[],
+): boolean {
+	const stillLive = baseGroups.some((group) =>
+		group.rows.some((row) => row.id === workspaceId),
+	);
+	if (stillLive) {
+		return false;
+	}
+
+	return baseArchivedSummaries.some((summary) => summary.id === workspaceId);
+}
+
+export function shouldReconcilePendingCreation(
+	pendingCreation: PendingCreationEntry,
+	baseGroups: WorkspaceGroup[],
+): boolean {
+	const resolvedWorkspaceId = pendingCreation.resolvedWorkspaceId;
+	if (pendingCreation.stage !== "confirmed" || !resolvedWorkspaceId) {
+		return false;
+	}
+
+	return baseGroups.some((group) =>
+		group.rows.some((row) => row.id === resolvedWorkspaceId),
+	);
+}
+
+function insertPendingCreationRow(
+	groups: WorkspaceGroup[],
+	row: WorkspaceRow,
+): WorkspaceGroup[] {
+	return groups.map((group) =>
+		group.id === "progress"
+			? {
+					...group,
+					rows: group.rows.some((item) => item.id === row.id)
+						? group.rows
+						: [row, ...group.rows],
+				}
+			: group,
+	);
+}

--- a/src/lib/workspace-helpers.ts
+++ b/src/lib/workspace-helpers.ts
@@ -80,6 +80,49 @@ export function findInitialWorkspaceId(
 	return null;
 }
 
+export function flattenWorkspaceRowsForNavigation(
+	groups: WorkspaceGroup[],
+	archivedRows: WorkspaceRow[],
+) {
+	return [...groups.flatMap((group) => group.rows), ...archivedRows];
+}
+
+export function findReplacementWorkspaceIdAfterRemoval({
+	currentGroups,
+	currentArchivedRows,
+	nextGroups,
+	nextArchivedRows,
+	removedWorkspaceId,
+}: {
+	currentGroups: WorkspaceGroup[];
+	currentArchivedRows: WorkspaceRow[];
+	nextGroups: WorkspaceGroup[];
+	nextArchivedRows: WorkspaceRow[];
+	removedWorkspaceId: string;
+}): string | null {
+	const currentRows = flattenWorkspaceRowsForNavigation(
+		currentGroups,
+		currentArchivedRows,
+	);
+	const removedIndex = currentRows.findIndex(
+		(row) => row.id === removedWorkspaceId,
+	);
+	const nextRows = flattenWorkspaceRowsForNavigation(
+		nextGroups,
+		nextArchivedRows,
+	);
+
+	if (nextRows.length === 0) {
+		return null;
+	}
+
+	if (removedIndex === -1) {
+		return nextRows[0]?.id ?? null;
+	}
+
+	return nextRows[removedIndex]?.id ?? nextRows[removedIndex - 1]?.id ?? null;
+}
+
 export function hasWorkspaceId(
 	workspaceId: string,
 	groups: WorkspaceGroup[],


### PR DESCRIPTION
## What changed
- extracted sidebar projection into a dedicated module so pending archive and creation state is reconciled in one place
- kept workspace row rendering stable during archive/create flows, including row keys and replacement selection behavior
- added regression coverage for repeated archive actions, optimistic creation upgrades, and archive/live deduping

## Why
- the sidebar could briefly jump, duplicate rows, or leave a gap while optimistic state and server snapshots were catching up
- centralizing the projection logic makes those transitions deterministic and easier to test

## Test notes
- not run manually in this session
- pre-commit hook ran `biome check --write --error-on-warnings --no-errors-on-unmatched --files-ignore-unknown=true --config-path=./biome.json` during commit