### PR TITLE
fix(release): include root package in workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 	"packageManager": "bun@1.3.2",
 	"type": "module",
 	"workspaces": [
+		".",
 		"apps/*",
 		"packages/*"
 	],


### PR DESCRIPTION
## Summary

- #135 introduced `workspaces: ["apps/*", "packages/*"]` but did not include the root `helmor` package. Changesets enumerates workspace members via the `workspaces` field, so the release workflow failed to find `helmor` and crashed with `Found changeset ... for package helmor which is not in the workspace` (e.g. [this run](https://github.com/dohooo/helmor/actions/runs/24646125109/job/72059040420)).
- Fix: add `"."` to `workspaces`. Bun supports this natively, Changesets (`@manypkg/get-packages`) now recognizes the root as a workspace member, and all existing changesets parse again.

## Test plan

- [x] Local `bun install` produces no lockfile drift
- [x] Local `bun run release:version` gets past the original "not in the workspace" error (stops locally on the GitHub changelog step due to missing `GITHUB_TOKEN`, which CI has)
- [ ] After merge, confirm the "Create release PR or publish" workflow completes and refreshes the release PR