### PR TITLE
chore(claude): per-user git identity via SessionStart hook

### DIFF
--- a/.claude/hooks/set-git-identity.sh
+++ b/.claude/hooks/set-git-identity.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# SessionStart hook: set git commit identity from per-user env vars.
+#
+# Each contributor can configure their own commit identity for Claude Code
+# sessions on this repo by setting HELMOR_GIT_AUTHOR_NAME and
+# HELMOR_GIT_AUTHOR_EMAIL as environment variables in THEIR claude.ai/code
+# web environment (Settings → Environments → helmor → Environment
+# variables). The values they set there are injected into their web
+# sessions only — other contributors' sessions don't see them.
+#
+# If the env vars are unset (e.g. a contributor hasn't configured them yet,
+# or this is a fresh local CLI session), the hook is a no-op and falls
+# back to whatever git identity the environment already has.
+#
+# We deliberately use HELMOR_GIT_AUTHOR_* rather than the standard
+# GIT_AUTHOR_NAME / GIT_AUTHOR_EMAIL env vars: those git natives would
+# break GPG/SSH commit signature verification when set in web sandboxes
+# (documented in anthropics/claude-code#18715). Writing via `git config`
+# updates .git/config instead, which is safe.
+
+if [ -n "$HELMOR_GIT_AUTHOR_NAME" ]; then
+	git config user.name "$HELMOR_GIT_AUTHOR_NAME" || true
+fi
+if [ -n "$HELMOR_GIT_AUTHOR_EMAIL" ]; then
+	git config user.email "$HELMOR_GIT_AUTHOR_EMAIL" || true
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,5 +2,18 @@
 	"attribution": {
 		"commit": "",
 		"pr": ""
+	},
+	"hooks": {
+		"SessionStart": [
+			{
+				"matcher": "startup|resume",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/set-git-identity.sh\""
+					}
+				]
+			}
+		]
 	}
 }

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ test-results/
 *.pending-snap
 .claude/*
 !.claude/settings.json
+!.claude/hooks
+!.claude/hooks/*


### PR DESCRIPTION
Follow-up to PR #101 (attribution trailers removed repo-wide): add a
SessionStart hook that sets `git config user.name` / `user.email` from
per-user env vars, so each contributor's Claude sessions commit as
themselves without forcing any single identity on other contributors.

How it works

- `.claude/hooks/set-git-identity.sh` reads HELMOR_GIT_AUTHOR_NAME and
  HELMOR_GIT_AUTHOR_EMAIL from the session's environment. If either is
  set, it runs `git config user.name/email` to apply it. If unset the
  hook no-ops and whatever default git identity the environment has
  wins.

- `.claude/settings.json` registers the hook on SessionStart (matcher:
  startup|resume) so it runs at the top of every new or resumed session.

Why HELMOR_-prefixed env vars instead of the git natives

Setting the standard GIT_AUTHOR_NAME / GIT_AUTHOR_EMAIL env vars inside
a Claude Code web sandbox breaks commit signature verification (see
anthropics/claude-code#18715). Writing via `git config` updates
.git/config instead, which is safe — hence the indirect env-var naming.

How each contributor activates this for themselves

Open claude.ai/code → Environments → helmor → Environment variables,
and set:

  HELMOR_GIT_AUTHOR_NAME   = your git name
  HELMOR_GIT_AUTHOR_EMAIL  = your git email

Those values are scoped to YOUR environment for this repo — other
contributors don't see them. If you don't set them, Claude web sessions
fall back to the sandbox default (currently "Claude
<noreply@anthropic.com>", which GitHub attributes to @claude).

.gitignore update

The whole `.claude/` tree was previously git-ignored. PR #101
un-ignored `.claude/settings.json`; this PR extends the un-ignore
to `.claude/hooks/` so shared hooks can ship with the repo. Skills,
plugin caches, and ad-hoc personal files under `.claude/` remain
ignored.

Honest caveat

No community source turned up a production pattern identical to this
(we searched: the closest is a single-user `claude.sh` launcher-wrapper
pattern, no multi-user SessionStart hook variant). This is a
plausible-but-unvalidated design. Worth watching on the first few
Claude web sessions to confirm the hook fires and the git config
sticks.