### PR TITLE
refactor(workspace): split create into prepare+finalize to kill flicker

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1783,7 +1783,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "helmor"
-version = "0.1.4"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/src/commands/editor_commands.rs
+++ b/src-tauri/src/commands/editor_commands.rs
@@ -1,6 +1,8 @@
 use anyhow::Context;
 
-use crate::{editor_files, git_ops, models::workspaces as workspace_models};
+use crate::{
+    editor_files, git_ops, models::workspaces as workspace_models, workspace_state::WorkspaceState,
+};
 
 use super::common::{run_blocking, CmdResult};
 
@@ -89,6 +91,27 @@ pub async fn get_workspace_git_action_status(
     run_blocking(move || {
         let record = workspace_models::load_workspace_record_by_id(&workspace_id)?
             .with_context(|| format!("Workspace not found: {workspace_id}"))?;
+        // A workspace that hasn't finished Phase 2 has no worktree on disk —
+        // running `git status` against it would error. A freshly-created
+        // workspace always starts clean (0 uncommitted, 0 conflicts, in sync
+        // with its base branch, not yet pushed), so short-circuit to the
+        // canonical "fresh" status. The frontend paints the same values
+        // post-ready, so the state transition causes zero visual change.
+        if record.state == WorkspaceState::Initializing {
+            return Ok(git_ops::WorkspaceGitActionStatus {
+                uncommitted_count: 0,
+                conflict_count: 0,
+                sync_target_branch: record
+                    .intended_target_branch
+                    .clone()
+                    .or_else(|| record.default_branch.clone()),
+                sync_status: git_ops::WorkspaceSyncStatus::UpToDate,
+                behind_target_count: 0,
+                remote_tracking_ref: None,
+                ahead_of_remote_count: 0,
+                push_status: git_ops::WorkspacePushStatus::Unpublished,
+            });
+        }
         let workspace_dir =
             crate::data_dir::workspace_dir(&record.repo_name, &record.directory_name)?;
         let remote = record.remote.as_deref();

--- a/src-tauri/src/commands/tests/workspace_creation.rs
+++ b/src-tauri/src/commands/tests/workspace_creation.rs
@@ -174,3 +174,516 @@ fn create_workspace_from_repo_cleans_up_after_worktree_failure() {
     assert_eq!(workspace_count, 0);
     assert_eq!(session_count, 0);
 }
+
+// ---------------------------------------------------------------------------
+// prepare / finalize split — direct coverage
+// ---------------------------------------------------------------------------
+
+#[test]
+fn prepare_workspace_inserts_initializing_row_without_creating_worktree() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let harness = CreateTestHarness::new();
+
+    harness.commit_repo_files(&[(
+        "helmor.json",
+        r#"{"scripts":{"setup":"bun install","run":"bun run dev"}}"#,
+    )]);
+
+    let prepared = workspaces::prepare_workspace_from_repo_impl(&harness.repo_id).unwrap();
+
+    // DB row exists in `initializing` and matches the returned metadata.
+    let connection = Connection::open(harness.db_path()).unwrap();
+    let (state, directory_name, branch): (String, String, String) = connection
+        .query_row(
+            "SELECT state, directory_name, branch FROM workspaces WHERE id = ?1",
+            [&prepared.workspace_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(state, "initializing");
+    assert_eq!(directory_name, prepared.directory_name);
+    assert_eq!(branch, prepared.branch);
+
+    let session_workspace_id: String = connection
+        .query_row(
+            "SELECT workspace_id FROM sessions WHERE id = ?1",
+            [&prepared.initial_session_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(session_workspace_id, prepared.workspace_id);
+
+    // Worktree has NOT been created yet — that's Phase 2's job.
+    let workspace_dir = harness.workspace_dir(&prepared.directory_name);
+    assert!(
+        !workspace_dir.exists(),
+        "Phase 1 must not create the worktree"
+    );
+
+    // Repo scripts came from the source repo root's helmor.json (worktree
+    // is still missing, so the 3-tier priority falls back to repo root).
+    assert_eq!(
+        prepared.repo_scripts.setup_script.as_deref(),
+        Some("bun install")
+    );
+    assert_eq!(
+        prepared.repo_scripts.run_script.as_deref(),
+        Some("bun run dev")
+    );
+    assert_eq!(prepared.repo_scripts.archive_script, None);
+    assert!(prepared.repo_scripts.setup_from_project);
+    assert!(prepared.repo_scripts.run_from_project);
+}
+
+#[test]
+fn finalize_workspace_transitions_initializing_to_ready_and_creates_worktree() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let harness = CreateTestHarness::new();
+
+    let prepared = workspaces::prepare_workspace_from_repo_impl(&harness.repo_id).unwrap();
+    let workspace_dir = harness.workspace_dir(&prepared.directory_name);
+    assert!(!workspace_dir.exists());
+
+    let finalized = workspaces::finalize_workspace_from_repo_impl(&prepared.workspace_id).unwrap();
+
+    assert_eq!(finalized.workspace_id, prepared.workspace_id);
+    assert_eq!(finalized.final_state, WorkspaceState::Ready);
+
+    // Worktree + scaffold exist after Phase 2.
+    assert!(workspace_dir.join(".git").exists());
+    assert!(workspace_dir.join(".context/notes.md").exists());
+
+    // DB row flipped to ready.
+    let connection = Connection::open(harness.db_path()).unwrap();
+    let state: String = connection
+        .query_row(
+            "SELECT state FROM workspaces WHERE id = ?1",
+            [&prepared.workspace_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(state, "ready");
+}
+
+#[test]
+fn finalize_workspace_reports_setup_pending_when_helmor_json_has_setup() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let harness = CreateTestHarness::new();
+
+    harness.commit_repo_files(&[("helmor.json", r#"{"scripts":{"setup":"echo hi"}}"#)]);
+
+    let prepared = workspaces::prepare_workspace_from_repo_impl(&harness.repo_id).unwrap();
+    let finalized = workspaces::finalize_workspace_from_repo_impl(&prepared.workspace_id).unwrap();
+
+    assert_eq!(finalized.final_state, WorkspaceState::SetupPending);
+}
+
+#[test]
+fn finalize_workspace_cleans_up_row_on_worktree_failure() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let harness = CreateTestHarness::new();
+
+    let prepared = workspaces::prepare_workspace_from_repo_impl(&harness.repo_id).unwrap();
+
+    // Pre-create the target worktree dir so finalize's guard trips.
+    let workspace_dir = harness.workspace_dir(&prepared.directory_name);
+    fs::create_dir_all(&workspace_dir).unwrap();
+    fs::write(workspace_dir.join("squat.txt"), "squat").unwrap();
+
+    let error = workspaces::finalize_workspace_from_repo_impl(&prepared.workspace_id).unwrap_err();
+    assert!(error.to_string().contains("already exists"));
+
+    // Both rows should be gone (cascade by workspace_id).
+    let connection = Connection::open(harness.db_path()).unwrap();
+    let (workspace_count, session_count): (i64, i64) = connection
+        .query_row(
+            "SELECT
+                (SELECT COUNT(*) FROM workspaces WHERE id = ?1),
+                (SELECT COUNT(*) FROM sessions WHERE workspace_id = ?1)",
+            [&prepared.workspace_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(workspace_count, 0);
+    assert_eq!(session_count, 0);
+}
+
+#[test]
+fn finalize_workspace_refuses_non_initializing_workspace() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let harness = CreateTestHarness::new();
+
+    let prepared = workspaces::prepare_workspace_from_repo_impl(&harness.repo_id).unwrap();
+    workspaces::finalize_workspace_from_repo_impl(&prepared.workspace_id).unwrap();
+
+    // Second finalize on the same (now ready) workspace must reject —
+    // the state guard protects against accidental double-finalize that
+    // would try to recreate an existing worktree.
+    let error = workspaces::finalize_workspace_from_repo_impl(&prepared.workspace_id).unwrap_err();
+    assert!(
+        error.to_string().contains("initializing"),
+        "Expected guard error, got: {error}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Orphan cleanup on startup
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cleanup_orphaned_initializing_workspaces_purges_old_rows_and_cascades_sessions() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let harness = CreateTestHarness::new();
+
+    // Row 1: stale initializing — should be purged.
+    let stale = workspaces::prepare_workspace_from_repo_impl(&harness.repo_id).unwrap();
+    let connection = Connection::open(harness.db_path()).unwrap();
+    connection
+        .execute(
+            "UPDATE workspaces SET created_at = datetime('now', '-1 hour') WHERE id = ?1",
+            [&stale.workspace_id],
+        )
+        .unwrap();
+
+    // Row 2: fresh initializing — should be kept.
+    let fresh = workspaces::prepare_workspace_from_repo_impl(&harness.repo_id).unwrap();
+
+    let purged = workspaces::cleanup_orphaned_initializing_workspaces(300).unwrap();
+    assert_eq!(purged, 1);
+
+    // Stale row + its session are gone.
+    let stale_exists: i64 = connection
+        .query_row(
+            "SELECT COUNT(*) FROM workspaces WHERE id = ?1",
+            [&stale.workspace_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(stale_exists, 0);
+    let stale_sessions: i64 = connection
+        .query_row(
+            "SELECT COUNT(*) FROM sessions WHERE workspace_id = ?1",
+            [&stale.workspace_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(stale_sessions, 0);
+
+    // Fresh row (still within cutoff) is kept.
+    let fresh_exists: i64 = connection
+        .query_row(
+            "SELECT COUNT(*) FROM workspaces WHERE id = ?1",
+            [&fresh.workspace_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(fresh_exists, 1);
+}
+
+// ---------------------------------------------------------------------------
+// Initializing-state short-circuits (drive inspector / commit-button flicker
+// fix: the Phase-1 paint and the Phase-2 refetch must return identical data
+// so flipping `state` from initializing → ready causes zero visible change).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn git_action_status_returns_fresh_defaults_for_initializing_workspace() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let harness = CreateTestHarness::new();
+
+    let prepared = workspaces::prepare_workspace_from_repo_impl(&harness.repo_id).unwrap();
+
+    // Worktree does not exist yet — a naive git call would error. The
+    // short-circuit must catch this before we ever touch the disk.
+    let workspace_dir = harness.workspace_dir(&prepared.directory_name);
+    assert!(!workspace_dir.exists());
+
+    let status = tauri::async_runtime::block_on(
+        crate::commands::editor_commands::get_workspace_git_action_status(
+            prepared.workspace_id.clone(),
+        ),
+    )
+    .expect("get_workspace_git_action_status should succeed for initializing workspace");
+
+    assert_eq!(status.uncommitted_count, 0);
+    assert_eq!(status.conflict_count, 0);
+    assert_eq!(status.behind_target_count, 0);
+    assert_eq!(status.ahead_of_remote_count, 0);
+    assert_eq!(
+        status.sync_status,
+        git_ops::WorkspaceSyncStatus::UpToDate,
+        "fresh workspace must paint as in-sync so the Phase-2 refetch causes no visual change",
+    );
+    assert_eq!(
+        status.push_status,
+        git_ops::WorkspacePushStatus::Unpublished,
+    );
+}
+
+#[test]
+fn pr_lookups_short_circuit_for_initializing_workspace_without_network() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let harness = CreateTestHarness::new();
+
+    let prepared = workspaces::prepare_workspace_from_repo_impl(&harness.repo_id).unwrap();
+
+    // `lookup_workspace_pr` and `lookup_workspace_pr_action_status` both
+    // need to short-circuit to the canonical "no PR" answer — if they
+    // reached the network layer here (no GitHub auth in tests), they'd
+    // fail or return an "unavailable" row that would flicker when the
+    // real query lands post-ready.
+    let pr = crate::github_graphql::lookup_workspace_pr(&prepared.workspace_id)
+        .expect("lookup_workspace_pr should succeed for initializing workspace");
+    assert!(pr.is_none(), "fresh workspace cannot have a PR yet");
+
+    let status = crate::github_graphql::lookup_workspace_pr_action_status(&prepared.workspace_id)
+        .expect("lookup_workspace_pr_action_status should succeed for initializing workspace");
+    assert!(status.pr.is_none());
+    assert!(status.deployments.is_empty());
+    assert!(status.checks.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// `load_repo_scripts` three-tier priority
+// (worktree helmor.json > source repo root helmor.json > DB override)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn load_repo_scripts_priority_1_worktree_helmor_json_wins() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let harness = CreateTestHarness::new();
+
+    // Commit a repo-root helmor.json and seed a DB script override — both
+    // should be SHADOWED by the worktree's own helmor.json.
+    harness.commit_repo_files(&[(
+        "helmor.json",
+        r#"{"scripts":{"setup":"source-root-setup","run":"source-root-run"}}"#,
+    )]);
+    Connection::open(harness.db_path())
+        .unwrap()
+        .execute(
+            "UPDATE repos SET setup_script = ?1, run_script = ?2 WHERE id = ?3",
+            ("db-setup", "db-run", &harness.repo_id),
+        )
+        .unwrap();
+
+    // Finalize so the worktree exists, then rewrite the worktree's
+    // helmor.json to a distinctly different value.
+    let prepared = workspaces::prepare_workspace_from_repo_impl(&harness.repo_id).unwrap();
+    workspaces::finalize_workspace_from_repo_impl(&prepared.workspace_id).unwrap();
+    let worktree_dir = harness.workspace_dir(&prepared.directory_name);
+    fs::write(
+        worktree_dir.join("helmor.json"),
+        r#"{"scripts":{"setup":"worktree-setup","run":"worktree-run"}}"#,
+    )
+    .unwrap();
+
+    let scripts =
+        crate::repos::load_repo_scripts(&harness.repo_id, Some(&prepared.workspace_id)).unwrap();
+    assert_eq!(scripts.setup_script.as_deref(), Some("worktree-setup"));
+    assert_eq!(scripts.run_script.as_deref(), Some("worktree-run"));
+    assert!(scripts.setup_from_project);
+    assert!(scripts.run_from_project);
+}
+
+#[test]
+fn load_repo_scripts_priority_2_repo_root_wins_when_worktree_missing() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let harness = CreateTestHarness::new();
+
+    // Repo root has helmor.json, DB has its own overrides. Workspace is
+    // still in Phase 1 — worktree directory does not exist yet.
+    harness.commit_repo_files(&[(
+        "helmor.json",
+        r#"{"scripts":{"setup":"source-root-setup"}}"#,
+    )]);
+    Connection::open(harness.db_path())
+        .unwrap()
+        .execute(
+            "UPDATE repos SET setup_script = ?1, run_script = ?2 WHERE id = ?3",
+            ("db-setup", "db-run", &harness.repo_id),
+        )
+        .unwrap();
+
+    let prepared = workspaces::prepare_workspace_from_repo_impl(&harness.repo_id).unwrap();
+    let worktree_dir = harness.workspace_dir(&prepared.directory_name);
+    assert!(!worktree_dir.exists());
+
+    let scripts =
+        crate::repos::load_repo_scripts(&harness.repo_id, Some(&prepared.workspace_id)).unwrap();
+    // setup: worktree absent → falls to repo root.
+    assert_eq!(scripts.setup_script.as_deref(), Some("source-root-setup"));
+    assert!(scripts.setup_from_project);
+    // run: no project value anywhere → falls to DB.
+    assert_eq!(scripts.run_script.as_deref(), Some("db-run"));
+    assert!(!scripts.run_from_project);
+}
+
+#[test]
+fn load_repo_scripts_priority_3_falls_through_to_db_when_no_helmor_json_anywhere() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let harness = CreateTestHarness::new();
+
+    // Neither repo root nor worktree has a helmor.json — DB override is
+    // the only source.
+    Connection::open(harness.db_path())
+        .unwrap()
+        .execute(
+            "UPDATE repos SET setup_script = ?1, run_script = ?2, archive_script = ?3 WHERE id = ?4",
+            ("db-setup", "db-run", "db-archive", &harness.repo_id),
+        )
+        .unwrap();
+
+    let prepared = workspaces::prepare_workspace_from_repo_impl(&harness.repo_id).unwrap();
+    workspaces::finalize_workspace_from_repo_impl(&prepared.workspace_id).unwrap();
+
+    let scripts =
+        crate::repos::load_repo_scripts(&harness.repo_id, Some(&prepared.workspace_id)).unwrap();
+    assert_eq!(scripts.setup_script.as_deref(), Some("db-setup"));
+    assert_eq!(scripts.run_script.as_deref(), Some("db-run"));
+    assert_eq!(scripts.archive_script.as_deref(), Some("db-archive"));
+    assert!(!scripts.setup_from_project);
+    assert!(!scripts.run_from_project);
+    assert!(!scripts.archive_from_project);
+}
+
+// ---------------------------------------------------------------------------
+// `delete_workspace_and_session_rows` cascade isolation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn delete_workspace_and_session_rows_leaves_other_workspaces_intact() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let harness = CreateTestHarness::new();
+
+    // Two sibling workspaces + sessions for the same repo.
+    let keep = workspaces::prepare_workspace_from_repo_impl(&harness.repo_id).unwrap();
+    workspaces::finalize_workspace_from_repo_impl(&keep.workspace_id).unwrap();
+    let drop = workspaces::prepare_workspace_from_repo_impl(&harness.repo_id).unwrap();
+    workspaces::finalize_workspace_from_repo_impl(&drop.workspace_id).unwrap();
+
+    // Plant a session_message + attachment on each so the cascade is
+    // observable across every dependent table.
+    let connection = Connection::open(harness.db_path()).unwrap();
+    let now = crate::models::db::current_timestamp().unwrap();
+    for (session_id, workspace_id) in [
+        (&keep.initial_session_id, &keep.workspace_id),
+        (&drop.initial_session_id, &drop.workspace_id),
+    ] {
+        connection
+            .execute(
+                "INSERT INTO session_messages (id, session_id, role, content, created_at)
+                 VALUES (?1, ?2, 'user', '{}', ?3)",
+                (
+                    format!("msg-{workspace_id}"),
+                    session_id.as_str(),
+                    now.as_str(),
+                ),
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO attachments (id, session_id, is_draft, created_at)
+                 VALUES (?1, ?2, 0, ?3)",
+                (
+                    format!("att-{workspace_id}"),
+                    session_id.as_str(),
+                    now.as_str(),
+                ),
+            )
+            .unwrap();
+    }
+
+    crate::models::workspaces::delete_workspace_and_session_rows(&drop.workspace_id).unwrap();
+
+    // Dropped workspace + everything under it is gone.
+    let (dropped_ws, dropped_sessions, dropped_msgs, dropped_atts): (i64, i64, i64, i64) =
+        connection
+            .query_row(
+                "SELECT
+                    (SELECT COUNT(*) FROM workspaces WHERE id = ?1),
+                    (SELECT COUNT(*) FROM sessions WHERE workspace_id = ?1),
+                    (SELECT COUNT(*) FROM session_messages WHERE session_id = ?2),
+                    (SELECT COUNT(*) FROM attachments WHERE session_id = ?2)",
+                [&drop.workspace_id, &drop.initial_session_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+    assert_eq!(dropped_ws, 0);
+    assert_eq!(dropped_sessions, 0);
+    assert_eq!(dropped_msgs, 0);
+    assert_eq!(dropped_atts, 0);
+
+    // Sibling workspace is fully intact — cascade must not leak across
+    // workspace_id.
+    let (kept_ws, kept_sessions, kept_msgs, kept_atts): (i64, i64, i64, i64) = connection
+        .query_row(
+            "SELECT
+                (SELECT COUNT(*) FROM workspaces WHERE id = ?1),
+                (SELECT COUNT(*) FROM sessions WHERE workspace_id = ?1),
+                (SELECT COUNT(*) FROM session_messages WHERE session_id = ?2),
+                (SELECT COUNT(*) FROM attachments WHERE session_id = ?2)",
+            [&keep.workspace_id, &keep.initial_session_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .unwrap();
+    assert_eq!(kept_ws, 1);
+    assert_eq!(kept_sessions, 1);
+    assert_eq!(kept_msgs, 1);
+    assert_eq!(kept_atts, 1);
+}
+
+#[test]
+fn cleanup_orphaned_initializing_workspaces_skips_non_initializing_states() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let harness = CreateTestHarness::new();
+
+    // Old but already finalized — must not be touched by the purge.
+    let prepared = workspaces::prepare_workspace_from_repo_impl(&harness.repo_id).unwrap();
+    workspaces::finalize_workspace_from_repo_impl(&prepared.workspace_id).unwrap();
+    let connection = Connection::open(harness.db_path()).unwrap();
+    connection
+        .execute(
+            "UPDATE workspaces SET created_at = datetime('now', '-1 hour') WHERE id = ?1",
+            [&prepared.workspace_id],
+        )
+        .unwrap();
+
+    let purged = workspaces::cleanup_orphaned_initializing_workspaces(300).unwrap();
+    assert_eq!(purged, 0);
+
+    let still_exists: i64 = connection
+        .query_row(
+            "SELECT COUNT(*) FROM workspaces WHERE id = ?1",
+            [&prepared.workspace_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(still_exists, 1);
+}

--- a/src-tauri/src/commands/workspace_commands.rs
+++ b/src-tauri/src/commands/workspace_commands.rs
@@ -16,6 +16,48 @@ fn notify_workspace_changed_in_background(app: AppHandle) {
     });
 }
 
+/// Phase 1: fast (<20ms) preparation. Inserts the DB row in `initializing`
+/// state and returns the full metadata (directory name, branch, scripts,
+/// generated workspace/session IDs) needed to paint the final UI. The
+/// frontend should follow up with `finalize_workspace_from_repo` to kick
+/// off the slow git worktree creation; UI remains visible during that
+/// phase with state=initializing.
+#[tauri::command]
+pub async fn prepare_workspace_from_repo(
+    app: AppHandle,
+    repo_id: String,
+) -> CmdResult<workspaces::PrepareWorkspaceResponse> {
+    let result = {
+        let _lock = db::WORKSPACE_MUTATION_LOCK.lock().await;
+        run_blocking(move || workspaces::prepare_workspace_from_repo_impl(&repo_id)).await?
+    };
+    notify_workspace_changed_in_background(app);
+    Ok(result)
+}
+
+/// Phase 2: slow (~200ms-2s) materialization. Creates the git worktree,
+/// scaffolds `.context`, probes `helmor.json` for a setup script, and flips
+/// the workspace row from `initializing` to `ready` / `setup_pending`. On
+/// failure, the workspace + session rows are deleted and the worktree is
+/// cleaned up so the user can retry.
+#[tauri::command]
+pub async fn finalize_workspace_from_repo(
+    app: AppHandle,
+    workspace_id: String,
+) -> CmdResult<workspaces::FinalizeWorkspaceResponse> {
+    let ws_lock = db::workspace_mutation_lock(&workspace_id);
+    let _lock = ws_lock.lock().await;
+    let result = {
+        let workspace_id = workspace_id.clone();
+        run_blocking(move || workspaces::finalize_workspace_from_repo_impl(&workspace_id)).await?
+    };
+    notify_workspace_changed_in_background(app);
+    Ok(result)
+}
+
+/// Legacy combined flow (prepare + finalize in a single call). Retained
+/// for CLI / MCP / add-repository callers that don't benefit from the
+/// two-phase UI split.
 #[tauri::command]
 pub async fn create_workspace_from_repo(
     app: AppHandle,

--- a/src-tauri/src/github/graphql.rs
+++ b/src-tauri/src/github/graphql.rs
@@ -150,6 +150,13 @@ pub fn lookup_workspace_pr(workspace_id: &str) -> Result<Option<PullRequestInfo>
         bail!("Workspace not found: {workspace_id}");
     };
 
+    // A workspace in Phase 1 hasn't been pushed yet — there can't be a PR.
+    // Short-circuit to match the post-ready answer and avoid a pointless
+    // GitHub round-trip plus the UI flicker that would come with it.
+    if record.state == crate::workspace_state::WorkspaceState::Initializing {
+        return Ok(None);
+    }
+
     let Some(remote_url) = record.remote_url.as_deref() else {
         return Ok(None);
     };
@@ -276,6 +283,13 @@ pub fn lookup_workspace_pr_action_status(workspace_id: &str) -> Result<Workspace
     let Some(record) = workspace_models::load_workspace_record_by_id(workspace_id)? else {
         bail!("Workspace not found: {workspace_id}");
     };
+
+    // Phase 1 workspace: definitively no PR yet. Return the `no_pr` state
+    // directly so the inspector paints the final empty review list from
+    // the first frame, without a GitHub round-trip.
+    if record.state == crate::workspace_state::WorkspaceState::Initializing {
+        return Ok(WorkspacePrActionStatus::no_pr());
+    }
 
     let Some(remote_url) = record.remote_url.as_deref() else {
         return Ok(WorkspacePrActionStatus::unavailable(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -96,6 +96,19 @@ pub fn run() {
                 Err(e) => tracing::warn!("Failed to purge orphaned workspaces: {e:#}"),
             }
 
+            // Clear rows stuck in `initializing` state past the cutoff —
+            // happens when the app is force-quit mid-create (Phase 2 never
+            // gets to flip the state to ready/setup_pending). Five minutes
+            // is well past the worst-case git worktree creation time.
+            const INITIALIZING_ORPHAN_CUTOFF_SECONDS: i64 = 300;
+            match workspace::workspaces::cleanup_orphaned_initializing_workspaces(
+                INITIALIZING_ORPHAN_CUTOFF_SECONDS,
+            ) {
+                Ok(0) => {}
+                Ok(n) => tracing::info!(count = n, "Cleaned up orphan initializing workspaces"),
+                Err(e) => tracing::warn!("Failed to clean up initializing orphans: {e:#}"),
+            }
+
             // On macOS, GUI-launched apps only see the minimal system PATH.
             // Capture the user's login-shell PATH (Homebrew, nvm, bun, cargo,
             // etc.) so every child process — sidecar, git, workspace scripts —
@@ -140,6 +153,8 @@ pub fn run() {
             commands::github_commands::cancel_github_identity_connect,
             commands::workspace_commands::complete_workspace_setup,
             commands::workspace_commands::create_workspace_from_repo,
+            commands::workspace_commands::prepare_workspace_from_repo,
+            commands::workspace_commands::finalize_workspace_from_repo,
             commands::github_commands::disconnect_github_identity,
             commands::repository_commands::get_add_repository_defaults,
             commands::settings_commands::get_app_settings,

--- a/src-tauri/src/models/repos.rs
+++ b/src-tauri/src/models/repos.rs
@@ -397,7 +397,43 @@ pub struct RepoScripts {
     pub archive_from_project: bool,
 }
 
+/// Resolve repo scripts using a fixed priority:
+///
+///   1. The workspace's worktree `helmor.json` — highest priority, only
+///      consulted when `workspace_id` is supplied AND the worktree dir
+///      exists on disk.
+///   2. The source repo root's `helmor.json` — used whenever (1) can't
+///      apply: no `workspace_id`, unknown workspace, or worktree missing
+///      (archived / broken / pre-Phase-2 creation).
+///   3. DB-level config (`repos.setup_script/run_script/archive_script`) —
+///      the per-user override set via the Settings UI, used as a final
+///      fallback when neither `helmor.json` source provides a value.
+///
+/// The same rule applies regardless of caller (runtime panel, settings
+/// page, script execution, archive hook) — there is no special-case
+/// branch for "creation in flight" or "no workspace context".
 pub fn load_repo_scripts(repo_id: &str, workspace_id: Option<&str>) -> Result<RepoScripts> {
+    // Priority 1: workspace worktree helmor.json.
+    let worktree_project = workspace_id.and_then(|ws_id| {
+        crate::models::workspaces::load_workspace_record_by_id(ws_id)
+            .ok()
+            .flatten()
+            .and_then(|ws| crate::data_dir::workspace_dir(&ws.repo_name, &ws.directory_name).ok())
+            .filter(|dir| dir.is_dir())
+            .and_then(|dir| load_helmor_json_scripts(&dir))
+    });
+
+    // Priority 2: source repo root helmor.json (worktree missing or no
+    // workspace context at all).
+    let project = worktree_project.or_else(|| {
+        load_repository_by_id(repo_id)
+            .ok()
+            .flatten()
+            .and_then(|repo| load_helmor_json_scripts(&PathBuf::from(repo.root_path.trim())))
+    });
+
+    // Priority 3: DB values — picked up by `pick_script` when the project
+    // config doesn't provide a value.
     let connection = db::open_connection(false)?;
     let mut statement = connection
         .prepare("SELECT setup_script, run_script, archive_script FROM repos WHERE id = ?1")
@@ -412,15 +448,6 @@ pub fn load_repo_scripts(repo_id: &str, workspace_id: Option<&str>) -> Result<Re
             ))
         })
         .with_context(|| format!("Repository not found: {repo_id}"))?;
-
-    // Only read helmor.json from the workspace directory — never from repo root.
-    let project = workspace_id.and_then(|ws_id| {
-        crate::models::workspaces::load_workspace_record_by_id(ws_id)
-            .ok()
-            .flatten()
-            .and_then(|ws| crate::data_dir::workspace_dir(&ws.repo_name, &ws.directory_name).ok())
-            .and_then(|dir| load_helmor_json_scripts(&dir))
-    });
 
     let (setup_script, setup_from_project) =
         pick_script(project.as_ref().and_then(|p| p.setup.as_deref()), db_setup);

--- a/src-tauri/src/models/workspaces.rs
+++ b/src-tauri/src/models/workspaces.rs
@@ -278,10 +278,7 @@ pub(crate) fn update_workspace_state(
     Ok(())
 }
 
-pub(crate) fn delete_workspace_and_session_rows(
-    workspace_id: &str,
-    session_id: &str,
-) -> Result<()> {
+pub(crate) fn delete_workspace_and_session_rows(workspace_id: &str) -> Result<()> {
     let mut connection = db::open_connection(true)?;
     let transaction = connection
         .transaction()
@@ -289,19 +286,24 @@ pub(crate) fn delete_workspace_and_session_rows(
 
     transaction
         .execute(
-            "DELETE FROM attachments WHERE session_id = ?1",
-            [session_id],
+            "DELETE FROM attachments
+             WHERE session_id IN (SELECT id FROM sessions WHERE workspace_id = ?1)",
+            [workspace_id],
         )
         .context("Failed to delete create-flow attachments")?;
     transaction
         .execute(
-            "DELETE FROM session_messages WHERE session_id = ?1",
-            [session_id],
+            "DELETE FROM session_messages
+             WHERE session_id IN (SELECT id FROM sessions WHERE workspace_id = ?1)",
+            [workspace_id],
         )
         .context("Failed to delete create-flow session messages")?;
     transaction
-        .execute("DELETE FROM sessions WHERE id = ?1", [session_id])
-        .context("Failed to delete create-flow session")?;
+        .execute(
+            "DELETE FROM sessions WHERE workspace_id = ?1",
+            [workspace_id],
+        )
+        .context("Failed to delete create-flow sessions")?;
     transaction
         .execute("DELETE FROM workspaces WHERE id = ?1", [workspace_id])
         .context("Failed to delete create-flow workspace")?;
@@ -309,6 +311,34 @@ pub(crate) fn delete_workspace_and_session_rows(
     transaction
         .commit()
         .context("Failed to commit create cleanup transaction")
+}
+
+/// Orphan lookup for the startup cleanup path: returns workspace rows
+/// stuck in `initializing` state whose `created_at` is older than
+/// `max_age_seconds` seconds ago. These are typically left behind when
+/// the app was force-quit during Phase 2 of workspace creation.
+pub(crate) fn list_initializing_workspaces_older_than(
+    max_age_seconds: i64,
+) -> Result<Vec<OrphanedInitializingWorkspace>> {
+    let connection = db::open_connection(false)?;
+    let cutoff = format!("datetime('now', '-{} seconds')", max_age_seconds.max(0));
+    let sql = format!("{WORKSPACE_RECORD_SQL} WHERE w.state = ?1 AND w.created_at < {cutoff}",);
+    let mut statement = connection.prepare(&sql)?;
+    let rows = statement.query_map(
+        [WorkspaceState::Initializing.as_str()],
+        workspace_record_from_row,
+    )?;
+
+    let records: Vec<WorkspaceRecord> = rows.collect::<std::result::Result<Vec<_>, _>>()?;
+
+    Ok(records
+        .into_iter()
+        .map(|record| OrphanedInitializingWorkspace { record })
+        .collect())
+}
+
+pub(crate) struct OrphanedInitializingWorkspace {
+    pub record: WorkspaceRecord,
 }
 
 pub(crate) fn update_archived_workspace_state(

--- a/src-tauri/src/workspace/lifecycle.rs
+++ b/src-tauri/src/workspace/lifecycle.rs
@@ -55,6 +55,38 @@ pub struct CreateWorkspaceResponse {
     pub branch: String,
 }
 
+/// Response from the fast Phase 1 of workspace creation. Returned after
+/// the DB row has been inserted but before the git worktree has been
+/// materialized on disk. Contains everything the frontend needs to paint
+/// the final UI state (directory name, branch, repo scripts) without any
+/// placeholders. `state` is always `Initializing` at this point.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PrepareWorkspaceResponse {
+    pub workspace_id: String,
+    pub initial_session_id: String,
+    pub repo_id: String,
+    pub repo_name: String,
+    pub directory_name: String,
+    pub branch: String,
+    pub default_branch: String,
+    pub state: WorkspaceState,
+    /// DB-level repo scripts. After Phase 2 (worktree creation) the frontend
+    /// may refetch to pick up any `helmor.json` overrides copied into the
+    /// worktree, but for a freshly cloned workspace these match exactly.
+    pub repo_scripts: repos::RepoScripts,
+}
+
+/// Response from the slow Phase 2 (git worktree + scaffold + setup probe).
+/// The workspace row has been upgraded from `Initializing` to whatever
+/// `final_state` reports (usually `Ready` or `SetupPending`).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FinalizeWorkspaceResponse {
+    pub workspace_id: String,
+    pub final_state: WorkspaceState,
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ValidateRestoreResponse {
@@ -72,7 +104,17 @@ pub struct TargetBranchConflict {
     pub remote: String,
 }
 
-pub fn create_workspace_from_repo_impl(repo_id: &str) -> Result<CreateWorkspaceResponse> {
+/// Phase 1 of workspace creation: all the fast (<20ms total) preparatory
+/// work. Validates the source repo, allocates a unique directory name,
+/// computes the branch name, inserts the initializing DB row + initial
+/// session, and loads repo-level scripts. Returns the full metadata the
+/// frontend needs to paint the final UI state.
+///
+/// Phase 2 (`finalize_workspace_from_repo_impl`) creates the actual git
+/// worktree on disk and flips the workspace row from `Initializing` to
+/// `Ready` / `SetupPending`. It can run in the background while the UI
+/// already shows the workspace.
+pub fn prepare_workspace_from_repo_impl(repo_id: &str) -> Result<PrepareWorkspaceResponse> {
     let repository = repos::load_repository_by_id(repo_id)?
         .with_context(|| format!("Repository not found: {repo_id}"))?;
     let repo_root = PathBuf::from(repository.root_path.trim());
@@ -100,9 +142,7 @@ pub fn create_workspace_from_repo_impl(repo_id: &str) -> Result<CreateWorkspaceR
         .unwrap_or_else(|| "main".to_string());
     let workspace_id = uuid::Uuid::new_v4().to_string();
     let session_id = uuid::Uuid::new_v4().to_string();
-    let workspace_dir = crate::data_dir::workspace_dir(&repository.name, &directory_name)?;
     let timestamp = db::current_timestamp()?;
-    let mut created_worktree = false;
 
     workspace_models::insert_initializing_workspace_and_session(
         &repository,
@@ -114,7 +154,77 @@ pub fn create_workspace_from_repo_impl(repo_id: &str) -> Result<CreateWorkspaceR
         &timestamp,
     )?;
 
-    let create_result = (|| -> Result<CreateWorkspaceResponse> {
+    // `load_repo_scripts` is the single truth source. The worktree
+    // doesn't exist yet, but the function knows to fall back to the
+    // source repo root's `helmor.json` when the worktree dir is missing
+    // — so the frontend gets the correct "missing script" count from
+    // the first paint.
+    let repo_scripts = match repos::load_repo_scripts(repo_id, Some(&workspace_id)) {
+        Ok(scripts) => scripts,
+        Err(error) => {
+            tracing::warn!(%error, "Failed to load repo scripts during prepare; defaulting to empty");
+            repos::RepoScripts {
+                setup_script: None,
+                run_script: None,
+                archive_script: None,
+                setup_from_project: false,
+                run_from_project: false,
+                archive_from_project: false,
+            }
+        }
+    };
+
+    Ok(PrepareWorkspaceResponse {
+        workspace_id,
+        initial_session_id: session_id,
+        repo_id: repository.id,
+        repo_name: repository.name,
+        directory_name,
+        branch,
+        default_branch,
+        state: WorkspaceState::Initializing,
+        repo_scripts,
+    })
+}
+
+/// Phase 2 of workspace creation: creates the git worktree, seeds the
+/// `.context` scaffold, probes `helmor.json` for a setup script, and
+/// upgrades the workspace row from `Initializing` to `Ready` /
+/// `SetupPending`. On failure, cleans up the worktree + DB rows so the
+/// caller can surface the error without leaving a broken workspace
+/// lingering.
+pub fn finalize_workspace_from_repo_impl(workspace_id: &str) -> Result<FinalizeWorkspaceResponse> {
+    let record = workspace_models::load_workspace_record_by_id(workspace_id)?
+        .ok_or_else(|| coded(ErrorCode::WorkspaceNotFound))
+        .with_context(|| format!("Workspace not found: {workspace_id}"))?;
+
+    if record.state != WorkspaceState::Initializing {
+        bail!(
+            "Workspace {workspace_id} is not in initializing state (current: {})",
+            record.state
+        );
+    }
+
+    let repository = repos::load_repository_by_id(&record.repo_id)?
+        .with_context(|| format!("Repository not found: {}", record.repo_id))?;
+    let repo_root = PathBuf::from(repository.root_path.trim());
+    let remote = repository
+        .remote
+        .clone()
+        .unwrap_or_else(|| "origin".to_string());
+    let default_branch = record
+        .default_branch
+        .clone()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "main".to_string());
+    let branch = helpers::non_empty(&record.branch)
+        .map(ToOwned::to_owned)
+        .with_context(|| format!("Workspace {workspace_id} is missing branch"))?;
+    let workspace_dir = crate::data_dir::workspace_dir(&repository.name, &record.directory_name)?;
+    let timestamp = db::current_timestamp()?;
+    let mut created_worktree = false;
+
+    let finalize_result = (|| -> Result<FinalizeWorkspaceResponse> {
         if workspace_dir.exists() {
             bail!(
                 "Workspace target already exists at {}",
@@ -147,7 +257,7 @@ pub fn create_workspace_from_repo_impl(repo_id: &str) -> Result<CreateWorkspaceR
         let initialization_files_copied = git_ops::tracked_file_count(&workspace_dir)?;
 
         workspace_models::update_workspace_initialization_metadata(
-            &workspace_id,
+            workspace_id,
             initialization_files_copied,
             &timestamp,
         )?;
@@ -166,24 +276,19 @@ pub fn create_workspace_from_repo_impl(repo_id: &str) -> Result<CreateWorkspaceR
         } else {
             WorkspaceState::Ready
         };
-        workspace_models::update_workspace_state(&workspace_id, final_state, &timestamp)?;
+        workspace_models::update_workspace_state(workspace_id, final_state, &timestamp)?;
 
-        Ok(CreateWorkspaceResponse {
-            created_workspace_id: workspace_id.clone(),
-            selected_workspace_id: workspace_id.clone(),
-            initial_session_id: session_id.clone(),
-            created_state: final_state,
-            directory_name,
-            branch: branch.clone(),
+        Ok(FinalizeWorkspaceResponse {
+            workspace_id: workspace_id.to_string(),
+            final_state,
         })
     })();
 
-    match create_result {
+    match finalize_result {
         Ok(response) => Ok(response),
         Err(error) => {
             cleanup_failed_created_workspace(
-                &workspace_id,
-                &session_id,
+                workspace_id,
                 &repo_root,
                 &workspace_dir,
                 &branch,
@@ -192,6 +297,67 @@ pub fn create_workspace_from_repo_impl(repo_id: &str) -> Result<CreateWorkspaceR
             Err(error)
         }
     }
+}
+
+/// Legacy combined flow. Runs Phase 1 + Phase 2 back-to-back and returns
+/// the old-shape response. Used by CLI, MCP, and `add_repository_from_local_path`
+/// — all non-UI callers that do not benefit from the prepare/finalize split.
+pub fn create_workspace_from_repo_impl(repo_id: &str) -> Result<CreateWorkspaceResponse> {
+    let prepared = prepare_workspace_from_repo_impl(repo_id)?;
+    let finalized = finalize_workspace_from_repo_impl(&prepared.workspace_id)?;
+
+    Ok(CreateWorkspaceResponse {
+        created_workspace_id: prepared.workspace_id.clone(),
+        selected_workspace_id: prepared.workspace_id,
+        initial_session_id: prepared.initial_session_id,
+        created_state: finalized.final_state,
+        directory_name: prepared.directory_name,
+        branch: prepared.branch,
+    })
+}
+
+/// Remove workspace rows stuck in the `Initializing` state longer than the
+/// supplied cutoff. Called at app startup to clean up rows left behind when
+/// the process exited mid-finalize (e.g. the app was force-quit while the
+/// git worktree was being created). Best-effort: returns the number of
+/// rows purged and logs failures rather than propagating them.
+pub fn cleanup_orphaned_initializing_workspaces(max_age_seconds: i64) -> Result<usize> {
+    let orphans = workspace_models::list_initializing_workspaces_older_than(max_age_seconds)?;
+    let orphan_count = orphans.len();
+
+    for orphan in orphans {
+        let record = &orphan.record;
+        let repo_root_value = record.root_path.as_deref().unwrap_or("").trim();
+        let repo_root = PathBuf::from(repo_root_value);
+        let workspace_dir =
+            match crate::data_dir::workspace_dir(&record.repo_name, &record.directory_name) {
+                Ok(path) => path,
+                Err(error) => {
+                    tracing::warn!(
+                        workspace_id = %record.id,
+                        error = %error,
+                        "Failed to resolve workspace dir for orphan cleanup",
+                    );
+                    continue;
+                }
+            };
+        let branch = record.branch.as_deref().unwrap_or("");
+
+        cleanup_failed_created_workspace(
+            &record.id,
+            &repo_root,
+            &workspace_dir,
+            branch,
+            workspace_dir.exists(),
+        );
+
+        tracing::info!(
+            workspace_id = %record.id,
+            "Cleaned up orphaned initializing workspace",
+        );
+    }
+
+    Ok(orphan_count)
 }
 
 #[derive(Debug, Clone)]
@@ -720,7 +886,6 @@ pub fn restore_workspace_impl(
 
 fn cleanup_failed_created_workspace(
     workspace_id: &str,
-    session_id: &str,
     repo_root: &Path,
     workspace_dir: &Path,
     branch: &str,
@@ -731,8 +896,10 @@ fn cleanup_failed_created_workspace(
         let _ = fs::remove_dir_all(workspace_dir);
     }
 
-    let _ = git_ops::remove_branch(repo_root, branch);
-    let _ = workspace_models::delete_workspace_and_session_rows(workspace_id, session_id);
+    if !branch.is_empty() {
+        let _ = git_ops::remove_branch(repo_root, branch);
+    }
+    let _ = workspace_models::delete_workspace_and_session_rows(workspace_id);
 }
 
 fn cleanup_failed_restore(

--- a/src-tauri/src/workspace/workspaces.rs
+++ b/src-tauri/src/workspace/workspaces.rs
@@ -24,9 +24,11 @@ pub use super::branching::{
     UpdateIntendedTargetBranchResponse,
 };
 pub use super::lifecycle::{
-    archive_workspace_impl, create_workspace_from_repo_impl, prepare_archive_plan,
-    restore_workspace_impl, validate_archive_workspace, validate_restore_workspace,
-    ArchivePreparedPlan, ArchiveWorkspaceResponse, BranchRename, CreateWorkspaceResponse,
+    archive_workspace_impl, cleanup_orphaned_initializing_workspaces,
+    create_workspace_from_repo_impl, finalize_workspace_from_repo_impl, prepare_archive_plan,
+    prepare_workspace_from_repo_impl, restore_workspace_impl, validate_archive_workspace,
+    validate_restore_workspace, ArchivePreparedPlan, ArchiveWorkspaceResponse, BranchRename,
+    CreateWorkspaceResponse, FinalizeWorkspaceResponse, PrepareWorkspaceResponse,
     RestoreWorkspaceResponse, TargetBranchConflict, ValidateRestoreResponse,
 };
 

--- a/src/App.create.test.tsx
+++ b/src/App.create.test.tsx
@@ -10,12 +10,17 @@ const apiMocks = vi.hoisted(() => ({
 	loadWorkspaceSessions: vi.fn(),
 	loadSessionThreadMessages: vi.fn(),
 	loadSessionAttachments: vi.fn(),
+	loadRepoScripts: vi.fn(),
 	listRepositories: vi.fn(),
 	createWorkspaceFromRepo: vi.fn(),
+	prepareWorkspaceFromRepo: vi.fn(),
+	finalizeWorkspaceFromRepo: vi.fn(),
 }));
 
 const createRuntime = vi.hoisted(() => ({
 	created: false,
+	workspaceId: null as string | null,
+	sessionId: null as string | null,
 }));
 
 vi.mock("./App.css", () => ({}));
@@ -36,8 +41,11 @@ vi.mock("./lib/api", async (importOriginal) => {
 		loadSessionMessages: apiMocks.loadSessionThreadMessages,
 		loadSessionThreadMessages: apiMocks.loadSessionThreadMessages,
 		loadSessionAttachments: apiMocks.loadSessionAttachments,
+		loadRepoScripts: apiMocks.loadRepoScripts,
 		listRepositories: apiMocks.listRepositories,
 		createWorkspaceFromRepo: apiMocks.createWorkspaceFromRepo,
+		prepareWorkspaceFromRepo: apiMocks.prepareWorkspaceFromRepo,
+		finalizeWorkspaceFromRepo: apiMocks.finalizeWorkspaceFromRepo,
 	};
 });
 
@@ -46,6 +54,8 @@ import App from "./App";
 describe("App create workspace flow", () => {
 	beforeEach(() => {
 		createRuntime.created = false;
+		createRuntime.workspaceId = null;
+		createRuntime.sessionId = null;
 
 		apiMocks.loadWorkspaceGroups.mockReset();
 		apiMocks.loadArchivedWorkspaces.mockReset();
@@ -54,6 +64,15 @@ describe("App create workspace flow", () => {
 		apiMocks.loadWorkspaceSessions.mockReset();
 		apiMocks.loadSessionThreadMessages.mockReset();
 		apiMocks.loadSessionAttachments.mockReset();
+		apiMocks.loadRepoScripts.mockReset();
+		apiMocks.loadRepoScripts.mockResolvedValue({
+			setupScript: null,
+			runScript: null,
+			archiveScript: null,
+			setupFromProject: false,
+			runFromProject: false,
+			archiveFromProject: false,
+		});
 		apiMocks.listRepositories.mockReset();
 		apiMocks.createWorkspaceFromRepo.mockReset();
 
@@ -70,39 +89,43 @@ describe("App create workspace flow", () => {
 				id: "progress",
 				label: "In progress",
 				tone: "progress",
-				rows: createRuntime.created
-					? [
-							{
-								id: "workspace-existing",
-								title: "Existing workspace",
-								repoName: "helmor-core",
-								state: "ready",
-							},
-							{
-								id: "workspace-created",
-								title: "Acamar",
-								directoryName: "acamar",
-								repoName: "dosu-cli",
-								state: "ready",
-							},
-						]
-					: [
-							{
-								id: "workspace-existing",
-								title: "Existing workspace",
-								repoName: "helmor-core",
-								state: "ready",
-							},
-						],
+				rows:
+					createRuntime.created && createRuntime.workspaceId
+						? [
+								{
+									id: "workspace-existing",
+									title: "Existing workspace",
+									repoName: "helmor-core",
+									state: "ready",
+								},
+								{
+									id: createRuntime.workspaceId,
+									title: "Acamar",
+									directoryName: "acamar",
+									repoName: "dosu-cli",
+									state: "ready",
+								},
+							]
+						: [
+								{
+									id: "workspace-existing",
+									title: "Existing workspace",
+									repoName: "helmor-core",
+									state: "ready",
+								},
+							],
 			},
 		]);
 		apiMocks.loadArchivedWorkspaces.mockResolvedValue([]);
 		apiMocks.loadAgentModelSections.mockResolvedValue([]);
 		apiMocks.loadWorkspaceDetail.mockImplementation(
 			async (workspaceId: string) => {
-				if (workspaceId === "workspace-created") {
+				if (
+					createRuntime.workspaceId &&
+					workspaceId === createRuntime.workspaceId
+				) {
 					return {
-						id: "workspace-created",
+						id: workspaceId,
 						title: "Acamar",
 						repoId: "repo-1",
 						repoName: "dosu-cli",
@@ -114,7 +137,7 @@ describe("App create workspace flow", () => {
 						unreadSessionCount: 0,
 						derivedStatus: "in-progress",
 						manualStatus: null,
-						activeSessionId: "session-created",
+						activeSessionId: createRuntime.sessionId,
 						activeSessionTitle: "Untitled",
 						activeSessionAgentType: "claude",
 						activeSessionStatus: "idle",
@@ -165,11 +188,15 @@ describe("App create workspace flow", () => {
 		);
 		apiMocks.loadWorkspaceSessions.mockImplementation(
 			async (workspaceId: string) => {
-				if (workspaceId === "workspace-created") {
+				if (
+					createRuntime.workspaceId &&
+					workspaceId === createRuntime.workspaceId &&
+					createRuntime.sessionId
+				) {
 					return [
 						{
-							id: "session-created",
-							workspaceId: "workspace-created",
+							id: createRuntime.sessionId,
+							workspaceId,
 							title: "Untitled",
 							agentType: "claude",
 							status: "idle",
@@ -224,17 +251,45 @@ describe("App create workspace flow", () => {
 		);
 		apiMocks.loadSessionThreadMessages.mockResolvedValue([]);
 		apiMocks.loadSessionAttachments.mockResolvedValue([]);
-		apiMocks.createWorkspaceFromRepo.mockImplementation(async () => {
-			createRuntime.created = true;
-
+		apiMocks.prepareWorkspaceFromRepo.mockReset();
+		apiMocks.finalizeWorkspaceFromRepo.mockReset();
+		apiMocks.prepareWorkspaceFromRepo.mockImplementation(async () => {
+			// Backend generates the ids now. Mirror by generating once per
+			// call and stashing for subsequent finalize + detail mocks.
+			createRuntime.workspaceId = crypto.randomUUID();
+			createRuntime.sessionId = crypto.randomUUID();
 			return {
-				createdWorkspaceId: "workspace-created",
-				selectedWorkspaceId: "workspace-created",
-				initialSessionId: "session-created",
-				createdState: "ready",
+				workspaceId: createRuntime.workspaceId,
+				initialSessionId: createRuntime.sessionId,
+				repoId: "repo-1",
+				repoName: "dosu-cli",
 				directoryName: "acamar",
 				branch: "testuser/acamar",
+				defaultBranch: "main",
+				state: "initializing",
+				repoScripts: {
+					setupScript: null,
+					runScript: null,
+					archiveScript: null,
+					setupFromProject: false,
+					runFromProject: false,
+					archiveFromProject: false,
+				},
 			};
+		});
+		apiMocks.finalizeWorkspaceFromRepo.mockImplementation(async () => {
+			createRuntime.created = true;
+			return {
+				workspaceId: createRuntime.workspaceId!,
+				finalState: "ready",
+			};
+		});
+		// Combined create path is unused under the prepare/finalize flow —
+		// still mock it so accidental calls surface clearly in test output.
+		apiMocks.createWorkspaceFromRepo.mockImplementation(async () => {
+			throw new Error(
+				"createWorkspaceFromRepo should not be called under prepare/finalize flow",
+			);
 		});
 	});
 
@@ -252,24 +307,27 @@ describe("App create workspace flow", () => {
 		await user.click(await screen.findByText("dosu-cli"));
 
 		await waitFor(() => {
-			expect(apiMocks.createWorkspaceFromRepo).toHaveBeenCalledWith("repo-1");
+			expect(apiMocks.prepareWorkspaceFromRepo).toHaveBeenCalledWith("repo-1");
 		});
 		await waitFor(() => {
-			expect(apiMocks.loadWorkspaceDetail).toHaveBeenCalledWith(
-				"workspace-created",
+			expect(createRuntime.workspaceId).not.toBeNull();
+		});
+		await waitFor(() => {
+			expect(apiMocks.finalizeWorkspaceFromRepo).toHaveBeenCalledWith(
+				createRuntime.workspaceId,
 			);
 		});
 		await waitFor(() => {
-			expect(apiMocks.loadWorkspaceSessions).toHaveBeenCalledWith(
-				"workspace-created",
-			);
+			expect(screen.getByText("Acamar")).toBeInTheDocument();
 		});
-		await waitFor(() => {
-			expect(apiMocks.loadSessionThreadMessages).toHaveBeenCalledWith(
-				"session-created",
-			);
-		});
-
-		expect(screen.getByText("Acamar")).toBeInTheDocument();
+		// Thread messages for the newly created session are NOT fetched —
+		// use-controller pre-seeds an empty thread via the prepare response
+		// so the panel paints "nothing here yet" on the first frame without
+		// a cold placeholder. Loads from unrelated sessions (e.g. the
+		// previously selected workspace) are fine; this test only cares
+		// about the new one.
+		expect(apiMocks.loadSessionThreadMessages).not.toHaveBeenCalledWith(
+			createRuntime.sessionId,
+		);
 	});
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -108,10 +108,7 @@ import {
 	useSettings,
 } from "./lib/settings";
 import { useOsNotifications } from "./lib/use-os-notifications";
-import {
-	isOptimisticCreatingWorkspaceId,
-	summaryToArchivedRow,
-} from "./lib/workspace-helpers";
+import { summaryToArchivedRow } from "./lib/workspace-helpers";
 import {
 	type WorkspaceToastOptions,
 	WorkspaceToastProvider,
@@ -483,10 +480,7 @@ function AppShell({
 	);
 	const selectedWorkspaceDetailQuery = useQuery({
 		...workspaceDetailQueryOptions(selectedWorkspaceId ?? "__none__"),
-		enabled:
-			isIdentityConnected &&
-			selectedWorkspaceId !== null &&
-			!isOptimisticCreatingWorkspaceId(selectedWorkspaceId),
+		enabled: isIdentityConnected && selectedWorkspaceId !== null,
 	});
 	const handleOpenSettings = useCallback(() => {
 		onOpenSettings(
@@ -531,12 +525,12 @@ function AppShell({
 
 	// Persistent PR state for the current workspace's branch. Drives the
 	// commit button's resting mode and the "Git · PR #xxx" header badge.
+	// No `initializing` gate: the Rust impls short-circuit to the
+	// canonical "fresh workspace" answers (no PR, clean git tree) so the
+	// Phase 1 paint already matches what the Phase 2 refetch returns.
 	const workspacePrQuery = useQuery({
 		...workspacePrQueryOptions(selectedWorkspaceId ?? "__none__"),
-		enabled:
-			isIdentityConnected &&
-			selectedWorkspaceId !== null &&
-			!isOptimisticCreatingWorkspaceId(selectedWorkspaceId),
+		enabled: isIdentityConnected && selectedWorkspaceId !== null,
 	});
 	const workspacePrInfo = workspacePrQuery.data ?? null;
 
@@ -545,10 +539,7 @@ function AppShell({
 	// button's mode derivation — shared cache with inspector's actions.tsx.
 	const workspacePrActionStatusQuery = useQuery({
 		...workspacePrActionStatusQueryOptions(selectedWorkspaceId ?? "__none__"),
-		enabled:
-			isIdentityConnected &&
-			selectedWorkspaceId !== null &&
-			!isOptimisticCreatingWorkspaceId(selectedWorkspaceId),
+		enabled: isIdentityConnected && selectedWorkspaceId !== null,
 	});
 	const workspacePrActionStatus = workspacePrActionStatusQuery.data ?? null;
 
@@ -556,7 +547,6 @@ function AppShell({
 		...workspaceGitActionStatusQueryOptions(selectedWorkspaceId ?? "__none__"),
 		enabled:
 			selectedWorkspaceId !== null &&
-			!isOptimisticCreatingWorkspaceId(selectedWorkspaceId) &&
 			selectedWorkspaceDetail?.state !== "archived",
 	});
 	const workspaceGitActionStatus = workspaceGitActionStatusQuery.data ?? null;
@@ -857,13 +847,6 @@ function AppShell({
 
 	const primeWorkspaceDisplay = useCallback(
 		async (workspaceId: string) => {
-			if (isOptimisticCreatingWorkspaceId(workspaceId)) {
-				return {
-					workspaceId,
-					sessionId: null,
-				};
-			}
-
 			const [workspaceDetail, workspaceSessions] = await Promise.all([
 				queryClient.ensureQueryData(workspaceDetailQueryOptions(workspaceId)),
 				queryClient.ensureQueryData(workspaceSessionsQueryOptions(workspaceId)),
@@ -910,7 +893,6 @@ function AppShell({
 				null;
 			const hasSessionMessages =
 				sessionId === null ||
-				isOptimisticCreatingWorkspaceId(workspaceId) ||
 				queryClient.getQueryData([
 					...helmorQueryKeys.sessionMessages(sessionId),
 					"thread",
@@ -1079,7 +1061,13 @@ function AppShell({
 			setSelectedSessionId(immediateSessionId);
 
 			if (workspaceId) {
-				if (!isOptimisticCreatingWorkspaceId(workspaceId)) {
+				// Skip git fetch while the worktree is still being created —
+				// `state === "initializing"` means Phase 2 hasn't finished
+				// materializing the worktree on disk yet.
+				const cachedDetail = queryClient.getQueryData<WorkspaceDetail | null>(
+					helmorQueryKeys.workspaceDetail(workspaceId),
+				);
+				if (cachedDetail?.state !== "initializing") {
 					triggerWorkspaceFetch(workspaceId);
 				}
 			}

--- a/src/features/composer/container.test.tsx
+++ b/src/features/composer/container.test.tsx
@@ -30,6 +30,8 @@ vi.mock("./index", async () => {
 			contextKey: string;
 			selectedModelId: string | null;
 			fastMode?: boolean;
+			disabled?: boolean;
+			submitDisabled?: boolean;
 		}) => {
 			composerMockState.renders.push(props.contextKey);
 			React.useEffect(() => {
@@ -43,6 +45,8 @@ vi.mock("./index", async () => {
 				<div
 					data-testid="workspace-composer-mock"
 					data-fast-mode={props.fastMode ? "on" : "off"}
+					data-disabled={props.disabled ? "true" : "false"}
+					data-submit-disabled={props.submitDisabled ? "true" : "false"}
 				>
 					{props.contextKey}:{props.selectedModelId ?? "none"}
 				</div>
@@ -433,5 +437,77 @@ describe("WorkspaceComposerContainer", () => {
 			"data-fast-mode",
 			"on",
 		);
+	});
+
+	// `composerUnavailable` vs `composerAwaitingFinalize`: the composer
+	// container must ONLY dim the whole UI when the workspace is genuinely
+	// unusable (archived / no selection). During the Phase 2 initializing
+	// window the editor + toolbar stay fully live and only the send action
+	// is blocked, so users can type-ahead without a visible 60% dim.
+	const renderContainerForState = (workspaceState: string) => {
+		const queryClient = createHelmorQueryClient();
+		queryClient.setQueryData(
+			helmorQueryKeys.agentModelSections,
+			MODEL_SECTIONS,
+		);
+		queryClient.setQueryData(helmorQueryKeys.workspaceDetail("workspace-1"), {
+			...WORKSPACE_DETAIL,
+			state: workspaceState,
+		});
+		queryClient.setQueryData(
+			helmorQueryKeys.workspaceSessions("workspace-1"),
+			WORKSPACE_SESSIONS,
+		);
+
+		render(
+			<QueryClientProvider client={queryClient}>
+				<WorkspaceComposerContainer
+					displayedWorkspaceId="workspace-1"
+					displayedSessionId="session-1"
+					disabled={false}
+					sending={false}
+					sendError={null}
+					restoreDraft={null}
+					restoreImages={[]}
+					restoreFiles={[]}
+					restoreNonce={0}
+					modelSelections={{}}
+					effortLevels={{}}
+					permissionModes={{}}
+					fastModes={{}}
+					onSelectModel={vi.fn()}
+					onSelectEffort={vi.fn()}
+					onChangePermissionMode={vi.fn()}
+					onChangeFastMode={vi.fn()}
+					onSubmit={vi.fn()}
+				/>
+			</QueryClientProvider>,
+		);
+	};
+
+	it("stays fully enabled while the workspace is initializing, blocking only the send action", () => {
+		renderContainerForState("initializing");
+
+		const composer = screen.getByTestId("workspace-composer-mock");
+		// Editor + toolbar must NOT be dimmed — the user can type and pick
+		// model/effort while Phase 2 finishes.
+		expect(composer).toHaveAttribute("data-disabled", "false");
+		// Send is gated so messages can't race with finalize.
+		expect(composer).toHaveAttribute("data-submit-disabled", "true");
+	});
+
+	it("fully disables the composer for archived workspaces", () => {
+		renderContainerForState("archived");
+
+		const composer = screen.getByTestId("workspace-composer-mock");
+		expect(composer).toHaveAttribute("data-disabled", "true");
+	});
+
+	it("is fully interactive for ready workspaces", () => {
+		renderContainerForState("ready");
+
+		const composer = screen.getByTestId("workspace-composer-mock");
+		expect(composer).toHaveAttribute("data-disabled", "false");
+		expect(composer).toHaveAttribute("data-submit-disabled", "false");
 	});
 });

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -32,7 +32,6 @@ import {
 	findModelOption,
 	getComposerContextKey,
 	isNewSession,
-	isOptimisticCreatingWorkspaceId,
 	resolveSessionSelectedModelId,
 } from "@/lib/workspace-helpers";
 import type { DeferredToolResponseHandler } from "./deferred-tool";
@@ -139,15 +138,11 @@ export const WorkspaceComposerContainer = memo(
 		const modelSectionsQuery = useQuery(agentModelSectionsQueryOptions());
 		const workspaceDetailQuery = useQuery({
 			...workspaceDetailQueryOptions(displayedWorkspaceId ?? "__none__"),
-			enabled:
-				Boolean(displayedWorkspaceId) &&
-				!isOptimisticCreatingWorkspaceId(displayedWorkspaceId),
+			enabled: Boolean(displayedWorkspaceId),
 		});
 		const sessionsQuery = useQuery({
 			...workspaceSessionsQueryOptions(displayedWorkspaceId ?? "__none__"),
-			enabled:
-				Boolean(displayedWorkspaceId) &&
-				!isOptimisticCreatingWorkspaceId(displayedWorkspaceId),
+			enabled: Boolean(displayedWorkspaceId),
 		});
 
 		const modelSections = modelSectionsQuery.data ?? EMPTY_MODEL_SECTIONS;
@@ -230,11 +225,24 @@ export const WorkspaceComposerContainer = memo(
 		const loadingConversationContext =
 			Boolean(displayedWorkspaceId) &&
 			(workspaceDetailQuery.isPending || sessionsQuery.isPending);
-		const composerDisabled =
+		// Split the "disabled" concept along two axes:
+		//
+		//   * `composerUnavailable` — the composer is conceptually not
+		//     usable here (no workspace selected, or workspace archived).
+		//     Entire UI dims to opacity-60, all toolbars disabled.
+		//
+		//   * `composerAwaitingFinalize` — workspace is still in Phase 2
+		//     (`initializing`). The composer is fully live visually so the
+		//     user can compose / tweak settings while the worktree is
+		//     materializing; only the Send button is blocked (see
+		//     `submitDisabled` below) to keep sends from racing with
+		//     finalize. The typical ~200-500ms window ends long before the
+		//     user finishes typing, so there is no visible transition.
+		const composerUnavailable =
 			displayedWorkspaceId === null ||
-			isOptimisticCreatingWorkspaceId(displayedWorkspaceId) ||
-			workspaceDetailQuery.data?.state === "initializing" ||
 			workspaceDetailQuery.data?.state === "archived";
+		const composerAwaitingFinalize =
+			workspaceDetailQuery.data?.state === "initializing";
 
 		// Auto-close opt-in state comes from settings: `auto_close_action_kinds`
 		// is the persistent list of action kinds the user has enabled. A given
@@ -546,7 +554,7 @@ export const WorkspaceComposerContainer = memo(
 								aria-label={
 									autoCloseEnabled ? "Disable Auto Close" : "Enable Auto Close"
 								}
-								disabled={composerDisabled}
+								disabled={composerUnavailable}
 								onClick={() => {
 									void handleToggleAutoClose();
 								}}
@@ -567,8 +575,10 @@ export const WorkspaceComposerContainer = memo(
 					<WorkspaceComposer
 						contextKey={composerContextKey}
 						onSubmit={handleComposerSubmit}
-						disabled={composerDisabled}
-						submitDisabled={disabled || loadingConversationContext}
+						disabled={composerUnavailable}
+						submitDisabled={
+							disabled || loadingConversationContext || composerAwaitingFinalize
+						}
 						onStop={onStop}
 						sending={sending}
 						selectedModelId={effectiveSelectedModelId}

--- a/src/features/navigation/hooks/use-controller.test.tsx
+++ b/src/features/navigation/hooks/use-controller.test.tsx
@@ -26,6 +26,8 @@ const apiMocks = vi.hoisted(() => {
 	return {
 		addRepositoryFromLocalPath: vi.fn(),
 		createWorkspaceFromRepo: vi.fn(),
+		prepareWorkspaceFromRepo: vi.fn(),
+		finalizeWorkspaceFromRepo: vi.fn(),
 		listRepositories: vi.fn(),
 		loadAddRepositoryDefaults: vi.fn(),
 		loadArchivedWorkspaces: vi.fn(),
@@ -75,6 +77,8 @@ vi.mock("@/lib/api", async (importOriginal) => {
 		...actual,
 		addRepositoryFromLocalPath: apiMocks.addRepositoryFromLocalPath,
 		createWorkspaceFromRepo: apiMocks.createWorkspaceFromRepo,
+		prepareWorkspaceFromRepo: apiMocks.prepareWorkspaceFromRepo,
+		finalizeWorkspaceFromRepo: apiMocks.finalizeWorkspaceFromRepo,
 		listRepositories: apiMocks.listRepositories,
 		loadAddRepositoryDefaults: apiMocks.loadAddRepositoryDefaults,
 		loadArchivedWorkspaces: apiMocks.loadArchivedWorkspaces,
@@ -391,22 +395,17 @@ describe("useWorkspacesSidebarController archive flow", () => {
 		expect(pushWorkspaceToast).not.toHaveBeenCalled();
 	});
 
-	it("inserts an initializing placeholder while creating a workspace, then swaps to the real one", async () => {
+	it("paints the workspace with final metadata after prepare, then finalizes to ready in place", async () => {
 		const queryClient = new QueryClient({
 			defaultOptions: { queries: { retry: false } },
 		});
 		const onSelectWorkspace = vi.fn();
 		const pushWorkspaceToast = vi.fn();
-		let resolveCreate:
-			| ((value: {
-					createdWorkspaceId: string;
-					selectedWorkspaceId: string;
-					initialSessionId: string;
-					createdState: string;
-					directoryName: string;
-					branch: string;
-			  }) => void)
+		let resolveFinalize:
+			| ((value: { workspaceId: string; finalState: string }) => void)
 			| null = null;
+		const generatedWorkspaceId = crypto.randomUUID();
+		const generatedSessionId = crypto.randomUUID();
 
 		apiMocks.listRepositories.mockResolvedValue([
 			{
@@ -416,10 +415,28 @@ describe("useWorkspacesSidebarController archive flow", () => {
 				repoInitials: "HE",
 			},
 		]);
-		apiMocks.createWorkspaceFromRepo.mockImplementation(
+		apiMocks.prepareWorkspaceFromRepo.mockResolvedValue({
+			workspaceId: generatedWorkspaceId,
+			initialSessionId: generatedSessionId,
+			repoId: "repo-1",
+			repoName: "helmor",
+			directoryName: "vega",
+			branch: "feature/vega",
+			defaultBranch: "main",
+			state: "initializing" as const,
+			repoScripts: {
+				setupScript: null,
+				runScript: null,
+				archiveScript: null,
+				setupFromProject: false,
+				runFromProject: false,
+				archiveFromProject: false,
+			},
+		});
+		apiMocks.finalizeWorkspaceFromRepo.mockImplementation(
 			() =>
 				new Promise((resolve) => {
-					resolveCreate = resolve;
+					resolveFinalize = resolve;
 				}),
 		);
 
@@ -437,52 +454,57 @@ describe("useWorkspacesSidebarController archive flow", () => {
 			expect(result.current.groups[0]?.rows).toHaveLength(2);
 		});
 
-		act(() => {
+		await act(async () => {
 			void result.current.handleCreateWorkspaceFromRepo("repo-1");
 		});
 
-		const optimisticRow = result.current.groups[0]?.rows[0];
-		expect(optimisticRow?.state).toBe("initializing");
-		expect(optimisticRow?.title).toContain("Creating helmor");
-		expect(onSelectWorkspace).toHaveBeenCalledWith(
-			expect.stringMatching(/^creating-workspace:/),
+		await waitFor(() => {
+			expect(result.current.groups[0]?.rows[0]?.id).toBe(generatedWorkspaceId);
+		});
+
+		const preparedRow = result.current.groups[0]?.rows[0];
+		expect(preparedRow?.state).toBe("initializing");
+		// Title, directory, branch are all final-state immediately — prepare
+		// returned real values so there is no placeholder-to-real swap.
+		expect(preparedRow?.title).toBe("helmor workspace");
+		expect(preparedRow?.directoryName).toBe("vega");
+		expect(preparedRow?.branch).toBe("feature/vega");
+		expect(apiMocks.prepareWorkspaceFromRepo).toHaveBeenCalledWith("repo-1");
+		expect(onSelectWorkspace).toHaveBeenCalledWith(generatedWorkspaceId);
+		expect(apiMocks.finalizeWorkspaceFromRepo).toHaveBeenCalledWith(
+			generatedWorkspaceId,
 		);
 
 		await act(async () => {
-			resolveCreate?.({
-				createdWorkspaceId: "ws-created",
-				selectedWorkspaceId: "ws-created",
-				initialSessionId: "session-created",
-				createdState: "ready",
-				directoryName: "vega",
-				branch: "feature/vega",
+			resolveFinalize?.({
+				workspaceId: generatedWorkspaceId,
+				finalState: "ready",
 			});
 		});
 
+		// After Phase 2, the detail flips to state=ready in place — no new
+		// row, no id swap.
 		await waitFor(() => {
 			expect(
-				apiMocks.loadWorkspaceGroups.mock.calls.length,
-			).toBeGreaterThanOrEqual(2);
+				queryClient.getQueryData(
+					helmorQueryKeys.workspaceDetail(generatedWorkspaceId),
+				),
+			).toMatchObject({
+				id: generatedWorkspaceId,
+				state: "ready",
+			});
 		});
-		expect(onSelectWorkspace).toHaveBeenCalledWith("ws-created");
+		expect(generatedSessionId).toBeTruthy();
 		expect(pushWorkspaceToast).not.toHaveBeenCalled();
 	});
 
-	it("upgrades the optimistic row to the real workspace on success so the sidebar never goes empty", async () => {
+	it("paints the workspace detail + sessions cache from prepare response", async () => {
 		const queryClient = new QueryClient({
 			defaultOptions: { queries: { retry: false } },
 		});
 		const onSelectWorkspace = vi.fn();
-		let resolveCreate:
-			| ((value: {
-					createdWorkspaceId: string;
-					selectedWorkspaceId: string;
-					initialSessionId: string;
-					createdState: string;
-					directoryName: string;
-					branch: string;
-			  }) => void)
-			| null = null;
+		const generatedWorkspaceId = crypto.randomUUID();
+		const generatedSessionId = crypto.randomUUID();
 
 		apiMocks.listRepositories.mockResolvedValue([
 			{
@@ -492,11 +514,28 @@ describe("useWorkspacesSidebarController archive flow", () => {
 				repoInitials: "HE",
 			},
 		]);
-		apiMocks.createWorkspaceFromRepo.mockImplementation(
-			() =>
-				new Promise((resolve) => {
-					resolveCreate = resolve;
-				}),
+		apiMocks.prepareWorkspaceFromRepo.mockResolvedValue({
+			workspaceId: generatedWorkspaceId,
+			initialSessionId: generatedSessionId,
+			repoId: "repo-1",
+			repoName: "helmor",
+			directoryName: "testuser-helmor",
+			branch: "testuser/helmor",
+			defaultBranch: "main",
+			state: "initializing" as const,
+			repoScripts: {
+				setupScript: null,
+				runScript: null,
+				archiveScript: null,
+				setupFromProject: false,
+				runFromProject: false,
+				archiveFromProject: false,
+			},
+		});
+		// Keep Phase 2 suspended so we can assert the Phase 1 painted state
+		// independently.
+		apiMocks.finalizeWorkspaceFromRepo.mockImplementation(
+			() => new Promise(() => {}),
 		);
 
 		const { result } = renderHook(
@@ -516,48 +555,76 @@ describe("useWorkspacesSidebarController archive flow", () => {
 			]);
 		});
 
-		act(() => {
+		await act(async () => {
 			void result.current.handleCreateWorkspaceFromRepo("repo-1");
 		});
 
 		await waitFor(() => {
-			expect(result.current.groups[0]?.rows[0]?.id).toMatch(
-				/^creating-workspace:/,
-			);
+			expect(result.current.groups[0]?.rows[0]?.id).toBe(generatedWorkspaceId);
 		});
 
-		await act(async () => {
-			resolveCreate?.({
-				createdWorkspaceId: "ws-created",
-				selectedWorkspaceId: "ws-created",
-				initialSessionId: "session-created",
-				createdState: "initializing",
-				directoryName: "testuser-helmor",
-				branch: "testuser/helmor",
-			});
-		});
-
-		await waitFor(() => {
-			expect(result.current.groups[0]?.rows[0]?.id).toBe("ws-created");
-		});
-
+		// After Phase 1, the detail + sessions cache is already seeded with
+		// the final directory/branch — no re-render needed later for those.
+		// Branch/remote fields must match what Phase 2's refetch returns so
+		// the inspector's `workspaceTargetBranch` doesn't flip `null →
+		// "origin/main"` and flash the "Remote" BranchDiffSection header.
 		expect(
-			queryClient.getQueryData(helmorQueryKeys.workspaceDetail("ws-created")),
+			queryClient.getQueryData(
+				helmorQueryKeys.workspaceDetail(generatedWorkspaceId),
+			),
 		).toMatchObject({
-			id: "ws-created",
+			id: generatedWorkspaceId,
 			directoryName: "testuser-helmor",
 			branch: "testuser/helmor",
+			state: "initializing",
+			remote: "origin",
+			defaultBranch: "main",
+			intendedTargetBranch: "main",
+			initializationParentBranch: "main",
 		});
 		expect(
-			queryClient.getQueryData(helmorQueryKeys.workspaceSessions("ws-created")),
+			queryClient.getQueryData(
+				helmorQueryKeys.workspaceSessions(generatedWorkspaceId),
+			),
 		).toMatchObject([
 			{
-				id: "session-created",
-				workspaceId: "ws-created",
+				id: generatedSessionId,
+				workspaceId: generatedWorkspaceId,
 				active: true,
 			},
 		]);
-		expect(onSelectWorkspace).toHaveBeenCalledWith("ws-created");
+
+		// Git + PR status caches are seeded with the canonical "fresh
+		// workspace" empty state so the inspector's Actions section never
+		// falls through to EMPTY_*_STATUS (which renders the misleading
+		// "Sync status unavailable" / "Waiting for PR review" labels).
+		expect(
+			queryClient.getQueryData(
+				helmorQueryKeys.workspaceGitActionStatus(generatedWorkspaceId),
+			),
+		).toMatchObject({
+			uncommittedCount: 0,
+			conflictCount: 0,
+			syncStatus: "upToDate",
+			pushStatus: "unpublished",
+		});
+		expect(
+			queryClient.getQueryData(
+				helmorQueryKeys.workspacePr(generatedWorkspaceId),
+			),
+		).toBeNull();
+		expect(
+			queryClient.getQueryData(
+				helmorQueryKeys.workspacePrActionStatus(generatedWorkspaceId),
+			),
+		).toMatchObject({
+			pr: null,
+			remoteState: "noPr",
+			deployments: [],
+			checks: [],
+		});
+
+		expect(onSelectWorkspace).toHaveBeenCalledWith(generatedWorkspaceId);
 	});
 
 	it("does not optimistically reorder sidebar groups when setting manual status", async () => {
@@ -602,27 +669,20 @@ describe("useWorkspacesSidebarController archive flow", () => {
 		).toEqual([]);
 	});
 
-	// Retry: even with the mock + timeout fixes this test exercises the most
-	// timing-sensitive microtask ordering in the suite (mutation resolve →
-	// setQueryData injection → fire-and-forget refetchNavigation vs
-	// reconciliation effect). Allow two local retries so a single CI hiccup
-	// does not fail the whole Rust/Frontend matrix and force a full re-run.
-	it("does not show the optimistic upgrade alongside the cached real workspace on success", {
+	// The pending creation row and the navigation refetch share the same
+	// workspace id. Once the canonical row lands in base groups, reconciliation
+	// drops the pending entry — exactly one row remains.
+	it("does not duplicate the row when the canonical workspace groups refetch", {
 		retry: 2,
 	}, async () => {
 		const queryClient = new QueryClient({
 			defaultOptions: { queries: { retry: false } },
 		});
-		let resolveCreate:
-			| ((value: {
-					createdWorkspaceId: string;
-					selectedWorkspaceId: string;
-					initialSessionId: string;
-					createdState: string;
-					directoryName: string;
-					branch: string;
-			  }) => void)
+		let resolveFinalize:
+			| ((value: { workspaceId: string; finalState: string }) => void)
 			| null = null;
+		const generatedWorkspaceId = crypto.randomUUID();
+		const generatedSessionId = crypto.randomUUID();
 
 		apiMocks.listRepositories.mockResolvedValue([
 			{
@@ -632,10 +692,28 @@ describe("useWorkspacesSidebarController archive flow", () => {
 				repoInitials: "HE",
 			},
 		]);
-		apiMocks.createWorkspaceFromRepo.mockImplementation(
+		apiMocks.prepareWorkspaceFromRepo.mockResolvedValue({
+			workspaceId: generatedWorkspaceId,
+			initialSessionId: generatedSessionId,
+			repoId: "repo-1",
+			repoName: "helmor",
+			directoryName: "testuser-helmor",
+			branch: "testuser/helmor",
+			defaultBranch: "main",
+			state: "initializing" as const,
+			repoScripts: {
+				setupScript: null,
+				runScript: null,
+				archiveScript: null,
+				setupFromProject: false,
+				runFromProject: false,
+				archiveFromProject: false,
+			},
+		});
+		apiMocks.finalizeWorkspaceFromRepo.mockImplementation(
 			() =>
 				new Promise((resolve) => {
-					resolveCreate = resolve;
+					resolveFinalize = resolve;
 				}),
 		);
 
@@ -656,14 +734,12 @@ describe("useWorkspacesSidebarController archive flow", () => {
 			]);
 		});
 
-		act(() => {
+		await act(async () => {
 			void result.current.handleCreateWorkspaceFromRepo("repo-1");
 		});
 
 		await waitFor(() => {
-			expect(result.current.groups[0]?.rows[0]?.id).toMatch(
-				/^creating-workspace:/,
-			);
+			expect(result.current.groups[0]?.rows[0]?.id).toBe(generatedWorkspaceId);
 		});
 
 		const upgradedGroups = [
@@ -672,8 +748,8 @@ describe("useWorkspacesSidebarController archive flow", () => {
 				rows: [
 					{
 						...workspaceGroups[0].rows[0],
-						id: "ws-created",
-						title: "Workspace created",
+						id: generatedWorkspaceId,
+						title: "helmor workspace",
 						state: "initializing" as const,
 						branch: "testuser/helmor",
 					},
@@ -681,11 +757,6 @@ describe("useWorkspacesSidebarController archive flow", () => {
 				],
 			},
 		];
-
-		// Keep `loadWorkspaceGroups` aligned with the injected cache so the
-		// post-success `refetchNavigation()` inside the hook does not race with
-		// reconciliation and replace the cache with a stale ws-1/ws-2 snapshot
-		// that lacks ws-created (which was flaky under slow CI timing).
 		apiMocks.loadWorkspaceGroups.mockResolvedValue(upgradedGroups);
 
 		act(() => {
@@ -693,21 +764,154 @@ describe("useWorkspacesSidebarController archive flow", () => {
 		});
 
 		await act(async () => {
-			resolveCreate?.({
-				createdWorkspaceId: "ws-created",
-				selectedWorkspaceId: "ws-created",
-				initialSessionId: "session-created",
-				createdState: "initializing",
-				directoryName: "testuser-helmor",
-				branch: "testuser/helmor",
+			resolveFinalize?.({
+				workspaceId: generatedWorkspaceId,
+				finalState: "ready",
 			});
 		});
 
 		await waitFor(() => {
 			expect(
-				result.current.groups[0]?.rows.filter((row) => row.id === "ws-created"),
+				result.current.groups[0]?.rows.filter(
+					(row) => row.id === generatedWorkspaceId,
+				),
 			).toHaveLength(1);
 		});
+	});
+
+	// When Phase 2 rejects, Rust has already cleaned up the DB row +
+	// worktree. The frontend must tear down its mirror: drop the pending
+	// row, remove all seeded caches (detail/sessions/messages/scripts),
+	// surface an error toast, and (if the user is still parked on the
+	// failing workspace) switch selection back to the previously-selected
+	// workspace via the `selectedWorkspaceIdRef` path.
+	it("tears down the mirror and restores previous selection when finalize rejects", async () => {
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false } },
+		});
+		const onSelectWorkspace = vi.fn();
+		const pushWorkspaceToast = vi.fn();
+		const generatedWorkspaceId = crypto.randomUUID();
+		const generatedSessionId = crypto.randomUUID();
+
+		apiMocks.listRepositories.mockResolvedValue([
+			{
+				id: "repo-1",
+				name: "helmor",
+				defaultBranch: "main",
+				repoInitials: "HE",
+			},
+		]);
+		apiMocks.prepareWorkspaceFromRepo.mockResolvedValue({
+			workspaceId: generatedWorkspaceId,
+			initialSessionId: generatedSessionId,
+			repoId: "repo-1",
+			repoName: "helmor",
+			directoryName: "testuser-helmor",
+			branch: "testuser/helmor",
+			defaultBranch: "main",
+			state: "initializing" as const,
+			repoScripts: {
+				setupScript: null,
+				runScript: null,
+				archiveScript: null,
+				setupFromProject: false,
+				runFromProject: false,
+				archiveFromProject: false,
+			},
+		});
+		apiMocks.finalizeWorkspaceFromRepo.mockRejectedValue(
+			new Error("worktree create failed"),
+		);
+
+		let currentSelection: string | null = "ws-1";
+		onSelectWorkspace.mockImplementation((id: string | null) => {
+			currentSelection = id;
+		});
+
+		const { result, rerender } = renderHook(
+			({ selectedWorkspaceId }: { selectedWorkspaceId: string | null }) =>
+				useWorkspacesSidebarController({
+					selectedWorkspaceId,
+					onSelectWorkspace,
+					pushWorkspaceToast,
+				}),
+			{
+				initialProps: { selectedWorkspaceId: currentSelection },
+				wrapper: createWrapper(queryClient),
+			},
+		);
+
+		await waitFor(() => {
+			expect(result.current.groups[0]?.rows.map((row) => row.id)).toEqual([
+				"ws-1",
+				"ws-2",
+			]);
+		});
+
+		await act(async () => {
+			void result.current.handleCreateWorkspaceFromRepo("repo-1");
+		});
+
+		// Phase 1 painted the pending row + selected the new workspace.
+		await waitFor(() => {
+			expect(onSelectWorkspace).toHaveBeenCalledWith(generatedWorkspaceId);
+		});
+		rerender({ selectedWorkspaceId: currentSelection });
+
+		// Wait for the rejection to propagate through `.catch().finally()`.
+		await waitFor(() => {
+			expect(pushWorkspaceToast).toHaveBeenCalled();
+		});
+
+		// Pending entry + every seeded cache key is removed.
+		expect(
+			queryClient.getQueryData(
+				helmorQueryKeys.workspaceDetail(generatedWorkspaceId),
+			),
+		).toBeUndefined();
+		expect(
+			queryClient.getQueryData(
+				helmorQueryKeys.workspaceSessions(generatedWorkspaceId),
+			),
+		).toBeUndefined();
+		expect(
+			queryClient.getQueryData([
+				...helmorQueryKeys.sessionMessages(generatedSessionId),
+				"thread",
+			]),
+		).toBeUndefined();
+		expect(
+			queryClient.getQueryData(
+				helmorQueryKeys.repoScripts("repo-1", generatedWorkspaceId),
+			),
+		).toBeUndefined();
+		expect(
+			queryClient.getQueryData(
+				helmorQueryKeys.workspaceGitActionStatus(generatedWorkspaceId),
+			),
+		).toBeUndefined();
+		expect(
+			queryClient.getQueryData(
+				helmorQueryKeys.workspacePr(generatedWorkspaceId),
+			),
+		).toBeUndefined();
+		expect(
+			queryClient.getQueryData(
+				helmorQueryKeys.workspacePrActionStatus(generatedWorkspaceId),
+			),
+		).toBeUndefined();
+		expect(
+			result.current.groups[0]?.rows.find(
+				(row) => row.id === generatedWorkspaceId,
+			),
+		).toBeUndefined();
+
+		// Selection: the user was parked on the failing workspace, so the
+		// catch branch switches them back to the previous selection.
+		const lastSelectCall =
+			onSelectWorkspace.mock.calls[onSelectWorkspace.mock.calls.length - 1];
+		expect(lastSelectCall?.[0]).toBe("ws-1");
 	});
 
 	it("rolls back the optimistic update when the background start fails immediately", async () => {

--- a/src/features/navigation/hooks/use-controller.ts
+++ b/src/features/navigation/hooks/use-controller.ts
@@ -3,8 +3,8 @@ import { open } from "@tauri-apps/plugin-dialog";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
 	addRepositoryFromLocalPath,
-	createWorkspaceFromRepo,
 	type DerivedStatus,
+	finalizeWorkspaceFromRepo,
 	listenArchiveExecutionFailed,
 	listenArchiveExecutionSucceeded,
 	loadAddRepositoryDefaults,
@@ -13,6 +13,7 @@ import {
 	permanentlyDeleteWorkspace,
 	pinWorkspace,
 	prepareArchiveWorkspace,
+	prepareWorkspaceFromRepo,
 	type RepositoryCreateOption,
 	restoreWorkspace,
 	setWorkspaceManualStatus,
@@ -20,7 +21,6 @@ import {
 	unpinWorkspace,
 	validateRestoreWorkspace,
 	type WorkspaceDetail,
-	type WorkspaceGroup,
 	type WorkspaceRow,
 	type WorkspaceSessionSummary,
 	type WorkspaceState,
@@ -40,7 +40,6 @@ import {
 	clearWorkspaceUnreadFromGroups,
 	clearWorkspaceUnreadFromSummaries,
 	createOptimisticCreatingWorkspaceDetail,
-	createOptimisticCreatingWorkspaceId,
 	describeUnknownError,
 	findInitialWorkspaceId,
 	findReplacementWorkspaceIdAfterRemoval,
@@ -106,12 +105,19 @@ export function useWorkspacesSidebarController({
 			string,
 			{
 				entry: PendingCreationEntry;
-				previousGroups: WorkspaceGroup[] | undefined;
+				// Workspace id selected before the creation started — used
+				// by the Phase 2 failure path to restore selection when the
+				// user is still sitting on the failing workspace.
 				previousSelection: string | null;
 			}
 		>
 	>(() => new Map());
 	const sidebarMutationCountRef = useRef(0);
+	// Live mirror of `selectedWorkspaceId` so async callbacks (Phase 2
+	// finalize catch, archive/restore handlers, etc.) can read the
+	// current selection rather than a stale closure snapshot.
+	const selectedWorkspaceIdRef = useRef(selectedWorkspaceId);
+	selectedWorkspaceIdRef.current = selectedWorkspaceId;
 
 	const flushSidebarLists = useCallback(() => {
 		void queryClient.invalidateQueries({
@@ -853,150 +859,266 @@ export function useWorkspacesSidebarController({
 				return;
 			}
 
-			const optimisticWorkspaceId = createOptimisticCreatingWorkspaceId(repoId);
-			const optimisticSessionId = `${optimisticWorkspaceId}:initial-session`;
-			const optimisticRow = createOptimisticWorkspaceRow(
-				repository,
-				optimisticWorkspaceId,
-			);
-			const optimisticSession = createOptimisticWorkspaceSession(
-				optimisticWorkspaceId,
-				optimisticSessionId,
-				new Date().toISOString(),
-			);
-			const previousGroups = queryClient.getQueryData<WorkspaceGroup[]>(
-				helmorQueryKeys.workspaceGroups,
-			);
-			setPendingCreations((current) => {
-				const next = new Map(current);
-				next.set(optimisticWorkspaceId, {
-					entry: {
-						repoId,
-						row: optimisticRow,
-						stage: "creating",
-						resolvedWorkspaceId: null,
-					},
-					previousGroups,
-					previousSelection: selectedWorkspaceId,
-				});
-				return next;
-			});
-
-			queryClient.setQueryData<WorkspaceDetail | null>(
-				helmorQueryKeys.workspaceDetail(optimisticWorkspaceId),
-				createOptimisticCreatingWorkspaceDetail(
-					optimisticRow,
-					repoId,
-					optimisticSessionId,
-				),
-			);
-			queryClient.setQueryData<WorkspaceSessionSummary[]>(
-				helmorQueryKeys.workspaceSessions(optimisticWorkspaceId),
-				[optimisticSession],
-			);
-
+			const previousSelection = selectedWorkspaceId;
 			setCreatingWorkspaceRepoId(repoId);
-			onSelectWorkspace(optimisticWorkspaceId);
 
+			let prepareResponse: Awaited<ReturnType<typeof prepareWorkspaceFromRepo>>;
 			try {
-				const response = await createWorkspaceFromRepo(repoId);
-				const resolvedOptimisticRow = createResolvedWorkspaceRow(
-					optimisticRow,
-					response,
-				);
-				setPendingCreations((current) => {
-					const pendingCreation = current.get(optimisticWorkspaceId);
-					if (!pendingCreation) {
-						return current;
-					}
-					const next = new Map(current);
-					next.set(optimisticWorkspaceId, {
-						...pendingCreation,
-						entry: {
-							...pendingCreation.entry,
-							row: resolvedOptimisticRow,
-							stage: "confirmed",
-							resolvedWorkspaceId: response.selectedWorkspaceId,
-						},
-					});
-					return next;
-				});
-				queryClient.setQueryData<WorkspaceDetail | null>(
-					helmorQueryKeys.workspaceDetail(response.selectedWorkspaceId),
-					(current) =>
-						current ??
-						createOptimisticResolvedWorkspaceDetail(
-							resolvedOptimisticRow,
-							repoId,
-							response.initialSessionId,
-						),
-				);
-				queryClient.setQueryData<WorkspaceSessionSummary[]>(
-					helmorQueryKeys.workspaceSessions(response.selectedWorkspaceId),
-					(current) =>
-						current ?? [
-							createOptimisticWorkspaceSession(
-								response.selectedWorkspaceId,
-								response.initialSessionId,
-								optimisticSession.createdAt,
-							),
-						],
-				);
-				queryClient.removeQueries({
-					queryKey: helmorQueryKeys.workspaceDetail(optimisticWorkspaceId),
-					exact: true,
-				});
-				queryClient.removeQueries({
-					queryKey: helmorQueryKeys.workspaceSessions(optimisticWorkspaceId),
-					exact: true,
-				});
-				onSelectWorkspace(response.selectedWorkspaceId);
-				prefetchWorkspace(response.selectedWorkspaceId);
-				void refetchNavigation();
+				// Phase 1 — fast backend prep (<20ms). Blocks until we have
+				// the real workspace/session ids, directory name, branch,
+				// and repo scripts. Nothing is painted yet; the sidebar +
+				// panel are still showing the previously selected workspace.
+				prepareResponse = await prepareWorkspaceFromRepo(repoId);
 			} catch (error) {
-				const rollbackHolder = {
-					value: null as {
-						entry: PendingCreationEntry;
-						previousGroups: WorkspaceGroup[] | undefined;
-						previousSelection: string | null;
-					} | null,
-				};
-				setPendingCreations((current) => {
-					const pendingCreation = current.get(optimisticWorkspaceId) ?? null;
-					if (!pendingCreation) {
-						return current;
-					}
-					rollbackHolder.value = pendingCreation;
-					const next = new Map(current);
-					next.delete(optimisticWorkspaceId);
-					return next;
-				});
-				const rollback = rollbackHolder.value;
-				if (rollback?.previousGroups) {
-					queryClient.setQueryData(
-						helmorQueryKeys.workspaceGroups,
-						rollback.previousGroups,
-					);
-				}
-				queryClient.removeQueries({
-					queryKey: helmorQueryKeys.workspaceDetail(optimisticWorkspaceId),
-					exact: true,
-				});
-				queryClient.removeQueries({
-					queryKey: helmorQueryKeys.workspaceSessions(optimisticWorkspaceId),
-					exact: true,
-				});
-				if (selectedWorkspaceId === optimisticWorkspaceId) {
-					onSelectWorkspace(
-						rollback?.previousSelection ?? findInitialWorkspaceId(groups),
-					);
-				}
+				setCreatingWorkspaceRepoId(null);
 				pushWorkspaceToast(
 					describeUnknownError(error, "Unable to create workspace."),
 				);
-			} finally {
-				setCreatingWorkspaceRepoId(null);
+				return;
 			}
+
+			// Phase 1 succeeded. Paint immediately using the real metadata —
+			// no optimistic title, no optimistic scripts, no placeholder.
+			const createdAt = new Date().toISOString();
+			const preparedRow = createPreparedWorkspaceRow(
+				repository,
+				prepareResponse,
+			);
+			const preparedSession = createOptimisticWorkspaceSession(
+				prepareResponse.workspaceId,
+				prepareResponse.initialSessionId,
+				createdAt,
+			);
+			setPendingCreations((current) => {
+				const next = new Map(current);
+				next.set(prepareResponse.workspaceId, {
+					entry: {
+						repoId,
+						row: preparedRow,
+						stage: "creating",
+						resolvedWorkspaceId: prepareResponse.workspaceId,
+					},
+					previousSelection,
+				});
+				return next;
+			});
+			queryClient.setQueryData<WorkspaceDetail | null>(
+				helmorQueryKeys.workspaceDetail(prepareResponse.workspaceId),
+				{
+					...createOptimisticCreatingWorkspaceDetail(
+						preparedRow,
+						repoId,
+						prepareResponse.initialSessionId,
+					),
+					// Populate branch/remote fields from Phase 1's real
+					// values — the helper defaults these to null, but the
+					// inspector computes `workspaceTargetBranch` from them
+					// (`${remote}/${intendedTargetBranch || defaultBranch}`)
+					// and the ChangesSection flips `branchSwitching=true`
+					// whenever `workspaceTargetBranch` changes within the
+					// same workspace. Leaving these null during Phase 1
+					// means the value flips `null → "origin/main"` when the
+					// real detail lands, briefly flashing the "Remote"
+					// BranchDiffSection header. Fresh workspace points at
+					// `defaultBranch` for both initialization parent and
+					// intended target, matching what Phase 2 writes.
+					remote: repository.remote ?? "origin",
+					defaultBranch: prepareResponse.defaultBranch,
+					initializationParentBranch: prepareResponse.defaultBranch,
+					intendedTargetBranch: prepareResponse.defaultBranch,
+				},
+			);
+			queryClient.setQueryData<WorkspaceSessionSummary[]>(
+				helmorQueryKeys.workspaceSessions(prepareResponse.workspaceId),
+				[preparedSession],
+			);
+			// Empty thread array — the panel renders the final "nothing here
+			// yet" state from the first frame instead of falling through to
+			// the cold placeholder.
+			queryClient.setQueryData(
+				[
+					...helmorQueryKeys.sessionMessages(prepareResponse.initialSessionId),
+					"thread",
+				],
+				[],
+			);
+			// Real repo scripts delivered by Phase 1 — the EmptyState shows
+			// the correct "missing script" button count immediately.
+			queryClient.setQueryData(
+				helmorQueryKeys.repoScripts(repoId, prepareResponse.workspaceId),
+				prepareResponse.repoScripts,
+			);
+			// Seed git + PR statuses so the inspector's Actions section
+			// paints its final "fresh workspace" empty rows from the first
+			// frame — otherwise the query is in-flight, `data` is undefined
+			// and the UI falls back to `EMPTY_*_STATUS` which shows the
+			// misleading "Sync status unavailable" / "Waiting for PR review"
+			// placeholders until the short-circuited backend responds a few
+			// ms later. Values mirror the Rust short-circuits in
+			// `get_workspace_git_action_status` and
+			// `lookup_workspace_pr_action_status` — keep them in sync.
+			queryClient.setQueryData(
+				helmorQueryKeys.workspaceGitActionStatus(prepareResponse.workspaceId),
+				{
+					uncommittedCount: 0,
+					conflictCount: 0,
+					syncTargetBranch: prepareResponse.defaultBranch,
+					syncStatus: "upToDate",
+					behindTargetCount: 0,
+					remoteTrackingRef: null,
+					aheadOfRemoteCount: 0,
+					pushStatus: "unpublished",
+				},
+			);
+			queryClient.setQueryData(
+				helmorQueryKeys.workspacePr(prepareResponse.workspaceId),
+				null,
+			);
+			queryClient.setQueryData(
+				helmorQueryKeys.workspacePrActionStatus(prepareResponse.workspaceId),
+				{
+					pr: null,
+					reviewDecision: null,
+					mergeable: null,
+					deployments: [],
+					checks: [],
+					remoteState: "noPr",
+					message: null,
+				},
+			);
+			onSelectWorkspace(prepareResponse.workspaceId);
+
+			// Phase 2 — slow git worktree creation (~200ms-2s). Runs in the
+			// background so the UI is already interactive. State flips from
+			// "initializing" → "ready"/"setup_pending" when it completes;
+			// the only visible change is the composer enabling.
+			finalizeWorkspaceFromRepo(prepareResponse.workspaceId)
+				.then((finalized) => {
+					queryClient.setQueryData<WorkspaceDetail | null>(
+						helmorQueryKeys.workspaceDetail(prepareResponse.workspaceId),
+						(current) =>
+							current ? { ...current, state: finalized.finalState } : current,
+					);
+					setPendingCreations((current) => {
+						const pending = current.get(prepareResponse.workspaceId);
+						if (!pending) {
+							return current;
+						}
+						const next = new Map(current);
+						next.set(prepareResponse.workspaceId, {
+							...pending,
+							entry: {
+								...pending.entry,
+								row: { ...pending.entry.row, state: finalized.finalState },
+								stage: "confirmed",
+							},
+						});
+						return next;
+					});
+					void queryClient.invalidateQueries({
+						queryKey: helmorQueryKeys.workspaceDetail(
+							prepareResponse.workspaceId,
+						),
+					});
+					// Phase 1 probed helmor.json at the source repo root, which
+					// matches the worktree for a fresh clone. If the user had
+					// uncommitted local edits to helmor.json the two can
+					// diverge — invalidate so the canonical worktree-side
+					// probe runs once the dir exists.
+					void queryClient.invalidateQueries({
+						queryKey: helmorQueryKeys.repoScripts(
+							repoId,
+							prepareResponse.workspaceId,
+						),
+					});
+					// Same story for git status — we seeded 0/0/UpToDate
+					// during Phase 1, but once the worktree is on disk the
+					// canonical git query returns the real tree state (still
+					// 0/0 in practice for a fresh clone, but invalidate so
+					// any divergence — e.g. a setup script that edited
+					// files — shows up promptly).
+					void queryClient.invalidateQueries({
+						queryKey: helmorQueryKeys.workspaceGitActionStatus(
+							prepareResponse.workspaceId,
+						),
+					});
+					prefetchWorkspace(prepareResponse.workspaceId);
+					void refetchNavigation();
+				})
+				.catch((error) => {
+					// Rust already cleaned up the DB row + worktree. Tear
+					// down the frontend mirror so the sidebar doesn't show
+					// a ghost "initializing" workspace.
+					setPendingCreations((current) => {
+						if (!current.has(prepareResponse.workspaceId)) {
+							return current;
+						}
+						const next = new Map(current);
+						next.delete(prepareResponse.workspaceId);
+						return next;
+					});
+					queryClient.removeQueries({
+						queryKey: helmorQueryKeys.workspaceDetail(
+							prepareResponse.workspaceId,
+						),
+						exact: true,
+					});
+					queryClient.removeQueries({
+						queryKey: helmorQueryKeys.workspaceSessions(
+							prepareResponse.workspaceId,
+						),
+						exact: true,
+					});
+					queryClient.removeQueries({
+						queryKey: [
+							...helmorQueryKeys.sessionMessages(
+								prepareResponse.initialSessionId,
+							),
+							"thread",
+						],
+						exact: true,
+					});
+					queryClient.removeQueries({
+						queryKey: helmorQueryKeys.repoScripts(
+							repoId,
+							prepareResponse.workspaceId,
+						),
+						exact: true,
+					});
+					queryClient.removeQueries({
+						queryKey: helmorQueryKeys.workspaceGitActionStatus(
+							prepareResponse.workspaceId,
+						),
+						exact: true,
+					});
+					queryClient.removeQueries({
+						queryKey: helmorQueryKeys.workspacePr(prepareResponse.workspaceId),
+						exact: true,
+					});
+					queryClient.removeQueries({
+						queryKey: helmorQueryKeys.workspacePrActionStatus(
+							prepareResponse.workspaceId,
+						),
+						exact: true,
+					});
+					// Read current selection via ref — the closure's
+					// `selectedWorkspaceId` is the value from when the user
+					// clicked create, which is before `onSelectWorkspace`
+					// landed the new id, so comparing against the captured
+					// value would always miss.
+					if (selectedWorkspaceIdRef.current === prepareResponse.workspaceId) {
+						onSelectWorkspace(
+							previousSelection ?? findInitialWorkspaceId(groups),
+						);
+					}
+					pushWorkspaceToast(
+						describeUnknownError(error, "Unable to create workspace."),
+					);
+					void refetchNavigation();
+				})
+				.finally(() => {
+					setCreatingWorkspaceRepoId(null);
+				});
 		},
 		[
 			creatingWorkspaceRepoId,
@@ -1503,32 +1625,40 @@ export function useWorkspacesSidebarController({
 	};
 }
 
-function createOptimisticWorkspaceRow(
+function createPreparedWorkspaceRow(
 	repository: RepositoryCreateOption,
-	workspaceId: string,
+	prepared: {
+		workspaceId: string;
+		initialSessionId: string;
+		directoryName: string;
+		branch: string;
+		state: WorkspaceState;
+	},
 ): WorkspaceRow {
 	return {
-		id: workspaceId,
-		title: `Creating ${repository.name}`,
-		directoryName: workspaceId,
+		id: prepared.workspaceId,
+		// Prepare returns the final directory and branch, so the row is
+		// already in its terminal shape — no placeholder → real swap.
+		title: `${repository.name} workspace`,
+		directoryName: prepared.directoryName,
 		repoName: repository.name,
 		repoIconSrc: repository.repoIconSrc ?? null,
 		repoInitials: repository.repoInitials ?? null,
-		state: "initializing",
+		state: prepared.state,
 		hasUnread: false,
 		workspaceUnread: 0,
 		sessionUnreadTotal: 0,
 		unreadSessionCount: 0,
 		derivedStatus: "in-progress",
 		manualStatus: null,
-		branch: null,
-		activeSessionId: null,
-		activeSessionTitle: null,
+		branch: prepared.branch,
+		activeSessionId: prepared.initialSessionId,
+		activeSessionTitle: "Untitled",
 		activeSessionAgentType: null,
-		activeSessionStatus: null,
+		activeSessionStatus: "idle",
 		prTitle: null,
 		pinnedAt: null,
-		sessionCount: 0,
+		sessionCount: 1,
 		messageCount: 0,
 		attachmentCount: 0,
 	};
@@ -1563,39 +1693,5 @@ function createOptimisticWorkspaceSession(
 		isCompacting: false,
 		actionKind: null,
 		active: true,
-	};
-}
-
-function createResolvedWorkspaceRow(
-	row: WorkspaceRow,
-	response: {
-		selectedWorkspaceId: string;
-		createdState: WorkspaceState;
-		directoryName: string;
-		branch: string;
-	},
-): WorkspaceRow {
-	return {
-		...row,
-		id: response.selectedWorkspaceId,
-		title: row.repoName ? `${row.repoName} workspace` : row.title,
-		directoryName: response.directoryName,
-		state: response.createdState,
-		branch: response.branch,
-	};
-}
-
-function createOptimisticResolvedWorkspaceDetail(
-	row: WorkspaceRow,
-	repoId: string,
-	initialSessionId: string,
-): WorkspaceDetail {
-	return {
-		...createOptimisticCreatingWorkspaceDetail(row, repoId, initialSessionId),
-		id: row.id,
-		title: row.title,
-		directoryName: row.directoryName ?? row.id,
-		state: row.state ?? "initializing",
-		branch: row.branch ?? null,
 	};
 }

--- a/src/features/panel/container.test.tsx
+++ b/src/features/panel/container.test.tsx
@@ -3,7 +3,6 @@ import { useEffect } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createHelmorQueryClient, helmorQueryKeys } from "@/lib/query-client";
 import { DEFAULT_SETTINGS, SettingsContext } from "@/lib/settings";
-import { createOptimisticCreatingWorkspaceId } from "@/lib/workspace-helpers";
 import { renderWithProviders } from "@/test/render-with-providers";
 
 const apiMocks = vi.hoisted(() => ({
@@ -1009,29 +1008,35 @@ describe("WorkspacePanelContainer loading semantics", () => {
 		expect(apiMocks.createSession).not.toHaveBeenCalled();
 	});
 
-	it("does not request thread messages for an optimistic workspace session", async () => {
+	it("renders a pre-seeded initializing workspace without re-fetching thread messages", async () => {
+		// When use-controller's prepare/paint/finalize flow seeds the detail
+		// + sessions + empty thread cache, the panel paints from cache alone.
+		// The thread messages query's SESSION_STALE_TIME keeps the seeded
+		// empty array fresh, so no backend fetch fires while Phase 2 is
+		// still materializing the worktree.
 		const queryClient = createHelmorQueryClient();
-		const optimisticWorkspaceId = createOptimisticCreatingWorkspaceId("repo-1");
-		const optimisticSessionId = `${optimisticWorkspaceId}:initial-session`;
+		const workspaceId = crypto.randomUUID();
+		const sessionId = crypto.randomUUID();
 
+		queryClient.setQueryData(helmorQueryKeys.workspaceDetail(workspaceId), {
+			...createWorkspaceDetail(workspaceId, sessionId),
+			state: "initializing",
+		});
+		queryClient.setQueryData(helmorQueryKeys.workspaceSessions(workspaceId), [
+			createWorkspaceSessionSummary(sessionId, {
+				workspaceId,
+				active: true,
+			}),
+		]);
 		queryClient.setQueryData(
-			helmorQueryKeys.workspaceDetail(optimisticWorkspaceId),
-			createWorkspaceDetail(optimisticWorkspaceId, optimisticSessionId),
-		);
-		queryClient.setQueryData(
-			helmorQueryKeys.workspaceSessions(optimisticWorkspaceId),
-			[
-				createWorkspaceSessionSummary(optimisticSessionId, {
-					workspaceId: optimisticWorkspaceId,
-					active: true,
-				}),
-			],
+			[...helmorQueryKeys.sessionMessages(sessionId), "thread"],
+			[],
 		);
 
 		renderWithProviders(
 			<WorkspacePanelContainer
-				selectedWorkspaceId={optimisticWorkspaceId}
-				displayedWorkspaceId={optimisticWorkspaceId}
+				selectedWorkspaceId={workspaceId}
+				displayedWorkspaceId={workspaceId}
 				selectedSessionId={null}
 				displayedSessionId={null}
 				sending={false}
@@ -1042,17 +1047,11 @@ describe("WorkspacePanelContainer loading semantics", () => {
 		);
 
 		await waitFor(() => {
-			expect(getLatestPanelProps().sessions).toMatchObject([
-				{ id: optimisticSessionId },
-			]);
+			expect(getLatestPanelProps().sessions).toMatchObject([{ id: sessionId }]);
 		});
 
 		expect(apiMocks.loadSessionThreadMessages).not.toHaveBeenCalledWith(
-			optimisticSessionId,
-		);
-		expect(apiMocks.loadRepoScripts).not.toHaveBeenCalledWith(
-			expect.any(String),
-			optimisticWorkspaceId,
+			sessionId,
 		);
 	});
 

--- a/src/features/panel/container.tsx
+++ b/src/features/panel/container.tsx
@@ -17,10 +17,7 @@ import {
 	workspaceSessionsQueryOptions,
 } from "@/lib/query-client";
 import { useSettings } from "@/lib/settings";
-import {
-	isOptimisticCreatingWorkspaceId,
-	resolveSessionDisplayProvider,
-} from "@/lib/workspace-helpers";
+import { resolveSessionDisplayProvider } from "@/lib/workspace-helpers";
 import {
 	WORKSPACE_SCRIPT_PROMPTS,
 	type WorkspaceScriptType,
@@ -73,16 +70,14 @@ export const WorkspacePanelContainer = memo(function WorkspacePanelContainer({
 }: WorkspacePanelContainerProps) {
 	const queryClient = useQueryClient();
 	const { settings } = useSettings();
-	const isOptimisticWorkspace =
-		isOptimisticCreatingWorkspaceId(displayedWorkspaceId);
 
 	const detailQuery = useQuery({
 		...workspaceDetailQueryOptions(displayedWorkspaceId ?? "__none__"),
-		enabled: Boolean(displayedWorkspaceId) && !isOptimisticWorkspace,
+		enabled: Boolean(displayedWorkspaceId),
 	});
 	const sessionsQuery = useQuery({
 		...workspaceSessionsQueryOptions(displayedWorkspaceId ?? "__none__"),
-		enabled: Boolean(displayedWorkspaceId) && !isOptimisticWorkspace,
+		enabled: Boolean(displayedWorkspaceId),
 	});
 
 	const workspace = detailQuery.data ?? null;
@@ -277,18 +272,18 @@ export const WorkspacePanelContainer = memo(function WorkspacePanelContainer({
 	}, [displayedSessionId, onResolveDisplayedSession, threadSessionId]);
 
 	useEffect(() => {
-		if (!threadSessionId || isOptimisticWorkspace) {
+		if (!threadSessionId) {
 			return;
 		}
 
 		void queryClient.prefetchQuery(
 			sessionThreadMessagesQueryOptions(threadSessionId),
 		);
-	}, [isOptimisticWorkspace, queryClient, threadSessionId]);
+	}, [queryClient, threadSessionId]);
 
 	const messagesQuery = useQuery({
 		...sessionThreadMessagesQueryOptions(threadSessionId ?? "__none__"),
-		enabled: Boolean(threadSessionId) && !isOptimisticWorkspace,
+		enabled: Boolean(threadSessionId),
 	});
 	const repoScriptsQuery = useQuery({
 		queryKey: helmorQueryKeys.repoScripts(
@@ -296,9 +291,7 @@ export const WorkspacePanelContainer = memo(function WorkspacePanelContainer({
 			displayedWorkspaceId,
 		),
 		queryFn: () => loadRepoScripts(workspace!.repoId, displayedWorkspaceId),
-		enabled:
-			Boolean(workspace?.repoId && displayedWorkspaceId) &&
-			!isOptimisticWorkspace,
+		enabled: Boolean(workspace?.repoId && displayedWorkspaceId),
 		staleTime: 0,
 	});
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -343,6 +343,23 @@ export type CreateWorkspaceResponse = {
 	branch: string;
 };
 
+export type PrepareWorkspaceResponse = {
+	workspaceId: string;
+	initialSessionId: string;
+	repoId: string;
+	repoName: string;
+	directoryName: string;
+	branch: string;
+	defaultBranch: string;
+	state: WorkspaceState;
+	repoScripts: RepoScripts;
+};
+
+export type FinalizeWorkspaceResponse = {
+	workspaceId: string;
+	finalState: WorkspaceState;
+};
+
 export type MarkWorkspaceReadResponse = undefined;
 
 export type SessionAttachmentRecord = {
@@ -1357,6 +1374,35 @@ export async function createWorkspaceFromRepo(
 	});
 }
 
+/**
+ * Phase 1 of workspace creation. Fast (<20ms): validates the repo,
+ * allocates a unique directory, computes the branch name, generates the
+ * workspace + session UUIDs, inserts the `initializing` DB row + initial
+ * session, and returns all metadata plus repo-level scripts. The
+ * frontend paints with this response immediately — no placeholders.
+ */
+export async function prepareWorkspaceFromRepo(
+	repoId: string,
+): Promise<PrepareWorkspaceResponse> {
+	return invoke<PrepareWorkspaceResponse>("prepare_workspace_from_repo", {
+		repoId,
+	});
+}
+
+/**
+ * Phase 2 of workspace creation. Slow (~200ms-2s): creates the git
+ * worktree, scaffolds `.context`, probes `helmor.json`, and flips the
+ * workspace row from `initializing` to `ready` / `setup_pending`. On
+ * failure, the workspace row is cleaned up automatically.
+ */
+export async function finalizeWorkspaceFromRepo(
+	workspaceId: string,
+): Promise<FinalizeWorkspaceResponse> {
+	return invoke<FinalizeWorkspaceResponse>("finalize_workspace_from_repo", {
+		workspaceId,
+	});
+}
+
 export async function completeWorkspaceSetup(
 	workspaceId: string,
 ): Promise<void> {
@@ -1855,6 +1901,19 @@ export type ScriptEvent =
 	| { type: "exited"; code: number | null }
 	| { type: "error"; message: string };
 
+/**
+ * Resolve repo scripts using a fixed priority (enforced in Rust):
+ *   1. Workspace worktree `helmor.json` (when `workspaceId` is given AND
+ *      the worktree exists on disk)
+ *   2. Source repo root `helmor.json` (fallback for any missing workspace
+ *      / worktree — archived, broken, or caller with no workspace context)
+ *   3. DB-level override (Settings UI edit)
+ *
+ * Pass `workspaceId` when you have a specific workspace context (runtime
+ * panel, inspector, script execution, archive hook). Omit for contexts
+ * that only care about the repo's defaults (Settings page editing a repo
+ * that isn't the current workspace's repo).
+ */
 export async function loadRepoScripts(
 	repoId: string,
 	workspaceId?: string | null,

--- a/src/lib/workspace-helpers.ts
+++ b/src/lib/workspace-helpers.ts
@@ -13,21 +13,6 @@ import type {
 } from "./api";
 import { extractError } from "./errors";
 
-export const OPTIMISTIC_CREATING_WORKSPACE_ID_PREFIX = "creating-workspace:";
-
-export function createOptimisticCreatingWorkspaceId(repoId: string): string {
-	return `${OPTIMISTIC_CREATING_WORKSPACE_ID_PREFIX}${repoId}:${crypto.randomUUID()}`;
-}
-
-export function isOptimisticCreatingWorkspaceId(
-	workspaceId: string | null | undefined,
-): boolean {
-	return (
-		typeof workspaceId === "string" &&
-		workspaceId.startsWith(OPTIMISTIC_CREATING_WORKSPACE_ID_PREFIX)
-	);
-}
-
 export function createOptimisticCreatingWorkspaceDetail(
 	row: WorkspaceRow,
 	repoId: string,


### PR DESCRIPTION
## Summary

Workspace creation previously painted with an optimistic placeholder ID (`creating-workspace:...`), swapped to the real ID once the backend returned, and let a flurry of queries (git status, PR info, scripts) resolve sequentially — each transition produced a visible flicker in the sidebar, panel header, and inspector.

This change splits `create_workspace_from_repo` into two phases so the UI can paint the **final** visual state from frame 1 while the slow git work continues in the background.

- **Phase 1 — `prepare_workspace_from_repo` (<20ms)**: validates the repo, allocates a unique directory, computes the branch, generates workspace/session IDs, inserts the DB row in `initializing` state, loads repo scripts (from worktree helmor.json if present, else source repo root). Returns the full metadata the frontend needs to paint.
- **Phase 2 — `finalize_workspace_from_repo` (~200ms–2s)**: creates the git worktree, scaffolds `.context`, probes `helmor.json`, and flips the state from `initializing` → `ready` / `setup_pending`. Runs in the background.
- Short-circuits in `get_workspace_git_action_status`, `lookup_workspace_pr`, and `lookup_workspace_pr_action_status` return the canonical "fresh workspace" answer for rows in `initializing` state — same values Phase 2 settles on, so the state transition causes zero repaint.
- Query cache in `useWorkspacesSidebarController` is pre-seeded with the same canonical values, so the inspector's Actions section never shows "Sync status unavailable" / "Waiting for PR review" placeholders.
- Removed the `creating-workspace:` optimistic ID prefix + all `isOptimisticCreatingWorkspaceId` gating. The old combined `create_workspace_from_repo` is retained for CLI / MCP / add-repository flows.
- Added a startup cleanup pass that drops workspace rows stuck in `initializing` for more than 5 minutes (happens when the app is force-quit mid-create).

## Why

The flicker was particularly visible as: sidebar → grey placeholder title, inspector → "Sync status unavailable", header → no remote/PR badge. The backend always had the real values within ~20ms; the flicker was purely a UI-layer artifact of racing a placeholder paint against the authoritative one. Splitting the backend lets the first paint be authoritative.

## Test plan

- [ ] `bun run test` — all three suites pass
- [ ] `cd src-tauri && cargo test --tests` — integration tests for the new two-phase flow (see `commands/tests/workspace_creation.rs`)
- [ ] Manual: create a new workspace from the sidebar; confirm no title flash, no "Sync status unavailable" flash, no empty → filled header badge transition
- [ ] Manual: force-quit the app mid-create; restart and confirm the stuck `initializing` row is cleaned up
- [ ] Manual: CLI `helmor workspace create` still uses the legacy combined flow and works end-to-end