### PR TITLE
refactor(slash-commands): repo-keyed cache with two-tier fallback

### DIFF
--- a/sidecar/src/claude-session-manager.ts
+++ b/sidecar/src/claude-session-manager.ts
@@ -44,7 +44,7 @@ import {
  * unresponsive `claude-code` binary parks the request forever and the popup
  * spinner never resolves.
  */
-const SLASH_COMMANDS_TIMEOUT_MS = 8_000;
+const SLASH_COMMANDS_TIMEOUT_MS = 20_000;
 
 /**
  * `supportedModels()` resolves noticeably slower than `supportedCommands()`
@@ -624,7 +624,7 @@ export class ClaudeSessionManager implements SessionManager {
 	async listSlashCommands(
 		params: ListSlashCommandsParams,
 	): Promise<readonly SlashCommandInfo[]> {
-		const { cwd, model } = params;
+		const { cwd } = params;
 		const abortController = new AbortController();
 
 		let resolveDone: () => void = () => undefined;
@@ -653,7 +653,6 @@ export class ClaudeSessionManager implements SessionManager {
 				pathToClaudeCodeExecutable: CLAUDE_CLI_PATH,
 				...executableOptions(),
 				cwd: cwd || undefined,
-				model: model || undefined,
 				permissionMode: "bypassPermissions",
 				allowDangerouslySkipPermissions: true,
 				includePartialMessages: false,
@@ -675,7 +674,6 @@ export class ClaudeSessionManager implements SessionManager {
 				if (!isAbortError(err)) {
 					logger.error("Claude slash-command drain failed", {
 						cwd: cwd || "(none)",
-						model: model || "(default)",
 						...errorDetails(err),
 					});
 				}
@@ -696,7 +694,6 @@ export class ClaudeSessionManager implements SessionManager {
 			} catch (err) {
 				logger.error("Claude slash-command timeout abort failed", {
 					cwd: cwd || "(none)",
-					model: model || "(default)",
 					...errorDetails(err),
 				});
 			}
@@ -736,7 +733,6 @@ export class ClaudeSessionManager implements SessionManager {
 			} catch (err) {
 				logger.error("Claude slash-command cleanup failed during abort()", {
 					cwd: cwd || "(none)",
-					model: model || "(default)",
 					...errorDetails(err),
 				});
 			}
@@ -745,7 +741,6 @@ export class ClaudeSessionManager implements SessionManager {
 			} catch (err) {
 				logger.error("Claude slash-command cleanup failed during q.close()", {
 					cwd: cwd || "(none)",
-					model: model || "(default)",
 					...errorDetails(err),
 				});
 			}
@@ -753,7 +748,6 @@ export class ClaudeSessionManager implements SessionManager {
 				if (!isAbortError(err)) {
 					logger.error("Claude slash-command drain join failed", {
 						cwd: cwd || "(none)",
-						model: model || "(default)",
 						...errorDetails(err),
 					});
 				}

--- a/sidecar/src/codex-app-server-manager.ts
+++ b/sidecar/src/codex-app-server-manager.ts
@@ -451,9 +451,12 @@ export class CodexAppServerManager implements SessionManager {
 			await server.sendRequest("initialize", HELMOR_CLIENT_INFO);
 			server.writeNotification("initialized");
 
+			// 20s — mirrors the Claude sidecar slash-command timeout so both
+			// providers fail the same way when their CLI is missing/slow.
 			const result = await server.sendRequest<Record<string, unknown>>(
 				"skills/list",
 				{ cwds: [cwd] },
+				20_000,
 			);
 
 			return parseSkillsResponse(result, cwd);

--- a/sidecar/src/request-parser.ts
+++ b/sidecar/src/request-parser.ts
@@ -133,7 +133,6 @@ export function parseListSlashCommandsParams(
 ): ListSlashCommandsParams {
 	return {
 		cwd: optionalString(params, "cwd"),
-		model: optionalString(params, "model"),
 	};
 }
 

--- a/sidecar/src/session-manager.ts
+++ b/sidecar/src/session-manager.ts
@@ -22,7 +22,6 @@ export interface SendMessageParams {
 
 export interface ListSlashCommandsParams {
 	readonly cwd: string | undefined;
-	readonly model: string | undefined;
 }
 
 /**

--- a/src-tauri/src/agents.rs
+++ b/src-tauri/src/agents.rs
@@ -42,6 +42,18 @@ pub fn prewarm_slash_command_cache(app: &AppHandle) {
     queries::prewarm_slash_command_cache(app);
 }
 
+/// Tauri command — called from the frontend on workspace switch.
+/// Kicks off a background refresh for the target workspace so the next
+/// `/` press in the composer hits a warm cache.
+#[tauri::command]
+pub async fn prewarm_slash_commands_for_workspace(
+    app: AppHandle,
+    workspace_id: String,
+) -> CmdResult<()> {
+    queries::prewarm_slash_command_cache_for_workspace(&app, &workspace_id);
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Streaming event types
 // ---------------------------------------------------------------------------

--- a/src-tauri/src/agents/queries.rs
+++ b/src-tauri/src/agents/queries.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::sync::Mutex;
 
 use anyhow::Result;
@@ -331,8 +330,15 @@ pub async fn generate_session_title(
 pub struct ListSlashCommandsRequest {
     pub provider: String,
     pub working_directory: Option<String>,
-    pub model_id: Option<String>,
+    /// Repo id of the workspace — used to serve a repo-level fallback when the
+    /// exact workspace cache is cold (different workspaces on the same repo
+    /// usually share the same skill directories).
+    pub repo_id: Option<String>,
 }
+
+/// Sidecar timeout for `listSlashCommands`. Claude's in-sidecar AbortController
+/// fires at 20s; leave some buffer so the sidecar error surfaces first.
+const LIST_SLASH_COMMANDS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(25);
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -358,123 +364,152 @@ pub async fn list_slash_commands(
     cache: tauri::State<'_, super::slash_commands::SlashCommandCache>,
     request: ListSlashCommandsRequest,
 ) -> CmdResult<SlashCommandsResponse> {
+    let cwd = request.working_directory.as_deref().unwrap_or("");
+    let repo_id = request.repo_id.as_deref().unwrap_or("");
     tracing::debug!(
         provider = %request.provider,
-        cwd = request.working_directory.as_deref().unwrap_or(""),
-        model = request.model_id.as_deref().unwrap_or(""),
+        cwd,
+        repo_id,
         "list_slash_commands request"
     );
-    let cache_key = super::slash_commands::cache_key(
+
+    let ws_key = super::slash_commands::workspace_key(
         &request.provider,
         request.working_directory.as_deref(),
-        request.model_id.as_deref(),
     );
 
-    // 1. Check cache
-    if let Some((commands, is_complete)) = cache.get(&cache_key) {
-        tracing::debug!(
-            provider = %request.provider,
-            cwd = request.working_directory.as_deref().unwrap_or(""),
-            model = request.model_id.as_deref().unwrap_or(""),
-            count = commands.len(),
-            is_complete,
-            "list_slash_commands cache hit"
-        );
-        // Cache hit — return immediately and revalidate in the background.
-        // The frontend does not cache slash commands; a later request will
-        // pick up whatever this refresh writes into the backend cache.
-        spawn_background_refresh(&app, &cache, &request, cache_key);
+    // 1. Workspace-level exact hit → return instantly + SWR refresh.
+    if let Some((commands, is_complete)) = cache.get_workspace(&ws_key) {
+        spawn_background_refresh(&app, &cache, &request, ws_key);
         return Ok(SlashCommandsResponse {
             commands,
             is_complete,
         });
     }
 
+    // 2. Repo-level fallback → return stale-but-plausible + SWR refresh.
+    //    `is_complete: false` tells the UI the list is still loading.
+    if !repo_id.is_empty() {
+        let rkey = super::slash_commands::repo_key(&request.provider, repo_id);
+        if let Some((commands, _)) = cache.get_repo(&rkey) {
+            tracing::debug!(
+                provider = %request.provider,
+                cwd,
+                repo_id,
+                count = commands.len(),
+                "list_slash_commands serving repo fallback"
+            );
+            spawn_background_refresh(&app, &cache, &request, ws_key);
+            return Ok(SlashCommandsResponse {
+                commands,
+                is_complete: false,
+            });
+        }
+    }
+
+    // 3. Cold miss on both tiers — synchronous sidecar fetch.
     tracing::debug!(
         provider = %request.provider,
-        cwd = request.working_directory.as_deref().unwrap_or(""),
-        model = request.model_id.as_deref().unwrap_or(""),
+        cwd,
+        repo_id,
         "list_slash_commands cache miss; fetching full result synchronously"
     );
     let commands = fetch_from_sidecar(&sidecar, &request)?;
     tracing::debug!(
         provider = %request.provider,
-        cwd = request.working_directory.as_deref().unwrap_or(""),
-        model = request.model_id.as_deref().unwrap_or(""),
+        cwd,
+        repo_id,
         count = commands.len(),
         "list_slash_commands sync fetch succeeded"
     );
-    cache.set(cache_key, commands.clone(), true);
+    cache.set(ws_key, request.repo_id.as_deref(), commands.clone(), true);
     Ok(SlashCommandsResponse {
         commands,
         is_complete: true,
     })
 }
 
+/// Prewarm the slash-command cache for a single workspace (both providers).
+/// Safe to call repeatedly — the cache's per-key refresh lock dedupes.
+pub fn prewarm_slash_command_cache_for_workspace(app: &AppHandle, workspace_id: &str) {
+    let app = app.clone();
+    let workspace_id = workspace_id.to_string();
+    let _ = std::thread::Builder::new()
+        .name("slash-cmd-prewarm-ws".into())
+        .spawn(move || {
+            let record = match crate::models::workspaces::load_workspace_record_by_id(&workspace_id)
+            {
+                Ok(Some(r)) => r,
+                Ok(None) => {
+                    tracing::debug!(workspace_id, "Slash-command prewarm: workspace not found");
+                    return;
+                }
+                Err(e) => {
+                    tracing::warn!(workspace_id, error = %e, "Slash-command prewarm: load failed");
+                    return;
+                }
+            };
+            let Some(root_path) = record
+                .root_path
+                .as_deref()
+                .map(str::trim)
+                .filter(|p| !p.is_empty())
+            else {
+                tracing::debug!(
+                    workspace_id,
+                    "Slash-command prewarm: workspace has no root_path"
+                );
+                return;
+            };
+            dispatch_prewarm_for(&app, root_path, &record.repo_id);
+        });
+}
+
+/// Prewarm on startup: only the last-selected workspace (persisted in
+/// `settings.app.last_workspace_id`). The frontend's workspace-switch handler
+/// also fires `prewarm_slash_commands_for_workspace` on initial selection —
+/// `SlashCommandCache::try_start_refresh` dedupes the two calls.
 pub fn prewarm_slash_command_cache(app: &AppHandle) {
     let app = app.clone();
     let _ = std::thread::Builder::new()
         .name("slash-cmd-prewarm".into())
         .spawn(move || {
-            let cache: tauri::State<'_, super::slash_commands::SlashCommandCache> = app.state();
-            let mut seen_roots = HashSet::new();
-            let mut roots = Vec::new();
-            for workspace in crate::models::workspaces::load_workspace_records().unwrap_or_default()
+            let last_id = match crate::models::settings::load_setting_value("app.last_workspace_id")
             {
-                if let Some(root_path) = workspace.root_path {
-                    let trimmed = root_path.trim();
-                    if !trimmed.is_empty() && seen_roots.insert(trimmed.to_string()) {
-                        roots.push(trimmed.to_string());
-                    }
+                Ok(Some(id)) if !id.trim().is_empty() => id,
+                _ => {
+                    tracing::debug!(
+                        "Slash-command prewarm skipped: no last_workspace_id persisted"
+                    );
+                    return;
                 }
-            }
-
-            tracing::debug!(
-                workspace_count = roots.len(),
-                claude_model = "default",
-                "Slash-command prewarm started"
-            );
-            for root_path in roots {
-                tracing::debug!(cwd = %root_path, "Slash-command prewarm workspace");
-                let claude_key = super::slash_commands::cache_key(
-                    "claude",
-                    Some(root_path.as_str()),
-                    Some("default"),
-                );
-                let claude_request = ListSlashCommandsRequest {
-                    provider: "claude".to_string(),
-                    working_directory: Some(root_path.clone()),
-                    model_id: Some("default".to_string()),
-                };
-                tracing::debug!(
-                    provider = "claude",
-                    cwd = %root_path,
-                    model = "default",
-                    "Slash-command prewarm dispatching background refresh"
-                );
-                spawn_background_refresh(&app, &cache, &claude_request, claude_key);
-
-                let codex_key =
-                    super::slash_commands::cache_key("codex", Some(root_path.as_str()), None);
-                let codex_request = ListSlashCommandsRequest {
-                    provider: "codex".to_string(),
-                    working_directory: Some(root_path.clone()),
-                    model_id: None,
-                };
-                tracing::debug!(
-                    provider = "codex",
-                    cwd = %root_path,
-                    "Slash-command prewarm dispatching background refresh"
-                );
-                spawn_background_refresh(&app, &cache, &codex_request, codex_key);
-            }
-            tracing::debug!("Slash-command prewarm finished");
+            };
+            tracing::debug!(workspace_id = %last_id, "Slash-command prewarm using last workspace");
+            prewarm_slash_command_cache_for_workspace(&app, &last_id);
         });
 }
 
-/// Run the sidecar `listSlashCommands` call synchronously (blocking the
-/// current async task).  Used for the non-claude fast path and by the
-/// background refresh thread.
+fn dispatch_prewarm_for(app: &AppHandle, root_path: &str, repo_id: &str) {
+    let cache: tauri::State<'_, super::slash_commands::SlashCommandCache> = app.state();
+    for provider in ["claude", "codex"] {
+        let request = ListSlashCommandsRequest {
+            provider: provider.to_string(),
+            working_directory: Some(root_path.to_string()),
+            repo_id: Some(repo_id.to_string()),
+        };
+        let ws_key = super::slash_commands::workspace_key(provider, Some(root_path));
+        tracing::debug!(
+            provider,
+            cwd = root_path,
+            repo_id,
+            "Slash-command prewarm dispatching background refresh"
+        );
+        spawn_background_refresh(app, &cache, &request, ws_key);
+    }
+}
+
+/// Blocking sidecar call for `listSlashCommands`. Used by both the
+/// synchronous cold-miss path and the background refresh thread.
 fn fetch_from_sidecar(
     sidecar: &crate::sidecar::ManagedSidecar,
     request: &ListSlashCommandsRequest,
@@ -485,9 +520,6 @@ fn fetch_from_sidecar(
     params.insert("provider".into(), Value::String(request.provider.clone()));
     if let Some(cwd) = request.working_directory.as_ref() {
         params.insert("cwd".into(), Value::String(cwd.clone()));
-    }
-    if let Some(model) = request.model_id.as_ref() {
-        params.insert("model".into(), Value::String(model.clone()));
     }
 
     let sidecar_req = crate::sidecar::SidecarRequest {
@@ -504,10 +536,9 @@ fn fetch_from_sidecar(
 
     let mut commands: Vec<SlashCommandEntry> = Vec::new();
     let mut error: Option<String> = None;
-    let timeout = std::time::Duration::from_secs(10);
 
     loop {
-        match rx.recv_timeout(timeout) {
+        match rx.recv_timeout(LIST_SLASH_COMMANDS_TIMEOUT) {
             Ok(event) => match event.event_type() {
                 "slashCommandsListed" => {
                     if let Some(entries) = event.raw.get("commands").and_then(Value::as_array) {
@@ -554,7 +585,10 @@ fn fetch_from_sidecar(
                 _ => {}
             },
             Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-                error = Some("listSlashCommands timed out after 10s".to_string());
+                error = Some(format!(
+                    "listSlashCommands timed out after {}s",
+                    LIST_SLASH_COMMANDS_TIMEOUT.as_secs()
+                ));
                 break;
             }
             Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
@@ -572,34 +606,32 @@ fn fetch_from_sidecar(
     }
 }
 
-/// Fire-and-forget background thread that fetches the full command list from
-/// the sidecar and updates the cache + emits a Tauri event on success.
+/// Fire-and-forget background thread that refreshes the workspace-level
+/// cache entry. Writes into both workspace and repo tiers on success.
 fn spawn_background_refresh(
     app: &AppHandle,
     cache: &super::slash_commands::SlashCommandCache,
     request: &ListSlashCommandsRequest,
-    cache_key: (String, String, String),
+    ws_key: super::slash_commands::WorkspaceKey,
 ) {
-    if !cache.try_start_refresh(&cache_key) {
+    if !cache.try_start_refresh(&ws_key) {
         tracing::debug!(
             provider = %request.provider,
             cwd = request.working_directory.as_deref().unwrap_or(""),
-            model = request.model_id.as_deref().unwrap_or(""),
             "Background slash command refresh skipped; another refresh is in flight"
         );
-        return; // another refresh already in flight
+        return;
     }
 
     tracing::debug!(
         provider = %request.provider,
         cwd = request.working_directory.as_deref().unwrap_or(""),
-        model = request.model_id.as_deref().unwrap_or(""),
         "Background slash command refresh started"
     );
 
     let app = app.clone();
     let request = request.clone();
-    let refresh_key = cache_key.clone();
+    let refresh_key = ws_key.clone();
 
     std::thread::Builder::new()
         .name("slash-cmd-refresh".into())
@@ -613,11 +645,10 @@ fn spawn_background_refresh(
                     tracing::debug!(
                         provider = %request.provider,
                         cwd = request.working_directory.as_deref().unwrap_or(""),
-                        model = request.model_id.as_deref().unwrap_or(""),
                         count = commands.len(),
                         "Background slash command refresh succeeded"
                     );
-                    cache_state.set(cache_key, commands, true);
+                    cache_state.set(ws_key, request.repo_id.as_deref(), commands, true);
                 }
                 Err(e) => {
                     // Don't clear the cache — stale local data is better than nothing.

--- a/src-tauri/src/agents/slash_commands.rs
+++ b/src-tauri/src/agents/slash_commands.rs
@@ -1,42 +1,43 @@
-//! Slash command cache.
+//! Slash-command cache.
 //!
-//! Stores the last successful full result (from the
-//!    sidecar/SDK) per `(provider, cwd, model)` key so subsequent `/` presses
-//!    resolve instantly.
+//! Two-tier cache:
+//! 1. **Workspace tier** — keyed by `(provider, cwd)`. Primary cache — an exact
+//!    hit returns instantly and we revalidate in the background.
+//! 2. **Repo tier** — keyed by `(provider, repo_id)`. Fallback used when the
+//!    workspace tier misses. Different workspaces on the same repo usually
+//!    share the same `~/.claude/skills/` and `.claude/commands/`, so we can
+//!    show stale-but-plausible commands while the real scan runs.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Mutex, RwLock};
 
 use super::queries::SlashCommandEntry;
 
-// ---------------------------------------------------------------------------
-// Cache
-// ---------------------------------------------------------------------------
+pub type WorkspaceKey = (String, String); // (provider, cwd)
+pub type RepoKey = (String, String); // (provider, repo_id)
 
-type CacheKey = (String, String, String); // (provider, cwd, model)
-
-pub fn cache_key(
-    provider: &str,
-    working_directory: Option<&str>,
-    _model_id: Option<&str>,
-) -> CacheKey {
+pub fn workspace_key(provider: &str, working_directory: Option<&str>) -> WorkspaceKey {
     (
         provider.to_string(),
         working_directory.unwrap_or_default().to_string(),
-        String::new(),
     )
 }
 
+pub fn repo_key(provider: &str, repo_id: &str) -> RepoKey {
+    (provider.to_string(), repo_id.to_string())
+}
+
+#[derive(Clone)]
 struct CachedResult {
     commands: Vec<SlashCommandEntry>,
     is_complete: bool,
 }
 
 pub struct SlashCommandCache {
-    entries: RwLock<HashMap<CacheKey, CachedResult>>,
-    /// Prevents duplicate background refreshes for the same cache key while
-    /// still allowing different workspaces/providers to refresh concurrently.
-    refreshing: Mutex<std::collections::HashSet<CacheKey>>,
+    workspaces: RwLock<HashMap<WorkspaceKey, CachedResult>>,
+    repos: RwLock<HashMap<RepoKey, CachedResult>>,
+    /// Prevents duplicate background refreshes for the same workspace key.
+    refreshing: Mutex<HashSet<WorkspaceKey>>,
 }
 
 impl Default for SlashCommandCache {
@@ -48,56 +49,74 @@ impl Default for SlashCommandCache {
 impl SlashCommandCache {
     pub fn new() -> Self {
         Self {
-            entries: RwLock::new(HashMap::new()),
-            refreshing: Mutex::new(std::collections::HashSet::new()),
+            workspaces: RwLock::new(HashMap::new()),
+            repos: RwLock::new(HashMap::new()),
+            refreshing: Mutex::new(HashSet::new()),
         }
     }
 
-    pub fn get(&self, key: &CacheKey) -> Option<(Vec<SlashCommandEntry>, bool)> {
-        let map = self.entries.read().ok()?;
-        if let Some(cached) = map.get(key) {
-            tracing::debug!(
-                provider = %key.0,
-                cwd = %key.1,
-                model = %key.2,
-                count = cached.commands.len(),
-                is_complete = cached.is_complete,
-                "Slash-command cache exact hit"
-            );
-            return Some((cached.commands.clone(), cached.is_complete));
-        }
-
+    /// Exact workspace-level lookup.
+    pub fn get_workspace(&self, key: &WorkspaceKey) -> Option<(Vec<SlashCommandEntry>, bool)> {
+        let map = self.workspaces.read().ok()?;
+        let cached = map.get(key)?;
         tracing::debug!(
             provider = %key.0,
             cwd = %key.1,
-            model = %key.2,
-            "Slash-command cache miss"
+            count = cached.commands.len(),
+            is_complete = cached.is_complete,
+            "Slash-command workspace cache hit"
         );
-        None
+        Some((cached.commands.clone(), cached.is_complete))
     }
 
-    pub fn set(&self, key: CacheKey, commands: Vec<SlashCommandEntry>, is_complete: bool) {
-        if let Ok(mut map) = self.entries.write() {
-            map.insert(
-                key,
-                CachedResult {
-                    commands,
-                    is_complete,
-                },
-            );
+    /// Repo-level fallback lookup — used only when the workspace tier misses.
+    pub fn get_repo(&self, key: &RepoKey) -> Option<(Vec<SlashCommandEntry>, bool)> {
+        let map = self.repos.read().ok()?;
+        let cached = map.get(key)?;
+        tracing::debug!(
+            provider = %key.0,
+            repo_id = %key.1,
+            count = cached.commands.len(),
+            "Slash-command repo-level fallback hit"
+        );
+        Some((cached.commands.clone(), cached.is_complete))
+    }
+
+    /// Write a result into the workspace tier, and also mirror it to the repo
+    /// tier (latest-wins) so future workspaces on the same repo get a good
+    /// fallback on first access.
+    pub fn set(
+        &self,
+        workspace_key: WorkspaceKey,
+        repo_id: Option<&str>,
+        commands: Vec<SlashCommandEntry>,
+        is_complete: bool,
+    ) {
+        let entry = CachedResult {
+            commands,
+            is_complete,
+        };
+        if let Ok(mut map) = self.workspaces.write() {
+            map.insert(workspace_key.clone(), entry.clone());
+        }
+        if let Some(repo_id) = repo_id.filter(|id| !id.is_empty()) {
+            let rkey = repo_key(&workspace_key.0, repo_id);
+            if let Ok(mut map) = self.repos.write() {
+                map.insert(rkey, entry);
+            }
         }
     }
 
-    /// Try to claim the refresh lock for a single cache key. Returns `true`
-    /// if this caller won.
-    pub fn try_start_refresh(&self, key: &CacheKey) -> bool {
+    /// Try to claim the refresh lock for a workspace key. Returns `true` if
+    /// this caller won.
+    pub fn try_start_refresh(&self, key: &WorkspaceKey) -> bool {
         let Ok(mut refreshing) = self.refreshing.lock() else {
             return false;
         };
         refreshing.insert(key.clone())
     }
 
-    pub fn finish_refresh(&self, key: &CacheKey) {
+    pub fn finish_refresh(&self, key: &WorkspaceKey) {
         if let Ok(mut refreshing) = self.refreshing.lock() {
             refreshing.remove(key);
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -133,6 +133,7 @@ pub fn run() {
             agents::respond_to_elicitation_request,
             agents::generate_session_title,
             agents::list_slash_commands,
+            agents::prewarm_slash_commands_for_workspace,
             commands::workspace_commands::prepare_archive_workspace,
             commands::workspace_commands::start_archive_workspace,
             commands::workspace_commands::validate_archive_workspace,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,6 +69,7 @@ import {
 	listenGitBranchChanged,
 	listenGitRefsChanged,
 	openWorkspaceInEditor,
+	prewarmSlashCommandsForWorkspace,
 	setWorkspaceManualStatus,
 	triggerWorkspaceFetch,
 	type WorkspaceDetail,
@@ -1082,6 +1083,10 @@ function AppShell({
 			if (workspaceId) {
 				if (!isOptimisticCreatingWorkspaceId(workspaceId)) {
 					triggerWorkspaceFetch(workspaceId);
+					// Prewarm the slash-command cache for the new workspace so
+					// the next `/` press hits warm data (or at least falls back
+					// to the repo-level cache while this refresh completes).
+					void prewarmSlashCommandsForWorkspace(workspaceId);
 				}
 			}
 

--- a/src/features/composer/container.test.tsx
+++ b/src/features/composer/container.test.tsx
@@ -350,7 +350,7 @@ describe("WorkspaceComposerContainer", () => {
 			expect(apiMockState.listSlashCommands).toHaveBeenCalledWith({
 				provider: "claude",
 				workingDirectory: "/tmp/helmor",
-				modelId: "opus-1m",
+				repoId: "repo-1",
 			}),
 		);
 	});

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -350,7 +350,7 @@ export const WorkspaceComposerContainer = memo(
 			...slashCommandsQueryOptions(
 				slashProvider,
 				workingDirectory,
-				selectedModelId,
+				workspaceDetailQuery.data?.repoId ?? null,
 			),
 			enabled: Boolean(workingDirectory),
 		});

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -655,20 +655,33 @@ export type SlashCommandsResponse = {
 export async function listSlashCommands(input: {
 	provider: AgentProvider;
 	workingDirectory?: string | null;
-	modelId?: string | null;
+	repoId?: string | null;
 }): Promise<SlashCommandsResponse> {
 	try {
 		return await invoke<SlashCommandsResponse>("list_slash_commands", {
 			request: {
 				provider: input.provider,
 				workingDirectory: input.workingDirectory ?? null,
-				modelId: input.modelId ?? null,
+				repoId: input.repoId ?? null,
 			},
 		});
 	} catch (error) {
 		throw new Error(
 			describeInvokeError(error, "Unable to load slash commands."),
 		);
+	}
+}
+
+/** Fire-and-forget: prewarm the backend slash-command cache for a workspace. */
+export async function prewarmSlashCommandsForWorkspace(
+	workspaceId: string,
+): Promise<void> {
+	try {
+		await invoke<void>("prewarm_slash_commands_for_workspace", {
+			workspaceId,
+		});
+	} catch {
+		// Best-effort; cache will still be populated lazily on first /.
 	}
 }
 

--- a/src/lib/query-client.test.ts
+++ b/src/lib/query-client.test.ts
@@ -5,28 +5,9 @@ import type {
 	WorkspacePrActionStatus,
 } from "./api";
 import {
-	helmorQueryKeys,
 	prActionStatusRefetchInterval,
 	prRefetchInterval,
 } from "./query-client";
-
-describe("helmorQueryKeys.slashCommands", () => {
-	it("ignores model id for claude keys", () => {
-		expect(
-			helmorQueryKeys.slashCommands("claude", "/tmp/workspace", "default"),
-		).toEqual(
-			helmorQueryKeys.slashCommands("claude", "/tmp/workspace", "opus-1m"),
-		);
-	});
-
-	it("ignores model id for codex keys", () => {
-		expect(
-			helmorQueryKeys.slashCommands("codex", "/tmp/workspace", "gpt-5.4"),
-		).toEqual(
-			helmorQueryKeys.slashCommands("codex", "/tmp/workspace", "gpt-5"),
-		);
-	});
-});
 
 const OPEN_PR: PullRequestInfo = {
 	url: "https://github.com/acme/repo/pull/1",

--- a/src/lib/query-client.ts
+++ b/src/lib/query-client.ts
@@ -60,11 +60,8 @@ export const helmorQueryKeys = {
 	autoCloseActionKinds: ["autoCloseActionKinds"] as const,
 	autoCloseOptInAsked: ["autoCloseOptInAsked"] as const,
 	detectedEditors: ["detectedEditors"] as const,
-	slashCommands: (
-		provider: AgentProvider,
-		workingDirectory: string | null,
-		_modelId: string | null,
-	) => ["slashCommands", provider, workingDirectory ?? "", ""] as const,
+	slashCommands: (provider: AgentProvider, workingDirectory: string | null) =>
+		["slashCommands", provider, workingDirectory ?? ""] as const,
 };
 
 export function createHelmorQueryClient() {
@@ -190,19 +187,15 @@ export function sessionAttachmentsQueryOptions(sessionId: string) {
 export function slashCommandsQueryOptions(
 	provider: AgentProvider,
 	workingDirectory: string | null,
-	modelId: string | null,
+	repoId: string | null,
 ) {
 	return queryOptions({
-		queryKey: helmorQueryKeys.slashCommands(
-			provider,
-			workingDirectory,
-			modelId,
-		),
+		queryKey: helmorQueryKeys.slashCommands(provider, workingDirectory),
 		queryFn: () =>
 			listSlashCommands({
 				provider,
 				workingDirectory,
-				modelId,
+				repoId,
 			}),
 		// The backend owns slash-command caching and background refresh. Keep
 		// the frontend layer as a thin request shell only.


### PR DESCRIPTION
## Summary

Rework the slash-command cache so `/` pops fast on workspace switch, even on cold cache.

### What changed

- **Cache key: `modelId` → `repoId`.** Slash commands are filesystem-driven (`~/.claude/skills/`, `.claude/commands/`), not model-dependent, so keying by model was wasteful. `list_slash_commands` and the sidecar `listSlashCommands` request now drop `model` entirely.
- **Two-tier cache** (`src-tauri/src/agents/slash_commands.rs`):
  1. **Workspace tier** — exact `(provider, cwd)` hit returns instantly + SWR refresh.
  2. **Repo tier** — `(provider, repo_id)` fallback. When a fresh workspace on a known repo first asks for commands, we serve the repo-level list with `is_complete: false` while the real scan runs, instead of making the UI wait.
- **Per-workspace prewarm.** New Tauri command `prewarm_slash_commands_for_workspace` wired into the frontend's workspace-switch handler in `App.tsx`. Startup prewarm now only warms the *last selected* workspace (from `settings.app.last_workspace_id`) instead of iterating every workspace — cheaper and focused on what the user will actually see first.
- **Timeouts bumped.** Claude sidecar slash-command timeout `8s → 20s`; matching 20s timeout added to the Codex app-server `skills/list` call; Rust-side sidecar-recv timeout `10s → 25s` (buffered behind the 20s sidecar AbortController so the inner error surfaces first). Fixes spurious timeouts on large skill trees / slow CLIs.

### Why

- Reduces redundant scans: switching models no longer invalidates the cache.
- Cold cache now has a plausible fallback instead of an empty spinner.
- Tighter prewarm: we stop scanning every workspace at boot.
- Pulls both providers onto the same timeout contract.

## Test plan

- [ ] `bun run test` (all three suites) — updated `container.test.tsx` + `query-client.test.ts`
- [ ] `bun run lint` (biome + clippy -D warnings)
- [ ] Manual: open `/` on a brand-new workspace inside a repo with an existing workspace; verify repo-tier fallback pops instantly and refreshes to the real list
- [ ] Manual: switch between workspaces rapidly; confirm no duplicate sidecar fetches (dedup via `try_start_refresh`)
- [ ] Manual: kill the Claude CLI mid-request and confirm the 20s timeout fires cleanly (no hung spinner)