### PR TITLE
fix(github): skip PR lookup for unpublished workspace branches

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1783,7 +1783,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "helmor"
-version = "0.1.4"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -780,7 +780,13 @@ fn current_upstream_ref(workspace_dir: &Path) -> Option<String> {
     .filter(|value| !value.is_empty())
 }
 
-fn resolve_remote_tracking_ref(workspace_dir: &Path, remote: Option<&str>) -> Option<String> {
+/// Returns the workspace branch's effective remote-tracking ref, if any.
+/// Tries upstream config first, then falls back to a literal
+/// `refs/remotes/<remote>/<branch>` lookup so manually-pushed branches
+/// (without `-u`) are still recognised. `None` means the local branch has
+/// no corresponding remote ref Helmor can see — treat as "branch was
+/// never published".
+pub fn resolve_remote_tracking_ref(workspace_dir: &Path, remote: Option<&str>) -> Option<String> {
     if let Some(upstream) = current_upstream_ref(workspace_dir) {
         return Some(upstream);
     }
@@ -1333,6 +1339,73 @@ mod tests {
         assert!(
             !has_upstream(clone.path(), "workspace/test"),
             "workspace branch should have no upstream after creation"
+        );
+    }
+
+    #[test]
+    fn resolve_remote_tracking_ref_is_none_for_freshly_created_workspace() {
+        // After `create_worktree_from_start_point` unsets upstream, no
+        // remote-tracking ref should be reported even though the branch
+        // shares a name with `origin/main`'s history.
+        let (_origin, clone) = init_repo_with_remote();
+        let wt_dir = tempfile::tempdir().unwrap();
+        create_worktree_from_start_point(
+            clone.path(),
+            wt_dir.path(),
+            "dohooo/whirlpool",
+            "origin/main",
+        )
+        .unwrap();
+
+        assert_eq!(
+            resolve_remote_tracking_ref(wt_dir.path(), Some("origin")),
+            None,
+        );
+    }
+
+    #[test]
+    fn resolve_remote_tracking_ref_returns_upstream_after_push() {
+        let (_origin, clone) = init_repo_with_remote();
+        let wt_dir = tempfile::tempdir().unwrap();
+        create_worktree_from_start_point(
+            clone.path(),
+            wt_dir.path(),
+            "feature/published",
+            "origin/main",
+        )
+        .unwrap();
+
+        push_current_branch(wt_dir.path(), "origin").unwrap();
+
+        assert_eq!(
+            resolve_remote_tracking_ref(wt_dir.path(), Some("origin")).as_deref(),
+            Some("origin/feature/published"),
+        );
+    }
+
+    #[test]
+    fn resolve_remote_tracking_ref_recovers_via_remote_ref_when_upstream_unset() {
+        // Manual `git push origin <branch>` (no `-u`) leaves upstream unset
+        // but populates `refs/remotes/origin/<branch>`. The fallback path
+        // should still recognise the branch as published.
+        let (_origin, clone) = init_repo_with_remote();
+        let wt_dir = tempfile::tempdir().unwrap();
+        create_worktree_from_start_point(
+            clone.path(),
+            wt_dir.path(),
+            "feature/manual-push",
+            "origin/main",
+        )
+        .unwrap();
+        run(
+            wt_dir.path(),
+            &["push", "origin", "HEAD:refs/heads/feature/manual-push"],
+        );
+
+        assert!(!has_upstream(wt_dir.path(), "feature/manual-push"));
+        assert_eq!(
+            resolve_remote_tracking_ref(wt_dir.path(), Some("origin")).as_deref(),
+            Some("origin/feature/manual-push"),
         );
     }
 }

--- a/src-tauri/src/github/graphql.rs
+++ b/src-tauri/src/github/graphql.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::collections::BTreeMap;
 
-use crate::{auth, models::workspaces as workspace_models};
+use crate::{auth, git_ops, models::workspaces as workspace_models};
 
 /// A single pull request surfaced to the frontend.
 #[derive(Debug, Clone, Serialize)]
@@ -161,6 +161,13 @@ pub fn lookup_workspace_pr(workspace_id: &str) -> Result<Option<PullRequestInfo>
         return Ok(None);
     };
 
+    // No remote-tracking ref → this branch was never published, so any PR
+    // GitHub returns for `headRefName == branch` belongs to a previous owner
+    // of the name (e.g. a merged PR whose head branch was deleted). Skip.
+    if !workspace_branch_has_remote_tracking(&record) {
+        return Ok(None);
+    }
+
     let Some(access_token) = auth::load_valid_github_access_token()? else {
         // User isn't connected, or their refresh token has expired.
         return Ok(None);
@@ -292,6 +299,13 @@ pub fn lookup_workspace_pr_action_status(workspace_id: &str) -> Result<Workspace
             "Workspace has no current branch",
         ));
     };
+    // Same guard as `lookup_workspace_pr` — without a remote-tracking ref the
+    // branch was never published, so any PR returned would belong to a prior
+    // owner of the same head ref. Surface as `no_pr` so the inspector hides
+    // checks/deployments instead of showing a ghost PR's history.
+    if !workspace_branch_has_remote_tracking(&record) {
+        return Ok(WorkspacePrActionStatus::no_pr());
+    }
     let Some(access_token) = auth::load_valid_github_access_token()? else {
         return Ok(WorkspacePrActionStatus::unavailable(
             "GitHub account is not connected",
@@ -741,6 +755,23 @@ mutation($prId: ID!) {
     }
 
     lookup_workspace_pr(workspace_id)
+}
+
+/// `true` when the workspace's local branch has a remote-tracking ref
+/// (upstream config OR a `refs/remotes/<remote>/<branch>` known locally).
+/// Used by both PR lookups to bail before hitting GitHub when the branch
+/// can't possibly have a PR — avoids ghost matches against historical PRs
+/// whose head branch happens to share the workspace's placeholder name.
+fn workspace_branch_has_remote_tracking(record: &workspace_models::WorkspaceRecord) -> bool {
+    let Ok(workspace_dir) =
+        crate::data_dir::workspace_dir(&record.repo_name, &record.directory_name)
+    else {
+        return false;
+    };
+    if !workspace_dir.exists() {
+        return false;
+    }
+    git_ops::resolve_remote_tracking_ref(&workspace_dir, record.remote.as_deref()).is_some()
 }
 
 /// Parse `https://github.com/owner/repo(.git)` and `git@github.com:owner/repo(.git)`


### PR DESCRIPTION
## Summary
- Workspace PR lookups (`lookup_workspace_pr`, `lookup_workspace_pr_action_status`) now bail out when the local workspace branch has no remote-tracking ref. Without this, GitHub can return a PR whose `headRefName` matches a stale/merged branch that happens to share the name our workspace picked locally — a "ghost PR" that surfaces wrong checks/deployments in the inspector.
- Promotes `resolve_remote_tracking_ref` from module-private to `pub` so `github::graphql` can reuse it, and teaches it to fall back to `refs/remotes/<remote>/<branch>` so manually-pushed branches (no `-u`) are still recognised as published.
- Adds unit tests for the three cases that matter: freshly-created worktree (no ref), upstream set via `-u`, and manual `git push origin <branch>` with no upstream.

## Why
Users saw PR metadata appearing in the inspector for workspaces whose branches had never been pushed. Root cause: GitHub happily answers a `headRefName` query for any previous owner of that name, even long-deleted/merged ones. The new guard ensures we only ask GitHub about branches that actually exist on the remote.

## Test plan
- [x] `cargo test --manifest-path src-tauri/Cargo.toml` (new `resolve_remote_tracking_ref_*` tests)
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings` via pre-commit
- [ ] Manual: open a fresh workspace, confirm no PR / action-status is rendered until the branch is pushed
- [ ] Manual: push the branch with `-u` and confirm PR info appears as expected
- [ ] Manual: push a branch with no upstream (`git push origin HEAD:refs/heads/foo`) and confirm PR info still appears