### PR TITLE
refactor(settings): remove auto-update toggles from app updates panel

### DIFF
--- a/src/features/settings/panels/app-updates.tsx
+++ b/src/features/settings/panels/app-updates.tsx
@@ -3,8 +3,6 @@ import { Loader2, RefreshCw } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Switch } from "@/components/ui/switch";
 import {
 	type AppUpdateStatus,
 	checkForAppUpdate,
@@ -12,7 +10,6 @@ import {
 	installDownloadedAppUpdate,
 	listenAppUpdateStatus,
 } from "@/lib/api";
-import { useSettings } from "@/lib/settings";
 
 function formatStatusDescription(status: AppUpdateStatus): string {
 	if (!status.configured) {
@@ -42,7 +39,6 @@ function formatStatusDescription(status: AppUpdateStatus): string {
 }
 
 export function AppUpdatesPanel() {
-	const { settings, updateSettings } = useSettings();
 	const [status, setStatus] = useState<AppUpdateStatus | null>(null);
 	const [checking, setChecking] = useState(false);
 	const [installing, setInstalling] = useState(false);
@@ -151,88 +147,6 @@ export function AppUpdatesPanel() {
 						)}
 					</div>
 				</div>
-			</div>
-
-			<div className="flex items-center justify-between rounded-xl border border-border/30 bg-muted/30 px-5 py-4">
-				<div className="mr-8">
-					<div className="text-[13px] font-medium leading-snug text-foreground">
-						Automatic checks
-					</div>
-					<div className="mt-1 text-[12px] leading-snug text-muted-foreground">
-						Check for updates after launch, on focus, and on the background
-						timer.
-					</div>
-				</div>
-				<Switch
-					checked={settings.autoUpdateEnabled}
-					onCheckedChange={(checked) =>
-						updateSettings({ autoUpdateEnabled: checked })
-					}
-				/>
-			</div>
-
-			<div className="flex items-center justify-between rounded-xl border border-border/30 bg-muted/30 px-5 py-4">
-				<div className="mr-8">
-					<div className="text-[13px] font-medium leading-snug text-foreground">
-						Check on launch
-					</div>
-					<div className="mt-1 text-[12px] leading-snug text-muted-foreground">
-						Run a background check shortly after Helmor starts.
-					</div>
-				</div>
-				<Switch
-					checked={settings.autoUpdateCheckOnLaunch}
-					onCheckedChange={(checked) =>
-						updateSettings({ autoUpdateCheckOnLaunch: checked })
-					}
-					disabled={!settings.autoUpdateEnabled}
-				/>
-			</div>
-
-			<div className="flex items-center justify-between rounded-xl border border-border/30 bg-muted/30 px-5 py-4">
-				<div className="mr-8">
-					<div className="text-[13px] font-medium leading-snug text-foreground">
-						Check when Helmor is focused
-					</div>
-					<div className="mt-1 text-[12px] leading-snug text-muted-foreground">
-						Use a throttled focus/resume trigger to pick up freshly published
-						releases.
-					</div>
-				</div>
-				<Switch
-					checked={settings.autoUpdateCheckOnFocus}
-					onCheckedChange={(checked) =>
-						updateSettings({ autoUpdateCheckOnFocus: checked })
-					}
-					disabled={!settings.autoUpdateEnabled}
-				/>
-			</div>
-
-			<div className="flex items-center justify-between rounded-xl border border-border/30 bg-muted/30 px-5 py-4">
-				<div className="mr-8">
-					<div className="text-[13px] font-medium leading-snug text-foreground">
-						Background interval
-					</div>
-					<div className="mt-1 text-[12px] leading-snug text-muted-foreground">
-						Minimum minutes between background checks.
-					</div>
-				</div>
-				<Input
-					type="number"
-					min={1}
-					step={1}
-					value={String(settings.autoUpdateIntervalMinutes)}
-					onChange={(event) =>
-						updateSettings({
-							autoUpdateIntervalMinutes: Math.max(
-								1,
-								Number(event.target.value) || 1,
-							),
-						})
-					}
-					className="w-28 bg-muted/30 text-right text-[13px] text-foreground"
-					disabled={!settings.autoUpdateEnabled}
-				/>
 			</div>
 		</div>
 	);

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -9,10 +9,6 @@ export type AppSettings = {
 	branchPrefixCustom: string;
 	theme: ThemeMode;
 	notifications: boolean;
-	autoUpdateEnabled: boolean;
-	autoUpdateCheckOnLaunch: boolean;
-	autoUpdateCheckOnFocus: boolean;
-	autoUpdateIntervalMinutes: number;
 	lastWorkspaceId: string | null;
 	lastSessionId: string | null;
 	defaultModelId: string | null;
@@ -28,10 +24,6 @@ export const DEFAULT_SETTINGS: AppSettings = {
 	branchPrefixCustom: "",
 	theme: "system",
 	notifications: true,
-	autoUpdateEnabled: true,
-	autoUpdateCheckOnLaunch: true,
-	autoUpdateCheckOnFocus: true,
-	autoUpdateIntervalMinutes: 360,
 	lastWorkspaceId: null,
 	lastSessionId: null,
 	defaultModelId: null,
@@ -48,10 +40,6 @@ const SETTINGS_KEY_MAP: Record<Exclude<keyof AppSettings, "theme">, string> = {
 	branchPrefixType: "branch_prefix_type",
 	branchPrefixCustom: "branch_prefix_custom",
 	notifications: "app.notifications",
-	autoUpdateEnabled: "app.auto_update_enabled",
-	autoUpdateCheckOnLaunch: "app.auto_update_check_on_launch",
-	autoUpdateCheckOnFocus: "app.auto_update_check_on_focus",
-	autoUpdateIntervalMinutes: "app.auto_update_interval_minutes",
 	lastWorkspaceId: "app.last_workspace_id",
 	lastSessionId: "app.last_session_id",
 	defaultModelId: "app.default_model_id",
@@ -83,22 +71,6 @@ export async function loadSettings(): Promise<AppSettings> {
 				raw[SETTINGS_KEY_MAP.notifications] !== undefined
 					? raw[SETTINGS_KEY_MAP.notifications] === "true"
 					: DEFAULT_SETTINGS.notifications,
-			autoUpdateEnabled:
-				raw[SETTINGS_KEY_MAP.autoUpdateEnabled] !== undefined
-					? raw[SETTINGS_KEY_MAP.autoUpdateEnabled] === "true"
-					: DEFAULT_SETTINGS.autoUpdateEnabled,
-			autoUpdateCheckOnLaunch:
-				raw[SETTINGS_KEY_MAP.autoUpdateCheckOnLaunch] !== undefined
-					? raw[SETTINGS_KEY_MAP.autoUpdateCheckOnLaunch] === "true"
-					: DEFAULT_SETTINGS.autoUpdateCheckOnLaunch,
-			autoUpdateCheckOnFocus:
-				raw[SETTINGS_KEY_MAP.autoUpdateCheckOnFocus] !== undefined
-					? raw[SETTINGS_KEY_MAP.autoUpdateCheckOnFocus] === "true"
-					: DEFAULT_SETTINGS.autoUpdateCheckOnFocus,
-			autoUpdateIntervalMinutes:
-				raw[SETTINGS_KEY_MAP.autoUpdateIntervalMinutes] !== undefined
-					? Number(raw[SETTINGS_KEY_MAP.autoUpdateIntervalMinutes])
-					: DEFAULT_SETTINGS.autoUpdateIntervalMinutes,
 			lastWorkspaceId: raw[SETTINGS_KEY_MAP.lastWorkspaceId] || null,
 			lastSessionId: raw[SETTINGS_KEY_MAP.lastSessionId] || null,
 			defaultModelId:


### PR DESCRIPTION
## Summary
- Drops the four auto-update controls (enabled, check on launch, check on focus, background interval) from the App Updates settings panel.
- Removes the matching `autoUpdate*` fields from `AppSettings`, defaults, key map, and persistence loader in `src/lib/settings.ts`.
- Cleans up now-unused imports (`Input`, `Switch`, `useSettings`) in the panel.

## Why
These toggles surfaced configuration for an auto-update flow that is no longer user-configurable; keeping the UI implied functionality that wasn't backed end-to-end. Removing them simplifies the panel to the manual "Check for updates" action and avoids persisting stale settings keys.

## Test plan
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] Open Settings -> App Updates and confirm only the manual check card remains; existing stored `app.auto_update_*` keys are ignored without errors.