### PR TITLE
ci(release): auto-tag + auto-publish after release PR merge

### DIFF
--- a/.github/workflows/release-plan.yml
+++ b/.github/workflows/release-plan.yml
@@ -26,6 +26,12 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          # HELMOR_RELEASE_PAT so subsequent `git push` operations in this
+          # workflow (see the tag step below) are authenticated as the PAT
+          # owner instead of github-actions[bot]. GitHub suppresses workflow
+          # runs for pushes authored by the default GITHUB_TOKEN (recursion
+          # guard) — a PAT-authored tag push DOES trigger publish.yml.
+          token: ${{ secrets.HELMOR_RELEASE_PAT }}
 
       - name: Setup JS toolchain
         uses: ./.github/actions/setup-js
@@ -40,4 +46,20 @@ jobs:
           commit: "chore(release): version packages"
           title: "chore(release): version packages"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.HELMOR_RELEASE_PAT }}
+
+      # When a "chore(release): version packages" merge lands on main the
+      # version is bumped but no tag exists. Push the v<version> tag here
+      # so publish.yml (on: push: tags: v*) runs and ships the DMGs.
+      - name: Push release tag after release merge
+        if: |
+          github.event_name == 'push' &&
+          contains(github.event.head_commit.message, 'chore(release): version packages')
+        run: |
+          version=$(node -p "require('./package.json').version")
+          if git rev-parse "v${version}" >/dev/null 2>&1; then
+            echo "Tag v${version} already exists — skipping"
+            exit 0
+          fi
+          git tag "v${version}"
+          git push origin "v${version}"


### PR DESCRIPTION
## Summary

Removes the manual `git tag v0.1.x && git push` step from the release flow. After this lands, shipping a release is:

1. Write code + `.changeset/*.md`, merge feature PR
2. Merge the `chore(release): version packages` PR that Changesets opens
3. Done — tag push, signed/notarized DMG build, GitHub Release, and `latest.json` all happen automatically

## Why

Two GitHub-level constraints layered on top of each other made automation impossible with the default `GITHUB_TOKEN`:

1. `changesets/action` only opens the release PR — it neither tags nor publishes for us.
2. Even if it pushed a tag, **GitHub suppresses workflow runs for pushes authored by the default `GITHUB_TOKEN`** (recursion guard), so `publish.yml` (which listens on `push: tags: v*`) would not fire.

Result: every release so far has needed someone to run `git tag v0.1.x && git push origin v0.1.x` by hand on their laptop.

## How

Uses a Personal Access Token (`HELMOR_RELEASE_PAT`) stored as a repo secret. PAT-authored pushes DO trigger downstream workflows. Three changes in `.github/workflows/release-plan.yml`:

1. `actions/checkout` uses the PAT so subsequent `git push` in this workflow is PAT-authenticated.
2. `changesets/action` receives the PAT via `GITHUB_TOKEN` env — the release PR it opens is now PAT-authored.
3. A new step runs after a `chore(release): version packages` merge lands on `main`: it reads the new version from `package.json`, tags it (`v<version>`), and pushes. The push triggers `publish.yml`, which builds + signs + notarizes + uploads the DMGs and `latest.json`.

The new step is gated on `contains(github.event.head_commit.message, 'chore(release): version packages')` rather than the `hasChangesets == false` output of the action, so feature PR merges (which also push to `main` with `hasChangesets == false` if no changeset was added) never accidentally fire a publish.

## Requirements

- [x] `HELMOR_RELEASE_PAT` secret already configured in repo settings (confirmed)
- [x] "Allow GitHub Actions to create and approve pull requests" setting already enabled — not strictly needed anymore once this merges (PAT bypasses it), but doesn't hurt to leave on

## Test plan

- [ ] Merge this PR
- [ ] Add a throwaway changeset on a feature branch, merge it → confirm `release-plan.yml` opens the `chore(release): version packages` PR with the new version bump
- [ ] Merge that release PR → confirm `release-plan.yml` runs again, sees the commit message, pushes `v<version>` tag
- [ ] Confirm `publish.yml` fires on the tag push and uploads DMGs + `latest.json`

## PAT lifecycle note

`HELMOR_RELEASE_PAT` is a personal credential. When it expires or the PAT owner rotates it, update the repo secret; no other changes required. If the PAT owner ever leaves the project, generate a new PAT under another maintainer's account and replace the secret.

https://claude.ai/code/session_01Bscrt6YSBgGAWFUk8Po1oh