### PR TITLE
fix(release): emit v<version> tags via custom publish script

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -12,7 +12,7 @@
 	"access": "restricted",
 	"baseBranch": "main",
 	"updateInternalDependencies": "patch",
-	"ignore": [],
+	"ignore": ["@helmor/marketing"],
 	"privatePackages": {
 		"version": true,
 		"tag": true

--- a/.github/workflows/release-plan.yml
+++ b/.github/workflows/release-plan.yml
@@ -1,31 +1,29 @@
 name: Release Plan
 
-# Canonical changesets/action flow for a non-npm, single-package repo:
+# Changesets/action flow, adapted for our bun workspace layout:
 #
 # 1. A feature PR with `.changeset/*.md` merges to main.
-#    → changesets/action sees pending changesets, opens/updates the
-#      "chore(release): version packages" PR (version bump + CHANGELOG
-#      edits, consuming the changeset files).
+#    → changesets/action opens/updates the "chore(release): version
+#      packages" PR (version bump + CHANGELOG, consuming changeset files).
 #
 # 2. Maintainer merges that "version packages" PR.
-#    → changesets/action sees no pending changesets and runs the
-#      `publish:` command below. For this repo that's `changeset tag`,
-#      which creates a local `v<version>` git tag (single-package repos
-#      use the `v` prefix; monorepos would use `<name>@<version>`).
-#    → Action parses `"New tag: ..."` from stdout, pushes the tag
-#      (authenticated as HELMOR_RELEASE_PAT via the checkout step so
-#      GitHub actually fires downstream workflows), and creates a
-#      GitHub Release with the Changesets-formatted body (thanks,
-#      PR links, bullets).
+#    → changesets/action runs the `publish:` command below, which is
+#      `bun run release:tag` — a custom script that reads the root
+#      package.json version and creates a single `v<version>` git tag.
+#    → Why NOT `changeset tag`: once we added `apps/marketing` to the
+#      workspace, `@manypkg/get-packages` flips changesets into monorepo
+#      mode and tags become `<name>@<version>` (e.g. `helmor@0.2.0`),
+#      which (a) doesn't match publish.yml's `tags: v*` trigger and
+#      (b) additionally tags `@helmor/marketing@...` which we don't want.
 #
 # 3. The tag push triggers `publish.yml` (on: push: tags: v*), which
 #    builds + signs + notarizes the DMGs via tauri-action. tauri-action
-#    detects the existing Release and uploads the artifacts into it.
+#    creates the GitHub Release itself with the release notes body.
 #
-# Why PAT instead of the default GITHUB_TOKEN: GitHub suppresses
-# workflow runs for pushes authored by GITHUB_TOKEN (recursion guard).
-# A PAT-authored tag push does fire downstream workflows, which is how
-# publish.yml knows to build.
+# Why PAT instead of GITHUB_TOKEN: GitHub suppresses workflow runs for
+# pushes authored by GITHUB_TOKEN (recursion guard). A PAT-authored tag
+# push does fire downstream workflows, which is how publish.yml knows to
+# build.
 
 on:
   workflow_dispatch:
@@ -65,7 +63,7 @@ jobs:
         uses: changesets/action@v1
         with:
           version: bun run release:version
-          publish: bun run changeset tag
+          publish: bun run release:tag
           commit: "chore(release): version packages"
           title: "chore(release): version packages"
         env:

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 		"prepare": "husky",
 		"release:notes": "node scripts/extract-release-notes.mjs",
 		"release:sync-versions": "node scripts/sync-release-versions.mjs",
+		"release:tag": "node scripts/create-release-tag.mjs",
 		"release:verify": "node scripts/verify-release-config.mjs",
 		"release:version": "changeset version && bun run release:sync-versions",
 		"storybook": "storybook dev -p 6006",

--- a/scripts/create-release-tag.mjs
+++ b/scripts/create-release-tag.mjs
@@ -1,0 +1,36 @@
+// Emit a single `v<version>` git tag from the root package.json version and
+// push it to origin. Used as the `publish` step of changesets/action in
+// release-plan.yml instead of `changeset tag` — which, since the marketing
+// monorepo conversion, produces `<name>@<version>` tags that don't match
+// publish.yml's `tags: v*` trigger.
+//
+// The trailing `New tag:` line is intentionally in the single-package shape
+// (no `@`) so changesets/action's stdout parser does NOT recognise it as a
+// published package — we want publish.yml + tauri-action to own the GitHub
+// Release, same as the v0.1.x releases.
+
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const { version } = JSON.parse(
+	fs.readFileSync(path.join(root, "package.json"), "utf8"),
+);
+
+if (!version) {
+	console.error("package.json is missing a version");
+	process.exit(1);
+}
+
+const tag = `v${version}`;
+
+try {
+	execSync(`git rev-parse --verify refs/tags/${tag}`, { stdio: "ignore" });
+	console.log(`Tag ${tag} already exists locally; skipping create`);
+} catch {
+	execSync(`git tag ${tag}`, { stdio: "inherit" });
+}
+
+execSync(`git push origin ${tag}`, { stdio: "inherit" });
+console.log(`New tag: ${tag}`);


### PR DESCRIPTION
## Summary

- `.changeset/config.json`: ignore `@helmor/marketing` so changesets never bumps or tags the marketing site.
- `scripts/create-release-tag.mjs`: new publish-step script that reads the root `package.json` version and pushes a single `v<version>` tag.
- `.github/workflows/release-plan.yml`: swap `publish: bun run changeset tag` → `bun run release:tag`; update the header comment to reflect the new rationale.

## Why

Merging #116 (the 0.2.0 version-packages PR) didn't produce any DMGs, left a `@helmor/marketing@0.0.0` tag lying around, and only created a tag named `helmor@0.2.0` — definitely not what we ship as `v0.2.0`.

Root cause: PR #135 introduced `apps/marketing` as a bun workspace, and the follow-up `bbd90a0` added `"."` back to the `workspaces` array so changesets could find the root `helmor` package again. That unblocked versioning but quietly flipped `@changesets/cli` into monorepo mode (via `@manypkg/get-packages`), so `changeset tag` now emits `<name>@<version>` instead of `v<version>`:

```
🦋  New tag:  helmor@0.2.0
🦋  New tag:  @helmor/marketing@0.0.0
```

Neither tag matches `publish.yml`'s `on: push: tags: "v*"` trigger, so `tauri-action` never ran and no installer was built. Additionally, `privatePackages.tag: true` in the changesets config caused the private marketing package to get its own tag too.

`@changesets/cli` picks the tag format from the presence of a `workspaces` field in root `package.json` — **not** from the number of packages — so there's no config switch to make it emit `v<version>` again while keeping the workspace. Fix: own the publish step ourselves.

## What this looks like going forward

1. Feature PR with `.changeset/*.md` merges to main.
2. Release-plan opens/updates the "chore(release): version packages" PR (unchanged behavior).
3. Maintainer merges that PR → release-plan runs `bun run release:tag` → pushes `v<version>` to origin.
4. `publish.yml` fires on the `v*` tag push → tauri-action builds + signs + notarizes macOS DMGs + creates the GitHub Release with notes extracted from `CHANGELOG.md` (same flow as v0.1.x).

Marketing continues to deploy via its own Vercel project; it's fully invisible to changesets now.

## Test plan

- [x] Biome lint passes locally for all 4 changed files.
- [ ] After merge, the next changesets version PR produces only a `v<version>` tag (no `@helmor/marketing@…`, no `helmor@…`).
- [ ] After merge + next release, `publish.yml` fires automatically and uploads DMG + `.app.tar.gz` + `latest.json` to the new release.

## Immediate recovery for 0.2.0

Already done in parallel: stale `helmor@0.2.0` and `@helmor/marketing@0.0.0` tags deleted from origin; `publish.yml` dispatched manually on `main` to produce the 0.2.0 DMGs (run in progress).