### PR TITLE
feat(pipeline): stable part IDs across streaming, persistence, and reload

### DIFF
--- a/.changeset/stable-part-ids.md
+++ b/.changeset/stable-part-ids.md
@@ -1,0 +1,9 @@
+---
+"helmor": minor
+---
+
+Stable part IDs across the streaming pipeline — thinking blocks no longer auto-collapse at block boundaries:
+- Every message part (Text, Reasoning, Image, TodoList, etc.) now carries a stable `id` minted at first sight and preserved through streaming deltas, turn commit, DB persistence, and historical reload. React keys use this id instead of array position, eliminating remounts caused by pipeline reordering (collapse grouping, tool-call folding, message merging).
+- Message-level IDs are pre-assigned as DB UUIDs at turn start instead of using temporary `stream-partial:N` identifiers that flip to a different UUID on commit. The entire `sync_persisted_ids` / `sync_result_id` post-hoc reconciliation machinery is removed.
+- Collapsed read-only tool groups now default to expanded and stop their loading spinner as soon as the last tool returns a result, instead of spinning until the overall message stream ends.
+- Subagent status labels (Subagent started / completed) no longer line-break on narrow viewports.

--- a/src-tauri/src/agents.rs
+++ b/src-tauri/src/agents.rs
@@ -645,6 +645,7 @@ mod tests {
             },
             None,
             "idle",
+            None,
         )
         .unwrap();
 
@@ -795,6 +796,7 @@ mod tests {
             },
             None,
             "idle",
+            None,
         )
         .unwrap();
 
@@ -850,7 +852,6 @@ mod tests {
             content_json:
                 r#"{"type":"assistant","message":{"content":[{"type":"text","text":"I'll help"}]}}"#
                     .to_string(),
-            collected_idx: None,
         };
         let turn2 = CollectedTurn {
             id: Uuid::new_v4().to_string(),
@@ -858,7 +859,6 @@ mod tests {
             content_json:
                 r#"{"type":"user","content":[{"type":"tool_result","tool_use_id":"t1"}]}"#
                     .to_string(),
-            collected_idx: None,
         };
 
         let _ = persist_turn_message(&conn, &ctx, &turn1, "opus").unwrap();

--- a/src-tauri/src/agents/persistence.rs
+++ b/src-tauri/src/agents/persistence.rs
@@ -172,6 +172,10 @@ pub(super) fn persist_exit_plan_message(
     Ok((msg_id, now))
 }
 
+/// Persist the session result row and finalize session metadata. The
+/// `preassigned_result_id` param, when present, is used as the DB row key
+/// — pass the accumulator's `take_result_id()` so the live-rendered id
+/// and the persisted id match.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn persist_result_and_finalize(
     conn: &Connection,
@@ -183,9 +187,11 @@ pub(super) fn persist_result_and_finalize(
     usage: &AgentUsage,
     raw_result_json: Option<&str>,
     status: &str,
+    preassigned_result_id: Option<String>,
 ) -> Result<String> {
     let now = current_timestamp_string()?;
-    let result_message_id = uuid::Uuid::new_v4().to_string();
+    let result_message_id =
+        preassigned_result_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
 
     let result_payload = raw_result_json.map(str::to_string).unwrap_or_else(|| {
         serde_json::json!({

--- a/src-tauri/src/agents/queries.rs
+++ b/src-tauri/src/agents/queries.rs
@@ -262,8 +262,23 @@ pub async fn generate_session_title(
                     "Skipping auto branch rename: branch already differs from default"
                 );
             } else {
-                let new_branch =
+                let base_branch =
                     crate::helpers::branch_name_for_directory(branch_segment, &branch_settings);
+
+                // Deduplicate: if the target branch already exists in git,
+                // append -2, -3, ... until we find a free name. Prevents
+                // collisions when multiple workspaces generate the same
+                // branch name from similar prompts.
+                let new_branch = if let Some(ref repo_root) = root_path {
+                    let repo = std::path::Path::new(repo_root);
+                    if repo.is_dir() {
+                        deduplicate_branch_name(&base_branch, repo)
+                    } else {
+                        base_branch
+                    }
+                } else {
+                    base_branch
+                };
 
                 if old_branch.as_deref() != Some(new_branch.as_str()) {
                     let fs_rename_attempted = matches!(
@@ -324,6 +339,38 @@ pub async fn generate_session_title(
         branch_renamed,
         skipped: false,
     })
+}
+
+/// If `base` already exists as a local branch, try `base-2`, `base-3`, …
+/// up to a small limit. Returns the first free name, or `base` unchanged
+/// if the check itself fails (defensive: let `git branch -m` report the
+/// real error).
+fn deduplicate_branch_name(base: &str, repo_root: &std::path::Path) -> String {
+    let repo_root_str = repo_root.display().to_string();
+    let exists = |name: &str| -> bool {
+        crate::git_ops::run_git(
+            [
+                "-C",
+                &repo_root_str,
+                "rev-parse",
+                "--verify",
+                &format!("refs/heads/{name}"),
+            ],
+            None,
+        )
+        .is_ok()
+    };
+    if !exists(base) {
+        return base.to_string();
+    }
+    for n in 2..=100 {
+        let candidate = format!("{base}-{n}");
+        if !exists(&candidate) {
+            return candidate;
+        }
+    }
+    // All 100 slots taken — return base and let git report the error.
+    base.to_string()
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src-tauri/src/agents/streaming.rs
+++ b/src-tauri/src/agents/streaming.rs
@@ -514,8 +514,6 @@ pub(super) fn stream_via_sidecar(
                                 }
                             }
                         }
-                        pipeline_state.accumulator.sync_persisted_ids();
-
                         let output = pipeline_state
                             .accumulator
                             .drain_output(resolved_session_id.as_deref());
@@ -534,7 +532,8 @@ pub(super) fn stream_via_sidecar(
                                     tracing::error!(rid = %rid, "Failed to finalize exchange: {error}");
                                 }
                             } else {
-                                match persist_result_and_finalize(
+                                let preassigned = pipeline_state.accumulator.take_result_id();
+                                if let Err(error) = persist_result_and_finalize(
                                     conn,
                                     ctx,
                                     &output.resolved_model,
@@ -544,13 +543,9 @@ pub(super) fn stream_via_sidecar(
                                     &output.usage,
                                     output.result_json.as_deref(),
                                     status,
+                                    preassigned,
                                 ) {
-                                    Ok(result_id) => {
-                                        pipeline_state.accumulator.sync_result_id(&result_id);
-                                    }
-                                    Err(error) => {
-                                        tracing::error!(rid = %rid, "Failed to finalize exchange: {error}");
-                                    }
+                                    tracing::error!(rid = %rid, "Failed to finalize exchange: {error}");
                                 }
                             }
                         }
@@ -661,8 +656,6 @@ pub(super) fn stream_via_sidecar(
                             }
                         }
 
-                        pipeline_state.accumulator.sync_persisted_ids();
-
                         let resolved_model =
                             pipeline_state.accumulator.resolved_model().to_string();
                         let persisted_metadata =
@@ -743,10 +736,9 @@ pub(super) fn stream_via_sidecar(
                         }
 
                         // Deferred pause is terminal for this stream from the
-                        // frontend's perspective. Sync persisted turn UUIDs before
-                        // the last Update so the cached thread keeps DB-stable ids
-                        // across the follow-up resume path.
-                        pipeline_state.accumulator.sync_persisted_ids();
+                        // frontend's perspective. IDs are already stable by
+                        // construction (same UUID in `collected[]` and
+                        // `CollectedTurn`), so no post-hoc sync is needed.
                         resolved_model = pipeline_state.accumulator.resolved_model().to_string();
 
                         let final_messages = pipeline_state.finish();

--- a/src-tauri/src/bin/helmor-cli.rs
+++ b/src-tauri/src/bin/helmor-cli.rs
@@ -373,7 +373,7 @@ fn cmd_send(
         match event {
             AgentStreamEvent::StreamingPartial { message } => {
                 for part in &message.content {
-                    if let ExtendedMessagePart::Basic(MessagePart::Text { text }) = part {
+                    if let ExtendedMessagePart::Basic(MessagePart::Text { text, .. }) = part {
                         let _ = write!(stdout, "{text}");
                         let _ = stdout.flush();
                     }

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -228,7 +228,7 @@ fn dispatch_tool(name: &str, args: &Value) -> Result<String> {
             let result = service::send_message(params, &mut |event| {
                 if let AgentStreamEvent::StreamingPartial { message } = event {
                     for part in &message.content {
-                        if let ExtendedMessagePart::Basic(MessagePart::Text { text }) = part {
+                        if let ExtendedMessagePart::Basic(MessagePart::Text { text, .. }) = part {
                             output.push_str(text);
                         }
                     }

--- a/src-tauri/src/pipeline/accumulator/codex.rs
+++ b/src-tauri/src/pipeline/accumulator/codex.rs
@@ -200,12 +200,12 @@ pub(super) fn handle_turn_completed(acc: &mut StreamAccumulator, raw_line: &str,
             "message": message,
         });
         let s = serde_json::to_string(&synthetic).unwrap_or_default();
-        acc.collect_message(&s, &synthetic, MessageRole::Error, None);
+        let turn_id = uuid::Uuid::new_v4().to_string();
+        acc.collect_message(&s, &synthetic, MessageRole::Error, Some(&turn_id));
         acc.turns.push(CollectedTurn {
-            id: uuid::Uuid::new_v4().to_string(),
+            id: turn_id,
             role: MessageRole::Error,
             content_json: raw_line.to_string(),
-            collected_idx: None,
         });
         return;
     }
@@ -228,8 +228,9 @@ pub(super) fn handle_turn_completed(acc: &mut StreamAccumulator, raw_line: &str,
     let enriched_str = serde_json::to_string(&enriched).unwrap_or_else(|_| raw_line.to_string());
 
     acc.result_json = Some(enriched_str.clone());
-    acc.result_collected_idx = Some(acc.collected.len());
-    acc.collect_message(&enriched_str, &enriched, MessageRole::Assistant, None);
+    let id = uuid::Uuid::new_v4().to_string();
+    acc.result_id = Some(id.clone());
+    acc.collect_message(&enriched_str, &enriched, MessageRole::Assistant, Some(&id));
 }
 
 // ---------------------------------------------------------------------------
@@ -310,6 +311,9 @@ fn handle_agent_message(
     item_id: Option<&str>,
     persist: bool,
 ) {
+    let collect_id = item_id
+        .map(|id| format!("codex-item:{id}"))
+        .unwrap_or_else(|| format!("codex-item:{}", acc.line_count));
     if persist {
         if let Some(text) = item.get("text").and_then(Value::as_str) {
             if !acc.assistant_text.is_empty() {
@@ -317,11 +321,12 @@ fn handle_agent_message(
             }
             acc.assistant_text.push_str(text);
         }
+        // Use the same id for the DB row and the live-rendered collected
+        // entry so historical reload and live streaming agree byte-for-byte.
         acc.turns.push(CollectedTurn {
-            id: uuid::Uuid::new_v4().to_string(),
+            id: collect_id.clone(),
             role: MessageRole::Assistant,
             content_json: raw_line.to_string(),
-            collected_idx: None,
         });
     }
     // Wrap in the envelope the adapter expects
@@ -330,12 +335,7 @@ fn handle_agent_message(
         "item": item,
     });
     let s = serde_json::to_string(&envelope).unwrap_or_default();
-    acc.collect_or_replace(
-        &s,
-        &envelope,
-        MessageRole::Assistant,
-        item_id.map(|id| format!("codex-item:{id}")),
-    );
+    acc.collect_or_replace(&s, &envelope, MessageRole::Assistant, Some(collect_id));
 }
 
 fn handle_command_execution(
@@ -375,12 +375,14 @@ fn handle_command_execution(
         }
     });
     let sa_str = serde_json::to_string(&synthetic_assistant).unwrap_or_default();
-    let asst_id = item_id.map(|id| format!("codex-cmd-asst:{id}"));
+    let asst_id = item_id
+        .map(|id| format!("codex-cmd-asst:{id}"))
+        .unwrap_or_else(|| format!("codex-cmd-asst:{}", acc.line_count));
     acc.collect_or_replace(
         &sa_str,
         &synthetic_assistant,
         MessageRole::Assistant,
-        asst_id,
+        Some(asst_id.clone()),
     );
 
     if !is_running {
@@ -407,10 +409,9 @@ fn handle_command_execution(
 
     if persist {
         acc.turns.push(CollectedTurn {
-            id: uuid::Uuid::new_v4().to_string(),
+            id: asst_id,
             role: MessageRole::Assistant,
             content_json: raw_line.to_string(),
-            collected_idx: None,
         });
     }
 }
@@ -450,12 +451,14 @@ fn handle_file_change(
         }
     });
     let sa_str = serde_json::to_string(&synthetic_assistant).unwrap_or_default();
-    let asst_id = item_id.map(|id| format!("codex-patch-asst:{id}"));
+    let asst_id = item_id
+        .map(|id| format!("codex-patch-asst:{id}"))
+        .unwrap_or_else(|| format!("codex-patch-asst:{}", acc.line_count));
     acc.collect_or_replace(
         &sa_str,
         &synthetic_assistant,
         MessageRole::Assistant,
-        asst_id,
+        Some(asst_id.clone()),
     );
 
     if let Some(s) = status {
@@ -481,10 +484,9 @@ fn handle_file_change(
 
     if persist {
         acc.turns.push(CollectedTurn {
-            id: uuid::Uuid::new_v4().to_string(),
+            id: asst_id,
             role: MessageRole::Assistant,
             content_json: raw_line.to_string(),
-            collected_idx: None,
         });
     }
 }
@@ -504,6 +506,9 @@ fn handle_reasoning(
     if text.is_empty() {
         return;
     }
+    let intermediate_id = item_id
+        .map(|id| format!("codex-reasoning:{id}"))
+        .unwrap_or_else(|| format!("codex-reasoning:{}", acc.line_count));
     let synthetic_assistant = serde_json::json!({
         "type": "assistant",
         "message": {
@@ -512,24 +517,23 @@ fn handle_reasoning(
             "content": [{
                 "type": "thinking",
                 "thinking": text,
+                "__part_id": format!("{intermediate_id}:blk:0"),
             }]
         }
     });
     let sa_str = serde_json::to_string(&synthetic_assistant).unwrap_or_default();
-    let intermediate_id = item_id.map(|id| format!("codex-reasoning:{id}"));
     acc.collect_or_replace(
         &sa_str,
         &synthetic_assistant,
         MessageRole::Assistant,
-        intermediate_id,
+        Some(intermediate_id.clone()),
     );
 
     if persist {
         acc.turns.push(CollectedTurn {
-            id: uuid::Uuid::new_v4().to_string(),
+            id: intermediate_id,
             role: MessageRole::Assistant,
             content_json: raw_line.to_string(),
-            collected_idx: None,
         });
     }
 }
@@ -586,12 +590,14 @@ fn handle_web_search(
         }
     });
     let sa_str = serde_json::to_string(&synthetic_assistant).unwrap_or_default();
-    let asst_id = item_id.map(|id| format!("codex-search-asst:{id}"));
+    let asst_id = item_id
+        .map(|id| format!("codex-search-asst:{id}"))
+        .unwrap_or_else(|| format!("codex-search-asst:{}", acc.line_count));
     acc.collect_or_replace(
         &sa_str,
         &synthetic_assistant,
         MessageRole::Assistant,
-        asst_id,
+        Some(asst_id.clone()),
     );
 
     if persist {
@@ -611,10 +617,9 @@ fn handle_web_search(
         acc.collect_or_replace(&sr_str, &synthetic_result, MessageRole::User, user_id);
 
         acc.turns.push(CollectedTurn {
-            id: uuid::Uuid::new_v4().to_string(),
+            id: asst_id,
             role: MessageRole::Assistant,
             content_json: raw_line.to_string(),
-            collected_idx: None,
         });
     }
 }
@@ -653,12 +658,14 @@ fn handle_mcp_tool_call(
         }
     });
     let sa_str = serde_json::to_string(&synthetic_assistant).unwrap_or_default();
-    let asst_id = item_id.map(|id| format!("codex-mcp-asst:{id}"));
+    let asst_id = item_id
+        .map(|id| format!("codex-mcp-asst:{id}"))
+        .unwrap_or_else(|| format!("codex-mcp-asst:{}", acc.line_count));
     acc.collect_or_replace(
         &sa_str,
         &synthetic_assistant,
         MessageRole::Assistant,
-        asst_id,
+        Some(asst_id.clone()),
     );
 
     if matches!(status, Some("completed") | Some("failed")) {
@@ -691,10 +698,9 @@ fn handle_mcp_tool_call(
 
     if persist {
         acc.turns.push(CollectedTurn {
-            id: uuid::Uuid::new_v4().to_string(),
+            id: asst_id,
             role: MessageRole::Assistant,
             content_json: raw_line.to_string(),
-            collected_idx: None,
         });
     }
 }
@@ -744,20 +750,21 @@ fn handle_todo_list(
         }
     });
     let sa_str = serde_json::to_string(&synthetic_assistant).unwrap_or_default();
-    let intermediate_id = item_id.map(|id| format!("codex-todo-msg:{id}"));
+    let intermediate_id = item_id
+        .map(|id| format!("codex-todo-msg:{id}"))
+        .unwrap_or_else(|| format!("codex-todo-msg:{}", acc.line_count));
     acc.collect_or_replace(
         &sa_str,
         &synthetic_assistant,
         MessageRole::Assistant,
-        intermediate_id,
+        Some(intermediate_id.clone()),
     );
 
     if persist {
         acc.turns.push(CollectedTurn {
-            id: uuid::Uuid::new_v4().to_string(),
+            id: intermediate_id,
             role: MessageRole::Assistant,
             content_json: raw_line.to_string(),
-            collected_idx: None,
         });
     }
 }
@@ -774,12 +781,10 @@ fn handle_plan_item(
         "item": item,
     });
     let s = serde_json::to_string(&envelope).unwrap_or_default();
-    acc.collect_or_replace(
-        &s,
-        &envelope,
-        MessageRole::Assistant,
-        item_id.map(|id| format!("codex-plan:{id}")),
-    );
+    let plan_id = item_id
+        .map(|id| format!("codex-plan:{id}"))
+        .unwrap_or_else(|| format!("codex-plan:{}", acc.line_count));
+    acc.collect_or_replace(&s, &envelope, MessageRole::Assistant, Some(plan_id.clone()));
 
     if persist {
         if let Some(text) = item.get("text").and_then(Value::as_str) {
@@ -789,10 +794,9 @@ fn handle_plan_item(
             acc.assistant_text.push_str(text);
         }
         acc.turns.push(CollectedTurn {
-            id: uuid::Uuid::new_v4().to_string(),
+            id: plan_id,
             role: MessageRole::Assistant,
             content_json: raw_line.to_string(),
-            collected_idx: None,
         });
     }
 }
@@ -871,14 +875,14 @@ fn handle_error_item(acc: &mut StreamAccumulator, raw_line: &str, item: &Value, 
         "message": message,
     });
     let s = serde_json::to_string(&synthetic).unwrap_or_default();
-    acc.collect_message(&s, &synthetic, MessageRole::Error, None);
+    let err_id = uuid::Uuid::new_v4().to_string();
+    acc.collect_message(&s, &synthetic, MessageRole::Error, Some(&err_id));
 
     if persist {
         acc.turns.push(CollectedTurn {
-            id: uuid::Uuid::new_v4().to_string(),
+            id: err_id,
             role: MessageRole::Error,
             content_json: raw_line.to_string(),
-            collected_idx: None,
         });
     }
 }

--- a/src-tauri/src/pipeline/accumulator/mod.rs
+++ b/src-tauri/src/pipeline/accumulator/mod.rs
@@ -90,9 +90,12 @@ pub struct StreamAccumulator {
     fallback_thinking: String,
     /// Stable timestamp for the current streaming partial.
     partial_created_at: Option<String>,
-    /// Stable UI message ID for the current in-progress assistant turn.
-    active_partial_id: Option<String>,
-    partial_count: u32,
+    /// DB UUID for the currently in-flight assistant turn. Minted on first
+    /// need (first streaming partial OR first `handle_assistant` of a new
+    /// turn), reused as `IntermediateMessage.id` for every partial / full
+    /// snapshot of that turn AND as `CollectedTurn.id` when the turn flushes.
+    /// Consumed via `take()` by `flush_assistant` / `materialize_partial`.
+    active_turn_id: Option<String>,
     line_count: u64,
 
     // ── Persistence state (replaces Rust ClaudeOutputAccumulator) ────
@@ -106,6 +109,12 @@ pub struct StreamAccumulator {
     usage: AgentUsage,
     /// Raw result JSON line.
     result_json: Option<String>,
+    /// Pre-assigned id for the result (Claude `result` / Codex
+    /// `turn.completed`) row. `handle_result` / codex's `handle_turn_completed`
+    /// mint this up-front and pass it as the `collected[]` id so the DB
+    /// insert done by `persist_result_and_finalize` can reuse the same
+    /// UUID — no post-hoc id sync needed.
+    result_id: Option<String>,
     /// Concatenated assistant text (for persistence finalization).
     assistant_text: String,
     /// Concatenated thinking text (Claude only).
@@ -120,15 +129,11 @@ pub struct StreamAccumulator {
     cur_asst_blocks: Vec<Value>,
     /// Template of the current assistant message (for rebuilding).
     cur_asst_template: Option<Value>,
-
-    // ── ID-unification tracking ────────────────────────────────────
-    /// Index into `collected[]` for the first entry of the current
-    /// pending assistant turn (set on the first `handle_assistant` of a
-    /// new SDK message ID, consumed by `flush_assistant`).
-    pending_turn_collected_idx: Option<usize>,
-    /// Index into `collected[]` for the result message (Claude `result`
-    /// or Codex `turn.completed`), used by `sync_result_id`.
-    result_collected_idx: Option<usize>,
+    /// Running count of content blocks accumulated across all `assistant`
+    /// events of the current turn. Used to assign globally-unique
+    /// `__part_id` indices when the SDK delivers finalized blocks in
+    /// separate per-block `assistant` events (delta-style).
+    cur_asst_block_count: usize,
 
     // ── Codex state ──────────────────────────────────────────────────
     /// Per-item delta accumulation for Codex App Server streaming.
@@ -218,14 +223,14 @@ impl StreamAccumulator {
             fallback_text: String::new(),
             fallback_thinking: String::new(),
             partial_created_at: None,
-            active_partial_id: None,
-            partial_count: 0,
+            active_turn_id: None,
             line_count: 0,
             turns: Vec::new(),
             session_id: None,
             resolved_model: fallback_model.to_string(),
             usage: AgentUsage::default(),
             result_json: None,
+            result_id: None,
             assistant_text: String::new(),
             thinking_text: String::new(),
             saw_text_delta: false,
@@ -233,8 +238,7 @@ impl StreamAccumulator {
             cur_asst_id: None,
             cur_asst_blocks: Vec::new(),
             cur_asst_template: None,
-            pending_turn_collected_idx: None,
-            result_collected_idx: None,
+            cur_asst_block_count: 0,
             codex_items: codex::new_item_states(),
             codex_partial_idx: None,
             codex_turn_started_at: None,
@@ -443,13 +447,16 @@ impl StreamAccumulator {
     /// Build only the trailing partial message (if any streaming content exists).
     /// Returns `None` if there is no active streaming content.
     /// This is the only allocation needed per render cycle.
+    ///
+    /// `_context_key` is retained for API compatibility; stable DB UUIDs
+    /// no longer need a disambiguating context prefix.
     pub fn build_partial(
         &mut self,
-        context_key: &str,
+        _context_key: &str,
         session_id: &str,
     ) -> Option<IntermediateMessage> {
         if !self.blocks.is_empty() {
-            let (partial_id, created_at) = self.get_or_create_partial_identity(context_key);
+            let (partial_id, created_at) = self.get_or_create_turn_identity();
             Some(streaming::build_partial_from_blocks(
                 self, session_id, partial_id, created_at,
             ))
@@ -457,7 +464,7 @@ impl StreamAccumulator {
             let text = self.fallback_text.trim();
             let thinking = self.fallback_thinking.trim();
             if !text.is_empty() || !thinking.is_empty() {
-                let (partial_id, created_at) = self.get_or_create_partial_identity(context_key);
+                let (partial_id, created_at) = self.get_or_create_turn_identity();
                 Some(streaming::build_partial_fallback(
                     self, session_id, partial_id, created_at,
                 ))
@@ -532,27 +539,11 @@ impl StreamAccumulator {
         self.result_json.as_deref()
     }
 
-    /// Propagate pre-assigned turn UUIDs back into the corresponding
-    /// `collected[]` entries so the IDs the frontend sees during streaming
-    /// match the IDs stored in the DB. Call after persisting turns.
-    pub fn sync_persisted_ids(&mut self) {
-        for turn in &self.turns {
-            if let Some(idx) = turn.collected_idx {
-                if idx < self.collected.len() {
-                    self.collected[idx].id = turn.id.clone();
-                }
-            }
-        }
-    }
-
-    /// Propagate the result message's DB row ID into the corresponding
-    /// `collected[]` entry. Call after `persist_result_and_finalize`.
-    pub fn sync_result_id(&mut self, result_id: &str) {
-        if let Some(idx) = self.result_collected_idx {
-            if idx < self.collected.len() {
-                self.collected[idx].id = result_id.to_string();
-            }
-        }
+    /// The id the accumulator used for the current result row — returned
+    /// so `persist_result_and_finalize` can reuse it as the DB row id,
+    /// keeping the live-rendered id and the persisted id identical.
+    pub fn take_result_id(&mut self) -> Option<String> {
+        self.result_id.take()
     }
 
     /// Reclassify any in-flight tool_use as `error` so the adapter's
@@ -649,12 +640,12 @@ impl StreamAccumulator {
     /// message so terminal notices can land after it in the rendered thread.
     /// Used by abort handling, where no final provider `assistant` event will
     /// arrive to consume the partial naturally.
-    pub(super) fn materialize_partial(&mut self, context_key: &str, _session_id: &str) {
+    pub(super) fn materialize_partial(&mut self, _context_key: &str, _session_id: &str) {
         if !self.has_active_partial() {
             return;
         }
 
-        let (partial_id, created_at) = self.get_or_create_partial_identity(context_key);
+        let (partial_id, created_at) = self.get_or_create_turn_identity();
         let partial = if !self.blocks.is_empty() {
             streaming::build_materialized_partial_from_blocks(self, partial_id, created_at)
         } else {
@@ -662,16 +653,18 @@ impl StreamAccumulator {
         };
 
         if let Some(message) = partial {
-            let collected_idx = self.collected.len();
             self.turns.push(CollectedTurn {
-                id: uuid::Uuid::new_v4().to_string(),
+                id: message.id.clone(),
                 role: MessageRole::Assistant,
                 content_json: message.raw_json.clone(),
-                collected_idx: Some(collected_idx),
             });
             self.collected.push(message);
         }
 
+        // Turn UUID has been consumed into turns/collected — drop it here
+        // so the next turn starts fresh. `finalize_blocks` no longer owns
+        // the turn UUID lifecycle.
+        self.active_turn_id = None;
         self.finalize_blocks();
     }
 
@@ -712,9 +705,9 @@ impl StreamAccumulator {
         });
 
         self.line_count += 1;
-        let collected_idx = self.collected.len();
+        let notice_id = uuid::Uuid::new_v4().to_string();
         self.collected.push(IntermediateMessage {
-            id: format!("abort:{}", self.line_count),
+            id: notice_id.clone(),
             role: MessageRole::Error,
             raw_json: NOTICE_JSON.to_string(),
             parsed: Some(parsed),
@@ -722,10 +715,9 @@ impl StreamAccumulator {
             is_streaming: false,
         });
         self.turns.push(CollectedTurn {
-            id: uuid::Uuid::new_v4().to_string(),
+            id: notice_id,
             role: MessageRole::Error,
             content_json: NOTICE_JSON.to_string(),
-            collected_idx: Some(collected_idx),
         });
     }
 
@@ -753,6 +745,8 @@ impl StreamAccumulator {
             .and_then(Value::as_str);
 
         // If we're already batching a different msg_id, flush it first.
+        // `flush_assistant` consumes `active_turn_id` for the OLD turn so
+        // the next mint below produces a fresh UUID for the NEW turn.
         let same_msg_id = self
             .cur_asst_id
             .as_deref()
@@ -761,35 +755,44 @@ impl StreamAccumulator {
             self.flush_assistant();
         }
 
-        // Track the collected[] index of the first entry in this
-        // assistant group so flush_assistant can link the turn to it.
-        if self.pending_turn_collected_idx.is_none() {
-            self.pending_turn_collected_idx = Some(self.collected.len());
-        }
+        // Ensure a turn UUID exists for this batch. If streaming partials
+        // already minted one for this turn it's still in `active_turn_id`
+        // and we reuse it; otherwise we mint here so `collect_message` and
+        // a later `flush_assistant` share a single identifier.
+        let turn_id = self.get_or_create_turn_identity().0;
 
         self.cur_asst_id = msg_id.map(str::to_string);
         self.cur_asst_template = Some(value.clone());
+
+        // The Claude SDK sends each finalized content block as its own
+        // `assistant` event with the SAME msg_id — i.e., delta-style,
+        // not cumulative snapshot. Stamp every block with a globally-
+        // unique `__part_id` derived from the turn UUID + a running
+        // counter so the adapter never falls back to positional synthesis
+        // (which would collide across events that each start at idx 0).
+        let mut stamped_value = value.clone();
         if let Some(blocks) = value
             .get("message")
             .and_then(|m| m.get("content"))
             .and_then(Value::as_array)
         {
-            // The Claude SDK sends each finalized content block as its own
-            // `assistant` event with the SAME msg_id — i.e., delta-style,
-            // not cumulative snapshot. Append, don't replace, so prior
-            // blocks (e.g. a thinking block immediately before a tool_use)
-            // survive into the persisted turn.
-            //
-            // The original code used `cur_asst_blocks = blocks.clone()`
-            // assuming each event carried a complete turn snapshot. That
-            // assumption was wrong, and silently dropped every thinking
-            // block followed by another block of the same turn — DB
-            // inspection from 2026-04 onwards showed zero thinking
-            // blocks in any persisted assistant row.
-            if same_msg_id {
-                self.cur_asst_blocks.extend_from_slice(blocks);
-            } else {
-                self.cur_asst_blocks = blocks.clone();
+            if !same_msg_id {
+                self.cur_asst_blocks.clear();
+                self.cur_asst_block_count = 0;
+            }
+            let mut stamped_blocks = blocks.clone();
+            for (i, block) in stamped_blocks.iter_mut().enumerate() {
+                if let Some(obj) = block.as_object_mut() {
+                    let part_id = format!("{turn_id}:blk:{}", self.cur_asst_block_count + i);
+                    obj.insert("__part_id".to_string(), Value::String(part_id));
+                }
+            }
+            self.cur_asst_block_count += stamped_blocks.len();
+            self.cur_asst_blocks.extend(stamped_blocks.iter().cloned());
+
+            // Also patch the value that goes into collected[] for rendering.
+            if let Some(msg) = stamped_value.get_mut("message") {
+                msg["content"] = Value::Array(stamped_blocks);
             }
         }
 
@@ -797,13 +800,14 @@ impl StreamAccumulator {
         // Finalize streaming blocks and push the full message to collected.
         // Matches TS behavior: always push, never replace.
         // The adapter's merge_adjacent_assistants handles merging.
-        let partial_id = self.active_partial_id.clone();
         self.finalize_blocks();
+        let stamped_raw =
+            serde_json::to_string(&stamped_value).unwrap_or_else(|_| raw_line.to_string());
         self.collect_message(
-            raw_line,
-            value,
+            &stamped_raw,
+            &stamped_value,
             MessageRole::Assistant,
-            partial_id.as_deref(),
+            Some(&turn_id),
         );
 
         // Turn-level failure category → error envelope.
@@ -821,16 +825,17 @@ impl StreamAccumulator {
     fn handle_user(&mut self, raw_line: &str, value: &Value) {
         // Persistence: flush any pending assistant turn
         self.flush_assistant();
-        let collected_idx = self.collected.len();
+        // Pre-mint the UUID so `collected[].id` and `CollectedTurn.id` are
+        // the same string — no more post-hoc `sync_persisted_ids`.
+        let turn_id = uuid::Uuid::new_v4().to_string();
         self.turns.push(CollectedTurn {
-            id: uuid::Uuid::new_v4().to_string(),
+            id: turn_id.clone(),
             role: MessageRole::User,
             content_json: raw_line.to_string(),
-            collected_idx: Some(collected_idx),
         });
 
         // Rendering
-        self.collect_message(raw_line, value, MessageRole::User, None);
+        self.collect_message(raw_line, value, MessageRole::User, Some(&turn_id));
     }
 
     fn handle_result(&mut self, value: &Value, raw_line: &str) {
@@ -846,9 +851,10 @@ impl StreamAccumulator {
         }
         self.result_json = Some(raw_line.to_string());
 
-        // Rendering — track index so sync_result_id can back-fill the DB UUID.
-        self.result_collected_idx = Some(self.collected.len());
-        self.collect_message(raw_line, value, MessageRole::Assistant, None);
+        // Rendering — pre-mint the id so DB and live-render agree.
+        let id = uuid::Uuid::new_v4().to_string();
+        self.result_id = Some(id.clone());
+        self.collect_message(raw_line, value, MessageRole::Assistant, Some(&id));
     }
 
     fn handle_error(&mut self, raw_line: &str, value: &Value) {
@@ -918,29 +924,44 @@ impl StreamAccumulator {
         self.fallback_text.clear();
         self.fallback_thinking.clear();
         self.partial_created_at = None;
-        self.active_partial_id = None;
+        // NOTE: `active_turn_id` is NOT cleared here — a single assistant
+        // turn can span multiple content-block cycles (each emitting its
+        // own `finalize_blocks` + `assistant` event batch), and the turn
+        // UUID must stay stable across all of them. It's consumed only by
+        // `flush_assistant` / `materialize_partial` at true turn boundaries.
     }
 
     fn flush_assistant(&mut self) {
         if self.cur_asst_blocks.is_empty() {
             self.cur_asst_id = None;
-            self.pending_turn_collected_idx = None;
+            self.active_turn_id = None;
+            self.cur_asst_block_count = 0;
             return;
         }
+
+        // Consume the turn UUID that every `collect_message` for this turn
+        // already used — so the persisted row and the live-rendered row
+        // end up with byte-identical ids. Fall back to a fresh UUID only
+        // for the vanishingly rare case of a flush with no prior partial
+        // / assistant event (defensive: shouldn't happen in practice).
+        let turn_id = self
+            .active_turn_id
+            .take()
+            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
 
         if let Some(mut template) = self.cur_asst_template.take() {
             if let Some(message) = template.get_mut("message") {
                 message["content"] = Value::Array(std::mem::take(&mut self.cur_asst_blocks));
             }
             self.turns.push(CollectedTurn {
-                id: uuid::Uuid::new_v4().to_string(),
+                id: turn_id,
                 role: MessageRole::Assistant,
                 content_json: template.to_string(),
-                collected_idx: self.pending_turn_collected_idx.take(),
             });
         }
 
         self.cur_asst_id = None;
+        self.cur_asst_block_count = 0;
     }
 
     pub(super) fn collect_message(
@@ -952,7 +973,7 @@ impl StreamAccumulator {
     ) {
         let id = override_id
             .map(|s| s.to_string())
-            .unwrap_or_else(|| format!("stream:{}:{}", self.line_count, role));
+            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
         let created_at = self.get_partial_created_at();
 
         self.collected.push(IntermediateMessage {
@@ -995,15 +1016,19 @@ impl StreamAccumulator {
         self.partial_created_at.clone().unwrap()
     }
 
-    fn get_or_create_partial_identity(&mut self, context_key: &str) -> (String, String) {
+    /// Mint the turn-wide UUID if none is set yet, and return it alongside
+    /// the turn's stable timestamp. The same pair feeds every streaming
+    /// partial, every `collect_message` for the turn, and ultimately
+    /// `CollectedTurn.id` — so the frontend sees one id from the first
+    /// partial emit through DB commit, without any intermediate swap.
+    ///
+    /// `pub(super)` so the `streaming` submodule can stamp fresh block
+    /// ids derived from the turn UUID at `content_block_start` time.
+    pub(super) fn get_or_create_turn_identity(&mut self) -> (String, String) {
         let created_at = self.get_partial_created_at();
-        if self.active_partial_id.is_none() {
-            self.partial_count += 1;
-            self.active_partial_id = Some(format!(
-                "{context_key}:stream-partial:{}",
-                self.partial_count
-            ));
+        if self.active_turn_id.is_none() {
+            self.active_turn_id = Some(uuid::Uuid::new_v4().to_string());
         }
-        (self.active_partial_id.clone().unwrap(), created_at)
+        (self.active_turn_id.clone().unwrap(), created_at)
     }
 }

--- a/src-tauri/src/pipeline/accumulator/streaming.rs
+++ b/src-tauri/src/pipeline/accumulator/streaming.rs
@@ -13,12 +13,19 @@ use crate::pipeline::types::{IntermediateMessage, MessageRole};
 
 /// Per-content-block streaming state. Indexed by `index` from the
 /// `content_block_start` event so deltas land in the right slot.
+///
+/// Every variant carries a stable `id` minted at `content_block_start`
+/// time — serialized into the partial block JSON as `__part_id` so it
+/// survives round-trips through the DB and lands on the matching
+/// `MessagePart` id field in the adapter.
 #[derive(Debug, Clone)]
 pub(super) enum StreamingBlock {
     Text {
+        id: String,
         text: String,
     },
     Thinking {
+        id: String,
         text: String,
         /// Set to true when content_block_stop arrives.
         done: bool,
@@ -76,11 +83,19 @@ fn handle_block_start(acc: &mut StreamAccumulator, event: &Value) {
         .and_then(Value::as_str)
         .unwrap_or("");
 
+    // Stable `__part_id` derived from the turn UUID and the SDK's
+    // content_block index. The SDK guarantees `index` is stable per
+    // block per message, so the resulting id survives all deltas and
+    // matches what the frontend keys on.
+    let turn_id = acc.get_or_create_turn_identity().0;
+    let part_id = format!("{turn_id}:blk:{index}");
+
     match block_type {
         "text" => {
             acc.blocks.insert(
                 index,
                 StreamingBlock::Text {
+                    id: part_id,
                     text: String::new(),
                 },
             );
@@ -89,6 +104,7 @@ fn handle_block_start(acc: &mut StreamAccumulator, event: &Value) {
             acc.blocks.insert(
                 index,
                 StreamingBlock::Thinking {
+                    id: part_id,
                     text: String::new(),
                     done: false,
                 },
@@ -131,7 +147,7 @@ fn handle_block_delta(acc: &mut StreamAccumulator, event: &Value) {
     let delta_type = delta.get("type").and_then(Value::as_str);
 
     match (block, delta_type) {
-        (StreamingBlock::Text { text }, Some("text_delta")) => {
+        (StreamingBlock::Text { text, .. }, Some("text_delta")) => {
             if let Some(dt) = delta.get("text").and_then(Value::as_str) {
                 text.push_str(dt);
                 // Also accumulate for persistence
@@ -244,16 +260,18 @@ pub(super) fn handle_tool_progress(acc: &mut StreamAccumulator, value: &Value) {
 
 fn append_to_last_text_block(acc: &mut StreamAccumulator, text: &str) {
     for block in acc.blocks.values_mut().rev() {
-        if let StreamingBlock::Text { text: t } = block {
+        if let StreamingBlock::Text { text: t, .. } = block {
             t.push_str(text);
             return;
         }
     }
     // No text block exists — create one
     let idx = acc.blocks.len();
+    let turn_id = acc.get_or_create_turn_identity().0;
     acc.blocks.insert(
         idx,
         StreamingBlock::Text {
+            id: format!("{turn_id}:blk:{idx}"),
             text: text.to_string(),
         },
     );
@@ -267,9 +285,11 @@ fn append_to_last_thinking_block(acc: &mut StreamAccumulator, text: &str) {
         }
     }
     let idx = acc.blocks.len();
+    let turn_id = acc.get_or_create_turn_identity().0;
     acc.blocks.insert(
         idx,
         StreamingBlock::Thinking {
+            id: format!("{turn_id}:blk:{idx}"),
             text: text.to_string(),
             done: false,
         },
@@ -285,20 +305,25 @@ pub(super) fn build_partial_from_blocks(
     let mut content_blocks = Vec::new();
     for block in acc.blocks.values() {
         match block {
-            StreamingBlock::Text { text } => {
+            StreamingBlock::Text { id, text } => {
                 let display = if text.is_empty() {
                     "..."
                 } else {
                     text.as_str()
                 };
-                content_blocks.push(serde_json::json!({"type": "text", "text": display}));
+                content_blocks.push(serde_json::json!({
+                    "type": "text",
+                    "text": display,
+                    "__part_id": id,
+                }));
             }
-            StreamingBlock::Thinking { text, done } => {
+            StreamingBlock::Thinking { id, text, done } => {
                 if !text.is_empty() {
                     content_blocks.push(serde_json::json!({
                         "type": "thinking",
                         "thinking": text,
                         "__is_streaming": !done,
+                        "__part_id": id,
                     }));
                 }
             }
@@ -312,6 +337,8 @@ pub(super) fn build_partial_from_blocks(
                 let input = parsed_input
                     .clone()
                     .unwrap_or_else(|| serde_json::json!({}));
+                // ToolCall's part id is its `tool_use_id` — no separate
+                // `__part_id` needed, adapter reads `tool_call_id` directly.
                 content_blocks.push(serde_json::json!({
                     "type": "tool_use",
                     "id": tool_use_id,
@@ -356,16 +383,21 @@ pub(super) fn build_materialized_partial_from_blocks(
     let mut content_blocks = Vec::new();
     for block in acc.blocks.values() {
         match block {
-            StreamingBlock::Text { text } => {
+            StreamingBlock::Text { id, text } => {
                 if !text.is_empty() {
-                    content_blocks.push(serde_json::json!({"type": "text", "text": text}));
+                    content_blocks.push(serde_json::json!({
+                        "type": "text",
+                        "text": text,
+                        "__part_id": id,
+                    }));
                 }
             }
-            StreamingBlock::Thinking { text, .. } => {
+            StreamingBlock::Thinking { id, text, .. } => {
                 if !text.is_empty() {
                     content_blocks.push(serde_json::json!({
                         "type": "thinking",
                         "thinking": text,
+                        "__part_id": id,
                     }));
                 }
             }
@@ -424,6 +456,13 @@ pub(super) fn build_partial_fallback(
     let thinking = acc.fallback_thinking.trim();
     let display_text = if text.is_empty() { "..." } else { text };
 
+    let thinking_part_id = format!("{partial_id}:blk:0");
+    let text_part_id = if thinking.is_empty() {
+        format!("{partial_id}:blk:0")
+    } else {
+        format!("{partial_id}:blk:1")
+    };
+
     let parsed = if !thinking.is_empty() {
         serde_json::json!({
             "type": "assistant",
@@ -431,8 +470,8 @@ pub(super) fn build_partial_fallback(
                 "type": "message",
                 "role": "assistant",
                 "content": [
-                    {"type": "thinking", "thinking": thinking},
-                    {"type": "text", "text": display_text},
+                    {"type": "thinking", "thinking": thinking, "__part_id": thinking_part_id},
+                    {"type": "text", "text": display_text, "__part_id": text_part_id},
                 ],
             },
             "__streaming": true,
@@ -444,7 +483,7 @@ pub(super) fn build_partial_fallback(
                 "type": "message",
                 "role": "assistant",
                 "content": [
-                    {"type": "text", "text": display_text},
+                    {"type": "text", "text": display_text, "__part_id": text_part_id},
                 ],
             },
             "__streaming": true,
@@ -474,16 +513,20 @@ pub(super) fn build_materialized_partial_fallback(
     }
 
     let mut content = Vec::new();
+    let mut idx = 0;
     if !thinking.is_empty() {
         content.push(serde_json::json!({
             "type": "thinking",
             "thinking": thinking,
+            "__part_id": format!("{partial_id}:blk:{idx}"),
         }));
+        idx += 1;
     }
     if !text.is_empty() {
         content.push(serde_json::json!({
             "type": "text",
             "text": text,
+            "__part_id": format!("{partial_id}:blk:{idx}"),
         }));
     }
 

--- a/src-tauri/src/pipeline/accumulator/tests.rs
+++ b/src-tauri/src/pipeline/accumulator/tests.rs
@@ -971,7 +971,7 @@ fn append_aborted_notice_appends_one_per_call() {
 }
 
 // -----------------------------------------------------------------------
-// ID unification: sync_persisted_ids / sync_result_id
+// ID unification: `collected[].id` == `CollectedTurn.id` by construction
 // -----------------------------------------------------------------------
 
 fn push_assistant_event(acc: &mut StreamAccumulator, msg_id: &str, text: &str) {
@@ -1007,7 +1007,7 @@ fn push_result_event(acc: &mut StreamAccumulator) {
 }
 
 #[test]
-fn sync_persisted_ids_propagates_turn_uuids_to_collected() {
+fn collected_and_turn_ids_match_by_construction() {
     let mut acc = StreamAccumulator::new("claude", "opus");
 
     // assistant turn (msg_id="m1") → collected[0]
@@ -1019,42 +1019,33 @@ fn sync_persisted_ids_propagates_turn_uuids_to_collected() {
     let asst_turn_id = acc.turn_at(0).id.clone();
     let user_turn_id = acc.turn_at(1).id.clone();
 
-    // Before sync: collected IDs are ephemeral stream:N:role
-    assert!(
-        acc.collected()[0].id.starts_with("stream:")
-            || acc.collected()[0].id.contains("stream-partial")
-    );
-    assert!(acc.collected()[1].id.starts_with("stream:"));
-
-    // Sync propagates turn UUIDs
-    acc.sync_persisted_ids();
+    // The new invariant: collected[].id equals the matching CollectedTurn.id
+    // without any post-hoc sync — they were minted together.
     assert_eq!(acc.collected()[0].id, asst_turn_id);
     assert_eq!(acc.collected()[1].id, user_turn_id);
 
-    // UUIDs are valid v4 format
     assert!(uuid::Uuid::parse_str(&asst_turn_id).is_ok());
     assert!(uuid::Uuid::parse_str(&user_turn_id).is_ok());
 }
 
 #[test]
-fn sync_result_id_propagates_to_result_collected_entry() {
+fn result_id_is_exposed_for_db_reuse() {
     let mut acc = StreamAccumulator::new("claude", "opus");
 
     push_assistant_event(&mut acc, "m1", "Thinking...");
     push_result_event(&mut acc);
 
-    // result is the last collected entry
     let result_idx = acc.collected().len() - 1;
-    let old_id = acc.collected()[result_idx].id.clone();
-    assert!(old_id.starts_with("stream:"));
-
-    let fake_db_id = "db-result-uuid-123";
-    acc.sync_result_id(fake_db_id);
-    assert_eq!(acc.collected()[result_idx].id, fake_db_id);
+    let collected_result_id = acc.collected()[result_idx].id.clone();
+    // `take_result_id` hands the accumulator-minted id to
+    // `persist_result_and_finalize` so the DB row key matches.
+    let taken = acc.take_result_id().expect("result id should be recorded");
+    assert_eq!(taken, collected_result_id);
+    assert!(uuid::Uuid::parse_str(&taken).is_ok());
 }
 
 #[test]
-fn sync_persisted_ids_with_multi_block_assistant() {
+fn multi_block_assistant_shares_one_turn_uuid() {
     let mut acc = StreamAccumulator::new("claude", "opus");
 
     // Two assistant events with same msg_id → batched into one turn
@@ -1067,12 +1058,11 @@ fn sync_persisted_ids_with_multi_block_assistant() {
     assert_eq!(acc.turns_len(), 1);
     let turn_id = acc.turn_at(0).id.clone();
 
-    // collected has 2 entries, but the turn maps to the FIRST
+    // Both collected entries share the same turn UUID — they represent
+    // one logical assistant turn split across multiple SDK events.
     assert_eq!(acc.collected().len(), 2);
-    acc.sync_persisted_ids();
     assert_eq!(acc.collected()[0].id, turn_id);
-    // Second entry keeps its original ID (collapse will merge them)
-    assert_ne!(acc.collected()[1].id, turn_id);
+    assert_eq!(acc.collected()[1].id, turn_id);
 }
 
 #[test]
@@ -1084,9 +1074,6 @@ fn deferred_pause_final_snapshot_uses_persisted_turn_id() {
 
     assert_eq!(acc.turns_len(), 1);
     let turn_id = acc.turn_at(0).id.clone();
-    assert_ne!(acc.collected()[0].id, turn_id);
-
-    acc.sync_persisted_ids();
 
     let snapshot = acc.snapshot("ctx", "sess");
     assert_eq!(snapshot.len(), 1);

--- a/src-tauri/src/pipeline/adapter/blocks.rs
+++ b/src-tauri/src/pipeline/adapter/blocks.rs
@@ -59,7 +59,17 @@ pub(super) fn assistant_has_recognized_blocks(parsed: Option<&Value>) -> bool {
     })
 }
 
-pub(super) fn parse_assistant_parts(parsed: Option<&Value>) -> Vec<MessagePart> {
+/// Read the stable part id stamped onto a block by the accumulator
+/// (`__part_id`). Falls back to a deterministic `{msg_id}:blk:{idx}`
+/// synthesis for historical rows written before stable ids landed.
+fn resolve_part_id(obj: &serde_json::Map<String, Value>, msg_id: &str, idx: usize) -> String {
+    obj.get("__part_id")
+        .and_then(Value::as_str)
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| format!("{msg_id}:blk:{idx}"))
+}
+
+pub(super) fn parse_assistant_parts(parsed: Option<&Value>, msg_id: &str) -> Vec<MessagePart> {
     let parsed = match parsed {
         Some(p) => p,
         None => return Vec::new(),
@@ -88,6 +98,7 @@ pub(super) fn parse_assistant_parts(parsed: Option<&Value>) -> Vec<MessagePart> 
                         .and_then(Value::as_bool)
                         .unwrap_or(false);
                     parts.push(MessagePart::Reasoning {
+                        id: resolve_part_id(obj, msg_id, idx),
                         text: text.to_string(),
                         streaming: if is_streaming { Some(true) } else { None },
                     });
@@ -95,6 +106,7 @@ pub(super) fn parse_assistant_parts(parsed: Option<&Value>) -> Vec<MessagePart> 
             }
             "redacted_thinking" => {
                 parts.push(MessagePart::Reasoning {
+                    id: resolve_part_id(obj, msg_id, idx),
                     text: "[Thinking redacted]".to_string(),
                     streaming: None,
                 });
@@ -102,18 +114,22 @@ pub(super) fn parse_assistant_parts(parsed: Option<&Value>) -> Vec<MessagePart> 
             "text" => {
                 if let Some(text) = obj.get("text").and_then(Value::as_str) {
                     parts.push(MessagePart::Text {
+                        id: resolve_part_id(obj, msg_id, idx),
                         text: text.to_string(),
                     });
                 }
             }
             "image" => {
-                if let Some(part) = parse_image_block(obj) {
+                if let Some(part) = parse_image_block(obj, msg_id, idx) {
                     parts.push(part);
                 }
             }
             "document" => {
                 if let Some(text) = parse_document_block(obj) {
-                    parts.push(MessagePart::Text { text });
+                    parts.push(MessagePart::Text {
+                        id: resolve_part_id(obj, msg_id, idx),
+                        text,
+                    });
                 }
             }
             // All Claude server-tool *_tool_result blocks. The block
@@ -152,7 +168,7 @@ pub(super) fn parse_assistant_parts(parsed: Option<&Value>) -> Vec<MessagePart> 
                 let server_name = obj.get("server_name").and_then(Value::as_str).unwrap_or("");
                 let mcp_tool_short = obj.get("name").and_then(Value::as_str).unwrap_or("");
                 let synthesized = format!("mcp__{server_name}__{mcp_tool_short}");
-                push_tool_use(&mut parts, obj, idx, Some(synthesized));
+                push_tool_use(&mut parts, obj, idx, Some(synthesized), msg_id);
             }
             // BetaContainerUploadBlock { file_id }. The user explicitly
             // asked us NOT to render these — model-side container file
@@ -174,13 +190,14 @@ pub(super) fn parse_assistant_parts(parsed: Option<&Value>) -> Vec<MessagePart> 
                     .filter(|s| !s.trim().is_empty())
                     .map(str::to_string);
                 parts.push(MessagePart::SystemNotice {
+                    id: resolve_part_id(obj, msg_id, idx),
                     severity: NoticeSeverity::Info,
                     label: "Context compacted".to_string(),
                     body,
                 });
             }
             "tool_use" | "server_tool_use" => {
-                push_tool_use(&mut parts, obj, idx, None);
+                push_tool_use(&mut parts, obj, idx, None, msg_id);
             }
             _ => {}
         }
@@ -200,6 +217,7 @@ fn push_tool_use(
     obj: &serde_json::Map<String, Value>,
     idx: usize,
     name_override: Option<String>,
+    msg_id: &str,
 ) {
     let args = obj
         .get("input")
@@ -232,7 +250,10 @@ fn push_tool_use(
     // case we fall through to the regular ToolCall.
     if tool_name == "TodoWrite" {
         if let Some(items) = parse_claude_todowrite_items(&args) {
-            parts.push(MessagePart::TodoList { items });
+            parts.push(MessagePart::TodoList {
+                id: resolve_part_id(obj, msg_id, idx),
+                items,
+            });
             return;
         }
     }
@@ -583,7 +604,11 @@ fn attach_mcp_tool_result(parts: &mut [MessagePart], obj: &serde_json::Map<Strin
 /// Recognizes both base64 (`{type: "base64", data, media_type}`) and
 /// url (`{type: "url", url}`) source variants. Returns None for any
 /// shape we can't decode so the parser stays liberal.
-fn parse_image_block(obj: &serde_json::Map<String, Value>) -> Option<MessagePart> {
+fn parse_image_block(
+    obj: &serde_json::Map<String, Value>,
+    msg_id: &str,
+    idx: usize,
+) -> Option<MessagePart> {
     let source = obj.get("source")?.as_object()?;
     let source_type = source.get("type").and_then(Value::as_str);
     match source_type {
@@ -594,6 +619,7 @@ fn parse_image_block(obj: &serde_json::Map<String, Value>) -> Option<MessagePart
                 .and_then(Value::as_str)
                 .map(str::to_string);
             Some(MessagePart::Image {
+                id: resolve_part_id(obj, msg_id, idx),
                 source: ImageSource::Base64 { data },
                 media_type,
             })
@@ -601,6 +627,7 @@ fn parse_image_block(obj: &serde_json::Map<String, Value>) -> Option<MessagePart
         Some("url") => {
             let url = source.get("url").and_then(Value::as_str)?.to_string();
             Some(MessagePart::Image {
+                id: resolve_part_id(obj, msg_id, idx),
                 source: ImageSource::Url { url },
                 media_type: None,
             })

--- a/src-tauri/src/pipeline/adapter/codex_items.rs
+++ b/src-tauri/src/pipeline/adapter/codex_items.rs
@@ -40,6 +40,7 @@ pub(super) fn render_item_completed(
                     id: Some(msg.id.clone()),
                     created_at: Some(msg.created_at.clone()),
                     content: vec![ExtendedMessagePart::Basic(MessagePart::Text {
+                        id: format!("{}:blk:0", msg.id),
                         text: text.to_string(),
                     })],
                     status: Some(MessageStatus {
@@ -113,7 +114,10 @@ fn render_todo_list(msg: &IntermediateMessage, item: &Value, result: &mut Vec<Th
             role: MessageRole::Assistant,
             id: Some(msg.id.clone()),
             created_at: Some(msg.created_at.clone()),
-            content: vec![ExtendedMessagePart::Basic(MessagePart::TodoList { items })],
+            content: vec![ExtendedMessagePart::Basic(MessagePart::TodoList {
+                id: format!("{}:blk:0", msg.id),
+                items,
+            })],
             status: Some(MessageStatus {
                 status_type: "complete".to_string(),
                 reason: Some("stop".to_string()),
@@ -131,6 +135,7 @@ fn render_reasoning(msg: &IntermediateMessage, item: &Value, result: &mut Vec<Th
                 id: Some(msg.id.clone()),
                 created_at: Some(msg.created_at.clone()),
                 content: vec![ExtendedMessagePart::Basic(MessagePart::Reasoning {
+                    id: format!("{}:blk:0", msg.id),
                     text: text.to_string(),
                     streaming: None,
                 })],

--- a/src-tauri/src/pipeline/adapter/grouping.rs
+++ b/src-tauri/src/pipeline/adapter/grouping.rs
@@ -29,11 +29,17 @@ pub(super) fn convert_user_message(
             .and_then(|m| m.get("content"))
             .and_then(Value::as_array)
         {
-            for b in blocks {
+            for (idx, b) in blocks.iter().enumerate() {
                 if let Some(obj) = b.as_object() {
                     if obj.get("type").and_then(Value::as_str) == Some("text") {
                         if let Some(text) = obj.get("text").and_then(Value::as_str) {
+                            let id = obj
+                                .get("__part_id")
+                                .and_then(Value::as_str)
+                                .map(str::to_string)
+                                .unwrap_or_else(|| format!("{}:blk:{idx}", msg.id));
                             parts.push(MessagePart::Text {
+                                id,
                                 text: text.to_string(),
                             });
                         }
@@ -45,6 +51,7 @@ pub(super) fn convert_user_message(
 
     if parts.is_empty() {
         parts.push(MessagePart::Text {
+            id: format!("{}:fallback", msg.id),
             text: extract_fallback(msg),
         });
     }
@@ -61,9 +68,17 @@ pub(super) fn convert_user_message(
 
 /// Split `text` on `@<path>` substrings (longer paths win on overlap),
 /// returning interleaved Text and FileMention parts.
-pub(crate) fn split_user_text_with_files(text: &str, files: &[String]) -> Vec<MessagePart> {
+pub(crate) fn split_user_text_with_files(
+    text: &str,
+    files: &[String],
+    msg_id: &str,
+) -> Vec<MessagePart> {
+    let text_id = |idx: usize| format!("{msg_id}:txt:{idx}");
+    let mention_id = |idx: usize| format!("{msg_id}:mention:{idx}");
+
     if files.is_empty() || text.is_empty() {
         return vec![MessagePart::Text {
+            id: text_id(0),
             text: text.to_string(),
         }];
     }
@@ -94,6 +109,7 @@ pub(crate) fn split_user_text_with_files(text: &str, files: &[String]) -> Vec<Me
 
     if matches.is_empty() {
         return vec![MessagePart::Text {
+            id: text_id(0),
             text: text.to_string(),
         }];
     }
@@ -102,22 +118,29 @@ pub(crate) fn split_user_text_with_files(text: &str, files: &[String]) -> Vec<Me
 
     let mut parts: Vec<MessagePart> = Vec::new();
     let mut cursor = 0usize;
-    for (start, end, path) in matches {
+    let mut text_seq = 0usize;
+    for (mention_seq, (start, end, path)) in matches.into_iter().enumerate() {
         if cursor < start {
             let chunk = &text[cursor..start];
             if !chunk.is_empty() {
                 parts.push(MessagePart::Text {
+                    id: text_id(text_seq),
                     text: chunk.to_string(),
                 });
+                text_seq += 1;
             }
         }
-        parts.push(MessagePart::FileMention { path });
+        parts.push(MessagePart::FileMention {
+            id: mention_id(mention_seq),
+            path,
+        });
         cursor = end;
     }
     if cursor < text.len() {
         let tail = &text[cursor..];
         if !tail.is_empty() {
             parts.push(MessagePart::Text {
+                id: text_id(text_seq),
                 text: tail.to_string(),
             });
         }

--- a/src-tauri/src/pipeline/adapter/labels.rs
+++ b/src-tauri/src/pipeline/adapter/labels.rs
@@ -18,6 +18,7 @@ pub(super) fn make_system(msg: &IntermediateMessage, text: &str) -> ThreadMessag
         id: Some(msg.id.clone()),
         created_at: Some(msg.created_at.clone()),
         content: vec![ExtendedMessagePart::Basic(MessagePart::Text {
+            id: format!("{}:label", msg.id),
             text: text.to_string(),
         })],
         status: None,
@@ -43,7 +44,14 @@ pub(super) fn make_system_notice(
 /// invoked for `status = "rejected"` (the caller hides every other
 /// status), so the output is always a Warning notice describing which
 /// bucket was hit and when it resets.
-pub(super) fn build_rate_limit_notice(parsed: Option<&Value>) -> MessagePart {
+/// Derive a stable id for a single-part system message.
+/// Every builder in this module uses this so the id is a deterministic
+/// function of the owning message id.
+pub(super) fn notice_part_id(msg_id: &str) -> String {
+    format!("{msg_id}:notice")
+}
+
+pub(super) fn build_rate_limit_notice(parsed: Option<&Value>, msg_id: &str) -> MessagePart {
     let info = parsed.and_then(|p| p.get("rate_limit_info"));
     let status = info
         .and_then(|i| i.get("status"))
@@ -71,6 +79,7 @@ pub(super) fn build_rate_limit_notice(parsed: Option<&Value>) -> MessagePart {
     let body = resets_at.map(|ts| format!("Resets at unix {ts}"));
 
     MessagePart::SystemNotice {
+        id: notice_part_id(msg_id),
         severity,
         label,
         body,
@@ -92,6 +101,7 @@ fn format_rate_limit_kind(kind: &str) -> String {
 pub(super) fn build_subagent_notice(
     subtype: Option<&str>,
     parsed: Option<&Value>,
+    msg_id: &str,
 ) -> Option<MessagePart> {
     let parsed = parsed?;
     let description = parsed
@@ -106,16 +116,19 @@ pub(super) fn build_subagent_notice(
 
     match subtype {
         Some("task_started") => Some(MessagePart::SystemNotice {
+            id: notice_part_id(msg_id),
             severity: NoticeSeverity::Info,
             label: "Subagent started".to_string(),
             body: description,
         }),
         Some("task_progress") => Some(MessagePart::SystemNotice {
+            id: notice_part_id(msg_id),
             severity: NoticeSeverity::Info,
             label: "Subagent progress".to_string(),
             body: summary.or(description),
         }),
         Some("task_completed") => Some(MessagePart::SystemNotice {
+            id: notice_part_id(msg_id),
             severity: NoticeSeverity::Info,
             label: "Subagent completed".to_string(),
             body: summary.or(description),
@@ -128,6 +141,7 @@ pub(super) fn build_subagent_notice(
                 _ => (NoticeSeverity::Info, format!("Subagent {status}")),
             };
             Some(MessagePart::SystemNotice {
+                id: notice_part_id(msg_id),
                 severity,
                 label,
                 body: summary.or(description),
@@ -147,7 +161,7 @@ pub(super) fn build_subagent_notice(
 /// reshape-target events (tool_use_summary, local_command_output)
 /// route through this single function so the frontend never has to
 /// distinguish between them.
-pub(super) fn build_system_notice(parsed: Option<&Value>) -> Option<MessagePart> {
+pub(super) fn build_system_notice(parsed: Option<&Value>, msg_id: &str) -> Option<MessagePart> {
     let parsed = parsed?;
     let sub = parsed.get("subtype").and_then(Value::as_str)?;
     match sub {
@@ -157,6 +171,7 @@ pub(super) fn build_system_notice(parsed: Option<&Value>) -> Option<MessagePart>
                 .and_then(Value::as_str)
                 .map(str::to_string);
             Some(MessagePart::SystemNotice {
+                id: notice_part_id(msg_id),
                 severity: NoticeSeverity::Info,
                 label: "Local command output".to_string(),
                 body: content,
@@ -178,13 +193,14 @@ pub(super) fn build_system_notice(parsed: Option<&Value>) -> Option<MessagePart>
                 "Tool output summarized".to_string()
             };
             Some(MessagePart::SystemNotice {
+                id: notice_part_id(msg_id),
                 severity: NoticeSeverity::Info,
                 label,
                 body: Some(summary),
             })
         }
-        "compact_boundary" => Some(build_compact_boundary_notice(parsed)),
-        "api_retry" => Some(build_api_retry_notice(parsed)),
+        "compact_boundary" => Some(build_compact_boundary_notice(parsed, msg_id)),
+        "api_retry" => Some(build_api_retry_notice(parsed, msg_id)),
         _ => None,
     }
 }
@@ -194,7 +210,7 @@ pub(super) fn build_system_notice(parsed: Option<&Value>) -> Option<MessagePart>
 /// just got shorter — Claude-only event, but the rendered shape is
 /// provider-agnostic so a future Codex equivalent can flow through
 /// the same UI.
-fn build_compact_boundary_notice(parsed: &Value) -> MessagePart {
+fn build_compact_boundary_notice(parsed: &Value, msg_id: &str) -> MessagePart {
     let meta = parsed.get("compact_metadata");
     let trigger = meta
         .and_then(|m| m.get("trigger"))
@@ -215,6 +231,7 @@ fn build_compact_boundary_notice(parsed: &Value) -> MessagePart {
         (other, None) => format!("Compacted ({other})"),
     };
     MessagePart::SystemNotice {
+        id: notice_part_id(msg_id),
         severity: NoticeSeverity::Info,
         label: "Context compacted".to_string(),
         body: Some(body),
@@ -225,7 +242,7 @@ fn build_compact_boundary_notice(parsed: &Value) -> MessagePart {
 /// error_status, error }`. Renders as a Warning notice during transient
 /// API failures — Claude-only at the source (Codex retries are
 /// SDK-internal and never surface).
-fn build_api_retry_notice(parsed: &Value) -> MessagePart {
+fn build_api_retry_notice(parsed: &Value, msg_id: &str) -> MessagePart {
     let attempt = parsed.get("attempt").and_then(Value::as_i64).unwrap_or(0);
     let max = parsed
         .get("max_retries")
@@ -251,6 +268,7 @@ fn build_api_retry_notice(parsed: &Value) -> MessagePart {
     body.push_str(&format!(" · {error}"));
 
     MessagePart::SystemNotice {
+        id: notice_part_id(msg_id),
         severity: NoticeSeverity::Warning,
         label: "Retrying".to_string(),
         body: Some(body),

--- a/src-tauri/src/pipeline/adapter/mod.rs
+++ b/src-tauri/src/pipeline/adapter/mod.rs
@@ -143,6 +143,7 @@ fn convert_flat(messages: &[IntermediateMessage]) -> Vec<ThreadMessageLike> {
                     id: Some(msg.id.clone()),
                     created_at: Some(msg.created_at.clone()),
                     content: vec![ExtendedMessagePart::Basic(MessagePart::PromptSuggestion {
+                        id: format!("{}:suggestion", msg.id),
                         text,
                     })],
                     status: None,
@@ -163,7 +164,7 @@ fn convert_flat(messages: &[IntermediateMessage]) -> Vec<ThreadMessageLike> {
         // assistant (by JSON type or by role for plain-text live messages)
         if msg_type == Some("assistant") || (parsed.is_none() && msg.role == MessageRole::Assistant)
         {
-            let mut parts = parse_assistant_parts(parsed);
+            let mut parts = parse_assistant_parts(parsed, &msg.id);
             // Pull the parent_tool_use_id (if any) so we can encode it in
             // the message id below — the grouping pass uses it to attach
             // the child to the EXACT parent Task tool, not whichever
@@ -209,7 +210,10 @@ fn convert_flat(messages: &[IntermediateMessage]) -> Vec<ThreadMessageLike> {
             if parts.is_empty() && !assistant_has_recognized_blocks(parsed) {
                 let fb = extract_fallback(msg);
                 if !fb.is_empty() {
-                    parts.push(MessagePart::Text { text: fb });
+                    parts.push(MessagePart::Text {
+                        id: format!("{}:fallback", msg.id),
+                        text: fb,
+                    });
                 }
             }
 
@@ -278,7 +282,7 @@ fn convert_flat(messages: &[IntermediateMessage]) -> Vec<ThreadMessageLike> {
                         .collect()
                 })
                 .unwrap_or_default();
-            let parts = grouping::split_user_text_with_files(&text, &files);
+            let parts = grouping::split_user_text_with_files(&text, &files, &msg.id);
             result.push(ThreadMessageLike {
                 role: MessageRole::User,
                 id: Some(msg.id.clone()),
@@ -497,7 +501,7 @@ fn convert_system_msg(msg: &IntermediateMessage, out: &mut Vec<ThreadMessageLike
             return;
         }
     }
-    if let Some(part) = build_subagent_notice(sub, parsed) {
+    if let Some(part) = build_subagent_notice(sub, parsed, &msg.id) {
         // Mark with `child:<tool_use_id>:<msg_id>` so the parent-grouping
         // pass folds these notices into the corresponding Task tool
         // call's children block. The tool_use_id field on the SDK
@@ -517,7 +521,7 @@ fn convert_system_msg(msg: &IntermediateMessage, out: &mut Vec<ThreadMessageLike
     // tool_use_summary, local_command_output) flow through a single
     // dispatcher in `labels::build_system_notice`. Adding a new
     // subtype is one match arm, no convert_system_msg edits.
-    if let Some(part) = build_system_notice(parsed) {
+    if let Some(part) = build_system_notice(parsed, &msg.id) {
         out.push(make_system_notice(msg, part));
         return;
     }
@@ -563,7 +567,10 @@ fn convert_rate_limit_msg(msg: &IntermediateMessage, out: &mut Vec<ThreadMessage
         .and_then(|i| i.get("status"))
         .and_then(Value::as_str);
     if status == Some("rejected") {
-        out.push(make_system_notice(msg, build_rate_limit_notice(parsed)));
+        out.push(make_system_notice(
+            msg,
+            build_rate_limit_notice(parsed, &msg.id),
+        ));
     }
 }
 

--- a/src-tauri/src/pipeline/adapter/tests.rs
+++ b/src-tauri/src/pipeline/adapter/tests.rs
@@ -85,7 +85,7 @@ fn claude_document_block_renders_as_text() {
     let result = convert(&messages);
     assert_eq!(result.len(), 1);
     match &result[0].content[0] {
-        ExtendedMessagePart::Basic(MessagePart::Text { text }) => {
+        ExtendedMessagePart::Basic(MessagePart::Text { text, .. }) => {
             assert_eq!(text, "doc body");
         }
         _ => panic!("expected text part"),
@@ -115,7 +115,9 @@ fn claude_image_block_renders_as_image_part() {
     let result = convert(&messages);
     assert_eq!(result.len(), 1);
     match &result[0].content[0] {
-        ExtendedMessagePart::Basic(MessagePart::Image { source, media_type }) => {
+        ExtendedMessagePart::Basic(MessagePart::Image {
+            source, media_type, ..
+        }) => {
             assert_eq!(media_type.as_deref(), Some("image/png"));
             match source {
                 crate::pipeline::types::ImageSource::Base64 { data } => {
@@ -141,7 +143,7 @@ fn codex_turn_failed_renders_as_system_error() {
     let result = convert(&messages);
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].role, MessageRole::System);
-    if let ExtendedMessagePart::Basic(MessagePart::Text { text }) = &result[0].content[0] {
+    if let ExtendedMessagePart::Basic(MessagePart::Text { text, .. }) = &result[0].content[0] {
         assert!(text.contains("rate exceeded"));
     } else {
         panic!("expected text part");
@@ -161,7 +163,7 @@ fn codex_error_event_renders_with_message() {
     let result = convert(&messages);
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].role, MessageRole::System);
-    if let ExtendedMessagePart::Basic(MessagePart::Text { text }) = &result[0].content[0] {
+    if let ExtendedMessagePart::Basic(MessagePart::Text { text, .. }) = &result[0].content[0] {
         assert!(text.contains("stream closed unexpectedly"));
     } else {
         panic!("expected text part");
@@ -230,7 +232,7 @@ fn parse_assistant_with_thinking_and_text() {
     ));
     assert!(matches!(
         &result[0].content[1],
-        ExtendedMessagePart::Basic(MessagePart::Text { text }) if text == "here is my answer"
+        ExtendedMessagePart::Basic(MessagePart::Text { text, .. }) if text == "here is my answer"
     ));
 }
 
@@ -483,7 +485,7 @@ fn interleaved_subagent_children_attach_to_correct_parent() {
         parts
             .iter()
             .filter_map(|p| match p {
-                ExtendedMessagePart::Basic(MessagePart::Text { text }) => Some(text.clone()),
+                ExtendedMessagePart::Basic(MessagePart::Text { text, .. }) => Some(text.clone()),
                 _ => None,
             })
             .collect()
@@ -661,7 +663,7 @@ fn user_text_event_after_assistant_renders_as_user_message() {
     let result = convert(&messages);
     assert_eq!(result.len(), 2);
     assert_eq!(result[1].role, MessageRole::User);
-    if let ExtendedMessagePart::Basic(MessagePart::Text { text }) = &result[1].content[0] {
+    if let ExtendedMessagePart::Basic(MessagePart::Text { text, .. }) = &result[1].content[0] {
         assert_eq!(text, "do the thing");
     } else {
         panic!("expected user text part");
@@ -708,7 +710,7 @@ fn prompt_suggestion_renders_as_system_part() {
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].role, MessageRole::System);
     match &result[0].content[0] {
-        ExtendedMessagePart::Basic(MessagePart::PromptSuggestion { text }) => {
+        ExtendedMessagePart::Basic(MessagePart::PromptSuggestion { text, .. }) => {
             assert_eq!(text, "Try running the tests");
         }
         other => panic!("expected PromptSuggestion, got {other:?}"),
@@ -819,7 +821,7 @@ fn claude_todowrite_collapses_to_todolist_via_convert() {
     let result = convert(&messages);
     assert_eq!(result.len(), 1);
     match &result[0].content[0] {
-        ExtendedMessagePart::Basic(MessagePart::TodoList { items }) => {
+        ExtendedMessagePart::Basic(MessagePart::TodoList { items, .. }) => {
             assert_eq!(items.len(), 3);
             assert_eq!(items[0].text, "Step A");
             assert_eq!(items[0].status, TodoStatus::Completed);
@@ -848,7 +850,7 @@ fn claude_todowrite_streaming_falls_back_to_toolcall() {
             }]
         }
     });
-    let parts = parse_assistant_parts(Some(&parsed));
+    let parts = parse_assistant_parts(Some(&parsed), "test-msg");
     assert_eq!(parts.len(), 1);
     match &parts[0] {
         MessagePart::ToolCall { tool_name, .. } => assert_eq!(tool_name, "TodoWrite"),
@@ -877,10 +879,10 @@ fn parse_assistant_parts_collapses_todowrite() {
             }]
         }
     });
-    let parts = parse_assistant_parts(Some(&parsed));
+    let parts = parse_assistant_parts(Some(&parsed), "test-msg");
     assert_eq!(parts.len(), 1);
     match &parts[0] {
-        MessagePart::TodoList { items } => {
+        MessagePart::TodoList { items, .. } => {
             assert_eq!(items.len(), 1);
             assert_eq!(items[0].text, "X");
             assert_eq!(items[0].status, TodoStatus::Pending);
@@ -914,6 +916,7 @@ fn subagent_task_started_renders_as_notice_with_child_id() {
             severity,
             label,
             body,
+            ..
         }) => {
             assert_eq!(*severity, NoticeSeverity::Info);
             assert_eq!(label, "Subagent started");

--- a/src-tauri/src/pipeline/collapse.rs
+++ b/src-tauri/src/pipeline/collapse.rs
@@ -333,12 +333,14 @@ mod tests {
 
     fn text(t: &str) -> ExtendedMessagePart {
         ExtendedMessagePart::Basic(MessagePart::Text {
+            id: format!("txt-{t}"),
             text: t.to_string(),
         })
     }
 
     fn reasoning(t: &str) -> ExtendedMessagePart {
         ExtendedMessagePart::Basic(MessagePart::Reasoning {
+            id: format!("r-{t}"),
             text: t.to_string(),
             streaming: None,
         })

--- a/src-tauri/src/pipeline/types.rs
+++ b/src-tauri/src/pipeline/types.rs
@@ -106,16 +106,22 @@ pub enum StreamingStatus {
 /// A single content part inside a message.
 ///
 /// Serialized as internally tagged `{"type": "text", ...}`, `{"type": "tool-call", ...}`, etc.
+///
+/// Every variant carries a stable `id` the frontend uses as the React key.
+/// `ToolCall` reuses its SDK-assigned `tool_call_id` (no separate `id` field);
+/// all others carry their own `id`. The `part_id()` accessor hides the
+/// difference so callers that just need "the key for this part" don't branch.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum MessagePart {
     /// Plain text block.
     #[serde(rename = "text")]
-    Text { text: String },
+    Text { id: String, text: String },
 
     /// Extended thinking / reasoning block.
     #[serde(rename = "reasoning")]
     Reasoning {
+        id: String,
         text: String,
         /// Per-part streaming state — only the active thinking block is streaming.
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -153,6 +159,7 @@ pub enum MessagePart {
     /// styled banner.
     #[serde(rename = "system-notice", rename_all = "camelCase")]
     SystemNotice {
+        id: String,
         severity: NoticeSeverity,
         label: String,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -163,13 +170,14 @@ pub enum MessagePart {
     /// Codex (`item.completed` of `todo_list`) collapse into this single
     /// shape so the frontend renders identically across providers.
     #[serde(rename = "todo-list", rename_all = "camelCase")]
-    TodoList { items: Vec<TodoItem> },
+    TodoList { id: String, items: Vec<TodoItem> },
 
     /// Inline image emitted as a content block by the Claude SDK. The
     /// payload is either a base64-encoded blob (with media type) or an
     /// external URL — the frontend renders both with `<img>`.
     #[serde(rename = "image", rename_all = "camelCase")]
     Image {
+        id: String,
         source: ImageSource,
         #[serde(skip_serializing_if = "Option::is_none")]
         media_type: Option<String>,
@@ -179,7 +187,7 @@ pub enum MessagePart {
     /// as a clickable chip — clicking copies the suggestion into the
     /// composer.
     #[serde(rename = "prompt-suggestion", rename_all = "camelCase")]
-    PromptSuggestion { text: String },
+    PromptSuggestion { id: String, text: String },
 
     /// Persisted ExitPlanMode review card. The plan itself needs to live in
     /// the chat thread so users can revisit it later even after the deferred
@@ -198,7 +206,26 @@ pub enum MessagePart {
 
     /// Inline file reference from the composer's @-mention picker.
     #[serde(rename = "file-mention", rename_all = "camelCase")]
-    FileMention { path: String },
+    FileMention { id: String, path: String },
+}
+
+impl MessagePart {
+    /// Stable id used as the React key for this part. Delegates to the
+    /// variant's natural id field (`tool_call_id` for ToolCall,
+    /// `tool_use_id` for PlanReview, `id` for everything else).
+    pub fn part_id(&self) -> &str {
+        match self {
+            Self::Text { id, .. }
+            | Self::Reasoning { id, .. }
+            | Self::SystemNotice { id, .. }
+            | Self::TodoList { id, .. }
+            | Self::Image { id, .. }
+            | Self::PromptSuggestion { id, .. }
+            | Self::FileMention { id, .. } => id,
+            Self::ToolCall { tool_call_id, .. } => tool_call_id,
+            Self::PlanReview { tool_use_id, .. } => tool_use_id,
+        }
+    }
 }
 
 /// Image payload variants. `Base64` carries the raw blob (no `data:` URI
@@ -258,12 +285,18 @@ pub enum CollapseCategory {
 }
 
 /// A collapsed summary replacing consecutive search/read tool calls.
+///
+/// `id` is derived from the first tool's `tool_call_id` (`group:{first_id}`)
+/// so the React key stays stable across renders — the tool IDs don't change
+/// as the group gains members during streaming, so the first-tool-derived
+/// id doesn't either.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CollapsedGroupPart {
     /// Always serialized as `"collapsed-group"`.
     #[serde(rename = "type")]
     pub part_type: String,
+    pub id: String,
     /// Whether this group contains search, read, or both.
     pub category: CollapseCategory,
     /// The original tool-call parts in this group.
@@ -281,8 +314,13 @@ impl CollapsedGroupPart {
         active: bool,
         summary: String,
     ) -> Self {
+        let id = tools
+            .first()
+            .map(|t| format!("group:{}", t.part_id()))
+            .unwrap_or_else(|| "group:empty".to_string());
         Self {
             part_type: "collapsed-group".to_string(),
+            id,
             category,
             tools,
             active,
@@ -301,6 +339,17 @@ impl CollapsedGroupPart {
 pub enum ExtendedMessagePart {
     Basic(MessagePart),
     CollapsedGroup(CollapsedGroupPart),
+}
+
+impl ExtendedMessagePart {
+    /// Stable id for this part. Matches `MessagePart::part_id` for `Basic`
+    /// and the group's own `id` for `CollapsedGroup`.
+    pub fn part_id(&self) -> &str {
+        match self {
+            Self::Basic(part) => part.part_id(),
+            Self::CollapsedGroup(group) => &group.id,
+        }
+    }
 }
 
 /// Completion status of a message.
@@ -355,20 +404,16 @@ pub struct IntermediateMessage {
 ///
 /// Moved here from `agents.rs` so that the pipeline accumulator and the
 /// persistence logic in `agents.rs` share the same type.
+///
+/// The `id` is the DB row key AND the id attached to the matching
+/// `IntermediateMessage` in `collected[]` — they're assigned in lockstep
+/// at turn creation so the frontend sees one stable id from the first
+/// streaming partial through DB commit.
 #[derive(Debug, Clone)]
 pub struct CollectedTurn {
-    /// Pre-assigned ID used as the `session_messages.id` DB row key.
-    /// Generated at turn creation so the same UUID can be propagated
-    /// back to the rendering `collected[]` entry via `sync_persisted_ids`,
-    /// unifying streaming and historical message IDs.
     pub id: String,
     pub role: MessageRole,
     pub content_json: String,
-    /// Index into the accumulator's `collected[]` for the first
-    /// `IntermediateMessage` that this turn maps to. `sync_persisted_ids`
-    /// copies `self.id` into `collected[idx].id` so the frontend cache
-    /// key matches what the historical DB loader produces.
-    pub collected_idx: Option<usize>,
 }
 
 /// Input record for converting historical (DB-persisted) messages through

--- a/src-tauri/tests/common/mod.rs
+++ b/src-tauri/tests/common/mod.rs
@@ -151,10 +151,16 @@ pub fn role_str(role: &MessageRole) -> String {
 
 fn normalize_basic(part: &MessagePart) -> NormPart {
     match part {
-        MessagePart::Text { text } => NormPart::Text {
+        // Part `id` is intentionally omitted from the normalized form so
+        // snapshots stay stable across UUID changes. The stable-id
+        // invariants are covered by dedicated pinning tests that read
+        // `part.part_id()` directly.
+        MessagePart::Text { text, .. } => NormPart::Text {
             text: truncate(text),
         },
-        MessagePart::Reasoning { text, streaming } => NormPart::Reasoning {
+        MessagePart::Reasoning {
+            text, streaming, ..
+        } => NormPart::Reasoning {
             text_length: utf16_len(text),
             text_preview: truncate(text),
             streaming: *streaming,
@@ -210,26 +216,29 @@ fn normalize_basic(part: &MessagePart) -> NormPart {
             severity,
             label,
             body,
+            ..
         } => NormPart::SystemNotice {
             severity: format!("{severity:?}").to_lowercase(),
             label: truncate(label),
             body: body.as_deref().map(truncate),
         },
-        MessagePart::TodoList { items } => NormPart::TodoList {
+        MessagePart::TodoList { items, .. } => NormPart::TodoList {
             item_count: items.len(),
             statuses: items
                 .iter()
                 .map(|i| format!("{:?}", i.status).to_lowercase())
                 .collect(),
         },
-        MessagePart::Image { source, media_type } => NormPart::Image {
+        MessagePart::Image {
+            source, media_type, ..
+        } => NormPart::Image {
             kind: match source {
                 helmor_lib::pipeline::types::ImageSource::Base64 { .. } => "base64".to_string(),
                 helmor_lib::pipeline::types::ImageSource::Url { .. } => "url".to_string(),
             },
             media_type: media_type.clone(),
         },
-        MessagePart::PromptSuggestion { text } => NormPart::PromptSuggestion {
+        MessagePart::PromptSuggestion { text, .. } => NormPart::PromptSuggestion {
             text_length: utf16_len(text),
             text_preview: truncate(text),
         },
@@ -250,7 +259,7 @@ fn normalize_basic(part: &MessagePart) -> NormPart {
                 .map(|entry| entry.tool.clone())
                 .collect(),
         },
-        MessagePart::FileMention { path } => NormPart::FileMention { path: path.clone() },
+        MessagePart::FileMention { path, .. } => NormPart::FileMention { path: path.clone() },
     }
 }
 

--- a/src-tauri/tests/snapshots/pipeline_fixtures__pipeline_fixtures@claude_large_collapse__input.json.snap
+++ b/src-tauri/tests/snapshots/pipeline_fixtures__pipeline_fixtures@claude_large_collapse__input.json.snap
@@ -8,6 +8,7 @@ input_file: tests/fixtures/pipeline/claude_large_collapse/input.json
   createdAt: "2026-01-01T00:00:00.000Z"
   content:
     - type: reasoning
+      id: "uuid_3:blk:0"
       text: ""
     - type: tool-call
       toolCallId: toolu_1
@@ -19,6 +20,7 @@ input_file: tests/fixtures/pipeline/claude_large_collapse/input.json
       result: "EPERM: operation not permitted, mkdir '$CLAUDE_HOME/session-env/uuid_1'"
       isError: true
     - type: collapsed-group
+      id: "group:toolu_2"
       category: mixed
       tools:
         - type: tool-call

--- a/src-tauri/tests/snapshots/pipeline_fixtures__pipeline_fixtures@codex_commits__input.json.snap
+++ b/src-tauri/tests/snapshots/pipeline_fixtures__pipeline_fixtures@codex_commits__input.json.snap
@@ -8,6 +8,7 @@ input_file: tests/fixtures/pipeline/codex_commits/input.json
   createdAt: "2026-01-01T00:00:00.000Z"
   content:
     - type: text
+      id: "uuid_1:blk:0"
       text: "Listing the repository root first, then I’ll summarize the files and directories present."
     - type: tool-call
       toolCallId: codex-cmd-uuid_2
@@ -17,6 +18,7 @@ input_file: tests/fixtures/pipeline/codex_commits/input.json
       argsText: "{\"command\":\"/bin/zsh -lc 'ls -la'\"}"
       result: "total 24\ndrwxr-xr-x@  9 fixture-user  staff  288 Apr 17 14:45 .\ndrwxr-xr-x@  3 fixture-user  staff   96 Apr 17 14:45 ..\ndrwxr-xr-x@ 14 fixture-user  staff  448 Apr 17 14:53 .git\ndrwxr-xr-x@  3 fixture-user  staff   96 Apr 17 14:45 docs\n-rw-r--r--@  1 fixture-user  staff  263 Apr 17 14:45 package.json\n-rw-r--r--@  1 fixture-user  staff   88 Apr 17 14:45 README.md\ndrwxr-xr-x@  3 fixture-user  staff   96 Apr 17 14:45 scripts\ndrwxr-xr-x@  5 fixture-user  staff  160 Apr 17 14:46 src\n-rw-r--r--@  1 fixture-user  staff  238 Apr 17 14:45 tsconfig.json\n"
     - type: text
+      id: "uuid_3:blk:0"
       text: "The repository root contains:\n\n- Directories: `.git`, `docs`, `scripts`, `src`\n- Files: `package.json`, `README.md`, `tsconfig.json`\n\nThis looks like a small TypeScript/Node repo with source code in `src`, supporting scripts in `scripts`, and documentation in `docs`."
   status:
     type: complete

--- a/src-tauri/tests/snapshots/pipeline_fixtures__pipeline_fixtures@codex_reviewer__input.json.snap
+++ b/src-tauri/tests/snapshots/pipeline_fixtures__pipeline_fixtures@codex_reviewer__input.json.snap
@@ -8,6 +8,7 @@ input_file: tests/fixtures/pipeline/codex_reviewer/input.json
   createdAt: "2026-01-01T00:00:00.000Z"
   content:
     - type: text
+      id: "uuid_19:blk:0"
       text: "I’m reading `package.json` directly so I can summarize the defined npm scripts without making any changes."
     - type: tool-call
       toolCallId: codex-cmd-uuid_20
@@ -17,6 +18,7 @@ input_file: tests/fixtures/pipeline/codex_reviewer/input.json
       argsText: "{\"command\":\"/bin/zsh -lc 'cat package.json'\"}"
       result: "{\n\t\"name\": \"fixture-dummy-repo\",\n\t\"version\": \"0.1.0\",\n\t\"private\": true,\n\t\"type\": \"module\",\n\t\"scripts\": {\n\t\t\"build\": \"tsc -p tsconfig.json\",\n\t\t\"lint\": \"node scripts/check-config.mjs\",\n\t\t\"test\": \"node --test\"\n\t},\n\t\"devDependencies\": {\n\t\t\"typescript\": \"^5.8.3\"\n\t}\n}\n"
     - type: text
+      id: "uuid_21:blk:0"
       text: "`package.json` contains three scripts:\n\n- `build`: runs TypeScript compilation with `tsc -p tsconfig.json`.\n- `lint`: runs a custom config check via `node scripts/check-config.mjs`.\n- `test`: runs the Node test runner with `node --test`.\n\nThe file also marks the package as private, uses ESM (`\"type\": \"module\"`), and only lists `typescript` as a dev dependency."
   status:
     type: complete

--- a/src-tauri/tests/snapshots/pipeline_fixtures__pipeline_fixtures@schedule_fetch__input.json.snap
+++ b/src-tauri/tests/snapshots/pipeline_fixtures__pipeline_fixtures@schedule_fetch__input.json.snap
@@ -8,6 +8,7 @@ input_file: tests/fixtures/pipeline/schedule_fetch/input.json
   createdAt: "2026-01-01T00:00:00.000Z"
   content:
     - type: reasoning
+      id: "uuid_22:blk:0"
       text: ""
     - type: tool-call
       toolCallId: toolu_1
@@ -18,6 +19,7 @@ input_file: tests/fixtures/pipeline/schedule_fetch/input.json
       argsText: "{\"max_results\":1,\"query\":\"select:TodoWrite\"}"
       result: ""
     - type: todo-list
+      id: "uuid_24:blk:0"
       items:
         - text: "Audit src-tauri/tests/fixtures/ for PII, tokens, absolute paths, and real identifiers"
           status: pending

--- a/src-tauri/tests/snapshots/pipeline_fixtures__pipeline_fixtures@small_chat_claude__input.json.snap
+++ b/src-tauri/tests/snapshots/pipeline_fixtures__pipeline_fixtures@small_chat_claude__input.json.snap
@@ -8,6 +8,7 @@ input_file: tests/fixtures/pipeline/small_chat_claude/input.json
   createdAt: "2026-01-01T00:00:01.000Z"
   content:
     - type: text
+      id: "hist-2:blk:0"
       text: Fixture smoke test.
   status:
     type: complete

--- a/src-tauri/tests/stable_part_ids.rs
+++ b/src-tauri/tests/stable_part_ids.rs
@@ -1,0 +1,432 @@
+//! Pinning tests for the stable-part-id invariant.
+//!
+//! Backs the guarantee the frontend relies on: every rendered part
+//! carries an id that stays equal to itself across
+//! - multiple streaming partials for the same block,
+//! - block boundaries within the same turn,
+//! - the partial → final transition at turn commit,
+//! - the live → historical reload round-trip.
+//!
+//! If any of these assertions break, `<Reasoning>` (and every other
+//! part with state) will start remounting mid-stream again — the exact
+//! regression the stable-id refactor exists to prevent.
+
+mod common;
+
+use common::*;
+use helmor_lib::pipeline::types::{ExtendedMessagePart, MessagePart};
+use serde_json::{json, Value};
+
+/// Feed an event and return the fully rendered thread snapshot.
+///
+/// `Partial` only carries the trailing streaming message; we call
+/// `finish()` after each event so the assertions can always reach every
+/// message — the partial id lives on the last entry of the returned Vec.
+fn push_and_render(pipeline: &mut MessagePipeline, event: Value) -> Vec<ThreadMessageLike> {
+    let line = serde_json::to_string(&event).unwrap();
+    let _ = pipeline.push_event(&event, &line);
+    pipeline.finish()
+}
+
+/// Pull the last assistant message's first `Reasoning` part's id out of a
+/// rendered snapshot. Returns `None` if the shape isn't what we expect.
+fn last_reasoning_id(messages: &[ThreadMessageLike]) -> Option<String> {
+    let last = messages.last()?;
+    for part in &last.content {
+        if let ExtendedMessagePart::Basic(MessagePart::Reasoning { id, .. }) = part {
+            return Some(id.clone());
+        }
+    }
+    None
+}
+
+/// Pull the last assistant message's first `Text` part's id.
+fn last_text_id(messages: &[ThreadMessageLike]) -> Option<String> {
+    let last = messages.last()?;
+    for part in &last.content {
+        if let ExtendedMessagePart::Basic(MessagePart::Text { id, .. }) = part {
+            return Some(id.clone());
+        }
+    }
+    None
+}
+
+#[test]
+fn reasoning_id_is_stable_across_deltas_and_block_boundary() {
+    let mut pipeline = MessagePipeline::new("claude", "opus", "ctx", "sess");
+
+    // content_block_start for a thinking block at index 0.
+    push_and_render(
+        &mut pipeline,
+        json!({
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": { "type": "thinking", "thinking": "" }
+            }
+        }),
+    );
+
+    // First delta — the reasoning part should appear.
+    let msgs_after_delta_1 = push_and_render(
+        &mut pipeline,
+        json!({
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": { "type": "thinking_delta", "thinking": "Let me " }
+            }
+        }),
+    );
+    let id_after_delta_1 = last_reasoning_id(&msgs_after_delta_1)
+        .expect("reasoning part should be present after first thinking delta");
+
+    // Second delta — same block, same id.
+    let msgs_after_delta_2 = push_and_render(
+        &mut pipeline,
+        json!({
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": { "type": "thinking_delta", "thinking": "think about this." }
+            }
+        }),
+    );
+    let id_after_delta_2 = last_reasoning_id(&msgs_after_delta_2)
+        .expect("reasoning part should be present after second delta");
+    assert_eq!(
+        id_after_delta_1, id_after_delta_2,
+        "reasoning id must not change between deltas of the same block",
+    );
+
+    // content_block_stop for the thinking block.
+    push_and_render(
+        &mut pipeline,
+        json!({
+            "type": "stream_event",
+            "event": { "type": "content_block_stop", "index": 0 }
+        }),
+    );
+
+    // Start a NEW content block (text) at index 1 — reasoning is now
+    // "done" but stays in the rendered output with the same id.
+    push_and_render(
+        &mut pipeline,
+        json!({
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_start",
+                "index": 1,
+                "content_block": { "type": "text" }
+            }
+        }),
+    );
+
+    let msgs_after_text_start = push_and_render(
+        &mut pipeline,
+        json!({
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "index": 1,
+                "delta": { "type": "text_delta", "text": "Here is the answer." }
+            }
+        }),
+    );
+    let id_after_block_boundary = last_reasoning_id(&msgs_after_text_start)
+        .expect("reasoning part should survive when a following text block starts");
+    assert_eq!(
+        id_after_delta_2, id_after_block_boundary,
+        "reasoning id must stay stable after the thinking block completes and a text block begins",
+    );
+
+    // The text part has its own id, different from the reasoning id.
+    let text_id =
+        last_text_id(&msgs_after_text_start).expect("text part should be present after text_delta");
+    assert_ne!(
+        text_id, id_after_block_boundary,
+        "text and reasoning parts must have distinct ids"
+    );
+
+    // Finalize the turn with an `assistant` event carrying both blocks.
+    let msgs_after_assistant = push_and_render(
+        &mut pipeline,
+        json!({
+            "type": "assistant",
+            "message": {
+                "id": "msg_pin_1",
+                "role": "assistant",
+                "content": [
+                    { "type": "thinking", "thinking": "Let me think about this." },
+                    { "type": "text", "text": "Here is the answer." },
+                ]
+            }
+        }),
+    );
+    let id_after_commit = last_reasoning_id(&msgs_after_assistant)
+        .expect("reasoning part should be present after assistant commit");
+    assert_eq!(
+        id_after_block_boundary, id_after_commit,
+        "reasoning id must stay stable across the partial → final transition at turn commit",
+    );
+}
+
+#[test]
+fn message_id_does_not_flip_between_partial_and_final() {
+    let mut pipeline = MessagePipeline::new("claude", "opus", "ctx", "sess");
+
+    // Kick off a streaming partial.
+    push_and_render(
+        &mut pipeline,
+        json!({
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": { "type": "text" }
+            }
+        }),
+    );
+    let partial_snapshot = push_and_render(
+        &mut pipeline,
+        json!({
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": { "type": "text_delta", "text": "Hello" }
+            }
+        }),
+    );
+    let partial_msg_id = partial_snapshot
+        .last()
+        .and_then(|m| m.id.clone())
+        .expect("partial should have a message id");
+
+    // Finalize with the matching assistant event.
+    let final_snapshot = push_and_render(
+        &mut pipeline,
+        json!({
+            "type": "assistant",
+            "message": {
+                "id": "msg_stable_1",
+                "role": "assistant",
+                "content": [{ "type": "text", "text": "Hello" }]
+            }
+        }),
+    );
+    let final_msg_id = final_snapshot
+        .last()
+        .and_then(|m| m.id.clone())
+        .expect("final render should have a message id");
+
+    assert_eq!(
+        partial_msg_id, final_msg_id,
+        "assistant message id must stay stable between partial and final — no more `stream-partial:N` → DB-UUID swap",
+    );
+
+    // And the same id must be used for the persisted turn.
+    pipeline.accumulator.flush_pending();
+    assert_eq!(pipeline.accumulator.turns_len(), 1);
+    assert_eq!(
+        pipeline.accumulator.turn_at(0).id,
+        final_msg_id,
+        "CollectedTurn.id must match the live-rendered message id",
+    );
+}
+
+#[test]
+fn part_id_roundtrips_through_historical_reload() {
+    let mut pipeline = MessagePipeline::new("claude", "opus", "ctx", "sess");
+
+    push_and_render(
+        &mut pipeline,
+        json!({
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": { "type": "thinking", "thinking": "" }
+            }
+        }),
+    );
+    let live_snapshot = push_and_render(
+        &mut pipeline,
+        json!({
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": { "type": "thinking_delta", "thinking": "stable" }
+            }
+        }),
+    );
+    let live_reasoning_id = last_reasoning_id(&live_snapshot).expect("reasoning present live");
+
+    push_and_render(
+        &mut pipeline,
+        json!({
+            "type": "assistant",
+            "message": {
+                "id": "msg_round_1",
+                "role": "assistant",
+                "content": [{ "type": "thinking", "thinking": "stable" }]
+            }
+        }),
+    );
+    pipeline.accumulator.flush_pending();
+
+    // Simulate historical reload by feeding the persisted turn's JSON
+    // back through `convert_historical`. The DB would hand us the same
+    // `content_json` the accumulator just serialized.
+    let turn = pipeline.accumulator.turn_at(0).clone();
+    let record = HistoricalRecord {
+        id: turn.id.clone(),
+        role: turn.role,
+        content: turn.content_json.clone(),
+        parsed_content: serde_json::from_str(&turn.content_json).ok(),
+        created_at: "2026-04-20T00:00:00.000Z".to_string(),
+    };
+    let historical = MessagePipeline::convert_historical(&[record]);
+    let historical_reasoning_id =
+        last_reasoning_id(&historical).expect("reasoning present on reload");
+
+    assert_eq!(
+        live_reasoning_id, historical_reasoning_id,
+        "reasoning id must survive the persist → historical-reload round-trip",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Multi-assistant-event merge (high-risk regression pinning)
+// ---------------------------------------------------------------------------
+
+/// Collect all part ids from every assistant message in a rendered snapshot.
+fn collect_all_part_ids(messages: &[ThreadMessageLike]) -> Vec<String> {
+    let mut ids = Vec::new();
+    for msg in messages {
+        if msg.role != helmor_lib::pipeline::types::MessageRole::Assistant {
+            continue;
+        }
+        for part in &msg.content {
+            ids.push(part.part_id().to_string());
+        }
+    }
+    ids
+}
+
+#[test]
+fn multi_assistant_event_same_msgid_no_duplicate_part_ids() {
+    // Claude SDK sends finalized content blocks as separate `assistant`
+    // events with the SAME msg_id. Each event's content array starts at
+    // index 0, so positional synthesis would collide. This test pins that
+    // the accumulator stamps unique `__part_id` across events.
+    let mut pipeline = MessagePipeline::new("claude", "opus", "ctx", "sess");
+
+    // Event 1: thinking block
+    push_and_render(
+        &mut pipeline,
+        json!({
+            "type": "assistant",
+            "message": {
+                "id": "m1",
+                "role": "assistant",
+                "content": [{"type": "thinking", "thinking": "deep thought"}]
+            }
+        }),
+    );
+
+    // Event 2: text block — same msg_id, content starts at idx 0 again
+    push_and_render(
+        &mut pipeline,
+        json!({
+            "type": "assistant",
+            "message": {
+                "id": "m1",
+                "role": "assistant",
+                "content": [{"type": "text", "text": "here is the answer"}]
+            }
+        }),
+    );
+
+    // Force flush so the turn is committed.
+    pipeline.accumulator.flush_pending();
+
+    // Re-render the full thread.
+    let rendered = pipeline.finish();
+    let ids = collect_all_part_ids(&rendered);
+
+    // Must have at least 2 parts (reasoning + text), all unique.
+    assert!(
+        ids.len() >= 2,
+        "expected at least reasoning + text, got {ids:?}",
+    );
+    let unique: std::collections::HashSet<&String> = ids.iter().collect();
+    assert_eq!(
+        ids.len(),
+        unique.len(),
+        "part ids must be unique across merged assistant events, got duplicates: {ids:?}",
+    );
+
+    // Historical reload must produce the same ids.
+    let turn = pipeline.accumulator.turn_at(0).clone();
+    let record = HistoricalRecord {
+        id: turn.id.clone(),
+        role: turn.role,
+        content: turn.content_json.clone(),
+        parsed_content: serde_json::from_str(&turn.content_json).ok(),
+        created_at: "2026-04-20T00:00:00.000Z".to_string(),
+    };
+    let historical = MessagePipeline::convert_historical(&[record]);
+    let hist_ids = collect_all_part_ids(&historical);
+    assert_eq!(
+        ids, hist_ids,
+        "part ids must be identical between live render and historical reload",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Codex reasoning round-trip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn codex_reasoning_id_roundtrips_through_historical_reload() {
+    let mut pipeline = MessagePipeline::new("codex", "codex-mini", "ctx", "sess");
+
+    // Simulate a Codex reasoning item.completed event.
+    push_and_render(
+        &mut pipeline,
+        json!({
+            "type": "item/completed",
+            "item": {
+                "id": "reason_42",
+                "type": "reasoning",
+                "text": "analyzing the request"
+            }
+        }),
+    );
+
+    let live = pipeline.finish();
+    let live_id = last_reasoning_id(&live).expect("reasoning part should be present live");
+
+    // Historical reload: the DB stores the raw item.completed event.
+    assert!(pipeline.accumulator.turns_len() >= 1);
+    let turn = pipeline.accumulator.turn_at(0).clone();
+    let record = HistoricalRecord {
+        id: turn.id.clone(),
+        role: turn.role,
+        content: turn.content_json.clone(),
+        parsed_content: serde_json::from_str(&turn.content_json).ok(),
+        created_at: "2026-04-20T00:00:00.000Z".to_string(),
+    };
+    let historical = MessagePipeline::convert_historical(&[record]);
+    let hist_id = last_reasoning_id(&historical).expect("reasoning present on historical reload");
+
+    assert_eq!(
+        live_id, hist_id,
+        "Codex reasoning part id must survive the live → DB → historical round-trip",
+    );
+}

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -671,6 +671,7 @@ describe("App", () => {
 			content: [
 				{
 					type: "text" as const,
+					id: `assistant-${index}:txt:0`,
 					text: `message ${index} `.repeat(8),
 				},
 			],

--- a/src/features/conversation/streaming-tail-collapse.test.ts
+++ b/src/features/conversation/streaming-tail-collapse.test.ts
@@ -77,6 +77,7 @@ describe("stabilizeStreamingMessages", () => {
 				[
 					{
 						type: "collapsed-group",
+						id: "group:cmd1",
 						category: "shell",
 						active: true,
 						summary: "Running 2 read-only commands...",
@@ -107,7 +108,13 @@ describe("stabilizeStreamingMessages", () => {
 			assistant("a1", [toolCall("cmd1", "cat src/App.tsx")], true),
 			assistant(
 				"a2",
-				[{ type: "text", text: "Let me inspect another file." }],
+				[
+					{
+						type: "text",
+						id: "a2:txt:0",
+						text: "Let me inspect another file.",
+					},
+				],
 				true,
 			),
 			assistant(

--- a/src/features/conversation/streaming-tail-collapse.ts
+++ b/src/features/conversation/streaming-tail-collapse.ts
@@ -255,12 +255,25 @@ function buildCollapsedGroup(
 					? "shell"
 					: "read";
 
+	// Mirror Rust `collapse.rs`: only active when streaming AND the last
+	// tool has no result yet. The caller's `active` flag means "the
+	// overall message is still streaming", but the spinner should stop
+	// once every tool in the group has finished.
+	const lastToolDone =
+		tools.length > 0 && tools[tools.length - 1]!.result != null;
+	const groupActive = active && !lastToolDone;
+
+	// Derive a stable id from the first tool's id — mirrors the Rust
+	// `CollapsedGroupPart::new` so backend- and frontend-collapsed groups
+	// agree on the React key.
+	const firstId = tools[0]?.toolCallId ?? "empty";
 	return {
 		type: "collapsed-group",
+		id: `group:${firstId}`,
 		category,
 		tools,
-		active,
-		summary: buildGroupSummary(tools, active),
+		active: groupActive,
+		summary: buildGroupSummary(tools, groupActive),
 	};
 }
 

--- a/src/features/panel/container.share.test.ts
+++ b/src/features/panel/container.share.test.ts
@@ -69,8 +69,8 @@ function taskCallMessage(
 	};
 }
 
-function textPart(text: string): ExtendedMessagePart {
-	return { type: "text", text };
+function textPart(text: string, id = `txt-${text}`): ExtendedMessagePart {
+	return { type: "text", id, text };
 }
 
 describe("messagesStructurallyEqual — Task children payloads", () => {
@@ -171,11 +171,13 @@ describe("partStructurallyEqual — direct branch coverage", () => {
 	it("treats reasoning parts equal when text and streaming match", () => {
 		const a: ExtendedMessagePart = {
 			type: "reasoning",
+			id: "r1",
 			text: "Considering the request",
 			streaming: false,
 		};
 		const b: ExtendedMessagePart = {
 			type: "reasoning",
+			id: "r1",
 			text: "Considering the request",
 			streaming: false,
 		};
@@ -183,8 +185,16 @@ describe("partStructurallyEqual — direct branch coverage", () => {
 	});
 
 	it("invalidates reasoning parts when text differs", () => {
-		const a: ExtendedMessagePart = { type: "reasoning", text: "first" };
-		const b: ExtendedMessagePart = { type: "reasoning", text: "second" };
+		const a: ExtendedMessagePart = {
+			type: "reasoning",
+			id: "r1",
+			text: "first",
+		};
+		const b: ExtendedMessagePart = {
+			type: "reasoning",
+			id: "r1",
+			text: "second",
+		};
 		expect(partStructurallyEqual(a, b)).toBe(false);
 	});
 
@@ -195,11 +205,13 @@ describe("partStructurallyEqual — direct branch coverage", () => {
 		// indicator on the post-completion render.
 		const a: ExtendedMessagePart = {
 			type: "reasoning",
+			id: "r1",
 			text: "same body",
 			streaming: true,
 		};
 		const b: ExtendedMessagePart = {
 			type: "reasoning",
+			id: "r1",
 			text: "same body",
 			streaming: false,
 		};
@@ -211,6 +223,7 @@ describe("partStructurallyEqual — direct branch coverage", () => {
 	): CollapsedGroupPart {
 		return {
 			type: "collapsed-group",
+			id: "group:tc1",
 			active: false,
 			category: "read",
 			summary: "Read 3 files",
@@ -359,7 +372,7 @@ describe("shareMessages — structural reference reuse", () => {
 			role: "user",
 			id,
 			createdAt: "2026-04-08T00:00:00Z",
-			content: [{ type: "text", text }],
+			content: [{ type: "text", id: `${id}:txt:0`, text }],
 		};
 	}
 

--- a/src/features/panel/message-components.test.tsx
+++ b/src/features/panel/message-components.test.tsx
@@ -88,8 +88,17 @@ describe("MemoConversationMessage plan review", () => {
 			role: "assistant",
 			createdAt: "2026-04-12T12:00:00.000Z",
 			content: [
-				{ type: "reasoning", text: "internal notes", streaming: false },
-				{ type: "text", text: "Final answer line 1" },
+				{
+					type: "reasoning",
+					id: "assistant-copy-1:blk:0",
+					text: "internal notes",
+					streaming: false,
+				},
+				{
+					type: "text",
+					id: "assistant-copy-1:blk:1",
+					text: "Final answer line 1",
+				},
 				{
 					type: "tool-call",
 					toolCallId: "tool-1",
@@ -98,7 +107,11 @@ describe("MemoConversationMessage plan review", () => {
 					argsText: '{"cmd":"date"}',
 					result: "Thu Apr 16",
 				},
-				{ type: "text", text: "Final answer line 2" },
+				{
+					type: "text",
+					id: "assistant-copy-1:blk:3",
+					text: "Final answer line 2",
+				},
 			],
 		};
 		expect(serializeMessageForClipboard(message)).toBe(
@@ -114,11 +127,16 @@ describe("MemoConversationMessage plan review", () => {
 			content: [
 				{
 					type: "system-notice",
+					id: "system-copy-1:notice",
 					severity: "warning",
 					label: "Paused",
 					body: "Waiting for input",
 				},
-				{ type: "prompt-suggestion", text: "Continue" },
+				{
+					type: "prompt-suggestion",
+					id: "system-copy-1:suggestion",
+					text: "Continue",
+				},
 			],
 		};
 
@@ -132,7 +150,13 @@ describe("MemoConversationMessage plan review", () => {
 			id: "assistant-copy-source",
 			role: "assistant",
 			createdAt: "2026-04-12T11:59:00.000Z",
-			content: [{ type: "text", text: "Real assistant reply" }],
+			content: [
+				{
+					type: "text",
+					id: "assistant-copy-source:txt:0",
+					text: "Real assistant reply",
+				},
+			],
 		};
 		const systemMessage: ThreadMessageLike = {
 			id: "assistant-meta-row",
@@ -141,6 +165,7 @@ describe("MemoConversationMessage plan review", () => {
 			content: [
 				{
 					type: "system-notice",
+					id: "assistant-meta-row:notice",
 					severity: "warning",
 					label: "aborted by user",
 				},

--- a/src/features/panel/message-components/assistant-message.tsx
+++ b/src/features/panel/message-components/assistant-message.tsx
@@ -5,7 +5,11 @@ import {
 	ReasoningContent,
 	ReasoningTrigger,
 } from "@/components/ai/reasoning";
-import type { ExtendedMessagePart, ToolCallPart } from "@/lib/api";
+import {
+	type ExtendedMessagePart,
+	partKey,
+	type ToolCallPart,
+} from "@/lib/api";
 import { useSettings } from "@/lib/settings";
 import { cn } from "@/lib/utils";
 import { ImageBlock, PlanReviewCard, TodoList } from "./content-parts";
@@ -150,22 +154,16 @@ export function ChatAssistantMessage({
 			data-message-role="assistant"
 			className="flex min-w-0 max-w-full flex-col gap-1"
 		>
-			{parts.map((part, index) => {
+			{parts.map((part) => {
+				const key = partKey(part);
 				if (isTextPart(part)) {
 					return (
-						<AssistantText
-							key={`text:${index}`}
-							text={part.text}
-							streaming={streaming}
-						/>
+						<AssistantText key={key} text={part.text} streaming={streaming} />
 					);
 				}
 				if (isReasoningPart(part)) {
 					return (
-						<Reasoning
-							key={`reasoning:${index}`}
-							isStreaming={part.streaming === true}
-						>
+						<Reasoning key={key} isStreaming={part.streaming === true}>
 							<ReasoningTrigger />
 							<ReasoningContent fontSize={settings.fontSize}>
 								{part.text}
@@ -174,17 +172,12 @@ export function ChatAssistantMessage({
 					);
 				}
 				if (isCollapsedGroupPart(part)) {
-					return (
-						<CollapsedToolGroup
-							key={`group-${part.tools[0]?.toolCallId ?? index}`}
-							group={part}
-						/>
-					);
+					return <CollapsedToolGroup key={key} group={part} />;
 				}
 				if (isToolCallPart(part)) {
 					return (
 						<AssistantToolCall
-							key={`tc:${part.toolCallId ?? `${part.toolName}:${index}`}`}
+							key={key}
 							toolName={part.toolName}
 							args={part.args}
 							result={part.result}
@@ -199,18 +192,13 @@ export function ChatAssistantMessage({
 					);
 				}
 				if (isTodoListPart(part)) {
-					return <TodoList key={`todo:${index}`} part={part} />;
+					return <TodoList key={key} part={part} />;
 				}
 				if (isImagePart(part)) {
-					return <ImageBlock key={`img:${index}`} part={part} />;
+					return <ImageBlock key={key} part={part} />;
 				}
 				if (isPlanReviewPart(part)) {
-					return (
-						<PlanReviewCard
-							key={`plan-review:${part.toolUseId}:${index}`}
-							part={part}
-						/>
-					);
+					return <PlanReviewCard key={key} part={part} />;
 				}
 				return null;
 			})}

--- a/src/features/panel/message-components/system-message.tsx
+++ b/src/features/panel/message-components/system-message.tsx
@@ -41,11 +41,13 @@ function SystemNotice({ part }: { part: SystemNoticePart }) {
 				? "text-chart-5"
 				: "text-chart-3";
 	return (
-		<span className="inline-flex items-center gap-1">
+		<span className="inline-flex items-center gap-1 whitespace-nowrap">
 			<Icon className={cn("size-3 shrink-0", iconClass)} strokeWidth={1.8} />
 			<span>{part.label}</span>
 			{part.body ? (
-				<span className="ml-1 text-muted-foreground/70">- {part.body}</span>
+				<span className="ml-1 truncate text-muted-foreground/70">
+					- {part.body}
+				</span>
 			) : null}
 		</span>
 	);

--- a/src/features/panel/message-components/tool-call.tsx
+++ b/src/features/panel/message-components/tool-call.tsx
@@ -15,7 +15,11 @@ import {
 	ReasoningTrigger,
 } from "@/components/ai/reasoning";
 import { Button } from "@/components/ui/button";
-import type { ExtendedMessagePart, ToolCallPart } from "@/lib/api";
+import {
+	type ExtendedMessagePart,
+	partKey,
+	type ToolCallPart,
+} from "@/lib/api";
 import { childrenStructurallyEqual } from "@/lib/structural-equality";
 import { cn } from "@/lib/utils";
 import { TodoList } from "./content-parts";
@@ -507,7 +511,7 @@ const AgentChildrenBlock = memo(function AgentChildrenBlock({
 	const hiddenCount = parts.length - collapsedVisibleCount;
 	const hasMore =
 		toolCallParts.length >= AGENT_PREVIEW_STEPS && hiddenCount > 0;
-	const canToggle = hasMore && (expanded || !streaming);
+	const canToggle = hasMore;
 
 	return (
 		<div className="flex flex-col">
@@ -555,11 +559,12 @@ const AgentChildrenBlock = memo(function AgentChildrenBlock({
 				) : null}
 
 				<div className="flex flex-col gap-0.5">
-					{visibleParts.map((part, index) => {
+					{visibleParts.map((part) => {
+						const key = partKey(part);
 						if (isToolCallPart(part)) {
 							return (
 								<AssistantToolCall
-									key={part.toolCallId ?? `tool-${index}`}
+									key={key}
 									toolName={part.toolName ?? "unknown"}
 									args={part.args ?? {}}
 									result={part.result}
@@ -572,7 +577,7 @@ const AgentChildrenBlock = memo(function AgentChildrenBlock({
 						if (part.type === "text" && part.text) {
 							return (
 								<div
-									key={`text-${index}`}
+									key={key}
 									className="text-[13px] leading-6 text-muted-foreground"
 								>
 									{part.text.slice(0, 300)}
@@ -582,14 +587,14 @@ const AgentChildrenBlock = memo(function AgentChildrenBlock({
 						}
 						if (part.type === "reasoning" && part.text) {
 							return (
-								<Reasoning key={`reason-${index}`}>
+								<Reasoning key={key}>
 									<ReasoningTrigger />
 									<ReasoningContent>{part.text}</ReasoningContent>
 								</Reasoning>
 							);
 						}
 						if (isTodoListPart(part)) {
-							return <TodoList key={`todo-${index}`} part={part} />;
+							return <TodoList key={key} part={part} />;
 						}
 						return null;
 					})}
@@ -606,10 +611,7 @@ export function CollapsedToolGroup({
 }: {
 	group: import("@/lib/api").CollapsedGroupPart;
 }) {
-	const [open, setOpen] = useState(group.active);
-	useEffect(() => {
-		setOpen(group.active);
-	}, [group.active]);
+	const [open, setOpen] = useState(true);
 	const collapsedGroupIconClassName = "size-3.5 text-muted-foreground";
 
 	const icon =
@@ -661,9 +663,9 @@ export function CollapsedToolGroup({
 			</summary>
 			{open ? (
 				<div className="ml-5 flex flex-col gap-0.5 border-l border-border/30 pl-3 pt-1">
-					{group.tools.map((tool, index) => (
+					{group.tools.map((tool) => (
 						<AssistantToolCall
-							key={tool.toolCallId ?? `${tool.toolName}:${index}`}
+							key={tool.toolCallId}
 							toolName={tool.toolName}
 							args={tool.args}
 							result={tool.result}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1429,9 +1429,17 @@ export type StreamingStatus =
 	| "done"
 	| "error";
 
-export type TextPart = { type: "text"; text: string };
+// Every part carries a stable `id` used as its React key. The Rust side
+// mints it at the earliest sighting of the block (accumulator's
+// `content_block_start` for Claude, `item.started` for Codex), serializes
+// it as `__part_id` in the block JSON, and the adapter reads it back onto
+// the typed part. `ToolCallPart` reuses its `toolCallId` (no separate `id`
+// field — `tool-call.tsx` already keys on `toolCallId`); every other
+// variant has its own `id`.
+export type TextPart = { type: "text"; id: string; text: string };
 export type ReasoningPart = {
 	type: "reasoning";
+	id: string;
 	text: string;
 	/** Per-part streaming state — only the active thinking block is streaming. */
 	streaming?: boolean;
@@ -1455,6 +1463,7 @@ export type ToolCallPart = {
 export type NoticeSeverity = "info" | "warning" | "error";
 export type SystemNoticePart = {
 	type: "system-notice";
+	id: string;
 	severity: NoticeSeverity;
 	label: string;
 	body?: string;
@@ -1463,6 +1472,7 @@ export type TodoStatus = "pending" | "in_progress" | "completed";
 export type TodoItem = { text: string; status: TodoStatus };
 export type TodoListPart = {
 	type: "todo-list";
+	id: string;
 	items: TodoItem[];
 };
 export type ImageSource =
@@ -1470,15 +1480,18 @@ export type ImageSource =
 	| { kind: "url"; url: string };
 export type ImagePart = {
 	type: "image";
+	id: string;
 	source: ImageSource;
 	mediaType?: string;
 };
 export type PromptSuggestionPart = {
 	type: "prompt-suggestion";
+	id: string;
 	text: string;
 };
 export type FileMentionPart = {
 	type: "file-mention";
+	id: string;
 	path: string;
 };
 export type PlanReviewAllowedPrompt = {
@@ -1506,11 +1519,21 @@ export type MessagePart =
 
 export type CollapsedGroupPart = {
 	type: "collapsed-group";
+	/** `group:{firstToolId}` — stable across streaming as tools accumulate. */
+	id: string;
 	category: "search" | "read" | "shell" | "mixed";
 	tools: ToolCallPart[];
 	active: boolean;
 	summary: string;
 };
+
+/** Stable React key for any `ExtendedMessagePart`. Hides the fact that
+ *  `ToolCallPart` uses `toolCallId` while other variants use `id`. */
+export function partKey(part: ExtendedMessagePart): string {
+	if (part.type === "tool-call") return part.toolCallId;
+	if (part.type === "plan-review") return part.toolUseId;
+	return part.id;
+}
 
 export type ExtendedMessagePart = MessagePart | CollapsedGroupPart;
 

--- a/src/lib/session-thread-cache.test.ts
+++ b/src/lib/session-thread-cache.test.ts
@@ -30,7 +30,7 @@ function makeMessage(
 		role,
 		id,
 		createdAt: "2026-04-08T00:00:00Z",
-		content: [{ type: "text", text }],
+		content: [{ type: "text", id: `${id}:txt:0`, text }],
 	};
 }
 
@@ -173,7 +173,7 @@ describe("shareMessages — structural reference reuse", () => {
 			role: "user",
 			id,
 			createdAt: "2026-04-08T00:00:00Z",
-			content: [{ type: "text", text }],
+			content: [{ type: "text", id: `${id}:txt:0`, text }],
 		};
 	}
 

--- a/src/lib/workspace-helpers.test.ts
+++ b/src/lib/workspace-helpers.test.ts
@@ -194,37 +194,46 @@ describe("getWorkspaceBranchTone", () => {
 
 describe("splitTextWithFiles", () => {
 	it("returns plain text when no files", () => {
-		expect(splitTextWithFiles("hello world", [])).toEqual([
-			{ type: "text", text: "hello world" },
+		expect(splitTextWithFiles("hello world", [], "m1")).toEqual([
+			{ type: "text", id: "m1:txt:0", text: "hello world" },
 		]);
 	});
 
 	it("splits on @path mentions", () => {
-		const result = splitTextWithFiles("look at @src/main.rs please", [
-			"src/main.rs",
-		]);
+		const result = splitTextWithFiles(
+			"look at @src/main.rs please",
+			["src/main.rs"],
+			"m1",
+		);
 		expect(result).toEqual([
-			{ type: "text", text: "look at " },
-			{ type: "file-mention", path: "src/main.rs" },
-			{ type: "text", text: " please" },
+			{ type: "text", id: "m1:txt:0", text: "look at " },
+			{ type: "file-mention", id: "m1:mention:0", path: "src/main.rs" },
+			{ type: "text", id: "m1:txt:1", text: " please" },
 		]);
 	});
 
 	it("handles multiple file mentions", () => {
-		const result = splitTextWithFiles("@a.ts and @b.ts", ["a.ts", "b.ts"]);
+		const result = splitTextWithFiles(
+			"@a.ts and @b.ts",
+			["a.ts", "b.ts"],
+			"m1",
+		);
 		expect(result).toEqual([
-			{ type: "file-mention", path: "a.ts" },
-			{ type: "text", text: " and " },
-			{ type: "file-mention", path: "b.ts" },
+			{ type: "file-mention", id: "m1:mention:0", path: "a.ts" },
+			{ type: "text", id: "m1:txt:0", text: " and " },
+			{ type: "file-mention", id: "m1:mention:1", path: "b.ts" },
 		]);
 	});
 
 	it("longer paths win on overlap", () => {
-		const result = splitTextWithFiles("@src/lib/api.ts", [
-			"src/lib/api.ts",
-			"api.ts",
+		const result = splitTextWithFiles(
+			"@src/lib/api.ts",
+			["src/lib/api.ts", "api.ts"],
+			"m1",
+		);
+		expect(result).toEqual([
+			{ type: "file-mention", id: "m1:mention:0", path: "src/lib/api.ts" },
 		]);
-		expect(result).toEqual([{ type: "file-mention", path: "src/lib/api.ts" }]);
 	});
 });
 

--- a/src/lib/workspace-helpers.ts
+++ b/src/lib/workspace-helpers.ts
@@ -472,13 +472,20 @@ export function findModelOption(
  * Split `text` on `@<path>` substrings (longer paths win on overlap),
  * returning interleaved Text and FileMention parts. Mirrors the Rust
  * `split_user_text_with_files` so optimistic and persisted renders match.
+ *
+ * `msgId` namespaces the per-part ids to match the Rust side's
+ * `{msgId}:txt:N` / `{msgId}:mention:N` scheme so optimistic ids survive
+ * the round-trip through the adapter without remounting.
  */
 export function splitTextWithFiles(
 	text: string,
 	files: readonly string[],
+	msgId: string,
 ): MessagePart[] {
+	const textId = (idx: number): string => `${msgId}:txt:${idx}`;
+	const mentionId = (idx: number): string => `${msgId}:mention:${idx}`;
 	if (files.length === 0 || text.length === 0) {
-		return [{ type: "text", text }];
+		return [{ type: "text", id: textId(0), text }];
 	}
 	const sorted = [...files].sort((a, b) => b.length - a.length);
 	const matches: { start: number; end: number; path: string }[] = [];
@@ -495,19 +502,29 @@ export function splitTextWithFiles(
 			searchStart = end;
 		}
 	}
-	if (matches.length === 0) return [{ type: "text", text }];
+	if (matches.length === 0) return [{ type: "text", id: textId(0), text }];
 	matches.sort((a, b) => a.start - b.start);
 	const parts: MessagePart[] = [];
 	let cursor = 0;
+	let textSeq = 0;
+	let mentionSeq = 0;
 	for (const m of matches) {
 		if (cursor < m.start) {
-			parts.push({ type: "text", text: text.slice(cursor, m.start) });
+			parts.push({
+				type: "text",
+				id: textId(textSeq++),
+				text: text.slice(cursor, m.start),
+			});
 		}
-		parts.push({ type: "file-mention", path: m.path });
+		parts.push({
+			type: "file-mention",
+			id: mentionId(mentionSeq++),
+			path: m.path,
+		});
 		cursor = m.end;
 	}
 	if (cursor < text.length) {
-		parts.push({ type: "text", text: text.slice(cursor) });
+		parts.push({ type: "text", id: textId(textSeq), text: text.slice(cursor) });
 	}
 	return parts;
 }
@@ -530,7 +547,7 @@ export function createLiveThreadMessage({
 		role,
 		id,
 		createdAt,
-		content: splitTextWithFiles(text, files),
+		content: splitTextWithFiles(text, files, id),
 	};
 }
 

--- a/src/test/perf/fixture-loader.ts
+++ b/src/test/perf/fixture-loader.ts
@@ -152,12 +152,19 @@ function newAssistantMessage(id: string): IncrementalAssistantMessage {
 	};
 }
 
+let __perfFixtureSeq = 0;
+
 function asTextPart(text: string): TextPart {
-	return { type: "text", text };
+	return { type: "text", id: `perf-fixture:txt:${__perfFixtureSeq++}`, text };
 }
 
 function asReasoningPart(text: string): ReasoningPart {
-	return { type: "reasoning", text, streaming: true };
+	return {
+		type: "reasoning",
+		id: `perf-fixture:rsn:${__perfFixtureSeq++}`,
+		text,
+		streaming: true,
+	};
 }
 
 function asToolCallPart(


### PR DESCRIPTION
## Summary

Gives every message part (text, reasoning, image, todo list, tool call, etc.) a stable identity that survives the full pipeline — streaming deltas, turn commit, DB persistence, and historical reload — so React can key on it. The end-user symptom this fixes: thinking blocks were auto-collapsing mid-stream because pipeline reordering (collapse grouping, tool-call folding, message merging) was remounting them at block boundaries.

- **Stable part IDs.** Each `Part` now carries an `id` minted at first sight and preserved through the accumulator → adapter → collapse pipeline. Frontend message components key on `part.id` instead of array position, eliminating remounts.
- **Pre-assigned DB UUIDs for messages.** Message-level IDs are generated as DB UUIDs at turn start instead of using temporary `stream-partial:N` identifiers that flipped to a different UUID on commit. The entire `sync_persisted_ids` / `sync_result_id` post-hoc reconciliation machinery is removed in favor of threading the real ID through from the start. `persist_result_and_finalize` now accepts an optional `preassigned_result_id` so the live-rendered id and the persisted id match.
- **Collapsed read-only tool groups** default to expanded and stop their loading spinner as soon as the last tool returns a result, rather than spinning until the overall message stream ends.
- **Subagent status labels** (\"Subagent started\" / \"Subagent completed\") no longer line-break on narrow viewports.

## Why

Users reported thinking blocks visibly collapsing themselves mid-reasoning. Root cause: React keys were derived from array index, so any pipeline reordering (a new tool_use arriving that triggers collapse grouping, or a streaming assistant message getting merged with a prior one) remounted the thinking component, which reset its collapse state. Fixing keys required a stable identity, which required carrying IDs through every stage — including the previously-unreliable streaming ↔ persisted transition.

## Test plan

- [x] `bun run test:rust` — new `src-tauri/tests/stable_part_ids.rs` integration test plus updated pipeline snapshots (5 fixture snapshots refreshed to reflect the new stable-id shape).
- [x] `bun run test:frontend` — updated `App.test.tsx`, `streaming-tail-collapse.test.ts`, `message-components.test.tsx`, `session-thread-cache.test.ts`, `workspace-helpers.test.ts`, `container.share.test.ts` for the new id-based keying / payload shape.
- [x] `bun run lint` — biome + clippy clean via pre-commit hooks.
- [ ] Manual smoke: stream a long Claude turn with thinking + multiple tool calls; verify thinking block stays expanded across tool-call collapses and that reload from DB preserves the same ids.
- [ ] Manual smoke: Codex session with commits/reviewer flows — snapshot fixtures were regenerated, visually confirm in-app.

## Follow-ups

Snapshot diffs should be reviewed closely — the id-shape change touches a lot of persisted JSON. If any snapshot drift looks unintended rather than \"every part now has an id\", flag it before merging.