### PR TITLE
fix: drop lingering "Loading more commands…" banner from slash menu

### DIFF
--- a/.changeset/fix-slash-commands-loading-banner.md
+++ b/.changeset/fix-slash-commands-loading-banner.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix the slash-command popup to stop showing a "Loading more commands…" banner that could linger indefinitely once commands were already visible.

--- a/src-tauri/src/agents/queries.rs
+++ b/src-tauri/src/agents/queries.rs
@@ -400,9 +400,6 @@ pub struct SlashCommandEntry {
 #[serde(rename_all = "camelCase")]
 pub struct SlashCommandsResponse {
     pub commands: Vec<SlashCommandEntry>,
-    /// `false` while the background sidecar refresh is still in flight
-    /// (the commands shown are from a local disk scan only).
-    pub is_complete: bool,
 }
 
 pub async fn list_slash_commands(
@@ -430,16 +427,12 @@ pub async fn list_slash_commands(
         );
         if !repo_id.is_empty() {
             let rkey = super::slash_commands::repo_key(&request.provider, repo_id);
-            if let Some((commands, _)) = cache.get_repo(&rkey) {
-                return Ok(SlashCommandsResponse {
-                    commands,
-                    is_complete: false,
-                });
+            if let Some(commands) = cache.get_repo(&rkey) {
+                return Ok(SlashCommandsResponse { commands });
             }
         }
         return Ok(SlashCommandsResponse {
             commands: Vec::new(),
-            is_complete: true,
         });
     }
 
@@ -449,19 +442,15 @@ pub async fn list_slash_commands(
     );
 
     // 1. Workspace-level exact hit → return instantly + SWR refresh.
-    if let Some((commands, is_complete)) = cache.get_workspace(&ws_key) {
+    if let Some(commands) = cache.get_workspace(&ws_key) {
         spawn_background_refresh(&app, &cache, &request, ws_key);
-        return Ok(SlashCommandsResponse {
-            commands,
-            is_complete,
-        });
+        return Ok(SlashCommandsResponse { commands });
     }
 
     // 2. Repo-level fallback → return stale-but-plausible + SWR refresh.
-    //    `is_complete: false` tells the UI the list is still loading.
     if !repo_id.is_empty() {
         let rkey = super::slash_commands::repo_key(&request.provider, repo_id);
-        if let Some((commands, _)) = cache.get_repo(&rkey) {
+        if let Some(commands) = cache.get_repo(&rkey) {
             tracing::debug!(
                 provider = %request.provider,
                 cwd,
@@ -470,10 +459,7 @@ pub async fn list_slash_commands(
                 "list_slash_commands serving repo fallback"
             );
             spawn_background_refresh(&app, &cache, &request, ws_key);
-            return Ok(SlashCommandsResponse {
-                commands,
-                is_complete: false,
-            });
+            return Ok(SlashCommandsResponse { commands });
         }
     }
 
@@ -492,11 +478,8 @@ pub async fn list_slash_commands(
         count = commands.len(),
         "list_slash_commands sync fetch succeeded"
     );
-    cache.set(ws_key, request.repo_id.as_deref(), commands.clone(), true);
-    Ok(SlashCommandsResponse {
-        commands,
-        is_complete: true,
-    })
+    cache.set(ws_key, request.repo_id.as_deref(), commands.clone());
+    Ok(SlashCommandsResponse { commands })
 }
 
 /// Prewarm the slash-command cache for a single workspace (both providers).
@@ -730,7 +713,7 @@ fn spawn_background_refresh(
                         count = commands.len(),
                         "Background slash command refresh succeeded"
                     );
-                    cache_state.set(ws_key, request.repo_id.as_deref(), commands, true);
+                    cache_state.set(ws_key, request.repo_id.as_deref(), commands);
                 }
                 Err(e) => {
                     // Don't clear the cache — stale local data is better than nothing.

--- a/src-tauri/src/agents/slash_commands.rs
+++ b/src-tauri/src/agents/slash_commands.rs
@@ -27,15 +27,9 @@ pub fn repo_key(provider: &str, repo_id: &str) -> RepoKey {
     (provider.to_string(), repo_id.to_string())
 }
 
-#[derive(Clone)]
-struct CachedResult {
-    commands: Vec<SlashCommandEntry>,
-    is_complete: bool,
-}
-
 pub struct SlashCommandCache {
-    workspaces: RwLock<HashMap<WorkspaceKey, CachedResult>>,
-    repos: RwLock<HashMap<RepoKey, CachedResult>>,
+    workspaces: RwLock<HashMap<WorkspaceKey, Vec<SlashCommandEntry>>>,
+    repos: RwLock<HashMap<RepoKey, Vec<SlashCommandEntry>>>,
     /// Prevents duplicate background refreshes for the same workspace key.
     refreshing: Mutex<HashSet<WorkspaceKey>>,
 }
@@ -56,30 +50,29 @@ impl SlashCommandCache {
     }
 
     /// Exact workspace-level lookup.
-    pub fn get_workspace(&self, key: &WorkspaceKey) -> Option<(Vec<SlashCommandEntry>, bool)> {
+    pub fn get_workspace(&self, key: &WorkspaceKey) -> Option<Vec<SlashCommandEntry>> {
         let map = self.workspaces.read().ok()?;
-        let cached = map.get(key)?;
+        let commands = map.get(key)?.clone();
         tracing::debug!(
             provider = %key.0,
             cwd = %key.1,
-            count = cached.commands.len(),
-            is_complete = cached.is_complete,
+            count = commands.len(),
             "Slash-command workspace cache hit"
         );
-        Some((cached.commands.clone(), cached.is_complete))
+        Some(commands)
     }
 
     /// Repo-level fallback lookup — used only when the workspace tier misses.
-    pub fn get_repo(&self, key: &RepoKey) -> Option<(Vec<SlashCommandEntry>, bool)> {
+    pub fn get_repo(&self, key: &RepoKey) -> Option<Vec<SlashCommandEntry>> {
         let map = self.repos.read().ok()?;
-        let cached = map.get(key)?;
+        let commands = map.get(key)?.clone();
         tracing::debug!(
             provider = %key.0,
             repo_id = %key.1,
-            count = cached.commands.len(),
+            count = commands.len(),
             "Slash-command repo-level fallback hit"
         );
-        Some((cached.commands.clone(), cached.is_complete))
+        Some(commands)
     }
 
     /// Write a result into the workspace tier, and also mirror it to the repo
@@ -90,19 +83,14 @@ impl SlashCommandCache {
         workspace_key: WorkspaceKey,
         repo_id: Option<&str>,
         commands: Vec<SlashCommandEntry>,
-        is_complete: bool,
     ) {
-        let entry = CachedResult {
-            commands,
-            is_complete,
-        };
         if let Ok(mut map) = self.workspaces.write() {
-            map.insert(workspace_key.clone(), entry.clone());
+            map.insert(workspace_key.clone(), commands.clone());
         }
         if let Some(repo_id) = repo_id.filter(|id| !id.is_empty()) {
             let rkey = repo_key(&workspace_key.0, repo_id);
             if let Ok(mut map) = self.repos.write() {
-                map.insert(rkey, entry);
+                map.insert(rkey, commands);
             }
         }
     }

--- a/src/features/composer/container.test.tsx
+++ b/src/features/composer/container.test.tsx
@@ -177,7 +177,6 @@ describe("WorkspaceComposerContainer", () => {
 		apiMockState.listSlashCommands.mockReset();
 		apiMockState.listSlashCommands.mockResolvedValue({
 			commands: [],
-			isComplete: true,
 		});
 	});
 

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -362,9 +362,8 @@ export const WorkspaceComposerContainer = memo(
 			),
 			enabled: Boolean(workingDirectory),
 		});
-		const slashCommandsResponse = slashCommandsQuery.data;
 		const slashCommands =
-			slashCommandsResponse?.commands ?? EMPTY_SLASH_COMMANDS;
+			slashCommandsQuery.data?.commands ?? EMPTY_SLASH_COMMANDS;
 		// Pending only (`isPending`) covers the very first fetch with no data
 		// yet; once we have data, `isFetching` covers background refetches but
 		// users don't need a spinner for those — the cached list is fine.
@@ -374,10 +373,6 @@ export const WorkspaceComposerContainer = memo(
 			!slashCommandsQuery.isError;
 		const slashCommandsError =
 			Boolean(workingDirectory) && slashCommandsQuery.isError;
-		// True when local skills are shown but the full list is still loading
-		// in the background via the sidecar.
-		const slashCommandsRefreshing =
-			slashCommandsResponse != null && !slashCommandsResponse.isComplete;
 		const refetchSlashCommands = useCallback(() => {
 			void slashCommandsQuery.refetch();
 		}, [slashCommandsQuery]);
@@ -618,7 +613,6 @@ export const WorkspaceComposerContainer = memo(
 						slashCommands={slashCommands}
 						slashCommandsLoading={slashCommandsLoading}
 						slashCommandsError={slashCommandsError}
-						slashCommandsRefreshing={slashCommandsRefreshing}
 						onRetrySlashCommands={refetchSlashCommands}
 						workspaceRootPath={workingDirectory}
 					/>

--- a/src/features/composer/editor/plugins/slash-command-plugin.tsx
+++ b/src/features/composer/editor/plugins/slash-command-plugin.tsx
@@ -98,7 +98,6 @@ export function SlashCommandPlugin({
 	commands,
 	isLoading = false,
 	isError = false,
-	isRefreshing = false,
 	onRetry,
 	popupAnchorRef,
 }: {
@@ -107,8 +106,6 @@ export function SlashCommandPlugin({
 	isLoading?: boolean;
 	/** True when the query rejected (sidecar timeout, missing CLI, etc). */
 	isError?: boolean;
-	/** True when local skills are shown but the full list is still loading. */
-	isRefreshing?: boolean;
 	/** Click handler for the "retry" row in the error state. */
 	onRetry?: () => void;
 	/**
@@ -295,12 +292,6 @@ export function SlashCommandPlugin({
 										})}
 									</CommandGroup>
 								) : null}
-								{hasOptions && isRefreshing && (
-									<div className="flex items-center gap-2 border-t border-border/40 px-3 py-1.5 text-[12px] text-muted-foreground">
-										<Loader2 className="size-3 shrink-0 animate-spin" />
-										<span>Loading more commands…</span>
-									</div>
-								)}
 							</CommandList>
 						</Command>
 					</div>,

--- a/src/features/composer/index.tsx
+++ b/src/features/composer/index.tsx
@@ -105,7 +105,6 @@ type WorkspaceComposerProps = {
 	slashCommands?: readonly SlashCommandEntry[];
 	slashCommandsLoading?: boolean;
 	slashCommandsError?: boolean;
-	slashCommandsRefreshing?: boolean;
 	onRetrySlashCommands?: () => void;
 	workspaceRootPath?: string | null;
 	pendingElicitation?: PendingElicitation | null;
@@ -166,7 +165,6 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 	slashCommands = EMPTY_SLASH_COMMANDS,
 	slashCommandsLoading = false,
 	slashCommandsError = false,
-	slashCommandsRefreshing = false,
 	onRetrySlashCommands,
 	workspaceRootPath = null,
 	pendingElicitation = null,
@@ -404,7 +402,6 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 							commands={slashCommands}
 							isLoading={slashCommandsLoading}
 							isError={slashCommandsError}
-							isRefreshing={slashCommandsRefreshing}
 							onRetry={onRetrySlashCommands}
 							popupAnchorRef={composerRootRef}
 						/>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -661,8 +661,6 @@ export type SlashCommandEntry = {
 
 export type SlashCommandsResponse = {
 	commands: SlashCommandEntry[];
-	/** `false` while the background sidecar refresh is still in flight. */
-	isComplete: boolean;
 };
 
 /**


### PR DESCRIPTION
## Summary

The slash-command popup was showing a persistent **"Loading more commands…"** banner that could linger indefinitely once the initial list was already visible. The banner was driven by an `isComplete` flag that flowed from the Rust cache all the way to the Lexical `SlashCommandPlugin`, and because the stale-while-revalidate path returned `isComplete: false` from repo-level fallback hits, there was no reliable signal to flip it back to `true` from the frontend's perspective.

This change rips the flag out end-to-end — the commands list on its own is enough, and the background SWR refresh will quietly swap in the fresh list when it lands.

## What changed

- **Rust (`src-tauri/src/agents/`)**: removed `is_complete` from `SlashCommandsResponse`, `SlashCommandCache::get_workspace` / `get_repo` / `set`, and the `CachedResult` wrapper (cache now stores `Vec<SlashCommandEntry>` directly).
- **Frontend (`src/features/composer/`, `src/lib/api.ts`)**: dropped `isComplete` from the `SlashCommandsResponse` type, the `slashCommandsRefreshing` prop chain (container → `WorkspaceComposer` → `SlashCommandPlugin`), and the "Loading more commands…" banner node.
- **Tests**: updated `container.test.tsx` fixture to match the new response shape.
- **Changeset**: `patch` entry describing the user-visible fix.

## Why

The banner was a UX bug — once commands render, users should not see an indeterminate "still loading" indicator. Keeping the SWR behavior server-side without surfacing `isComplete` gives us the freshness we want without the flicker.

## Test notes

- `bun run test` — frontend, sidecar, rust all green locally
- `bun run lint` — biome + clippy clean (enforced by pre-commit hook; commit went through)
- Manual: open slash menu in a workspace, confirm no persistent "Loading more commands…" row under the results