### PR TITLE
fix(agents): only adopt Claude session id from system.init

### DIFF
--- a/.changeset/fix-claude-resume.md
+++ b/.changeset/fix-claude-resume.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix resuming a Claude conversation sometimes failing with "No conversation found".

--- a/src-tauri/src/agents/streaming.rs
+++ b/src-tauri/src/agents/streaming.rs
@@ -250,6 +250,16 @@ pub fn convert_elicitation_content_to_codex_answers(content: &Value) -> Value {
     Value::Object(answers)
 }
 
+fn should_adopt_provider_session_id(
+    current_provider_session_id: Option<&str>,
+    observed_provider_session_id: &str,
+    helmor_session_id: Option<&str>,
+) -> bool {
+    !observed_provider_session_id.is_empty()
+        && helmor_session_id != Some(observed_provider_session_id)
+        && current_provider_session_id.is_none()
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(super) fn stream_via_sidecar(
     app: AppHandle,
@@ -349,7 +359,7 @@ pub(super) fn stream_via_sidecar(
     tauri::async_runtime::spawn_blocking(move || {
         let sidecar_state: tauri::State<'_, crate::sidecar::ManagedSidecar> = app.state();
         let active_streams_state: tauri::State<'_, ActiveStreams> = app.state();
-        let mut resolved_session_id: Option<String> = None;
+        let mut resolved_session_id: Option<String> = resume_session_id.clone();
         let context_key = rid.clone();
         let pipeline_session_id = hsid_copy.clone().unwrap_or_else(|| context_key.clone());
         let mut pipeline = hsid_copy.as_ref().map(|_| {
@@ -411,23 +421,39 @@ pub(super) fn stream_via_sidecar(
         for event in rx.iter() {
             event_count += 1;
 
-            if let Some(sid) = event.session_id() {
-                if resolved_session_id.is_none() {
-                    resolved_session_id = Some(sid.to_string());
-                    if resume_only {
-                        tracing::debug!(
-                            rid = %rid,
-                            provider_session_id = sid,
-                            "Skipping provider session persistence for resume-only stream"
-                        );
-                    } else if let (Some(ctx), Some(conn)) = (&exchange_ctx, &db_conn) {
-                        if let Err(error) = conn.execute(
-                            "UPDATE sessions SET provider_session_id = ?2, agent_type = ?3 WHERE id = ?1",
-                            params![ctx.helmor_session_id, sid, ctx.model_provider],
-                        ) {
-                            tracing::error!(rid = %rid, "Failed to persist session id: {error}");
-                        } else {
-                            tracing::debug!(rid = %rid, provider_session_id = sid, "Session ID persisted");
+            // Claude's authoritative session_id comes only from `system.init`.
+            // Earlier events — notably SessionStart:resume hook notifications —
+            // carry a transient session_id that does NOT map to any real
+            // conversation jsonl. Adopting them poisons the next resume with
+            // "No conversation found". Codex flattens every notification with
+            // its real thread_id, so any event is safe.
+            let is_provider_session_marker = match model_copy.provider.as_str() {
+                "claude" => event.is_claude_session_init(),
+                _ => true,
+            };
+            if is_provider_session_marker {
+                if let Some(sid) = event.session_id() {
+                    if should_adopt_provider_session_id(
+                        resolved_session_id.as_deref(),
+                        sid,
+                        hsid_copy.as_deref(),
+                    ) {
+                        resolved_session_id = Some(sid.to_string());
+                        if resume_only {
+                            tracing::debug!(
+                                rid = %rid,
+                                provider_session_id = sid,
+                                "Skipping provider session persistence for resume-only stream"
+                            );
+                        } else if let (Some(ctx), Some(conn)) = (&exchange_ctx, &db_conn) {
+                            if let Err(error) = conn.execute(
+                                "UPDATE sessions SET provider_session_id = ?2, agent_type = ?3 WHERE id = ?1",
+                                params![ctx.helmor_session_id, sid, ctx.model_provider],
+                            ) {
+                                tracing::error!(rid = %rid, "Failed to persist session id: {error}");
+                            } else {
+                                tracing::debug!(rid = %rid, provider_session_id = sid, "Session ID persisted");
+                            }
                         }
                     }
                 }
@@ -970,6 +996,35 @@ fn build_exit_plan_review_message(
 mod tests {
     use super::*;
     use insta::assert_yaml_snapshot;
+
+    #[test]
+    fn provider_session_id_is_adopted_only_once() {
+        assert!(should_adopt_provider_session_id(
+            None,
+            "provider-session-1",
+            None
+        ));
+        assert!(!should_adopt_provider_session_id(
+            Some("provider-session-1"),
+            "provider-session-1",
+            None,
+        ));
+        assert!(!should_adopt_provider_session_id(
+            Some("provider-session-1"),
+            "provider-session-2",
+            None,
+        ));
+    }
+
+    #[test]
+    fn provider_session_id_rejects_empty_and_helmor_echo_values() {
+        assert!(!should_adopt_provider_session_id(None, "", None));
+        assert!(!should_adopt_provider_session_id(
+            None,
+            "helmor-session-1",
+            Some("helmor-session-1"),
+        ));
+    }
 
     #[test]
     fn build_elicitation_request_event_maps_raw_sidecar_payload() {

--- a/src-tauri/src/service.rs
+++ b/src-tauri/src/service.rs
@@ -282,13 +282,22 @@ pub fn send_message(
     let mut resolved_session_id: Option<String> = None;
 
     for event in rx.iter() {
-        if let Some(sid) = event.session_id() {
-            if resolved_session_id.is_none() {
-                resolved_session_id = Some(sid.to_string());
-                let _ = conn.execute(
-                    "UPDATE sessions SET provider_session_id = ?2, agent_type = ?3 WHERE id = ?1",
-                    params![session_id, sid, model.provider],
-                );
+        // Match streaming.rs: only Claude's `system.init` carries an
+        // authoritative session_id. SessionStart hook events emit a stale
+        // session_id that would poison the next resume.
+        let is_provider_session_marker = match model.provider.as_str() {
+            "claude" => event.is_claude_session_init(),
+            _ => true,
+        };
+        if is_provider_session_marker {
+            if let Some(sid) = event.session_id() {
+                if resolved_session_id.is_none() {
+                    resolved_session_id = Some(sid.to_string());
+                    let _ = conn.execute(
+                        "UPDATE sessions SET provider_session_id = ?2, agent_type = ?3 WHERE id = ?1",
+                        params![session_id, sid, model.provider],
+                    );
+                }
             }
         }
 

--- a/src-tauri/src/sidecar.rs
+++ b/src-tauri/src/sidecar.rs
@@ -56,6 +56,15 @@ impl SidecarEvent {
     pub fn session_id(&self) -> Option<&str> {
         self.raw.get("session_id")?.as_str()
     }
+
+    /// Claude SDK emits `system.init` to announce the authoritative session
+    /// id for the current turn. Earlier events (e.g. `SessionStart:resume`
+    /// hook events) carry a transient `session_id` that does NOT map to any
+    /// real conversation jsonl — persisting it would poison the next resume.
+    pub fn is_claude_session_init(&self) -> bool {
+        self.raw.get("type").and_then(Value::as_str) == Some("system")
+            && self.raw.get("subtype").and_then(Value::as_str) == Some("init")
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -632,6 +641,57 @@ mod tests {
         assert_eq!(event.id(), None);
         assert_eq!(event.event_type(), "unknown");
         assert_eq!(event.session_id(), None);
+    }
+
+    #[test]
+    fn is_claude_session_init_rejects_hook_events() {
+        // Regression: SessionStart:resume hook notifications fire before
+        // system.init with a transient session_id that does NOT map to any
+        // real conversation jsonl. Capturing it poisons the next resume.
+        let hook_started = SidecarEvent {
+            raw: serde_json::json!({
+                "type": "system",
+                "subtype": "hook_started",
+                "hook_name": "SessionStart:resume",
+                "session_id": "02ad5522-df10-4180-aef4-c17489f42ec2",
+            }),
+        };
+        assert!(!hook_started.is_claude_session_init());
+
+        let hook_response = SidecarEvent {
+            raw: serde_json::json!({
+                "type": "system",
+                "subtype": "hook_response",
+                "session_id": "02ad5522-df10-4180-aef4-c17489f42ec2",
+            }),
+        };
+        assert!(!hook_response.is_claude_session_init());
+
+        let status = SidecarEvent {
+            raw: serde_json::json!({
+                "type": "system",
+                "subtype": "status",
+                "session_id": "152f1faa-85bf-40dd-aae3-0a3aa8d9abfa",
+            }),
+        };
+        assert!(!status.is_claude_session_init());
+
+        let assistant = SidecarEvent {
+            raw: serde_json::json!({
+                "type": "assistant",
+                "session_id": "152f1faa-85bf-40dd-aae3-0a3aa8d9abfa",
+            }),
+        };
+        assert!(!assistant.is_claude_session_init());
+
+        let init = SidecarEvent {
+            raw: serde_json::json!({
+                "type": "system",
+                "subtype": "init",
+                "session_id": "152f1faa-85bf-40dd-aae3-0a3aa8d9abfa",
+            }),
+        };
+        assert!(init.is_claude_session_init());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Resuming a Claude conversation sometimes failed with "No conversation found" because Helmor was persisting a transient `session_id` from `SessionStart:resume` hook events instead of Claude's authoritative `system.init` id.
- Gate provider-session adoption behind `system.init` for Claude (Codex unchanged), and keep the already-known resume id stable for the rest of the stream instead of overwriting it from the first hook event.
- Adds unit tests for `is_claude_session_init` (rejects hook/status/assistant events, accepts `system.init`) and for the `should_adopt_provider_session_id` gate.

## Test plan
- [ ] `cd src-tauri && cargo test` passes
- [ ] Start a Claude conversation, quit, relaunch, and resume it more than once — no "No conversation found"
- [ ] Codex resume still works unchanged