### PR TITLE
chore(release): version packages

### DIFF
--- a/.changeset/fix-release-model-list-empty.md
+++ b/.changeset/fix-release-model-list-empty.md
@@ -1,5 +1,0 @@
----
-"helmor": patch
----
-
-- Fix the empty model list in signed/notarized macOS release builds.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.2
+
+### Patch Changes
+
+- [#91](https://github.com/dohooo/helmor/pull/91) [`8567d35`](https://github.com/dohooo/helmor/commit/8567d355d2be84fdeea68436c18be31fcd76ef0c) Thanks [@natllian](https://github.com/natllian)! - - Fix the empty model list in signed/notarized macOS release builds.
+
 ## 0.1.1
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "helmor",
 	"description": "The local-first IDE for coding agent orchestration.",
 	"private": true,
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"packageManager": "bun@1.3.2",
 	"type": "module",
 	"scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1783,7 +1783,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "helmor"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helmor"
-version = "0.1.1"
+version = "0.1.2"
 description = "The local-first IDE for coding agent orchestration."
 authors = ["Caspian Zhao", "Nathan Lian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Helmor",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"identifier": "ai.helmor.desktop",
 	"build": {
 		"beforeDevCommand": "bun x vite",


### PR DESCRIPTION
## Summary

Bumps Helmor to **0.1.2** based on the pending changeset from #91.

Manually prepared because the `release-plan.yml` workflow cannot create PRs without the "Allow GitHub Actions to create and approve pull requests" repo permission (same situation as #90).

## Changes

- `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.lock` → `0.1.2`
- `CHANGELOG.md` gets a new `## 0.1.2` section
- Consumes `.changeset/fix-release-model-list-empty.md`

## Release notes

- Fix the empty model list in signed/notarized macOS release builds — the bundled Bun runtime now ships with the JIT entitlements it needs under hardened runtime, so the agent sidecar no longer crashes with "Ran out of executable memory" before any prompt can be sent.

## Next steps

After this merges, pushing tag \`v0.1.2\` on the merge commit triggers \`publish.yml\` which builds + signs + uploads the macOS DMGs and \`latest.json\`.