### PR TITLE
refactor(logging): bounded size-ring appender

### DIFF
--- a/.changeset/refactor-logging-size-ring.md
+++ b/.changeset/refactor-logging-size-ring.md
@@ -1,0 +1,7 @@
+---
+"helmor": patch
+---
+
+Replace date-based log rotation with a bounded single-file ring:
+- Both the Rust host and the sidecar now write to `rust.jsonl` / `sidecar.jsonl` with a `.1` backup that is overwritten on rotation, capping each component's log footprint at ~20 MB instead of accumulating a week of daily files.
+- Removes the background cleanup thread and the `tracing-appender` / `flate2` dependencies; no more gzip pass, no UTC/local date races.

--- a/sidecar/src/logger.ts
+++ b/sidecar/src/logger.ts
@@ -1,13 +1,25 @@
 /**
  * Structured JSON logger for the sidecar process.
  *
- * - NDJSON to a single file per day: `sidecar.YYYY-MM-DD.jsonl`.
+ * - NDJSON to a single-file size ring: `sidecar.jsonl` (active) + `sidecar.jsonl.1`
+ *   (previous segment). Disk use is bounded at 2 × MAX_BYTES; no dates, no
+ *   cleanup pass.
  * - Dev stderr matches Rust tracing-subscriber's default format so both
  *   processes produce visually identical terminal output.
  * - stdout is NEVER touched — it is the exclusive JSON protocol channel.
  */
 
-import { createWriteStream, mkdirSync, type WriteStream } from "node:fs";
+import {
+	createWriteStream,
+	existsSync,
+	mkdirSync,
+	renameSync,
+	statSync,
+	unlinkSync,
+	type WriteStream,
+} from "node:fs";
+
+const MAX_BYTES = 10 * 1024 * 1024;
 
 type Level = "debug" | "info" | "error";
 const LEVELS: Record<Level, number> = { debug: 0, info: 1, error: 2 };
@@ -71,6 +83,9 @@ class Logger {
 	private minLevel: number;
 	private file: WriteStream | undefined;
 	private devStderr: boolean;
+	private primaryPath: string | undefined;
+	private backupPath: string | undefined;
+	private bytes = 0;
 
 	constructor() {
 		const envLevel = process.env.HELMOR_LOG?.toLowerCase();
@@ -86,10 +101,10 @@ class Logger {
 		const logDir = process.env.HELMOR_LOG_DIR;
 		if (logDir) {
 			mkdirSync(logDir, { recursive: true });
-			const today = localTs().slice(0, 10);
-			this.file = createWriteStream(`${logDir}/sidecar.${today}.jsonl`, {
-				flags: "a",
-			});
+			this.primaryPath = `${logDir}/sidecar.jsonl`;
+			this.backupPath = `${logDir}/sidecar.jsonl.1`;
+			this.bytes = fileSize(this.primaryPath);
+			this.file = createWriteStream(this.primaryPath, { flags: "a" });
 		}
 	}
 
@@ -115,7 +130,7 @@ class Logger {
 		const type = String(evt.type ?? "unknown");
 
 		const line = `${JSON.stringify({ ts, level: "debug", source: "sidecar", msg: "sdk_event", requestId, type, event })}\n`;
-		this.file?.write(line);
+		this.writeLine(line);
 
 		if (this.devStderr) {
 			const { label, color } = LEVEL_FMT.debug;
@@ -135,7 +150,7 @@ class Logger {
 
 		const ts = localTs();
 		const line = `${JSON.stringify({ ts, level, source: "sidecar", msg, ...data })}\n`;
-		this.file?.write(line);
+		this.writeLine(line);
 
 		// Human-readable stderr matching Rust tracing format
 		if (this.devStderr) {
@@ -150,6 +165,39 @@ class Logger {
 				`${DIM}${localTs()}${RESET} ${color}${label}${RESET} ${DIM}sidecar:${RESET} ${msg}${fields}\n`,
 			);
 		}
+	}
+
+	private writeLine(line: string): void {
+		if (!this.file || !this.primaryPath || !this.backupPath) return;
+		const len = Buffer.byteLength(line);
+		if (this.bytes + len > MAX_BYTES) {
+			this.rotate();
+		}
+		this.file.write(line);
+		this.bytes += len;
+	}
+
+	private rotate(): void {
+		if (!this.file || !this.primaryPath || !this.backupPath) return;
+		// Close async; already-buffered writes flush to the old fd (which, after
+		// rename, points to the backup file) — that's the desired behaviour.
+		this.file.end();
+		try {
+			if (existsSync(this.backupPath)) unlinkSync(this.backupPath);
+			renameSync(this.primaryPath, this.backupPath);
+		} catch {
+			// Best-effort: keep appending to whatever primary currently is.
+		}
+		this.file = createWriteStream(this.primaryPath, { flags: "a" });
+		this.bytes = fileSize(this.primaryPath);
+	}
+}
+
+function fileSize(path: string): number {
+	try {
+		return statSync(path).size;
+	} catch {
+		return 0;
 	}
 }
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1790,7 +1790,6 @@ dependencies = [
  "chrono",
  "clap",
  "dotenvy",
- "flate2",
  "insta",
  "libc",
  "notify",
@@ -1810,7 +1809,6 @@ dependencies = [
  "tauri-plugin-updater",
  "tempfile",
  "tracing",
- "tracing-appender",
  "tracing-subscriber",
  "url",
  "uuid",
@@ -5652,18 +5650,6 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-appender"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
-dependencies = [
- "crossbeam-channel",
- "thiserror 2.0.18",
- "time",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,7 +23,6 @@ tauri-build = { version = "2", features = [] }
 anyhow = "1"
 base64 = "0.22.1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
-flate2 = "1"
 clap = { version = "4", features = ["derive"] }
 rand = "0.10.0"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
@@ -40,7 +39,6 @@ tauri-plugin-updater = "2"
 notify = "7"
 notify-debouncer-full = "0.4"
 tracing = "0.1"
-tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter", "chrono"] }
 url = "2"
 uuid = { version = "1", features = ["v4"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -65,18 +65,11 @@ pub fn run() {
             // Ensure data directory structure exists
             data_dir::ensure_directory_structure()?;
 
-            // Initialize structured logging (must come before any tracing macro call)
+            // Initialize structured logging (must come before any tracing macro call).
+            // Logs live in `<data_dir>/logs/{rust,sidecar}.jsonl` with a `.1` backup;
+            // the size-ring appender bounds disk use without a cleanup pass.
             let logs_dir = data_dir::logs_dir()?;
             logging::init(&logs_dir)?;
-
-            // Background cleanup: compress old logs, purge > 7 days
-            let cleanup_dir = logs_dir;
-            if let Err(error) = std::thread::Builder::new()
-                .name("log-cleanup".into())
-                .spawn(move || logging::cleanup(&cleanup_dir))
-            {
-                tracing::error!(error = %error, "Failed to spawn log cleanup thread");
-            }
 
             // Initialize database schema
             let db_path = data_dir::db_path()?;

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -1,21 +1,28 @@
-//! Structured JSON logging with daily rotation.
+//! Structured JSON logging with a single-file size-based ring.
 //!
-//! Single file per component: `rust.YYYY-MM-DD.jsonl` under the data-dir `logs/` folder.
+//! Two files per component in the data-dir `logs/` folder:
+//!   `rust.jsonl`    — active, appended until it hits `MAX_BYTES`
+//!   `rust.jsonl.1`  — previous segment, overwritten on each rotation
+//!
+//! Total disk use is bounded at `2 × MAX_BYTES` per component. No dates in
+//! filenames, no background cleanup, no UTC/local races.
+//!
 //! Dev builds also print human-readable output to stderr.
-//! Old log files are gzip-compressed on startup; files older than 7 days are purged.
-//!
-//! Level defaults: `debug` (dev), `info` (release). Override with `HELMOR_LOG=debug|info|error`.
+//! Level defaults: `debug` (dev), `info` (release). Override with `HELMOR_LOG`.
 
-use std::fs;
+use std::fs::{self, File, OpenOptions};
 use std::io;
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 
 use anyhow::{Context, Result};
-use tracing_appender::rolling::{RollingFileAppender, Rotation};
 use tracing_subscriber::{
-    filter::LevelFilter, fmt, fmt::time::ChronoLocal, layer::SubscriberExt,
+    filter::LevelFilter, fmt, fmt::time::ChronoLocal, fmt::MakeWriter, layer::SubscriberExt,
     util::SubscriberInitExt, Layer,
 };
+
+/// Per-file size cap. `rust.jsonl` + `rust.jsonl.1` together never exceed 2×.
+const MAX_BYTES: u64 = 10 * 1024 * 1024;
 
 /// Set up the global tracing subscriber.
 ///
@@ -25,27 +32,17 @@ pub fn init(logs_dir: &Path) -> Result<()> {
     let is_dev = crate::data_dir::is_dev();
     let level = resolve_level(is_dev);
 
-    // Macro avoids repeating the json format config for each file layer.
-    // Each invocation produces the same concrete type so the registry chain compiles.
-    macro_rules! file_layer {
-        ($prefix:literal, $level:expr) => {{
-            let appender = RollingFileAppender::builder()
-                .rotation(Rotation::DAILY)
-                .filename_prefix($prefix)
-                .filename_suffix("jsonl")
-                .max_log_files(7)
-                .build(logs_dir)
-                .context(concat!("log appender: ", $prefix))?;
-            fmt::layer()
-                .json()
-                .flatten_event(true)
-                .with_current_span(false)
-                .with_span_list(false)
-                .with_timer(ChronoLocal::default())
-                .with_writer(appender)
-                .with_filter($level)
-        }};
-    }
+    fs::create_dir_all(logs_dir)
+        .with_context(|| format!("create logs dir: {}", logs_dir.display()))?;
+
+    let rust_layer = fmt::layer()
+        .json()
+        .flatten_event(true)
+        .with_current_span(false)
+        .with_span_list(false)
+        .with_timer(ChronoLocal::default())
+        .with_writer(SizeRingAppender::new(logs_dir, "rust.jsonl", MAX_BYTES)?)
+        .with_filter(level);
 
     let stderr_layer = is_dev.then(|| {
         fmt::layer()
@@ -56,45 +53,11 @@ pub fn init(logs_dir: &Path) -> Result<()> {
     });
 
     tracing_subscriber::registry()
-        .with(file_layer!("rust", level))
+        .with(rust_layer)
         .with(stderr_layer)
         .init();
 
     Ok(())
-}
-
-/// Compress yesterday's `.jsonl` files and delete `.jsonl.gz` older than 7 days.
-/// Run once on startup, typically from a background thread.
-pub fn cleanup(logs_dir: &Path) {
-    let today = chrono::Local::now().format("%Y-%m-%d").to_string();
-    let cutoff = (chrono::Local::now() - chrono::Duration::days(7))
-        .format("%Y-%m-%d")
-        .to_string();
-
-    let entries = match fs::read_dir(logs_dir) {
-        Ok(e) => e,
-        Err(_) => return,
-    };
-
-    for entry in entries.flatten() {
-        let path = entry.path();
-        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
-            continue;
-        };
-
-        // Compress non-today .jsonl -> .jsonl.gz
-        if name.ends_with(".jsonl") && !name.contains(&today) {
-            if let Err(e) = gzip(&path) {
-                tracing::warn!(file = %path.display(), "log compression failed: {e}");
-            }
-            continue;
-        }
-
-        // Purge old .jsonl.gz beyond retention
-        if name.ends_with(".jsonl.gz") && extract_date(name).is_some_and(|d| d < cutoff.as_str()) {
-            let _ = fs::remove_file(&path);
-        }
-    }
 }
 
 /// Returns the resolved `logs/` directory path. Convenience for callers that
@@ -103,7 +66,85 @@ pub fn logs_dir() -> Result<PathBuf> {
     crate::data_dir::logs_dir()
 }
 
-// --- helpers ----------------------------------------------------------------
+/// Single-file ring appender. When the active file exceeds `max_bytes`, it is
+/// renamed to `<name>.1` (replacing any prior backup) and a fresh active file
+/// is opened. Rotation is best-effort — if `rename` fails we keep appending.
+pub struct SizeRingAppender {
+    primary: PathBuf,
+    backup: PathBuf,
+    max_bytes: u64,
+    state: Mutex<AppenderState>,
+}
+
+struct AppenderState {
+    file: File,
+    written: u64,
+}
+
+impl SizeRingAppender {
+    fn new(logs_dir: &Path, name: &str, max_bytes: u64) -> Result<Self> {
+        let primary = logs_dir.join(name);
+        let backup = logs_dir.join(format!("{name}.1"));
+        let file = OpenOptions::new()
+            .append(true)
+            .create(true)
+            .open(&primary)
+            .with_context(|| format!("open log file: {}", primary.display()))?;
+        let written = file.metadata().map(|m| m.len()).unwrap_or(0);
+        Ok(Self {
+            primary,
+            backup,
+            max_bytes,
+            state: Mutex::new(AppenderState { file, written }),
+        })
+    }
+
+    fn rotate(&self, state: &mut AppenderState) -> io::Result<()> {
+        let _ = fs::remove_file(&self.backup);
+        let _ = fs::rename(&self.primary, &self.backup);
+        let file = OpenOptions::new()
+            .append(true)
+            .create(true)
+            .open(&self.primary)?;
+        let written = file.metadata().map(|m| m.len()).unwrap_or(0);
+        state.file = file;
+        state.written = written;
+        Ok(())
+    }
+}
+
+impl io::Write for &SizeRingAppender {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|e| io::Error::other(format!("log lock poisoned: {e}")))?;
+
+        if state.written.saturating_add(buf.len() as u64) > self.max_bytes {
+            // Best-effort; if rotation fails we keep appending and retry later.
+            let _ = self.rotate(&mut state);
+        }
+
+        let n = state.file.write(buf)?;
+        state.written = state.written.saturating_add(n as u64);
+        Ok(n)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|e| io::Error::other(format!("log lock poisoned: {e}")))?;
+        state.file.flush()
+    }
+}
+
+impl<'a> MakeWriter<'a> for SizeRingAppender {
+    type Writer = &'a SizeRingAppender;
+    fn make_writer(&'a self) -> Self::Writer {
+        self
+    }
+}
 
 fn resolve_level(is_dev: bool) -> LevelFilter {
     std::env::var("HELMOR_LOG")
@@ -123,70 +164,105 @@ fn resolve_level(is_dev: bool) -> LevelFilter {
         })
 }
 
-fn gzip(src: &Path) -> Result<()> {
-    use flate2::write::GzEncoder;
-    use flate2::Compression;
-
-    let dst = append_gz(src);
-    let input = fs::File::open(src).with_context(|| format!("open {}", src.display()))?;
-    let output = fs::File::create(&dst).with_context(|| format!("create {}", dst.display()))?;
-
-    let mut enc = GzEncoder::new(output, Compression::default());
-    io::copy(&mut io::BufReader::new(input), &mut enc)?;
-    enc.finish()?;
-
-    fs::remove_file(src)?;
-    Ok(())
-}
-
-fn append_gz(path: &Path) -> PathBuf {
-    let mut s = path.as_os_str().to_owned();
-    s.push(".gz");
-    PathBuf::from(s)
-}
-
-/// Extract the `YYYY-MM-DD` segment from a log filename like `rust-error.2026-04-11.jsonl.gz`.
-fn extract_date(filename: &str) -> Option<&str> {
-    filename.split('.').find(|s| {
-        s.len() == 10 && s.as_bytes().get(4) == Some(&b'-') && s.as_bytes().get(7) == Some(&b'-')
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn extract_date_from_jsonl() {
-        assert_eq!(
-            extract_date("rust-error.2026-04-11.jsonl"),
-            Some("2026-04-11")
-        );
-    }
-
-    #[test]
-    fn extract_date_from_gz() {
-        assert_eq!(
-            extract_date("sidecar-debug.2026-01-01.jsonl.gz"),
-            Some("2026-01-01")
-        );
-    }
-
-    #[test]
-    fn extract_date_returns_none_for_bad_name() {
-        assert_eq!(extract_date("random-file.txt"), None);
-    }
+    use std::io::{Read, Write};
 
     #[test]
     fn resolve_level_defaults_debug_in_dev() {
-        // In test (debug) builds, default should be DEBUG
-        let level = resolve_level(true);
-        assert_eq!(level, LevelFilter::DEBUG);
+        assert_eq!(resolve_level(true), LevelFilter::DEBUG);
     }
 
     #[test]
     fn resolve_level_defaults_info_in_prod() {
-        let level = resolve_level(false);
-        assert_eq!(level, LevelFilter::INFO);
+        assert_eq!(resolve_level(false), LevelFilter::INFO);
+    }
+
+    #[test]
+    fn appender_creates_primary_and_appends() {
+        let tmp = tempfile::tempdir().unwrap();
+        let appender = SizeRingAppender::new(tmp.path(), "rust.jsonl", 1024).unwrap();
+        let primary = tmp.path().join("rust.jsonl");
+        assert!(primary.exists());
+
+        (&appender).write_all(b"a\n").unwrap();
+        (&appender).write_all(b"b\n").unwrap();
+        (&appender).flush().unwrap();
+
+        let mut s = String::new();
+        File::open(&primary)
+            .unwrap()
+            .read_to_string(&mut s)
+            .unwrap();
+        assert_eq!(s, "a\nb\n");
+    }
+
+    #[test]
+    fn appender_rotates_when_exceeding_max_bytes() {
+        let tmp = tempfile::tempdir().unwrap();
+        // 16-byte cap: first line fits, second line triggers rotation.
+        let appender = SizeRingAppender::new(tmp.path(), "rust.jsonl", 16).unwrap();
+        let primary = tmp.path().join("rust.jsonl");
+        let backup = tmp.path().join("rust.jsonl.1");
+
+        (&appender).write_all(b"0123456789abcd\n").unwrap(); // 15 bytes
+        assert!(!backup.exists(), "first write should not rotate");
+
+        (&appender).write_all(b"second\n").unwrap();
+        assert!(backup.exists(), "second write should trigger rotation");
+
+        let mut old = String::new();
+        File::open(&backup)
+            .unwrap()
+            .read_to_string(&mut old)
+            .unwrap();
+        assert_eq!(old, "0123456789abcd\n");
+
+        let mut new_ = String::new();
+        File::open(&primary)
+            .unwrap()
+            .read_to_string(&mut new_)
+            .unwrap();
+        assert_eq!(new_, "second\n");
+    }
+
+    #[test]
+    fn second_rotation_overwrites_previous_backup() {
+        let tmp = tempfile::tempdir().unwrap();
+        let appender = SizeRingAppender::new(tmp.path(), "rust.jsonl", 8).unwrap();
+        let backup = tmp.path().join("rust.jsonl.1");
+
+        (&appender).write_all(b"first\n").unwrap();
+        (&appender).write_all(b"second\n").unwrap(); // rotates: backup = "first\n"
+        (&appender).write_all(b"third\n").unwrap(); // rotates: backup = "second\n"
+
+        let mut s = String::new();
+        File::open(&backup).unwrap().read_to_string(&mut s).unwrap();
+        assert_eq!(s, "second\n", "backup keeps only the most recent segment");
+
+        // Only two files ever exist.
+        let entries: Vec<_> = fs::read_dir(tmp.path())
+            .unwrap()
+            .filter_map(|e| e.ok().map(|e| e.file_name()))
+            .collect();
+        assert_eq!(entries.len(), 2);
+    }
+
+    #[test]
+    fn appender_picks_up_existing_file_size() {
+        let tmp = tempfile::tempdir().unwrap();
+        let primary = tmp.path().join("rust.jsonl");
+        fs::write(&primary, b"preexisting\n").unwrap();
+
+        let appender = SizeRingAppender::new(tmp.path(), "rust.jsonl", 20).unwrap();
+        // "preexisting\n" = 12 bytes; next write of 10 bytes should trigger rotate.
+        (&appender).write_all(b"abcdefghi\n").unwrap();
+
+        let backup = tmp.path().join("rust.jsonl.1");
+        assert!(backup.exists(), "rotation should honor starting-file size");
+        let mut s = String::new();
+        File::open(&backup).unwrap().read_to_string(&mut s).unwrap();
+        assert_eq!(s, "preexisting\n");
     }
 }


### PR DESCRIPTION
## Summary
- Replace the date-based daily rotation (`rust.YYYY-MM-DD.jsonl` + gzip + 7-day purge) with a single-file size-ring: `rust.jsonl` (active) + `rust.jsonl.1` (previous segment), overwritten on rotation. Disk use is bounded at `2 × MAX_BYTES` (~20 MB) per component with no background cleanup pass.
- Mirror the same design in the sidecar's TypeScript logger (`sidecar.jsonl` + `sidecar.jsonl.1`).
- Drop the `tracing-appender` and `flate2` crates and the `log-cleanup` background thread; remove UTC/local date races and the gzip step entirely.

## Why
The previous scheme accumulated one file per day, compressed yesterday's file on startup, and purged anything older than 7 days — three moving parts (rotation, gzip, purge) to solve a problem that's really just "don't let logs grow forever." A size-bounded ring is simpler, doesn't depend on the wall clock, has no startup work, and keeps a strict upper bound on disk usage regardless of how chatty a session gets. It also removes two dependencies and a background thread from the Rust host.

## What changed
- `src-tauri/src/logging.rs` — new `SizeRingAppender` (`impl Write + MakeWriter`) with per-instance `Mutex<AppenderState>`. Rotation is best-effort on `rename` failure. Unit tests cover create/append, rotation-on-overflow, second-rotation-overwrites-backup, and honoring a pre-existing file's size.
- `src-tauri/src/lib.rs` — drop the `log-cleanup` thread spawn.
- `src-tauri/Cargo.{toml,lock}` — remove `tracing-appender` and `flate2`.
- `sidecar/src/logger.ts` — same size-ring behaviour, same `MAX_BYTES = 10 MiB`, same two-file layout.
- `.changeset/refactor-logging-size-ring.md` — patch release note.

## Test plan
- [ ] `bun run test:rust` — new `SizeRingAppender` unit tests pass (4 new tests + existing level tests).
- [ ] `bun run test:sidecar` — sidecar unit tests still green.
- [ ] `bun run lint` — clippy clean, biome clean.
- [ ] Smoke: `bun run dev`, let it log for a bit, confirm `~/helmor-dev/logs/rust.jsonl` and `sidecar.jsonl` exist and that forcing enough traffic produces a `.1` sibling.