### PR TITLE
Fix inspector hover-zoom blur behavior

### DIFF
--- a/.changeset/cool-geckos-smoke.md
+++ b/.changeset/cool-geckos-smoke.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Keep the inspector's Setup/Run hover-zoom expanded until the pointer actually leaves the zoomed panel, and stop triggering blur pulses when no zoom animation is happening.

--- a/src/features/inspector/index.test.tsx
+++ b/src/features/inspector/index.test.tsx
@@ -1,4 +1,10 @@
-import { cleanup, screen, waitFor, within } from "@testing-library/react";
+import {
+	cleanup,
+	fireEvent,
+	screen,
+	waitFor,
+	within,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ComponentProps } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -910,5 +916,26 @@ describe("WorkspaceInspectorSidebar Actions section", () => {
 		renderInspector({ workspaceRemote: "upstream" });
 
 		await screen.findByText("Up to date with upstream/main");
+	});
+
+	it("does not blur the tabs panel when hover zoom never became eligible", async () => {
+		const user = userEvent.setup();
+		renderInspector();
+
+		await user.click(
+			screen.getByRole("button", { name: "Toggle inspector tabs section" }),
+		);
+
+		const tabsBody = await screen.findByLabelText("Inspector tabs body");
+		const filterLayer = tabsBody.parentElement;
+		const tabsSection = screen.getByLabelText("Inspector section Tabs");
+
+		expect(filterLayer).not.toBeNull();
+		expect(filterLayer).toHaveStyle({ filter: "blur(0)" });
+
+		fireEvent.mouseEnter(tabsBody);
+		fireEvent.mouseLeave(tabsSection.parentElement as HTMLElement);
+
+		expect(filterLayer).toHaveStyle({ filter: "blur(0)" });
 	});
 });

--- a/src/features/inspector/layout.test.tsx
+++ b/src/features/inspector/layout.test.tsx
@@ -1,0 +1,114 @@
+import { act, cleanup, fireEvent, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderWithProviders } from "@/test/render-with-providers";
+import {
+	InspectorTabsSection,
+	TABS_BLUR_HOLD_UNTIL_MS,
+	TABS_HOVER_ACTIVATION_MS,
+	TABS_HOVER_ZOOM_MULTIPLIER,
+} from "./layout";
+
+describe("InspectorTabsSection", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+		cleanup();
+	});
+
+	it("does not re-trigger blur when moving from header back into body while zoomed", () => {
+		vi.useFakeTimers();
+
+		renderWithProviders(
+			<InspectorTabsSection
+				wrapperRef={createRef<HTMLDivElement>()}
+				open
+				onToggle={vi.fn()}
+				activeTab="run"
+				onTabChange={vi.fn()}
+				setupScriptState="idle"
+				runScriptState="running"
+				canHoverExpand
+			>
+				<div>Terminal body</div>
+			</InspectorTabsSection>,
+		);
+
+		const tabsBody = screen.getByLabelText("Inspector tabs body");
+		const filterLayer = tabsBody.parentElement as HTMLElement;
+		const header = screen.getByRole("tablist").parentElement as HTMLElement;
+
+		fireEvent.mouseEnter(tabsBody);
+		act(() => {
+			vi.advanceTimersByTime(TABS_HOVER_ACTIVATION_MS);
+		});
+
+		expect(filterLayer).toHaveStyle({ filter: "blur(6px)" });
+
+		act(() => {
+			vi.advanceTimersByTime(TABS_BLUR_HOLD_UNTIL_MS);
+		});
+
+		expect(filterLayer).toHaveStyle({ filter: "blur(0)" });
+
+		fireEvent.mouseEnter(header);
+		fireEvent.mouseEnter(tabsBody);
+
+		expect(filterLayer).toHaveStyle({ filter: "blur(0)" });
+	});
+
+	it("stays zoomed when the active tab becomes non-zoomable until the pointer leaves", () => {
+		vi.useFakeTimers();
+
+		const view = renderWithProviders(
+			<InspectorTabsSection
+				wrapperRef={createRef<HTMLDivElement>()}
+				open
+				onToggle={vi.fn()}
+				activeTab="run"
+				onTabChange={vi.fn()}
+				setupScriptState="idle"
+				runScriptState="running"
+				canHoverExpand
+			>
+				<div>Terminal body</div>
+			</InspectorTabsSection>,
+		);
+
+		const tabsBody = screen.getByLabelText("Inspector tabs body");
+		const zoomContainer = screen.getByLabelText("Inspector section Tabs")
+			.parentElement as HTMLElement;
+		const expectedZoomedSize = `${TABS_HOVER_ZOOM_MULTIPLIER * 100}%`;
+
+		fireEvent.mouseEnter(zoomContainer);
+		fireEvent.mouseEnter(tabsBody);
+		act(() => {
+			vi.advanceTimersByTime(TABS_HOVER_ACTIVATION_MS);
+			vi.advanceTimersByTime(TABS_BLUR_HOLD_UNTIL_MS);
+		});
+
+		expect(zoomContainer).toHaveStyle({ width: expectedZoomedSize });
+
+		view.rerender(
+			<InspectorTabsSection
+				wrapperRef={createRef<HTMLDivElement>()}
+				open
+				onToggle={vi.fn()}
+				activeTab="setup"
+				onTabChange={vi.fn()}
+				setupScriptState="idle"
+				runScriptState="running"
+				canHoverExpand={false}
+			>
+				<div>Placeholder body</div>
+			</InspectorTabsSection>,
+		);
+
+		expect(zoomContainer).toHaveStyle({ width: expectedZoomedSize });
+
+		fireEvent.mouseLeave(zoomContainer);
+
+		expect(zoomContainer.firstElementChild?.firstElementChild).toHaveStyle({
+			filter: "blur(6px)",
+		});
+	});
+});

--- a/src/features/inspector/layout.tsx
+++ b/src/features/inspector/layout.tsx
@@ -53,7 +53,7 @@ const TABS_BLUR_PEAK_PX = 6;
 const TABS_BLUR_FADE_MS = 120;
 // Hold blur past the end of the transition so the xterm re-fit (which
 // runs ~50ms after the main transition finishes) is still hidden.
-const TABS_BLUR_HOLD_UNTIL_MS = TABS_HOVER_TRANSITION_MS - 50;
+export const TABS_BLUR_HOLD_UNTIL_MS = TABS_HOVER_TRANSITION_MS - 50;
 // Minimum layout height of the collapsed wrapper. The real content lives
 // inside an absolutely-positioned child, so we need to reserve this
 // space explicitly to keep the header row visible when the panel is
@@ -164,6 +164,7 @@ export function InspectorTabsSection({
 	const hoverTimerRef = useRef<number | null>(null);
 	const presentationClearTimerRef = useRef<number | null>(null);
 	const blurClearTimerRef = useRef<number | null>(null);
+	const pointerInsideContainerRef = useRef(false);
 	// Holds the outstanding `suspendTerminalFit()` release while the CSS
 	// width/height transition is running, plus the timer that will release it
 	// and trigger the final fit.
@@ -273,6 +274,7 @@ export function InspectorTabsSection({
 	// but the intent signal now requires engaging with the actual output area.
 	const handleBodyMouseEnter = useCallback(() => {
 		if (!open || !canHoverExpand) return;
+		if (isHoverExpanded) return;
 		clearHoverTimer();
 		hoverTimerRef.current = window.setTimeout(() => {
 			beginZoomAnimation();
@@ -282,6 +284,7 @@ export function InspectorTabsSection({
 	}, [
 		open,
 		canHoverExpand,
+		isHoverExpanded,
 		clearHoverTimer,
 		beginZoomAnimation,
 		setZoomTarget,
@@ -291,10 +294,21 @@ export function InspectorTabsSection({
 	// body). Moving from body up into the header keeps the zoom alive so the
 	// Stop/Rerun action and the tab switcher stay reachable while zoomed.
 	const handleContainerMouseLeave = useCallback(() => {
+		pointerInsideContainerRef.current = false;
+		const hadPendingHoverIntent = hoverTimerRef.current !== null;
 		clearHoverTimer();
+		if (hadPendingHoverIntent || (!isHoverExpanded && !isZoomPresented)) {
+			return;
+		}
 		beginZoomAnimation();
 		setZoomTarget(false);
-	}, [clearHoverTimer, beginZoomAnimation, setZoomTarget]);
+	}, [
+		clearHoverTimer,
+		isHoverExpanded,
+		isZoomPresented,
+		beginZoomAnimation,
+		setZoomTarget,
+	]);
 
 	// When the panel collapses we must drop any pending/active zoom so it
 	// doesn't linger over the neighbouring sections. Also release any
@@ -324,6 +338,7 @@ export function InspectorTabsSection({
 	useEffect(() => {
 		if (canHoverExpand) return;
 		clearHoverTimer();
+		if (pointerInsideContainerRef.current) return;
 		if (!isHoverExpanded && !isZoomPresented) return;
 		beginZoomAnimation();
 		setZoomTarget(false);
@@ -372,6 +387,9 @@ export function InspectorTabsSection({
 		>
 			<div
 				data-tabs-zoomed={isZoomPresented ? "true" : undefined}
+				onMouseEnter={() => {
+					pointerInsideContainerRef.current = true;
+				}}
 				onMouseLeave={handleContainerMouseLeave}
 				className={cn(
 					// `bg-sidebar` is the safety floor — it guarantees the zoomed


### PR DESCRIPTION
## What changed
- keeps the inspector Setup/Run hover-zoom expanded until the pointer actually leaves the zoomed container
- stops triggering blur pulses when hover zoom never became active, including transitions between the header and body
- adds focused tests for the blur/zoom edge cases and a patch changeset entry

## Why
The inspector could briefly blur or collapse at the wrong time, which made the hover-zoom interaction feel unstable and caused unnecessary visual pulses when no zoom animation was happening. This tightens the hover intent tracking so the panel only blurs or contracts when the pointer truly leaves the zoomed area.

## Follow-up / test notes
- Tests were not run manually in this session; the commit completed after the repo's staged-file Biome hook passed.
- Added coverage in `src/features/inspector/index.test.tsx` and `src/features/inspector/layout.test.tsx` for the new hover behavior.