### PR TITLE
Fix merged workspace status when new local changes appear

### DIFF
--- a/.changeset/tidy-cobras-switch.md
+++ b/.changeset/tidy-cobras-switch.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Treat merged workspaces with new local changes as in progress again so the sidebar and PR actions stop showing the old merged PR while you continue working.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -110,6 +110,10 @@ import {
 	useSettings,
 } from "./lib/settings";
 import { useOsNotifications } from "./lib/use-os-notifications";
+import {
+	buildWorkspaceGroupsForDisplay,
+	shouldDisplayWorkspaceAsInProgress,
+} from "./lib/workspace-display-state";
 import { summaryToArchivedRow } from "./lib/workspace-helpers";
 import {
 	type WorkspaceToastOptions,
@@ -554,6 +558,37 @@ function AppShell({
 			selectedWorkspaceDetail?.state !== "archived",
 	});
 	const workspaceGitActionStatus = workspaceGitActionStatusQuery.data ?? null;
+	const shouldDisplaySelectedWorkspaceAsInProgress = useMemo(
+		() =>
+			shouldDisplayWorkspaceAsInProgress({
+				manualStatus: selectedWorkspaceDetailQuery.data?.manualStatus ?? null,
+				derivedStatus: selectedWorkspaceDetailQuery.data?.derivedStatus ?? null,
+				prInfo: workspacePrInfo,
+				gitActionStatus: workspaceGitActionStatus,
+			}),
+		[
+			selectedWorkspaceDetailQuery.data?.derivedStatus,
+			selectedWorkspaceDetailQuery.data?.manualStatus,
+			workspaceGitActionStatus,
+			workspacePrInfo,
+		],
+	);
+	const effectiveWorkspacePrInfo = shouldDisplaySelectedWorkspaceAsInProgress
+		? null
+		: workspacePrInfo;
+	const displayWorkspaceGroups = useMemo(
+		() =>
+			buildWorkspaceGroupsForDisplay({
+				groups: workspaceGroups,
+				selectedWorkspaceId,
+				shouldDisplaySelectedWorkspaceAsInProgress,
+			}),
+		[
+			selectedWorkspaceId,
+			shouldDisplaySelectedWorkspaceAsInProgress,
+			workspaceGroups,
+		],
+	);
 
 	// Reactively transition workspace sidebar status when the PR query
 	// detects a state change. Handles PRs created/merged/closed externally.
@@ -990,7 +1025,7 @@ function AppShell({
 		}
 
 		const candidateWorkspaceIds = flattenWorkspaceRows(
-			workspaceGroups,
+			displayWorkspaceGroups,
 			archivedRows,
 		)
 			.map((row) => row.id)
@@ -1044,7 +1079,7 @@ function AppShell({
 		isIdentityConnected,
 		primeWorkspaceDisplay,
 		selectedWorkspaceId,
-		workspaceGroups,
+		displayWorkspaceGroups,
 	]);
 
 	const handleSelectWorkspace = useCallback(
@@ -1229,7 +1264,7 @@ function AppShell({
 		selectedWorkspaceIdRef,
 		selectedRepoId: selectedWorkspaceDetailQuery.data?.repoId ?? null,
 		workspaceManualStatus: selectedWorkspaceManualStatus,
-		workspacePrInfo,
+		workspacePrInfo: effectiveWorkspacePrInfo,
 		workspacePrActionStatus,
 		workspaceGitActionStatus,
 		completedSessionIds: settledSessionIds,
@@ -1464,7 +1499,7 @@ function AppShell({
 	const handleNavigateWorkspaces = useCallback(
 		(offset: -1 | 1) => {
 			const nextWorkspaceId = findAdjacentWorkspaceId(
-				workspaceGroups,
+				displayWorkspaceGroups,
 				archivedRows,
 				selectedWorkspaceIdRef.current,
 				offset,
@@ -1476,7 +1511,7 @@ function AppShell({
 
 			handleSelectWorkspace(nextWorkspaceId);
 		},
-		[archivedRows, handleSelectWorkspace, workspaceGroups],
+		[archivedRows, displayWorkspaceGroups, handleSelectWorkspace],
 	);
 
 	const handleResolveDisplayedSession = useCallback(
@@ -1840,6 +1875,7 @@ function AppShell({
 														interactionRequiredWorkspaceIds={
 															interactionRequiredWorkspaceIds
 														}
+														groupsOverride={displayWorkspaceGroups}
 														onSelectWorkspace={handleSelectWorkspace}
 														pushWorkspaceToast={pushWorkspaceToast}
 													/>
@@ -1961,7 +1997,7 @@ function AppShell({
 													interactionRequiredSessionIds
 												}
 												onSessionCompleted={handleSessionCompleted}
-												workspacePrInfo={workspacePrInfo}
+												workspacePrInfo={effectiveWorkspacePrInfo}
 												pendingPromptForSession={pendingPromptForSession}
 												onPendingPromptConsumed={handlePendingPromptConsumed}
 												pendingInsertRequests={pendingComposerInserts}
@@ -2146,7 +2182,10 @@ function AppShell({
 										pushToast={pushWorkspaceToast}
 										commitButtonMode={commitButtonMode}
 										commitButtonState={commitButtonState}
-										prInfo={workspacePrInfo}
+										prInfo={effectiveWorkspacePrInfo}
+										suppressMergedPrStatus={
+											shouldDisplaySelectedWorkspaceAsInProgress
+										}
 										onOpenSettings={handleOpenSettings}
 									/>
 								</aside>

--- a/src/features/inspector/index.tsx
+++ b/src/features/inspector/index.tsx
@@ -42,6 +42,7 @@ type WorkspaceInspectorSidebarProps = {
 	commitButtonMode?: WorkspaceCommitButtonMode;
 	commitButtonState?: CommitButtonState;
 	prInfo?: PullRequestInfo | null;
+	suppressMergedPrStatus?: boolean;
 	onOpenSettings?: () => void;
 };
 
@@ -63,6 +64,7 @@ export function WorkspaceInspectorSidebar({
 	commitButtonMode,
 	commitButtonState,
 	prInfo,
+	suppressMergedPrStatus = false,
 	onOpenSettings,
 }: WorkspaceInspectorSidebarProps) {
 	const {
@@ -181,6 +183,7 @@ export function WorkspaceInspectorSidebar({
 				commitButtonMode={commitButtonMode}
 				commitButtonState={commitButtonState}
 				prInfo={prInfo ?? null}
+				suppressMergedPrStatus={suppressMergedPrStatus}
 			/>
 
 			{tabsOpen && (

--- a/src/features/inspector/sections/actions.tsx
+++ b/src/features/inspector/sections/actions.tsx
@@ -112,6 +112,7 @@ type ActionsSectionProps = {
 	commitButtonMode?: WorkspaceCommitButtonMode;
 	commitButtonState?: CommitButtonState;
 	prInfo: PullRequestInfo | null;
+	suppressMergedPrStatus?: boolean;
 };
 
 function buildSyncResolutionPrompt(
@@ -154,6 +155,7 @@ export function ActionsSection({
 	commitButtonMode,
 	commitButtonState,
 	prInfo,
+	suppressMergedPrStatus = false,
 }: ActionsSectionProps) {
 	const queryClient = useQueryClient();
 	const [syncPending, setSyncPending] = useState(false);
@@ -166,7 +168,11 @@ export function ActionsSection({
 		enabled: workspaceId !== null,
 	});
 	const gitStatus = gitStatusQuery.data ?? EMPTY_GIT_ACTION_STATUS;
-	const prStatus = prStatusQuery.data ?? EMPTY_PR_ACTION_STATUS;
+	const rawPrStatus = prStatusQuery.data ?? EMPTY_PR_ACTION_STATUS;
+	const prStatus =
+		suppressMergedPrStatus && rawPrStatus.pr?.isMerged
+			? EMPTY_PR_ACTION_STATUS
+			: rawPrStatus;
 	const gitRows = sortStatusRows(buildGitRows(gitStatus, workspaceRemote));
 	const reviewRows = sortStatusRows(buildReviewRows(prStatus, prInfo));
 	const sortedDeployments = sortActionItems(prStatus.deployments);

--- a/src/features/navigation/container.tsx
+++ b/src/features/navigation/container.tsx
@@ -1,4 +1,5 @@
 import { memo } from "react";
+import type { WorkspaceGroup } from "@/lib/api";
 import { useWorkspacesSidebarController } from "./hooks/use-controller";
 import { WorkspacesSidebar } from "./index";
 
@@ -9,6 +10,7 @@ type WorkspacesSidebarContainerProps = {
 	sendingWorkspaceIds?: Set<string>;
 	completedWorkspaceIds?: Set<string>;
 	interactionRequiredWorkspaceIds?: Set<string>;
+	groupsOverride?: WorkspaceGroup[];
 	onSelectWorkspace: (workspaceId: string | null) => void;
 	pushWorkspaceToast: (
 		description: string,
@@ -27,6 +29,7 @@ export const WorkspacesSidebarContainer = memo(
 		sendingWorkspaceIds,
 		completedWorkspaceIds,
 		interactionRequiredWorkspaceIds,
+		groupsOverride,
 		onSelectWorkspace,
 		pushWorkspaceToast,
 	}: WorkspacesSidebarContainerProps) {
@@ -55,7 +58,7 @@ export const WorkspacesSidebarContainer = memo(
 
 		return (
 			<WorkspacesSidebar
-				groups={groups}
+				groups={groupsOverride ?? groups}
 				archivedRows={archivedRows}
 				availableRepositories={availableRepositories}
 				addingRepository={addingRepository}

--- a/src/lib/workspace-display-state.test.ts
+++ b/src/lib/workspace-display-state.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import type { WorkspaceGroup } from "./api";
+import {
+	buildWorkspaceGroupsForDisplay,
+	hasWorkspaceLocalActivity,
+	shouldDisplayWorkspaceAsInProgress,
+} from "./workspace-display-state";
+
+describe("hasWorkspaceLocalActivity", () => {
+	it("returns true when uncommitted changes exist", () => {
+		expect(
+			hasWorkspaceLocalActivity({
+				uncommittedCount: 1,
+				conflictCount: 0,
+				syncTargetBranch: null,
+				syncStatus: "unknown",
+				behindTargetCount: 0,
+				remoteTrackingRef: null,
+				aheadOfRemoteCount: 0,
+				pushStatus: "unknown",
+			}),
+		).toBe(true);
+	});
+
+	it("returns true when local commits exist without a published PR", () => {
+		expect(
+			hasWorkspaceLocalActivity({
+				uncommittedCount: 0,
+				conflictCount: 0,
+				syncTargetBranch: null,
+				syncStatus: "unknown",
+				behindTargetCount: 0,
+				remoteTrackingRef: null,
+				aheadOfRemoteCount: 1,
+				pushStatus: "unknown",
+			}),
+		).toBe(true);
+		expect(
+			hasWorkspaceLocalActivity({
+				uncommittedCount: 0,
+				conflictCount: 0,
+				syncTargetBranch: null,
+				syncStatus: "unknown",
+				behindTargetCount: 0,
+				remoteTrackingRef: null,
+				aheadOfRemoteCount: 0,
+				pushStatus: "unpublished",
+			}),
+		).toBe(true);
+	});
+});
+
+describe("shouldDisplayWorkspaceAsInProgress", () => {
+	it("returns true for done + merged + local activity", () => {
+		expect(
+			shouldDisplayWorkspaceAsInProgress({
+				manualStatus: "done",
+				prInfo: { state: "MERGED", isMerged: true },
+				gitActionStatus: {
+					uncommittedCount: 1,
+					conflictCount: 0,
+					syncTargetBranch: null,
+					syncStatus: "unknown",
+					behindTargetCount: 0,
+					remoteTrackingRef: null,
+					aheadOfRemoteCount: 0,
+					pushStatus: "unknown",
+				},
+			}),
+		).toBe(true);
+	});
+
+	it("returns false for review workspaces", () => {
+		expect(
+			shouldDisplayWorkspaceAsInProgress({
+				manualStatus: "review",
+				prInfo: { state: "OPEN", isMerged: false },
+				gitActionStatus: {
+					uncommittedCount: 1,
+					conflictCount: 0,
+					syncTargetBranch: null,
+					syncStatus: "unknown",
+					behindTargetCount: 0,
+					remoteTrackingRef: null,
+					aheadOfRemoteCount: 0,
+					pushStatus: "unknown",
+				},
+			}),
+		).toBe(false);
+	});
+});
+
+describe("buildWorkspaceGroupsForDisplay", () => {
+	it("moves the selected row from done to progress for display only", () => {
+		const groups: WorkspaceGroup[] = [
+			{
+				id: "done",
+				label: "Done",
+				tone: "done",
+				rows: [
+					{
+						id: "w1",
+						title: "Workspace 1",
+						manualStatus: "done",
+						derivedStatus: "done",
+					},
+				],
+			},
+			{
+				id: "progress",
+				label: "In progress",
+				tone: "progress",
+				rows: [],
+			},
+		];
+
+		const next = buildWorkspaceGroupsForDisplay({
+			groups,
+			selectedWorkspaceId: "w1",
+			shouldDisplaySelectedWorkspaceAsInProgress: true,
+		});
+
+		expect(next.find((group) => group.id === "done")?.rows).toEqual([]);
+		expect(
+			next.find((group) => group.id === "progress")?.rows[0],
+		).toMatchObject({
+			id: "w1",
+			manualStatus: "in-progress",
+		});
+	});
+});

--- a/src/lib/workspace-display-state.ts
+++ b/src/lib/workspace-display-state.ts
@@ -1,0 +1,85 @@
+import type {
+	PullRequestInfo,
+	WorkspaceGitActionStatus,
+	WorkspaceGroup,
+	WorkspaceRow,
+} from "./api";
+
+export function hasWorkspaceLocalActivity(
+	gitActionStatus?: WorkspaceGitActionStatus | null,
+): boolean {
+	if (!gitActionStatus) return false;
+	return (
+		gitActionStatus.uncommittedCount > 0 ||
+		gitActionStatus.conflictCount > 0 ||
+		gitActionStatus.aheadOfRemoteCount > 0 ||
+		gitActionStatus.pushStatus === "unpublished"
+	);
+}
+
+export function shouldDisplayWorkspaceAsInProgress({
+	manualStatus,
+	derivedStatus,
+	prInfo,
+	gitActionStatus,
+}: {
+	manualStatus?: string | null;
+	derivedStatus?: string | null;
+	prInfo?: Pick<PullRequestInfo, "state" | "isMerged"> | null;
+	gitActionStatus?: WorkspaceGitActionStatus | null;
+}): boolean {
+	const effectiveStatus = (manualStatus ?? derivedStatus ?? "")
+		.trim()
+		.toLowerCase();
+	if (effectiveStatus !== "done") return false;
+	if (!(prInfo?.isMerged || prInfo?.state === "MERGED")) return false;
+	return hasWorkspaceLocalActivity(gitActionStatus);
+}
+
+export function buildWorkspaceGroupsForDisplay({
+	groups,
+	selectedWorkspaceId,
+	shouldDisplaySelectedWorkspaceAsInProgress,
+}: {
+	groups: WorkspaceGroup[];
+	selectedWorkspaceId: string | null;
+	shouldDisplaySelectedWorkspaceAsInProgress: boolean;
+}): WorkspaceGroup[] {
+	if (!selectedWorkspaceId || !shouldDisplaySelectedWorkspaceAsInProgress) {
+		return groups;
+	}
+
+	let movedRow: WorkspaceRow | null = null;
+
+	const nextGroups = groups.map((group) => {
+		const rowIndex = group.rows.findIndex(
+			(row) => row.id === selectedWorkspaceId,
+		);
+		if (rowIndex === -1) {
+			return group;
+		}
+
+		movedRow = {
+			...group.rows[rowIndex],
+			manualStatus: "in-progress",
+		};
+
+		return {
+			...group,
+			rows: [
+				...group.rows.slice(0, rowIndex),
+				...group.rows.slice(rowIndex + 1),
+			],
+		};
+	});
+
+	if (!movedRow) {
+		return groups;
+	}
+
+	return nextGroups.map((group) =>
+		group.id === "progress"
+			? { ...group, rows: [movedRow as WorkspaceRow, ...group.rows] }
+			: group,
+	);
+}


### PR DESCRIPTION
## What changed
- add shared workspace display-state helpers to detect local activity after a workspace was previously marked done
- treat a selected merged workspace with fresh local work as in progress in the sidebar and navigation ordering
- suppress the stale merged PR state in the inspector/actions UI while that follow-up work is active
- add a focused frontend test for the new display-state logic
- include a patch changeset for the behavior fix

## Why
When a merged workspace picks up new commits or local edits, the UI was still presenting it as done and showing the old merged PR. That made continued work on the same workspace look finished even though it had active local changes again.

## Test notes
- `bun x vitest run src/lib/workspace-display-state.test.ts`