### PR TITLE
fix: keep thinking block expanded through completion

### DIFF
--- a/.changeset/fix-thinking-block-display.md
+++ b/.changeset/fix-thinking-block-display.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Keep streamed thinking blocks expanded through completion and show a "Thought for Ns" label once reasoning finishes instead of falling back to a collapsed generic "Thinking" state.

--- a/src-tauri/src/pipeline/accumulator/mod.rs
+++ b/src-tauri/src/pipeline/accumulator/mod.rs
@@ -200,6 +200,22 @@ fn patch_tool_use_block(block: &mut Value, resolved: &HashSet<String>) -> bool {
     true
 }
 
+fn assistant_block_type(block: &Value) -> Option<&str> {
+    block.get("type").and_then(Value::as_str)
+}
+
+fn cumulative_assistant_snapshot_prefix_matches(prev: &[Value], next: &[Value]) -> bool {
+    if next.len() < prev.len() {
+        return false;
+    }
+
+    prev.iter()
+        .zip(next.iter())
+        .all(|(prev_block, next_block)| {
+            assistant_block_type(prev_block) == assistant_block_type(next_block)
+        })
+}
+
 fn collect_resolved_id(block: &Value, resolved: &mut HashSet<String>) {
     let Some(obj) = block.as_object() else {
         return;
@@ -776,19 +792,37 @@ impl StreamAccumulator {
             .and_then(|m| m.get("content"))
             .and_then(Value::as_array)
         {
-            if !same_msg_id {
+            let cumulative_snapshot = same_msg_id
+                && cumulative_assistant_snapshot_prefix_matches(&self.cur_asst_blocks, blocks);
+
+            if !same_msg_id || cumulative_snapshot {
                 self.cur_asst_blocks.clear();
                 self.cur_asst_block_count = 0;
             }
             let mut stamped_blocks = blocks.clone();
             for (i, block) in stamped_blocks.iter_mut().enumerate() {
                 if let Some(obj) = block.as_object_mut() {
-                    let part_id = format!("{turn_id}:blk:{}", self.cur_asst_block_count + i);
+                    let part_id = if cumulative_snapshot {
+                        self.cur_asst_blocks
+                            .get(i)
+                            .and_then(Value::as_object)
+                            .and_then(|prev| prev.get("__part_id"))
+                            .and_then(Value::as_str)
+                            .map(str::to_string)
+                            .unwrap_or_else(|| format!("{turn_id}:blk:{i}"))
+                    } else {
+                        format!("{turn_id}:blk:{}", self.cur_asst_block_count + i)
+                    };
                     obj.insert("__part_id".to_string(), Value::String(part_id));
                 }
             }
-            self.cur_asst_block_count += stamped_blocks.len();
-            self.cur_asst_blocks.extend(stamped_blocks.iter().cloned());
+            if cumulative_snapshot {
+                self.cur_asst_block_count = stamped_blocks.len();
+                self.cur_asst_blocks = stamped_blocks.clone();
+            } else {
+                self.cur_asst_block_count += stamped_blocks.len();
+                self.cur_asst_blocks.extend(stamped_blocks.iter().cloned());
+            }
 
             // Also patch the value that goes into collected[] for rendering.
             if let Some(msg) = stamped_value.get_mut("message") {

--- a/src-tauri/src/pipeline/accumulator/mod.rs
+++ b/src-tauri/src/pipeline/accumulator/mod.rs
@@ -795,9 +795,15 @@ impl StreamAccumulator {
             let cumulative_snapshot = same_msg_id
                 && cumulative_assistant_snapshot_prefix_matches(&self.cur_asst_blocks, blocks);
 
-            if !same_msg_id || cumulative_snapshot {
+            // Cumulative: reset count so reused indices produce stable part_ids.
+            // Non-cumulative new-msg: clear buffer but keep count monotonic so
+            // part_ids don't collide with the previous message when two events
+            // share the same active turn_id (e.g. no explicit `message.id`).
+            if cumulative_snapshot {
                 self.cur_asst_blocks.clear();
                 self.cur_asst_block_count = 0;
+            } else if !same_msg_id {
+                self.cur_asst_blocks.clear();
             }
             let mut stamped_blocks = blocks.clone();
             for (i, block) in stamped_blocks.iter_mut().enumerate() {

--- a/src-tauri/src/pipeline/adapter/grouping.rs
+++ b/src-tauri/src/pipeline/adapter/grouping.rs
@@ -17,6 +17,20 @@ use crate::pipeline::types::{
     ExtendedMessagePart, IntermediateMessage, MessagePart, MessageRole, ThreadMessageLike,
 };
 
+fn is_cumulative_same_id_snapshot(prev: &ThreadMessageLike, next: &ThreadMessageLike) -> bool {
+    if prev.id != next.id || next.content.len() < prev.content.len() {
+        return false;
+    }
+
+    prev.content
+        .iter()
+        .zip(next.content.iter())
+        .all(|(prev_part, next_part)| {
+            std::mem::discriminant(prev_part) == std::mem::discriminant(next_part)
+                && prev_part.part_id() == next_part.part_id()
+        })
+}
+
 pub(super) fn convert_user_message(
     msg: &IntermediateMessage,
     parsed: Option<&Value>,
@@ -278,12 +292,18 @@ pub(super) fn merge_adjacent_assistants(msgs: Vec<ThreadMessageLike>) -> Vec<Thr
 
         if should_merge {
             let prev = out.last_mut().unwrap();
-            prev.content.extend(msg.content);
-            if msg.status.is_some() {
+            if is_cumulative_same_id_snapshot(prev, &msg) {
+                prev.content = msg.content;
                 prev.status = msg.status;
-            }
-            if prev.streaming == Some(true) || msg.streaming == Some(true) {
-                prev.streaming = Some(true);
+                prev.streaming = msg.streaming;
+            } else {
+                prev.content.extend(msg.content);
+                if msg.status.is_some() {
+                    prev.status = msg.status;
+                }
+                if prev.streaming == Some(true) || msg.streaming == Some(true) {
+                    prev.streaming = Some(true);
+                }
             }
         } else {
             out.push(msg);

--- a/src-tauri/src/pipeline/adapter/tests.rs
+++ b/src-tauri/src/pipeline/adapter/tests.rs
@@ -304,6 +304,70 @@ fn merge_adjacent_assistant_messages() {
 }
 
 #[test]
+fn merge_adjacent_same_id_assistant_messages_replaces_with_latest_snapshot() {
+    let messages = vec![
+        im(
+            "same",
+            "assistant",
+            json!({
+                "type": "assistant",
+                "__streaming": true,
+                "message": {
+                    "role": "assistant",
+                    "content": [{
+                        "type": "thinking",
+                        "thinking": "draft",
+                        "__part_id": "same:blk:0",
+                        "__is_streaming": true
+                    }]
+                }
+            }),
+        ),
+        im(
+            "same",
+            "assistant",
+            json!({
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "thinking",
+                            "thinking": "draft",
+                            "__part_id": "same:blk:0"
+                        },
+                        {
+                            "type": "text",
+                            "text": "done",
+                            "__part_id": "same:blk:1"
+                        }
+                    ]
+                }
+            }),
+        ),
+    ];
+
+    let result = convert(&messages);
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].content.len(), 2);
+    assert_eq!(result[0].streaming, None);
+
+    match &result[0].content[0] {
+        ExtendedMessagePart::Basic(MessagePart::Reasoning { id, streaming, .. }) => {
+            assert_eq!(id, "same:blk:0");
+            assert_eq!(*streaming, None);
+        }
+        other => panic!("expected reasoning part, got {other:?}"),
+    }
+    match &result[0].content[1] {
+        ExtendedMessagePart::Basic(MessagePart::Text { text, .. }) => {
+            assert_eq!(text, "done");
+        }
+        other => panic!("expected text part, got {other:?}"),
+    }
+}
+
+#[test]
 fn result_label_formatting() {
     let label = build_result_label(Some(&json!({
         "type": "result",

--- a/src-tauri/tests/snapshots/pipeline_streams__stream_replay@claude__thinking-text.jsonl.snap
+++ b/src-tauri/tests/snapshots/pipeline_streams__stream_replay@claude__thinking-text.jsonl.snap
@@ -22,7 +22,6 @@ checkpoints:
       - assistant
     last_part_types:
       - reasoning
-      - reasoning
       - text
   - line_index: 13
     event_type: result
@@ -36,14 +35,13 @@ final_state:
   roles:
     - assistant
     - system
-  total_parts: 4
+  total_parts: 3
 persisted_turns:
   turn_count: 1
-  total_blocks: 3
+  total_blocks: 2
   turns:
     - role: assistant
       block_types:
-        - thinking
         - thinking
         - text
 historical_render:
@@ -51,6 +49,5 @@ historical_render:
   messages:
     - role: assistant
       part_types:
-        - reasoning
         - reasoning
         - text

--- a/src/features/panel/message-components.test.tsx
+++ b/src/features/panel/message-components.test.tsx
@@ -1,4 +1,10 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+	act,
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ThreadMessageLike } from "@/lib/api";
 import { MemoConversationMessage } from "./message-components";
@@ -9,6 +15,7 @@ let writeTextMock: ReturnType<typeof vi.fn>;
 
 afterEach(() => {
 	cleanup();
+	vi.useRealTimers();
 });
 
 beforeEach(() => {
@@ -184,5 +191,74 @@ describe("MemoConversationMessage plan review", () => {
 		fireEvent.click(screen.getByRole("button", { name: "Copy message" }));
 
 		expect(writeTextMock).toHaveBeenCalledWith("Real assistant reply");
+	});
+
+	it("keeps a completed reasoning block open and shows elapsed time", () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-04-20T12:00:00.000Z"));
+
+		const streamingMessage: ThreadMessageLike = {
+			id: "assistant-reasoning-1",
+			role: "assistant",
+			createdAt: "2026-04-20T12:00:00.000Z",
+			streaming: true,
+			content: [
+				{
+					type: "reasoning",
+					id: "assistant-reasoning-1:blk:0",
+					text: "Inspecting the streamed reasoning block.",
+					streaming: true,
+				},
+			],
+		};
+
+		const { rerender } = render(
+			<MemoConversationMessage
+				message={streamingMessage}
+				sessionId="session-1"
+				itemIndex={0}
+			/>,
+		);
+
+		expect(screen.getByText("Thinking...")).toBeInTheDocument();
+		expect(
+			screen.getByText("Inspecting the streamed reasoning block."),
+		).toBeInTheDocument();
+
+		act(() => {
+			vi.advanceTimersByTime(2_000);
+		});
+
+		const completedMessage: ThreadMessageLike = {
+			...streamingMessage,
+			streaming: undefined,
+			content: [
+				{
+					type: "reasoning",
+					id: "assistant-reasoning-1:blk:0",
+					text: "Inspecting the streamed reasoning block.",
+					streaming: false,
+				},
+				{
+					type: "text",
+					id: "assistant-reasoning-1:blk:1",
+					text: "Done.",
+				},
+			],
+		};
+
+		rerender(
+			<MemoConversationMessage
+				message={completedMessage}
+				sessionId="session-1"
+				itemIndex={0}
+			/>,
+		);
+
+		expect(screen.getByText("Thought for 2s")).toBeInTheDocument();
+		expect(
+			screen.getByText("Inspecting the streamed reasoning block."),
+		).toBeInTheDocument();
+		expect(screen.getByText("Done.")).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
## Summary

- Keep streamed thinking blocks expanded once reasoning finishes and show a `Thought for Ns` label instead of collapsing back to a generic `Thinking` state.
- Teach the pipeline accumulator and adapter grouping to recognize cumulative assistant snapshots (same message id, prefix-compatible block types) and replace rather than duplicate the block list.
- Preserve stable `__part_id`s across snapshots so reasoning/text parts keep their identity while streaming completes.

## Why

When the SDK delivered a final full-message snapshot for the same assistant message id, the accumulator was appending blocks instead of replacing, producing duplicate reasoning parts. The duplicate made the UI pick the second (non-streaming) copy and drop the elapsed-time indicator — the block would "snap closed" on completion. This fix detects the cumulative-snapshot case and rewrites the current block list in place, keeping ids and streaming state consistent across the final frame.

## Test plan

- [x] `cd src-tauri && cargo test --tests` (including updated `pipeline_streams` snapshot + new adapter test)
- [x] `bun run test:frontend` (new `message-components` reasoning-block test)
- [x] `bun run lint` / pre-commit hooks (biome + clippy + cargo fmt)
- [ ] Manual smoke: stream a reasoning-heavy prompt and confirm the `Thought for Ns` label persists after completion