### PR TITLE
fix(sidecar): keep raw prompt in steer event so @-refs survive reload

### DIFF
--- a/sidecar/src/claude-session-manager.ts
+++ b/sidecar/src/claude-session-manager.ts
@@ -607,9 +607,16 @@ export class ClaudeSessionManager implements SessionManager {
 	 * streaming-input queue so the SDK folds it into the current extended
 	 * turn, and emit a `user_prompt` passthrough event so the accumulator
 	 * renders the user bubble at the correct position AND streaming.rs
-	 * persists it exactly once (no extra DB path). Event shape matches
-	 * what the adapter's `user_prompt` branch reads on reload so
-	 * live/reload rendering stay identical — `files` included.
+	 * persists it exactly once (no extra DB path).
+	 *
+	 * Event shape matches `persist_user_message`'s DB row exactly:
+	 * `{ type: "user_prompt", text: <raw prompt>, steer: true, files }`.
+	 * We emit the RAW prompt (not the image-stripped version), keeping
+	 * every `@/image.png` / `@src/foo.ts` / custom-tag sigil intact —
+	 * that's what the adapter's `split_user_text_with_files` relies on
+	 * to produce FileMention badges, and matches what a non-steer
+	 * initial prompt stores. The image stripping is ONLY used to build
+	 * the `SDKUserMessage` base64 image blocks we hand to the SDK.
 	 *
 	 * Two correctness properties this method enforces:
 	 *
@@ -640,15 +647,18 @@ export class ClaudeSessionManager implements SessionManager {
 			return false;
 		}
 
-		const { text, imagePaths } = parseImageRefs(prompt);
+		// Strip image refs to build the SDK's base64 image content. Keep
+		// the raw prompt separately — that's what the synthetic event +
+		// DB row need so `@-refs` survive the round-trip.
+		const { text: stripped, imagePaths } = parseImageRefs(prompt);
 		const sdkMessage =
 			imagePaths.length === 0
 				? ({
 						type: "user",
-						message: { role: "user", content: text },
+						message: { role: "user", content: prompt },
 						parent_tool_use_id: null,
 					} as SDKUserMessage)
-				: await buildUserMessageWithImages(text, imagePaths);
+				: await buildUserMessageWithImages(stripped, imagePaths);
 
 		// Re-check after the image-loading await — during those awaits
 		// the for-await loop may have hit the extended turn's single
@@ -663,13 +673,14 @@ export class ClaudeSessionManager implements SessionManager {
 			text: string;
 			steer: true;
 			files?: string[];
-		} = { type: "user_prompt", text, steer: true };
+		} = { type: "user_prompt", text: prompt, steer: true };
 		if (files.length > 0) event.files = [...files];
 		session.emitter.passthrough(session.requestId, event);
 		session.promptSource.push(sdkMessage);
 		logger.info(`steer ${sessionId}`, {
-			preview: text.slice(0, 60),
+			preview: prompt.slice(0, 60),
 			fileCount: files.length,
+			imageCount: imagePaths.length,
 		});
 		return true;
 	}

--- a/sidecar/src/claude-steer-race.test.ts
+++ b/sidecar/src/claude-steer-race.test.ts
@@ -144,3 +144,97 @@ describe("ClaudeSessionManager.steer ghost-steer guards", () => {
 		});
 	});
 });
+
+describe("ClaudeSessionManager.steer @-ref preservation", () => {
+	/**
+	 * The synthetic event's `text` MUST be the raw prompt, not the
+	 * `parseImageRefs`-stripped version. `split_user_text_with_files`
+	 * (both the Rust adapter and the frontend mirror) finds
+	 * `@<path>` tokens by exact match — if we strip them the bubble
+	 * loses its FileMention badges after the accumulator flush
+	 * replaces the optimistic append. Same shape as
+	 * `persist_user_message` writes for initial prompts.
+	 */
+	test("preserves image refs in synthetic event text", async () => {
+		const manager = new ClaudeSessionManager();
+		const { emitter, passthroughs } = makeSpyEmitter();
+		const promptSource = createPushable<SDKUserMessage>();
+
+		injectSession(manager, "s1", {
+			query: queryStub,
+			abortController: new AbortController(),
+			promptSource,
+			requestId: "rid-1",
+			emitter,
+		});
+
+		await manager.steer("s1", "check this @/tmp/foo.png please", []);
+
+		const [first] = passthroughs;
+		if (!first) throw new Error("expected emit");
+		// Image ref must still be in text. If the old
+		// parseImageRefs-stripped version leaks back in, this reads
+		// "check this  please" (double space + missing ref) and the
+		// bubble loses every `@/image.png` on reload.
+		expect(first.message).toMatchObject({
+			type: "user_prompt",
+			text: "check this @/tmp/foo.png please",
+			steer: true,
+		});
+	});
+
+	test("preserves file mention refs in synthetic event text", async () => {
+		const manager = new ClaudeSessionManager();
+		const { emitter, passthroughs } = makeSpyEmitter();
+		const promptSource = createPushable<SDKUserMessage>();
+
+		injectSession(manager, "s1", {
+			query: queryStub,
+			abortController: new AbortController(),
+			promptSource,
+			requestId: "rid-1",
+			emitter,
+		});
+
+		await manager.steer("s1", "review @src/foo.ts and @src/bar.ts", [
+			"src/foo.ts",
+			"src/bar.ts",
+		]);
+
+		const [first] = passthroughs;
+		if (!first) throw new Error("expected emit");
+		// Both `@<file>` tokens AND the `files` array must be intact —
+		// the adapter uses both to build FileMention parts.
+		expect(first.message).toMatchObject({
+			type: "user_prompt",
+			text: "review @src/foo.ts and @src/bar.ts",
+			steer: true,
+			files: ["src/foo.ts", "src/bar.ts"],
+		});
+	});
+
+	test("preserves mixed image + file + custom-tag inline text", async () => {
+		const manager = new ClaudeSessionManager();
+		const { emitter, passthroughs } = makeSpyEmitter();
+		const promptSource = createPushable<SDKUserMessage>();
+
+		injectSession(manager, "s1", {
+			query: queryStub,
+			abortController: new AbortController(),
+			promptSource,
+			requestId: "rid-1",
+			emitter,
+		});
+
+		// The composer inlines custom-tag submitText into the prompt
+		// before submit (see `$extractComposerContent`), so from the
+		// sidecar's viewpoint they look like any other text. The steer
+		// path must pass the whole thing through untouched.
+		const raw = "@tasks:cleanup inspect @/img.png for @src/a.ts issues";
+		await manager.steer("s1", raw, ["src/a.ts"]);
+
+		const [first] = passthroughs;
+		if (!first) throw new Error("expected emit");
+		expect((first.message as { text: string }).text).toBe(raw);
+	});
+});


### PR DESCRIPTION
## Summary
- Steer path was persisting the image-stripped prompt in the synthetic `user_prompt` event, dropping `@/image.png`, `@src/foo.ts`, and custom-tag sigils from the DB row. On reload the adapter's `split_user_text_with_files` couldn't match them, so FileMention badges disappeared.
- Keep the stripped version only for the SDK's base64 image content; pass the raw prompt through to the synthetic event + DB row, matching what a non-steer initial prompt stores.
- Adds regression tests covering image refs, file mentions, and mixed custom-tag inputs.

## Test plan
- [ ] `bun run test:sidecar` passes, including the new `@-ref preservation` describe block.
- [ ] Manual: mid-turn Steer with `@/path/to/image.png` — bubble keeps the image badge after refresh.
- [ ] Manual: mid-turn Steer with `@src/foo.ts` — FileMention badge survives reload.
- [ ] Manual: mixed custom-tag + file + image in one steer — text round-trips untouched.