### PR TITLE
fix(release): add JIT entitlements so Bun sidecar starts under hardened runtime

### DIFF
--- a/.changeset/fix-release-model-list-empty.md
+++ b/.changeset/fix-release-model-list-empty.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+- Fix the empty model list in signed/notarized macOS release builds.

--- a/scripts/prepare-sidecar.mjs
+++ b/scripts/prepare-sidecar.mjs
@@ -15,17 +15,53 @@
  *   node scripts/prepare-sidecar.mjs
  *   bun scripts/prepare-sidecar.mjs      # equivalent, Tauri uses this form
  */
-import { execSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import { copyFileSync, existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const sidecarDir = resolve(repoRoot, "sidecar");
+const entitlementsPlist = resolve(repoRoot, "src-tauri", "Entitlements.plist");
 
 function run(cmd, cwd) {
 	console.log(`[prepare-sidecar] $ ${cmd} (cwd: ${cwd})`);
 	execSync(cmd, { cwd, stdio: "inherit" });
+}
+
+// Pre-sign the compiled sidecar with JIT entitlements so Bun's JSC runtime
+// can allocate executable memory under hardened runtime. Tauri may re-sign
+// this binary during bundling, but codesign preserves the entitlements blob
+// unless --entitlements is passed again with a different plist.
+function signSidecarWithEntitlements(path) {
+	const identity = process.env.APPLE_SIGNING_IDENTITY?.trim();
+	if (!identity) {
+		console.log(
+			"[prepare-sidecar] APPLE_SIGNING_IDENTITY unset — skipping sidecar pre-sign (dev / unsigned build)",
+		);
+		return;
+	}
+	if (!existsSync(entitlementsPlist)) {
+		throw new Error(
+			`[prepare-sidecar] Entitlements.plist missing at ${entitlementsPlist}`,
+		);
+	}
+	console.log(`[prepare-sidecar] codesign (+entitlements) ${path}`);
+	execFileSync(
+		"codesign",
+		[
+			"--force",
+			"--sign",
+			identity,
+			"--timestamp",
+			"--options",
+			"runtime",
+			"--entitlements",
+			entitlementsPlist,
+			path,
+		],
+		{ stdio: "inherit" },
+	);
 }
 
 function detectTargetTriple() {
@@ -59,6 +95,10 @@ function main() {
 		);
 	}
 	copyFileSync(source, destination);
+
+	// Sign the target-suffixed copy (the one Tauri ingests as externalBin).
+	// No-op when APPLE_SIGNING_IDENTITY is unset.
+	signSidecarWithEntitlements(destination);
 
 	console.log(`[prepare-sidecar] staged → ${destination}`);
 }

--- a/sidecar/scripts/stage-vendor.ts
+++ b/sidecar/scripts/stage-vendor.ts
@@ -128,26 +128,42 @@ function humanSize(path: string): string {
 	return `${bytes} B`;
 }
 
-function maybeSignMacBinary(path: string): void {
+// Shared entitlements plist — Bun's JSC JIT needs allow-jit +
+// allow-unsigned-executable-memory under hardened runtime, otherwise
+// spawn fails with "Ran out of executable memory while allocating N bytes".
+const ENTITLEMENTS_PLIST = join(
+	SIDECAR_ROOT,
+	"..",
+	"src-tauri",
+	"Entitlements.plist",
+);
+
+function maybeSignMacBinary(path: string, withEntitlements: boolean): void {
 	const identity = process.env.APPLE_SIGNING_IDENTITY?.trim();
 	if (!identity) return;
 
-	console.log(`[stage-vendor] signing ${path}`);
-	execFileSync(
-		"codesign",
-		[
-			"--force",
-			"--sign",
-			identity,
-			"--timestamp",
-			"--options",
-			"runtime",
-			path,
-		],
-		{
-			stdio: "inherit",
-		},
+	const args = [
+		"--force",
+		"--sign",
+		identity,
+		"--timestamp",
+		"--options",
+		"runtime",
+	];
+	if (withEntitlements) {
+		if (!existsSync(ENTITLEMENTS_PLIST)) {
+			throw new Error(
+				`[stage-vendor] Entitlements.plist missing at ${ENTITLEMENTS_PLIST}`,
+			);
+		}
+		args.push("--entitlements", ENTITLEMENTS_PLIST);
+	}
+	args.push(path);
+
+	console.log(
+		`[stage-vendor] signing ${path}${withEntitlements ? " (+entitlements)" : ""}`,
 	);
+	execFileSync("codesign", args, { stdio: "inherit" });
 }
 
 // ---------------------------------------------------------------------------
@@ -196,7 +212,7 @@ ensureExists(codexSrc, `${target.codexPkg} codex binary`);
 const codexDest = join(DIST_VENDOR, "codex", "codex");
 copyFile(codexSrc, codexDest);
 chmodSync(codexDest, 0o755);
-maybeSignMacBinary(codexDest);
+maybeSignMacBinary(codexDest, false);
 
 // ----- Bun (JS runtime for cli.js) -----
 function locateHostBun(): string {
@@ -219,7 +235,7 @@ const bunSrc = locateHostBun();
 const bunDest = join(DIST_VENDOR, "bun", "bun");
 copyFile(bunSrc, bunDest);
 chmodSync(bunDest, 0o755);
-maybeSignMacBinary(bunDest);
+maybeSignMacBinary(bunDest, true);
 
 for (const rel of [
 	join(ccDest, "vendor", "ripgrep", target.ccVendorArch, "rg"),
@@ -232,7 +248,7 @@ for (const rel of [
 	),
 ]) {
 	if (existsSync(rel)) {
-		maybeSignMacBinary(rel);
+		maybeSignMacBinary(rel, false);
 	}
 }
 

--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!--
+		The 3-key minimum for shipping a JIT runtime (Bun / V8 / JSC) under
+		macOS hardened runtime. Same set electron-builder applies by default
+		and what Grafana k6-studio / PicGo / etc. actually ship.
+
+		Without these, Bun's JSC fails at spawn with
+		"Ran out of executable memory while allocating N bytes".
+	-->
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+</dict>
+</plist>

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -32,71 +32,11 @@ pub use workspace::files as editor_files;
 pub use workspace::helpers;
 pub use workspace::workspaces;
 
-use tauri::path::BaseDirectory;
 use tauri::Manager;
 
 /// Initialise the database schema (call once at startup).
 pub fn schema_init(conn: &rusqlite::Connection) {
     schema::ensure_schema(conn).expect("Failed to initialize database schema");
-}
-
-/// Resolve bundled Claude Code / Codex CLI resource paths (as declared in
-/// `tauri.conf.json > bundle.resources`) and set them as env vars so the
-/// sidecar subprocess inherits them on spawn.
-///
-/// This runs unconditionally in `setup`, but is a no-op in dev because the
-/// `vendor/` resource layout only exists inside bundled `.app` / installer
-/// builds. When the resolved path is missing we leave the env var unset and
-/// the sidecar falls back to its own `node_modules` lookup.
-fn export_bundled_agent_paths(handle: &tauri::AppHandle) {
-    let cli_js = handle
-        .path()
-        .resolve("vendor/claude-code/cli.js", BaseDirectory::Resource)
-        .ok()
-        .filter(|p| p.is_file());
-    if let Some(path) = cli_js {
-        tracing::info!(path = %path.display(), "Claude Code CLI (bundled resource)");
-        // SAFETY: set_var is `unsafe` in Rust 2024 editions; we're in setup
-        // before any threads spawn that would race with env reads.
-        unsafe {
-            std::env::set_var("HELMOR_CLAUDE_CODE_CLI_PATH", path);
-        }
-    }
-
-    let codex_bin_name = if cfg!(windows) { "codex.exe" } else { "codex" };
-    let codex_bin = handle
-        .path()
-        .resolve(
-            format!("vendor/codex/{codex_bin_name}"),
-            BaseDirectory::Resource,
-        )
-        .ok()
-        .filter(|p| p.is_file());
-    if let Some(path) = codex_bin {
-        tracing::info!(path = %path.display(), "Codex CLI (bundled resource)");
-        unsafe {
-            std::env::set_var("HELMOR_CODEX_BIN_PATH", path);
-        }
-    }
-
-    // Bundled bun — the JS runtime the Claude Agent SDK spawns cli.js through.
-    // Without this the SDK does `spawn("bun", ...)` which fails inside a
-    // Finder-launched `.app` bundle (PATH = /usr/bin:/bin:/usr/sbin:/sbin).
-    let bun_bin_name = if cfg!(windows) { "bun.exe" } else { "bun" };
-    let bun_bin = handle
-        .path()
-        .resolve(
-            format!("vendor/bun/{bun_bin_name}"),
-            BaseDirectory::Resource,
-        )
-        .ok()
-        .filter(|p| p.is_file());
-    if let Some(path) = bun_bin {
-        tracing::info!(path = %path.display(), "bun runtime (bundled resource)");
-        unsafe {
-            std::env::set_var("HELMOR_BUN_PATH", path);
-        }
-    }
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -159,18 +99,6 @@ pub fn run() {
             // etc.) so every child process — sidecar, git, workspace scripts —
             // can find developer tools without manual PATH hacks.
             shell_env::inherit_login_shell_env();
-
-            // Resolve bundled Claude Code + Codex CLI resources and publish
-            // them to the sidecar via env vars before it ever spawns. The
-            // sidecar reads `HELMOR_CLAUDE_CODE_CLI_PATH` /
-            // `HELMOR_CODEX_BIN_PATH` at module load and passes them through
-            // to the SDKs' explicit path options.
-            //
-            // In dev (no `bundle.resources` in play) `resolve(..., Resource)`
-            // returns a path that doesn't exist — skip silently so the
-            // sidecar falls back to its own `createRequire` / SDK lookup
-            // against `node_modules`.
-            export_bundled_agent_paths(app.handle());
 
             updater::configure()?;
             updater::spawn_startup_check(app.handle().clone());

--- a/src-tauri/src/sidecar.rs
+++ b/src-tauri/src/sidecar.rs
@@ -67,6 +67,38 @@ struct SidecarProcess {
     stdin: Arc<Mutex<std::process::ChildStdin>>,
 }
 
+#[derive(Debug, Default)]
+struct BundledAgentPaths {
+    claude_cli: Option<PathBuf>,
+    codex_bin: Option<PathBuf>,
+    bun_bin: Option<PathBuf>,
+}
+
+fn resolve_bundled_agent_paths() -> BundledAgentPaths {
+    std::env::current_exe()
+        .ok()
+        .and_then(|exe| resolve_bundled_agent_paths_for_exe(&exe))
+        .unwrap_or_default()
+}
+
+fn resolve_bundled_agent_paths_for_exe(exe: &std::path::Path) -> Option<BundledAgentPaths> {
+    let exe_dir = exe.parent()?;
+    let contents_dir = exe_dir.parent()?;
+    let resources_dir = contents_dir.join("Resources");
+    let codex_bin_name = if cfg!(windows) { "codex.exe" } else { "codex" };
+    let bun_bin_name = if cfg!(windows) { "bun.exe" } else { "bun" };
+
+    let claude_cli = resources_dir.join("vendor/claude-code/cli.js");
+    let codex_bin = resources_dir.join(format!("vendor/codex/{codex_bin_name}"));
+    let bun_bin = resources_dir.join(format!("vendor/bun/{bun_bin_name}"));
+
+    Some(BundledAgentPaths {
+        claude_cli: claude_cli.is_file().then_some(claude_cli),
+        codex_bin: codex_bin.is_file().then_some(codex_bin),
+        bun_bin: bun_bin.is_file().then_some(bun_bin),
+    })
+}
+
 impl SidecarProcess {
     /// Start the sidecar process and wait for the "ready" signal.
     /// Returns the process and a BufReader for stdout (to be consumed by the reader thread).
@@ -104,6 +136,27 @@ impl SidecarProcess {
             cmd.env("HELMOR_LOG", level);
         } else if crate::data_dir::is_dev() {
             cmd.env("HELMOR_LOG", "debug");
+        }
+
+        if !is_dev {
+            let bundled_paths = resolve_bundled_agent_paths();
+            let exe = std::env::current_exe().ok();
+            tracing::info!(
+                exe = ?exe,
+                claude_cli = ?bundled_paths.claude_cli,
+                codex_bin = ?bundled_paths.codex_bin,
+                bun_bin = ?bundled_paths.bun_bin,
+                "Resolved bundled agent paths"
+            );
+            if let Some(path) = bundled_paths.claude_cli {
+                cmd.env("HELMOR_CLAUDE_CODE_CLI_PATH", &path);
+            }
+            if let Some(path) = bundled_paths.codex_bin {
+                cmd.env("HELMOR_CODEX_BIN_PATH", &path);
+            }
+            if let Some(path) = bundled_paths.bun_bin {
+                cmd.env("HELMOR_BUN_PATH", &path);
+            }
         }
 
         tracing::debug!(
@@ -676,5 +729,36 @@ mod tests {
         let e2 = rx2.recv().unwrap();
         assert_eq!(e2.id(), Some("req-2"));
         assert_eq!(e2.event_type(), "error");
+    }
+
+    #[test]
+    fn bundled_agent_paths_resolve_from_running_app() {
+        let root = tempfile::tempdir().unwrap();
+        let exe = root.path().join("Helmor.app/Contents/MacOS/Helmor");
+        let resources = root.path().join("Helmor.app/Contents/Resources/vendor");
+        std::fs::create_dir_all(resources.join("claude-code")).unwrap();
+        std::fs::create_dir_all(resources.join("codex")).unwrap();
+        std::fs::create_dir_all(resources.join("bun")).unwrap();
+        std::fs::write(resources.join("claude-code/cli.js"), "").unwrap();
+        std::fs::write(resources.join("codex/codex"), "").unwrap();
+        std::fs::write(resources.join("bun/bun"), "").unwrap();
+
+        let paths = resolve_bundled_agent_paths_for_exe(&exe).unwrap();
+
+        assert_eq!(
+            paths.claude_cli.unwrap(),
+            root.path()
+                .join("Helmor.app/Contents/Resources/vendor/claude-code/cli.js")
+        );
+        assert_eq!(
+            paths.codex_bin.unwrap(),
+            root.path()
+                .join("Helmor.app/Contents/Resources/vendor/codex/codex")
+        );
+        assert_eq!(
+            paths.bun_bin.unwrap(),
+            root.path()
+                .join("Helmor.app/Contents/Resources/vendor/bun/bun")
+        );
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -61,6 +61,9 @@
 			"icons/128x128.png",
 			"icons/128x128@2x.png",
 			"icons/icon.icns"
-		]
+		],
+		"macOS": {
+			"entitlements": "Entitlements.plist"
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Signed + notarized macOS release builds shipped without the JIT entitlements Bun's JSC needs. The sidecar crashed at spawn with `Ran out of executable memory while allocating N bytes`, which surfaced in the UI as an empty model list (every `listModels` timed out).

- Add `src-tauri/Entitlements.plist` with the 3-key minimum that `electron-builder` ships by default — `allow-jit`, `allow-unsigned-executable-memory`, `disable-library-validation`.
- Wire it into `tauri.conf.json` via `bundle.macOS.entitlements` (covers main app + `externalBin` sidecar).
- Re-sign bundled `bun` runtime in `stage-vendor.ts` with the same plist; pre-sign `helmor-sidecar` in `prepare-sidecar.mjs` as a guard against [tauri#11992](https://github.com/tauri-apps/tauri/issues/11992).
- Move bundled-resource path resolution from `lib.rs` setup hook into `sidecar.rs` (set env directly on child Command, no parent-process pollution); add an `info!` log dumping resolved paths so future regressions show up in `rust.jsonl`.

## Test plan

Cannot fully validate locally — release env vars (`APPLE_*`, `TAURI_SIGNING_*`) live only in CI. Validation must happen on a CI-built signed dmg:

- [ ] Trigger `Publish Release` workflow via `workflow_dispatch` with `draft: true` to produce signed/notarized dmgs without publishing.
- [ ] Download the arm64 dmg from the draft release, install to `/Applications`.
- [ ] Verify entitlements landed:
  ```bash
  for bin in helmor helmor-sidecar Resources/vendor/bun/bun; do
    echo "=== \$bin ==="
    codesign -d --entitlements - --xml "/Applications/Helmor.app/Contents/MacOS/\$bin" 2>/dev/null \
      | grep -E "allow-jit|allow-unsigned-executable-memory" \
      || echo "  ❌ MISSING"
  done
  ```
- [ ] Open the app, start a session, confirm Claude + Codex model lists populate.
- [ ] Inspect `~/helmor/logs/sidecar.*.jsonl` — should NOT contain "Ran out of executable memory".
- [ ] Inspect `~/helmor/logs/rust.*.jsonl` — should contain a "Resolved bundled agent paths" log line listing all three vendored binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)