### PR TITLE
ci(release): scan all push commits for release marker (not just head)

### DIFF
--- a/.github/workflows/release-plan.yml
+++ b/.github/workflows/release-plan.yml
@@ -48,13 +48,23 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.HELMOR_RELEASE_PAT }}
 
-      # When a "chore(release): version packages" merge lands on main the
-      # version is bumped but no tag exists. Push the v<version> tag here
+      # When the "chore(release): version packages" PR merges into main the
+      # version is bumped but no tag exists yet. Push the v<version> tag here
       # so publish.yml (on: push: tags: v*) runs and ships the DMGs.
+      #
+      # Why we scan `github.event.commits` rather than just `head_commit`:
+      # under the repo's default "Create a merge commit" merge mode, the
+      # head commit on main IS the merge commit (message starts with
+      # "Merge pull request #N from ..."), and the actual release commit
+      # rides along inside `commits[]`. A `head_commit.message` substring
+      # check would silently miss those merges. Scanning the full commits
+      # array catches release commits regardless of merge style (merge,
+      # squash, or rebase) — squash/rebase land the release message on
+      # head_commit; merge commits land it on a non-head entry.
       - name: Push release tag after release merge
         if: |
           github.event_name == 'push' &&
-          contains(github.event.head_commit.message, 'chore(release): version packages')
+          contains(toJSON(github.event.commits.*.message), 'chore(release): version packages')
         run: |
           version=$(node -p "require('./package.json').version")
           if git rev-parse "v${version}" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Fixes the bug surfaced by PR #98's merge: `release-plan.yml` ran but never tagged `v0.1.4`, so `publish.yml` never fired and 0.1.4 didn't ship without manual intervention.

## Why

The auto-tag step gated on:

```yaml
if: contains(github.event.head_commit.message, 'chore(release): version packages')
```

That works for **squash** and **rebase** merge modes (the release commit lands on `head_commit`), but **silently miss-fires for "Create a merge commit"** mode — which is the default for this repo. In merge-commit mode the head commit on `main` is the merge commit (`"Merge pull request #98 from dohooo/changeset-release/main"`), and the actual release commit (`"chore(release): version packages"`) rides along inside `github.event.commits[]` as a non-head entry.

Result for PR #98: `release-plan.yml` ran, but the if-clause evaluated to false against the merge-commit message, so the tag step skipped. No tag, no `publish.yml`, no DMG.

## Fix

Switch the check to scan every commit's message in the push payload:

```yaml
if: contains(toJSON(github.event.commits.*.message), 'chore(release): version packages')
```

`toJSON(...)` serializes the full message array; `contains()` does substring match across the whole thing. Now catches the release commit regardless of merge style:
- **squash / rebase**: release message lands on `head_commit` → still matched (string is in the array, even if it's a one-element array).
- **merge commit**: release message lands on a non-head entry → matched.

## Aftermath of the original miss

0.1.4 itself needs to be shipped manually one more time via `Actions → Publish Release → workflow_dispatch (draft=false)` — same as 0.1.3. After this PR merges and a future release PR lands, the auto-flow takes over for real.

## Test plan

- [ ] Merge this PR
- [ ] Add a throwaway changeset, merge a feature PR, merge the resulting "version packages" PR — confirm `release-plan.yml` tags `v<version>` and `publish.yml` fires automatically without any manual step

https://claude.ai/code/session_01Bscrt6YSBgGAWFUk8Po1oh