### PR TITLE
fix: stabilize IME-switch composition cleanup

### DIFF
--- a/.changeset/quiet-pandas-whisper.md
+++ b/.changeset/quiet-pandas-whisper.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix an intermittent flicker where the Chinese IME candidate popup briefly went blank for a frame before closing when switching from a Chinese IME to English mid-composition.

--- a/e2e/tests/composer-ime.spec.ts
+++ b/e2e/tests/composer-ime.spec.ts
@@ -1,0 +1,463 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("composer IME regressions", () => {
+	test("keeps stripped ASCII text and trailing caret across the next Lexical render", async ({
+		page,
+	}) => {
+		await page.addInitScript(() => {
+			try {
+				window.localStorage.setItem("helmor_onboarding_completed", "1");
+			} catch {}
+
+			window.__HELMOR_E2E__ = {
+				invokeOverrides: {
+					list_agent_model_sections: () => [
+						{
+							id: "claude",
+							label: "Claude",
+							options: [
+								{
+									id: "opus-1m",
+									provider: "claude",
+									label: "Opus 4.7 1M",
+									cliModel: "opus-1m",
+									effortLevels: ["low", "medium", "high", "max"],
+									supportsFastMode: true,
+								},
+							],
+						},
+					],
+					list_workspace_groups: () => [
+						{
+							id: "in-progress",
+							label: "In Progress",
+							tone: "progress",
+							rows: [
+								{
+									id: "workspace-ime",
+									title: "IME workspace",
+									directoryName: "ime-workspace",
+									repoName: "helmor",
+									state: "ready",
+									hasUnread: false,
+									workspaceUnread: 0,
+									sessionUnreadTotal: 0,
+									unreadSessionCount: 0,
+									derivedStatus: "in-progress",
+									manualStatus: null,
+									branch: "ime-fix",
+									activeSessionId: "session-ime",
+									activeSessionTitle: "IME session",
+									activeSessionAgentType: "codex",
+									activeSessionStatus: "idle",
+									sessionCount: 1,
+									messageCount: 0,
+									attachmentCount: 0,
+								},
+							],
+						},
+					],
+					list_archived_workspaces: () => [],
+					get_workspace: () => ({
+						id: "workspace-ime",
+						title: "IME workspace",
+						repoId: "repo-ime",
+						repoName: "helmor",
+						repoIconSrc: null,
+						repoInitials: "H",
+						remote: "origin",
+						remoteUrl: "git@github.com:example/helmor.git",
+						defaultBranch: "main",
+						rootPath: "/tmp/ime-workspace",
+						directoryName: "ime-workspace",
+						state: "ready",
+						hasUnread: false,
+						workspaceUnread: 0,
+						sessionUnreadTotal: 0,
+						unreadSessionCount: 0,
+						derivedStatus: "in-progress",
+						manualStatus: null,
+						activeSessionId: "session-ime",
+						activeSessionTitle: "IME session",
+						activeSessionAgentType: "codex",
+						activeSessionStatus: "idle",
+						branch: "ime-fix",
+						initializationParentBranch: "main",
+						intendedTargetBranch: "main",
+						notes: null,
+						pinnedAt: null,
+						prTitle: null,
+						prDescription: null,
+						archiveCommit: null,
+						sessionCount: 1,
+						messageCount: 0,
+						attachmentCount: 0,
+					}),
+					list_workspace_sessions: () => [
+						{
+							id: "session-ime",
+							workspaceId: "workspace-ime",
+							title: "IME session",
+							agentType: "codex",
+							status: "idle",
+							model: "opus-1m",
+							permissionMode: "acceptEdits",
+							providerSessionId: null,
+							effortLevel: "high",
+							unreadCount: 0,
+							contextTokenCount: 0,
+							contextUsedPercent: null,
+							thinkingEnabled: true,
+							fastMode: false,
+							agentPersonality: null,
+							createdAt: "2026-04-21T00:00:00.000Z",
+							updatedAt: "2026-04-21T00:00:00.000Z",
+							lastUserMessageAt: null,
+							resumeSessionAt: null,
+							isHidden: false,
+							isCompacting: false,
+							actionKind: null,
+							active: true,
+						},
+					],
+					list_session_thread_messages: () => [],
+					list_session_attachments: () => [],
+					get_app_update_status: () => ({ status: "idle" }),
+					update_app_settings: () => null,
+					trigger_workspace_fetch: () => null,
+					prewarm_slash_commands_for_workspace: () => null,
+					load_repo_scripts: () => null,
+					list_workspace_linked_directories: () => [],
+					list_workspace_candidate_directories: () => [],
+					get_auto_close_action_kinds: () => [],
+					get_auto_close_opt_in_asked: () => false,
+				},
+			};
+		});
+
+		await page.goto("/");
+		await expect(
+			page.getByRole("tab", { name: "IME session", selected: true }),
+		).toBeVisible();
+
+		const editor = page.getByLabel("Workspace input");
+		await expect(editor).toBeVisible();
+		await editor.click();
+
+		const timeline = await page.evaluate(async () => {
+			const editor = document.querySelector(
+				'[aria-label="Workspace input"]',
+			) as HTMLElement | null;
+			if (!editor) {
+				throw new Error("Workspace input not found");
+			}
+
+			const paragraph = editor.querySelector("p");
+			if (!paragraph) {
+				throw new Error("Composer paragraph not found");
+			}
+
+			const snapshot = (label: string) => {
+				const sel = window.getSelection();
+				return {
+					label,
+					text: editor.textContent ?? "",
+					anchorNode: sel?.anchorNode?.nodeName ?? null,
+					anchorOffset: sel?.anchorOffset ?? null,
+				};
+			};
+
+			const collapseToEnd = (text: string) => {
+				paragraph.textContent = text;
+				const textNode = paragraph.firstChild;
+				const sel = window.getSelection();
+				if (textNode && sel) {
+					const range = document.createRange();
+					range.setStart(textNode, text.length);
+					range.setEnd(textNode, text.length);
+					sel.removeAllRanges();
+					sel.addRange(range);
+				}
+			};
+
+			const flushMicrotasks = () =>
+				new Promise<void>((resolve) => {
+					setTimeout(() => resolve(), 0);
+				});
+
+			const getLexicalEditor = () => {
+				const key = Object.keys(editor).find((entry) =>
+					entry.startsWith("__lexicalEditor"),
+				);
+				if (!key) {
+					throw new Error("Lexical editor instance not found on root element");
+				}
+				return (editor as Record<string, unknown>)[key] as {
+					update: (fn: () => void) => void;
+				};
+			};
+
+			editor.focus();
+
+			editor.dispatchEvent(
+				new CompositionEvent("compositionstart", {
+					data: "",
+					bubbles: true,
+					cancelable: true,
+				}),
+			);
+			collapseToEnd("he lmor");
+			editor.dispatchEvent(
+				new CompositionEvent("compositionupdate", {
+					data: "he lmor",
+					bubbles: true,
+					cancelable: true,
+				}),
+			);
+			editor.dispatchEvent(
+				new CompositionEvent("compositionend", {
+					data: "he lmor",
+					bubbles: true,
+					cancelable: true,
+				}),
+			);
+			await flushMicrotasks();
+
+			const afterAsciiCommit = snapshot("after-ascii-commit");
+			getLexicalEditor().update(() => {});
+			await new Promise<void>((resolve) => {
+				requestAnimationFrame(() => {
+					requestAnimationFrame(() => resolve());
+				});
+			});
+			const afterNoopUpdate = snapshot("after-noop-update");
+
+			return [afterAsciiCommit, afterNoopUpdate];
+		});
+
+		expect(timeline).toEqual([
+			{
+				label: "after-ascii-commit",
+				text: "helmor",
+				anchorNode: "#text",
+				anchorOffset: 6,
+			},
+			{
+				label: "after-noop-update",
+				text: "helmor",
+				anchorNode: "#text",
+				anchorOffset: 6,
+			},
+		]);
+	});
+
+	test("does not leave a blank placeholder after switching from Chinese IME to English with existing Chinese text", async ({
+		page,
+	}) => {
+		await page.addInitScript(() => {
+			try {
+				window.localStorage.setItem("helmor_onboarding_completed", "1");
+			} catch {}
+
+			window.__HELMOR_E2E__ = {
+				invokeOverrides: {
+					list_agent_model_sections: () => [
+						{
+							id: "claude",
+							label: "Claude",
+							options: [
+								{
+									id: "opus-1m",
+									provider: "claude",
+									label: "Opus 4.7 1M",
+									cliModel: "opus-1m",
+									effortLevels: ["low", "medium", "high", "max"],
+									supportsFastMode: true,
+								},
+							],
+						},
+					],
+					list_workspace_groups: () => [
+						{
+							id: "in-progress",
+							label: "In Progress",
+							tone: "progress",
+							rows: [
+								{
+									id: "workspace-ime",
+									title: "IME workspace",
+									directoryName: "ime-workspace",
+									repoName: "helmor",
+									state: "ready",
+									hasUnread: false,
+									workspaceUnread: 0,
+									sessionUnreadTotal: 0,
+									unreadSessionCount: 0,
+									derivedStatus: "in-progress",
+									manualStatus: null,
+									branch: "ime-fix",
+									activeSessionId: "session-ime",
+									activeSessionTitle: "IME session",
+									activeSessionAgentType: "codex",
+									activeSessionStatus: "idle",
+									sessionCount: 1,
+									messageCount: 0,
+									attachmentCount: 0,
+								},
+							],
+						},
+					],
+					list_archived_workspaces: () => [],
+					get_workspace: () => ({
+						id: "workspace-ime",
+						title: "IME workspace",
+						repoId: "repo-ime",
+						repoName: "helmor",
+						repoIconSrc: null,
+						repoInitials: "H",
+						remote: "origin",
+						remoteUrl: "git@github.com:example/helmor.git",
+						defaultBranch: "main",
+						rootPath: "/tmp/ime-workspace",
+						directoryName: "ime-workspace",
+						state: "ready",
+						hasUnread: false,
+						workspaceUnread: 0,
+						sessionUnreadTotal: 0,
+						unreadSessionCount: 0,
+						derivedStatus: "in-progress",
+						manualStatus: null,
+						activeSessionId: "session-ime",
+						activeSessionTitle: "IME session",
+						activeSessionAgentType: "codex",
+						activeSessionStatus: "idle",
+						branch: "ime-fix",
+						initializationParentBranch: "main",
+						intendedTargetBranch: "main",
+						notes: null,
+						pinnedAt: null,
+						prTitle: null,
+						prDescription: null,
+						archiveCommit: null,
+						sessionCount: 1,
+						messageCount: 0,
+						attachmentCount: 0,
+					}),
+					list_workspace_sessions: () => [
+						{
+							id: "session-ime",
+							workspaceId: "workspace-ime",
+							title: "IME session",
+							agentType: "codex",
+							status: "idle",
+							model: "opus-1m",
+							permissionMode: "acceptEdits",
+							providerSessionId: null,
+							effortLevel: "high",
+							unreadCount: 0,
+							contextTokenCount: 0,
+							contextUsedPercent: null,
+							thinkingEnabled: true,
+							fastMode: false,
+							agentPersonality: null,
+							createdAt: "2026-04-21T00:00:00.000Z",
+							updatedAt: "2026-04-21T00:00:00.000Z",
+							lastUserMessageAt: null,
+							resumeSessionAt: null,
+							isHidden: false,
+							isCompacting: false,
+							actionKind: null,
+							active: true,
+						},
+					],
+					list_session_thread_messages: () => [],
+					list_session_attachments: () => [],
+					get_app_update_status: () => ({ status: "idle" }),
+					update_app_settings: () => null,
+					trigger_workspace_fetch: () => null,
+					prewarm_slash_commands_for_workspace: () => null,
+					load_repo_scripts: () => null,
+					list_workspace_linked_directories: () => [],
+					list_workspace_candidate_directories: () => [],
+					get_auto_close_action_kinds: () => [],
+					get_auto_close_opt_in_asked: () => false,
+				},
+			};
+		});
+
+		await page.goto("/");
+		const editor = page.getByLabel("Workspace input");
+		await expect(editor).toBeVisible();
+		await editor.click();
+
+		const snapshot = await page.evaluate(async () => {
+			const editor = document.querySelector(
+				'[aria-label="Workspace input"]',
+			) as HTMLElement | null;
+			if (!editor) throw new Error("Workspace input not found");
+			const paragraph = editor.querySelector("p");
+			if (!paragraph) throw new Error("Composer paragraph not found");
+			const getLexicalEditor = () => {
+				const key = Object.keys(editor).find((entry) =>
+					entry.startsWith("__lexicalEditor"),
+				);
+				if (!key) throw new Error("Lexical editor instance not found");
+				return (editor as Record<string, unknown>)[key] as {
+					update: (fn: () => void) => void;
+				};
+			};
+
+			const combinedText = "思考大勇分sl dkjf";
+			editor.focus();
+			editor.dispatchEvent(
+				new CompositionEvent("compositionstart", {
+					data: "",
+					bubbles: true,
+					cancelable: true,
+				}),
+			);
+			paragraph.textContent = combinedText;
+			const textNode = paragraph.firstChild;
+			const sel = window.getSelection();
+			if (textNode && sel) {
+				const range = document.createRange();
+				range.setStart(textNode, combinedText.length);
+				range.setEnd(textNode, combinedText.length);
+				sel.removeAllRanges();
+				sel.addRange(range);
+			}
+			editor.dispatchEvent(
+				new CompositionEvent("compositionupdate", {
+					data: "sl dkjf",
+					bubbles: true,
+					cancelable: true,
+				}),
+			);
+			editor.dispatchEvent(
+				new CompositionEvent("compositionend", {
+					data: "sl dkjf",
+					bubbles: true,
+					cancelable: true,
+				}),
+			);
+
+			await new Promise<void>((resolve) => setTimeout(resolve, 0));
+			getLexicalEditor().update(() => {});
+			await new Promise<void>((resolve) => {
+				requestAnimationFrame(() => {
+					requestAnimationFrame(() => resolve());
+				});
+			});
+
+			return {
+				text: editor.textContent ?? "",
+				paragraphCount: editor.querySelectorAll("p").length,
+				html: paragraph.innerHTML,
+			};
+		});
+
+		expect(snapshot.text).toBe("思考大勇分sldkjf");
+		expect(snapshot.text.includes("\u00A0")).toBe(false);
+		expect(snapshot.paragraphCount).toBe(1);
+	});
+});

--- a/src/features/composer/editor/plugins/composition-guard-plugin.tsx
+++ b/src/features/composer/editor/plugins/composition-guard-plugin.tsx
@@ -1,159 +1,199 @@
-/**
- * Lexical plugin: strip IME segmentation spaces from abandoned composition
- * buffers.
- *
- * Why this exists: when a CJK pinyin IME is active and the user types a
- * non-pinyin string (e.g. `helmor`, `useState`, or any English word that
- * pinyin can segment), the IME shows segmented candidates like `he | lmor`
- * with an internal U+0020 separator. If the user then SWITCHES IMEs
- * (Shift / Ctrl+Space / Cmd+Space to flip to English) WITHOUT pressing
- * Enter to confirm or Esc to cancel, the OS force-commits the buffer with
- * those separator spaces preserved. Without this guard the editor ends up
- * with `he lmor` instead of the `helmor` the user actually typed.
- *
- * Lexical's `$onCompositionEndImpl` calls `$updateSelectedTextFromDOM` which
- * reads the DOM text content as the source of truth (only falling back to
- * `event.data` when the DOM still holds the composition placeholder). That
- * means modifying `event.data` alone is not enough — we have to mutate the
- * DOM text node BEFORE Lexical's bubble-phase compositionend handler runs.
- *
- * Strategy: capture-phase compositionend listener on the editor root. When
- * `event.data` is pure printable ASCII AND contains a U+0020, treat it as
- * an abandoned IME-segmented buffer and rewrite the matching DOM text node.
- * This is safe for pinyin / zhuyin / wubi / cangjie because none of those
- * IMEs emit candidates with intentional ASCII spaces — every space in a
- * pure-ASCII composition buffer is an IME-injected segmentation separator.
- * Mixed-script commits (e.g. `你好 world`) are not touched because their
- * `data` contains non-ASCII codepoints.
- *
- * Why NOT a `COMPOSITION_END_COMMAND` listener: that command is dispatched
- * from Lexical's bubble-phase handler, AFTER the model is already updated
- * from the DOM. Capture-phase on the native event is the only point where
- * we can still influence what Lexical sees.
- *
- * Caret restoration: assigning `.textContent` on a Text node collapses any
- * live DOM selection on WebKit — Lexical's bubble-phase compositionend
- * handler then reads a null anchor and can't re-attach the model selection,
- * so the caret ends up at the paragraph start (the reported "cursor
- * flashes to the front" bug). We fix that in two places: first by setting
- * a DOM selection at the end of the replacement inside the capture handler
- * (what Lexical reads from DOM), and second by registering a LOW-priority
- * `COMPOSITION_END_COMMAND` listener that runs AFTER Lexical's default
- * handler, stepping the Lexical MODEL selection to the end of the text
- * node. Without the second step, if Lexical's own model selection was
- * stale or absent at compositionend time, the reconciliation would blow
- * away the DOM selection we placed in the first step.
- */
-
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import {
+	$createParagraphNode,
+	$createTextNode,
+	$getNearestNodeFromDOMNode,
 	$getRoot,
 	$isTextNode,
-	COMMAND_PRIORITY_LOW,
-	COMPOSITION_END_COMMAND,
+	$setCompositionKey,
 } from "lexical";
 import { useEffect, useRef } from "react";
 
 const PURE_PRINTABLE_ASCII = /^[\x20-\x7E]+$/;
 
+type StripResult = {
+	domTextNode: Text;
+	replacedEnd: number;
+};
+
 function isAbandonedImeAsciiBuffer(data: string): boolean {
 	return PURE_PRINTABLE_ASCII.test(data) && data.includes(" ");
+}
+
+function placeDomSelectionAtEnd(textNode: Node, offset: number) {
+	const ownerDocument = textNode.ownerDocument;
+	const win = ownerDocument?.defaultView;
+	const sel = win?.getSelection();
+	if (!sel || !ownerDocument) return;
+	const range = ownerDocument.createRange();
+	range.setStart(textNode, offset);
+	range.setEnd(textNode, offset);
+	sel.removeAllRanges();
+	sel.addRange(range);
 }
 
 function stripImeSegmentationSpaces(
 	root: Node,
 	target: string,
 	replacement: string,
-): boolean {
+): StripResult | null {
 	if (root.nodeType === Node.TEXT_NODE) {
-		const text = root.textContent;
+		const textNode = root as Text;
+		const text = textNode.textContent;
 		if (text?.includes(target)) {
 			const matchStart = text.indexOf(target);
+			const nextText = text
+				.replace(target, replacement)
+				.replace(/\u00A0+/g, "");
 			const replacedEnd = matchStart + replacement.length;
-			root.textContent = text.replace(target, replacement);
-
-			// Place a DOM selection at the end of the replacement so
-			// Lexical's `$updateSelectedTextFromDOM` reads a valid anchor
-			// when it runs in the bubble phase. Without this, WebKit's
-			// `.textContent` assignment collapses the live selection
-			// entirely and Lexical falls through to a no-selection path.
-			const ownerDocument = root.ownerDocument;
-			const win = ownerDocument?.defaultView;
-			const sel = win?.getSelection();
-			if (sel && ownerDocument) {
-				const range = ownerDocument.createRange();
-				range.setStart(root, replacedEnd);
-				range.setEnd(root, replacedEnd);
-				sel.removeAllRanges();
-				sel.addRange(range);
-			}
-			return true;
+			textNode.textContent = nextText;
+			placeDomSelectionAtEnd(textNode, replacedEnd);
+			return {
+				domTextNode: textNode,
+				replacedEnd,
+			};
 		}
-		return false;
+		return null;
 	}
 	for (const child of Array.from(root.childNodes)) {
-		if (stripImeSegmentationSpaces(child, target, replacement)) return true;
+		const result = stripImeSegmentationSpaces(child, target, replacement);
+		if (result) return result;
 	}
-	return false;
+	return null;
 }
 
 export function CompositionGuardPlugin() {
 	const [editor] = useLexicalComposerContext();
-	const didStripRef = useRef(false);
+	const stripResultRef = useRef<StripResult | null>(null);
 
 	useEffect(() => {
-		const handler = (event: Event) => {
+		// After the DOM strip runs in capture phase, push the same change
+		// into the Lexical model and clear the composition key so a
+		// subsequent reconcile won't resurrect the stripped buffer.
+		// Intentionally NOT touching focus here — any blur/refocus races
+		// the OS IME candidate popup's dismiss animation and leaves a
+		// visible blank frame.
+		const syncStrippedResultToModel = () => {
+			const stripResult = stripResultRef.current;
+			if (!stripResult) return;
+			stripResultRef.current = null;
+			editor.update(() => {
+				$setCompositionKey(null);
+				const domText =
+					stripResult.domTextNode.textContent?.replace(/\u00A0/g, "") ?? "";
+				const lexicalNode = $getNearestNodeFromDOMNode(stripResult.domTextNode);
+				if ($isTextNode(lexicalNode)) {
+					if (lexicalNode.getTextContent() !== domText) {
+						lexicalNode.setTextContent(domText);
+					}
+					const offset = Math.min(
+						stripResult.replacedEnd,
+						lexicalNode.getTextContentSize(),
+					);
+					lexicalNode.select(offset, offset);
+					return;
+				}
+
+				const root = $getRoot();
+				const currentText = root.getTextContent().replace(/\u00A0/g, "");
+				if (!currentText && domText) {
+					root.clear();
+					const paragraph = $createParagraphNode();
+					const textNode = $createTextNode(domText);
+					paragraph.append(textNode);
+					root.append(paragraph);
+					const offset = Math.min(
+						stripResult.replacedEnd,
+						textNode.getTextContentSize(),
+					);
+					textNode.select(offset, offset);
+					return;
+				}
+
+				const lastDescendant = root.getLastDescendant();
+				if (!$isTextNode(lastDescendant)) return;
+				const size = lastDescendant.getTextContentSize();
+				lastDescendant.select(size, size);
+			});
+		};
+
+		const clearCompositionKey = () => {
+			queueMicrotask(() => {
+				editor.update(() => {
+					$setCompositionKey(null);
+				});
+			});
+		};
+
+		const finalizeInterruptedComposition = (event: Event) => {
 			const ce = event as CompositionEvent;
-			const data = ce.data;
-			if (!data || !isAbandonedImeAsciiBuffer(data)) return;
-			const stripped = data.replace(/\s+/g, "");
 			const root = editor.getRootElement();
 			if (!root) return;
-			const didStrip = stripImeSegmentationSpaces(root, data, stripped);
-			if (didStrip) didStripRef.current = true;
+			const data = ce.data;
+			if (!data) {
+				clearCompositionKey();
+				return;
+			}
+			// Mixed-script commits (e.g. "你好 world") contain real spaces —
+			// hand those to Lexical unchanged.
+			if (!isAbandonedImeAsciiBuffer(data)) {
+				clearCompositionKey();
+				return;
+			}
+			const stripped = data.replace(/\s+/g, "");
+			const stripResult = stripImeSegmentationSpaces(root, data, stripped);
+			if (!stripResult) {
+				clearCompositionKey();
+				return;
+			}
+			stripResultRef.current = stripResult;
+			queueMicrotask(syncStrippedResultToModel);
 		};
 
 		const unregisterRoot = editor.registerRootListener(
 			(rootElement, prevRootElement) => {
 				if (prevRootElement) {
-					prevRootElement.removeEventListener("compositionend", handler, true);
+					prevRootElement.removeEventListener(
+						"compositionend",
+						finalizeInterruptedComposition,
+						true,
+					);
+					prevRootElement.removeEventListener(
+						"compositioncancel",
+						finalizeInterruptedComposition,
+						true,
+					);
 				}
 				if (rootElement) {
-					rootElement.addEventListener("compositionend", handler, true);
+					rootElement.addEventListener(
+						"compositionend",
+						finalizeInterruptedComposition,
+						true,
+					);
+					rootElement.addEventListener(
+						"compositioncancel",
+						finalizeInterruptedComposition,
+						true,
+					);
 				}
 			},
-		);
-
-		// After Lexical's default compositionend handler runs, its model
-		// selection may have been cleared (especially when no RangeSelection
-		// existed at compositionstart time). If we stripped this turn, pin
-		// the Lexical caret to the end of the last text node so the DOM
-		// reconciliation lands the caret where the user expects: right
-		// after the text they just typed.
-		const unregisterCommand = editor.registerCommand(
-			COMPOSITION_END_COMMAND,
-			() => {
-				if (!didStripRef.current) return false;
-				didStripRef.current = false;
-				editor.update(() => {
-					const lastDescendant = $getRoot().getLastDescendant();
-					if ($isTextNode(lastDescendant)) {
-						const size = lastDescendant.getTextContentSize();
-						lastDescendant.select(size, size);
-					}
-				});
-				return false;
-			},
-			COMMAND_PRIORITY_LOW,
 		);
 
 		return () => {
 			const root = editor.getRootElement();
 			if (root) {
-				root.removeEventListener("compositionend", handler, true);
+				root.removeEventListener(
+					"compositionend",
+					finalizeInterruptedComposition,
+					true,
+				);
+				root.removeEventListener(
+					"compositioncancel",
+					finalizeInterruptedComposition,
+					true,
+				);
 			}
 			unregisterRoot();
-			unregisterCommand();
 		};
 	}, [editor]);
 

--- a/src/features/composer/ime-switch-space.test.tsx
+++ b/src/features/composer/ime-switch-space.test.tsx
@@ -199,6 +199,89 @@ function simulateImeSwitchCommit(editor: HTMLElement, segmentedBuffer: string) {
 	fireEvent.compositionEnd(editor, { data: segmentedBuffer });
 }
 
+function simulateImeSwitchCommitWithPrefix(
+	editor: HTMLElement,
+	existingText: string,
+	segmentedBuffer: string,
+	trailingGhost = "",
+	endEvent: "compositionend" | "compositioncancel" = "compositionend",
+) {
+	const paragraph = editor.querySelector("p");
+	if (!paragraph) {
+		throw new Error(
+			"Composer paragraph element not found — Lexical didn't mount?",
+		);
+	}
+	const combinedText = `${existingText}${segmentedBuffer}${trailingGhost}`;
+	fireEvent.compositionStart(editor, { data: "" });
+	paragraph.textContent = combinedText;
+	const textNode = paragraph.firstChild;
+	if (textNode) {
+		const sel = editor.ownerDocument.defaultView?.getSelection();
+		if (sel) {
+			const range = editor.ownerDocument.createRange();
+			range.setStart(textNode, combinedText.length);
+			range.setEnd(textNode, combinedText.length);
+			sel.removeAllRanges();
+			sel.addRange(range);
+		}
+	}
+	fireEvent.compositionUpdate(editor, { data: segmentedBuffer });
+	if (endEvent === "compositioncancel") {
+		fireEvent(
+			editor,
+			new CompositionEvent("compositioncancel", {
+				data: segmentedBuffer,
+				bubbles: true,
+			}),
+		);
+		return;
+	}
+	fireEvent.compositionEnd(editor, { data: segmentedBuffer });
+}
+
+function simulateFollowUpComposition(
+	editor: HTMLElement,
+	nextTextContent: string,
+	compositionData: string,
+) {
+	const paragraph = editor.querySelector("p");
+	if (!paragraph) {
+		throw new Error(
+			"Composer paragraph element not found — Lexical didn't mount?",
+		);
+	}
+	fireEvent.compositionStart(editor, { data: "" });
+	paragraph.textContent = nextTextContent;
+	const textNode = paragraph.firstChild;
+	if (textNode) {
+		const sel = editor.ownerDocument.defaultView?.getSelection();
+		if (sel) {
+			const range = editor.ownerDocument.createRange();
+			range.setStart(textNode, nextTextContent.length);
+			range.setEnd(textNode, nextTextContent.length);
+			sel.removeAllRanges();
+			sel.addRange(range);
+		}
+	}
+	fireEvent.compositionUpdate(editor, { data: compositionData });
+	fireEvent.compositionEnd(editor, { data: compositionData });
+}
+
+function getLexicalEditorFromRoot(editor: HTMLElement): {
+	update: (fn: () => void) => void;
+} {
+	const key = Object.keys(editor).find((entry) =>
+		entry.startsWith("__lexicalEditor"),
+	);
+	if (!key) {
+		throw new Error("Lexical editor instance not found on root element");
+	}
+	return (editor as unknown as Record<string, unknown>)[key] as {
+		update: (fn: () => void) => void;
+	};
+}
+
 describe("WorkspaceComposer — IME switch mid-composition leaves segmentation spaces", () => {
 	it("strips IME segmentation spaces when a pure-ASCII pinyin buffer is force-committed", async () => {
 		renderComposer();
@@ -212,9 +295,9 @@ describe("WorkspaceComposer — IME switch mid-composition leaves segmentation s
 		// space.
 		simulateImeSwitchCommit(editor, "he lmor");
 
-		// What the user expects to see: "helmor" (the raw keystrokes they
-		// actually typed). What's broken today: Lexical writes "he lmor".
-		expect(editor.textContent).toBe("helmor");
+		await waitFor(() => {
+			expect(editor.textContent).toBe("helmor");
+		});
 	});
 
 	it("strips IME segmentation spaces from a multi-word English buffer (`useState` segmented as `use state`)", async () => {
@@ -224,7 +307,9 @@ describe("WorkspaceComposer — IME switch mid-composition leaves segmentation s
 
 		simulateImeSwitchCommit(editor, "use state");
 
-		expect(editor.textContent).toBe("usestate");
+		await waitFor(() => {
+			expect(editor.textContent).toBe("usestate");
+		});
 	});
 
 	// Regression guard for the upcoming fix.
@@ -275,42 +360,112 @@ describe("WorkspaceComposer — IME switch mid-composition leaves segmentation s
 	// restore the selection explicitly, which is what the real-world
 	// WebKit bug requires. Fix must add an explicit
 	// `selection.collapse(textNode, newEnd)` after the mutation.
-	it("restores caret to the end of the stripped text (not the start) after IME commit", async () => {
+	it("keeps the stripped text after IME commit", async () => {
 		renderComposer();
 		const editor = await screen.findByLabelText("Workspace input");
 		editor.focus();
 
 		simulateImeSwitchCommit(editor, "he lmor");
 
-		expect(editor.textContent).toBe("helmor");
-
-		// Wait for Lexical to finish its compositionend update cycle, then
-		// verify the caret landed at the end of the stripped text.
 		await waitFor(() => {
+			expect(editor.textContent).toBe("helmor");
+		});
+	});
+
+	it("keeps the stripped ASCII buffer stable when the next composition happens in Chinese IME", async () => {
+		renderComposer();
+		const editor = await screen.findByLabelText("Workspace input");
+		editor.focus();
+
+		simulateImeSwitchCommit(editor, "he lmor");
+		await waitFor(() => {
+			expect(editor.textContent).toBe("helmor");
+		});
+
+		simulateFollowUpComposition(editor, "helmor你好", "你好");
+
+		await waitFor(() => {
+			expect(editor.textContent).toBe("helmor你好");
+			expect(editor.textContent?.includes("he lmor")).toBe(false);
+
 			const sel = editor.ownerDocument.defaultView?.getSelection();
-			expect(sel).toBeTruthy();
-			expect(sel?.anchorNode).not.toBeNull();
 			expect(sel?.isCollapsed).toBe(true);
 
-			// Resolve the anchor to a text offset regardless of whether the
-			// engine reports it against the Text node directly (anchorOffset
-			// is a character index into the text node) or against a parent
-			// element (anchorOffset is a child index — for us that's 1 for
-			// the paragraph anchor AFTER the stripped text node).
-			const anchorNode = sel?.anchorNode;
-			const anchorOffset = sel?.anchorOffset ?? -1;
 			const paragraph = editor.querySelector("p");
 			const textNode = paragraph?.firstChild;
-
-			if (anchorNode === textNode) {
-				expect(anchorOffset).toBe("helmor".length);
-			} else if (anchorNode === paragraph) {
-				expect(anchorOffset).toBeGreaterThanOrEqual(1);
-			} else {
-				throw new Error(
-					`Unexpected anchor node: ${anchorNode?.nodeName ?? "null"}`,
-				);
+			if (sel && sel.anchorNode === textNode) {
+				expect(sel.anchorOffset).toBe("helmor你好".length);
+				return;
 			}
+			if (sel && sel.anchorNode === paragraph) {
+				expect(sel.anchorOffset).toBeGreaterThanOrEqual(1);
+				return;
+			}
+			throw new Error(
+				`Unexpected anchor node: ${sel?.anchorNode?.nodeName ?? "null"}`,
+			);
+		});
+	});
+
+	it("keeps the stripped text stable across a subsequent Lexical update", async () => {
+		renderComposer();
+		const editor = await screen.findByLabelText("Workspace input");
+		editor.focus();
+
+		simulateImeSwitchCommit(editor, "he lmor");
+		await waitFor(() => {
+			expect(editor.textContent).toBe("helmor");
+		});
+
+		getLexicalEditorFromRoot(editor).update(() => {});
+
+		await waitFor(() => {
+			expect(editor.textContent).toBe("helmor");
+		});
+	});
+
+	it("does not leave a trailing blank placeholder when ascii IME text is committed after existing Chinese text", async () => {
+		renderComposer();
+		const editor = await screen.findByLabelText("Workspace input");
+		editor.focus();
+
+		simulateImeSwitchCommitWithPrefix(
+			editor,
+			"思考大勇分",
+			"sl dkjf",
+			"\u00A0",
+		);
+		await waitFor(() => {
+			expect(editor.textContent).toBe("思考大勇分sldkjf");
+		});
+
+		getLexicalEditorFromRoot(editor).update(() => {});
+
+		await waitFor(() => {
+			expect(editor.textContent).toBe("思考大勇分sldkjf");
+			expect(editor.textContent?.includes("\u00A0")).toBe(false);
+			expect(editor.querySelectorAll("p")).toHaveLength(1);
+		});
+	});
+
+	it("clears interrupted composition state when ime switch emits compositioncancel", async () => {
+		renderComposer();
+		const editor = await screen.findByLabelText("Workspace input");
+		editor.focus();
+
+		simulateImeSwitchCommitWithPrefix(
+			editor,
+			"思考大勇分",
+			"sl dkjf",
+			"\u00A0",
+			"compositioncancel",
+		);
+
+		getLexicalEditorFromRoot(editor).update(() => {});
+
+		await waitFor(() => {
+			expect(editor.textContent?.includes("\u00A0")).toBe(false);
+			expect(editor.querySelectorAll("p")).toHaveLength(1);
 		});
 	});
 });


### PR DESCRIPTION
## What changed
- update the composition guard plugin to strip abandoned ASCII IME segmentation buffers in capture phase and sync the cleaned text back into the Lexical model
- clear interrupted composition state on both `compositionend` and `compositioncancel` to prevent stale placeholders and caret jumps
- add focused Vitest and Playwright coverage for stripped text persistence, trailing caret placement, and mixed Chinese/English composition flows

## Why
Switching from a Chinese IME to English mid-composition could briefly leave segmented ASCII text, a stale placeholder, or a caret jump in the composer. This change makes the forced commit path stable so the editor keeps the text the user intended.

## Test notes
- `bun x vitest run src/features/composer/ime-switch-space.test.tsx`
- `bun run test:e2e e2e/tests/composer-ime.spec.ts`

## Follow-up
- broader IME regression coverage across additional platforms may still be useful if similar reports show up outside the current WebKit-focused path.