### PR TITLE
feat(composer): add mid-turn Steer button to inject messages into a running turn

### DIFF
--- a/.changeset/chat-steer.md
+++ b/.changeset/chat-steer.md
@@ -1,0 +1,5 @@
+---
+"helmor": minor
+---
+
+Add a mid-turn Steer button to the composer — type a new instruction while the agent is still streaming and click Steer to inject it into the running turn without stopping; works on both Claude and Codex.

--- a/sidecar/src/claude-session-manager.ts
+++ b/sidecar/src/claude-session-manager.ts
@@ -27,6 +27,7 @@ import { readImageWithResize } from "./image-resize.js";
 import { parseImageRefs } from "./images.js";
 import { errorDetails, logger } from "./logger.js";
 import { sortClaudeModels } from "./model-sort.js";
+import { createPushable, type Pushable } from "./pushable-iterable.js";
 import {
 	formatModelLabel,
 	type ListSlashCommandsParams,
@@ -124,6 +125,23 @@ function executableOptions(): {
 interface LiveSession {
 	readonly query: Query;
 	readonly abortController: AbortController;
+	/**
+	 * Streaming-input source. The initial prompt is pushed up front in
+	 * `sendMessage`; each `steer()` call pushes one more user message.
+	 * The SDK folds every pushed message into ONE extended turn and
+	 * emits a SINGLE terminal `result` when the whole trajectory is
+	 * done — verified empirically (steer mid-stream yields one merged
+	 * assistant message and one result, not per-push results). The
+	 * for-await loop therefore bails on the first result it sees.
+	 */
+	readonly promptSource: Pushable<SDKUserMessage>;
+	/** Request id owning this session; needed by `steer()` to synthesize
+	 *  a user passthrough event for the active stream. */
+	readonly requestId: string;
+	/** Emitter bound to the active stream — used by `steer()` to fan a
+	 *  synthetic user event to the pipeline so the UI renders the mid-turn
+	 *  bubble at the correct position instead of tacking it onto the end. */
+	readonly emitter: SidecarEmitter;
 }
 
 const VALID_PERMISSION_MODES = [
@@ -380,17 +398,27 @@ export class ClaudeSessionManager implements SessionManager {
 		const additionalDirectories = await resolveGitAccessDirectories(cwd);
 
 		const { text, imagePaths } = parseImageRefs(prompt);
-		const promptValue: string | AsyncIterable<SDKUserMessage> =
+		// Always use streaming-input mode so `steer()` can push additional
+		// `SDKUserMessage`s into the same turn. For Claude real steer, the
+		// SDK consumes subsequent pushes as part of the in-flight turn and
+		// emits ONE final `result` — so bail-on-first-result semantics are
+		// unchanged.
+		const promptSource = createPushable<SDKUserMessage>();
+		const initialMessage =
 			imagePaths.length === 0
-				? prompt
-				: (async function* () {
-						yield await buildUserMessageWithImages(text, imagePaths);
-					})();
+				? ({
+						type: "user",
+						message: { role: "user", content: text },
+						parent_tool_use_id: null,
+					} as SDKUserMessage)
+				: await buildUserMessageWithImages(text, imagePaths);
+		promptSource.push(initialMessage);
+
 		const effectiveFastMode =
 			fastMode === true && claudeModelSupportsFastMode(model);
 
 		const q = query({
-			prompt: promptValue,
+			prompt: promptSource,
 			options: {
 				abortController,
 				pathToClaudeCodeExecutable: CLAUDE_CLI_PATH,
@@ -506,7 +534,13 @@ export class ClaudeSessionManager implements SessionManager {
 			},
 		});
 
-		this.sessions.set(sessionId, { query: q, abortController });
+		this.sessions.set(sessionId, {
+			query: q,
+			abortController,
+			promptSource,
+			requestId,
+			emitter,
+		});
 
 		try {
 			for await (const message of q) {
@@ -525,6 +559,14 @@ export class ClaudeSessionManager implements SessionManager {
 					emitter.passthrough(requestId, passthroughMessage);
 				}
 				if (isTerminalSuccessResult(message)) {
+					// The SDK emits ONE terminal `result` for the entire
+					// streaming-input session, even when `steer()` pushed
+					// additional messages — all pushes fold into one
+					// extended turn. Bail on the first one we see; any
+					// steer() still in its image-load await at this point
+					// will find `promptSource.closed` via the finally
+					// block below and return false (see the re-check in
+					// `steer()`).
 					emitter.end(requestId);
 					return;
 				}
@@ -551,12 +593,85 @@ export class ClaudeSessionManager implements SessionManager {
 					...errorDetails(closeErr),
 				});
 			}
+			promptSource.close();
 			this.sessions.delete(sessionId);
 			for (const [elicitationId, resolve] of this.pendingElicitations) {
 				this.pendingElicitations.delete(elicitationId);
 				resolve({ action: "cancel" });
 			}
 		}
+	}
+
+	/**
+	 * Real mid-turn steer: push a `SDKUserMessage` into the active turn's
+	 * streaming-input queue so the SDK folds it into the current extended
+	 * turn, and emit a `user_prompt` passthrough event so the accumulator
+	 * renders the user bubble at the correct position AND streaming.rs
+	 * persists it exactly once (no extra DB path). Event shape matches
+	 * what the adapter's `user_prompt` branch reads on reload so
+	 * live/reload rendering stay identical — `files` included.
+	 *
+	 * Two correctness properties this method enforces:
+	 *
+	 *   1. **Ghost-steer rejection.** The SDK emits ONE terminal `result`
+	 *      for the whole streaming session; once the for-await loop sees
+	 *      it, the finally block closes `promptSource`. If our image-
+	 *      loading await straddles that boundary, a naive post-await
+	 *      emit would plant a synthetic event into the pipeline with no
+	 *      assistant response behind it. Re-check `promptSource.closed`
+	 *      after the await to refuse the steer in that window.
+	 *
+	 *   2. **Strict ordering with post-steer deltas.** Emit the synthetic
+	 *      event BEFORE `promptSource.push()`. Both are synchronous so
+	 *      no other JS code can interleave, and the accumulator observes
+	 *      `user_prompt` strictly before any deltas the SDK generates
+	 *      in response.
+	 *
+	 * Returns `true` on success, `false` when no active session or when
+	 * the turn finished while we were preparing the message.
+	 */
+	async steer(
+		sessionId: string,
+		prompt: string,
+		files: readonly string[],
+	): Promise<boolean> {
+		const session = this.sessions.get(sessionId);
+		if (!session || session.promptSource.closed) {
+			return false;
+		}
+
+		const { text, imagePaths } = parseImageRefs(prompt);
+		const sdkMessage =
+			imagePaths.length === 0
+				? ({
+						type: "user",
+						message: { role: "user", content: text },
+						parent_tool_use_id: null,
+					} as SDKUserMessage)
+				: await buildUserMessageWithImages(text, imagePaths);
+
+		// Re-check after the image-loading await — during those awaits
+		// the for-await loop may have hit the extended turn's single
+		// terminal result and closed our queue. Without this guard a
+		// late image-steer call would plant a ghost bubble.
+		if (session.promptSource.closed) {
+			return false;
+		}
+
+		const event: {
+			type: "user_prompt";
+			text: string;
+			steer: true;
+			files?: string[];
+		} = { type: "user_prompt", text, steer: true };
+		if (files.length > 0) event.files = [...files];
+		session.emitter.passthrough(session.requestId, event);
+		session.promptSource.push(sdkMessage);
+		logger.info(`steer ${sessionId}`, {
+			preview: text.slice(0, 60),
+			fileCount: files.length,
+		});
+		return true;
 	}
 
 	async generateTitle(

--- a/sidecar/src/claude-steer-race.test.ts
+++ b/sidecar/src/claude-steer-race.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Ghost-steer regression for `ClaudeSessionManager.steer()`.
+ *
+ * The race: the SDK emits ONE terminal `result` for the entire
+ * streaming-input session (initial prompt + any `steer()` pushes fold
+ * into one extended turn). The for-await loop bails on that result,
+ * and the finally block closes `promptSource`. A `steer()` call whose
+ * internal image-loading await straddles that boundary would — without
+ * a post-await guard — emit a synthetic event into the pipeline (and
+ * persist a DB row) with no assistant response behind it.
+ *
+ * Fix under test: `steer()` re-checks `promptSource.closed` AFTER any
+ * internal async work, before emitting the synthetic event. If the
+ * stream tore down during the await, the call quietly returns false.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { Query, SDKUserMessage } from "@anthropic-ai/claude-agent-sdk";
+import { ClaudeSessionManager } from "./claude-session-manager.js";
+import type { SidecarEmitter } from "./emitter.js";
+import { createPushable, type Pushable } from "./pushable-iterable.js";
+
+/** Build the minimal SidecarEmitter that `steer()` touches — just
+ *  `passthrough`. All other methods fail loudly so a test drift that
+ *  starts calling them would be obvious. */
+function makeSpyEmitter(): {
+	emitter: SidecarEmitter;
+	passthroughs: Array<{ requestId: string; message: object }>;
+} {
+	const passthroughs: Array<{ requestId: string; message: object }> = [];
+	const emitter = {
+		passthrough: (requestId: string, message: object) => {
+			passthroughs.push({ requestId, message });
+		},
+	} as unknown as SidecarEmitter;
+	return { emitter, passthroughs };
+}
+
+/** Minimal `Query` stub — `steer()` never invokes it. */
+const queryStub = {} as unknown as Query;
+
+/** Inject a fake live session into the manager. The `as any` is
+ *  deliberately narrow: the test only touches public `steer()` which
+ *  reads `sessions.get(...)` internally, and the returned map entry is
+ *  structurally whatever `steer()` destructures. */
+interface InjectedSession {
+	query: Query;
+	abortController: AbortController;
+	promptSource: Pushable<SDKUserMessage>;
+	requestId: string;
+	emitter: SidecarEmitter;
+}
+
+function injectSession(
+	manager: ClaudeSessionManager,
+	sessionId: string,
+	entry: InjectedSession,
+): InjectedSession {
+	// biome-ignore lint/suspicious/noExplicitAny: reach into private sessions map for test injection
+	(manager as any).sessions.set(sessionId, entry);
+	return entry;
+}
+
+describe("ClaudeSessionManager.steer ghost-steer guards", () => {
+	test("returns false when promptSource is closed BEFORE the call", async () => {
+		const manager = new ClaudeSessionManager();
+		const { emitter, passthroughs } = makeSpyEmitter();
+		const promptSource = createPushable<SDKUserMessage>();
+		promptSource.close(); // simulate post-terminal-result state
+
+		injectSession(manager, "s1", {
+			query: queryStub,
+			abortController: new AbortController(),
+			promptSource,
+			requestId: "rid-1",
+			emitter,
+		});
+
+		const accepted = await manager.steer("s1", "ignored prompt", []);
+
+		expect(accepted).toBe(false);
+		expect(passthroughs).toHaveLength(0);
+	});
+
+	test("returns false when promptSource closes DURING the build await (image race)", async () => {
+		const manager = new ClaudeSessionManager();
+		const { emitter, passthroughs } = makeSpyEmitter();
+		const promptSource = createPushable<SDKUserMessage>();
+
+		injectSession(manager, "s1", {
+			query: queryStub,
+			abortController: new AbortController(),
+			promptSource,
+			requestId: "rid-1",
+			emitter,
+		});
+
+		// Kick off a steer with an `@image` ref — this takes the
+		// `buildUserMessageWithImages` branch, which has an internal
+		// `await readImageWithResize(...)`. That await is our race
+		// window.
+		const promise = manager.steer("s1", "hey @/nonexistent-test-image.png", []);
+
+		// While steer's image-load await is in flight, the streaming
+		// loop terminates the turn — closes the prompt source before
+		// steer resumes.
+		promptSource.close();
+
+		const accepted = await promise;
+
+		// The post-await re-check must reject so no synthetic event
+		// leaks into the pipeline — that's exactly the bug.
+		expect(accepted).toBe(false);
+		expect(passthroughs).toHaveLength(0);
+	});
+
+	test("plain-text steer on an open session still works (no false-positive lockout)", async () => {
+		const manager = new ClaudeSessionManager();
+		const { emitter, passthroughs } = makeSpyEmitter();
+		const promptSource = createPushable<SDKUserMessage>();
+
+		injectSession(manager, "s1", {
+			query: queryStub,
+			abortController: new AbortController(),
+			promptSource,
+			requestId: "rid-1",
+			emitter,
+		});
+
+		const accepted = await manager.steer("s1", "focus on failing tests", [
+			"src/foo.ts",
+		]);
+
+		expect(accepted).toBe(true);
+		expect(passthroughs).toHaveLength(1);
+		const [first] = passthroughs;
+		if (!first) throw new Error("unreachable: already asserted length");
+		expect(first.requestId).toBe("rid-1");
+		expect(first.message).toEqual({
+			type: "user_prompt",
+			text: "focus on failing tests",
+			steer: true,
+			files: ["src/foo.ts"],
+		});
+	});
+});

--- a/sidecar/src/codex-app-server-manager.ts
+++ b/sidecar/src/codex-app-server-manager.ts
@@ -80,6 +80,22 @@ interface AppServerContext {
 	activeTurnId: string | null;
 	turnResolve: (() => void) | null;
 	turnReject: ((err: Error) => void) | null;
+	/** Request id for the currently streaming sendMessage invocation —
+	 *  used by `steer()` to route a synthetic user passthrough event into
+	 *  the right Channel so the pipeline renders the steer bubble at the
+	 *  correct streaming position (not at the tail). */
+	activeRequestId: string | null;
+	/** Emitter owning the active stream — `steer()` uses it to fan a
+	 *  synthetic `user` passthrough alongside the RPC. */
+	activeEmitter: SidecarEmitter | null;
+	/** When non-null, BOTH `handleNotification` and `handleRequest` await
+	 *  this promise before dispatching. `steer()` installs one for the
+	 *  duration of the `turn/steer` RPC so any post-steer deltas OR
+	 *  server-initiated tool/user-input requests that arrive before the
+	 *  RPC reply are queued at the dispatch boundary and don't reach
+	 *  the frontend pipeline/UI until after the synthetic user_prompt
+	 *  event lands. Microtask FIFO preserves their relative ordering. */
+	notificationGate: Promise<void> | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -224,6 +240,11 @@ export class CodexAppServerManager implements SessionManager {
 
 		let aborted = false;
 
+		// Stash the active stream's routing info so `steer()` can fire a
+		// synthetic user passthrough on the correct request id / emitter.
+		ctx.activeRequestId = requestId;
+		ctx.activeEmitter = emitter;
+
 		return new Promise<void>((resolve, reject) => {
 			ctx.turnResolve = resolve;
 			ctx.turnReject = (err) => {
@@ -235,7 +256,18 @@ export class CodexAppServerManager implements SessionManager {
 				emitter.passthrough(requestId, event);
 			};
 
-			const handleNotification = (n: JsonRpcNotification) => {
+			const handleNotification = async (n: JsonRpcNotification) => {
+				// Steer gate: if `steer()` is mid-RPC, hold this
+				// notification until the RPC resolves and the synthetic
+				// user_prompt event has been emitted. JS microtask FIFO
+				// keeps concurrent notifications in their arrival order,
+				// and the gate guarantees they all land AFTER the
+				// synthetic event — fixes the delta-before-RPC-reply race
+				// flagged in review.
+				if (ctx.notificationGate) {
+					await ctx.notificationGate;
+				}
+
 				// Codex sends errors as {method:"error", params:{error:{message:"..."}}}
 				// Extract the nested message and emit a proper error event.
 				if (n.method === "error") {
@@ -291,7 +323,18 @@ export class CodexAppServerManager implements SessionManager {
 				}
 			};
 
-			const handleRequest = (req: JsonRpcRequest) => {
+			const handleRequest = async (req: JsonRpcRequest) => {
+				// Same gate as handleNotification: server-initiated
+				// requests (tool approvals, user-input prompts) that
+				// arrive during a `steer()` RPC window must not reach
+				// the frontend UI before the synthetic user_prompt
+				// event lands. Otherwise the permission/input panel
+				// could pop before the steer bubble shows up, making
+				// the interaction order look inconsistent.
+				if (ctx.notificationGate) {
+					await ctx.notificationGate;
+				}
+
 				if (APPROVAL_METHODS.has(req.method)) {
 					const p = (req.params ?? {}) as Record<string, unknown>;
 					const permissionId = `codex-${crypto.randomUUID()}`;
@@ -537,6 +580,88 @@ export class CodexAppServerManager implements SessionManager {
 		pendingReject?.(abortErr);
 	}
 
+	/**
+	 * Real mid-turn steer via Codex's native `turn/steer` RPC — appends
+	 * user input to the active turn without starting a new one. Emits a
+	 * `user_prompt` passthrough so the accumulator places the bubble at
+	 * the current position AND streaming.rs persists it once (same DB
+	 * shape as initial prompts; adapter reads it identically on reload).
+	 *
+	 * Two correctness properties this method enforces:
+	 *
+	 *   1. **No ghost steer on rejection.** RPC goes first; the synthetic
+	 *      event is only emitted after the RPC resolves successfully. A
+	 *      thrown RPC error (expectedTurnId mismatch, timeout, server
+	 *      error) propagates up WITHOUT ever touching the pipeline.
+	 *
+	 *   2. **Strict ordering with post-steer notifications.** We install
+	 *      a `notificationGate` promise for the RPC window. Any
+	 *      server-side deltas that arrive before the RPC reply (possible
+	 *      if the server buffers the reply and streams tokens first) hit
+	 *      `handleNotification`, await the gate, and only flow into the
+	 *      pipeline AFTER the synthetic user_prompt event is emitted.
+	 *      JS microtask FIFO preserves their relative order.
+	 *
+	 * Returns `true` when accepted, `false` when no active turn exists.
+	 */
+	async steer(
+		sessionId: string,
+		prompt: string,
+		files: readonly string[],
+	): Promise<boolean> {
+		const ctx = this.sessions.get(sessionId);
+		if (!ctx?.providerThreadId || !ctx.activeTurnId) {
+			return false;
+		}
+		logger.info(`steer ${sessionId}`, {
+			threadId: ctx.providerThreadId,
+			turnId: ctx.activeTurnId,
+			preview: prompt.slice(0, 60),
+			fileCount: files.length,
+		});
+
+		let releaseGate: () => void = () => {};
+		ctx.notificationGate = new Promise<void>((resolve) => {
+			releaseGate = resolve;
+		});
+
+		try {
+			// RPC first. Thrown errors (reject, timeout, expectedTurnId
+			// mismatch) propagate WITHOUT emitting the synthetic event.
+			await ctx.server.sendRequest(
+				"turn/steer",
+				{
+					threadId: ctx.providerThreadId,
+					input: [{ type: "text", text: prompt }],
+					expectedTurnId: ctx.activeTurnId,
+				},
+				5_000,
+			);
+
+			// Provider accepted. Emit the synthetic event BEFORE releasing
+			// the gate so queued notifications land after it in FIFO.
+			if (ctx.activeEmitter && ctx.activeRequestId) {
+				const event: {
+					type: "user_prompt";
+					text: string;
+					steer: true;
+					files?: string[];
+				} = { type: "user_prompt", text: prompt, steer: true };
+				if (files.length > 0) event.files = [...files];
+				ctx.activeEmitter.passthrough(ctx.activeRequestId, event);
+			}
+			return true;
+		} finally {
+			// Always release the gate — rejection path lets queued
+			// notifications flow through normally (no synthetic ahead of
+			// them; Codex shouldn't have sent deltas for a rejected
+			// steer anyway, and if it did, treating them as main-stream
+			// events is the conservative choice).
+			ctx.notificationGate = null;
+			releaseGate();
+		}
+	}
+
 	async shutdown(): Promise<void> {
 		for (const [_id, ctx] of this.sessions) {
 			try {
@@ -638,6 +763,9 @@ export class CodexAppServerManager implements SessionManager {
 			activeTurnId: null,
 			turnResolve: null,
 			turnReject: null,
+			activeRequestId: null,
+			activeEmitter: null,
+			notificationGate: null,
 		};
 
 		this.sessions.set(sessionId, ctx);

--- a/sidecar/src/codex-steer-gate.test.ts
+++ b/sidecar/src/codex-steer-gate.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Gate-ordering regression test for `CodexAppServerManager.steer()`.
+ *
+ * We drive a real `CodexAppServerManager` against a fake
+ * `CodexAppServer` stub and exercise the REAL code path end-to-end:
+ * `sendMessage` installs `handleNotification` + `handleRequest` on the
+ * stub via `setHandlers`; the test then fires notifications / requests
+ * through those CAPTURED production closures while `steer()` holds the
+ * gate. If someone deletes `await ctx.notificationGate` from either
+ * handler the ordering check fails loudly.
+ *
+ * Properties under test:
+ *   1. Notifications that arrive between `turn/steer` send and reply
+ *      are dispatched AFTER the synthetic `user_prompt` event.
+ *   2. Server-initiated requests (approvals, user-input prompts) are
+ *      ALSO gated — otherwise a permission panel could pop before the
+ *      steer bubble lands in the thread.
+ *   3. Rejection path: queued events still drain, without a synthetic
+ *      ahead of them.
+ *
+ * Guards reviewer-flagged gaps in the previous pattern-only test.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { OnNotification, OnRequest } from "./codex-app-server.js";
+import { CodexAppServerManager } from "./codex-app-server-manager.js";
+import { createSidecarEmitter } from "./emitter.js";
+
+interface PendingRpc {
+	method: string;
+	resolve: (value: unknown) => void;
+	reject: (err: Error) => void;
+}
+
+/** Duck-typed stand-in for `CodexAppServer`. Captures the REAL
+ *  handlers the manager installs via `setHandlers`, and exposes
+ *  controllable `sendRequest` promises so the test can hold RPC
+ *  replies open while it fires events through the captured
+ *  production closures. */
+function makeFakeServer() {
+	let onNotification: OnNotification = () => {};
+	let onRequest: OnRequest = () => {};
+	const pending: PendingRpc[] = [];
+
+	const api = {
+		killed: false,
+		setHandlers(n: OnNotification, r: OnRequest): void {
+			onNotification = n;
+			onRequest = r;
+		},
+		setActiveRequestId(_id: string): void {},
+		async sendRequest<T>(method: string, _params?: unknown): Promise<T> {
+			return new Promise<T>((resolve, reject) => {
+				pending.push({
+					method,
+					resolve: resolve as (v: unknown) => void,
+					reject,
+				});
+			});
+		},
+		sendResponse(_id: string | number, _result: unknown): void {},
+		writeNotification(_method: string, _params?: unknown): void {},
+		kill(): void {
+			this.killed = true;
+		},
+	};
+
+	return {
+		server: api,
+		pending,
+		// Expose the CAPTURED production handlers. Tests fire through
+		// these — NOT through local replicas — so the real gate
+		// `await`s are exercised.
+		fireNotification(method: string, params?: Record<string, unknown>) {
+			return onNotification({
+				method,
+				params,
+			} as Parameters<OnNotification>[0]);
+		},
+		fireRequest(id: string, method: string, params?: Record<string, unknown>) {
+			return onRequest({
+				id,
+				method,
+				params,
+			} as Parameters<OnRequest>[0]);
+		},
+		resolveNext(method: string, value: unknown = { ok: true }): boolean {
+			const idx = pending.findIndex((p) => p.method === method);
+			if (idx < 0) return false;
+			const [p] = pending.splice(idx, 1);
+			p?.resolve(value);
+			return true;
+		},
+		rejectNext(method: string, err: Error): boolean {
+			const idx = pending.findIndex((p) => p.method === method);
+			if (idx < 0) return false;
+			const [p] = pending.splice(idx, 1);
+			p?.reject(err);
+			return true;
+		},
+	};
+}
+
+/** Pre-seed the manager's private `sessions` map with a context
+ *  whose `server` is our fake, then start `sendMessage` so the real
+ *  production code path wires `handleNotification`/`handleRequest` via
+ *  `server.setHandlers`. Returns control back to the test with the
+ *  fake exposed for firing events and the event buffer for
+ *  assertions. `sendMessage`'s Promise parks awaiting `turn/completed`
+ *  — the test resolves it at the end. */
+async function driveToSendMessage(sessionId: string) {
+	const manager = new CodexAppServerManager();
+	const fake = makeFakeServer();
+	const events: object[] = [];
+	const emitter = createSidecarEmitter((e) => events.push(e));
+
+	// biome-ignore lint/suspicious/noExplicitAny: inject into private sessions
+	(manager as any).sessions.set(sessionId, {
+		server: fake.server,
+		providerThreadId: "thread-xyz",
+		activeTurnId: null, // `sendMessage` populates on turn/start reply
+		turnResolve: null,
+		turnReject: null,
+		activeRequestId: null,
+		activeEmitter: null,
+		notificationGate: null,
+	});
+
+	const sendMessagePromise = manager.sendMessage(
+		"stream-rid-1",
+		{
+			sessionId,
+			prompt: "initial question",
+			model: undefined,
+			cwd: undefined,
+			resume: undefined,
+			effortLevel: undefined,
+			permissionMode: undefined,
+			fastMode: undefined,
+		},
+		emitter,
+	);
+
+	// Let `sendMessage` run until it calls `sendRequest("turn/start")`
+	// and parks. At this point `setHandlers` has been called with the
+	// real handleNotification/handleRequest closures.
+	await new Promise((r) => setTimeout(r, 0));
+	await new Promise((r) => setTimeout(r, 0));
+
+	// Reply to turn/start with a valid turn id so ctx.activeTurnId
+	// populates — `steer()` won't proceed without it.
+	const turnStarted = fake.resolveNext("turn/start", {
+		turn: { id: "turn-active" },
+	});
+	expect(turnStarted).toBe(true);
+	await new Promise((r) => setTimeout(r, 0));
+
+	return { manager, fake, events, sessionId, sendMessagePromise };
+}
+
+/** Tear down a test by firing turn/completed (resolves sendMessage)
+ *  and awaiting all outstanding promises. */
+async function finish(
+	fake: ReturnType<typeof makeFakeServer>,
+	sendMessagePromise: Promise<void>,
+): Promise<void> {
+	fake.fireNotification("turn/completed", { turn: { id: "turn-active" } });
+	await sendMessagePromise;
+}
+
+const userPromptTypes = (events: object[]) =>
+	events
+		.filter((e): e is { type: string } => {
+			const t = (e as { type?: unknown }).type;
+			return typeof t === "string";
+		})
+		.map((e) => e.type);
+
+describe("CodexAppServerManager.steer gate — real manager wiring", () => {
+	test("notifications during turn/steer RPC land AFTER synthetic user_prompt", async () => {
+		const { manager, fake, events, sendMessagePromise } =
+			await driveToSendMessage("s1");
+
+		const steerPromise = manager.steer("s1", "focus on failing tests", []);
+		// Let steer() install the gate and park on sendRequest.
+		await new Promise((r) => setTimeout(r, 0));
+
+		// Fire two server-side deltas BEFORE the RPC reply — this is
+		// the race condition the gate defends against.
+		fake.fireNotification("item/delta-1", {
+			item: { id: "i1", type: "text", text: "hello" },
+		});
+		fake.fireNotification("item/delta-2", {
+			item: { id: "i2", type: "text", text: "world" },
+		});
+		await new Promise((r) => setTimeout(r, 0));
+
+		// Reply to turn/steer → synthetic emits → gate releases →
+		// queued notifications drain in FIFO.
+		expect(fake.resolveNext("turn/steer", {})).toBe(true);
+		expect(await steerPromise).toBe(true);
+		await new Promise((r) => setTimeout(r, 0));
+
+		const types = userPromptTypes(events);
+		// Pattern: somewhere in the sequence the synthetic user_prompt
+		// event must appear strictly before the two item/delta
+		// notifications (flattened by handleNotification).
+		const userPromptIdx = types.indexOf("user_prompt");
+		expect(userPromptIdx).toBeGreaterThanOrEqual(0);
+		const afterSteer = types.slice(userPromptIdx + 1);
+		// Both deltas flattened via `flattenNotification` (method
+		// becomes the outer type) — exact event kind depends on
+		// production flattener but ordering is the invariant.
+		expect(afterSteer.length).toBeGreaterThanOrEqual(2);
+
+		await finish(fake, sendMessagePromise);
+	});
+
+	test("server-initiated requests are ALSO gated behind synthetic", async () => {
+		const { manager, fake, events, sendMessagePromise } =
+			await driveToSendMessage("s1");
+
+		const steerPromise = manager.steer("s1", "switch direction", []);
+		await new Promise((r) => setTimeout(r, 0));
+
+		// Tool approval request mid-steer. Without handleRequest's
+		// gate await, this would fire `emitter.permissionRequest`
+		// BEFORE the synthetic user_prompt — permission panel pops
+		// before the steer bubble shows up.
+		fake.fireRequest("approval-1", "item/commandExecution/requestApproval", {
+			command: "echo hi",
+		});
+		await new Promise((r) => setTimeout(r, 0));
+
+		expect(fake.resolveNext("turn/steer", {})).toBe(true);
+		expect(await steerPromise).toBe(true);
+		await new Promise((r) => setTimeout(r, 0));
+
+		// Find indices of the synthetic and the permission request
+		// in the real emitter output.
+		const idxSynthetic = events.findIndex(
+			(e) => (e as { type?: string }).type === "user_prompt",
+		);
+		const idxPermission = events.findIndex(
+			(e) => (e as { type?: string }).type === "permissionRequest",
+		);
+		expect(idxSynthetic).toBeGreaterThanOrEqual(0);
+		expect(idxPermission).toBeGreaterThanOrEqual(0);
+		expect(idxSynthetic).toBeLessThan(idxPermission);
+
+		await finish(fake, sendMessagePromise);
+	});
+
+	test("RPC rejection: queued events drain without a synthetic ahead", async () => {
+		const { manager, fake, events, sendMessagePromise } =
+			await driveToSendMessage("s1");
+
+		const steerPromise = manager.steer("s1", "bad steer", []);
+		await new Promise((r) => setTimeout(r, 0));
+
+		fake.fireNotification("item/delta-1", {
+			item: { id: "i1", type: "text", text: "x" },
+		});
+		await new Promise((r) => setTimeout(r, 0));
+
+		// Reject turn/steer — e.g. expectedTurnId mismatch.
+		expect(
+			fake.rejectNext("turn/steer", new Error("turn already completed")),
+		).toBe(true);
+		await expect(steerPromise).rejects.toThrow("turn already completed");
+		await new Promise((r) => setTimeout(r, 0));
+
+		// No synthetic emitted on rejection path.
+		const idxSynthetic = events.findIndex(
+			(e) => (e as { type?: string }).type === "user_prompt",
+		);
+		expect(idxSynthetic).toBe(-1);
+
+		await finish(fake, sendMessagePromise);
+	});
+
+	test("steady-state: notifications flow through when no steer is pending", async () => {
+		const { fake, events, sendMessagePromise } = await driveToSendMessage("s1");
+
+		fake.fireNotification("item/delta-pre", {
+			item: { id: "x", type: "text", text: "hi" },
+		});
+		await new Promise((r) => setTimeout(r, 0));
+
+		// No gate is installed; handler should fall through normally.
+		// Exact event type depends on the flattener — we just assert
+		// the handler wasn't blocked (at least one event emitted after
+		// sendMessage's own init output).
+		expect(events.length).toBeGreaterThan(0);
+
+		await finish(fake, sendMessagePromise);
+	});
+});

--- a/sidecar/src/emitter.ts
+++ b/sidecar/src/emitter.ts
@@ -38,6 +38,14 @@ export type StoppedEvent = {
 	readonly sessionId: string;
 };
 
+export type SteeredEvent = {
+	readonly id: string;
+	readonly type: "steered";
+	readonly sessionId: string;
+	readonly accepted: boolean;
+	readonly reason?: string;
+};
+
 export type PongEvent = { readonly id: string; readonly type: "pong" };
 
 export type TitleGeneratedEvent = {
@@ -130,6 +138,7 @@ export type SidecarControlEvent =
 	| AbortedEvent
 	| ErrorEvent
 	| StoppedEvent
+	| SteeredEvent
 	| PongEvent
 	| TitleGeneratedEvent
 	| SlashCommandsListedEvent
@@ -154,6 +163,12 @@ export interface SidecarEmitter {
 	aborted(requestId: string, reason: string): void;
 	error(requestId: string | null, message: string, internal?: boolean): void;
 	stopped(requestId: string, sessionId: string): void;
+	steered(
+		requestId: string,
+		sessionId: string,
+		accepted: boolean,
+		reason?: string,
+	): void;
 	pong(requestId: string): void;
 	titleGenerated(
 		requestId: string,
@@ -233,6 +248,14 @@ export function createSidecarEmitter(
 			),
 		stopped: (requestId, sessionId) =>
 			write({ id: requestId, type: "stopped", sessionId }),
+		steered: (requestId, sessionId, accepted, reason) =>
+			write({
+				id: requestId,
+				type: "steered",
+				sessionId,
+				accepted,
+				...(reason ? { reason } : {}),
+			}),
 		pong: (requestId) => write({ id: requestId, type: "pong" }),
 		titleGenerated: (requestId, title, branchName) =>
 			write({ id: requestId, type: "titleGenerated", title, branchName }),

--- a/sidecar/src/index.ts
+++ b/sidecar/src/index.ts
@@ -23,6 +23,7 @@ import {
 	parseProvider,
 	parseRequest,
 	parseSendMessageParams,
+	parseSteerSessionParams,
 	type RawRequest,
 	requireString,
 } from "./request-parser.js";
@@ -196,6 +197,35 @@ async function handleStopSession(
 	}
 }
 
+async function handleSteerSession(
+	id: string,
+	params: Record<string, unknown>,
+): Promise<void> {
+	try {
+		const provider = parseProvider(params.provider);
+		const { sessionId, prompt, files } = parseSteerSessionParams(params);
+		logger.debug(`[${id}] steerSession`, {
+			sessionId,
+			provider,
+			preview: prompt.slice(0, 80),
+			fileCount: files.length,
+		});
+		const accepted = await managers[provider].steer(sessionId, prompt, files);
+		emitter.steered(
+			id,
+			sessionId,
+			accepted,
+			accepted ? undefined : "no_active_turn",
+		);
+	} catch (err) {
+		const msg = errorMessage(err);
+		logger.error(`[${id}] steerSession FAILED: ${msg}`, errorDetails(err));
+		const sessionId =
+			typeof params.sessionId === "string" ? params.sessionId : "";
+		emitter.steered(id, sessionId, false, msg);
+	}
+}
+
 function optionalObject(
 	params: Record<string, unknown>,
 	key: string,
@@ -296,6 +326,9 @@ for await (const line of rl) {
 				break;
 			case "stopSession":
 				await handleStopSession(id, params);
+				break;
+			case "steerSession":
+				await handleSteerSession(id, params);
 				break;
 			case "shutdown":
 				await handleShutdown(id);

--- a/sidecar/src/pushable-iterable.test.ts
+++ b/sidecar/src/pushable-iterable.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { createPushable } from "./pushable-iterable.js";
+
+describe("createPushable", () => {
+	test("delivers pushed values in FIFO order", async () => {
+		const p = createPushable<number>();
+		p.push(1);
+		p.push(2);
+		p.push(3);
+		p.close();
+
+		const out: number[] = [];
+		for await (const v of p) out.push(v);
+		expect(out).toEqual([1, 2, 3]);
+	});
+
+	test("waiter wakes up on push", async () => {
+		const p = createPushable<string>();
+		const it = p[Symbol.asyncIterator]();
+		const nextPromise = it.next();
+		p.push("hi");
+		expect((await nextPromise).value).toBe("hi");
+	});
+
+	test("waiter resolves to done on close with empty queue", async () => {
+		const p = createPushable<string>();
+		const it = p[Symbol.asyncIterator]();
+		const nextPromise = it.next();
+		p.close();
+		expect((await nextPromise).done).toBe(true);
+	});
+
+	test("pushes after close are ignored", async () => {
+		const p = createPushable<number>();
+		p.push(1);
+		p.close();
+		p.push(2);
+		const out: number[] = [];
+		for await (const v of p) out.push(v);
+		expect(out).toEqual([1]);
+	});
+
+	test("break exits cleanly via return()", async () => {
+		const p = createPushable<number>();
+		p.push(1);
+		p.push(2);
+		let sum = 0;
+		for await (const v of p) {
+			sum += v;
+			if (v === 2) break;
+		}
+		expect(sum).toBe(3);
+		expect(p.closed).toBe(true);
+	});
+});

--- a/sidecar/src/pushable-iterable.ts
+++ b/sidecar/src/pushable-iterable.ts
@@ -1,0 +1,76 @@
+/**
+ * Queue-backed `AsyncIterable<T>` for Claude Agent SDK streaming-input mode.
+ *
+ * The SDK's `query({ prompt })` accepts an `AsyncIterable<SDKUserMessage>`
+ * that stays open across the life of a session. `streamInput()` and
+ * mid-turn `steer()` both rely on the iterable reading new messages
+ * after the initial prompt — so we hand the SDK a pushable queue and
+ * `push()` into it whenever we want to inject another user message.
+ */
+
+export interface Pushable<T> extends AsyncIterable<T> {
+	push(value: T): void;
+	close(): void;
+	/** True once `close()` has been called. Further pushes are ignored. */
+	readonly closed: boolean;
+}
+
+export function createPushable<T>(): Pushable<T> {
+	const queue: T[] = [];
+	let closed = false;
+	let waiter: ((result: IteratorResult<T>) => void) | null = null;
+
+	const iterator: AsyncIterator<T> = {
+		next(): Promise<IteratorResult<T>> {
+			if (queue.length > 0) {
+				return Promise.resolve({ value: queue.shift() as T, done: false });
+			}
+			if (closed) {
+				return Promise.resolve({
+					value: undefined as unknown as T,
+					done: true,
+				});
+			}
+			return new Promise((resolve) => {
+				waiter = resolve;
+			});
+		},
+		return(): Promise<IteratorResult<T>> {
+			closed = true;
+			if (waiter) {
+				const w = waiter;
+				waiter = null;
+				w({ value: undefined as unknown as T, done: true });
+			}
+			return Promise.resolve({ value: undefined as unknown as T, done: true });
+		},
+	};
+
+	return {
+		push(value: T) {
+			if (closed) return;
+			if (waiter) {
+				const w = waiter;
+				waiter = null;
+				w({ value, done: false });
+				return;
+			}
+			queue.push(value);
+		},
+		close() {
+			if (closed) return;
+			closed = true;
+			if (waiter) {
+				const w = waiter;
+				waiter = null;
+				w({ value: undefined as unknown as T, done: true });
+			}
+		},
+		get closed() {
+			return closed;
+		},
+		[Symbol.asyncIterator]() {
+			return iterator;
+		},
+	};
+}

--- a/sidecar/src/request-parser.ts
+++ b/sidecar/src/request-parser.ts
@@ -136,6 +136,26 @@ export function parseListSlashCommandsParams(
 	};
 }
 
+export interface SteerSessionParams {
+	readonly sessionId: string;
+	readonly prompt: string;
+	readonly files: readonly string[];
+}
+
+export function parseSteerSessionParams(
+	params: Record<string, unknown>,
+): SteerSessionParams {
+	const rawFiles = params.files;
+	const files: string[] = Array.isArray(rawFiles)
+		? rawFiles.filter((f): f is string => typeof f === "string")
+		: [];
+	return {
+		sessionId: requireString(params, "sessionId"),
+		prompt: requireString(params, "prompt"),
+		files,
+	};
+}
+
 export function errorMessage(err: unknown): string {
 	return err instanceof Error ? err.message : String(err);
 }

--- a/sidecar/src/session-manager.ts
+++ b/sidecar/src/session-manager.ts
@@ -118,6 +118,20 @@ export interface SessionManager {
 	stopSession(sessionId: string): Promise<void>;
 
 	/**
+	 * Inject an additional user message into an in-flight turn (real
+	 * mid-turn steer). Returns `true` when the input was delivered to
+	 * the provider, `false` when no active turn exists for `sessionId`.
+	 * Implementations MUST confirm provider acceptance before emitting
+	 * any pipeline event — a failed steer must not pollute the stream.
+	 * Throws on SDK-level rejection.
+	 */
+	steer(
+		sessionId: string,
+		prompt: string,
+		files: readonly string[],
+	): Promise<boolean>;
+
+	/**
 	 * Tear down every in-flight session this manager owns. Called when the
 	 * sidecar is shutting down (parent process is exiting). Implementations
 	 * must release SDK resources — Claude's `Query.close()`, Codex's

--- a/src-tauri/src/agents.rs
+++ b/src-tauri/src/agents.rs
@@ -1,3 +1,5 @@
+use std::time::{Duration, Instant};
+
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tauri::{ipc::Channel, AppHandle, Manager};
@@ -275,6 +277,128 @@ pub async fn stop_agent_stream(
         .send(&stop_req)
         .map_err(|e| anyhow::anyhow!("Failed to stop session: {e}"))?;
     Ok(())
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentSteerRequest {
+    pub session_id: String,
+    pub provider: Option<String>,
+    pub prompt: String,
+    #[serde(default)]
+    pub files: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentSteerResponse {
+    pub accepted: bool,
+    pub reason: Option<String>,
+}
+
+/// Inject a user message into an in-flight turn (real mid-turn steer).
+/// Thin wrapper around the sidecar's `steerSession` RPC — the sidecar
+/// routes to provider-native APIs (`streamInput` for Claude, `turn/steer`
+/// for Codex) and emits a `user_prompt` passthrough event into the active
+/// stream ONLY after the provider has confirmed acceptance. That event
+/// flows through the same accumulator + `persist_turn_message` path as
+/// any other user turn, so there's no separate persistence path and no
+/// chance of a ghost steer from an emit-before-ack race.
+///
+/// Returns `{ accepted: false }` when the turn already completed or the
+/// provider rejected the input — the frontend uses that to roll back the
+/// optimistic bubble and restore the composer draft. Does NOT write to
+/// the database: persistence is owned entirely by the streaming pipeline.
+#[tauri::command]
+pub async fn steer_agent_stream(
+    app: AppHandle,
+    sidecar: tauri::State<'_, crate::sidecar::ManagedSidecar>,
+    request: AgentSteerRequest,
+) -> CmdResult<AgentSteerResponse> {
+    let prompt = request.prompt.trim().to_string();
+    if prompt.is_empty() {
+        return Err(anyhow::anyhow!("Steer prompt cannot be empty.").into());
+    }
+
+    let active_streams = app.state::<ActiveStreams>();
+    let handle = active_streams
+        .lookup_by_sidecar_session_id(&request.session_id)
+        .ok_or_else(|| anyhow::anyhow!("No active stream for session {}", request.session_id))?;
+
+    let provider = request
+        .provider
+        .clone()
+        .unwrap_or_else(|| handle.provider.clone());
+    let request_id = Uuid::new_v4().to_string();
+    let files = request.files.clone().unwrap_or_default();
+
+    let steer_req = crate::sidecar::SidecarRequest {
+        id: request_id.clone(),
+        method: "steerSession".to_string(),
+        params: serde_json::json!({
+            "sessionId": request.session_id,
+            "provider": provider,
+            "prompt": prompt,
+            "files": files,
+        }),
+    };
+
+    let rx = sidecar.subscribe(&request_id);
+    if let Err(error) = sidecar.send(&steer_req) {
+        sidecar.unsubscribe(&request_id);
+        return Err(anyhow::anyhow!("Sidecar send failed: {error}").into());
+    }
+
+    let rid_for_worker = request_id.clone();
+    let outcome = tauri::async_runtime::spawn_blocking(move || {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return Err(anyhow::anyhow!("Steer timed out waiting for sidecar"));
+            }
+            match rx.recv_timeout(remaining) {
+                Ok(event) => {
+                    if event.event_type() == "steered" {
+                        let accepted = event
+                            .raw
+                            .get("accepted")
+                            .and_then(Value::as_bool)
+                            .unwrap_or(false);
+                        let reason = event
+                            .raw
+                            .get("reason")
+                            .and_then(Value::as_str)
+                            .map(str::to_string);
+                        return Ok((accepted, reason));
+                    }
+                    if event.event_type() == "error" {
+                        let msg = event
+                            .raw
+                            .get("message")
+                            .and_then(Value::as_str)
+                            .unwrap_or("sidecar error")
+                            .to_string();
+                        return Err(anyhow::anyhow!(msg));
+                    }
+                    // Other event types on this request id are noise —
+                    // keep waiting for the terminal `steered` response.
+                }
+                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                    return Err(anyhow::anyhow!("Steer timed out waiting for sidecar"));
+                }
+                Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                    return Err(anyhow::anyhow!("Sidecar disconnected before responding"));
+                }
+            }
+        }
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("Steer worker join failed: {e}"))?;
+
+    sidecar.unsubscribe(&rid_for_worker);
+    let (accepted, reason) = outcome?;
+    Ok(AgentSteerResponse { accepted, reason })
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -885,6 +1009,126 @@ mod tests {
             )
             .unwrap();
         assert_eq!(msg_count, 3, "Should have user + 2 turn messages");
+
+        std::env::remove_var("HELMOR_DATA_DIR");
+    }
+
+    /// End-to-end: simulate the sidecar firing a `user_prompt` passthrough
+    /// event (what `ClaudeSessionManager.steer()` / `CodexAppServerManager
+    /// .steer()` emit after provider ack) into the accumulator, drain the
+    /// turns the streaming loop would persist, and assert DB contains
+    /// EXACTLY ONE row per logical user message (no double-persist, no
+    /// orphan `type: user` row) AND that reload returns a single bubble
+    /// per message with `files` + `steer` preserved.
+    ///
+    /// Explicitly exists to guard against the two bugs the code-review
+    /// flagged: (a) accumulator producing a turn + `persist_steer_message`
+    /// writing a second row, and (b) `type: user` wrapper drifting loose
+    /// from the `type: user_prompt` shape on reload.
+    #[test]
+    fn steer_user_prompt_event_persists_once_and_reloads_at_correct_position() {
+        use crate::pipeline::accumulator::StreamAccumulator;
+        use crate::pipeline::types::MessageRole as PipelineRole;
+
+        let dir = tempfile::tempdir().unwrap();
+        let _guard = crate::data_dir::TEST_ENV_LOCK.lock().unwrap();
+        std::env::set_var("HELMOR_DATA_DIR", dir.path());
+
+        let db_path = setup_test_db(dir.path());
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute(
+            "INSERT INTO sessions (id, workspace_id, status, title) VALUES ('s1', 'w1', 'idle', 'Test')",
+            [],
+        )
+        .unwrap();
+
+        let ctx = ExchangeContext {
+            helmor_session_id: "s1".to_string(),
+            turn_id: "turn-1".to_string(),
+            model_id: "opus-1m".to_string(),
+            model_provider: "claude".to_string(),
+            assistant_sdk_message_id: "assistant-1".to_string(),
+            user_message_id: "user-initial".to_string(),
+        };
+
+        // 1. Initial prompt persisted via the normal path.
+        persist_user_message(&conn, &ctx, "investigate the bug", &[]).unwrap();
+
+        // 2. Drive the accumulator the same way the streaming loop does:
+        //    assistant deltas, steer event, more assistant deltas, result.
+        let mut acc = StreamAccumulator::new("claude", "opus-1m");
+        let asst_first = serde_json::json!({
+            "type": "assistant",
+            "message": {
+                "id": "msg_a",
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Checking files..."}]
+            }
+        });
+        acc.push_event(&asst_first, &asst_first.to_string());
+
+        let steer_event = serde_json::json!({
+            "type": "user_prompt",
+            "text": "focus on failing tests",
+            "steer": true,
+            "files": ["src/foo.ts"],
+        });
+        acc.push_event(&steer_event, &steer_event.to_string());
+
+        let asst_second = serde_json::json!({
+            "type": "assistant",
+            "message": {
+                "id": "msg_b",
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Switching focus."}]
+            }
+        });
+        acc.push_event(&asst_second, &asst_second.to_string());
+
+        acc.flush_pending();
+
+        // 3. Persist every turn the accumulator produced — this mirrors
+        //    the `while persisted < turns_len { persist_turn_message(...) }`
+        //    loop in `streaming.rs`.
+        for i in 0..acc.turns_len() {
+            persist_turn_message(&conn, &ctx, acc.turn_at(i), &ctx.model_id).unwrap();
+        }
+
+        // 4. Assert one-shot persistence: exactly one DB row per user
+        //    message — the initial prompt + the steer. If the old
+        //    `persist_steer_message` path ever returns, this goes to 3.
+        let user_row_count: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM session_messages WHERE session_id = 's1' AND role = 'user'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            user_row_count, 2,
+            "expected initial prompt + steer user rows, no duplicates"
+        );
+
+        // 5. Reload via the exact production path and verify rendering.
+        let records = crate::models::sessions::list_session_historical_records("s1").unwrap();
+        let messages = crate::pipeline::MessagePipeline::convert_historical(&records);
+
+        // Message shape: [user: initial, assistant: first, user: steer, assistant: second]
+        let user_msgs: Vec<&crate::pipeline::types::ThreadMessageLike> = messages
+            .iter()
+            .filter(|m| m.role == PipelineRole::User)
+            .collect();
+        assert_eq!(
+            user_msgs.len(),
+            2,
+            "reload must show one bubble per user message, not two per steer"
+        );
+
+        // Sandwich order: initial user → assistant → steer user → assistant
+        assert_eq!(messages[0].role, PipelineRole::User);
+        assert_eq!(messages[1].role, PipelineRole::Assistant);
+        assert_eq!(messages[2].role, PipelineRole::User);
+        assert_eq!(messages[3].role, PipelineRole::Assistant);
 
         std::env::remove_var("HELMOR_DATA_DIR");
     }

--- a/src-tauri/src/agents/streaming.rs
+++ b/src-tauri/src/agents/streaming.rs
@@ -19,10 +19,10 @@ use super::{
 };
 
 #[derive(Debug, Clone)]
-struct ActiveStreamHandle {
-    request_id: String,
-    sidecar_session_id: String,
-    provider: String,
+pub(crate) struct ActiveStreamHandle {
+    pub request_id: String,
+    pub sidecar_session_id: String,
+    pub provider: String,
 }
 
 #[derive(Default)]
@@ -52,6 +52,17 @@ impl ActiveStreams {
             .lock()
             .map(|map| map.values().cloned().collect())
             .unwrap_or_default()
+    }
+
+    pub(crate) fn lookup_by_sidecar_session_id(
+        &self,
+        sidecar_session_id: &str,
+    ) -> Option<ActiveStreamHandle> {
+        self.inner.lock().ok().and_then(|map| {
+            map.values()
+                .find(|h| h.sidecar_session_id == sidecar_session_id)
+                .cloned()
+        })
     }
 
     pub(crate) fn len(&self) -> usize {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -134,6 +134,7 @@ pub fn run() {
             agents::list_agent_model_sections,
             agents::send_agent_message_stream,
             agents::stop_agent_stream,
+            agents::steer_agent_stream,
             agents::respond_to_permission_request,
             agents::respond_to_deferred_tool,
             agents::respond_to_elicitation_request,

--- a/src-tauri/src/pipeline/accumulator/mod.rs
+++ b/src-tauri/src/pipeline/accumulator/mod.rs
@@ -306,6 +306,17 @@ impl StreamAccumulator {
                 self.handle_user(raw_line, value);
                 PushOutcome::Finalized
             }
+            // Mid-turn steer injection — same semantics as a regular user
+            // turn boundary (flush in-flight assistant, push a user turn,
+            // subsequent assistant events start a fresh message). The
+            // inner JSON shape matches what `persist_user_message` writes
+            // for initial prompts, so streaming persistence and reload
+            // both go through the adapter's existing `user_prompt` branch
+            // without any special-case handling.
+            Some("user_prompt") => {
+                self.handle_user(raw_line, value);
+                PushOutcome::Finalized
+            }
             Some("result") => {
                 self.handle_result(value, raw_line);
                 PushOutcome::Finalized

--- a/src-tauri/src/pipeline/accumulator/tests.rs
+++ b/src-tauri/src/pipeline/accumulator/tests.rs
@@ -151,6 +151,81 @@ fn full_assistant_clears_blocks() {
 }
 
 #[test]
+fn mid_stream_user_prompt_event_splits_assistant_turn() {
+    // Locks in the steer positioning + persistence contract.
+    //
+    // The sidecar's `steer()` (Claude `streamInput`, Codex `turn/steer`)
+    // emits a `user_prompt` passthrough into the active stream AFTER the
+    // provider confirms acceptance. The accumulator must:
+    //   (a) flush the currently-streaming assistant message,
+    //   (b) push a user turn whose `content_json` is the raw event JSON
+    //       (which matches the adapter's `user_prompt` shape — same as
+    //       initial prompts, so streaming.rs persistence is one-shot),
+    //   (c) open a fresh assistant message for any subsequent events.
+    //
+    // This is the single contract that keeps the steer bubble in the
+    // right place AND prevents the double-persist bug that a separate
+    // `persist_steer_message` path introduced in a previous attempt.
+    let mut acc = StreamAccumulator::new("claude", "opus");
+
+    // Assistant's first segment (pre-steer).
+    let asst_first = json!({
+        "type": "assistant",
+        "message": {
+            "id": "msg_a",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "Analyzing..."}]
+        }
+    });
+    acc.push_event(&asst_first, &asst_first.to_string());
+
+    // Synthetic steer event (matches what sidecar emits post-ack).
+    let steer_event = json!({
+        "type": "user_prompt",
+        "text": "stop analyzing",
+        "steer": true,
+        "files": ["src/foo.ts"],
+    });
+    let steer_raw = steer_event.to_string();
+    acc.push_event(&steer_event, &steer_raw);
+
+    // Assistant's response to the steer.
+    let asst_second = json!({
+        "type": "assistant",
+        "message": {
+            "id": "msg_b",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "OK, stopping."}]
+        }
+    });
+    acc.push_event(&asst_second, &asst_second.to_string());
+
+    // `result` / stream end flushes the trailing staged assistant.
+    acc.flush_pending();
+
+    assert_eq!(acc.turns_len(), 3, "expected assistant + user + assistant");
+
+    // Middle turn MUST carry the full `user_prompt` JSON (with `steer`
+    // marker AND files) as its content_json — this is what
+    // `persist_turn_message` writes to the DB, and what the adapter's
+    // `user_prompt` branch reads on reload. Breaks here = double-persist
+    // bug returning or files dropping on reload.
+    let middle_turn = acc.turn_at(1);
+    assert_eq!(middle_turn.role, MessageRole::User);
+    let middle_parsed: Value = serde_json::from_str(&middle_turn.content_json).unwrap();
+    assert_eq!(middle_parsed["type"], "user_prompt");
+    assert_eq!(middle_parsed["text"], "stop analyzing");
+    assert_eq!(middle_parsed["steer"], true);
+    assert_eq!(middle_parsed["files"], json!(["src/foo.ts"]));
+
+    let snapshot = acc.snapshot("ctx", "sess");
+    assert_eq!(snapshot.len(), 3);
+    assert_eq!(snapshot[0].role, MessageRole::Assistant);
+    assert_eq!(snapshot[1].role, MessageRole::User);
+    assert_eq!(snapshot[2].role, MessageRole::Assistant);
+}
+
+#[test]
 fn codex_command_execution_synthesis() {
     let mut acc = StreamAccumulator::new("codex", "gpt-5.4");
     let event = json!({

--- a/src-tauri/tests/common/mod.rs
+++ b/src-tauri/tests/common/mod.rs
@@ -366,6 +366,17 @@ pub fn user_prompt_with_files(id: &str, text: &str, files: &[&str]) -> Historica
     make_record(id, "user", &serde_json::to_string(&parsed).unwrap())
 }
 
+/// Mid-turn steer prompt. Same shape as `user_prompt` but with the
+/// `steer: true` marker written by `persist_steer_message`.
+pub fn user_prompt_steer(id: &str, text: &str) -> HistoricalRecord {
+    let parsed = json!({
+        "type": "user_prompt",
+        "text": text,
+        "steer": true,
+    });
+    make_record(id, "user", &serde_json::to_string(&parsed).unwrap())
+}
+
 pub fn exit_plan_mode(
     id: &str,
     tool_use_id: &str,

--- a/src-tauri/tests/pipeline_scenarios.rs
+++ b/src-tauri/tests/pipeline_scenarios.rs
@@ -184,6 +184,38 @@ fn user_prompt_files_array_present_but_empty() {
 }
 
 #[test]
+fn user_prompt_steer_flag_renders_as_user() {
+    // A steer prompt is a regular user turn with `steer: true` added to
+    // the JSON payload. The adapter should ignore the flag for rendering
+    // (the marker only exists so the UI can later add a distinct badge).
+    let msgs = vec![user_prompt_steer("u1", "actually focus on failing tests")];
+    assert_yaml_snapshot!(run_normalized(msgs));
+}
+
+#[test]
+fn user_prompt_steer_groups_in_same_turn() {
+    // Two user prompts in the same turn (initial + steer) + an assistant
+    // response between them. Shape check: the second prompt still renders
+    // as a user bubble and groups inline with the surrounding messages
+    // rather than truncating or dropping.
+    let msgs = vec![
+        user_prompt("u1", "start investigating"),
+        assistant_json(
+            "a1",
+            json!([{ "type": "text", "text": "Looking into it..." }]),
+            None,
+        ),
+        user_prompt_steer("u2", "focus on failing tests first"),
+        assistant_json(
+            "a2",
+            json!([{ "type": "text", "text": "OK, switching focus." }]),
+            None,
+        ),
+    ];
+    assert_yaml_snapshot!(run_normalized(msgs));
+}
+
+#[test]
 fn user_json_text_swallowed() {
     // JSON user message with pure text content is dropped (the assistant
     // already has the prompt; this avoids double-rendering).

--- a/src-tauri/tests/snapshots/pipeline_scenarios__user_prompt_steer_flag_renders_as_user.snap
+++ b/src-tauri/tests/snapshots/pipeline_scenarios__user_prompt_steer_flag_renders_as_user.snap
@@ -1,0 +1,12 @@
+---
+source: tests/pipeline_scenarios.rs
+expression: run_normalized(msgs)
+---
+- role: user
+  id: msg-1
+  content_length: 1
+  content:
+    - type: text
+      text: actually focus on failing tests
+  status: ~
+  streaming: ~

--- a/src-tauri/tests/snapshots/pipeline_scenarios__user_prompt_steer_groups_in_same_turn.snap
+++ b/src-tauri/tests/snapshots/pipeline_scenarios__user_prompt_steer_groups_in_same_turn.snap
@@ -1,0 +1,40 @@
+---
+source: tests/pipeline_scenarios.rs
+expression: run_normalized(msgs)
+---
+- role: user
+  id: msg-1
+  content_length: 1
+  content:
+    - type: text
+      text: start investigating
+  status: ~
+  streaming: ~
+- role: assistant
+  id: msg-2
+  content_length: 1
+  content:
+    - type: text
+      text: Looking into it...
+  status:
+    type: complete
+    reason: stop
+  streaming: ~
+- role: user
+  id: msg-3
+  content_length: 1
+  content:
+    - type: text
+      text: focus on failing tests first
+  status: ~
+  streaming: ~
+- role: assistant
+  id: msg-4
+  content_length: 1
+  content:
+    - type: text
+      text: "OK, switching focus."
+  status:
+    type: complete
+    reason: stop
+  streaming: ~

--- a/src/features/composer/index.tsx
+++ b/src/features/composer/index.tsx
@@ -226,13 +226,19 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 	const toolbarDisabled = disabled || hasPendingInteraction;
 	const composerToolbarTriggerClassName =
 		"cursor-pointer rounded-[9px] px-1 py-0.5 text-[13px] font-medium transition-colors hover:bg-accent/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50";
-	const sendDisabled =
-		disabled ||
-		submitDisabled ||
-		sending ||
-		hasPendingInteraction ||
-		!selectedModel ||
-		!hasContent;
+	// Shared gate for Send and Steer — the only difference is whether a
+	// stream is currently running. When sending, ⌘Enter / Enter still
+	// fires `handleSubmit`; the use-streaming hook dispatches to the
+	// steer path based on `sendingContextKeys`.
+	const submitEnabled =
+		!disabled &&
+		!submitDisabled &&
+		!hasPendingInteraction &&
+		Boolean(selectedModel) &&
+		hasContent;
+	const sendDisabled = !submitEnabled || sending;
+	const steerDisabled = !submitEnabled || !sending;
+	const submitDisabledForPlugin = !submitEnabled;
 
 	// Lexical initial config — must be a new object per mount for key resets
 	const initialConfig = useRef({
@@ -400,7 +406,10 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 							onRetry={onRetrySlashCommands}
 						/>
 						<FileMentionPlugin workspaceRootPath={workspaceRootPath} />
-						<SubmitPlugin onSubmit={handleSubmit} disabled={sendDisabled} />
+						<SubmitPlugin
+							onSubmit={handleSubmit}
+							disabled={submitDisabledForPlugin}
+						/>
 						<CompositionGuardPlugin />
 						<PasteImagePlugin />
 						<DropFilePlugin />
@@ -639,16 +648,30 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 									</Button>
 								</>
 							) : sending ? (
-								<Button
-									variant="destructive"
-									size="icon"
-									aria-label="Stop"
-									onClick={onStop}
-									disabled={disabled || submitDisabled}
-									className="rounded-[9px]"
-								>
-									<Square className="size-3 fill-current" strokeWidth={0} />
-								</Button>
+								<div className="flex items-center gap-1.5">
+									<Button
+										variant="destructive"
+										size="icon"
+										aria-label="Stop"
+										onClick={onStop}
+										disabled={disabled || submitDisabled}
+										className="rounded-[9px]"
+									>
+										<Square className="size-3 fill-current" strokeWidth={0} />
+									</Button>
+									{hasContent ? (
+										<Button
+											variant="outline"
+											size="icon"
+											aria-label="Steer"
+											onClick={handleSubmit}
+											disabled={steerDisabled}
+											className="rounded-[9px]"
+										>
+											<ArrowUp className="size-[15px]" strokeWidth={2.2} />
+										</Button>
+									) : null}
+								</div>
 							) : (
 								<Button
 									variant="outline"

--- a/src/features/conversation/hooks/use-streaming.test.tsx
+++ b/src/features/conversation/hooks/use-streaming.test.tsx
@@ -22,6 +22,7 @@ const apiMocks = vi.hoisted(() => ({
 	respondToElicitationRequest: vi.fn(),
 	respondToPermissionRequest: vi.fn(),
 	startAgentMessageStream: vi.fn(),
+	steerAgentStream: vi.fn(),
 	stopAgentStream: vi.fn(),
 }));
 
@@ -37,6 +38,7 @@ vi.mock("@/lib/api", async (importOriginal) => {
 		respondToElicitationRequest: apiMocks.respondToElicitationRequest,
 		respondToPermissionRequest: apiMocks.respondToPermissionRequest,
 		startAgentMessageStream: apiMocks.startAgentMessageStream,
+		steerAgentStream: apiMocks.steerAgentStream,
 		stopAgentStream: apiMocks.stopAgentStream,
 	};
 });
@@ -153,6 +155,7 @@ describe("useConversationStreaming", () => {
 		apiMocks.respondToDeferredTool.mockReset();
 		apiMocks.respondToPermissionRequest.mockReset();
 		apiMocks.startAgentMessageStream.mockReset();
+		apiMocks.steerAgentStream.mockReset();
 		apiMocks.stopAgentStream.mockReset();
 
 		apiMocks.generateSessionTitle.mockResolvedValue(null);
@@ -161,6 +164,10 @@ describe("useConversationStreaming", () => {
 		apiMocks.respondToDeferredTool.mockResolvedValue(undefined);
 		apiMocks.respondToElicitationRequest.mockResolvedValue(undefined);
 		apiMocks.respondToPermissionRequest.mockResolvedValue(undefined);
+		// Default: steer claims the turn ended so tests that don't opt in to
+		// steer semantics fall through to the normal send path. Individual
+		// tests override this when they want to exercise the steer branch.
+		apiMocks.steerAgentStream.mockResolvedValue({ accepted: false });
 		apiMocks.stopAgentStream.mockResolvedValue(undefined);
 	});
 
@@ -408,6 +415,139 @@ describe("useConversationStreaming", () => {
 		});
 
 		expect(result.current.hasPlanReview).toBe(false);
+	});
+
+	it("routes a second submit while sending to steerAgentStream, not startAgentMessageStream", async () => {
+		// Stream mock returns without firing `done` → isSending stays true.
+		apiMocks.startAgentMessageStream.mockImplementation(
+			async (_payload: unknown, _onEvent: (event: unknown) => void) => {
+				return undefined;
+			},
+		);
+		apiMocks.steerAgentStream.mockResolvedValue({
+			accepted: true,
+			messageId: "steer-msg-1",
+		});
+
+		const { Wrapper } = createWrapper();
+		const { result } = renderHook(
+			() =>
+				useConversationStreaming({
+					composerContextKey: "session:session-1",
+					displayedSelectedModelId: MODEL.id,
+					displayedSessionId: "session-1",
+					displayedWorkspaceId: "workspace-1",
+					selectionPending: false,
+				}),
+			{ wrapper: Wrapper },
+		);
+
+		await act(async () => {
+			await result.current.handleComposerSubmit({
+				prompt: "kick things off",
+				imagePaths: [],
+				filePaths: [],
+				customTags: [],
+				model: MODEL,
+				workingDirectory: "/tmp/helmor",
+				effortLevel: "medium",
+				permissionMode: "default",
+				fastMode: false,
+			});
+		});
+
+		expect(result.current.isSending).toBe(true);
+		apiMocks.startAgentMessageStream.mockClear();
+
+		await act(async () => {
+			await result.current.handleComposerSubmit({
+				prompt: "focus on failing tests first",
+				imagePaths: [],
+				filePaths: ["src/foo.ts"],
+				customTags: [],
+				model: MODEL,
+				workingDirectory: "/tmp/helmor",
+				effortLevel: "medium",
+				permissionMode: "default",
+				fastMode: false,
+			});
+		});
+
+		expect(apiMocks.steerAgentStream).toHaveBeenCalledWith(
+			expect.objectContaining({
+				sessionId: "session-1",
+				prompt: "focus on failing tests first",
+				files: ["src/foo.ts"],
+			}),
+		);
+		expect(apiMocks.startAgentMessageStream).not.toHaveBeenCalled();
+	});
+
+	it("restores draft and surfaces error when steer is rejected", async () => {
+		apiMocks.startAgentMessageStream.mockImplementation(
+			async (_payload: unknown, _onEvent: (event: unknown) => void) => {
+				return undefined;
+			},
+		);
+		apiMocks.steerAgentStream.mockResolvedValue({
+			accepted: false,
+			reason: "no_active_turn",
+		});
+
+		const { Wrapper } = createWrapper();
+		const { result } = renderHook(
+			() =>
+				useConversationStreaming({
+					composerContextKey: "session:session-1",
+					displayedSelectedModelId: MODEL.id,
+					displayedSessionId: "session-1",
+					displayedWorkspaceId: "workspace-1",
+					selectionPending: false,
+				}),
+			{ wrapper: Wrapper },
+		);
+
+		await act(async () => {
+			await result.current.handleComposerSubmit({
+				prompt: "first",
+				imagePaths: [],
+				filePaths: [],
+				customTags: [],
+				model: MODEL,
+				workingDirectory: "/tmp/helmor",
+				effortLevel: "medium",
+				permissionMode: "default",
+				fastMode: false,
+			});
+		});
+
+		expect(result.current.isSending).toBe(true);
+		apiMocks.startAgentMessageStream.mockClear();
+
+		await act(async () => {
+			await result.current.handleComposerSubmit({
+				prompt: "focus on failing tests",
+				imagePaths: [],
+				filePaths: ["src/foo.ts"],
+				customTags: [],
+				model: MODEL,
+				workingDirectory: "/tmp/helmor",
+				effortLevel: "medium",
+				permissionMode: "default",
+				fastMode: false,
+			});
+		});
+
+		expect(apiMocks.steerAgentStream).toHaveBeenCalledTimes(1);
+		// Rejected steer must NOT silently auto-open a new stream — user
+		// gets explicit control.
+		expect(apiMocks.startAgentMessageStream).not.toHaveBeenCalled();
+		// Draft + files + error must all be surfaced back to the composer
+		// so the user can resend without retyping. Guards against the
+		// draft-loss bug flagged in review #4.
+		expect(result.current.restoreDraft).toBe("focus on failing tests");
+		expect(result.current.restoreFiles).toEqual(["src/foo.ts"]);
+		expect(result.current.activeSendError).toContain("no_active_turn");
 	});
 
 	it("seeds the session title from the first prompt before async title generation", async () => {

--- a/src/features/conversation/hooks/use-streaming.ts
+++ b/src/features/conversation/hooks/use-streaming.ts
@@ -18,6 +18,7 @@ import {
 	respondToElicitationRequest,
 	respondToPermissionRequest,
 	startAgentMessageStream,
+	steerAgentStream,
 	stopAgentStream,
 } from "@/lib/api";
 import type { ComposerCustomTag } from "@/lib/composer-insert";
@@ -960,6 +961,98 @@ export function useConversationStreaming({
 
 			const contextKey = composerContextKey;
 
+			// Steer branch: if a stream is already running for this context,
+			// inject the new prompt into the active turn instead of opening a
+			// fresh one. On rejection (turn already completed or provider
+			// refused) we restore the composer draft + surface an error and
+			// STOP — the user explicitly decides whether to resend as a new
+			// turn. Do NOT silently auto-fallback; that was an earlier
+			// design and is no longer the contract.
+			const liveStream = activeSessionByContext[contextKey];
+			const hasPlanReviewForContext = planReviewByContext[contextKey] ?? false;
+			// Skip steer when a plan review is pending — the composer's
+			// plan-review UI (Request Changes / Implement) is the intended
+			// path for responding to plans, and submitting a free-form
+			// message there means "abandon the plan and start fresh".
+			// Fall through to the normal send path which clears plan state.
+			if (
+				sendingContextKeys.has(contextKey) &&
+				liveStream &&
+				!hasPlanReviewForContext
+			) {
+				// Real mid-turn steer. The sidecar routes to the provider's
+				// native steer API AND (only after provider ack) emits a
+				// `user_prompt` passthrough event into the active stream.
+				// The accumulator picks that up, splits the assistant turn,
+				// and streaming.rs persists via `persist_turn_message` —
+				// one event, one DB row, no separate persistence path.
+				//
+				// Optimistic bubble covers the RPC round-trip; the next
+				// flush replaces it with the accumulator's authoritative
+				// version that lives at the correct position in the thread.
+				const cacheSessionId = displayedSessionId;
+				const steerMessageId = crypto.randomUUID();
+				const optimisticSteer = createLiveThreadMessage({
+					id: steerMessageId,
+					role: "user",
+					text: trimmedPrompt,
+					createdAt: new Date().toISOString(),
+					files: filePaths,
+				});
+				const rollback = appendUserMessage(
+					queryClient,
+					cacheSessionId,
+					optimisticSteer,
+				);
+				setComposerRestoreState(null);
+
+				// Composer clears its editor synchronously after onSubmit.
+				// On steer failure we must seed `composerRestoreState` with
+				// the draft so the user's input isn't silently lost — same
+				// contract the normal send path upholds on its error path.
+				const restoreDraftOnFailure = () => {
+					restoreSnapshot(queryClient, cacheSessionId, rollback);
+					setComposerRestoreState({
+						contextKey,
+						draft: trimmedPrompt,
+						images: imagePaths,
+						files: filePaths,
+						customTags,
+						nonce: Date.now(),
+					});
+				};
+
+				try {
+					const response = await steerAgentStream({
+						sessionId: liveStream.stopSessionId,
+						provider: liveStream.provider,
+						prompt: trimmedPrompt,
+						files: filePaths,
+					});
+					if (!response.accepted) {
+						// Turn already completed / provider rejected —
+						// restore the draft so the user can resend it as
+						// a fresh turn (or edit before resending).
+						restoreDraftOnFailure();
+						if (response.reason) {
+							setSendErrorsByContext((current) => ({
+								...current,
+								[contextKey]: `Steer rejected: ${response.reason}`,
+							}));
+						}
+					}
+					return;
+				} catch (err) {
+					console.warn("[conversation] steer failed:", err);
+					restoreDraftOnFailure();
+					setSendErrorsByContext((current) => ({
+						...current,
+						[contextKey]: err instanceof Error ? err.message : String(err),
+					}));
+					return;
+				}
+			}
+
 			const now = new Date().toISOString();
 			const userMessageId = crypto.randomUUID();
 			const optimisticUserMessage = createLiveThreadMessage({
@@ -1319,6 +1412,9 @@ export function useConversationStreaming({
 			selectionPending,
 			refreshSessionThreadFromDb,
 			setFastPreludeActive,
+			activeSessionByContext,
+			sendingContextKeys,
+			planReviewByContext,
 		],
 	);
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1721,6 +1721,37 @@ export async function stopAgentStream(
 	});
 }
 
+export type AgentSteerRequest = {
+	sessionId: string;
+	provider?: string;
+	prompt: string;
+	files?: string[];
+};
+
+export type AgentSteerResponse = {
+	accepted: boolean;
+	reason?: string;
+};
+
+/**
+ * Inject an additional user message into an in-flight agent turn.
+ *
+ * On `{ accepted: true }` the sidecar has confirmed provider acceptance
+ * AND emitted a `user_prompt` passthrough event into the active stream,
+ * which the accumulator places at the current streaming position and
+ * `persist_turn_message` writes to the DB — no separate persistence path.
+ *
+ * On `{ accepted: false }` (turn already completed, provider rejected,
+ * RPC timeout), the pipeline is untouched. Callers should surface the
+ * rejection reason and restore the composer draft so the user can resend
+ * — do NOT silently auto-open a fresh `startAgentMessageStream`.
+ */
+export async function steerAgentStream(
+	request: AgentSteerRequest,
+): Promise<AgentSteerResponse> {
+	return await invoke<AgentSteerResponse>("steer_agent_stream", { request });
+}
+
 export async function respondToPermissionRequest(
 	permissionId: string,
 	behavior: "allow" | "deny",


### PR DESCRIPTION
## Summary

- New **Steer** button in the composer: while the agent is streaming, type a new instruction and click Steer (or ⌘Enter) to fold it into the active turn — no stop-and-resend round-trip.
- Works across both supported agents. Claude uses the SDK's streaming-input mode; Codex routes through a user-turn gate on the app-server so the message lands on the current turn.
- Pipeline renders the injected user message **in-place** inside the running assistant turn rather than appending it at the end, so the transcript reads the way the conversation actually happened.

## Why

Today, the only way to adjust a long-running turn is to Stop, edit, and re-send — losing the model's in-progress work and the ability to nudge it mid-stream. Steer makes mid-turn course-correction a first-class action, which is especially useful for Codex's long reasoning runs and for multi-step Claude tool chains where the right nudge early saves minutes.

## What changed

**Sidecar (`sidecar/src/`)**
- New `pushable-iterable.ts` — queue-backed `AsyncIterable<T>` that stays open across a session, so the Claude SDK's streaming-input `query({ prompt })` can receive additional user messages after the initial prompt.
- `claude-session-manager.ts` — switches the prompt source to a pushable iterable and exposes a `steer()` path that pushes a new `SDKUserMessage` into the live turn. New `claude-steer-race.test.ts` pins the race between final-turn completion and an in-flight steer.
- `codex-app-server-manager.ts` — adds a user-turn gate so a steer queued during tool execution is flushed at the next safe boundary. New `codex-steer-gate.test.ts` covers the gating state machine.
- `emitter.ts` / `index.ts` / `request-parser.ts` / `session-manager.ts` — wire a new `steer` request type end-to-end.

**Rust backend (`src-tauri/src/`)**
- `agents.rs` (new top-level module) — tracks the live streaming session per workspace so a `steer` IPC can find the right sidecar handle.
- `agents/streaming.rs` — dispatches `steer` alongside `start`/`stop`.
- `pipeline/accumulator/` and `pipeline/adapter/grouping.rs` — recognise the `user_prompt` "steer" flag and group the injected user message into the current assistant turn instead of starting a new one.
- New snapshot tests: `user_prompt_steer_flag_renders_as_user`, `user_prompt_steer_groups_in_same_turn`.

**Frontend (`src/`)**
- `features/composer/index.tsx` — splits the single send gate into `sendDisabled` / `steerDisabled`. When a stream is in flight and the composer has content, the Stop button sits next to a Steer button.
- `features/conversation/hooks/use-streaming.ts` (new) — routes submit to `startTurn` or `steerTurn` based on whether a stream key is already active; covered by `use-streaming.test.tsx`.
- `lib/api.ts` — typed IPC wrapper for the new `steer_turn` command.
- Cleanup in `features/composer/editor/plugins/slash-command-plugin.tsx`, `container.tsx`, and tests (drops the now-unused `slashCommandsRefreshing` prop chain from merged PR #145).

## Test notes

- `cd src-tauri && cargo test --tests` — new accumulator/adapter tests + two new `pipeline_scenarios` snapshots, all existing snapshots unchanged except one stream-replay that absorbed the new grouping.
- `bun run test:sidecar` — `claude-steer-race`, `codex-steer-gate`, `pushable-iterable` suites.
- `bun run test:frontend` — `use-streaming` hook tests + extended `message-components` / `composer/container` coverage.
- `bun run lint` — biome + clippy clean.
- Manual smoke: kick off a long Claude turn, type a nudge, click Steer → injected user message appears inline inside the running turn and the agent incorporates it without stopping. Repeat with Codex during a long reasoning run.