### PR TITLE
fix(navigation): keep sidebar status dot visible past row fade mask

### DIFF
--- a/.changeset/fix-sidebar-status-dot-clip.md
+++ b/.changeset/fix-sidebar-status-dot-clip.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix the sidebar workspace row so the green status dot on the avatar no longer gets clipped when you hover the row.

--- a/src/features/navigation/row-item.tsx
+++ b/src/features/navigation/row-item.tsx
@@ -186,7 +186,7 @@ export const WorkspaceRowItem = memo(
 					!selected && row.state === "archived" && "opacity-50",
 				)}
 			>
-				<div className="row-content-fade flex min-w-0 flex-1 items-center gap-2">
+				<div className="flex min-w-0 flex-1 items-center gap-2">
 					<WorkspaceAvatar
 						repoIconSrc={row.repoIconSrc}
 						repoInitials={row.repoInitials ?? row.avatar ?? null}
@@ -195,31 +195,34 @@ export const WorkspaceRowItem = memo(
 						badgeClassName={showStatusDot ? statusDotClassName : null}
 						badgeAriaLabel={statusDotLabel ?? undefined}
 					/>
-					{isSending && !isInteractionRequired ? (
-						<HelmorThinkingIndicator size={13} />
-					) : (
-						<GitBranch
-							className={cn(
-								"size-[13px] shrink-0",
-								branchToneClasses[branchTone],
-							)}
-							strokeWidth={1.9}
-						/>
-					)}
-					<span
-						className={cn(
-							"truncate leading-none",
-							selected
-								? row.hasUnread
-									? "font-semibold text-foreground"
-									: "font-medium text-foreground"
-								: row.hasUnread
-									? "font-semibold text-foreground"
-									: "font-medium",
+					{/* Fade is on an inner wrapper so the avatar's overflowing badge isn't clipped by mask-image. */}
+					<div className="row-content-fade flex min-w-0 flex-1 items-center gap-2">
+						{isSending && !isInteractionRequired ? (
+							<HelmorThinkingIndicator size={13} />
+						) : (
+							<GitBranch
+								className={cn(
+									"size-[13px] shrink-0",
+									branchToneClasses[branchTone],
+								)}
+								strokeWidth={1.9}
+							/>
 						)}
-					>
-						<HyperText text={displayTitle} className="inline" />
-					</span>
+						<span
+							className={cn(
+								"truncate leading-none",
+								selected
+									? row.hasUnread
+										? "font-semibold text-foreground"
+										: "font-medium text-foreground"
+									: row.hasUnread
+										? "font-semibold text-foreground"
+										: "font-medium",
+							)}
+						>
+							<HyperText text={displayTitle} className="inline" />
+						</span>
+					</div>
 				</div>
 
 				{hasActionHandler ? (


### PR DESCRIPTION
## Summary

The workspace row in the sidebar applies a `mask-image` fade (`row-content-fade`) so long titles fade out on overflow. But the `WorkspaceAvatar` renders a small status/notification dot that overflows its own bounding box, and because the fade was on the outer flex container that wraps the avatar, the dot was getting clipped by the mask.

Move `row-content-fade` onto an inner wrapper that holds only the branch icon + title, so the avatar (and its overflowing badge dot) sits outside the mask and renders fully.

## Why

Users couldn't see the unread/status dot on sidebar workspace rows because the fade mask was silently clipping it.

## Test plan

- [ ] Trigger a state that shows the status dot on a sidebar workspace row (e.g. unread message) and confirm the dot is fully visible, not clipped
- [ ] Confirm long titles still fade out on overflow as before
- [ ] `bun run test:frontend`