### PR TITLE
fix(release): sync Cargo.lock version alongside Cargo.toml

### DIFF
--- a/scripts/sync-release-versions.mjs
+++ b/scripts/sync-release-versions.mjs
@@ -4,6 +4,7 @@ import path from "node:path";
 const root = process.cwd();
 const packageJsonPath = path.join(root, "package.json");
 const cargoTomlPath = path.join(root, "src-tauri", "Cargo.toml");
+const cargoLockPath = path.join(root, "src-tauri", "Cargo.lock");
 const tauriConfigPath = path.join(root, "src-tauri", "tauri.conf.json");
 
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
@@ -24,6 +25,25 @@ if (cargoToml === nextCargoToml) {
 } else {
 	fs.writeFileSync(cargoTomlPath, nextCargoToml);
 	console.log(`Updated src-tauri/Cargo.toml to ${version}`);
+}
+
+// Cargo.lock keeps a `[[package]]` entry for the helmor crate with its own
+// version field. CI never runs cargo, so without this step the lockfile
+// drifts and everyone regenerates it locally via rust-analyzer.
+const cargoLock = fs.readFileSync(cargoLockPath, "utf8");
+const cargoLockPattern = /(^name = "helmor"\nversion = )"[^"]*"/m;
+if (!cargoLockPattern.test(cargoLock)) {
+	throw new Error(
+		'src-tauri/Cargo.lock is missing the `name = "helmor"` package entry',
+	);
+}
+const nextCargoLock = cargoLock.replace(cargoLockPattern, `$1"${version}"`);
+
+if (cargoLock === nextCargoLock) {
+	console.log(`Cargo.lock already matches ${version}`);
+} else {
+	fs.writeFileSync(cargoLockPath, nextCargoLock);
+	console.log(`Updated src-tauri/Cargo.lock to ${version}`);
 }
 
 const tauriConfig = JSON.parse(fs.readFileSync(tauriConfigPath, "utf8"));


### PR DESCRIPTION
## Summary

- `scripts/sync-release-versions.mjs` now bumps the `helmor` package entry in `src-tauri/Cargo.lock` in addition to `Cargo.toml` and `tauri.conf.json`.
- Throws if the expected `name = "helmor"` package entry is missing, so a future lockfile reshuffle fails loudly instead of silently drifting.

## Why

CI doesn't run `cargo` during the changeset version bump, so `Cargo.lock` kept its stale `version` field after each release. Locally, anyone who opened the repo in rust-analyzer would see the lockfile regenerate and have to commit the diff themselves. Keeping the lockfile in sync at version-bump time closes that gap.

## Test notes

- `node scripts/sync-release-versions.mjs` against a dirty version produces the expected `Updated src-tauri/Cargo.lock to <version>` log line and writes only the `helmor` package entry.
- Re-running the script is idempotent (logs `Cargo.lock already matches <version>`).
- No runtime code paths touched.