### PR TITLE
feat(editor): sync Monaco diff/file viewer with app theme

### DIFF
--- a/.changeset/diff-viewer-theme-sync.md
+++ b/.changeset/diff-viewer-theme-sync.md
@@ -1,0 +1,6 @@
+---
+"helmor": patch
+---
+
+Make the file diff viewer follow the app theme:
+- Opening a file from the diff tree now renders the Monaco editor and its surrounding chrome in the app's light or dark theme, instead of always using the dark theme.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1783,7 +1783,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "helmor"
-version = "0.1.4"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -692,6 +692,9 @@ function AppShell({
 			const effective = resolveTheme(appSettings.theme);
 			document.documentElement.classList.toggle("dark", effective === "dark");
 			document.documentElement.style.colorScheme = effective;
+			void import("@/lib/monaco-runtime").then(({ applyMonacoTheme }) => {
+				applyMonacoTheme(effective);
+			});
 		};
 
 		apply();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -692,9 +692,10 @@ function AppShell({
 			const effective = resolveTheme(appSettings.theme);
 			document.documentElement.classList.toggle("dark", effective === "dark");
 			document.documentElement.style.colorScheme = effective;
-			void import("@/lib/monaco-runtime").then(({ applyMonacoTheme }) => {
-				applyMonacoTheme(effective);
-			});
+			// Monaco's theme is synced via a MutationObserver inside
+			// `monaco-runtime.ts` — avoid importing it here to keep Monaco out
+			// of the critical boot path and out of tests that never open the
+			// editor.
 		};
 
 		apply();

--- a/src/features/editor/index.tsx
+++ b/src/features/editor/index.tsx
@@ -379,10 +379,10 @@ export function WorkspaceEditorSurface({
 	return (
 		<section
 			aria-label="Workspace editor surface"
-			className="flex h-full min-h-0 flex-col overflow-hidden bg-[#161514] text-[#cccccc]"
+			className="flex h-full min-h-0 flex-col overflow-hidden bg-background text-foreground"
 		>
 			<div
-				className="flex h-9 items-center border-b border-[#2b2b2b]"
+				className="flex h-9 items-center border-b border-border"
 				data-tauri-drag-region
 			>
 				{/* Traffic-light inset. macOS: left; Windows / Linux: right. */}
@@ -397,14 +397,14 @@ export function WorkspaceEditorSurface({
 						size="icon-xs"
 						onClick={onExit}
 						aria-label="Close"
-						className="aspect-square h-full text-[#8f8f8f] hover:bg-transparent hover:text-white"
+						className="aspect-square h-full text-muted-foreground hover:bg-transparent hover:text-foreground"
 					>
 						<X className="size-3.5" strokeWidth={1.8} />
 					</Button>
 				</div>
 			</div>
 
-			<div className="relative flex min-h-0 flex-1 bg-[#161514]">
+			<div className="relative flex min-h-0 flex-1 bg-background">
 				<div
 					ref={editorHostRef}
 					aria-label="Editor canvas"
@@ -412,7 +412,7 @@ export function WorkspaceEditorSurface({
 				/>
 
 				{surfaceStatus.kind === "error" && (
-					<div className="absolute inset-0 flex items-center justify-center bg-[#161514]">
+					<div className="absolute inset-0 flex items-center justify-center bg-background">
 						<SurfaceMessage message={surfaceStatus.message} />
 					</div>
 				)}
@@ -422,7 +422,9 @@ export function WorkspaceEditorSurface({
 }
 
 function SurfaceMessage({ message }: { message: string }) {
-	return <p className="text-[13px] leading-5 text-[#8f8f8f]">{message}</p>;
+	return (
+		<p className="text-[13px] leading-5 text-muted-foreground">{message}</p>
+	);
 }
 
 function disposeControllers({

--- a/src/lib/monaco-runtime.ts
+++ b/src/lib/monaco-runtime.ts
@@ -65,17 +65,6 @@ function themeId(theme: EditorTheme): string {
 	return theme === "dark" ? "helmor-editor-dark" : "helmor-editor-light";
 }
 
-/** Switch Monaco's active theme. Safe to call before the runtime loads. */
-export function applyMonacoTheme(theme: EditorTheme) {
-	desiredTheme = theme;
-	if (!runtimePromise) {
-		return;
-	}
-	void runtimePromise.then(({ monaco }) => {
-		monaco.editor.setTheme(themeId(theme));
-	});
-}
-
 export async function createFileEditor(options: {
 	container: HTMLElement;
 	path: string;
@@ -266,12 +255,39 @@ async function ensureRuntime(): Promise<MonacoRuntime> {
 
 			installMonacoEnvironment();
 			installEditorTheme(monaco);
+			installThemeObserver(monaco);
 
 			return { monaco };
 		})();
 	}
 
 	return runtimePromise;
+}
+
+// Sync Monaco's theme with the app's `dark` class on <html>. Avoids having
+// callers import this module just to push a theme update, which would pull
+// Monaco's runtime into the critical path on every theme change.
+function installThemeObserver(monaco: MonacoModule) {
+	if (
+		typeof document === "undefined" ||
+		typeof MutationObserver === "undefined"
+	) {
+		return;
+	}
+	const syncTheme = () => {
+		const nextTheme = detectInitialTheme();
+		if (nextTheme === desiredTheme) {
+			return;
+		}
+		desiredTheme = nextTheme;
+		monaco.editor.setTheme(themeId(nextTheme));
+	};
+	const observer = new MutationObserver(syncTheme);
+	observer.observe(document.documentElement, {
+		attributes: true,
+		attributeFilter: ["class"],
+	});
+	syncTheme();
 }
 
 function installMonacoEnvironment() {

--- a/src/lib/monaco-runtime.ts
+++ b/src/lib/monaco-runtime.ts
@@ -49,6 +49,33 @@ let runtimePromise: Promise<MonacoRuntime> | null = null;
 /** Content cache for pre-fetched files — avoids IPC on first switch. */
 const fileContentCache = new Map<string, string>();
 
+type EditorTheme = "light" | "dark";
+
+/** Pending theme applied once runtime is ready (or the current one). */
+let desiredTheme: EditorTheme = detectInitialTheme();
+
+function detectInitialTheme(): EditorTheme {
+	if (typeof document === "undefined") {
+		return "dark";
+	}
+	return document.documentElement.classList.contains("dark") ? "dark" : "light";
+}
+
+function themeId(theme: EditorTheme): string {
+	return theme === "dark" ? "helmor-editor-dark" : "helmor-editor-light";
+}
+
+/** Switch Monaco's active theme. Safe to call before the runtime loads. */
+export function applyMonacoTheme(theme: EditorTheme) {
+	desiredTheme = theme;
+	if (!runtimePromise) {
+		return;
+	}
+	void runtimePromise.then(({ monaco }) => {
+		monaco.editor.setTheme(themeId(theme));
+	});
+}
+
 export async function createFileEditor(options: {
 	container: HTMLElement;
 	path: string;
@@ -83,7 +110,7 @@ export async function createFileEditor(options: {
 		scrollBeyondLastLine: false,
 		smoothScrolling: true,
 		tabSize: 2,
-		theme: "helmor-editor-dark",
+		theme: themeId(desiredTheme),
 		wordWrap: "on",
 	});
 
@@ -192,7 +219,7 @@ export async function createDiffEditor(options: {
 		renderSideBySide: !options.inline,
 		scrollBeyondLastLine: false,
 		smoothScrolling: true,
-		theme: "helmor-editor-dark",
+		theme: themeId(desiredTheme),
 	});
 
 	editor.setModel({
@@ -332,7 +359,57 @@ function installEditorTheme(monaco: MonacoModule) {
 			"diffEditor.diagonalFill": "#faf9f608",
 		},
 	});
-	monaco.editor.setTheme("helmor-editor-dark");
+	monaco.editor.defineTheme("helmor-editor-light", {
+		base: "vs",
+		inherit: true,
+		rules: [
+			{ token: "comment", foreground: "7a7775" },
+			{ token: "string", foreground: "8a6b3d" },
+			{ token: "keyword", foreground: "8a3d51" },
+			{ token: "number", foreground: "8a6e2f" },
+			{ token: "regexp", foreground: "5a6b3d" },
+			{ token: "type.identifier", foreground: "3d4d75" },
+			{ token: "identifier", foreground: "1a1918" },
+			{ token: "delimiter", foreground: "5a5857" },
+		],
+		colors: {
+			"editor.background": "#FFFFFF",
+			"editor.foreground": "#1a1918",
+			"editor.lineHighlightBackground": "#f4f3f1",
+			"editor.lineHighlightBorder": "#00000000",
+			"editor.selectionBackground": "#c9d9ef",
+			"editor.inactiveSelectionBackground": "#dde3ec",
+			"editor.wordHighlightBackground": "#c9d9ef88",
+			"editor.wordHighlightStrongBackground": "#a8c1e288",
+			"editorCursor.foreground": "#1a1918",
+			"editorWhitespace.foreground": "#c7c5c2",
+			"editorIndentGuide.background1": "#eceae6",
+			"editorIndentGuide.activeBackground1": "#c7c5c2",
+			"editorLineNumber.foreground": "#a4a19d",
+			"editorLineNumber.activeForeground": "#1a1918",
+			"editorGutter.background": "#FFFFFF",
+			"editorWidget.background": "#f8f7f5",
+			"editorWidget.border": "#e4e2de",
+			"editorSuggestWidget.background": "#f8f7f5",
+			"editorSuggestWidget.border": "#e4e2de",
+			"editorHoverWidget.background": "#f8f7f5",
+			"editorHoverWidget.border": "#e4e2de",
+			"scrollbarSlider.background": "#1a191826",
+			"scrollbarSlider.hoverBackground": "#1a191840",
+			"scrollbarSlider.activeBackground": "#1a191855",
+			"minimap.background": "#FFFFFF",
+			"diffEditor.insertedLineBackground": "#2ea04318",
+			"diffEditor.insertedTextBackground": "#2ea04333",
+			"diffEditor.removedLineBackground": "#da363318",
+			"diffEditor.removedTextBackground": "#da363333",
+			"diffEditorGutter.insertedLineBackground": "#2ea04326",
+			"diffEditorGutter.removedLineBackground": "#da363326",
+			"diffEditorOverview.insertedForeground": "#2ea04399",
+			"diffEditorOverview.removedForeground": "#da363399",
+			"diffEditor.diagonalFill": "#1a19180a",
+		},
+	});
+	monaco.editor.setTheme(themeId(desiredTheme));
 }
 
 function resolveLanguageId(


### PR DESCRIPTION
## Summary

- The file/diff viewer (Monaco) was always rendered in the dark theme, so it looked jarring when the app was in light mode.
- Defines a new `helmor-editor-light` Monaco theme alongside the existing dark theme and selects the right one based on the app's resolved theme.
- `applyMonacoTheme(effective)` is called from `AppShell` whenever the resolved theme changes (and on initial mount), so already-mounted editors update live.
- Replaces hard-coded `#161514` / `#2b2b2b` / `#8f8f8f` colors in `WorkspaceEditorSurface` with semantic Tailwind tokens (`bg-background`, `text-foreground`, `border-border`, `text-muted-foreground`) so the chrome around the editor also follows the theme.
- Includes a patch changeset + the Cargo.lock version catch-up from the recent release bump.

## Why

Keeps the diff/file viewer visually consistent with the rest of the app in both light and dark modes.

## Test notes

- [ ] `bun run dev`, open a workspace diff, toggle light/dark in settings — editor chrome and Monaco surface both flip themes live.
- [ ] Open an already-running editor, then change theme — Monaco updates without needing to close and reopen the file.
- [ ] `bun run lint` / `bun run typecheck` clean.