### PR TITLE
fix: restore model selection fallback

### DIFF
--- a/src/features/composer/index.tsx
+++ b/src/features/composer/index.tsx
@@ -542,7 +542,9 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 												<ClaudeIcon className="size-[13px]" />
 											)}
 											<span>
-												{selectedModel?.label ?? selectedModelId ?? ""}
+												{selectedModel?.label ??
+													selectedModelId ??
+													"Select model"}
 											</span>
 											<ChevronDown
 												className="size-3 opacity-40"

--- a/src/lib/workspace-helpers.test.ts
+++ b/src/lib/workspace-helpers.test.ts
@@ -70,14 +70,14 @@ describe("inferDefaultModelId", () => {
 		);
 	});
 
-	it("returns null when no settings default is provided", () => {
-		// ensureDefaultModel is responsible for populating the setting — this
-		// function no longer invents its own fallback.
-		expect(inferDefaultModelId(null, MODEL_SECTIONS)).toBeNull();
+	it("falls back to the first catalog model when no settings default is provided", () => {
+		expect(inferDefaultModelId(null, MODEL_SECTIONS)).toBe("default");
 	});
 
-	it("returns null when settings model ID is not in the catalog", () => {
-		expect(inferDefaultModelId(null, MODEL_SECTIONS, "nonexistent")).toBeNull();
+	it("falls back to the first catalog model when the settings model ID is invalid", () => {
+		expect(inferDefaultModelId(null, MODEL_SECTIONS, "nonexistent")).toBe(
+			"default",
+		);
 	});
 
 	it("returns null when model sections are empty", () => {
@@ -300,6 +300,22 @@ describe("resolveSessionSelectedModelId", () => {
 				settingsDefaultModelId: "gpt-4o",
 			}),
 		).toBe("gpt-4o");
+	});
+
+	it("falls back to the first available model when no session or settings model is available", () => {
+		expect(
+			resolveSessionSelectedModelId({
+				session: {
+					id: "session-4",
+					agentType: null,
+					model: null,
+					lastUserMessageAt: null,
+				},
+				modelSelections: {},
+				modelSections: MODEL_SECTIONS,
+				settingsDefaultModelId: null,
+			}),
+		).toBe("default");
 	});
 });
 

--- a/src/lib/workspace-helpers.ts
+++ b/src/lib/workspace-helpers.ts
@@ -413,6 +413,8 @@ export function inferDefaultModelId(
 	modelSections: AgentModelSection[],
 	settingsDefaultModelId?: string | null,
 ): string | null {
+	const allOptions = modelSections.flatMap((section) => section.options);
+
 	// Existing session with history → respect whatever model it used
 	if (!isNewSession(session)) {
 		const sessionModel = session?.model ?? null;
@@ -431,7 +433,9 @@ export function inferDefaultModelId(
 		return settingsDefaultModelId;
 	}
 
-	return null;
+	// Last-resort UI fallback so the composer never renders an empty model chip
+	// while settings bootstrap or self-heal catches up.
+	return allOptions[0]?.id ?? null;
 }
 
 export function describeUnknownError(error: unknown, fallback: string): string {


### PR DESCRIPTION
## What changed
- restore the composer's last-resort model fallback to the first available catalog model when settings are missing or invalid
- show "Select model" in the composer chip instead of rendering an empty label while the model state is bootstrapping
- add regression tests for default-model inference and session model resolution

## Why
The composer could render an empty model chip when the saved default model was absent or not loaded yet. This restores a stable fallback so model selection remains visible and usable during settings bootstrap or recovery.

## Test notes
- Not run (not requested).