### PR TITLE
fix: keep inspector resize hit area off the chat scrollbar

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -103,6 +103,10 @@ describe("App", () => {
 		).toBeInTheDocument();
 		expect(resizeHandle).toHaveAttribute("aria-valuenow", "336");
 		expect(inspectorResizeHandle).toHaveAttribute("aria-valuenow", "336");
+		expect(inspectorResizeHandle).toHaveStyle({
+			right: "316px",
+			width: "20px",
+		});
 		expect(safeAreas).toHaveLength(1);
 		expect(groupsScrollRegion).toHaveClass("overflow-y-auto");
 		expect(groupsScrollRegion).toHaveClass("flex-1");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2090,13 +2090,13 @@ function AppShell({
 									onKeyDown={handleResizeKeyDown("inspector")}
 									className="group absolute inset-y-0 z-30 cursor-ew-resize touch-none outline-none"
 									style={{
-										right: `${inspectorWidth - SIDEBAR_RESIZE_HIT_AREA / 2}px`,
+										right: `${Math.max(0, inspectorWidth - SIDEBAR_RESIZE_HIT_AREA)}px`,
 										width: `${SIDEBAR_RESIZE_HIT_AREA}px`,
 									}}
 								>
 									<span
 										aria-hidden="true"
-										className={`pointer-events-none absolute inset-y-0 left-1/2 -translate-x-1/2 transition-[width,background-color,box-shadow] ${
+										className={`pointer-events-none absolute inset-y-0 left-0 transition-[width,background-color,box-shadow] ${
 											isInspectorResizing
 												? "w-[2px] bg-transparent shadow-none"
 												: "w-px bg-border group-hover:w-[2px] group-hover:bg-muted-foreground/75 group-focus-visible:w-[2px] group-focus-visible:bg-muted-foreground/75"


### PR DESCRIPTION
## Summary
- The inspector's resize handle was centered on the panel's left edge (`right: inspectorWidth - HIT_AREA / 2`), so half of the 20px hit area overlapped the chat region — including the chat scrollbar. Dragging the chat scrollbar would instead trigger an inspector resize.
- Moved the handle fully inside the inspector by switching to `right: max(0, inspectorWidth - HIT_AREA)` and aligned the visual indicator with `left-0` (instead of `left-1/2 -translate-x-1/2`) so the rendered divider still sits on the boundary.
- `Math.max(0, …)` clamps the handle so it never extends past the window when the inspector is collapsed.

## Test plan
- [x] `bun run test:frontend` — `App.test.tsx` now asserts the new geometry (`right: 316px`, `width: 20px`).
- [ ] Manually drag the chat scrollbar and confirm it scrolls the thread instead of resizing the inspector.
- [ ] Manually drag the inspector's left edge and confirm resize still works normally.