### PR TITLE
refactor(settings): make default model setting the single source of truth

### DIFF
--- a/.changeset/unify-default-model-setting.md
+++ b/.changeset/unify-default-model-setting.md
@@ -1,0 +1,6 @@
+---
+"helmor": patch
+---
+
+Make the Default model setting the single source of truth:
+- The Settings panel now shows a real default instead of "Select model" on first launch, and new chats always use whatever is configured there.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1783,7 +1783,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "helmor"
-version = "0.1.4"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/src/models/sessions.rs
+++ b/src-tauri/src/models/sessions.rs
@@ -352,11 +352,11 @@ pub fn create_session(
 ) -> Result<CreateSessionResponse> {
     let mut connection = db::open_connection(true)?;
 
-    // Read user's default model/effort from settings
-    let default_model = settings::load_setting_value("app.default_model_id")
-        .ok()
-        .flatten()
-        .filter(|s| !s.is_empty() && s != "default");
+    // `model` is left NULL on create: the frontend owns model selection via
+    // `settings.defaultModelId` (kept valid by `useEnsureDefaultModel`), and
+    // the value gets persisted into `sessions.model` by the agent streaming
+    // finalizer on the first message. Reading settings here would be a
+    // redundant second source of truth.
     let default_effort = settings::load_setting_value("app.default_effort")
         .ok()
         .flatten()
@@ -388,7 +388,7 @@ pub fn create_session(
         .execute(
             r#"
             INSERT INTO sessions (id, workspace_id, status, title, permission_mode, action_kind, model, effort_level)
-            VALUES (?1, ?2, 'idle', ?3, ?4, ?5, ?6, ?7)
+            VALUES (?1, ?2, 'idle', ?3, ?4, ?5, NULL, ?6)
             "#,
             (
                 &session_id,
@@ -396,7 +396,6 @@ pub fn create_session(
                 title,
                 permission_mode.unwrap_or("default"),
                 action_kind,
-                &default_model,
                 &default_effort,
             ),
         )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,6 +45,7 @@ import {
 import { EditorIcon } from "@/shell/editor-icon";
 import { GithubIdentityGate } from "@/shell/github-identity-gate";
 import { GithubStatusMenu } from "@/shell/github-status-menu";
+import { useEnsureDefaultModel } from "@/shell/hooks/use-ensure-default-model";
 import { useGithubIdentity } from "@/shell/hooks/use-github-identity";
 import { useShellPanels } from "@/shell/hooks/use-panels";
 import {
@@ -135,6 +136,7 @@ function App() {
 	const settingsContextValue = useMemo(
 		() => ({
 			settings: appSettings ?? preloadSettings,
+			isLoaded: appSettings !== null,
 			updateSettings: (patch: Partial<AppSettings>) => {
 				setAppSettings((previous) => {
 					const next = { ...(previous ?? DEFAULT_SETTINGS), ...patch };
@@ -143,7 +145,7 @@ function App() {
 				});
 			},
 		}),
-		[appSettings],
+		[appSettings, preloadSettings],
 	);
 
 	const [splashVisible, setSplashVisible] = useState(true);
@@ -441,6 +443,7 @@ function AppShell({
 
 	const { settings: appSettings } = useSettings();
 	useAppUpdater();
+	useEnsureDefaultModel();
 	const notify = useOsNotifications(appSettings);
 	const [installedEditors, setInstalledEditors] = useState<DetectedEditor[]>(
 		[],

--- a/src/features/composer/container.test.tsx
+++ b/src/features/composer/container.test.tsx
@@ -401,6 +401,7 @@ describe("WorkspaceComposerContainer", () => {
 						defaultModelId: "gpt-5.4",
 						defaultFastMode: true,
 					},
+					isLoaded: true,
 					updateSettings: vi.fn(),
 				}}
 			>

--- a/src/features/navigation/hooks/use-controller.test.tsx
+++ b/src/features/navigation/hooks/use-controller.test.tsx
@@ -225,6 +225,7 @@ function createWrapper(queryClient: QueryClient) {
 			<SettingsContext.Provider
 				value={{
 					settings: DEFAULT_SETTINGS,
+					isLoaded: true,
 					updateSettings: () => {},
 				}}
 			>

--- a/src/features/panel/container.test.tsx
+++ b/src/features/panel/container.test.tsx
@@ -470,6 +470,7 @@ describe("WorkspacePanelContainer loading semantics", () => {
 						...DEFAULT_SETTINGS,
 						defaultModelId: "gpt-5.4",
 					},
+					isLoaded: true,
 					updateSettings: vi.fn(),
 				}}
 			>

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -146,11 +146,14 @@ export async function saveSettings(patch: Partial<AppSettings>): Promise<void> {
 
 export type SettingsContextValue = {
 	settings: AppSettings;
+	/** False while the initial load from SQLite is still in flight. */
+	isLoaded: boolean;
 	updateSettings: (patch: Partial<AppSettings>) => void;
 };
 
 export const SettingsContext = createContext<SettingsContextValue>({
 	settings: DEFAULT_SETTINGS,
+	isLoaded: false,
 	updateSettings: () => {},
 });
 

--- a/src/lib/workspace-helpers.test.ts
+++ b/src/lib/workspace-helpers.test.ts
@@ -70,18 +70,18 @@ describe("inferDefaultModelId", () => {
 		);
 	});
 
-	it("falls back to first Claude model when no settings", () => {
-		expect(inferDefaultModelId(null, MODEL_SECTIONS)).toBe("default");
+	it("returns null when no settings default is provided", () => {
+		// ensureDefaultModel is responsible for populating the setting — this
+		// function no longer invents its own fallback.
+		expect(inferDefaultModelId(null, MODEL_SECTIONS)).toBeNull();
 	});
 
-	it("ignores invalid settings model ID", () => {
-		expect(inferDefaultModelId(null, MODEL_SECTIONS, "nonexistent")).toBe(
-			"default",
-		);
+	it("returns null when settings model ID is not in the catalog", () => {
+		expect(inferDefaultModelId(null, MODEL_SECTIONS, "nonexistent")).toBeNull();
 	});
 
 	it("returns null when model sections are empty", () => {
-		expect(inferDefaultModelId(null, [])).toBeNull();
+		expect(inferDefaultModelId(null, [], "default")).toBeNull();
 	});
 });
 

--- a/src/lib/workspace-helpers.ts
+++ b/src/lib/workspace-helpers.ts
@@ -436,7 +436,9 @@ export function inferDefaultModelId(
 		}
 	}
 
-	// New session or no history → user setting takes priority
+	// New session or no valid session model → user setting is the only source.
+	// `useEnsureDefaultModel` is responsible for making sure this is non-null
+	// and valid once the catalog is loaded.
 	if (
 		settingsDefaultModelId &&
 		findModelOption(modelSections, settingsDefaultModelId)
@@ -444,11 +446,7 @@ export function inferDefaultModelId(
 		return settingsDefaultModelId;
 	}
 
-	// Ultimate fallback: first Claude model, then first available model.
-	const claudeSection = modelSections.find((s) => s.id === "claude");
-	return (
-		claudeSection?.options[0]?.id ?? modelSections[0]?.options[0]?.id ?? null
-	);
+	return null;
 }
 
 export function describeUnknownError(error: unknown, fallback: string): string {

--- a/src/shell/hooks/use-ensure-default-model.ts
+++ b/src/shell/hooks/use-ensure-default-model.ts
@@ -1,0 +1,37 @@
+import { useQuery } from "@tanstack/react-query";
+import { useEffect } from "react";
+import { agentModelSectionsQueryOptions } from "@/lib/query-client";
+import { useSettings } from "@/lib/settings";
+import { findModelOption } from "@/lib/workspace-helpers";
+
+/**
+ * Invariant: once the model catalog is ready, `settings.defaultModelId` must
+ * point to a model that exists in the catalog. If it doesn't (never set, or
+ * the previously-picked model is gone), pick a reasonable default and write
+ * it back. This is the single place that decides the initial default — every
+ * other consumer reads `settings.defaultModelId` directly.
+ */
+export function useEnsureDefaultModel() {
+	const { settings, isLoaded, updateSettings } = useSettings();
+	const modelSectionsQuery = useQuery(agentModelSectionsQueryOptions());
+	const sections = modelSectionsQuery.data;
+
+	useEffect(() => {
+		// Don't write until SQLite settings are loaded — otherwise we'd
+		// overwrite the user's real value with a default.
+		if (!isLoaded) return;
+		if (!sections || sections.length === 0) return;
+		if (
+			settings.defaultModelId &&
+			findModelOption(sections, settings.defaultModelId)
+		) {
+			return;
+		}
+		const pick =
+			sections.find((s) => s.id === "claude")?.options[0]?.id ??
+			sections[0]?.options[0]?.id ??
+			null;
+		if (!pick) return;
+		updateSettings({ defaultModelId: pick });
+	}, [isLoaded, sections, settings.defaultModelId, updateSettings]);
+}


### PR DESCRIPTION
## Summary

Unify how Helmor picks the model for a new chat so there's exactly one source of truth: `settings.defaultModelId`.

- **Frontend owns the invariant.** New `useEnsureDefaultModel` hook (mounted in `AppShell`) keeps `settings.defaultModelId` pointing at a model that actually exists in the catalog — populating it on first launch and healing it if the previously-picked model disappears.
- **`SettingsContext` exposes `isLoaded`.** The hook waits for the real value to load from SQLite before writing, so we never clobber the user's saved choice with a default.
- **`inferDefaultModelId` stops inventing fallbacks.** It returns `null` when there's no valid setting; the ensure-hook is now the only place that picks an initial default. Tests updated to match.
- **Backend stops reading `app.default_model_id` on session create.** `create_session` now inserts `model` as `NULL`; the streaming finalizer already persists the actual model on the first message, and the frontend controls selection via settings. Removes a redundant second source of truth.

## Why

Before this change, two things could decide what model a new session used — the frontend setting and a Rust read of the same setting at session-create time — and on first launch the Settings panel would show "Select model" because nothing had ever populated `defaultModelId`. This moves all of that logic to one place.

## Test notes

- [ ] `bun run test` (frontend + sidecar + rust)
- [ ] Fresh install: Settings panel shows a real default model (not "Select model")
- [ ] New chat from a fresh install uses whatever's configured as the default
- [ ] Existing users with a saved `defaultModelId` are not overwritten on launch