### PR TITLE
docs(skill): draft changeset first, then offer adjustment menu

### DIFF
--- a/.codex/skills/helmor-release/SKILL.md
+++ b/.codex/skills/helmor-release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: helmor-release
-description: Prepare Helmor releases by inspecting the current branch, asking the user a few targeted release questions, and creating or updating a user-facing Changesets entry. Use when the user wants to cut a release, write a changeset, decide patch/minor/major, draft GitHub release notes, or summarize branch changes into release-ready language.
+description: Prepare Helmor releases by inspecting the current branch, drafting a complete user-facing Changesets entry first (bump + summary + bullets), writing it to `.changeset/`, and then showing the user the result with a short menu of adjustments they can pick from. Use when the user wants to cut a release, write a changeset, decide patch/minor/major, draft GitHub release notes, or summarize branch changes into release-ready language.
 ---
 
 # Helmor Release
@@ -14,37 +14,47 @@ Use this skill to turn a branch's real changes into a clean `.changeset/*.md` en
    - commits since the base branch
    - changed files grouped by area
    - a short suggested summary
-3. Ask the user up to three short questions, one at a time:
-   - release bump: `patch`, `minor`, or `major`
-   - which user-visible changes to include
-   - any exclusions, caveats, or credits
-4. Create or update a single changeset file under `.changeset/`.
-5. Show the resulting changeset body back to the user for confirmation if the task is interactive.
+3. Draft the full changeset yourself, without asking the user upfront. Decide:
+   - the bump (`patch` / `minor` / `major`) using the Versioning Guidance below
+   - the prose summary line
+   - the bullet list of user-visible changes
 
-## Question Style
+   Prefer a conservative bump (`patch` unless there is a clear new user-visible capability). If you genuinely cannot decide the bump from the diff alone, default to `patch` and flag it in the confirmation step.
+4. Write the changeset to a single file under `.changeset/` right away. Do not wait for approval before creating the file — the user will adjust from a real draft, not a hypothetical one.
+5. Then, and only then, show the user what you created and offer the adjustment menu described in "Confirmation Style".
 
-Keep questions short and concrete.
+## Confirmation Style
+
+Do not ask the user anything before the draft is written. Once the changeset file exists, report what you created and offer a short menu of adjustments.
 
 Preferred pattern:
 
-1. Show the inspected changes in a compressed list.
-2. Offer a recommendation first.
-3. Accept free-form edits from the user.
+1. State the file path you created.
+2. Echo back the chosen bump, the summary line, and the bullets in a compact block.
+3. Present a numbered menu of the things the user might want to change. The user picks any subset (e.g. "1 and 3") or says nothing / "looks good" to accept. Never phrase this as an open question like "do you approve?".
 
 Example:
 
 ```text
-Suggested bump: minor
+I've written .changeset/brave-otters-smile.md:
 
-I found these user-facing changes:
-1. In-app auto-update checks and downloaded-update toast
-2. macOS signed/notarized release pipeline
-3. Release automation with Changesets + GitHub Releases
+  bump:    minor
+  summary: Ship a round of release and auto-update improvements:
+  bullets:
+    - Add in-app update checks that download updates in the background ...
+    - Add a signed and notarized macOS release pipeline ...
+    - Add release planning automation ...
 
-Which items should be included in the release notes, and should this be patch/minor/major?
+If you want to adjust anything, tell me which:
+  1. Version bump (currently: minor — say "make it patch" / "make it major")
+  2. Summary line
+  3. The bullet list (add / remove / rewrite specific items)
+  4. Add a thanks/credits line
+
+Otherwise we're done — no reply needed.
 ```
 
-If structured choice tools are unavailable, ask in plain text and let the user reply naturally.
+If structured choice tools are unavailable, present the menu in plain text and let the user reply naturally.
 
 ## Changeset Rules
 


### PR DESCRIPTION
## Summary

- Rework the `helmor-release` skill so it drafts and writes the changeset file **before** talking to the user, instead of interviewing them upfront.
- Replace the free-form "Question Style" section with a "Confirmation Style" section that tells the skill to echo what it wrote and present a numbered adjustment menu (bump / summary / bullets / credits). The user reacts to a real draft, not hypotheticals.
- Update the frontmatter `description` so the skill router picks this behavior up.

## Test plan

- [ ] Trigger the skill on a branch with real commits and confirm it writes `.changeset/*.md` first, then shows the adjustment menu.
- [ ] Reply with "1" (or "make it patch") and confirm the skill only rewrites the bump.
- [ ] Reply with nothing / "looks good" and confirm the skill treats the draft as accepted without further questions.

https://claude.ai/code/session_01K6qFatCCCPCYFzhQWBR9j2