### PR TITLE
feat(marketing): add architecture picker dropdown to download CTA

### DIFF
--- a/apps/marketing/app/download-dropdown.tsx
+++ b/apps/marketing/app/download-dropdown.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { RepoData } from "@/lib/github";
+
+/** Grace period before a hover-out closes the menu — long enough for the
+ * pointer to cross the 8px gap from trigger to panel without dismissing. */
+const CLOSE_DELAY_MS = 140;
+
+type Props = {
+	data: Pick<
+		RepoData,
+		| "version"
+		| "releasesUrl"
+		| "armDmgUrl"
+		| "armDmgSize"
+		| "intelDmgUrl"
+		| "intelDmgSize"
+		| "signedAndNotarized"
+	>;
+};
+
+/**
+ * Primary CTA with an expandable architecture picker.
+ *
+ * Behavior (ported from Marketing Site.html):
+ *  - hover opens, hover-out schedules a delayed close (cancelable on re-enter)
+ *  - click toggles, focus on trigger opens
+ *  - outside click or Escape closes
+ *
+ * The menu uses `data-open` for CSS transitions and `aria-expanded` for a11y.
+ */
+export function DownloadDropdown({ data }: Props) {
+	const [open, setOpen] = useState(false);
+	const menuRef = useRef<HTMLDivElement | null>(null);
+	const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	const clearCloseTimer = useCallback(() => {
+		if (closeTimerRef.current != null) {
+			clearTimeout(closeTimerRef.current);
+			closeTimerRef.current = null;
+		}
+	}, []);
+
+	const openNow = useCallback(() => {
+		clearCloseTimer();
+		setOpen(true);
+	}, [clearCloseTimer]);
+
+	const closeNow = useCallback(() => {
+		clearCloseTimer();
+		setOpen(false);
+	}, [clearCloseTimer]);
+
+	const scheduleClose = useCallback(() => {
+		clearCloseTimer();
+		closeTimerRef.current = setTimeout(() => setOpen(false), CLOSE_DELAY_MS);
+	}, [clearCloseTimer]);
+
+	// Outside click + Escape. Only mounted while open to avoid idle listeners.
+	useEffect(() => {
+		if (!open) return;
+		const onDocPointerDown = (e: MouseEvent) => {
+			if (!menuRef.current?.contains(e.target as Node)) setOpen(false);
+		};
+		const onKey = (e: KeyboardEvent) => {
+			if (e.key === "Escape") setOpen(false);
+		};
+		document.addEventListener("mousedown", onDocPointerDown);
+		document.addEventListener("keydown", onKey);
+		return () => {
+			document.removeEventListener("mousedown", onDocPointerDown);
+			document.removeEventListener("keydown", onKey);
+		};
+	}, [open]);
+
+	// Cancel any pending close timer on unmount to prevent setState-after-unmount.
+	useEffect(() => clearCloseTimer, [clearCloseTimer]);
+
+	return (
+		<div
+			className="dl-menu"
+			data-open={open}
+			ref={menuRef}
+			onMouseEnter={openNow}
+			onMouseLeave={scheduleClose}
+		>
+			<button
+				type="button"
+				className="btn primary dl-trigger"
+				aria-haspopup="menu"
+				aria-expanded={open}
+				onFocus={openNow}
+				onClick={() => (open ? closeNow() : openNow())}
+			>
+				<DownloadIcon />
+				Download for macOS
+				<CaretIcon />
+			</button>
+			<div className="dl-panel" role="menu">
+				<a
+					className="dl-item"
+					href={data.armDmgUrl}
+					role="menuitem"
+					onClick={closeNow}
+				>
+					<span className="dl-chip">ARM</span>
+					<span className="dl-text">
+						<span className="dl-title">Apple Silicon</span>
+						<span className="dl-sub">M1 · M2 · M3 · M4</span>
+					</span>
+					<span className="dl-size">
+						·dmg {formatMegabytes(data.armDmgSize)}
+					</span>
+				</a>
+				<a
+					className="dl-item"
+					href={data.intelDmgUrl}
+					role="menuitem"
+					onClick={closeNow}
+				>
+					<span className="dl-chip">x64</span>
+					<span className="dl-text">
+						<span className="dl-title">Intel</span>
+						<span className="dl-sub">macOS 12+</span>
+					</span>
+					<span className="dl-size">
+						·dmg {formatMegabytes(data.intelDmgSize)}
+					</span>
+				</a>
+				<div className="dl-foot">
+					<span>
+						{data.version}
+						{data.signedAndNotarized ? (
+							<>
+								{" · "}
+								<span className="ok">signed &amp; notarized</span>
+							</>
+						) : null}
+					</span>
+					<a href={data.releasesUrl} onClick={closeNow}>
+						All downloads →
+					</a>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+/** "67319398" → "64.2 MB". Matches the mono-type spec strings in the design. */
+function formatMegabytes(bytes: number): string {
+	return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function DownloadIcon() {
+	return (
+		<svg
+			width="13"
+			height="13"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+		>
+			<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+			<polyline points="7 10 12 15 17 10" />
+			<line x1="12" y1="15" x2="12" y2="3" />
+		</svg>
+	);
+}
+
+function CaretIcon() {
+	return (
+		<svg
+			className="caret"
+			width="10"
+			height="10"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2.5"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+		>
+			<polyline points="6 9 12 15 18 9" />
+		</svg>
+	);
+}

--- a/apps/marketing/app/marketing-shell.tsx
+++ b/apps/marketing/app/marketing-shell.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { RepoData } from "@/lib/github";
+import { DownloadDropdown } from "./download-dropdown";
 
 type Theme = "light" | "dark";
 
@@ -277,10 +278,7 @@ export function MarketingShell({ data }: { data: RepoData }) {
 						</p>
 
 						<div className="cta">
-							<a className="btn primary" href={data.latestReleaseUrl}>
-								<DownloadIcon />
-								Download for macOS
-							</a>
+							<DownloadDropdown data={data} />
 							<a className="btn outline" href={data.repoUrl}>
 								<GithubIcon />
 								View on GitHub
@@ -364,26 +362,6 @@ function MoonIcon() {
 			aria-hidden="true"
 		>
 			<path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
-		</svg>
-	);
-}
-
-function DownloadIcon() {
-	return (
-		<svg
-			width="13"
-			height="13"
-			viewBox="0 0 24 24"
-			fill="none"
-			stroke="currentColor"
-			strokeWidth="2"
-			strokeLinecap="round"
-			strokeLinejoin="round"
-			aria-hidden="true"
-		>
-			<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-			<polyline points="7 10 12 15 17 10" />
-			<line x1="12" y1="15" x2="12" y2="3" />
 		</svg>
 	);
 }

--- a/apps/marketing/app/marketing.css
+++ b/apps/marketing/app/marketing.css
@@ -278,6 +278,125 @@ h1.hero .and {
 	background: var(--muted);
 }
 
+/* ---------- Download dropdown ---------- */
+/* Positioning anchor for .dl-panel. The menu itself is only as tall as the
+ * trigger; the panel floats 8px below via position:absolute. */
+.dl-menu {
+	position: relative;
+}
+.dl-trigger .caret {
+	margin-left: 2px;
+	margin-right: -4px;
+	opacity: 0.75;
+	transition: transform var(--motion-fast);
+}
+.dl-menu[data-open="true"] .dl-trigger .caret {
+	transform: rotate(180deg);
+}
+.dl-panel {
+	position: absolute;
+	top: calc(100% + 8px);
+	left: 0;
+	width: 280px;
+	background: var(--popover);
+	border: 1px solid var(--border);
+	border-radius: 10px;
+	box-shadow:
+		0 24px 48px -16px oklch(0 0 0 / 40%),
+		0 6px 16px -6px oklch(0 0 0 / 25%);
+	padding: 4px;
+	/* Closed: transparent, slightly lifted + shrunk, non-interactive.
+	 * CSS drives the transition; React just flips data-open. */
+	opacity: 0;
+	transform: translateY(-4px) scale(0.98);
+	pointer-events: none;
+	transition:
+		opacity 160ms var(--ease-out),
+		transform 160ms var(--ease-out);
+	z-index: 50;
+}
+.dl-menu[data-open="true"] .dl-panel {
+	opacity: 1;
+	transform: translateY(0) scale(1);
+	pointer-events: auto;
+}
+.dl-item {
+	display: grid;
+	grid-template-columns: auto 1fr auto;
+	align-items: center;
+	gap: 10px;
+	padding: 8px 10px;
+	border-radius: 7px;
+	cursor: pointer;
+	transition: background var(--motion-fast);
+}
+.dl-item:hover {
+	background: var(--muted);
+}
+.dl-item + .dl-item {
+	margin-top: 2px;
+}
+.dl-chip {
+	font-family: var(--font-mono);
+	font-size: 9.5px;
+	font-weight: 600;
+	letter-spacing: 0.04em;
+	padding: 3px 6px;
+	border: 1px solid var(--border);
+	border-radius: 5px;
+	color: var(--muted-foreground);
+	background: var(--muted);
+	min-width: 28px;
+	text-align: center;
+}
+.dl-text {
+	display: flex;
+	flex-direction: column;
+	gap: 1px;
+	min-width: 0;
+}
+.dl-title {
+	font-size: 12.5px;
+	font-weight: 500;
+	color: var(--foreground);
+	line-height: 1.2;
+}
+.dl-sub {
+	font-family: var(--font-mono);
+	font-size: 10px;
+	color: var(--muted-foreground);
+	line-height: 1.2;
+}
+.dl-size {
+	font-family: var(--font-mono);
+	font-size: 10px;
+	color: var(--muted-foreground);
+	white-space: nowrap;
+}
+.dl-foot {
+	margin-top: 4px;
+	padding: 8px 10px 6px;
+	border-top: 1px solid var(--border);
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	font-family: var(--font-mono);
+	font-size: 10px;
+	color: var(--muted-foreground);
+}
+.dl-foot .ok {
+	color: var(--status-progress);
+}
+/* biome-ignore lint/style/noDescendingSpecificity: targets a different ancestor than .rail .links a */
+.dl-foot a {
+	color: var(--muted-foreground);
+	transition: color var(--motion-fast);
+}
+/* biome-ignore lint/style/noDescendingSpecificity: targets a different ancestor than .rail .links a:hover */
+.dl-foot a:hover {
+	color: var(--foreground);
+}
+
 /* Meta line */
 .meta {
 	display: flex;

--- a/apps/marketing/lib/github.ts
+++ b/apps/marketing/lib/github.ts
@@ -19,8 +19,10 @@ const REVALIDATE_SECONDS = 3600;
 
 // Fallbacks mirror what the design shipped with. Used when the GitHub API is
 // unreachable, rate-limited, or the repo has no releases yet.
+// The DMG byte sizes are chosen so `(bytes / 1 MiB).toFixed(1)` renders the
+// exact strings shown in the design ("64.2 MB" / "68.7 MB").
 const FALLBACK = {
-	version: "v0.4.0",
+	version: "v0.4.2",
 	versionShort: "v0.4",
 	branch: "main",
 	shortSha: "62d8e51",
@@ -28,6 +30,11 @@ const FALLBACK = {
 	repoUrl: `https://github.com/${REPO}`,
 	releasesUrl: `https://github.com/${REPO}/releases`,
 	latestReleaseUrl: `https://github.com/${REPO}/releases/latest`,
+	armDmgUrl: `https://github.com/${REPO}/releases/latest`,
+	armDmgSize: 67319398, // 64.2 MB
+	intelDmgUrl: `https://github.com/${REPO}/releases/latest`,
+	intelDmgSize: 72037171, // 68.7 MB
+	signedAndNotarized: true,
 } as const;
 
 export type RepoData = {
@@ -39,12 +46,24 @@ export type RepoData = {
 	repoUrl: string;
 	releasesUrl: string;
 	latestReleaseUrl: string;
+	armDmgUrl: string;
+	armDmgSize: number;
+	intelDmgUrl: string;
+	intelDmgSize: number;
+	signedAndNotarized: boolean;
 };
 
+type Asset = {
+	name: string;
+	browser_download_url: string;
+	size: number;
+};
 type Release = {
 	tag_name: string;
 	name?: string | null;
 	html_url: string;
+	body?: string | null;
+	assets?: Asset[];
 };
 type Commit = { sha: string };
 type Repo = {
@@ -102,6 +121,13 @@ export async function getRepoData(): Promise<RepoData> {
 		: FALLBACK.version;
 	const versionShort = toShortVersion(version);
 
+	const arm = pickDmgAsset(release?.assets, /aarch64|arm64/i);
+	const intel = pickDmgAsset(release?.assets, /x64|x86[_-]?64|intel/i);
+	const signedAndNotarized =
+		release?.body != null && /notariz/i.test(release.body)
+			? true
+			: FALLBACK.signedAndNotarized;
+
 	return {
 		version,
 		versionShort,
@@ -111,5 +137,23 @@ export async function getRepoData(): Promise<RepoData> {
 		repoUrl: FALLBACK.repoUrl,
 		releasesUrl: FALLBACK.releasesUrl,
 		latestReleaseUrl: release?.html_url ?? FALLBACK.latestReleaseUrl,
+		armDmgUrl: arm?.browser_download_url ?? FALLBACK.armDmgUrl,
+		armDmgSize: arm?.size ?? FALLBACK.armDmgSize,
+		intelDmgUrl: intel?.browser_download_url ?? FALLBACK.intelDmgUrl,
+		intelDmgSize: intel?.size ?? FALLBACK.intelDmgSize,
+		signedAndNotarized,
 	};
+}
+
+/** Find the first `.dmg` asset whose filename matches `archPattern`. */
+function pickDmgAsset(
+	assets: Asset[] | undefined,
+	archPattern: RegExp,
+): Asset | null {
+	if (!assets) return null;
+	for (const a of assets) {
+		if (!a.name.toLowerCase().endsWith(".dmg")) continue;
+		if (archPattern.test(a.name)) return a;
+	}
+	return null;
 }


### PR DESCRIPTION
## Summary

Replaces the single **Download for macOS** link in the marketing hero with a hover/click dropdown that lets visitors pick the right build for their machine.

## What changed

- New `apps/marketing/app/download-dropdown.tsx` — primary CTA + expandable architecture picker.
  - Hover opens; hover-out closes after a 140 ms grace period (so the cursor can cross the 8 px gap to the panel without dismissing it).
  - Click toggles, focus opens, outside-click and `Escape` close.
  - `data-open` drives CSS transitions; `aria-expanded` / `role="menu"` / `role="menuitem"` cover a11y.
- `marketing-shell.tsx` swaps the inline `<a class="btn primary">` for `<DownloadDropdown />` and drops the now-unused inline `DownloadIcon` (moved into the dropdown component).
- `marketing.css` adds the `.dl-menu / .dl-trigger / .dl-panel / .dl-item / .dl-chip / .dl-text / .dl-size / .dl-foot` styles, including the open/close transition and caret rotation.
- `lib/github.ts` extends `RepoData` with per-architecture DMG URL + byte size and a `signedAndNotarized` flag.
  - New `pickDmgAsset` helper finds the first `.dmg` asset matching an arch regex (`aarch64|arm64` for ARM, `x64|x86[_-]?64|intel` for Intel).
  - `signedAndNotarized` is inferred from `/notariz/i` in the release body, with a fallback of `true`.
  - Fallback DMG sizes are chosen so `(bytes / 1 MiB).toFixed(1)` renders the exact strings shown in the design (`64.2 MB` / `68.7 MB`).

## Why

The marketing site previously linked straight to the GitHub release page, which left the user to hunt for the right asset. Surfacing ARM vs Intel inline (with size + signed/notarized status) matches the design and removes a click for the most common path.

## Test notes

- [ ] Run the marketing app locally and verify the dropdown opens on hover, click, and focus, and closes on outside-click / `Escape`.
- [ ] Confirm both DMG links resolve to the correct release assets when the GitHub API is reachable, and to the latest-release page when it isn't.
- [ ] Check the panel transition (opacity + translate + caret rotation) feels smooth in both light and dark themes.
- [ ] Verify keyboard navigation reaches both menu items and the "All downloads" link.