### PR TITLE
fix(updater): derive release-page URL from version so change-log link renders

### DIFF
--- a/.changeset/fix-update-toast-changelog-link.md
+++ b/.changeset/fix-update-toast-changelog-link.md
@@ -2,4 +2,5 @@
 "helmor": patch
 ---
 
-- Fix the "View change log" link never showing in the update-ready toast (and the Settings → App Updates panel). The release page URL is now derived deterministically from the update version instead of relying on a field that `latest.json` never actually contains.
+Fix the missing change-log link in the app update flow:
+- The "View change log" button now appears in the update-ready toast and in Settings → App Updates, opening the matching GitHub release page.

--- a/.changeset/fix-update-toast-changelog-link.md
+++ b/.changeset/fix-update-toast-changelog-link.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+- Fix the "View change log" link never showing in the update-ready toast (and the Settings → App Updates panel). The release page URL is now derived deterministically from the update version instead of relying on a field that `latest.json` never actually contains.

--- a/.codex/skills/helmor-release/SKILL.md
+++ b/.codex/skills/helmor-release/SKILL.md
@@ -53,7 +53,7 @@ Write changesets for users, not for maintainers.
 Do:
 
 - explain what changed from the user's point of view
-- group related work into 2-5 short bullets
+- always open the body with a prose summary line (no leading `- `), then enumerate concrete changes as `- ` sub-items underneath
 - keep bullets concrete and outcome-focused
 - mention new workflows or capabilities
 - include a short thanks line only if the user explicitly wants credits
@@ -64,25 +64,33 @@ Do not:
 - list internal refactors unless they changed release behavior
 - mention implementation-only details like exact file names
 - create multiple changesets for one coordinated release task unless the user asks
-- start the changeset body with a `- ` bullet (see format rule below)
+- start the changeset body with a `- ` bullet, or skip the summary line and go straight to bullets (see format rule below)
 
 ## Default Changeset Format
 
-`@changesets/changelog-github` inlines the first line of the body after `Thanks @user! -` when rendering `CHANGELOG.md` / GitHub Release. If the first line is itself a bullet (`- Fix X`), the output becomes `! - - Fix X` with the first item glued to the attribution. **Never start the body with `- `.**
+Every changeset body has **two parts**:
 
-### Single-item changeset
+1. A prose **summary line** that sets the release theme at a glance, written with no leading `- `.
+2. One or more **bullet sub-items** underneath (each starting with `- `) that enumerate concrete user-visible changes.
 
-Write the body as one sentence, no leading dash:
+Both parts are required, even when there is only one underlying change — the summary gives the CHANGELOG reader context; the bullets carry the outcomes.
+
+`@changesets/changelog-github` inlines the first line of the body after `Thanks @user! -` when rendering `CHANGELOG.md` / GitHub Release. If the first line is itself a bullet (`- Fix X`), the output becomes `! - - Fix X` with the first item glued to the attribution. **Never start the body with `- `**, and never submit a changeset whose body is a single sentence with no bullets — always give readers a summary + at least one bullet.
+
+### Single-change example
+
+Summary line describes the area; one bullet captures the specific outcome:
 
 ```md
 ---
 "helmor": patch
 ---
 
-Fix Chinese / Japanese / Korean IME pressing Enter to confirm a candidate accidentally sending the message.
+Fix a Chinese IME regression in the composer:
+- Pressing Enter to confirm an IME candidate no longer accidentally sends the message.
 ```
 
-### Multi-item changeset
+### Multi-change example
 
 First line is a prose summary ending with `:`. Bullets start from the next line:
 

--- a/.codex/skills/helmor-release/references/release-format.md
+++ b/.codex/skills/helmor-release/references/release-format.md
@@ -49,15 +49,23 @@ Bad:
 
 ## Body Structure
 
-`@changesets/changelog-github` inlines the first line of the body onto the same line as `Thanks @user! -`. The body must therefore never start with a `- ` bullet, or the rendered CHANGELOG gets `! - - Fix X` with the first item glued to the attribution line.
+Every changeset body has two mandatory parts:
 
-Single item → one sentence, no leading dash:
+1. A prose **summary line** with no leading `- `.
+2. One or more **bullet sub-items** (each starting with `- `) underneath.
+
+Both parts are required, even for a single-change fix. The summary gives the CHANGELOG reader context at a glance; the bullets carry the concrete outcomes. Do not submit changesets that are a single prose sentence with no bullets, and never start the body with `- `.
+
+`@changesets/changelog-github` inlines the first line of the body onto the same line as `Thanks @user! -` when rendering `CHANGELOG.md` / GitHub Release. Starting with `- ` produces `! - - Fix X` with the first item glued to the attribution line, which is why the summary-first rule is enforced.
+
+Single change — summary line describes the area, one bullet captures the outcome:
 
 ```md
-Fix the caret jumping to the start of the paragraph after an IME buffer is stripped.
+Fix a composer IME regression:
+- The caret no longer jumps to the start of the paragraph after an IME buffer is stripped.
 ```
 
-Multiple items → prose summary on line 1 (ending with `:`), bullets from line 2:
+Multiple changes — summary line ends with `:`, bullets follow:
 
 ```md
 Harden Chinese / Japanese / Korean IME handling in the composer:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,7 @@ When a snapshot drifts: look at the diff first. Only accept after confirming the
 - **File editor**: Monaco, lazy via `src/lib/monaco-runtime.ts`.
 - **Linting**: Biome (tab indent). `lint-staged` enforces on pre-commit.
 - **Testing**: Vitest + jsdom (frontend), `bun test` (sidecar), cargo test + insta (Rust). Tests co-located with source.
+- **Changesets**: Every `.changeset/*.md` body starts with a prose summary line (no leading `- `), then lists each user-visible change as a `- ` sub-item underneath. Both parts are required, even for a single-change fix. See the `helmor-release` skill for full format and rationale.
 - **Data dir**: `~/helmor/` (release) or `~/helmor-dev/` (debug). Override: `HELMOR_DATA_DIR`.
 - **macOS chrome**: Overlay title bar, traffic lights at (16, 24). Drag via `data-tauri-drag-region`.
 - **Serde**: `#[serde(rename_all = "camelCase")]` -- JSON fields match TypeScript directly.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1783,7 +1783,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "helmor"
-version = "0.1.2"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/src/updater/events.rs
+++ b/src-tauri/src/updater/events.rs
@@ -22,8 +22,7 @@ pub struct UpdateInfoSnapshot {
     pub version: String,
     pub body: Option<String>,
     pub date: Option<String>,
-    pub release_url: Option<String>,
-    pub changelog_url: Option<String>,
+    pub release_url: String,
 }
 
 #[derive(Clone, Debug, Serialize)]

--- a/src-tauri/src/updater/service.rs
+++ b/src-tauri/src/updater/service.rs
@@ -2,7 +2,6 @@ use std::sync::{Mutex, OnceLock};
 use std::thread;
 
 use chrono::Utc;
-use serde_json::Value;
 use tauri::{AppHandle, Emitter, Runtime};
 use tauri_plugin_updater::UpdaterExt;
 
@@ -305,24 +304,17 @@ fn should_attempt(
 }
 
 fn snapshot_from_update(update: &tauri_plugin_updater::Update) -> UpdateInfoSnapshot {
-    let release_url = raw_json_string(&update.raw_json, &["releaseUrl", "release_url"]);
-    let changelog_url = raw_json_string(&update.raw_json, &["changelogUrl", "changelog_url"]);
-
     UpdateInfoSnapshot {
         current_version: update.current_version.clone(),
         version: update.version.clone(),
         body: update.body.clone(),
         date: update.date.map(|value| value.to_string()),
-        release_url,
-        changelog_url,
+        release_url: release_url_for_version(&update.version),
     }
 }
 
-fn raw_json_string(value: &Value, keys: &[&str]) -> Option<String> {
-    keys.iter().find_map(|key| {
-        value
-            .get(key)
-            .and_then(Value::as_str)
-            .map(ToOwned::to_owned)
-    })
+// CI enforces tag == `v{package.json.version}` in .github/workflows/publish.yml,
+// so every installable update has a corresponding GitHub release page at this URL.
+fn release_url_for_version(version: &str) -> String {
+    format!("https://github.com/dohooo/helmor/releases/tag/v{version}")
 }

--- a/src-tauri/src/updater/tests.rs
+++ b/src-tauri/src/updater/tests.rs
@@ -56,8 +56,7 @@ fn update_status_snapshot_serializes_camel_case_fields() {
             version: "0.2.0".into(),
             body: Some("release notes".into()),
             date: None,
-            release_url: Some("https://example.com/release".into()),
-            changelog_url: None,
+            release_url: "https://github.com/dohooo/helmor/releases/tag/v0.2.0".into(),
         }),
         last_error: Some("network".into()),
         last_attempt_at: Some("2026-04-17T00:00:00Z".into()),
@@ -70,7 +69,10 @@ fn update_status_snapshot_serializes_camel_case_fields() {
     assert_eq!(value["autoUpdateEnabled"], true);
     assert_eq!(value["update"]["currentVersion"], "0.1.0");
     assert_eq!(value["update"]["version"], "0.2.0");
-    assert_eq!(value["update"]["releaseUrl"], "https://example.com/release");
+    assert_eq!(
+        value["update"]["releaseUrl"],
+        "https://github.com/dohooo/helmor/releases/tag/v0.2.0"
+    );
     assert_eq!(value["lastError"], "network");
     assert_eq!(value["lastAttemptAt"], "2026-04-17T00:00:00Z");
 }

--- a/src/features/updater/use-app-updater.ts
+++ b/src/features/updater/use-app-updater.ts
@@ -47,18 +47,16 @@ function showDownloadedUpdateToast(
 			},
 			"Update and restart",
 		),
-		cancel: status.update.releaseUrl
-			? createElement(
-					"button",
-					{
-						type: "button",
-						"data-button": true,
-						"data-cancel": true,
-						onClick: () => void openUrl(status.update.releaseUrl ?? ""),
-					},
-					"View change log",
-				)
-			: undefined,
+		cancel: createElement(
+			"button",
+			{
+				type: "button",
+				"data-button": true,
+				"data-cancel": true,
+				onClick: () => void openUrl(status.update.releaseUrl),
+			},
+			"View change log",
+		),
 		duration: Number.POSITIVE_INFINITY,
 	});
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -401,8 +401,7 @@ export type AppUpdateInfo = {
 	version: string;
 	body?: string | null;
 	date?: string | null;
-	releaseUrl?: string | null;
-	changelogUrl?: string | null;
+	releaseUrl: string;
 };
 
 export type AppUpdateStatus = {

--- a/src/test/e2e-mocks/tauri-webview.ts
+++ b/src/test/e2e-mocks/tauri-webview.ts
@@ -1,0 +1,5 @@
+export function getCurrentWebview() {
+	return {
+		setZoom: async (_zoom: number) => {},
+	};
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -55,6 +55,12 @@ vi.mock("@tauri-apps/api/window", () => ({
 	})),
 }));
 
+vi.mock("@tauri-apps/api/webview", () => ({
+	getCurrentWebview: vi.fn(() => ({
+		setZoom: vi.fn(async () => {}),
+	})),
+}));
+
 // `src/lib/api.ts` always calls `invoke` from `@tauri-apps/api/core` now —
 // there is no browser-mode fallback layer anymore. jsdom has no Tauri runtime,
 // so without this mock every test that triggers a real API function (via

--- a/vite.e2e.config.ts
+++ b/vite.e2e.config.ts
@@ -39,6 +39,7 @@ export default defineConfig({
 			"@tauri-apps/api/core": path.resolve(MOCK_DIR, "tauri-core.ts"),
 			"@tauri-apps/api/event": path.resolve(MOCK_DIR, "tauri-event.ts"),
 			"@tauri-apps/api/window": path.resolve(MOCK_DIR, "tauri-window.ts"),
+			"@tauri-apps/api/webview": path.resolve(MOCK_DIR, "tauri-webview.ts"),
 			"@tauri-apps/plugin-opener": path.resolve(MOCK_DIR, "plugin-opener.ts"),
 			"@tauri-apps/plugin-dialog": path.resolve(MOCK_DIR, "plugin-dialog.ts"),
 			"@tauri-apps/plugin-notification": path.resolve(


### PR DESCRIPTION
The 'View change log' button in the update-ready toast (and the Settings
-> App Updates panel) never appeared because it was gated on
`status.update.releaseUrl`, which came from reading `releaseUrl` /
`release_url` out of the updater manifest's raw JSON. tauri-action's
`latest.json` schema does not include those fields, so the value was
always `None`.

publish.yml already enforces `tag == v{package.json.version}`, so the
GitHub release URL is deterministic from the update version. Build it
directly in the backend and drop the dead `changelog_url` plumbing.