### PR TITLE
chore: add changeset for 0.1.1 patch

### DIFF
--- a/.changeset/fix-workspace-session-and-sidebar.md
+++ b/.changeset/fix-workspace-session-and-sidebar.md
@@ -1,0 +1,6 @@
+---
+"helmor": patch
+---
+
+- Fix new workspaces occasionally creating a duplicate session on first open.
+- Stop reshuffling the sidebar optimistically when you change a session's status manually.


### PR DESCRIPTION
## Summary
- Adds a patch changeset so release-plan.yml can prepare v0.1.1.

## Release notes preview
- Fix new workspaces occasionally creating a duplicate session on first open.
- Stop reshuffling the sidebar optimistically when you change a session's status manually.

## Next steps
Merging this will trigger `release-plan.yml` to open a `chore(release): version packages` PR. Merging that PR + pushing tag `v0.1.1` publishes the release.