### PR TITLE
feat: add Cmd+=/-/0 webview zoom on macOS

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1783,7 +1783,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "helmor"
-version = "0.1.2"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
 	"permissions": [
 		"core:default",
 		"core:window:allow-start-dragging",
+		"core:webview:allow-set-webview-zoom",
 		"deep-link:default",
 		"dialog:default",
 		"notification:default",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,6 +56,7 @@ import {
 	PREFERRED_EDITOR_STORAGE_KEY,
 	SIDEBAR_RESIZE_HIT_AREA,
 } from "@/shell/layout";
+import { useZoom } from "@/shell/use-zoom";
 import {
 	type ConductorWorkspace,
 	createSession,
@@ -255,6 +256,7 @@ function AppShell({
 		workspaceRepoId: string | null,
 	) => void;
 }) {
+	useZoom();
 	const queryClient = useQueryClient();
 	const workspaceSelectionRequestRef = useRef(0);
 	const sessionSelectionRequestRef = useRef(0);

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -18,6 +18,8 @@ export type AppSettings = {
 	defaultModelId: string | null;
 	defaultEffort: string | null;
 	defaultFastMode: boolean;
+	/** Webview zoom factor. 1.0 = 100%. Range 0.5–2.0. */
+	zoomLevel: number;
 };
 
 export const DEFAULT_SETTINGS: AppSettings = {
@@ -35,6 +37,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
 	defaultModelId: null,
 	defaultEffort: "high",
 	defaultFastMode: false,
+	zoomLevel: 1.0,
 };
 
 export const THEME_STORAGE_KEY = "helmor-theme";
@@ -54,6 +57,7 @@ const SETTINGS_KEY_MAP: Record<Exclude<keyof AppSettings, "theme">, string> = {
 	defaultModelId: "app.default_model_id",
 	defaultEffort: "app.default_effort",
 	defaultFastMode: "app.default_fast_mode",
+	zoomLevel: "app.zoom_level",
 };
 
 export async function loadSettings(): Promise<AppSettings> {
@@ -107,6 +111,9 @@ export async function loadSettings(): Promise<AppSettings> {
 				raw[SETTINGS_KEY_MAP.defaultFastMode] !== undefined
 					? raw[SETTINGS_KEY_MAP.defaultFastMode] === "true"
 					: DEFAULT_SETTINGS.defaultFastMode,
+			zoomLevel: raw[SETTINGS_KEY_MAP.zoomLevel]
+				? Number(raw[SETTINGS_KEY_MAP.zoomLevel])
+				: DEFAULT_SETTINGS.zoomLevel,
 		};
 	} catch {
 		return { ...DEFAULT_SETTINGS };

--- a/src/shell/use-zoom.ts
+++ b/src/shell/use-zoom.ts
@@ -1,0 +1,51 @@
+import { getCurrentWebview } from "@tauri-apps/api/webview";
+import { useEffect } from "react";
+import { isPrimaryModifier } from "@/lib/keyboard-modifier";
+import { useSettings } from "@/lib/settings";
+
+const MIN_ZOOM = 0.5;
+const MAX_ZOOM = 2.0;
+const ZOOM_STEP = 0.1;
+
+function clampZoom(value: number): number {
+	if (!Number.isFinite(value)) return 1.0;
+	const clamped = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, value));
+	// Snap to 2 decimals so repeated +/- doesn't drift (0.1 isn't exact in fp).
+	return Math.round(clamped * 100) / 100;
+}
+
+/**
+ * Binds Cmd+= / Cmd+- / Cmd+0 to webview zoom and persists the level.
+ * Applies the current zoom to the webview whenever the setting changes.
+ */
+export function useZoom(): void {
+	const { settings, updateSettings } = useSettings();
+	const zoom = settings.zoomLevel;
+
+	useEffect(() => {
+		void getCurrentWebview()
+			.setZoom(zoom)
+			.catch(() => {
+				// webview may not be ready yet, or we're in a non-Tauri env
+			});
+	}, [zoom]);
+
+	useEffect(() => {
+		const handler = (e: KeyboardEvent) => {
+			if (!isPrimaryModifier(e)) return;
+			// Cmd+= is "zoom in" on macOS (Cmd++ requires shift); accept both.
+			if (e.key === "=" || e.key === "+") {
+				e.preventDefault();
+				updateSettings({ zoomLevel: clampZoom(zoom + ZOOM_STEP) });
+			} else if (e.key === "-") {
+				e.preventDefault();
+				updateSettings({ zoomLevel: clampZoom(zoom - ZOOM_STEP) });
+			} else if (e.key === "0") {
+				e.preventDefault();
+				updateSettings({ zoomLevel: 1.0 });
+			}
+		};
+		window.addEventListener("keydown", handler);
+		return () => window.removeEventListener("keydown", handler);
+	}, [zoom, updateSettings]);
+}


### PR DESCRIPTION
## Summary
- Add a `useZoom` hook that binds Cmd+=/Cmd+-/Cmd+0 to the Tauri webview zoom, clamped to [0.5, 2.0] with 0.1 steps.
- Persist the current zoom level in app settings (`app.zoom_level`) so it survives restarts.
- Grant the `core:webview:allow-set-webview-zoom` capability so `getCurrentWebview().setZoom()` works.

## Why
Users on high-DPI/Retina or external displays wanted a quick way to scale the entire UI without restarting. This wires up the platform-standard zoom shortcuts and keeps the chosen level sticky.

## Test notes
- `bun run dev`, then Cmd+= / Cmd+- / Cmd+0 — UI scales up / down / resets.
- Restart the app; last zoom level is restored.
- Values stay inside 0.5–2.0 even after repeated presses (snap-to-2-decimals prevents float drift).