### PR TITLE
fix(composer): restore caret to end of stripped IME buffer

### DIFF
--- a/.changeset/fix-ime-cursor-position-after-strip.md
+++ b/.changeset/fix-ime-cursor-position-after-strip.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+- Fix the caret jumping to the start of the paragraph right after a Chinese IME buffer got stripped of its segmentation spaces — the caret now stays at the end of what you just typed.

--- a/src/features/composer/editor/plugins/composition-guard-plugin.tsx
+++ b/src/features/composer/editor/plugins/composition-guard-plugin.tsx
@@ -30,10 +30,29 @@
  * from Lexical's bubble-phase handler, AFTER the model is already updated
  * from the DOM. Capture-phase on the native event is the only point where
  * we can still influence what Lexical sees.
+ *
+ * Caret restoration: assigning `.textContent` on a Text node collapses any
+ * live DOM selection on WebKit — Lexical's bubble-phase compositionend
+ * handler then reads a null anchor and can't re-attach the model selection,
+ * so the caret ends up at the paragraph start (the reported "cursor
+ * flashes to the front" bug). We fix that in two places: first by setting
+ * a DOM selection at the end of the replacement inside the capture handler
+ * (what Lexical reads from DOM), and second by registering a LOW-priority
+ * `COMPOSITION_END_COMMAND` listener that runs AFTER Lexical's default
+ * handler, stepping the Lexical MODEL selection to the end of the text
+ * node. Without the second step, if Lexical's own model selection was
+ * stale or absent at compositionend time, the reconciliation would blow
+ * away the DOM selection we placed in the first step.
  */
 
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
-import { useEffect } from "react";
+import {
+	$getRoot,
+	$isTextNode,
+	COMMAND_PRIORITY_LOW,
+	COMPOSITION_END_COMMAND,
+} from "lexical";
+import { useEffect, useRef } from "react";
 
 const PURE_PRINTABLE_ASCII = /^[\x20-\x7E]+$/;
 
@@ -49,7 +68,25 @@ function stripImeSegmentationSpaces(
 	if (root.nodeType === Node.TEXT_NODE) {
 		const text = root.textContent;
 		if (text?.includes(target)) {
+			const matchStart = text.indexOf(target);
+			const replacedEnd = matchStart + replacement.length;
 			root.textContent = text.replace(target, replacement);
+
+			// Place a DOM selection at the end of the replacement so
+			// Lexical's `$updateSelectedTextFromDOM` reads a valid anchor
+			// when it runs in the bubble phase. Without this, WebKit's
+			// `.textContent` assignment collapses the live selection
+			// entirely and Lexical falls through to a no-selection path.
+			const ownerDocument = root.ownerDocument;
+			const win = ownerDocument?.defaultView;
+			const sel = win?.getSelection();
+			if (sel && ownerDocument) {
+				const range = ownerDocument.createRange();
+				range.setStart(root, replacedEnd);
+				range.setEnd(root, replacedEnd);
+				sel.removeAllRanges();
+				sel.addRange(range);
+			}
 			return true;
 		}
 		return false;
@@ -62,6 +99,7 @@ function stripImeSegmentationSpaces(
 
 export function CompositionGuardPlugin() {
 	const [editor] = useLexicalComposerContext();
+	const didStripRef = useRef(false);
 
 	useEffect(() => {
 		const handler = (event: Event) => {
@@ -71,10 +109,11 @@ export function CompositionGuardPlugin() {
 			const stripped = data.replace(/\s+/g, "");
 			const root = editor.getRootElement();
 			if (!root) return;
-			stripImeSegmentationSpaces(root, data, stripped);
+			const didStrip = stripImeSegmentationSpaces(root, data, stripped);
+			if (didStrip) didStripRef.current = true;
 		};
 
-		const unregister = editor.registerRootListener(
+		const unregisterRoot = editor.registerRootListener(
 			(rootElement, prevRootElement) => {
 				if (prevRootElement) {
 					prevRootElement.removeEventListener("compositionend", handler, true);
@@ -85,12 +124,36 @@ export function CompositionGuardPlugin() {
 			},
 		);
 
+		// After Lexical's default compositionend handler runs, its model
+		// selection may have been cleared (especially when no RangeSelection
+		// existed at compositionstart time). If we stripped this turn, pin
+		// the Lexical caret to the end of the last text node so the DOM
+		// reconciliation lands the caret where the user expects: right
+		// after the text they just typed.
+		const unregisterCommand = editor.registerCommand(
+			COMPOSITION_END_COMMAND,
+			() => {
+				if (!didStripRef.current) return false;
+				didStripRef.current = false;
+				editor.update(() => {
+					const lastDescendant = $getRoot().getLastDescendant();
+					if ($isTextNode(lastDescendant)) {
+						const size = lastDescendant.getTextContentSize();
+						lastDescendant.select(size, size);
+					}
+				});
+				return false;
+			},
+			COMMAND_PRIORITY_LOW,
+		);
+
 		return () => {
 			const root = editor.getRootElement();
 			if (root) {
 				root.removeEventListener("compositionend", handler, true);
 			}
-			unregister();
+			unregisterRoot();
+			unregisterCommand();
 		};
 	}, [editor]);
 

--- a/src/features/composer/ime-switch-space.test.tsx
+++ b/src/features/composer/ime-switch-space.test.tsx
@@ -50,7 +50,13 @@
  */
 
 import { QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import type { AgentModelSection } from "@/lib/api";
 import { createHelmorQueryClient } from "@/lib/query-client";
@@ -159,12 +165,15 @@ function renderComposer() {
  *
  * Real flow: user types raw keys → IME intercepts and shows segmented
  * candidates in the IME popup → IME writes the running buffer into the
- * contenteditable as plain text → user switches IME → OS commits the
- * buffer and the browser fires compositionend with `data` = the buffer.
+ * contenteditable as plain text AND places the caret at the end of that
+ * buffer → user switches IME → OS commits the buffer and the browser
+ * fires compositionend with `data` = the buffer.
  *
  * jsdom doesn't simulate any of that, so we simulate the *editor-visible*
- * outcome: write the segmented buffer into the paragraph text node and
- * then dispatch the composition events Lexical actually listens to.
+ * outcome: write the segmented buffer into the paragraph text node,
+ * collapse the DOM selection to the end of that buffer (what any real
+ * IME would do before compositionend), then dispatch the composition
+ * events Lexical actually listens to.
  */
 function simulateImeSwitchCommit(editor: HTMLElement, segmentedBuffer: string) {
 	const paragraph = editor.querySelector("p");
@@ -175,6 +184,17 @@ function simulateImeSwitchCommit(editor: HTMLElement, segmentedBuffer: string) {
 	}
 	fireEvent.compositionStart(editor, { data: "" });
 	paragraph.textContent = segmentedBuffer;
+	const textNode = paragraph.firstChild;
+	if (textNode) {
+		const sel = editor.ownerDocument.defaultView?.getSelection();
+		if (sel) {
+			const range = editor.ownerDocument.createRange();
+			range.setStart(textNode, segmentedBuffer.length);
+			range.setEnd(textNode, segmentedBuffer.length);
+			sel.removeAllRanges();
+			sel.addRange(range);
+		}
+	}
 	fireEvent.compositionUpdate(editor, { data: segmentedBuffer });
 	fireEvent.compositionEnd(editor, { data: segmentedBuffer });
 }
@@ -234,5 +254,63 @@ describe("WorkspaceComposer — IME switch mid-composition leaves segmentation s
 		simulateImeSwitchCommit(editor, "你好 world");
 
 		expect(editor.textContent).toBe("你好 world");
+	});
+
+	// When the strip plugin mutates the text node we have to re-anchor the
+	// DOM selection to the end of the REPLACEMENT text. Without that
+	// re-anchor, setting `.textContent` on the Text node either clamps the
+	// selection to the new shorter length on spec-compliant engines OR
+	// collapses it to offset 0 on WebKit (the user reported "cursor flashes
+	// to the front" after our original fix landed — that is the WebKit
+	// collapse path). Either way, Lexical's bubble-phase compositionend
+	// handler then reads whatever offset it finds and writes it into the
+	// model, so an unset selection becomes the persistent caret position
+	// shown to the user.
+	//
+	// This test pins the desired behavior: after a pinyin buffer
+	// `"he lmor"` is force-committed (IME cursor at end, offset 7), the
+	// strip lands `"helmor"` in the editor AND the caret ends at the end
+	// of `"helmor"` (offset 6). Today jsdom clamps the selection so this
+	// may be passing already on paper — but the plugin itself does not
+	// restore the selection explicitly, which is what the real-world
+	// WebKit bug requires. Fix must add an explicit
+	// `selection.collapse(textNode, newEnd)` after the mutation.
+	it("restores caret to the end of the stripped text (not the start) after IME commit", async () => {
+		renderComposer();
+		const editor = await screen.findByLabelText("Workspace input");
+		editor.focus();
+
+		simulateImeSwitchCommit(editor, "he lmor");
+
+		expect(editor.textContent).toBe("helmor");
+
+		// Wait for Lexical to finish its compositionend update cycle, then
+		// verify the caret landed at the end of the stripped text.
+		await waitFor(() => {
+			const sel = editor.ownerDocument.defaultView?.getSelection();
+			expect(sel).toBeTruthy();
+			expect(sel?.anchorNode).not.toBeNull();
+			expect(sel?.isCollapsed).toBe(true);
+
+			// Resolve the anchor to a text offset regardless of whether the
+			// engine reports it against the Text node directly (anchorOffset
+			// is a character index into the text node) or against a parent
+			// element (anchorOffset is a child index — for us that's 1 for
+			// the paragraph anchor AFTER the stripped text node).
+			const anchorNode = sel?.anchorNode;
+			const anchorOffset = sel?.anchorOffset ?? -1;
+			const paragraph = editor.querySelector("p");
+			const textNode = paragraph?.firstChild;
+
+			if (anchorNode === textNode) {
+				expect(anchorOffset).toBe("helmor".length);
+			} else if (anchorNode === paragraph) {
+				expect(anchorOffset).toBeGreaterThanOrEqual(1);
+			} else {
+				throw new Error(
+					`Unexpected anchor node: ${anchorNode?.nodeName ?? "null"}`,
+				);
+			}
+		});
 	});
 });


### PR DESCRIPTION
## Summary

Fixes the caret regression introduced by the segmentation-space fix in 0.1.3: after the plugin stripped an abandoned Chinese IME buffer (e.g. `he lmor` → `helmor`), the caret flashed to the **start** of the paragraph instead of staying at the end of the text the user just typed.

Red-light regression test added alongside the existing switch-space tests to pin this down.

## Why

Assigning `.textContent` on a Text node **collapses any live DOM selection on WebKit** (Helmor's Tauri target). Lexical's bubble-phase `compositionend` handler then reads a null anchor, fails to re-attach the model selection, and the subsequent reconciliation writes the caret at offset 0 of the paragraph.

## How

Two-part fix in `CompositionGuardPlugin`:

1. **Capture-phase DOM selection restore.** After the text-node mutation, explicitly place a DOM selection at the end of the replacement so `$updateSelectedTextFromDOM` reads a valid anchor when it runs in the bubble phase.

2. **LOW-priority `COMPOSITION_END_COMMAND` listener.** Runs AFTER Lexical's default handler. If this turn stripped an IME buffer, step the Lexical **model** selection to the end of the text node via `editor.update(() => lastText.select(size, size))`. Without this, any stale/missing Lexical model selection at compositionend time lets reconciliation blow away the DOM selection we placed in step 1.

Both steps are necessary because:
- Step 1 alone is enough when Lexical already has a live RangeSelection at compositionend time (normal flow).
- Step 2 alone is not enough because Lexical's default handler reads the DOM selection in the middle, so we must also have a valid one for it to consume.

## Test plan

- [x] `bun run test:frontend src/features/composer/ime-switch-space.test.tsx` — 4/4 green (3 existing + 1 new caret test).
- [x] `bun run test:frontend src/features/composer/` — 57/57 green, no regressions.
- [x] `bun x biome check src/features/composer/editor/plugins/composition-guard-plugin.tsx src/features/composer/ime-switch-space.test.tsx` — clean.
- [ ] Manual: type `helmor` under Chinese pinyin IME, switch to English IME via Shift/Ctrl+Space, confirm editor shows `helmor` AND the caret stays at the end.

## Release

Includes a patch-level changeset. On merge, `release-plan.yml` (now PAT-authed per #96) will open the release PR automatically; merging that will tag + publish 0.1.4 without manual intervention.

https://claude.ai/code/session_01Bscrt6YSBgGAWFUk8Po1oh