### PR TITLE
feat(chat): add follow-up queue for messages sent while AI is responding

### DIFF
--- a/.changeset/swift-rivers-gather.md
+++ b/.changeset/swift-rivers-gather.md
@@ -1,0 +1,8 @@
+---
+"helmor": minor
+---
+
+Add a follow-up queue for messages sent while the AI is still responding:
+- New Settings toggle (Follow-up behavior) picks between Queue and Steer — Queue stashes the next message and auto-sends it once the current turn finishes; Steer keeps the existing mid-turn interrupt.
+- Queued messages appear as stacked rows above the composer with Steer-now / remove actions, and survive session and workspace switches.
+- Pull-on-conflict and dirty-worktree resolution prompts now queue onto the active chat automatically instead of blocking with a toast when the AI is busy.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2139,11 +2139,9 @@ function AppShell({
 										onOpenEditorFile={handleOpenEditorFile}
 										onCommitAction={handleInspectorCommitAction}
 										currentSessionId={displayedSessionId}
-										sendingSessionIds={sendingSessionIds}
 										onQueuePendingPromptForSession={
 											queuePendingPromptForSession
 										}
-										pushToast={pushWorkspaceToast}
 										commitButtonMode={commitButtonMode}
 										commitButtonState={commitButtonState}
 										prInfo={workspacePrInfo}

--- a/src/features/commit/hooks/use-commit-lifecycle.ts
+++ b/src/features/commit/hooks/use-commit-lifecycle.ts
@@ -75,6 +75,11 @@ export type PendingPromptForSession = {
 	prompt: string;
 	modelId?: string | null;
 	permissionMode?: string | null;
+	/** When true, submit must queue if a turn is already streaming —
+	 *  regardless of the user's `followUpBehavior` setting. Used for
+	 *  host-triggered prompts (e.g. git-pull conflict resolution) that
+	 *  must never interrupt the active turn. */
+	forceQueue?: boolean;
 };
 
 export function useWorkspaceCommitLifecycle({

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -35,6 +35,7 @@ import {
 	workspaceSessionsQueryOptions,
 } from "@/lib/query-client";
 import { useSettings } from "@/lib/settings";
+import type { QueuedSubmit } from "@/lib/use-submit-queue";
 import { cn } from "@/lib/utils";
 import {
 	clampEffortToModel,
@@ -47,11 +48,13 @@ import type { DeferredToolResponseHandler } from "./deferred-tool";
 import type { AddDirPickerEntry } from "./editor/add-dir/typeahead-plugin";
 import type { ElicitationResponseHandler } from "./elicitation";
 import { WorkspaceComposer } from "./index";
+import { SubmitQueueList } from "./submit-queue-list";
 
 const EMPTY_MODEL_SECTIONS: AgentModelSection[] = [];
 const EMPTY_SLASH_COMMANDS: SlashCommandEntry[] = [];
 const EMPTY_LINKED_DIRECTORIES: readonly string[] = [];
 const EMPTY_CANDIDATE_DIRECTORIES: readonly CandidateDirectory[] = [];
+const EMPTY_QUEUE_ITEMS: readonly QueuedSubmit[] = [];
 
 /**
  * Host-app built-in slash commands. Prepended to the agent-supplied list
@@ -105,6 +108,8 @@ type WorkspaceComposerContainerProps = {
 		effortLevel: string;
 		permissionMode: string;
 		fastMode: boolean;
+		/** Force queue (bypass `followUpBehavior`) if a turn is streaming. */
+		forceQueue?: boolean;
 	}) => void;
 	/** Prompt queued by an external caller to auto-submit once the displayed
 	 * session matches `sessionId`. */
@@ -113,12 +118,18 @@ type WorkspaceComposerContainerProps = {
 		prompt: string;
 		modelId?: string | null;
 		permissionMode?: string | null;
+		/** Force queue (bypass `followUpBehavior`) if a turn is streaming. */
+		forceQueue?: boolean;
 	} | null;
 	/** Called after the pending prompt has been dispatched, so the caller can
 	 * clear the queue. */
 	onPendingPromptConsumed?: () => void;
 	pendingInsertRequests?: ResolvedComposerInsertRequest[];
 	onPendingInsertRequestsConsumed?: (ids: string[]) => void;
+	/** Follow-up queue rendered above composer when `followUpBehavior === 'queue'`. */
+	queueItems?: readonly QueuedSubmit[];
+	onSteerQueued?: (itemId: string) => void;
+	onRemoveQueued?: (itemId: string) => void;
 };
 
 const noopDeferredToolResponse: DeferredToolResponseHandler = () => {};
@@ -158,6 +169,9 @@ export const WorkspaceComposerContainer = memo(
 		onPendingPromptConsumed,
 		pendingInsertRequests = [],
 		onPendingInsertRequestsConsumed,
+		queueItems = EMPTY_QUEUE_ITEMS,
+		onSteerQueued,
+		onRemoveQueued,
 	}: WorkspaceComposerContainerProps) {
 		const queryClient = useQueryClient();
 		const { settings } = useSettings();
@@ -573,6 +587,7 @@ export const WorkspaceComposerContainer = memo(
 				pendingPromptForSession.prompt,
 				pendingPromptForSession.modelId ?? "",
 				pendingPromptForSession.permissionMode ?? "",
+				pendingPromptForSession.forceQueue ? "q" : "",
 			].join("|");
 			if (dispatchedPromptKeyRef.current === dispatchKey) {
 				return;
@@ -589,6 +604,7 @@ export const WorkspaceComposerContainer = memo(
 				effortLevel,
 				permissionMode: effectivePermissionMode,
 				fastMode: supportsFastMode ? fastMode : false,
+				forceQueue: pendingPromptForSession.forceQueue,
 			});
 			onPendingPromptConsumed?.();
 		}, [
@@ -705,6 +721,13 @@ export const WorkspaceComposerContainer = memo(
 						}
 					/>
 				) : null}
+
+				<SubmitQueueList
+					items={queueItems}
+					onSteer={(id) => onSteerQueued?.(id)}
+					onRemove={(id) => onRemoveQueued?.(id)}
+					disabled={composerUnavailable}
+				/>
 
 				<div className="relative z-10">
 					<WorkspaceComposer

--- a/src/features/composer/submit-queue-list/index.tsx
+++ b/src/features/composer/submit-queue-list/index.tsx
@@ -1,0 +1,135 @@
+/**
+ * Vertical stack of queued follow-up messages, rendered above the
+ * composer when `followUpBehavior === 'queue'` is active and the user
+ * has typed additional messages while a turn is still running. Stacked
+ * `ActionRow`s (the same primitive the auto-close banner uses) keep
+ * the visual continuous-card look: each row's border collapses into
+ * the next, and the bottom row overlaps the composer top edge via
+ * `-mb-px`.
+ *
+ * Every row offers two actions: steer (convert this queued entry into
+ * a `steerAgentStream` call and send now, interrupting the active
+ * turn), or trash (remove from the local queue — no provider side
+ * effect).
+ *
+ * Renders nothing when the queue for the given session is empty — the
+ * composer's outer layout doesn't reserve space.
+ */
+
+import { Clock, CornerDownLeft, Trash2 } from "lucide-react";
+import { ActionRow } from "@/components/action-row";
+import { Button } from "@/components/ui/button";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
+import type { QueuedSubmit } from "@/lib/use-submit-queue";
+import { cn } from "@/lib/utils";
+
+export type SubmitQueueListProps = {
+	items: readonly QueuedSubmit[];
+	onSteer: (id: string) => void;
+	onRemove: (id: string) => void;
+	disabled?: boolean;
+};
+
+export function SubmitQueueList({
+	items,
+	onSteer,
+	onRemove,
+	disabled,
+}: SubmitQueueListProps) {
+	if (items.length === 0) return null;
+	return (
+		<div className="relative z-0 mx-auto -mb-px w-[90%] overflow-hidden rounded-t-2xl border border-b-0 border-secondary/80 bg-background">
+			{items.map((item, idx) => (
+				<QueueRow
+					key={item.id}
+					item={item}
+					isLast={idx === items.length - 1}
+					onSteer={() => onSteer(item.id)}
+					onRemove={() => onRemove(item.id)}
+					disabled={disabled}
+				/>
+			))}
+		</div>
+	);
+}
+
+function QueueRow({
+	item,
+	isLast,
+	onSteer,
+	onRemove,
+	disabled,
+}: {
+	item: QueuedSubmit;
+	isLast: boolean;
+	onSteer: () => void;
+	onRemove: () => void;
+	disabled?: boolean;
+}) {
+	const preview = item.payload.prompt.trim();
+	return (
+		<ActionRow
+			className={cn(
+				"border-0 bg-transparent px-3 py-1 pb-0.5 pt-0.5",
+				!isLast && "border-b border-b-border/30",
+			)}
+			leading={
+				<>
+					<Clock
+						className="size-3.5 shrink-0 text-muted-foreground/70"
+						strokeWidth={1.8}
+						aria-hidden
+					/>
+					<span className="truncate text-[12px] font-medium tracking-[0.01em] text-foreground">
+						{preview}
+					</span>
+				</>
+			}
+			trailing={
+				<>
+					<Button
+						type="button"
+						aria-label="Steer now"
+						variant="ghost"
+						size="sm"
+						disabled={disabled}
+						onClick={onSteer}
+						className="h-7 gap-1 rounded-md px-2 text-[12px] font-medium text-muted-foreground hover:text-foreground"
+					>
+						<CornerDownLeft
+							className="size-[13px] shrink-0"
+							strokeWidth={1.8}
+						/>
+						<span>Steer</span>
+					</Button>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								type="button"
+								aria-label="Remove from queue"
+								variant="ghost"
+								size="icon-xs"
+								disabled={disabled}
+								onClick={onRemove}
+								className="size-7 rounded-md text-muted-foreground hover:text-destructive"
+							>
+								<Trash2 className="size-3.5" strokeWidth={1.8} />
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent
+							side="top"
+							sideOffset={6}
+							className="flex h-[22px] items-center rounded-md px-1.5 text-[11px] leading-none"
+						>
+							<span>Remove from queue</span>
+						</TooltipContent>
+					</Tooltip>
+				</>
+			}
+		/>
+	);
+}

--- a/src/features/conversation/hooks/use-streaming.test.tsx
+++ b/src/features/conversation/hooks/use-streaming.test.tsx
@@ -11,8 +11,23 @@ import type {
 } from "@/lib/api";
 import { helmorQueryKeys } from "@/lib/query-client";
 import { sessionThreadCacheKey } from "@/lib/session-thread-cache";
+import type {
+	QueuedSubmitContext,
+	SubmitQueueApi,
+} from "@/lib/use-submit-queue";
 import { WorkspaceToastProvider } from "@/lib/workspace-toast-context";
 import { useConversationStreaming } from "./use-streaming";
+
+// Tests that don't exercise the queue branch can share this no-op
+// stub — matches the shape of `SubmitQueueApi` without side effects.
+const noopSubmitQueue: SubmitQueueApi = {
+	getQueue: () => [],
+	findById: () => undefined,
+	enqueue: () => "",
+	remove: () => {},
+	popNext: () => undefined,
+	clear: () => {},
+};
 
 const apiMocks = vi.hoisted(() => ({
 	generateSessionTitle: vi.fn(),
@@ -200,6 +215,8 @@ describe("useConversationStreaming", () => {
 						interactionSnapshots.push(new Map(sessionWorkspaceMap));
 					},
 					selectionPending: false,
+					followUpBehavior: "steer",
+					submitQueue: noopSubmitQueue,
 				}),
 			{
 				initialProps: {
@@ -291,6 +308,8 @@ describe("useConversationStreaming", () => {
 					displayedSessionId: "session-1",
 					displayedWorkspaceId: "workspace-1",
 					selectionPending: false,
+					followUpBehavior: "steer",
+					submitQueue: noopSubmitQueue,
 				}),
 			{ wrapper: Wrapper },
 		);
@@ -343,6 +362,8 @@ describe("useConversationStreaming", () => {
 					displayedSessionId: "session-1",
 					displayedWorkspaceId: "workspace-1",
 					selectionPending: false,
+					followUpBehavior: "steer",
+					submitQueue: noopSubmitQueue,
 				}),
 			{ wrapper: Wrapper },
 		);
@@ -380,6 +401,8 @@ describe("useConversationStreaming", () => {
 					displayedSessionId: "session-1",
 					displayedWorkspaceId: "workspace-1",
 					selectionPending: false,
+					followUpBehavior: "steer",
+					submitQueue: noopSubmitQueue,
 				}),
 			{ wrapper: Wrapper },
 		);
@@ -442,6 +465,8 @@ describe("useConversationStreaming", () => {
 					displayedSessionId: "session-1",
 					displayedWorkspaceId: "workspace-1",
 					selectionPending: false,
+					followUpBehavior: "steer",
+					submitQueue: noopSubmitQueue,
 				}),
 			{ wrapper: Wrapper },
 		);
@@ -511,6 +536,8 @@ describe("useConversationStreaming", () => {
 					displayedWorkspaceId: "workspace-1",
 					repoId: "repo-1",
 					selectionPending: false,
+					followUpBehavior: "steer",
+					submitQueue: noopSubmitQueue,
 				}),
 			{ wrapper: Wrapper },
 		);
@@ -558,6 +585,8 @@ describe("useConversationStreaming", () => {
 					displayedSessionId: "session-1",
 					displayedWorkspaceId: "workspace-1",
 					selectionPending: false,
+					followUpBehavior: "steer",
+					submitQueue: noopSubmitQueue,
 				}),
 			{ wrapper: Wrapper },
 		);
@@ -711,6 +740,8 @@ describe("useConversationStreaming", () => {
 					displayedSessionId: "session-1",
 					displayedWorkspaceId: "workspace-1",
 					selectionPending: false,
+					followUpBehavior: "steer",
+					submitQueue: noopSubmitQueue,
 				}),
 			{ wrapper: Wrapper },
 		);
@@ -771,6 +802,8 @@ describe("useConversationStreaming", () => {
 						interactionSnapshots.push(new Map(sessionWorkspaceMap));
 					},
 					selectionPending: false,
+					followUpBehavior: "steer",
+					submitQueue: noopSubmitQueue,
 				}),
 			{ wrapper: Wrapper },
 		);
@@ -858,6 +891,8 @@ describe("useConversationStreaming", () => {
 					displayedSessionId: "session-1",
 					displayedWorkspaceId: "workspace-1",
 					selectionPending: false,
+					followUpBehavior: "steer",
+					submitQueue: noopSubmitQueue,
 				}),
 			{ wrapper: Wrapper },
 		);
@@ -951,6 +986,8 @@ describe("useConversationStreaming", () => {
 					displayedSessionId: "session-1",
 					displayedWorkspaceId: "workspace-1",
 					selectionPending: false,
+					followUpBehavior: "steer",
+					submitQueue: noopSubmitQueue,
 				}),
 			{ wrapper: Wrapper },
 		);
@@ -1000,6 +1037,8 @@ describe("useConversationStreaming", () => {
 					displayedSessionId,
 					displayedWorkspaceId: "workspace-1",
 					selectionPending: false,
+					followUpBehavior: "steer",
+					submitQueue: noopSubmitQueue,
 				}),
 			{
 				initialProps: {
@@ -1100,6 +1139,8 @@ describe("useConversationStreaming", () => {
 					displayedSessionId: "session-1",
 					displayedWorkspaceId: "workspace-1",
 					selectionPending: false,
+					followUpBehavior: "steer",
+					submitQueue: noopSubmitQueue,
 				}),
 			{ wrapper: Wrapper },
 		);
@@ -1147,6 +1188,8 @@ describe("useConversationStreaming", () => {
 					displayedSessionId: "session-1",
 					displayedWorkspaceId: "workspace-1",
 					selectionPending: false,
+					followUpBehavior: "steer",
+					submitQueue: noopSubmitQueue,
 				}),
 			{ wrapper: Wrapper },
 		);
@@ -1166,5 +1209,825 @@ describe("useConversationStreaming", () => {
 		);
 		expect(result.current.pendingElicitation).toBeNull();
 		expect(result.current.isSending).toBe(true);
+	});
+
+	describe("follow-up queue", () => {
+		// Minimal in-memory queue that mirrors `useSubmitQueue` for tests.
+		// The real hook keeps state in React; here we just need a stable
+		// api whose mutations are observable synchronously.
+		function createFakeQueue(): SubmitQueueApi & {
+			snapshot: () => Map<
+				string,
+				Array<{ id: string; prompt: string; context: QueuedSubmitContext }>
+			>;
+		} {
+			const store = new Map<
+				string,
+				Array<{
+					id: string;
+					context: QueuedSubmitContext;
+					payload: Parameters<SubmitQueueApi["enqueue"]>[1];
+				}>
+			>();
+			let counter = 0;
+			return {
+				getQueue: (sessionId) =>
+					store.get(sessionId)?.map((e) => ({
+						id: e.id,
+						context: e.context,
+						payload: e.payload,
+						enqueuedAt: 0,
+					})) ?? [],
+				findById: (id) => {
+					for (const list of store.values()) {
+						const match = list.find((e) => e.id === id);
+						if (match) {
+							return {
+								id: match.id,
+								context: match.context,
+								payload: match.payload,
+								enqueuedAt: 0,
+							};
+						}
+					}
+					return undefined;
+				},
+				enqueue: (context, payload) => {
+					counter += 1;
+					const id = `q-${counter}`;
+					const list = store.get(context.sessionId) ?? [];
+					list.push({ id, context, payload });
+					store.set(context.sessionId, list);
+					return id;
+				},
+				remove: (sessionId, id) => {
+					const list = store.get(sessionId);
+					if (!list) return;
+					const filtered = list.filter((e) => e.id !== id);
+					if (filtered.length === 0) store.delete(sessionId);
+					else store.set(sessionId, filtered);
+				},
+				popNext: (sessionId) => {
+					const list = store.get(sessionId);
+					if (!list || list.length === 0) return undefined;
+					const [head, ...rest] = list;
+					if (rest.length === 0) store.delete(sessionId);
+					else store.set(sessionId, rest);
+					return {
+						id: head.id,
+						context: head.context,
+						payload: head.payload,
+						enqueuedAt: 0,
+					};
+				},
+				clear: (sessionId) => {
+					store.delete(sessionId);
+				},
+				snapshot: () => {
+					const out = new Map<
+						string,
+						Array<{ id: string; prompt: string; context: QueuedSubmitContext }>
+					>();
+					for (const [sid, list] of store) {
+						out.set(
+							sid,
+							list.map((e) => ({
+								id: e.id,
+								prompt: e.payload.prompt,
+								context: e.context,
+							})),
+						);
+					}
+					return out;
+				},
+			};
+		}
+
+		it("queues follow-up submits instead of steering when behavior is 'queue'", async () => {
+			const streamCallbacks: Array<(event: unknown) => void> = [];
+			apiMocks.startAgentMessageStream.mockImplementation(
+				async (_payload: unknown, onEvent: (event: unknown) => void) => {
+					streamCallbacks.push(onEvent);
+				},
+			);
+			const queue = createFakeQueue();
+
+			const { Wrapper } = createWrapper();
+			const { result } = renderHook(
+				() =>
+					useConversationStreaming({
+						composerContextKey: "session:session-1",
+						displayedSelectedModelId: MODEL.id,
+						displayedSessionId: "session-1",
+						displayedWorkspaceId: "workspace-1",
+						selectionPending: false,
+						followUpBehavior: "queue",
+						submitQueue: queue,
+					}),
+				{ wrapper: Wrapper },
+			);
+
+			// Start a real turn first — this establishes the activeSession
+			// and sending state that the queue branch checks for.
+			await act(async () => {
+				await result.current.handleComposerSubmit({
+					prompt: "First",
+					imagePaths: [],
+					filePaths: [],
+					customTags: [],
+					model: MODEL,
+					workingDirectory: "/tmp/helmor",
+					effortLevel: "medium",
+					permissionMode: "default",
+					fastMode: false,
+				});
+			});
+			expect(streamCallbacks).toHaveLength(1);
+			expect(result.current.isSending).toBe(true);
+
+			// Follow-up while the turn is active — should enqueue, not steer.
+			await act(async () => {
+				await result.current.handleComposerSubmit({
+					prompt: "Follow up",
+					imagePaths: [],
+					filePaths: [],
+					customTags: [],
+					model: MODEL,
+					workingDirectory: "/tmp/helmor",
+					effortLevel: "medium",
+					permissionMode: "default",
+					fastMode: false,
+				});
+			});
+			expect(apiMocks.steerAgentStream).not.toHaveBeenCalled();
+			const enqueued = queue.snapshot().get("session-1");
+			expect(enqueued).toHaveLength(1);
+			expect(enqueued?.[0]).toMatchObject({
+				id: "q-1",
+				prompt: "Follow up",
+				context: {
+					sessionId: "session-1",
+					workspaceId: "workspace-1",
+					contextKey: "session:session-1",
+				},
+			});
+		});
+
+		it("drains the queue when the active turn finishes", async () => {
+			const streamCallbacks: Array<(event: unknown) => void> = [];
+			apiMocks.startAgentMessageStream.mockImplementation(
+				async (_payload: unknown, onEvent: (event: unknown) => void) => {
+					streamCallbacks.push(onEvent);
+				},
+			);
+			const queue = createFakeQueue();
+
+			const { Wrapper } = createWrapper();
+			const { result } = renderHook(
+				() =>
+					useConversationStreaming({
+						composerContextKey: "session:session-1",
+						displayedSelectedModelId: MODEL.id,
+						displayedSessionId: "session-1",
+						displayedWorkspaceId: "workspace-1",
+						selectionPending: false,
+						followUpBehavior: "queue",
+						submitQueue: queue,
+					}),
+				{ wrapper: Wrapper },
+			);
+
+			// Kick off the primary turn.
+			await act(async () => {
+				await result.current.handleComposerSubmit({
+					prompt: "Primary",
+					imagePaths: [],
+					filePaths: [],
+					customTags: [],
+					model: MODEL,
+					workingDirectory: "/tmp/helmor",
+					effortLevel: "medium",
+					permissionMode: "default",
+					fastMode: false,
+				});
+			});
+
+			// Enqueue a follow-up.
+			await act(async () => {
+				await result.current.handleComposerSubmit({
+					prompt: "Queued",
+					imagePaths: [],
+					filePaths: [],
+					customTags: [],
+					model: MODEL,
+					workingDirectory: "/tmp/helmor",
+					effortLevel: "medium",
+					permissionMode: "default",
+					fastMode: false,
+				});
+			});
+			expect(queue.snapshot().get("session-1")).toHaveLength(1);
+
+			// Finish the first turn — drain effect should pop + replay.
+			await act(async () => {
+				streamCallbacks[0]({
+					kind: "done",
+					provider: "codex",
+					modelId: MODEL.id,
+					resolvedModel: MODEL.cliModel,
+					sessionId: "provider-session-1",
+					workingDirectory: "/tmp/helmor",
+					persisted: false,
+				});
+			});
+			// Drain is scheduled via `queueMicrotask`; let it run.
+			await act(async () => {
+				await Promise.resolve();
+			});
+
+			expect(queue.snapshot().has("session-1")).toBe(false);
+			// Second `startAgentMessageStream` call carries the queued prompt.
+			expect(apiMocks.startAgentMessageStream).toHaveBeenCalledTimes(2);
+			const secondCallPayload = apiMocks.startAgentMessageStream.mock
+				.calls[1][0] as { prompt: string };
+			expect(secondCallPayload.prompt).toBe("Queued");
+		});
+
+		it("handleRemoveQueued removes an item without firing any API", async () => {
+			const queue = createFakeQueue();
+			queue.enqueue(
+				{
+					sessionId: "session-1",
+					workspaceId: "workspace-1",
+					contextKey: "session:session-1",
+				},
+				{
+					prompt: "drop me",
+					imagePaths: [],
+					filePaths: [],
+					customTags: [],
+					model: MODEL,
+					workingDirectory: "/tmp/helmor",
+					effortLevel: "medium",
+					permissionMode: "default",
+					fastMode: false,
+				},
+			);
+
+			const { Wrapper } = createWrapper();
+			const { result } = renderHook(
+				() =>
+					useConversationStreaming({
+						composerContextKey: "session:session-1",
+						displayedSelectedModelId: MODEL.id,
+						displayedSessionId: "session-1",
+						displayedWorkspaceId: "workspace-1",
+						selectionPending: false,
+						followUpBehavior: "queue",
+						submitQueue: queue,
+					}),
+				{ wrapper: Wrapper },
+			);
+
+			act(() => {
+				result.current.handleRemoveQueued("q-1");
+			});
+			expect(queue.snapshot().has("session-1")).toBe(false);
+			expect(apiMocks.steerAgentStream).not.toHaveBeenCalled();
+			expect(apiMocks.startAgentMessageStream).not.toHaveBeenCalled();
+		});
+
+		it("handleSteerQueued converts a queued item to a steer", async () => {
+			const streamCallbacks: Array<(event: unknown) => void> = [];
+			apiMocks.startAgentMessageStream.mockImplementation(
+				async (_payload: unknown, onEvent: (event: unknown) => void) => {
+					streamCallbacks.push(onEvent);
+				},
+			);
+			apiMocks.steerAgentStream.mockResolvedValue({ accepted: true });
+
+			const queue = createFakeQueue();
+			const { Wrapper } = createWrapper();
+			const { result } = renderHook(
+				() =>
+					useConversationStreaming({
+						composerContextKey: "session:session-1",
+						displayedSelectedModelId: MODEL.id,
+						displayedSessionId: "session-1",
+						displayedWorkspaceId: "workspace-1",
+						selectionPending: false,
+						followUpBehavior: "queue",
+						submitQueue: queue,
+					}),
+				{ wrapper: Wrapper },
+			);
+
+			// Kick off a turn so an activeSession exists for steer to target.
+			await act(async () => {
+				await result.current.handleComposerSubmit({
+					prompt: "Primary",
+					imagePaths: [],
+					filePaths: [],
+					customTags: [],
+					model: MODEL,
+					workingDirectory: "/tmp/helmor",
+					effortLevel: "medium",
+					permissionMode: "default",
+					fastMode: false,
+				});
+			});
+
+			// Queue a follow-up.
+			await act(async () => {
+				await result.current.handleComposerSubmit({
+					prompt: "Actually, go faster",
+					imagePaths: [],
+					filePaths: [],
+					customTags: [],
+					model: MODEL,
+					workingDirectory: "/tmp/helmor",
+					effortLevel: "medium",
+					permissionMode: "default",
+					fastMode: false,
+				});
+			});
+
+			// Trigger steer on the queued item.
+			await act(async () => {
+				await result.current.handleSteerQueued("q-1");
+			});
+
+			expect(queue.snapshot().has("session-1")).toBe(false);
+			expect(apiMocks.steerAgentStream).toHaveBeenCalledWith(
+				expect.objectContaining({ prompt: "Actually, go faster" }),
+			);
+		});
+
+		it("drains against the queued session even after the user navigates away", async () => {
+			const streamCallbacks: Array<(event: unknown) => void> = [];
+			apiMocks.startAgentMessageStream.mockImplementation(
+				async (_payload: unknown, onEvent: (event: unknown) => void) => {
+					streamCallbacks.push(onEvent);
+				},
+			);
+			const queue = createFakeQueue();
+
+			const { Wrapper } = createWrapper();
+			// Start displayed on session A.
+			const { result, rerender } = renderHook(
+				({ sessionId, workspaceId, contextKey }) =>
+					useConversationStreaming({
+						composerContextKey: contextKey,
+						displayedSelectedModelId: MODEL.id,
+						displayedSessionId: sessionId,
+						displayedWorkspaceId: workspaceId,
+						selectionPending: false,
+						followUpBehavior: "queue",
+						submitQueue: queue,
+					}),
+				{
+					initialProps: {
+						sessionId: "session-A",
+						workspaceId: "workspace-1",
+						contextKey: "session:session-A",
+					},
+					wrapper: Wrapper,
+				},
+			);
+
+			// Kick off a turn in session A.
+			await act(async () => {
+				await result.current.handleComposerSubmit({
+					prompt: "A primary",
+					imagePaths: [],
+					filePaths: [],
+					customTags: [],
+					model: MODEL,
+					workingDirectory: "/tmp/helmor",
+					effortLevel: "medium",
+					permissionMode: "default",
+					fastMode: false,
+				});
+			});
+			// Queue a follow-up in session A.
+			await act(async () => {
+				await result.current.handleComposerSubmit({
+					prompt: "A follow-up",
+					imagePaths: [],
+					filePaths: [],
+					customTags: [],
+					model: MODEL,
+					workingDirectory: "/tmp/helmor",
+					effortLevel: "medium",
+					permissionMode: "default",
+					fastMode: false,
+				});
+			});
+			expect(queue.snapshot().get("session-A")).toHaveLength(1);
+
+			// User navigates to session B BEFORE A's turn finishes.
+			rerender({
+				sessionId: "session-B",
+				workspaceId: "workspace-1",
+				contextKey: "session:session-B",
+			});
+
+			// A's turn finishes → drain fires.
+			await act(async () => {
+				streamCallbacks[0]({
+					kind: "done",
+					provider: "codex",
+					modelId: MODEL.id,
+					resolvedModel: MODEL.cliModel,
+					sessionId: "provider-session-A",
+					workingDirectory: "/tmp/helmor",
+					persisted: false,
+				});
+			});
+			await act(async () => {
+				await Promise.resolve();
+			});
+
+			// Queue for A is empty, queue for B untouched.
+			expect(queue.snapshot().has("session-A")).toBe(false);
+			expect(queue.snapshot().has("session-B")).toBe(false);
+			// The drained submit targeted session A (NOT B, which is
+			// currently displayed) — verified via the helmorSessionId
+			// passed to the second `startAgentMessageStream` call.
+			expect(apiMocks.startAgentMessageStream).toHaveBeenCalledTimes(2);
+			const drainedPayload = apiMocks.startAgentMessageStream.mock
+				.calls[1][0] as { prompt: string; helmorSessionId: string };
+			expect(drainedPayload.prompt).toBe("A follow-up");
+			expect(drainedPayload.helmorSessionId).toBe("session-A");
+		});
+
+		it("forceQueue bypasses followUpBehavior='steer' and always queues", async () => {
+			apiMocks.startAgentMessageStream.mockImplementation(
+				async (_payload: unknown, _onEvent: (event: unknown) => void) => {
+					// Leave the turn streaming — don't emit 'done'.
+				},
+			);
+			apiMocks.steerAgentStream.mockResolvedValue({ accepted: true });
+			const queue = createFakeQueue();
+
+			const { Wrapper } = createWrapper();
+			const { result } = renderHook(
+				() =>
+					useConversationStreaming({
+						composerContextKey: "session:session-1",
+						displayedSelectedModelId: MODEL.id,
+						displayedSessionId: "session-1",
+						displayedWorkspaceId: "workspace-1",
+						selectionPending: false,
+						// User has `steer` configured — normally the next
+						// submit would steer. `forceQueue: true` must override.
+						followUpBehavior: "steer",
+						submitQueue: queue,
+					}),
+				{ wrapper: Wrapper },
+			);
+
+			// Kick off a turn.
+			await act(async () => {
+				await result.current.handleComposerSubmit({
+					prompt: "Primary",
+					imagePaths: [],
+					filePaths: [],
+					customTags: [],
+					model: MODEL,
+					workingDirectory: "/tmp/helmor",
+					effortLevel: "medium",
+					permissionMode: "default",
+					fastMode: false,
+				});
+			});
+			expect(result.current.isSending).toBe(true);
+
+			// Host-triggered submit with forceQueue=true while streaming.
+			await act(async () => {
+				await result.current.handleComposerSubmit({
+					prompt: "Resolve conflict",
+					imagePaths: [],
+					filePaths: [],
+					customTags: [],
+					model: MODEL,
+					workingDirectory: "/tmp/helmor",
+					effortLevel: "medium",
+					permissionMode: "default",
+					fastMode: false,
+					forceQueue: true,
+				});
+			});
+
+			// Must have queued — not steered.
+			expect(apiMocks.steerAgentStream).not.toHaveBeenCalled();
+			const enqueued = queue.snapshot().get("session-1");
+			expect(enqueued).toHaveLength(1);
+			expect(enqueued?.[0]?.prompt).toBe("Resolve conflict");
+		});
+
+		it("handleSteerQueued re-enqueues the item when provider rejects the steer", async () => {
+			apiMocks.startAgentMessageStream.mockImplementation(
+				async (_payload: unknown, _onEvent: (event: unknown) => void) => {
+					// Leave turn streaming.
+				},
+			);
+			// Provider says "too late" — the turn already ended between
+			// click and RPC. Without the re-enqueue, the queued prompt
+			// is silently lost.
+			apiMocks.steerAgentStream.mockResolvedValue({
+				accepted: false,
+				reason: "turn already completed",
+			});
+			const queue = createFakeQueue();
+
+			const { Wrapper } = createWrapper();
+			const { result } = renderHook(
+				() =>
+					useConversationStreaming({
+						composerContextKey: "session:session-1",
+						displayedSelectedModelId: MODEL.id,
+						displayedSessionId: "session-1",
+						displayedWorkspaceId: "workspace-1",
+						selectionPending: false,
+						followUpBehavior: "queue",
+						submitQueue: queue,
+					}),
+				{ wrapper: Wrapper },
+			);
+
+			// Kick off a turn + queue a follow-up.
+			await act(async () => {
+				await result.current.handleComposerSubmit({
+					prompt: "Primary",
+					imagePaths: [],
+					filePaths: [],
+					customTags: [],
+					model: MODEL,
+					workingDirectory: "/tmp/helmor",
+					effortLevel: "medium",
+					permissionMode: "default",
+					fastMode: false,
+				});
+			});
+			await act(async () => {
+				await result.current.handleComposerSubmit({
+					prompt: "Follow-up",
+					imagePaths: [],
+					filePaths: [],
+					customTags: [],
+					model: MODEL,
+					workingDirectory: "/tmp/helmor",
+					effortLevel: "medium",
+					permissionMode: "default",
+					fastMode: false,
+				});
+			});
+			expect(queue.snapshot().get("session-1")).toHaveLength(1);
+
+			// Steer attempt — provider rejects.
+			await act(async () => {
+				await result.current.handleSteerQueued("q-1");
+			});
+
+			// The item must have been put back in the queue (new id OK,
+			// same prompt). The user's prompt is NOT lost.
+			const after = queue.snapshot().get("session-1");
+			expect(after).toHaveLength(1);
+			expect(after?.[0]?.prompt).toBe("Follow-up");
+			// Error surfaces in the send-error bag so UI can toast / show it.
+			expect(result.current.activeSendError).toMatch(/Steer rejected/);
+		});
+
+		it("handleSteerQueued falls back to a fresh turn when the stream has already ended", async () => {
+			apiMocks.startAgentMessageStream.mockImplementation(
+				async (_payload: unknown, _onEvent: (event: unknown) => void) => {
+					// Leave streaming.
+				},
+			);
+			const queue = createFakeQueue();
+
+			const { Wrapper } = createWrapper();
+			const { result } = renderHook(
+				() =>
+					useConversationStreaming({
+						composerContextKey: "session:session-1",
+						displayedSelectedModelId: MODEL.id,
+						displayedSessionId: "session-1",
+						displayedWorkspaceId: "workspace-1",
+						selectionPending: false,
+						followUpBehavior: "queue",
+						submitQueue: queue,
+					}),
+				{ wrapper: Wrapper },
+			);
+
+			// Manually seed the queue without an active stream — the
+			// "user clicked Steer just after turn ended" race.
+			act(() => {
+				queue.enqueue(
+					{
+						sessionId: "session-1",
+						workspaceId: "workspace-1",
+						contextKey: "session:session-1",
+					},
+					{
+						prompt: "Orphan",
+						imagePaths: [],
+						filePaths: [],
+						customTags: [],
+						model: MODEL,
+						workingDirectory: "/tmp/helmor",
+						effortLevel: "medium",
+						permissionMode: "default",
+						fastMode: false,
+					},
+				);
+			});
+
+			await act(async () => {
+				await result.current.handleSteerQueued("q-1");
+			});
+
+			// Should have started a fresh turn with the payload instead
+			// of dropping it silently. The prompt may be wrapped in a
+			// repo-preferences prelude for the first user message, so
+			// just check the Orphan string appears in it.
+			expect(apiMocks.steerAgentStream).not.toHaveBeenCalled();
+			expect(apiMocks.startAgentMessageStream).toHaveBeenCalledTimes(1);
+			const firstCall = apiMocks.startAgentMessageStream.mock.calls[0][0] as {
+				prompt: string;
+				helmorSessionId: string;
+			};
+			expect(firstCall.prompt).toContain("Orphan");
+			expect(firstCall.helmorSessionId).toBe("session-1");
+			expect(queue.snapshot().has("session-1")).toBe(false);
+		});
+
+		it("drains queued items one-per-turn across chained turns", async () => {
+			const streamCallbacks: Array<(event: unknown) => void> = [];
+			apiMocks.startAgentMessageStream.mockImplementation(
+				async (_payload: unknown, onEvent: (event: unknown) => void) => {
+					streamCallbacks.push(onEvent);
+				},
+			);
+			const queue = createFakeQueue();
+
+			const { Wrapper } = createWrapper();
+			const { result } = renderHook(
+				() =>
+					useConversationStreaming({
+						composerContextKey: "session:session-1",
+						displayedSelectedModelId: MODEL.id,
+						displayedSessionId: "session-1",
+						displayedWorkspaceId: "workspace-1",
+						selectionPending: false,
+						followUpBehavior: "queue",
+						submitQueue: queue,
+					}),
+				{ wrapper: Wrapper },
+			);
+
+			// Start primary.
+			await act(async () => {
+				await result.current.handleComposerSubmit({
+					prompt: "Primary",
+					imagePaths: [],
+					filePaths: [],
+					customTags: [],
+					model: MODEL,
+					workingDirectory: "/tmp/helmor",
+					effortLevel: "medium",
+					permissionMode: "default",
+					fastMode: false,
+				});
+			});
+			// Queue two follow-ups.
+			for (const prompt of ["One", "Two"]) {
+				await act(async () => {
+					await result.current.handleComposerSubmit({
+						prompt,
+						imagePaths: [],
+						filePaths: [],
+						customTags: [],
+						model: MODEL,
+						workingDirectory: "/tmp/helmor",
+						effortLevel: "medium",
+						permissionMode: "default",
+						fastMode: false,
+					});
+				});
+			}
+			expect(queue.snapshot().get("session-1")).toHaveLength(2);
+
+			// Finish primary → drain pops "One".
+			await act(async () => {
+				streamCallbacks[0]({
+					kind: "done",
+					provider: "codex",
+					modelId: MODEL.id,
+					resolvedModel: MODEL.cliModel,
+					sessionId: "provider-session-1",
+					workingDirectory: "/tmp/helmor",
+					persisted: false,
+				});
+			});
+			await act(async () => {
+				await Promise.resolve();
+			});
+			expect(apiMocks.startAgentMessageStream).toHaveBeenCalledTimes(2);
+			expect(queue.snapshot().get("session-1")).toHaveLength(1);
+
+			// Finish second → drain pops "Two".
+			await act(async () => {
+				streamCallbacks[1]({
+					kind: "done",
+					provider: "codex",
+					modelId: MODEL.id,
+					resolvedModel: MODEL.cliModel,
+					sessionId: "provider-session-1",
+					workingDirectory: "/tmp/helmor",
+					persisted: false,
+				});
+			});
+			await act(async () => {
+				await Promise.resolve();
+			});
+			expect(apiMocks.startAgentMessageStream).toHaveBeenCalledTimes(3);
+			expect(queue.snapshot().has("session-1")).toBe(false);
+			const thirdPayload = apiMocks.startAgentMessageStream.mock
+				.calls[2][0] as { prompt: string };
+			expect(thirdPayload.prompt).toBe("Two");
+		});
+
+		it("drains queued items when the prior turn errors instead of done", async () => {
+			const streamCallbacks: Array<(event: unknown) => void> = [];
+			apiMocks.startAgentMessageStream.mockImplementation(
+				async (_payload: unknown, onEvent: (event: unknown) => void) => {
+					streamCallbacks.push(onEvent);
+				},
+			);
+			const queue = createFakeQueue();
+
+			const { Wrapper } = createWrapper();
+			const { result } = renderHook(
+				() =>
+					useConversationStreaming({
+						composerContextKey: "session:session-1",
+						displayedSelectedModelId: MODEL.id,
+						displayedSessionId: "session-1",
+						displayedWorkspaceId: "workspace-1",
+						selectionPending: false,
+						followUpBehavior: "queue",
+						submitQueue: queue,
+					}),
+				{ wrapper: Wrapper },
+			);
+
+			await act(async () => {
+				await result.current.handleComposerSubmit({
+					prompt: "Primary",
+					imagePaths: [],
+					filePaths: [],
+					customTags: [],
+					model: MODEL,
+					workingDirectory: "/tmp/helmor",
+					effortLevel: "medium",
+					permissionMode: "default",
+					fastMode: false,
+				});
+			});
+			await act(async () => {
+				await result.current.handleComposerSubmit({
+					prompt: "Queued after error",
+					imagePaths: [],
+					filePaths: [],
+					customTags: [],
+					model: MODEL,
+					workingDirectory: "/tmp/helmor",
+					effortLevel: "medium",
+					permissionMode: "default",
+					fastMode: false,
+				});
+			});
+
+			await act(async () => {
+				streamCallbacks[0]({
+					kind: "error",
+					provider: "codex",
+					modelId: MODEL.id,
+					message: "boom",
+					persisted: true,
+					internal: false,
+				});
+			});
+			await act(async () => {
+				await Promise.resolve();
+			});
+
+			// error-path also drains — queued prompt doesn't get stuck.
+			expect(apiMocks.startAgentMessageStream).toHaveBeenCalledTimes(2);
+			expect(queue.snapshot().has("session-1")).toBe(false);
+		});
 	});
 });

--- a/src/features/conversation/hooks/use-streaming.ts
+++ b/src/features/conversation/hooks/use-streaming.ts
@@ -1,5 +1,12 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
+import {
+	useCallback,
+	useEffect,
+	useLayoutEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import {
 	buildPendingDeferredTool,
 	getDeferredToolResumeModelId,
@@ -38,6 +45,8 @@ import {
 	sessionThreadCacheKey,
 	shareMessages,
 } from "@/lib/session-thread-cache";
+import type { FollowUpBehavior } from "@/lib/settings";
+import type { SubmitQueueApi } from "@/lib/use-submit-queue";
 import {
 	createLiveThreadMessage,
 	findModelOption,
@@ -94,6 +103,11 @@ type SubmitPayload = {
 	effortLevel: string;
 	permissionMode: string;
 	fastMode: boolean;
+	/** When true, route to the follow-up queue instead of steering if a
+	 *  turn is already streaming — regardless of the user's
+	 *  `followUpBehavior` setting. Set by host-triggered submits (e.g.
+	 *  git-pull conflict resolution) that must never interrupt the turn. */
+	forceQueue?: boolean;
 };
 
 type UseConversationStreamingArgs = {
@@ -103,6 +117,14 @@ type UseConversationStreamingArgs = {
 	repoId?: string | null;
 	displayedSelectedModelId: string | null;
 	selectionPending: boolean;
+	/** Follow-up behavior when submitting while the agent is already
+	 *  responding: `'queue'` stashes the message locally to auto-fire
+	 *  as a new turn once the agent finishes; `'steer'` injects into
+	 *  the active turn (provider-native mid-turn steer). */
+	followUpBehavior: FollowUpBehavior;
+	/** App-level queue handle (read + mutate). Shared across session /
+	 *  workspace switches so the queue survives navigation. */
+	submitQueue: SubmitQueueApi;
 	onSendingWorkspacesChange?: (workspaceIds: Set<string>) => void;
 	onSendingSessionsChange?: (sessionIds: Set<string>) => void;
 	onInteractionSessionsChange?: (
@@ -119,6 +141,8 @@ export function useConversationStreaming({
 	repoId,
 	displayedSelectedModelId,
 	selectionPending,
+	followUpBehavior,
+	submitQueue,
 	onSendingWorkspacesChange,
 	onSendingSessionsChange,
 	onInteractionSessionsChange,
@@ -947,54 +971,102 @@ export function useConversationStreaming({
 	);
 
 	const handleComposerSubmit = useCallback(
-		async ({
-			prompt,
-			imagePaths,
-			filePaths,
-			customTags,
-			model,
-			workingDirectory,
-			effortLevel,
-			permissionMode,
-			fastMode,
-		}: SubmitPayload) => {
+		async (
+			{
+				prompt,
+				imagePaths,
+				filePaths,
+				customTags,
+				model,
+				workingDirectory,
+				effortLevel,
+				permissionMode,
+				fastMode,
+				forceQueue,
+			}: SubmitPayload,
+			// Override for drain / queued-steer. When present, all
+			// session/workspace lookups use the override instead of the
+			// currently displayed view. This is how a queued message from
+			// session A fires against A even when the user has since
+			// navigated to session B.
+			override?: {
+				sessionId: string;
+				workspaceId: string | null;
+				contextKey: string;
+			},
+		) => {
+			const isOverride = override !== undefined;
+			const targetSessionId = override?.sessionId ?? displayedSessionId;
+			const targetWorkspaceId = override?.workspaceId ?? displayedWorkspaceId;
+			const targetContextKey = override?.contextKey ?? composerContextKey;
+
 			const trimmedPrompt = prompt.trim();
-			if (!trimmedPrompt || selectionPending || !displayedSessionId) {
+			// `selectionPending` is a UI-only guard (user clicked a session
+			// that hasn't loaded yet); drain / queued-steer bypass it.
+			if (
+				!trimmedPrompt ||
+				(!isOverride && selectionPending) ||
+				!targetSessionId
+			) {
 				return;
 			}
 
-			const contextKey = composerContextKey;
+			const contextKey = targetContextKey;
 
-			// Steer branch: if a stream is already running for this context,
-			// inject the new prompt into the active turn instead of opening a
-			// fresh one. On rejection (turn already completed or provider
-			// refused) we restore the composer draft + surface an error and
-			// STOP — the user explicitly decides whether to resend as a new
-			// turn. Do NOT silently auto-fallback; that was an earlier
-			// design and is no longer the contract.
+			// Follow-up branch: if a stream is already running for this
+			// context, either inject mid-turn (`steer`) or stash locally
+			// to fire as a fresh turn when the agent finishes (`queue`).
+			// The choice is user-controlled via the Follow-up behavior
+			// setting. Plan-review takes precedence over both: submitting
+			// a free-form message while a plan is pending means "abandon
+			// the plan and start fresh," so fall through to normal send.
 			const liveStream = activeSessionByContext[contextKey];
 			const hasPlanReviewForContext = planReviewByContext[contextKey] ?? false;
-			// Skip steer when a plan review is pending — the composer's
-			// plan-review UI (Request Changes / Implement) is the intended
-			// path for responding to plans, and submitting a free-form
-			// message there means "abandon the plan and start fresh".
-			// Fall through to the normal send path which clears plan state.
 			if (
 				sendingContextKeys.has(contextKey) &&
 				liveStream &&
 				!hasPlanReviewForContext
 			) {
+				// `forceQueue` is a caller-supplied override that pins
+				// the routing to the queue regardless of the user's
+				// `followUpBehavior` setting — used for host-triggered
+				// prompts (e.g. git-pull) that must never steer.
+				const effectiveBehavior = forceQueue ? "queue" : followUpBehavior;
+				if (effectiveBehavior === "queue" && !isOverride) {
+					// App-level queue: capture the current (session,
+					// workspace, contextKey) so drain can replay faithfully
+					// even if the user has navigated away. Without this,
+					// a queued message from session A would fire into
+					// whatever session is currently displayed.
+					submitQueue.enqueue(
+						{
+							sessionId: targetSessionId,
+							workspaceId: targetWorkspaceId,
+							contextKey: targetContextKey,
+						},
+						{
+							prompt: trimmedPrompt,
+							imagePaths,
+							filePaths,
+							customTags,
+							model,
+							workingDirectory,
+							effortLevel,
+							permissionMode,
+							fastMode,
+						},
+					);
+					setComposerRestoreState(null);
+					return;
+				}
+
 				// Real mid-turn steer. The sidecar routes to the provider's
 				// native steer API AND (only after provider ack) emits a
 				// `user_prompt` passthrough event into the active stream.
 				// The accumulator picks that up, splits the assistant turn,
 				// and streaming.rs persists via `persist_turn_message` —
 				// one event, one DB row, no separate persistence path.
-				//
-				// Optimistic bubble covers the RPC round-trip; the next
-				// flush replaces it with the accumulator's authoritative
-				// version that lives at the correct position in the thread.
-				const cacheSessionId = displayedSessionId;
+				const cacheSessionId = targetSessionId;
 				const steerMessageId = crypto.randomUUID();
 				const optimisticSteer = createLiveThreadMessage({
 					id: steerMessageId,
@@ -1014,8 +1086,12 @@ export function useConversationStreaming({
 				// On steer failure we must seed `composerRestoreState` with
 				// the draft so the user's input isn't silently lost — same
 				// contract the normal send path upholds on its error path.
+				// Skip when this is a drain / queued-steer (isOverride): the
+				// composer the user currently sees may belong to a different
+				// session, and restoring the draft there would be confusing.
 				const restoreDraftOnFailure = () => {
 					restoreSnapshot(queryClient, cacheSessionId, rollback);
+					if (isOverride) return;
 					setComposerRestoreState({
 						contextKey,
 						draft: trimmedPrompt,
@@ -1065,15 +1141,15 @@ export function useConversationStreaming({
 			// Always use the real session ID — never fall back to a
 			// workspace-level contextKey, which would share cache entries
 			// across sessions and leak provider session IDs on resume.
-			const cacheSessionId = displayedSessionId;
+			const cacheSessionId = targetSessionId;
 			const currentThread = readSessionThread(queryClient, cacheSessionId);
-			const currentSessions = displayedWorkspaceId
+			const currentSessions = targetWorkspaceId
 				? queryClient.getQueryData<Array<Record<string, unknown>>>(
-						helmorQueryKeys.workspaceSessions(displayedWorkspaceId),
+						helmorQueryKeys.workspaceSessions(targetWorkspaceId),
 					)
 				: undefined;
 			const currentSession = currentSessions?.find(
-				(session) => session.id === displayedSessionId,
+				(session) => session.id === targetSessionId,
 			);
 			const currentTitle =
 				typeof currentSession?.title === "string"
@@ -1098,8 +1174,8 @@ export function useConversationStreaming({
 			let titleSeed: string | null = null;
 			if (isFirstUserMessage) {
 				titleSeed = buildTitleSeed(trimmedPrompt);
-				seedSessionTitle(displayedSessionId, displayedWorkspaceId, titleSeed);
-				void renameSession(displayedSessionId, titleSeed).catch((error) => {
+				seedSessionTitle(targetSessionId, targetWorkspaceId, titleSeed);
+				void renameSession(targetSessionId, titleSeed).catch((error) => {
 					console.warn("[conversation] failed to seed session title:", error);
 				});
 			}
@@ -1108,7 +1184,9 @@ export function useConversationStreaming({
 				cacheSessionId,
 				optimisticUserMessage,
 			);
-			setComposerRestoreState(null);
+			if (!isOverride) {
+				setComposerRestoreState(null);
+			}
 			setSendErrorsByContext((current) => ({
 				...current,
 				[contextKey]: null,
@@ -1120,9 +1198,9 @@ export function useConversationStreaming({
 				[contextKey]: null,
 			}));
 			clearPendingElicitation(contextKey);
-			rememberInteractionWorkspace(contextKey, displayedWorkspaceId);
-			if (displayedWorkspaceId) {
-				sendingWorkspaceMapRef.current.set(contextKey, displayedWorkspaceId);
+			rememberInteractionWorkspace(contextKey, targetWorkspaceId);
+			if (targetWorkspaceId) {
+				sendingWorkspaceMapRef.current.set(contextKey, targetWorkspaceId);
 			}
 			setSendingContextKeys((current) => {
 				const next = new Set(current);
@@ -1136,9 +1214,9 @@ export function useConversationStreaming({
 			}
 
 			try {
-				if (displayedSessionId) {
+				if (targetSessionId) {
 					void generateSessionTitle(
-						displayedSessionId,
+						targetSessionId,
 						trimmedPrompt,
 						titleSeed,
 					).then((result) => {
@@ -1147,16 +1225,16 @@ export function useConversationStreaming({
 								queryClient.invalidateQueries({
 									queryKey: helmorQueryKeys.workspaceGroups,
 								}),
-								displayedWorkspaceId
+								targetWorkspaceId
 									? queryClient.invalidateQueries({
 											queryKey:
-												helmorQueryKeys.workspaceSessions(displayedWorkspaceId),
+												helmorQueryKeys.workspaceSessions(targetWorkspaceId),
 										})
 									: undefined,
-								displayedWorkspaceId
+								targetWorkspaceId
 									? queryClient.invalidateQueries({
 											queryKey:
-												helmorQueryKeys.workspaceDetail(displayedWorkspaceId),
+												helmorQueryKeys.workspaceDetail(targetWorkspaceId),
 										})
 									: undefined,
 							]);
@@ -1164,7 +1242,7 @@ export function useConversationStreaming({
 					});
 				}
 
-				const stopSessionId = displayedSessionId;
+				const stopSessionId = targetSessionId;
 				setActiveSessionByContext((current) => ({
 					...current,
 					[contextKey]: {
@@ -1218,7 +1296,7 @@ export function useConversationStreaming({
 						modelId: model.id,
 						prompt: finalPrompt,
 						sessionId: providerSessionId,
-						helmorSessionId: displayedSessionId,
+						helmorSessionId: targetSessionId,
 						workingDirectory,
 						effortLevel,
 						permissionMode,
@@ -1241,7 +1319,7 @@ export function useConversationStreaming({
 						}
 
 						if (event.kind === "permissionRequest") {
-							rememberInteractionWorkspace(contextKey, displayedWorkspaceId);
+							rememberInteractionWorkspace(contextKey, targetWorkspaceId);
 							appendPendingPermission(contextKey, {
 								permissionId: event.permissionId,
 								toolName: event.toolName,
@@ -1253,13 +1331,13 @@ export function useConversationStreaming({
 						}
 
 						if (event.kind === "planCaptured") {
-							rememberInteractionWorkspace(contextKey, displayedWorkspaceId);
+							rememberInteractionWorkspace(contextKey, targetWorkspaceId);
 							setPlanReviewActive(contextKey);
 							return;
 						}
 
 						if (event.kind === "elicitationRequest") {
-							rememberInteractionWorkspace(contextKey, displayedWorkspaceId);
+							rememberInteractionWorkspace(contextKey, targetWorkspaceId);
 							const nextElicitation = buildPendingElicitation(event, model.id);
 							if (!nextElicitation) {
 								setSendErrorsByContext((current) => ({
@@ -1274,7 +1352,7 @@ export function useConversationStreaming({
 						}
 
 						if (event.kind === "deferredToolUse") {
-							rememberInteractionWorkspace(contextKey, displayedWorkspaceId);
+							rememberInteractionWorkspace(contextKey, targetWorkspaceId);
 							const nextDeferred = buildPendingDeferredTool(event, model.id);
 							if (frameId !== null) {
 								window.cancelAnimationFrame(frameId);
@@ -1308,9 +1386,9 @@ export function useConversationStreaming({
 							clearFastPrelude(contextKey);
 
 							if (event.kind === "done") {
-								const sid = event.sessionId ?? displayedSessionId;
-								if (sid && displayedWorkspaceId) {
-									onSessionCompletedRef.current?.(sid, displayedWorkspaceId);
+								const sid = event.sessionId ?? targetSessionId;
+								if (sid && targetWorkspaceId) {
+									onSessionCompletedRef.current?.(sid, targetWorkspaceId);
 								}
 							}
 
@@ -1335,7 +1413,7 @@ export function useConversationStreaming({
 								// here. The streaming snapshot IS the correct data
 								// and its message IDs differ from DB IDs, so a
 								// refetch would cause a full re-render flicker.
-								void invalidateConversationQueries(displayedWorkspaceId, null);
+								void invalidateConversationQueries(targetWorkspaceId, null);
 							}
 							return;
 						}
@@ -1364,19 +1442,21 @@ export function useConversationStreaming({
 								// DB may have partial data that the snapshot doesn't
 								// reflect correctly.
 								void invalidateConversationQueries(
-									displayedWorkspaceId,
-									displayedSessionId,
+									targetWorkspaceId,
+									targetSessionId,
 								);
 							} else {
 								restoreSnapshot(queryClient, cacheSessionId, rollbackSnapshot);
-								setComposerRestoreState({
-									contextKey,
-									draft: trimmedPrompt,
-									images: imagePaths,
-									files: filePaths,
-									customTags,
-									nonce: Date.now(),
-								});
+								if (!isOverride) {
+									setComposerRestoreState({
+										contextKey,
+										draft: trimmedPrompt,
+										images: imagePaths,
+										files: filePaths,
+										customTags,
+										nonce: Date.now(),
+									});
+								}
 							}
 						}
 					},
@@ -1388,14 +1468,16 @@ export function useConversationStreaming({
 					...current,
 					[contextKey]: errorMsg,
 				}));
-				setComposerRestoreState({
-					contextKey,
-					draft: trimmedPrompt,
-					images: imagePaths,
-					files: filePaths,
-					customTags,
-					nonce: Date.now(),
-				});
+				if (!isOverride) {
+					setComposerRestoreState({
+						contextKey,
+						draft: trimmedPrompt,
+						images: imagePaths,
+						files: filePaths,
+						customTags,
+						nonce: Date.now(),
+					});
+				}
 				restoreSnapshot(queryClient, cacheSessionId, rollbackSnapshot);
 				clearFastPrelude(contextKey);
 				clearSendingState(contextKey);
@@ -1424,7 +1506,101 @@ export function useConversationStreaming({
 			activeSessionByContext,
 			sendingContextKeys,
 			planReviewByContext,
+			followUpBehavior,
+			submitQueue,
 		],
+	);
+
+	// Queue drain — pops the first queued entry for any session whose
+	// stream just terminated and replays it through `handleComposerSubmit`
+	// using the queued item's stored context (not the currently displayed
+	// one). Ref indirection keeps the effect dep list to sending-state
+	// only; `queueMicrotask` defers the replay so it doesn't call
+	// `setSendingContextKeys` inside a React commit phase.
+	const handleComposerSubmitRef = useRef(handleComposerSubmit);
+	handleComposerSubmitRef.current = handleComposerSubmit;
+	const previousSendingRef = useRef<Set<string>>(new Set());
+	useEffect(() => {
+		const previous = previousSendingRef.current;
+		const current = sendingContextKeys;
+		const justFinished: string[] = [];
+		for (const key of previous) {
+			if (!current.has(key)) justFinished.push(key);
+		}
+		previousSendingRef.current = new Set(current);
+
+		for (const key of justFinished) {
+			if (!key.startsWith("session:")) continue;
+			const sessionId = key.slice("session:".length);
+			const next = submitQueue.popNext(sessionId);
+			if (!next) continue;
+			queueMicrotask(() => {
+				handleComposerSubmitRef.current(next.payload, next.context);
+			});
+		}
+	}, [sendingContextKeys, submitQueue]);
+
+	// Row actions: Steer now / Remove. Both key off the item's stored
+	// context (NOT the currently displayed session) so row clicks from
+	// session A's queue always target A even if the user has navigated.
+	const handleSteerQueued = useCallback(
+		async (itemId: string) => {
+			const item = submitQueue.findById(itemId);
+			if (!item) return;
+
+			const ctx = item.context;
+			const liveStream = activeSessionByContext[ctx.contextKey] ?? null;
+
+			if (!liveStream) {
+				// No active turn to steer into — the turn must have ended
+				// between user click and handler run. Fall back to
+				// replaying the payload as a fresh turn so the prompt
+				// isn't lost.
+				submitQueue.remove(ctx.sessionId, itemId);
+				handleComposerSubmitRef.current(item.payload, ctx);
+				return;
+			}
+
+			// Optimistically remove so the UI reacts instantly; put back
+			// on rejection / RPC failure. Without the re-enqueue, a
+			// provider-rejected steer silently drops the user's prompt
+			// (common race: user clicks Steer just as the turn ends).
+			submitQueue.remove(ctx.sessionId, itemId);
+			try {
+				const response = await steerAgentStream({
+					sessionId: liveStream.stopSessionId,
+					provider: liveStream.provider,
+					prompt: item.payload.prompt,
+					files: item.payload.filePaths,
+				});
+				if (!response.accepted) {
+					submitQueue.enqueue(ctx, item.payload);
+					setSendErrorsByContext((current) => ({
+						...current,
+						[ctx.contextKey]: response.reason
+							? `Steer rejected: ${response.reason}`
+							: "Steer rejected — added back to the queue.",
+					}));
+				}
+			} catch (err) {
+				console.warn("[conversation] steer-from-queue failed:", err);
+				submitQueue.enqueue(ctx, item.payload);
+				setSendErrorsByContext((current) => ({
+					...current,
+					[ctx.contextKey]: err instanceof Error ? err.message : String(err),
+				}));
+			}
+		},
+		[activeSessionByContext, submitQueue],
+	);
+
+	const handleRemoveQueued = useCallback(
+		(itemId: string) => {
+			const item = submitQueue.findById(itemId);
+			if (!item) return;
+			submitQueue.remove(item.context.sessionId, itemId);
+		},
+		[submitQueue],
 	);
 
 	const restoreActive = composerRestoreState?.contextKey === composerContextKey;
@@ -1440,6 +1616,8 @@ export function useConversationStreaming({
 		handleElicitationResponse,
 		handlePermissionResponse,
 		handleStopStream,
+		handleSteerQueued,
+		handleRemoveQueued,
 		hasPlanReview,
 		isSending,
 		pendingElicitation,

--- a/src/features/conversation/index.tsx
+++ b/src/features/conversation/index.tsx
@@ -17,6 +17,8 @@ import type { ResolvedComposerInsertRequest } from "@/lib/composer-insert";
 import { insertRequestMatchesComposer } from "@/lib/composer-insert";
 import { hasUnresolvedPlanReview } from "@/lib/plan-review";
 import { sessionThreadMessagesQueryOptions } from "@/lib/query-client";
+import { useSettings } from "@/lib/settings";
+import { EMPTY_QUEUE, useSubmitQueue } from "@/lib/use-submit-queue";
 import { getComposerContextKey } from "@/lib/workspace-helpers";
 import { useConversationStreaming } from "./hooks/use-streaming";
 import {
@@ -55,6 +57,9 @@ type WorkspaceConversationContainerProps = {
 		prompt: string;
 		modelId?: string | null;
 		permissionMode?: string | null;
+		/** When true, submit must queue if a turn is already streaming,
+		 *  regardless of the user's `followUpBehavior` setting. */
+		forceQueue?: boolean;
 	} | null;
 	/** Called after the pending prompt has been handed off to the composer's
 	 * submit flow, so the caller can clear the queue. */
@@ -116,6 +121,13 @@ export const WorkspaceConversationContainer = memo(
 		const selectionPending =
 			selectedWorkspaceId !== displayedWorkspaceId ||
 			selectedSessionId !== displayedSessionId;
+
+		// App-level follow-up queue. Survives session / workspace
+		// switches because this container is mounted once in the App
+		// tree (not keyed by session id).
+		const { settings } = useSettings();
+		const { queuesBySessionId, api: submitQueueApi } = useSubmitQueue();
+
 		const {
 			activeSendError,
 			handleComposerSubmit,
@@ -123,6 +135,8 @@ export const WorkspaceConversationContainer = memo(
 			handleElicitationResponse,
 			handlePermissionResponse,
 			handleStopStream,
+			handleSteerQueued,
+			handleRemoveQueued,
 			elicitationResponsePending,
 			isSending,
 			pendingElicitation,
@@ -142,11 +156,17 @@ export const WorkspaceConversationContainer = memo(
 			displayedWorkspaceId,
 			repoId,
 			selectionPending,
+			followUpBehavior: settings.followUpBehavior,
+			submitQueue: submitQueueApi,
 			onSendingSessionsChange,
 			onSendingWorkspacesChange,
 			onInteractionSessionsChange,
 			onSessionCompleted,
 		});
+
+		const queueItems = displayedSessionId
+			? (queuesBySessionId.get(displayedSessionId) ?? EMPTY_QUEUE)
+			: EMPTY_QUEUE;
 
 		// Derived from thread messages — survives refresh / session switch.
 		const threadQuery = useQuery({
@@ -315,6 +335,9 @@ export const WorkspaceConversationContainer = memo(
 							onPendingPromptConsumed={onPendingPromptConsumed}
 							pendingInsertRequests={relevantPendingInsertRequests}
 							onPendingInsertRequestsConsumed={onPendingInsertRequestsConsumed}
+							queueItems={queueItems}
+							onSteerQueued={handleSteerQueued}
+							onRemoveQueued={handleRemoveQueued}
 						/>
 					</div>
 				</div>

--- a/src/features/inspector/index.test.tsx
+++ b/src/features/inspector/index.test.tsx
@@ -13,7 +13,6 @@ import type {
 	WorkspacePrActionStatus,
 } from "@/lib/api";
 import { ComposerInsertProvider } from "@/lib/composer-insert-context";
-import type { PushWorkspaceToast } from "@/lib/workspace-toast-context";
 import { renderWithProviders } from "@/test/render-with-providers";
 import { WorkspaceInspectorSidebar } from "./index";
 
@@ -87,7 +86,6 @@ function renderInspector(
 			editorMode={false}
 			onOpenEditorFile={vi.fn()}
 			currentSessionId="session-1"
-			sendingSessionIds={new Set<string>()}
 			{...props}
 		/>,
 	);
@@ -245,6 +243,7 @@ describe("WorkspaceInspectorSidebar Actions section", () => {
 				sessionId: "session-1",
 				prompt:
 					"Commit uncommitted changes, then merge testuser/main into this branch. Then push.",
+				forceQueue: true,
 			});
 		});
 	});
@@ -274,6 +273,7 @@ describe("WorkspaceInspectorSidebar Actions section", () => {
 			expect(onQueuePendingPromptForSession).toHaveBeenCalledWith({
 				sessionId: "session-1",
 				prompt: "Merge testuser/main into this branch. Then push.",
+				forceQueue: true,
 			});
 		});
 	});
@@ -306,14 +306,14 @@ describe("WorkspaceInspectorSidebar Actions section", () => {
 			expect(onQueuePendingPromptForSession).toHaveBeenCalledWith({
 				sessionId: "session-1",
 				prompt: "Merge Origin/testuser/testing into this branch. Then push.",
+				forceQueue: true,
 			});
 		});
 	});
 
-	it("still attempts pull while the current chat is streaming when no AI follow-up is needed", async () => {
+	it("attempts pull without queueing a prompt when no AI follow-up is needed", async () => {
 		const user = userEvent.setup();
 		const onQueuePendingPromptForSession = vi.fn();
-		const pushToast = vi.fn() as PushWorkspaceToast;
 		apiMocks.syncWorkspaceWithTargetBranch.mockResolvedValue({
 			outcome: "updated",
 			targetBranch: "main",
@@ -327,11 +327,7 @@ describe("WorkspaceInspectorSidebar Actions section", () => {
 			behindTargetCount: 2,
 		});
 
-		renderInspector({
-			onQueuePendingPromptForSession,
-			pushToast,
-			sendingSessionIds: new Set(["session-1"]),
-		});
+		renderInspector({ onQueuePendingPromptForSession });
 
 		await screen.findByText("2 commits behind testuser/main");
 		await user.click(screen.getByRole("button", { name: "Pull" }));
@@ -341,14 +337,12 @@ describe("WorkspaceInspectorSidebar Actions section", () => {
 				"workspace-1",
 			);
 		});
-		expect(pushToast).not.toHaveBeenCalled();
 		expect(onQueuePendingPromptForSession).not.toHaveBeenCalled();
 	});
 
-	it("shows a workspace toast instead of queueing when pull needs AI follow-up and the current chat is still streaming", async () => {
+	it("queues the merge prompt with forceQueue when pull hits a conflict — even if the chat is streaming", async () => {
 		const user = userEvent.setup();
 		const onQueuePendingPromptForSession = vi.fn();
-		const pushToast = vi.fn() as PushWorkspaceToast;
 		apiMocks.syncWorkspaceWithTargetBranch.mockResolvedValue({
 			outcome: "conflict",
 			targetBranch: "main",
@@ -362,25 +356,22 @@ describe("WorkspaceInspectorSidebar Actions section", () => {
 			behindTargetCount: 2,
 		});
 
-		renderInspector({
-			onQueuePendingPromptForSession,
-			pushToast,
-			sendingSessionIds: new Set(["session-1"]),
-		});
+		renderInspector({ onQueuePendingPromptForSession });
 
 		await screen.findByText("2 commits behind testuser/main");
 		await user.click(screen.getByRole("button", { name: "Pull" }));
 
 		await waitFor(() => {
-			expect(pushToast).toHaveBeenCalledWith(
-				expect.stringContaining("AI is still responding in the current chat"),
-				"AI is still responding",
+			expect(onQueuePendingPromptForSession).toHaveBeenCalledWith(
+				expect.objectContaining({
+					sessionId: "session-1",
+					forceQueue: true,
+				}),
 			);
 		});
 		expect(apiMocks.syncWorkspaceWithTargetBranch).toHaveBeenCalledWith(
 			"workspace-1",
 		);
-		expect(onQueuePendingPromptForSession).not.toHaveBeenCalled();
 	});
 
 	it("shows push when local branch is ahead of its remote tracking ref", async () => {

--- a/src/features/inspector/index.tsx
+++ b/src/features/inspector/index.tsx
@@ -6,7 +6,6 @@ import type {
 import type { PullRequestInfo } from "@/lib/api";
 import type { DiffOpenOptions } from "@/lib/editor-session";
 import { cn } from "@/lib/utils";
-import type { PushWorkspaceToast } from "@/lib/workspace-toast-context";
 import { useWorkspaceInspectorSidebar } from "./hooks/use-inspector";
 import { useScriptStatus } from "./hooks/use-script-status";
 import { useSetupAutoRun } from "./hooks/use-setup-auto-run";
@@ -31,14 +30,13 @@ type WorkspaceInspectorSidebarProps = {
 	onOpenMockReview?: (path: string) => void;
 	onCommitAction?: (mode: WorkspaceCommitButtonMode) => Promise<void>;
 	currentSessionId?: string | null;
-	sendingSessionIds?: Set<string>;
 	onQueuePendingPromptForSession?: (request: {
 		sessionId: string;
 		prompt: string;
 		modelId?: string | null;
 		permissionMode?: string | null;
+		forceQueue?: boolean;
 	}) => void;
-	pushToast?: PushWorkspaceToast;
 	commitButtonMode?: WorkspaceCommitButtonMode;
 	commitButtonState?: CommitButtonState;
 	prInfo?: PullRequestInfo | null;
@@ -57,9 +55,7 @@ export function WorkspaceInspectorSidebar({
 	onOpenEditorFile,
 	onCommitAction,
 	currentSessionId,
-	sendingSessionIds,
 	onQueuePendingPromptForSession,
-	pushToast,
 	commitButtonMode,
 	commitButtonState,
 	prInfo,
@@ -175,9 +171,7 @@ export function WorkspaceInspectorSidebar({
 				expanded={!tabsOpen}
 				onCommitAction={onCommitAction}
 				currentSessionId={currentSessionId ?? null}
-				sendingSessionIds={sendingSessionIds}
 				onQueuePendingPromptForSession={onQueuePendingPromptForSession}
-				pushToast={pushToast}
 				commitButtonMode={commitButtonMode}
 				commitButtonState={commitButtonState}
 				prInfo={prInfo ?? null}

--- a/src/features/inspector/sections/actions.tsx
+++ b/src/features/inspector/sections/actions.tsx
@@ -40,7 +40,6 @@ import {
 } from "@/lib/query-client";
 import { resolveRepoPreferencePrompt } from "@/lib/repo-preferences-prompts";
 import { cn } from "@/lib/utils";
-import type { PushWorkspaceToast } from "@/lib/workspace-toast-context";
 import {
 	INSPECTOR_SECTION_HEADER_CLASS,
 	INSPECTOR_SECTION_TITLE_CLASS,
@@ -101,14 +100,13 @@ type ActionsSectionProps = {
 	expanded: boolean;
 	onCommitAction?: (mode: WorkspaceCommitButtonMode) => Promise<void>;
 	currentSessionId?: string | null;
-	sendingSessionIds?: Set<string>;
 	onQueuePendingPromptForSession?: (request: {
 		sessionId: string;
 		prompt: string;
 		modelId?: string | null;
 		permissionMode?: string | null;
+		forceQueue?: boolean;
 	}) => void;
-	pushToast?: PushWorkspaceToast;
 	commitButtonMode?: WorkspaceCommitButtonMode;
 	commitButtonState?: CommitButtonState;
 	prInfo: PullRequestInfo | null;
@@ -148,9 +146,7 @@ export function ActionsSection({
 	expanded,
 	onCommitAction,
 	currentSessionId,
-	sendingSessionIds,
 	onQueuePendingPromptForSession,
-	pushToast,
 	commitButtonMode,
 	commitButtonState,
 	prInfo,
@@ -180,14 +176,11 @@ export function ActionsSection({
 			if (!currentSessionId || !onQueuePendingPromptForSession) {
 				return false;
 			}
-			if (sendingSessionIds?.has(currentSessionId)) {
-				pushToast?.(
-					"AI is still responding in the current chat. Wait for that reply to finish, then retry Pull so Helmor can send the merge task in this conversation.",
-					"AI is still responding",
-				);
-				return false;
-			}
 			const repoPreferences = repoId ? await loadRepoPreferences(repoId) : null;
+			// `forceQueue: true` — if a turn is already streaming, the
+			// prompt MUST queue (never steer), regardless of the user's
+			// followUpBehavior setting. The merge task is a fresh task,
+			// not a course correction for the current turn.
 			onQueuePendingPromptForSession({
 				sessionId: currentSessionId,
 				prompt: buildSyncResolutionPrompt(
@@ -195,17 +188,11 @@ export function ActionsSection({
 					repoPreferences,
 					workspaceRemote,
 				),
+				forceQueue: true,
 			});
 			return true;
 		},
-		[
-			currentSessionId,
-			onQueuePendingPromptForSession,
-			pushToast,
-			repoId,
-			sendingSessionIds,
-			workspaceRemote,
-		],
+		[currentSessionId, onQueuePendingPromptForSession, repoId, workspaceRemote],
 	);
 	const handleSync = useCallback(async () => {
 		if (!workspaceId || syncPending) {

--- a/src/features/settings/index.tsx
+++ b/src/features/settings/index.tsx
@@ -483,6 +483,44 @@ export const SettingsDialog = memo(function SettingsDialog({
 										</div>
 									</div>
 
+									{/* Follow-up behavior */}
+									<div className="flex items-center justify-between rounded-xl border border-border/30 bg-muted/30 px-5 py-4">
+										<div className="mr-8">
+											<div className="text-[13px] font-medium leading-snug text-foreground">
+												Follow-up behavior
+											</div>
+											<div className="mt-1 text-[12px] leading-snug text-muted-foreground">
+												Queue follow-ups while the agent runs, or steer the
+												current run.
+											</div>
+										</div>
+										<ToggleGroup
+											type="single"
+											value={settings.followUpBehavior}
+											onValueChange={(value) => {
+												if (value === "queue" || value === "steer") {
+													updateSettings({ followUpBehavior: value });
+												}
+											}}
+											className="gap-1 bg-muted/40"
+										>
+											<ToggleGroupItem
+												value="queue"
+												aria-label="Queue"
+												className="h-7 rounded-md px-2.5 text-[12px] font-medium text-muted-foreground data-[state=on]:bg-accent data-[state=on]:text-foreground"
+											>
+												Queue
+											</ToggleGroupItem>
+											<ToggleGroupItem
+												value="steer"
+												aria-label="Steer"
+												className="h-7 rounded-md px-2.5 text-[12px] font-medium text-muted-foreground data-[state=on]:bg-accent data-[state=on]:text-foreground"
+											>
+												Steer
+											</ToggleGroupItem>
+										</ToggleGroup>
+									</div>
+
 									<AppUpdatesPanel />
 								</div>
 							)}

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -3,6 +3,12 @@ import { createContext, useContext } from "react";
 
 export type ThemeMode = "system" | "light" | "dark";
 
+/** Behavior when submitting a message while the agent is still responding.
+ *  - `steer`: inject into the active turn (provider-native mid-turn steer).
+ *  - `queue`: stash locally; auto-fire as a new turn once the agent finishes.
+ */
+export type FollowUpBehavior = "steer" | "queue";
+
 export type AppSettings = {
 	fontSize: number;
 	branchPrefixType: "github" | "custom" | "none";
@@ -16,6 +22,7 @@ export type AppSettings = {
 	defaultFastMode: boolean;
 	/** Webview zoom factor. 1.0 = 100%. Range 0.5–2.0. */
 	zoomLevel: number;
+	followUpBehavior: FollowUpBehavior;
 };
 
 export const DEFAULT_SETTINGS: AppSettings = {
@@ -30,6 +37,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
 	defaultEffort: "high",
 	defaultFastMode: false,
 	zoomLevel: 1.0,
+	followUpBehavior: "steer",
 };
 
 export const THEME_STORAGE_KEY = "helmor-theme";
@@ -46,6 +54,7 @@ const SETTINGS_KEY_MAP: Record<Exclude<keyof AppSettings, "theme">, string> = {
 	defaultEffort: "app.default_effort",
 	defaultFastMode: "app.default_fast_mode",
 	zoomLevel: "app.zoom_level",
+	followUpBehavior: "app.follow_up_behavior",
 };
 
 export async function loadSettings(): Promise<AppSettings> {
@@ -86,6 +95,12 @@ export async function loadSettings(): Promise<AppSettings> {
 			zoomLevel: raw[SETTINGS_KEY_MAP.zoomLevel]
 				? Number(raw[SETTINGS_KEY_MAP.zoomLevel])
 				: DEFAULT_SETTINGS.zoomLevel,
+			followUpBehavior: (() => {
+				const v = raw[SETTINGS_KEY_MAP.followUpBehavior];
+				return v === "queue" || v === "steer"
+					? v
+					: DEFAULT_SETTINGS.followUpBehavior;
+			})(),
 		};
 	} catch {
 		return { ...DEFAULT_SETTINGS };

--- a/src/lib/use-submit-queue.ts
+++ b/src/lib/use-submit-queue.ts
@@ -1,0 +1,182 @@
+/**
+ * App-level submit queue — stores follow-up messages the user wants to
+ * send once the current turn finishes.
+ *
+ * Why app-level instead of inside `use-streaming`: the queue must
+ * survive session / workspace switches so the user can navigate away
+ * from a long-running session and come back to see their queue still
+ * intact. `use-streaming` is mounted per-conversation-view so its
+ * state would be dropped the moment the displayed session changes.
+ *
+ * State lives in React state (not persisted anywhere). If the app
+ * restarts the queue is lost — that's the intended trade-off: the
+ * queue is a short-lived intent, not a durable artifact like a
+ * message. Individual rows are identified by client-generated UUIDs
+ * so row-level cancel / steer actions have stable targets across
+ * re-renders.
+ */
+
+import { useCallback, useMemo, useRef, useState } from "react";
+import type { AgentModelOption } from "./api";
+import type { ComposerCustomTag } from "./composer-insert";
+
+/** Minimal serialisable copy of `SubmitPayload` — enough to replay
+ *  through `handleComposerSubmit` when the drain fires after the
+ *  current turn ends. */
+export type QueuedSubmitPayload = {
+	prompt: string;
+	imagePaths: string[];
+	filePaths: string[];
+	customTags: ComposerCustomTag[];
+	model: AgentModelOption;
+	workingDirectory: string | null;
+	effortLevel: string;
+	permissionMode: string;
+	fastMode: boolean;
+};
+
+/** Context captured at enqueue time so drain / Steer can replay
+ *  against the original session even if the user has since navigated
+ *  elsewhere. Without this, a queued message from session A would
+ *  fire into whatever session is currently displayed. */
+export type QueuedSubmitContext = {
+	sessionId: string;
+	workspaceId: string | null;
+	contextKey: string;
+};
+
+export type QueuedSubmit = {
+	/** Client-generated UUID; stable across re-renders. */
+	id: string;
+	context: QueuedSubmitContext;
+	payload: QueuedSubmitPayload;
+	enqueuedAt: number;
+};
+
+export type SubmitQueueApi = {
+	/** Shallow-cloned queue for the given session. Empty array when none. */
+	getQueue: (sessionId: string) => QueuedSubmit[];
+	/** Find an entry by id across all sessions. Undefined when not found. */
+	findById: (id: string) => QueuedSubmit | undefined;
+	/** Append to the queue for the enqueue-time context. Returns the generated id. */
+	enqueue: (
+		context: QueuedSubmitContext,
+		payload: QueuedSubmitPayload,
+	) => string;
+	/** Remove a queued entry by id. No-op if not found. */
+	remove: (sessionId: string, id: string) => void;
+	/** Pop the head (FIFO) for a session. Returns undefined when empty. */
+	popNext: (sessionId: string) => QueuedSubmit | undefined;
+	/** Drop the entire queue for a session — used on session deletion. */
+	clear: (sessionId: string) => void;
+};
+
+/** Used by the composer to render the list; `queuesBySessionId` maps
+ *  sessionId → ordered list. Empty sessions are omitted from the map. */
+export type SubmitQueueState = {
+	queuesBySessionId: ReadonlyMap<string, readonly QueuedSubmit[]>;
+	api: SubmitQueueApi;
+};
+
+const EMPTY: readonly QueuedSubmit[] = Object.freeze([]);
+
+export function useSubmitQueue(): SubmitQueueState {
+	const [queues, setQueues] = useState<Map<string, QueuedSubmit[]>>(
+		() => new Map(),
+	);
+
+	// Ref mirror so read-only accessors (`getQueue`, `findById`,
+	// `popNext`) don't need `queues` in their dep lists — keeping the
+	// exposed `api` object identity stable across queue mutations.
+	const queuesRef = useRef(queues);
+	queuesRef.current = queues;
+
+	const getQueue = useCallback(
+		(sessionId: string): QueuedSubmit[] =>
+			queuesRef.current.get(sessionId)?.slice() ?? [],
+		[],
+	);
+
+	const findById = useCallback((id: string): QueuedSubmit | undefined => {
+		for (const entries of queuesRef.current.values()) {
+			const match = entries.find((e) => e.id === id);
+			if (match) return match;
+		}
+		return undefined;
+	}, []);
+
+	const enqueue = useCallback(
+		(context: QueuedSubmitContext, payload: QueuedSubmitPayload): string => {
+			const id = crypto.randomUUID();
+			const entry: QueuedSubmit = {
+				id,
+				context,
+				payload,
+				enqueuedAt: Date.now(),
+			};
+			setQueues((prev) => {
+				const next = new Map(prev);
+				const existing = next.get(context.sessionId) ?? [];
+				next.set(context.sessionId, [...existing, entry]);
+				return next;
+			});
+			return id;
+		},
+		[],
+	);
+
+	const remove = useCallback((sessionId: string, id: string): void => {
+		setQueues((prev) => {
+			const existing = prev.get(sessionId);
+			if (!existing) return prev;
+			const filtered = existing.filter((e) => e.id !== id);
+			if (filtered.length === existing.length) return prev;
+			const next = new Map(prev);
+			if (filtered.length === 0) next.delete(sessionId);
+			else next.set(sessionId, filtered);
+			return next;
+		});
+	}, []);
+
+	const popNext = useCallback((sessionId: string): QueuedSubmit | undefined => {
+		const existing = queuesRef.current.get(sessionId);
+		if (!existing || existing.length === 0) return undefined;
+		const head = existing[0];
+		setQueues((prev) => {
+			const cur = prev.get(sessionId);
+			if (!cur || cur.length === 0) return prev;
+			const rest = cur.slice(1);
+			const next = new Map(prev);
+			if (rest.length === 0) next.delete(sessionId);
+			else next.set(sessionId, rest);
+			return next;
+		});
+		return head;
+	}, []);
+
+	const clear = useCallback((sessionId: string): void => {
+		setQueues((prev) => {
+			if (!prev.has(sessionId)) return prev;
+			const next = new Map(prev);
+			next.delete(sessionId);
+			return next;
+		});
+	}, []);
+
+	// `queues` is already a `Map<string, QueuedSubmit[]>` — just widen
+	// the type to ReadonlyMap + readonly arrays at the boundary. No
+	// copy needed; we never mutate in place (always `new Map(prev)`).
+	const queuesBySessionId = queues as ReadonlyMap<
+		string,
+		readonly QueuedSubmit[]
+	>;
+
+	const api = useMemo<SubmitQueueApi>(
+		() => ({ getQueue, findById, enqueue, remove, popNext, clear }),
+		[getQueue, findById, enqueue, remove, popNext, clear],
+	);
+
+	return { queuesBySessionId, api };
+}
+
+export const EMPTY_QUEUE: readonly QueuedSubmit[] = EMPTY;


### PR DESCRIPTION
## Summary
- Introduces an app-level follow-up queue: when the user sends a message mid-turn, a new Settings toggle (Follow-up behavior: Queue / Steer) picks between stashing it to auto-fire as a fresh turn (**Queue**, opt-in) vs. the existing provider-native mid-turn interrupt (**Steer**, default).
- Queued entries render as stacked rows above the composer (⏱ + truncated prompt + Steer-now / remove) and survive session + workspace switches by carrying their origin context, so drain always targets the right session regardless of where the user has navigated.
- Pull-on-conflict and dirty-worktree prompts now queue automatically (via a `forceQueue: true` flag, independent of user setting) instead of toasting "AI is still responding" and blocking the operation.

## Test plan
- [x] `bun run typecheck`
- [x] `bunx biome check .`
- [x] `bun run test:frontend` — 539 passing (9 new tests covering: queue branch, cross-session drain, forceQueue override, Steer-rejection re-enqueue, no-stream fallback, chained drain, error-event drain)
- [ ] Manual: follow-up during a long turn with Queue on → row appears above composer, drains when turn ends
- [ ] Manual: Steer-now on a queued row mid-turn → injected into active turn
- [ ] Manual: Queue in session A, navigate to session B, finish A's turn → drains into A (not B)
- [ ] Manual: Pull with conflict while AI is streaming → resolve-prompt queues instead of toasting