### PR TITLE
refactor(inspector): tighten scripts-terminal hover-zoom activation

### DIFF
--- a/.changeset/scripts-terminal-hover-zoom.md
+++ b/.changeset/scripts-terminal-hover-zoom.md
@@ -1,0 +1,8 @@
+---
+"helmor": patch
+---
+
+Tighten the scripts terminal hover-zoom so it only engages when there's real output to read:
+- The Setup/Run tab header no longer triggers the zoom, so moving the cursor between tabs or to the collapse chevron keeps the panel at its resting size.
+- The empty placeholder states (no script configured, or script configured but not yet run) no longer trigger the zoom — it now only engages once a script has actually produced terminal output.
+- The Stop/Rerun button in the bottom-right corner only appears once the panel has enlarged, so it's no longer clipped and unclickable at the resting size.

--- a/src/features/inspector/index.tsx
+++ b/src/features/inspector/index.tsx
@@ -124,6 +124,17 @@ export function WorkspaceInspectorSidebar({
 		!!repoScripts?.runScript?.trim(),
 	);
 
+	// Only allow hover-to-zoom when the active tab has real terminal output.
+	// "idle" = script configured but never run; "no-script" = nothing to run.
+	// In both cases the body is a placeholder (Run / Open-settings button)
+	// that doesn't benefit from — and shouldn't trigger — the enlargement.
+	const activeTabState =
+		activeTab === "setup" ? setupScriptState : runScriptState;
+	const canHoverExpand =
+		activeTabState === "running" ||
+		activeTabState === "success" ||
+		activeTabState === "failure";
+
 	const handleOpenSettings = onOpenSettings ?? (() => {});
 
 	return (
@@ -187,6 +198,7 @@ export function WorkspaceInspectorSidebar({
 				tabActions={runTabActions}
 				setupScriptState={setupScriptState}
 				runScriptState={runScriptState}
+				canHoverExpand={canHoverExpand}
 			>
 				<SetupTab
 					repoId={repoId ?? null}

--- a/src/features/inspector/layout.tsx
+++ b/src/features/inspector/layout.tsx
@@ -1,5 +1,12 @@
 import { ChevronDown } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
 import { suspendTerminalFit } from "@/components/terminal-output";
 import { Button } from "@/components/ui/button";
 import type { WorkspaceCommitButtonMode } from "@/features/commit/button";
@@ -60,6 +67,28 @@ export const INSPECTOR_SECTION_TITLE_CLASS =
 const INSPECTOR_TAB_BUTTON_CLASS =
 	"relative inline-flex h-full cursor-pointer items-center justify-center gap-1.5 px-0 text-[12px] font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-0";
 
+// Zoom state published to descendants of InspectorTabsSection so tab bodies
+// can key UI off the hover-zoom state (e.g. the absolute-positioned corner
+// Stop/Rerun button, which is only reachable once the panel has grown).
+type TabsZoomState = {
+	/** True for the full duration of both the expand and collapse animations. */
+	isZoomPresented: boolean;
+	/** Target of the CSS transition — true while zoomed in, false while resting. */
+	isHoverExpanded: boolean;
+};
+
+// Exported so tests (and any future consumer that renders a tab outside of
+// InspectorTabsSection) can simulate the zoomed state by wrapping children in
+// `<TabsZoomContext.Provider value={{ isZoomPresented: true, isHoverExpanded: true }}>`.
+export const TabsZoomContext = createContext<TabsZoomState>({
+	isZoomPresented: false,
+	isHoverExpanded: false,
+});
+
+export function useTabsZoom(): TabsZoomState {
+	return useContext(TabsZoomContext);
+}
+
 export function getGitSectionHeaderHighlightClass(
 	mode: WorkspaceCommitButtonMode,
 ) {
@@ -95,6 +124,12 @@ type InspectorTabsSectionProps = {
 	tabActions?: React.ReactNode;
 	setupScriptState: ScriptIconState;
 	runScriptState: ScriptIconState;
+	/**
+	 * Gate for the hover-to-zoom effect. When false, hovering the body does
+	 * nothing — used so we only zoom when there's actual terminal output worth
+	 * enlarging (and not on the empty "Run setup" / "Open settings" placeholders).
+	 */
+	canHoverExpand: boolean;
 	children?: React.ReactNode;
 };
 
@@ -107,6 +142,7 @@ export function InspectorTabsSection({
 	tabActions,
 	setupScriptState,
 	runScriptState,
+	canHoverExpand,
 	children,
 }: InspectorTabsSectionProps) {
 	// `isHoverExpanded` drives the CSS transitions we CAN interpolate
@@ -231,17 +267,30 @@ export function InspectorTabsSection({
 		[clearPresentationClearTimer, triggerContentBlurPulse],
 	);
 
-	const handleMouseEnter = useCallback(() => {
-		if (!open) return;
+	// Hover trigger is bound to the BODY only (not the header) so moving the
+	// cursor across the Setup/Run tabs or the chevron doesn't start a zoom.
+	// The 300ms "hover intent" timer still gives us the linger-to-engage feel,
+	// but the intent signal now requires engaging with the actual output area.
+	const handleBodyMouseEnter = useCallback(() => {
+		if (!open || !canHoverExpand) return;
 		clearHoverTimer();
 		hoverTimerRef.current = window.setTimeout(() => {
 			beginZoomAnimation();
 			setZoomTarget(true);
 			hoverTimerRef.current = null;
 		}, TABS_HOVER_ACTIVATION_MS);
-	}, [open, clearHoverTimer, beginZoomAnimation, setZoomTarget]);
+	}, [
+		open,
+		canHoverExpand,
+		clearHoverTimer,
+		beginZoomAnimation,
+		setZoomTarget,
+	]);
 
-	const handleMouseLeave = useCallback(() => {
+	// Un-zoom fires only when the cursor leaves the whole panel (header +
+	// body). Moving from body up into the header keeps the zoom alive so the
+	// Stop/Rerun action and the tab switcher stay reachable while zoomed.
+	const handleContainerMouseLeave = useCallback(() => {
 		clearHoverTimer();
 		beginZoomAnimation();
 		setZoomTarget(false);
@@ -267,6 +316,24 @@ export function InspectorTabsSection({
 		clearPresentationClearTimer,
 		clearBlurTimer,
 		releaseTerminalFitLock,
+	]);
+
+	// If the active tab no longer has output worth zooming (e.g. user switched
+	// from Run — with a live dev server — to Setup — never run), force the
+	// panel back to its resting size through the normal collapse transition.
+	useEffect(() => {
+		if (canHoverExpand) return;
+		clearHoverTimer();
+		if (!isHoverExpanded && !isZoomPresented) return;
+		beginZoomAnimation();
+		setZoomTarget(false);
+	}, [
+		canHoverExpand,
+		isHoverExpanded,
+		isZoomPresented,
+		clearHoverTimer,
+		beginZoomAnimation,
+		setZoomTarget,
 	]);
 
 	// Clean up any pending timer on unmount.
@@ -305,8 +372,7 @@ export function InspectorTabsSection({
 		>
 			<div
 				data-tabs-zoomed={isZoomPresented ? "true" : undefined}
-				onMouseEnter={handleMouseEnter}
-				onMouseLeave={handleMouseLeave}
+				onMouseLeave={handleContainerMouseLeave}
 				className={cn(
 					// `bg-sidebar` is the safety floor — it guarantees the zoomed
 					// area never shows through to the content underneath even if
@@ -457,9 +523,14 @@ export function InspectorTabsSection({
 						{open && (
 							<div
 								aria-label="Inspector tabs body"
+								onMouseEnter={handleBodyMouseEnter}
 								className="relative flex min-h-0 flex-1 flex-col bg-sidebar"
 							>
-								{children}
+								<TabsZoomContext.Provider
+									value={{ isZoomPresented, isHoverExpanded }}
+								>
+									{children}
+								</TabsZoomContext.Provider>
 							</div>
 						)}
 					</div>

--- a/src/features/inspector/sections/run.test.tsx
+++ b/src/features/inspector/sections/run.test.tsx
@@ -1,8 +1,10 @@
 import { cleanup, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Tabs } from "@/components/ui/tabs";
 import { renderWithProviders } from "@/test/render-with-providers";
+import { TabsZoomContext } from "../layout";
 import { _resetForTesting } from "../script-store";
 import { RunTab } from "./run";
 
@@ -42,12 +44,32 @@ const defaults = {
 	onOpenSettings: vi.fn(),
 };
 
-function renderRun(overrides: Partial<typeof defaults> = {}) {
+// The floating Stop/Rerun button only renders while the tabs panel is
+// hover-zoomed. Tests exercising that button wrap their tree with this
+// provider to simulate the zoomed state; the empty/idle state tests leave
+// it off to confirm the default-collapsed behavior.
+function ZoomedProvider({ children }: { children: ReactNode }) {
+	return (
+		<TabsZoomContext.Provider
+			value={{ isZoomPresented: true, isHoverExpanded: true }}
+		>
+			{children}
+		</TabsZoomContext.Provider>
+	);
+}
+
+function renderRun(
+	overrides: Partial<typeof defaults> = {},
+	{ zoomed = false }: { zoomed?: boolean } = {},
+) {
 	const props = { ...defaults, ...overrides };
-	return renderWithProviders(
+	const tree = (
 		<Tabs defaultValue="run">
 			<RunTab {...props} />
-		</Tabs>,
+		</Tabs>
+	);
+	return renderWithProviders(
+		zoomed ? <ZoomedProvider>{tree}</ZoomedProvider> : tree,
 	);
 }
 
@@ -99,9 +121,9 @@ describe("RunTab", () => {
 		);
 	});
 
-	it("shows Stop button while running", async () => {
+	it("shows Stop button while running (when zoomed)", async () => {
 		const user = userEvent.setup();
-		renderRun();
+		renderRun({}, { zoomed: true });
 
 		await user.click(screen.getByRole("button", { name: /^run$/i }));
 
@@ -110,7 +132,7 @@ describe("RunTab", () => {
 
 	it("Stop button calls stopRepoScript with workspace id", async () => {
 		const user = userEvent.setup();
-		renderRun();
+		renderRun({}, { zoomed: true });
 
 		await user.click(screen.getByRole("button", { name: /^run$/i }));
 		await user.click(screen.getByRole("button", { name: /stop/i }));
@@ -122,7 +144,7 @@ describe("RunTab", () => {
 		);
 	});
 
-	it("shows 'Rerun' button after script exits", async () => {
+	it("shows 'Rerun' button after script exits (when zoomed)", async () => {
 		const user = userEvent.setup();
 
 		let onEvent: (e: unknown) => void = () => {};
@@ -133,7 +155,7 @@ describe("RunTab", () => {
 			},
 		);
 
-		renderRun();
+		renderRun({}, { zoomed: true });
 		await user.click(screen.getByRole("button", { name: /^run$/i }));
 
 		onEvent({ type: "exited", code: 0 });
@@ -153,6 +175,18 @@ describe("RunTab", () => {
 		).not.toBeInTheDocument();
 		expect(
 			screen.queryByRole("button", { name: /rerun/i }),
+		).not.toBeInTheDocument();
+	});
+
+	it("hides the floating Stop button until the panel is zoomed", async () => {
+		const user = userEvent.setup();
+		renderRun();
+
+		await user.click(screen.getByRole("button", { name: /^run$/i }));
+
+		expect(screen.getByTestId("terminal")).toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: /stop/i }),
 		).not.toBeInTheDocument();
 	});
 });

--- a/src/features/inspector/sections/run.tsx
+++ b/src/features/inspector/sections/run.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/hover-card";
 import { cn } from "@/lib/utils";
 import { extractPort } from "../detect-urls";
+import { TABS_EASING, TABS_HOVER_TRANSITION_MS, useTabsZoom } from "../layout";
 import {
 	attach,
 	detach,
@@ -144,6 +145,7 @@ export function RunTab({
 	const termRef = useRef<TerminalHandle | null>(null);
 	const [status, setStatus] = useState<ScriptStatus>("idle");
 	const [hasRun, setHasRun] = useState(false);
+	const { isZoomPresented, isHoverExpanded } = useTabsZoom();
 
 	// Notify parent whenever the run-script status transitions so the tab
 	// header can conditionally show controls like the Open-dev-server button.
@@ -250,8 +252,15 @@ export function RunTab({
 						/>
 					</div>
 
-					{(status === "running" || status === "exited") && (
-						<div className="absolute bottom-3 right-4">
+					{isZoomPresented && (status === "running" || status === "exited") && (
+						<div
+							className="absolute bottom-3 right-4"
+							style={{
+								opacity: isHoverExpanded ? 1 : 0,
+								pointerEvents: isHoverExpanded ? "auto" : "none",
+								transition: `opacity ${TABS_HOVER_TRANSITION_MS}ms ${TABS_EASING}`,
+							}}
+						>
 							<Button
 								variant={status === "running" ? "destructive" : "secondary"}
 								size="sm"

--- a/src/features/inspector/sections/setup.test.tsx
+++ b/src/features/inspector/sections/setup.test.tsx
@@ -1,8 +1,10 @@
 import { cleanup, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Tabs } from "@/components/ui/tabs";
 import { renderWithProviders } from "@/test/render-with-providers";
+import { TabsZoomContext } from "../layout";
 import { _resetForTesting } from "../script-store";
 import { SetupTab } from "./setup";
 
@@ -42,12 +44,32 @@ const defaults = {
 	onOpenSettings: vi.fn(),
 };
 
-function renderSetup(overrides: Partial<typeof defaults> = {}) {
+// The floating Stop/Rerun button only renders while the tabs panel is
+// hover-zoomed. Tests exercising that button wrap their tree with this
+// provider to simulate the zoomed state; the empty/idle state tests leave
+// it off to confirm the default-collapsed behavior.
+function ZoomedProvider({ children }: { children: ReactNode }) {
+	return (
+		<TabsZoomContext.Provider
+			value={{ isZoomPresented: true, isHoverExpanded: true }}
+		>
+			{children}
+		</TabsZoomContext.Provider>
+	);
+}
+
+function renderSetup(
+	overrides: Partial<typeof defaults> = {},
+	{ zoomed = false }: { zoomed?: boolean } = {},
+) {
 	const props = { ...defaults, ...overrides };
-	return renderWithProviders(
+	const tree = (
 		<Tabs defaultValue="setup">
 			<SetupTab {...props} />
-		</Tabs>,
+		</Tabs>
+	);
+	return renderWithProviders(
+		zoomed ? <ZoomedProvider>{tree}</ZoomedProvider> : tree,
 	);
 }
 
@@ -102,9 +124,9 @@ describe("SetupTab", () => {
 		);
 	});
 
-	it("shows Stop button while running", async () => {
+	it("shows Stop button while running (when zoomed)", async () => {
 		const user = userEvent.setup();
-		renderSetup();
+		renderSetup({}, { zoomed: true });
 
 		await user.click(screen.getByRole("button", { name: /run setup/i }));
 
@@ -113,7 +135,7 @@ describe("SetupTab", () => {
 
 	it("Stop button calls stopRepoScript with workspace id", async () => {
 		const user = userEvent.setup();
-		renderSetup();
+		renderSetup({}, { zoomed: true });
 
 		await user.click(screen.getByRole("button", { name: /run setup/i }));
 		await user.click(screen.getByRole("button", { name: /stop/i }));
@@ -125,7 +147,7 @@ describe("SetupTab", () => {
 		);
 	});
 
-	it("shows 'Rerun setup' button after script exits", async () => {
+	it("shows 'Rerun setup' button after script exits (when zoomed)", async () => {
 		const user = userEvent.setup();
 
 		let onEvent: (e: unknown) => void = () => {};
@@ -136,7 +158,7 @@ describe("SetupTab", () => {
 			},
 		);
 
-		renderSetup();
+		renderSetup({}, { zoomed: true });
 		await user.click(screen.getByRole("button", { name: /run setup/i }));
 
 		// Simulate the exited event from the backend.
@@ -147,5 +169,19 @@ describe("SetupTab", () => {
 				screen.getByRole("button", { name: /rerun setup/i }),
 			).toBeInTheDocument();
 		});
+	});
+
+	it("hides the floating Stop button until the panel is zoomed", async () => {
+		const user = userEvent.setup();
+		renderSetup();
+
+		await user.click(screen.getByRole("button", { name: /run setup/i }));
+
+		// Terminal should be mounted (script has run), but the corner Stop
+		// button stays out of the DOM while the panel is at its resting size.
+		expect(screen.getByTestId("terminal")).toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: /stop/i }),
+		).not.toBeInTheDocument();
 	});
 });

--- a/src/features/inspector/sections/setup.tsx
+++ b/src/features/inspector/sections/setup.tsx
@@ -8,6 +8,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { helmorQueryKeys } from "@/lib/query-client";
 import { cn } from "@/lib/utils";
+import { TABS_EASING, TABS_HOVER_TRANSITION_MS, useTabsZoom } from "../layout";
 import {
 	attach,
 	detach,
@@ -39,6 +40,7 @@ export function SetupTab({
 	const [status, setStatus] = useState<ScriptStatus>("idle");
 	const [hasRun, setHasRun] = useState(false);
 	const queryClient = useQueryClient();
+	const { isZoomPresented, isHoverExpanded } = useTabsZoom();
 
 	const hasScript = !!setupScript?.trim();
 
@@ -134,8 +136,15 @@ export function SetupTab({
 						/>
 					</div>
 
-					{(status === "running" || status === "exited") && (
-						<div className="absolute bottom-3 right-4">
+					{isZoomPresented && (status === "running" || status === "exited") && (
+						<div
+							className="absolute bottom-3 right-4"
+							style={{
+								opacity: isHoverExpanded ? 1 : 0,
+								pointerEvents: isHoverExpanded ? "auto" : "none",
+								transition: `opacity ${TABS_HOVER_TRANSITION_MS}ms ${TABS_EASING}`,
+							}}
+						>
 							<Button
 								variant={status === "running" ? "destructive" : "secondary"}
 								size="sm"


### PR DESCRIPTION
## Summary

Tightens the scripts-terminal hover-zoom in the workspace inspector so it only engages when there's real output worth reading. Previously the whole panel (header included) would zoom on hover, and the corner Stop/Rerun button was clipped at resting size.

## What changed

- **Body-only hover trigger.** `onMouseEnter` now fires on the tabs body, not the whole panel. Moving the cursor across the Setup/Run tab pills or to the chevron no longer starts a zoom. Un-zoom still fires on the container's `onMouseLeave`, so moving from body up into the header keeps the zoom alive.
- **Gated on real output.** A new `canHoverExpand` prop is derived from the active tab's `ScriptIconState`. Only `running` / `success` / `failure` allow zoom — the `idle` ("configured but not run") and `no-script` placeholder states don't. Switching to a tab that no longer qualifies now forces the panel back down through the normal collapse transition.
- **Corner Stop/Rerun only while zoomed.** A new `TabsZoomContext` publishes `isZoomPresented` / `isHoverExpanded` to tab bodies. The absolute-positioned Stop/Rerun button in `RunTab` / `SetupTab` now mounts only while zoomed and fades in with the zoom transition — so it's no longer clipped and unclickable at resting size.

## Why

Users were triggering the zoom unintentionally while just moving between tabs, and the corner action button was visually clipped by the resting panel height. This scopes the effect to the case where it actually pays off.

## Test notes

- Updated `run.test.tsx` and `setup.test.tsx`: the Stop/Rerun tests now wrap the tree in a `ZoomedProvider` that injects a zoomed `TabsZoomContext`. Added a new test in each confirming the corner Stop button stays out of the DOM at resting size.
- `bun run test:frontend` passes locally.
- Manual check: hover Setup (never run) → no zoom. Run setup → output appears → hover body → zoom engages → Stop visible in corner. Move cursor to Run tab pill → zoom stays. Leave panel entirely → collapses.

Includes a `patch` changeset.