### PR TITLE
refactor(workspace): unblock setup_pending state and hoist setup auto-run to sidebar

### DIFF
--- a/src-tauri/src/agents/queries.rs
+++ b/src-tauri/src/agents/queries.rs
@@ -70,7 +70,7 @@ pub async fn generate_session_title(
                        FROM workspaces w
                        JOIN repos r ON r.id = w.repository_id
                        JOIN sessions s ON s.workspace_id = w.id
-                       WHERE s.id = ?1 AND w.state = 'ready'"#,
+                       WHERE s.id = ?1 AND w.state NOT IN ('archived', 'initializing')"#,
                     [&request.session_id],
                     |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
                 )

--- a/src-tauri/src/commands/tests/branch_switch.rs
+++ b/src-tauri/src/commands/tests/branch_switch.rs
@@ -145,8 +145,8 @@ fn branch_switch_archived_state_bails() {
     let err =
         workspaces::update_intended_target_branch_local(&harness.workspace_id, "dev").unwrap_err();
     assert!(
-        err.to_string().contains("not in ready state"),
-        "expected 'not in ready state' error, got: {err}"
+        err.to_string().contains("not found or archived"),
+        "expected 'not found or archived' error, got: {err}"
     );
 }
 

--- a/src-tauri/src/git/watcher.rs
+++ b/src-tauri/src/git/watcher.rs
@@ -105,8 +105,10 @@ impl GitWatcherManager {
     /// Sync watchers and auto-fetchers with the current DB state.
     pub fn sync_from_db<R: Runtime>(&self, app: AppHandle<R>) -> Result<()> {
         let workspaces = load_watchable_workspaces()?;
-        let ready: Vec<&WatchableWorkspace> =
-            workspaces.iter().filter(|w| w.state == "ready").collect();
+        let ready: Vec<&WatchableWorkspace> = workspaces
+            .iter()
+            .filter(|w| crate::helpers::is_operational_state(&w.state))
+            .collect();
         let ready_ids: HashMap<&str, &WatchableWorkspace> =
             ready.iter().map(|w| (w.id.as_str(), *w)).collect();
 
@@ -542,7 +544,7 @@ fn lookup_fetch_target(workspace_id: &str) -> Result<(PathBuf, String, String, S
                 COALESCE(w.intended_target_branch, r.default_branch), r.id
          FROM workspaces w
          JOIN repos r ON r.id = w.repository_id
-         WHERE w.id = ?1 AND w.state = 'ready'",
+         WHERE w.id = ?1 AND w.state NOT IN ('archived', 'initializing')",
     )?;
     let (repo_name, dir_name, remote, branch, repo_id) = stmt
         .query_row(rusqlite::params![workspace_id], |row| {
@@ -554,7 +556,7 @@ fn lookup_fetch_target(workspace_id: &str) -> Result<(PathBuf, String, String, S
                 row.get::<_, String>(4)?,
             ))
         })
-        .context("Workspace not found or not ready")?;
+        .context("Workspace not found or archived")?;
 
     let remote = remote.context("No remote configured")?;
     let branch = branch.context("No target branch configured")?;
@@ -633,11 +635,11 @@ fn update_branch_in_db(
     let connection = db::open_connection(true)?;
     let rows = match old_branch {
         Some(old) => connection.execute(
-            "UPDATE workspaces SET branch = ?1 WHERE id = ?2 AND state = 'ready' AND branch = ?3",
+            "UPDATE workspaces SET branch = ?1 WHERE id = ?2 AND state NOT IN ('archived', 'initializing') AND branch = ?3",
             (new_branch, workspace_id, old),
         ),
         None => connection.execute(
-            "UPDATE workspaces SET branch = ?1 WHERE id = ?2 AND state = 'ready' AND branch IS NULL",
+            "UPDATE workspaces SET branch = ?1 WHERE id = ?2 AND state NOT IN ('archived', 'initializing') AND branch IS NULL",
             (new_branch, workspace_id),
         ),
     }

--- a/src-tauri/src/models/repos.rs
+++ b/src-tauri/src/models/repos.rs
@@ -337,7 +337,7 @@ pub fn update_repository_remote(
 
     let mut stmt = connection
         .prepare(
-            "SELECT intended_target_branch FROM workspaces WHERE repository_id = ?1 AND state = 'ready'",
+            "SELECT intended_target_branch FROM workspaces WHERE repository_id = ?1 AND state NOT IN ('archived', 'initializing')",
         )
         .context("Failed to query workspace target branches")?;
     let targets: Vec<String> = stmt

--- a/src-tauri/src/workspace/branching.rs
+++ b/src-tauri/src/workspace/branching.rs
@@ -80,8 +80,11 @@ pub fn rename_workspace_branch(workspace_id: &str, new_branch: &str) -> Result<(
     let record = workspace_models::load_workspace_record_by_id(workspace_id)?
         .with_context(|| format!("Workspace not found: {workspace_id}"))?;
 
-    if record.state != "ready" {
-        bail!("Cannot rename branch: workspace is not in ready state");
+    if !helpers::is_operational_state(&record.state) {
+        bail!(
+            "Cannot rename branch: workspace is {} (archived or mid-creation)",
+            record.state
+        );
     }
 
     let old_branch = record
@@ -155,15 +158,13 @@ pub fn update_intended_target_branch_local(
         let connection = db::open_connection(true)?;
         let updated_rows = connection
             .execute(
-                "UPDATE workspaces SET intended_target_branch = ?2 WHERE id = ?1 AND state = 'ready'",
+                "UPDATE workspaces SET intended_target_branch = ?2 WHERE id = ?1 AND state NOT IN ('archived', 'initializing')",
                 (workspace_id, target_branch),
             )
             .context("Failed to update intended target branch")?;
 
         if updated_rows != 1 {
-            bail!(
-                "Cannot update target branch: workspace {workspace_id} not found or not in ready state"
-            );
+            bail!("Cannot update target branch: workspace {workspace_id} not found or archived");
         }
     }
 
@@ -193,7 +194,7 @@ fn try_realign_local_branch(
     record: &WorkspaceRecord,
     target_branch: &str,
 ) -> Result<Option<String>> {
-    if record.state != "ready" {
+    if !helpers::is_operational_state(&record.state) {
         return Ok(None);
     }
     if helpers::non_empty(&record.root_path).is_none() {
@@ -248,7 +249,7 @@ pub fn refresh_remote_and_realign(
     let Some(record) = workspace_models::load_workspace_record_by_id(workspace_id)? else {
         return Ok(false);
     };
-    if record.state != "ready" {
+    if !helpers::is_operational_state(&record.state) {
         return Ok(false);
     }
     let workspace_dir = crate::data_dir::workspace_dir(&record.repo_name, &record.directory_name)?;
@@ -267,7 +268,7 @@ pub fn refresh_remote_and_realign(
     let Some(fresh_record) = workspace_models::load_workspace_record_by_id(workspace_id)? else {
         return Ok(false);
     };
-    if fresh_record.state != "ready" {
+    if !helpers::is_operational_state(&fresh_record.state) {
         return Ok(false);
     }
 
@@ -358,7 +359,7 @@ pub fn prefetch_remote_refs(
     if let Some(ws_id) = workspace_id {
         let record = workspace_models::load_workspace_record_by_id(ws_id)?
             .with_context(|| format!("Workspace not found: {ws_id}"))?;
-        if record.state != "ready" {
+        if !helpers::is_operational_state(&record.state) {
             return Ok(PrefetchRemoteRefsResponse { fetched: false });
         }
         let workspace_dir =
@@ -382,8 +383,11 @@ pub fn sync_workspace_with_target_branch(
 ) -> Result<SyncWorkspaceTargetResponse> {
     let record = workspace_models::load_workspace_record_by_id(workspace_id)?
         .with_context(|| format!("Workspace not found: {workspace_id}"))?;
-    if record.state != "ready" {
-        bail!("Cannot sync target branch: workspace is not in ready state");
+    if !helpers::is_operational_state(&record.state) {
+        bail!(
+            "Cannot sync target branch: workspace is {} (archived or mid-creation)",
+            record.state
+        );
     }
 
     let target_branch = record
@@ -474,8 +478,11 @@ pub fn sync_workspace_with_target_branch(
 pub fn push_workspace_to_remote(workspace_id: &str) -> Result<PushWorkspaceToRemoteResponse> {
     let record = workspace_models::load_workspace_record_by_id(workspace_id)?
         .with_context(|| format!("Workspace not found: {workspace_id}"))?;
-    if record.state != "ready" {
-        bail!("Cannot push branch: workspace is not in ready state");
+    if !helpers::is_operational_state(&record.state) {
+        bail!(
+            "Cannot push branch: workspace is {} (archived or mid-creation)",
+            record.state
+        );
     }
 
     let remote = record

--- a/src-tauri/src/workspace/files/changes.rs
+++ b/src-tauri/src/workspace/files/changes.rs
@@ -273,7 +273,7 @@ pub(super) fn query_workspace_target(
             "SELECT r.remote, COALESCE(w.intended_target_branch, r.default_branch)
 			 FROM workspaces w
 			 JOIN repos r ON r.id = w.repository_id
-			 WHERE r.name = ?1 AND w.directory_name = ?2 AND w.state = 'ready'",
+			 WHERE r.name = ?1 AND w.directory_name = ?2 AND w.state NOT IN ('archived', 'initializing')",
         )
         .ok()?;
 

--- a/src-tauri/src/workspace/helpers.rs
+++ b/src-tauri/src/workspace/helpers.rs
@@ -55,6 +55,13 @@ pub fn non_empty(value: &Option<String>) -> Option<&str> {
     value.as_deref().filter(|inner| !inner.trim().is_empty())
 }
 
+/// Whether a workspace is operational for git/branch/sync ops.
+/// `setup_pending` counts as operational — it's a UI hint for auto-running
+/// setup scripts, not a lock on git state.
+pub fn is_operational_state(state: &str) -> bool {
+    !matches!(state, "archived" | "initializing")
+}
+
 // ---- Sidebar sorting helpers ----
 
 pub fn group_id_from_status(manual_status: &Option<String>, derived_status: &str) -> &'static str {

--- a/src/features/inspector/hooks/use-setup-auto-run.test.tsx
+++ b/src/features/inspector/hooks/use-setup-auto-run.test.tsx
@@ -1,0 +1,94 @@
+import { cleanup, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithProviders } from "@/test/render-with-providers";
+import { _resetForTesting } from "../script-store";
+import { useSetupAutoRun } from "./use-setup-auto-run";
+
+const apiMocks = vi.hoisted(() => ({
+	executeRepoScript: vi.fn(),
+	completeWorkspaceSetup: vi.fn(),
+}));
+
+vi.mock("@/lib/api", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/lib/api")>();
+	return {
+		...actual,
+		executeRepoScript: apiMocks.executeRepoScript,
+		completeWorkspaceSetup: apiMocks.completeWorkspaceSetup,
+	};
+});
+
+type Args = Parameters<typeof useSetupAutoRun>[0];
+
+function Harness(props: Args) {
+	useSetupAutoRun(props);
+	return null;
+}
+
+function renderHook(args: Partial<Args> = {}) {
+	const full: Args = {
+		repoId: "repo-1",
+		workspaceId: "ws-1",
+		workspaceState: "setup_pending",
+		setupScript: "echo hi",
+		scriptsLoaded: true,
+		...args,
+	};
+	return renderWithProviders(<Harness {...full} />);
+}
+
+describe("useSetupAutoRun", () => {
+	beforeEach(() => {
+		apiMocks.executeRepoScript.mockReset().mockResolvedValue(undefined);
+		apiMocks.completeWorkspaceSetup.mockReset().mockResolvedValue(undefined);
+	});
+
+	afterEach(() => {
+		_resetForTesting();
+		vi.restoreAllMocks();
+		cleanup();
+	});
+
+	it("auto-runs setup when pending and script is configured", () => {
+		renderHook();
+
+		expect(apiMocks.executeRepoScript).toHaveBeenCalledWith(
+			"repo-1",
+			"setup",
+			expect.any(Function),
+			"ws-1",
+		);
+	});
+
+	it("does NOT auto-run when workspace is ready", () => {
+		renderHook({ workspaceState: "ready" });
+
+		expect(apiMocks.executeRepoScript).not.toHaveBeenCalled();
+	});
+
+	it("does NOT auto-run when no script is configured", () => {
+		renderHook({ setupScript: null });
+
+		expect(apiMocks.executeRepoScript).not.toHaveBeenCalled();
+	});
+
+	it("auto-completes when pending and no script is configured", async () => {
+		renderHook({ setupScript: null });
+
+		await waitFor(() => {
+			expect(apiMocks.completeWorkspaceSetup).toHaveBeenCalledWith("ws-1");
+		});
+	});
+
+	it("does NOT auto-complete while scripts are still loading", () => {
+		renderHook({ setupScript: null, scriptsLoaded: false });
+
+		expect(apiMocks.completeWorkspaceSetup).not.toHaveBeenCalled();
+	});
+
+	it("does NOT auto-complete when workspaceId is null", () => {
+		renderHook({ workspaceId: null, setupScript: null });
+
+		expect(apiMocks.completeWorkspaceSetup).not.toHaveBeenCalled();
+	});
+});

--- a/src/features/inspector/hooks/use-setup-auto-run.ts
+++ b/src/features/inspector/hooks/use-setup-auto-run.ts
@@ -1,0 +1,65 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect } from "react";
+import { completeWorkspaceSetup } from "@/lib/api";
+import { helmorQueryKeys } from "@/lib/query-client";
+import { getScriptState, startScript } from "../script-store";
+
+type UseSetupAutoRunArgs = {
+	repoId: string | null;
+	workspaceId: string | null;
+	workspaceState: string | null;
+	setupScript: string | null;
+	scriptsLoaded: boolean;
+};
+
+/**
+ * Runs setup-script auto-trigger / auto-complete logic at the inspector
+ * sidebar level — independent of whether the Setup tab is mounted. The
+ * script-store is module-scoped, so triggering startScript here seamlessly
+ * hands output off to SetupTab if/when the user opens the tab.
+ */
+export function useSetupAutoRun({
+	repoId,
+	workspaceId,
+	workspaceState,
+	setupScript,
+	scriptsLoaded,
+}: UseSetupAutoRunArgs) {
+	const queryClient = useQueryClient();
+	const hasScript = !!setupScript?.trim();
+
+	// Auto-run setup when workspace is pending and a script is configured.
+	useEffect(() => {
+		if (
+			workspaceState !== "setup_pending" ||
+			!hasScript ||
+			!repoId ||
+			!workspaceId
+		) {
+			return;
+		}
+		// Module-level script-store dedup: if we've already started/finished
+		// a setup run for this workspace, don't trigger again.
+		if (getScriptState(workspaceId, "setup")) {
+			return;
+		}
+		startScript(repoId, "setup", workspaceId);
+	}, [workspaceState, hasScript, repoId, workspaceId]);
+
+	// Auto-complete if workspace is pending but no script is configured.
+	useEffect(() => {
+		if (
+			workspaceState !== "setup_pending" ||
+			!scriptsLoaded ||
+			hasScript ||
+			!workspaceId
+		) {
+			return;
+		}
+		void completeWorkspaceSetup(workspaceId).then(() => {
+			queryClient.invalidateQueries({
+				queryKey: helmorQueryKeys.workspaceDetail(workspaceId),
+			});
+		});
+	}, [workspaceState, scriptsLoaded, hasScript, workspaceId, queryClient]);
+}

--- a/src/features/inspector/index.tsx
+++ b/src/features/inspector/index.tsx
@@ -7,6 +7,7 @@ import type { DiffOpenOptions } from "@/lib/editor-session";
 import { cn } from "@/lib/utils";
 import type { PushWorkspaceToast } from "@/lib/workspace-toast-context";
 import { useWorkspaceInspectorSidebar } from "./hooks/use-inspector";
+import { useSetupAutoRun } from "./hooks/use-setup-auto-run";
 import { HorizontalResizeHandle, InspectorTabsSection } from "./layout";
 import { ActionsSection } from "./sections/actions";
 import { ChangesSection } from "./sections/changes";
@@ -87,6 +88,16 @@ export function WorkspaceInspectorSidebar({
 		repoId: repoId ?? null,
 	});
 
+	// Fire setup auto-run / auto-complete at the sidebar level so it runs even
+	// when the Setup tab isn't mounted (tabsOpen=false).
+	useSetupAutoRun({
+		repoId: repoId ?? null,
+		workspaceId: workspaceId ?? null,
+		workspaceState: workspaceState ?? null,
+		setupScript: repoScripts?.setupScript ?? null,
+		scriptsLoaded,
+	});
+
 	const handleOpenSettings = onOpenSettings ?? (() => {});
 
 	return (
@@ -151,9 +162,7 @@ export function WorkspaceInspectorSidebar({
 				<SetupTab
 					repoId={repoId ?? null}
 					workspaceId={workspaceId ?? null}
-					workspaceState={workspaceState ?? null}
 					setupScript={repoScripts?.setupScript ?? null}
-					scriptsLoaded={scriptsLoaded}
 					isActive={activeTab === "setup"}
 					onOpenSettings={handleOpenSettings}
 				/>

--- a/src/features/inspector/sections/setup.test.tsx
+++ b/src/features/inspector/sections/setup.test.tsx
@@ -11,7 +11,6 @@ import { SetupTab } from "./setup";
 const apiMocks = vi.hoisted(() => ({
 	executeRepoScript: vi.fn(),
 	stopRepoScript: vi.fn(),
-	completeWorkspaceSetup: vi.fn(),
 }));
 
 vi.mock("@/lib/api", async (importOriginal) => {
@@ -20,7 +19,6 @@ vi.mock("@/lib/api", async (importOriginal) => {
 		...actual,
 		executeRepoScript: apiMocks.executeRepoScript,
 		stopRepoScript: apiMocks.stopRepoScript,
-		completeWorkspaceSetup: apiMocks.completeWorkspaceSetup,
 	};
 });
 
@@ -35,9 +33,7 @@ vi.mock("@/components/terminal-output", () => ({
 const defaults = {
 	repoId: "repo-1",
 	workspaceId: "ws-1" as string | null,
-	workspaceState: "ready" as string | null,
 	setupScript: "echo hello" as string | null,
-	scriptsLoaded: true,
 	isActive: true,
 	onOpenSettings: vi.fn(),
 };
@@ -57,7 +53,6 @@ describe("SetupTab", () => {
 	beforeEach(() => {
 		apiMocks.executeRepoScript.mockReset().mockResolvedValue(undefined);
 		apiMocks.stopRepoScript.mockReset().mockResolvedValue(true);
-		apiMocks.completeWorkspaceSetup.mockReset().mockResolvedValue(undefined);
 	});
 
 	afterEach(() => {
@@ -83,49 +78,6 @@ describe("SetupTab", () => {
 		expect(
 			screen.getByRole("button", { name: /run setup/i }),
 		).toBeInTheDocument();
-	});
-
-	// ── Auto-run ───────────────────────────────────────────────────────────
-
-	it("auto-runs when workspace is setup_pending and script is available", () => {
-		renderSetup({ workspaceState: "setup_pending" });
-
-		expect(apiMocks.executeRepoScript).toHaveBeenCalledWith(
-			"repo-1",
-			"setup",
-			expect.any(Function),
-			"ws-1",
-		);
-	});
-
-	it("does NOT auto-run when workspace is ready", () => {
-		renderSetup({ workspaceState: "ready" });
-
-		expect(apiMocks.executeRepoScript).not.toHaveBeenCalled();
-	});
-
-	// ── Auto-complete race condition guard ─────────────────────────────────
-
-	it("does NOT auto-complete while scripts are still loading", () => {
-		renderSetup({
-			workspaceState: "setup_pending",
-			setupScript: null,
-			scriptsLoaded: false,
-		});
-
-		expect(apiMocks.completeWorkspaceSetup).not.toHaveBeenCalled();
-	});
-
-	it("auto-completes when scripts are loaded and no script is configured", async () => {
-		renderSetup({
-			workspaceState: "setup_pending",
-			setupScript: null,
-			scriptsLoaded: true,
-		});
-
-		await waitFor(() => {
-			expect(apiMocks.completeWorkspaceSetup).toHaveBeenCalledWith("ws-1");
-		});
 	});
 
 	// ── Manual run / stop / rerun ──────────────────────────────────────────
@@ -189,16 +141,5 @@ describe("SetupTab", () => {
 				screen.getByRole("button", { name: /rerun setup/i }),
 			).toBeInTheDocument();
 		});
-	});
-
-	it("does not auto-complete if workspaceId is null", () => {
-		renderSetup({
-			workspaceId: null,
-			workspaceState: "setup_pending",
-			setupScript: null,
-			scriptsLoaded: true,
-		});
-
-		expect(apiMocks.completeWorkspaceSetup).not.toHaveBeenCalled();
 	});
 });

--- a/src/features/inspector/sections/setup.tsx
+++ b/src/features/inspector/sections/setup.tsx
@@ -6,7 +6,6 @@ import {
 	TerminalOutput,
 } from "@/components/terminal-output";
 import { Button } from "@/components/ui/button";
-import { completeWorkspaceSetup } from "@/lib/api";
 import { helmorQueryKeys } from "@/lib/query-client";
 import { cn } from "@/lib/utils";
 import {
@@ -21,9 +20,7 @@ import {
 type SetupTabProps = {
 	repoId: string | null;
 	workspaceId: string | null;
-	workspaceState: string | null;
 	setupScript: string | null;
-	scriptsLoaded: boolean;
 	isActive: boolean;
 	onOpenSettings: () => void;
 };
@@ -31,16 +28,13 @@ type SetupTabProps = {
 export function SetupTab({
 	repoId,
 	workspaceId,
-	workspaceState,
 	setupScript,
-	scriptsLoaded,
 	isActive,
 	onOpenSettings,
 }: SetupTabProps) {
 	const termRef = useRef<TerminalHandle | null>(null);
 	const [status, setStatus] = useState<ScriptStatus>("idle");
 	const [hasRun, setHasRun] = useState(false);
-	const hasAutoRunRef = useRef(false);
 	const queryClient = useQueryClient();
 
 	const hasScript = !!setupScript?.trim();
@@ -79,7 +73,6 @@ export function SetupTab({
 		} else {
 			setHasRun(false);
 			setStatus("idle");
-			hasAutoRunRef.current = false;
 			termRef.current?.clear();
 		}
 
@@ -98,35 +91,6 @@ export function SetupTab({
 		if (!repoId || !workspaceId) return;
 		stopScript(repoId, "setup", workspaceId);
 	}, [repoId, workspaceId]);
-
-	// Auto-run setup when workspace is pending and script is available.
-	useEffect(() => {
-		if (
-			workspaceState === "setup_pending" &&
-			hasScript &&
-			status === "idle" &&
-			!hasAutoRunRef.current
-		) {
-			hasAutoRunRef.current = true;
-			handleRun();
-		}
-	}, [workspaceState, hasScript, status, handleRun]);
-
-	// Auto-complete if workspace is pending but no script is configured.
-	useEffect(() => {
-		if (
-			workspaceState === "setup_pending" &&
-			scriptsLoaded &&
-			!hasScript &&
-			workspaceId
-		) {
-			void completeWorkspaceSetup(workspaceId).then(() => {
-				queryClient.invalidateQueries({
-					queryKey: helmorQueryKeys.workspaceDetail(workspaceId),
-				});
-			});
-		}
-	}, [workspaceState, scriptsLoaded, hasScript, workspaceId, queryClient]);
 
 	return (
 		<div


### PR DESCRIPTION
## Summary

Two related fixes that make the `setup_pending` workspace state actually work end-to-end:

- **Backend — treat non-archived workspaces as operational.** A bunch of git/branch/sync paths gated on `state = 'ready'`, which meant workspaces in `setup_pending` (and any other transient-but-usable state) were silently skipped for fetches, branch updates, rename/sync/push, change queries, and title generation. Introduces `workspace::helpers::is_operational_state` (returns `true` unless `archived` or `initializing`) and routes callers through it. SQL queries switch from `state = 'ready'` to `state NOT IN ('archived', 'initializing')`. Error messages updated from "not ready" to "not found or archived" / "archived or mid-creation" to match the new semantics.
- **Frontend — hoist setup auto-run to the sidebar.** The Setup tab owned the `useEffect` that auto-runs the setup script (or auto-completes when no script is configured). That meant it only fired when the Setup tab was mounted — if the user selected a workspace with the Actions/Changes tab open, setup never kicked off. Extract the logic into `useSetupAutoRun` and mount it on `WorkspaceInspectorSidebar` so it runs for every selected workspace regardless of active tab. Relies on the module-scoped `script-store` so output still streams cleanly to `SetupTab` whenever the user opens it.

## Why

`setup_pending` workspaces looked dead: the setup script never fired unless you happened to have the Setup tab open, and even if setup completed, the backend refused to perform git ops on the workspace until state flipped to `ready`. Both had to move together.

## Test plan

- [ ] `bun run test:rust` (workspace/git changes)
- [ ] `bun run test:frontend` — existing `SetupTab` auto-run tests moved to new `use-setup-auto-run.test.tsx`; `setup.test.tsx` slimmed to manual-run coverage
- [ ] Manual: create a fresh workspace with a setup script, select it with a non-Setup tab active, confirm setup runs automatically
- [ ] Manual: create a workspace with no setup script configured → state should auto-advance from `setup_pending` to `ready`
- [ ] Manual: rename branch / sync target / push on a workspace currently in `setup_pending` → should succeed rather than bailing

🤖 Generated with [Claude Code](https://claude.com/claude-code)