### PR TITLE
chore(release): version packages

### DIFF
--- a/.changeset/fix-workspace-session-and-sidebar.md
+++ b/.changeset/fix-workspace-session-and-sidebar.md
@@ -1,6 +1,0 @@
----
-"helmor": patch
----
-
-- Fix new workspaces occasionally creating a duplicate session on first open.
-- Stop reshuffling the sidebar optimistically when you change a session's status manually.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.1.1
+
+### Patch Changes
+
+- [#89](https://github.com/dohooo/helmor/pull/89) [`e3fc20f`](https://github.com/dohooo/helmor/commit/e3fc20f4451a65c2d9d067c39b9233367d07bdd1) Thanks [@natllian](https://github.com/natllian)!
+  - Fix new workspaces occasionally creating a duplicate session on first open.
+  - Stop reshuffling the sidebar optimistically when you change a session's status manually.
+
 All notable changes to Helmor will be documented in this file.
 
 ## 0.1.0

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "helmor",
 	"description": "The local-first IDE for coding agent orchestration.",
 	"private": true,
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"packageManager": "bun@1.3.2",
 	"type": "module",
 	"scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1783,7 +1783,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "helmor"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helmor"
-version = "0.1.0"
+version = "0.1.1"
 description = "The local-first IDE for coding agent orchestration."
 authors = ["Caspian Zhao", "Nathan Lian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Helmor",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"identifier": "ai.helmor.desktop",
 	"build": {
 		"beforeDevCommand": "bun x vite",


### PR DESCRIPTION
## Summary

Bumps Helmor to **0.1.1** based on the pending changeset from #89.

Manually prepared because the `release-plan.yml` workflow cannot create PRs without the "Allow GitHub Actions to create and approve pull requests" repo permission (see failed run on #89's merge).

## Changes

- `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.lock` → `0.1.1`
- `CHANGELOG.md` gets a new `## 0.1.1` section
- Consumes `.changeset/fix-workspace-session-and-sidebar.md`

## Release notes

- Fix new workspaces occasionally creating a duplicate session on first open.
- Stop reshuffling the sidebar optimistically when you change a session's status manually.

## Next steps

After this merges, pushing tag `v0.1.1` on the merge commit triggers `publish.yml` which builds + signs + uploads the macOS DMGs and `latest.json`.