### PR TITLE
docs(skill): guide helmor-release to avoid bullet-first changeset bodies

### DIFF
--- a/.codex/skills/helmor-release/SKILL.md
+++ b/.codex/skills/helmor-release/SKILL.md
@@ -64,19 +64,46 @@ Do not:
 - list internal refactors unless they changed release behavior
 - mention implementation-only details like exact file names
 - create multiple changesets for one coordinated release task unless the user asks
+- start the changeset body with a `- ` bullet (see format rule below)
 
 ## Default Changeset Format
 
-Use this structure:
+`@changesets/changelog-github` inlines the first line of the body after `Thanks @user! -` when rendering `CHANGELOG.md` / GitHub Release. If the first line is itself a bullet (`- Fix X`), the output becomes `! - - Fix X` with the first item glued to the attribution. **Never start the body with `- `.**
+
+### Single-item changeset
+
+Write the body as one sentence, no leading dash:
+
+```md
+---
+"helmor": patch
+---
+
+Fix Chinese / Japanese / Korean IME pressing Enter to confirm a candidate accidentally sending the message.
+```
+
+### Multi-item changeset
+
+First line is a prose summary ending with `:`. Bullets start from the next line:
 
 ```md
 ---
 "helmor": minor
 ---
 
+Ship a round of release and auto-update improvements:
 - Add in-app update checks that download updates in the background and prompt once the update is ready to install.
 - Add a signed and notarized macOS release pipeline for GitHub Releases.
 - Add release planning automation so Helmor can publish user-facing release notes through Changesets.
+```
+
+This renders cleanly as:
+
+```md
+- [#NN] [`hash`] Thanks @user! - Ship a round of release and auto-update improvements:
+  - Add in-app update checks ...
+  - Add a signed and notarized macOS release pipeline ...
+  - Add release planning automation ...
 ```
 
 If the user wants credits, append a final bullet such as:

--- a/.codex/skills/helmor-release/references/release-format.md
+++ b/.codex/skills/helmor-release/references/release-format.md
@@ -47,6 +47,24 @@ Bad:
 - "Refactor updater state machine and reorganize release scripts."
 - "Update Cargo.toml, tauri.conf.json, and workflow files."
 
+## Body Structure
+
+`@changesets/changelog-github` inlines the first line of the body onto the same line as `Thanks @user! -`. The body must therefore never start with a `- ` bullet, or the rendered CHANGELOG gets `! - - Fix X` with the first item glued to the attribution line.
+
+Single item → one sentence, no leading dash:
+
+```md
+Fix the caret jumping to the start of the paragraph after an IME buffer is stripped.
+```
+
+Multiple items → prose summary on line 1 (ending with `:`), bullets from line 2:
+
+```md
+Harden Chinese / Japanese / Korean IME handling in the composer:
+- Pressing Enter to confirm a candidate no longer sends the message.
+- Segmentation spaces no longer leak when switching IME mid-composition.
+```
+
 ## Credits
 
 If the user wants credits, keep them short and explicit in the body. Example:


### PR DESCRIPTION
@changesets/changelog-github inlines the first line of the changeset body
after 'Thanks @user! -', so starting the body with a '- ' bullet produces
the ugly '! - - Fix X' double-dash we saw on the v0.1.3 Release page.
Update the helmor-release skill to write single-item bodies as prose and
multi-item bodies as a prose lead ending with ':' followed by bullets.