### PR TITLE
Remove default general prompt and model fallback

### DIFF
--- a/src/lib/repo-preferences-prompts.test.ts
+++ b/src/lib/repo-preferences-prompts.test.ts
@@ -6,10 +6,8 @@ import {
 } from "./repo-preferences-prompts";
 
 describe("repo preference prompts", () => {
-	it("falls back to the built-in preview when no override exists", () => {
-		expect(resolveRepoPreferencePreview("general", {})).toContain(
-			"Follow this repository's existing conventions closely.",
-		);
+	it("leaves the general preview empty when no override exists", () => {
+		expect(resolveRepoPreferencePreview("general", {})).toBe("");
 	});
 
 	it("uses the override instead of the built-in prompt", () => {
@@ -41,6 +39,12 @@ describe("repo preference prompts", () => {
 			}),
 		).toBe(
 			"Always explain the root cause first.\n\nUser request:\nFix the failing tests.",
+		);
+	});
+
+	it("leaves the first user message unchanged when general is empty", () => {
+		expect(prependGeneralPreferencePrompt("Fix the failing tests.", {})).toBe(
+			"Fix the failing tests.",
 		);
 	});
 });

--- a/src/lib/repo-preferences-prompts.ts
+++ b/src/lib/repo-preferences-prompts.ts
@@ -17,12 +17,6 @@ type ResolveRepoPreferencePromptArgs = {
 	dirtyWorktree?: boolean;
 };
 
-const DEFAULT_GENERAL_PROMPT = `Follow this repository's existing conventions closely.
-
-- Inspect nearby code before changing structure or style.
-- Prefer minimal, coherent changes over broad refactors.
-- Keep naming, formatting, and architecture aligned with the existing codebase.`;
-
 const DEFAULT_BRANCH_RENAME_PROMPT = `When you generate the branch name segment for a new chat:
 
 - Base it on the user's first message.
@@ -68,7 +62,7 @@ Do the following, in order:
 If a conflict is too ambiguous to resolve automatically, stop and ask.`,
 
 	branchRename: DEFAULT_BRANCH_RENAME_PROMPT,
-	general: DEFAULT_GENERAL_PROMPT,
+	general: "",
 };
 
 export const REPO_PREFERENCE_LABELS: Record<RepoPreferenceKey, string> = {


### PR DESCRIPTION
## What changed
- removed the built-in default content for `General preferences`, so the field now starts empty and only affects first-chat prompts when a repo override is explicitly set
- updated repo preference prompt tests to cover the empty-default behavior
- removed the last-resort automatic model fallback in workspace helpers and related tests so missing or invalid defaults now stay `null` instead of silently picking the first catalog model
- stopped rendering the composer model label fallback text when no model is resolved yet

## Why it changed
The repo-level general preference should be opt-in rather than silently injecting extra instructions into new chats. The model fallback cleanup keeps selection behavior explicit and avoids masking missing configuration by auto-selecting the first available model.

## Follow-up / test notes
- no additional test run in this step; this PR is based on the already pushed branch state
- branch includes a merge from `origin/main`
