### PR TITLE
refactor(sidecar): explicit Claude model overrides and provider-specific sorting

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@chenglou/pretext": "0.0.4",
         "@fontsource-variable/geist": "^5.2.8",
+        "@fontsource-variable/geist-mono": "^5.2.7",
         "@lexical/react": "^0.42.0",
         "@lobehub/icons": "^5.4.0",
         "@primer/octicons-react": "^19.23.1",
@@ -601,6 +602,8 @@
     "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
 
     "@fontsource-variable/geist": ["@fontsource-variable/geist@5.2.8", "", {}, "sha512-cJ6m9e+8MQ5dCYJsLylfZrgBh6KkG4bOLckB35Tr9J/EqdkEM6QllH5PxqP1dhTvFup+HtMRPuz9xOjxXJggxw=="],
+
+    "@fontsource-variable/geist-mono": ["@fontsource-variable/geist-mono@5.2.7", "", {}, "sha512-ZKlZ5sjtalb2TwXKs400mAGDlt/+2ENLNySPx0wTz3bP3mWARCsUW+rpxzZc7e05d2qGch70pItt3K4qttbIYA=="],
 
     "@gar/promisify": ["@gar/promisify@1.1.3", "", {}, "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw=="],
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 	"dependencies": {
 		"@chenglou/pretext": "0.0.4",
 		"@fontsource-variable/geist": "^5.2.8",
+		"@fontsource-variable/geist-mono": "^5.2.7",
 		"@lexical/react": "^0.42.0",
 		"@lobehub/icons": "^5.4.0",
 		"@primer/octicons-react": "^19.23.1",

--- a/sidecar/src/claude-model-overrides.ts
+++ b/sidecar/src/claude-model-overrides.ts
@@ -1,0 +1,100 @@
+/**
+ * Manual overrides for the Claude model list.
+ *
+ * `query.supportedModels()` from the Claude Agent SDK is the source of truth
+ * for what Claude models are currently available, but its output is:
+ *   - Unstable across calls (A/B rollout / account flags).
+ *   - Missing capability flags we care about (e.g. `supportsFastMode`).
+ *
+ * This file lets us patch that list by hand. Each entry's `id` matches
+ * against `ProviderModelInfo.id` returned by the SDK.
+ *
+ * Merge rules (see `applyClaudeModelOverrides`):
+ *   - id matches an SDK model  → fields present here override the SDK's;
+ *                                 fields omitted fall through to the SDK.
+ *   - id does NOT match any    → entry is added as a new model; omitted
+ *                                 fields get sensible defaults.
+ *
+ * Only `id` is required. Every other field is optional and only has effect
+ * if you explicitly set it. There is NO heuristic — if you want a model to
+ * show fast mode, set `supportsFastMode: true` on it here.
+ */
+
+import type { ProviderModelInfo } from "./session-manager.js";
+
+export type ClaudeModelOverride = { readonly id: string } & Partial<
+	Omit<ProviderModelInfo, "id">
+>;
+
+export const CLAUDE_MODEL_OVERRIDES: readonly ClaudeModelOverride[] = [
+	// Opus 4.6 1M — intermittently missing from `supportedModels()` output.
+	// Pin it here so it always shows up with fast mode enabled.
+	{
+		id: "claude-opus-4-6[1m]",
+		label: "Opus 4.6 1M",
+		cliModel: "claude-opus-4-6[1m]",
+		effortLevels: ["low", "medium", "high", "max"],
+		supportsFastMode: true,
+	},
+];
+
+/**
+ * Merge SDK-returned models with `CLAUDE_MODEL_OVERRIDES`.
+ * Preserves SDK ordering; any net-new entries are appended in override order.
+ */
+export function applyClaudeModelOverrides(
+	sdkModels: readonly ProviderModelInfo[],
+): ProviderModelInfo[] {
+	const byId = new Map<string, ProviderModelInfo>();
+	for (const m of sdkModels) byId.set(m.id, { ...m });
+
+	for (const override of CLAUDE_MODEL_OVERRIDES) {
+		const existing = byId.get(override.id);
+		if (existing) {
+			// Merge — any field set in override wins; unset keys keep SDK value.
+			byId.set(override.id, { ...existing, ...override });
+		} else {
+			// New model: fill gaps with safe defaults.
+			byId.set(override.id, {
+				id: override.id,
+				label: override.label ?? override.id,
+				cliModel: override.cliModel ?? override.id,
+				effortLevels: override.effortLevels ?? [],
+				supportsFastMode: override.supportsFastMode ?? false,
+			});
+		}
+	}
+
+	const out: ProviderModelInfo[] = [];
+	const seen = new Set<string>();
+	for (const m of sdkModels) {
+		const v = byId.get(m.id);
+		if (v) {
+			out.push(v);
+			seen.add(m.id);
+		}
+	}
+	for (const override of CLAUDE_MODEL_OVERRIDES) {
+		if (seen.has(override.id)) continue;
+		const v = byId.get(override.id);
+		if (v) out.push(v);
+	}
+	return out;
+}
+
+/**
+ * Server-side gate: does this model id have `supportsFastMode: true` in the
+ * override table? Used by `sendMessage` to ignore a `fastMode: true` flag
+ * coming from the UI when the selected model doesn't actually support it.
+ *
+ * Matches the UI gate (`supportsFastMode === true` on the listed model),
+ * so the two can't drift as long as both read from `CLAUDE_MODEL_OVERRIDES`.
+ */
+export function claudeModelSupportsFastMode(
+	modelId: string | undefined | null,
+): boolean {
+	if (!modelId) return false;
+	return CLAUDE_MODEL_OVERRIDES.some(
+		(o) => o.id === modelId && o.supportsFastMode === true,
+	);
+}

--- a/sidecar/src/claude-session-manager.ts
+++ b/sidecar/src/claude-session-manager.ts
@@ -17,11 +17,16 @@ import {
 	type SDKUserMessage,
 } from "@anthropic-ai/claude-agent-sdk";
 import { isAbortError } from "./abort.js";
+import {
+	applyClaudeModelOverrides,
+	claudeModelSupportsFastMode,
+} from "./claude-model-overrides.js";
 import type { SidecarEmitter } from "./emitter.js";
 import { resolveGitAccessDirectories } from "./git-access.js";
 import { readImageWithResize } from "./image-resize.js";
 import { parseImageRefs } from "./images.js";
 import { errorDetails, logger } from "./logger.js";
+import { sortClaudeModels } from "./model-sort.js";
 import {
 	formatModelLabel,
 	type ListSlashCommandsParams,
@@ -54,12 +59,6 @@ const SLASH_COMMANDS_TIMEOUT_MS = 8_000;
  * makes model loading flap and the Claude model section render empty.
  */
 const MODEL_LIST_TIMEOUT_MS = 15_000;
-
-function claudeSupportsFastMode(model: string | undefined): boolean {
-	const id = model?.trim().toLowerCase();
-	if (!id) return false;
-	return id === "default" || id.includes("opus");
-}
 
 /**
  * Resolve the path to `@anthropic-ai/claude-code`'s `cli.js`, used as the
@@ -388,7 +387,7 @@ export class ClaudeSessionManager implements SessionManager {
 						yield await buildUserMessageWithImages(text, imagePaths);
 					})();
 		const effectiveFastMode =
-			fastMode === true && claudeSupportsFastMode(model);
+			fastMode === true && claudeModelSupportsFastMode(model);
 
 		const q = query({
 			prompt: promptValue,
@@ -813,13 +812,13 @@ export class ClaudeSessionManager implements SessionManager {
 			// Pass `supportedEffortLevels` through as-is. Empty / missing means
 			// the model doesn't expose effort selection — the composer drops the
 			// effort picker entirely for that model, mirroring Claude Code.
-			return models.map((m) => ({
+			const mapped: ProviderModelInfo[] = models.map((m) => ({
 				id: m.value,
 				label: formatModelLabel(m.value, m.displayName || m.value),
 				cliModel: m.value,
 				effortLevels: m.supportedEffortLevels ?? [],
-				supportsFastMode: claudeSupportsFastMode(m.value),
 			}));
+			return sortClaudeModels(applyClaudeModelOverrides(mapped));
 		} catch (err) {
 			if (timedOut) {
 				throw new Error(

--- a/sidecar/src/codex-app-server-manager.ts
+++ b/sidecar/src/codex-app-server-manager.ts
@@ -16,6 +16,7 @@ import {
 import type { SidecarEmitter } from "./emitter.js";
 import { parseImageRefs } from "./images.js";
 import { errorDetails, logger } from "./logger.js";
+import { sortCodexModels } from "./model-sort.js";
 import {
 	formatModelLabel,
 	type ListSlashCommandsParams,
@@ -23,7 +24,6 @@ import {
 	type SendMessageParams,
 	type SessionManager,
 	type SlashCommandInfo,
-	sortModelsByVersion,
 } from "./session-manager.js";
 import {
 	buildTitlePrompt,
@@ -787,7 +787,7 @@ function parseModelListResponse(result: unknown): ProviderModelInfo[] {
 
 		return [{ id, label, cliModel, effortLevels, supportsFastMode }];
 	});
-	return sortModelsByVersion(models);
+	return sortCodexModels(models);
 }
 
 /**

--- a/sidecar/src/model-sort.ts
+++ b/sidecar/src/model-sort.ts
@@ -1,0 +1,98 @@
+/**
+ * Provider-specific sort rules for the model list returned by `listModels`.
+ *
+ * Two sorters live here, one per provider, with parallel naming so call
+ * sites read symmetrically:
+ *   - `sortCodexModels` — version desc, then id asc.
+ *   - `sortClaudeModels` — family (Opus → Sonnet → Haiku → other) →
+ *                          version desc → 1M first → id asc.
+ *
+ * Both take and return `ProviderModelInfo[]` so the session managers
+ * don't need to know which rule is in play.
+ */
+
+import type { ProviderModelInfo } from "./session-manager.js";
+
+// ---------------------------------------------------------------------------
+// Codex
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract a numeric version from a model id (e.g. "gpt-5.4" → 5.4).
+ * "default" gets Infinity so it sorts first (it's the primary model alias).
+ */
+function codexVersionOf(model: ProviderModelInfo): number {
+	if (model.id === "default") return Infinity;
+	const m = model.id.match(/(\d+(?:\.\d+)?)/);
+	return m?.[1] ? Number.parseFloat(m[1]) : 0;
+}
+
+/** Sort Codex models by version desc, then id asc. */
+export function sortCodexModels(
+	models: ProviderModelInfo[],
+): ProviderModelInfo[] {
+	return [...models].sort((a, b) => {
+		const va = codexVersionOf(a);
+		const vb = codexVersionOf(b);
+		if (va !== vb) return vb - va;
+		return a.id.localeCompare(b.id);
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Claude
+// ---------------------------------------------------------------------------
+// `default` is the CLI alias for the latest Opus, so it's pinned to the top
+// of the Opus group regardless of what label/version it carries.
+
+type ClaudeFamily = "opus" | "sonnet" | "haiku" | "other";
+
+const CLAUDE_FAMILY_RANK: Record<ClaudeFamily, number> = {
+	opus: 0,
+	sonnet: 1,
+	haiku: 2,
+	other: 3,
+};
+
+function claudeFamilyOf(model: ProviderModelInfo): ClaudeFamily {
+	if (model.id === "default") return "opus";
+	const haystack = `${model.id} ${model.label}`.toLowerCase();
+	if (haystack.includes("opus")) return "opus";
+	if (haystack.includes("sonnet")) return "sonnet";
+	if (haystack.includes("haiku")) return "haiku";
+	return "other";
+}
+
+function claudeVersionOf(model: ProviderModelInfo): number {
+	if (model.id === "default") return Infinity;
+	// Strip "1M" markers so they don't get parsed as a version number.
+	const label = model.label.replace(/\b1m\b/gi, "");
+	const id = model.id.replace(/\[1m\]/gi, "");
+	const m = label.match(/(\d+(?:\.\d+)?)/) ?? id.match(/(\d+(?:\.\d+)?)/);
+	return m?.[1] ? Number.parseFloat(m[1]) : 0;
+}
+
+function claudeHas1M(model: ProviderModelInfo): boolean {
+	return /\b1m\b/i.test(model.label) || /\[1m\]/i.test(model.id);
+}
+
+/** Sort Claude models by family → version desc → 1M first → id asc. */
+export function sortClaudeModels(
+	models: ProviderModelInfo[],
+): ProviderModelInfo[] {
+	return [...models].sort((a, b) => {
+		const fa = CLAUDE_FAMILY_RANK[claudeFamilyOf(a)];
+		const fb = CLAUDE_FAMILY_RANK[claudeFamilyOf(b)];
+		if (fa !== fb) return fa - fb;
+
+		const va = claudeVersionOf(a);
+		const vb = claudeVersionOf(b);
+		if (va !== vb) return vb - va;
+
+		const ma = claudeHas1M(a);
+		const mb = claudeHas1M(b);
+		if (ma !== mb) return ma ? -1 : 1;
+
+		return a.id.localeCompare(b.id);
+	});
+}

--- a/sidecar/src/session-manager.ts
+++ b/sidecar/src/session-manager.ts
@@ -76,28 +76,6 @@ export function formatModelLabel(id: string, rawLabel: string): string {
 	return label;
 }
 
-/**
- * Extract a numeric version from a model ID for sorting (e.g. "gpt-5.4" → 5.4).
- * "default" gets Infinity so it sorts first (it's the primary model).
- */
-function sortKey(id: string): number {
-	if (id === "default") return Infinity;
-	const m = id.match(/(\d+(?:\.\d+)?)/);
-	return m?.[1] ? Number.parseFloat(m[1]) : 0;
-}
-
-/** Sort models by version number descending, then alphabetically. */
-export function sortModelsByVersion(
-	models: ProviderModelInfo[],
-): ProviderModelInfo[] {
-	return [...models].sort((a, b) => {
-		const va = sortKey(a.id);
-		const vb = sortKey(b.id);
-		if (vb !== va) return vb - va;
-		return a.id.localeCompare(b.id);
-	});
-}
-
 export interface SessionManager {
 	/**
 	 * Stream a single user turn to the underlying provider SDK and forward

--- a/sidecar/test/claude-session-manager.test.ts
+++ b/sidecar/test/claude-session-manager.test.ts
@@ -231,7 +231,7 @@ describe("ClaudeSessionManager.sendMessage", () => {
 		expect(last).toEqual({ id: "REQ-1", type: "end" });
 	});
 
-	test("lists fast mode support only for opus-class models", async () => {
+	test("supportsFastMode comes from the overrides table, not the SDK", async () => {
 		mockQueryImpl = () =>
 			makeMockQuery({
 				supportedModels: async () => [
@@ -254,24 +254,20 @@ describe("ClaudeSessionManager.sendMessage", () => {
 			});
 
 		const models = await manager.listModels();
+		const bySupports = Object.fromEntries(
+			models.map((m) => [m.id, m.supportsFastMode]),
+		);
 
-		expect(models).toEqual([
-			expect.objectContaining({
-				id: "default",
-				supportsFastMode: true,
-			}),
-			expect.objectContaining({
-				id: "claude-opus-4-7",
-				supportsFastMode: true,
-			}),
-			expect.objectContaining({
-				id: "claude-sonnet-4-7",
-				supportsFastMode: false,
-			}),
-		]);
+		// SDK-supplied models (not in the override table) carry no flag.
+		expect(bySupports.default).toBeUndefined();
+		expect(bySupports["claude-opus-4-7"]).toBeUndefined();
+		expect(bySupports["claude-sonnet-4-7"]).toBeUndefined();
+
+		// The override adds claude-opus-4-6[1m] with the flag set.
+		expect(bySupports["claude-opus-4-6[1m]"]).toBe(true);
 	});
 
-	test("ignores fast mode for non-opus Claude models", async () => {
+	test("ignores fastMode for models not in the override table", async () => {
 		mockQueryImpl = () => makeMockQuery();
 
 		await manager.sendMessage(
@@ -1014,12 +1010,21 @@ describe("ClaudeSessionManager.listModels", () => {
 
 		const models = await manager.listModels();
 
+		// Order follows sortClaudeModels: opus family first (default pinned to
+		// top via Infinity, then opus-4-6[1m] injected by the override), then
+		// sonnet, then haiku. supportsFastMode only appears on override entries.
 		expect(models).toEqual([
 			{
 				id: "default",
 				label: "Opus 4.7 1M",
 				cliModel: "default",
 				effortLevels: ["low", "medium", "high", "xhigh", "max"],
+			},
+			{
+				id: "claude-opus-4-6[1m]",
+				label: "Opus 4.6 1M",
+				cliModel: "claude-opus-4-6[1m]",
+				effortLevels: ["low", "medium", "high", "max"],
 				supportsFastMode: true,
 			},
 			{
@@ -1027,14 +1032,12 @@ describe("ClaudeSessionManager.listModels", () => {
 				label: "Sonnet 1M",
 				cliModel: "sonnet",
 				effortLevels: ["low", "medium", "high"],
-				supportsFastMode: false,
 			},
 			{
 				id: "haiku",
 				label: "Haiku",
 				cliModel: "haiku",
 				effortLevels: [],
-				supportsFastMode: false,
 			},
 		]);
 		expect(lastQueryArgs).toMatchObject({

--- a/src/App.css
+++ b/src/App.css
@@ -1,4 +1,5 @@
 @import "@fontsource-variable/geist";
+@import "@fontsource-variable/geist-mono";
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
@@ -14,6 +15,9 @@
 	--font-sans:
 		"Geist Variable", "SF Pro Display", -apple-system, BlinkMacSystemFont,
 		"Segoe UI", sans-serif;
+	--font-mono:
+		"Geist Mono Variable", ui-monospace, "SF Mono", SFMono-Regular, Menlo,
+		Monaco, Consolas, monospace;
 }
 
 :root {
@@ -297,6 +301,9 @@ body {
 @theme inline {
 	--font-heading: var(--font-sans);
 	--font-sans: "Geist Variable", sans-serif;
+	--font-mono:
+		"Geist Mono Variable", ui-monospace, "SF Mono", SFMono-Regular, Menlo,
+		Monaco, Consolas, monospace;
 	--color-sidebar-ring: var(--sidebar-ring);
 	--color-sidebar-border: var(--sidebar-border);
 	--color-sidebar-accent-foreground: var(--sidebar-accent-foreground);

--- a/src/features/composer/index.tsx
+++ b/src/features/composer/index.tsx
@@ -478,7 +478,9 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 																		<ClaudeIcon className="size-[13px]" />
 																	)}
 																</span>
-																<span>{option.label}</span>
+																<span className="font-mono tabular-nums">
+																	{option.label}
+																</span>
 															</div>
 														</DropdownMenuItem>
 													))}


### PR DESCRIPTION
## Summary

- **Claude model overrides table.** Replace the inline `claudeSupportsFastMode` heuristic with `sidecar/src/claude-model-overrides.ts`, an explicit list that's the single source of truth for fast-mode capability and a place to pin models the SDK intermittently omits. First entry pins Opus 4.6 1M with fast mode enabled.
- **Provider-specific model sorting.** Split the generic `sortModelsByVersion` out of `session-manager.ts` into `sidecar/src/model-sort.ts` with `sortCodexModels` (version desc, then id) and `sortClaudeModels` (family Opus -> Sonnet -> Haiku -> other, then version desc, then 1M first, then id). Each session manager now uses its own sorter.
- **Composer model label styling.** Render model labels in the composer dropdown with Geist Mono + `tabular-nums` for legibility; adds `@fontsource-variable/geist-mono` and registers `--font-mono` in `App.css`.

## Why

The old `claudeSupportsFastMode` was a string-match heuristic (`includes("opus")`) that quietly broke whenever the SDK returned a model id that didn't match the pattern, and silently flipped fast mode off for variants we did want it on for. It also gave us no place to surface models the SDK was dropping (Opus 4.6 1M comes and goes depending on account flags). Pulling capabilities into an explicit override table makes both the fast-mode UI gate and the server-side enforcement read from the same list, so they can't drift.

The shared `sortModelsByVersion` was also doing double duty for two providers with very different ordering needs -- Claude lists were getting interleaved across families. Splitting the sorters keeps Codex's "newest GPT first" behavior intact while giving Claude a family-grouped order that matches how users think about the lineup.

## Test plan

- [ ] `bun run typecheck`
- [ ] `bun run test:sidecar`
- [ ] Manually verify the composer model dropdown:
  - Claude: Opus models grouped first (with Opus 4.6 1M visible), Sonnet next, Haiku last; fast-mode toggle only appears for Opus entries.
  - Codex: GPT models still sorted newest-first.
  - Labels render in Geist Mono with tabular-aligned digits.