### PR TITLE
Fix streaming footer overlap while tool groups expand

### DIFF
--- a/.changeset/tall-eagles-tickle.md
+++ b/.changeset/tall-eagles-tickle.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix the streaming loading/timer footer so it stays below the live assistant output while long tool groups expand, and add a regression test for the overlap case.

--- a/e2e/tests/streaming-footer-overlap.spec.ts
+++ b/e2e/tests/streaming-footer-overlap.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("streaming footer overlap regression", () => {
+	test("keeps the footer below the live assistant row while the collapsed tool group grows", async ({
+		page,
+	}) => {
+		await page.goto("/?e2eScenario=streaming-footer-overlap");
+		await expect(
+			page.getByRole("heading", { name: "Streaming Footer Overlap Scenario" }),
+		).toBeVisible();
+
+		let maxOverlap = Number.NEGATIVE_INFINITY;
+		let worstSample: null | {
+			tick: number;
+			overlap: number;
+			footerTop: number;
+			lastBottom: number;
+			footerText: string;
+			summaryText: string;
+		} = null;
+
+		for (let tick = 0; tick < 40; tick += 1) {
+			await page.waitForTimeout(120);
+			const sample = await page.evaluate(() => {
+				const footer = document.querySelector(
+					"[data-testid='streaming-footer']",
+				);
+				const assistantRows = Array.from(
+					document.querySelectorAll("[data-message-role='assistant']"),
+				);
+				const lastAssistantRow = assistantRows[assistantRows.length - 1] as
+					| HTMLElement
+					| undefined;
+				const summary = Array.from(document.querySelectorAll("summary")).find(
+					(node) => node.textContent?.includes("read-only commands"),
+				);
+				if (
+					!(footer instanceof HTMLElement) ||
+					!(lastAssistantRow instanceof HTMLElement) ||
+					!(summary instanceof HTMLElement)
+				) {
+					return null;
+				}
+
+				const footerRect = footer.getBoundingClientRect();
+				const lastRect = lastAssistantRow.getBoundingClientRect();
+				return {
+					overlap:
+						Math.min(footerRect.bottom, lastRect.bottom) -
+						Math.max(footerRect.top, lastRect.top),
+					footerTop: footerRect.top,
+					lastBottom: lastRect.bottom,
+					footerText: footer.textContent ?? "",
+					summaryText: summary.textContent ?? "",
+				};
+			});
+
+			if (sample && sample.overlap > maxOverlap) {
+				maxOverlap = sample.overlap;
+				worstSample = { tick, ...sample };
+			}
+		}
+
+		await expect(page.getByTestId("visible-tool-count")).toHaveText("18");
+		expect(maxOverlap, JSON.stringify(worstSample)).toBeLessThanOrEqual(0);
+	});
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -115,8 +115,22 @@ import {
 	type WorkspaceToastOptions,
 	WorkspaceToastProvider,
 } from "./lib/workspace-toast-context";
+import { StreamingFooterOverlapScenario } from "./test/e2e-scenarios/streaming-footer-overlap";
 
 function App() {
+	const e2eScenario =
+		typeof window === "undefined"
+			? null
+			: new URLSearchParams(window.location.search).get("e2eScenario");
+
+	if (e2eScenario === "streaming-footer-overlap") {
+		return <StreamingFooterOverlapScenario />;
+	}
+
+	return <MainApp />;
+}
+
+function MainApp() {
 	const [appSettings, setAppSettings] = useState<AppSettings | null>(null);
 	const [settingsOpen, setSettingsOpen] = useState(false);
 	const [settingsWorkspaceId, setSettingsWorkspaceId] = useState<string | null>(

--- a/src/features/panel/thread-viewport.test.ts
+++ b/src/features/panel/thread-viewport.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { resolveConversationRowHeight } from "./thread-viewport";
+
+describe("resolveConversationRowHeight", () => {
+	it("keeps the larger estimate for streaming rows until measurement catches up", () => {
+		expect(
+			resolveConversationRowHeight({
+				estimatedHeight: 168,
+				measuredHeight: 132,
+				streaming: true,
+			}),
+		).toBe(168);
+	});
+
+	it("trusts the measured height for non-streaming rows", () => {
+		expect(
+			resolveConversationRowHeight({
+				estimatedHeight: 168,
+				measuredHeight: 132,
+				streaming: false,
+			}),
+		).toBe(132);
+	});
+});

--- a/src/features/panel/thread-viewport.tsx
+++ b/src/features/panel/thread-viewport.tsx
@@ -46,6 +46,22 @@ const PROGRESSIVE_VIEWPORT_STREAMING_FOOTER_HEIGHT = 40;
 const CONVERSATION_BOTTOM_SPACER_HEIGHT = 40;
 const STICK_TO_BOTTOM_ESCAPE_OFFSET_PX = 54;
 
+export function resolveConversationRowHeight({
+	estimatedHeight,
+	measuredHeight,
+	streaming,
+}: {
+	estimatedHeight: number;
+	measuredHeight?: number;
+	streaming: boolean;
+}) {
+	if (measuredHeight === undefined) {
+		return estimatedHeight;
+	}
+
+	return streaming ? Math.max(measuredHeight, estimatedHeight) : measuredHeight;
+}
+
 export function ActiveThreadViewport({
 	hasSession,
 	pane,
@@ -606,8 +622,11 @@ function ProgressiveConversationViewport({
 						const key = message.id ?? `${message.role}:${index}`;
 						const estimatedHeight = estimatedHeights[index] ?? 72;
 						const measuredHeight = measuredHeights[key];
-						const height =
-							measuredHeight !== undefined ? measuredHeight : estimatedHeight;
+						const height = resolveConversationRowHeight({
+							estimatedHeight,
+							measuredHeight,
+							streaming: message.streaming === true,
+						});
 						const row = {
 							height,
 							index,
@@ -928,7 +947,10 @@ function StreamingFooter({ startTime }: { startTime: number }) {
 					.padStart(2, "0")}s`;
 
 	return (
-		<div className="flex items-center gap-1.5 px-5 py-3 text-[12px] tabular-nums text-muted-foreground">
+		<div
+			data-testid="streaming-footer"
+			className="flex items-center gap-1.5 px-5 py-3 text-[12px] tabular-nums text-muted-foreground"
+		>
 			<HelmorLogoAnimated size={14} className="opacity-80" />
 			{display}
 		</div>

--- a/src/lib/message-layout-estimator.test.ts
+++ b/src/lib/message-layout-estimator.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import type { ThreadMessageLike, ToolCallPart } from "./api";
+import { estimateThreadRowHeights } from "./message-layout-estimator";
+
+function makeTool(index: number): ToolCallPart {
+	return {
+		type: "tool-call",
+		toolCallId: `tool-${index}`,
+		toolName: "Bash",
+		args: { command: `sed -n '${index},${index + 8}p' src/file.ts` },
+		argsText: "",
+		result: index % 2 === 0 ? "line 1\nline 2\nline 3" : undefined,
+		streamingStatus: index === 3 ? "running" : "done",
+	};
+}
+
+describe("estimateThreadRowHeights", () => {
+	it("reserves expanded height for collapsed tool groups", () => {
+		const messages: ThreadMessageLike[] = [
+			{
+				id: "assistant-streaming",
+				role: "assistant",
+				streaming: true,
+				content: [
+					{ type: "text", id: "text-1", text: "Streaming response" },
+					{
+						type: "collapsed-group",
+						id: "group-1",
+						category: "shell",
+						active: true,
+						summary: "Running 4 read-only commands...",
+						tools: Array.from({ length: 4 }, (_, index) => makeTool(index)),
+					},
+				],
+			},
+		];
+
+		const [height] = estimateThreadRowHeights(messages, {
+			fontSize: 14,
+			paneWidth: 960,
+		});
+
+		expect(height).toBeGreaterThan(150);
+	});
+});

--- a/src/lib/message-layout-estimator.ts
+++ b/src/lib/message-layout-estimator.ts
@@ -434,7 +434,19 @@ function estimateToolCallHeight(part: ToolCallPart) {
 }
 
 function estimateCollapsedGroupHeight(group: CollapsedGroupPart) {
-	return group.active ? COLLAPSED_GROUP_HEIGHT + 4 : COLLAPSED_GROUP_HEIGHT;
+	if (group.tools.length === 0) {
+		return group.active ? COLLAPSED_GROUP_HEIGHT + 4 : COLLAPSED_GROUP_HEIGHT;
+	}
+
+	const childHeights = group.tools.map((tool) => estimateToolCallHeight(tool));
+	const childrenHeight = childHeights.reduce((sum, height) => sum + height, 0);
+	const childrenGapHeight = Math.max(0, group.tools.length - 1) * 2;
+	const expandedChildrenHeight = 4 + childrenHeight + childrenGapHeight;
+	const trailingToolHeight =
+		childHeights[childHeights.length - 1] ?? TOOL_SUMMARY_HEIGHT;
+	const activeBuffer = group.active ? trailingToolHeight + 8 : 0;
+
+	return COLLAPSED_GROUP_HEIGHT + expandedChildrenHeight + activeBuffer;
 }
 
 function looksLikeStructuredMarkdown(text: string) {

--- a/src/test/e2e-scenarios/streaming-footer-overlap.tsx
+++ b/src/test/e2e-scenarios/streaming-footer-overlap.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+	ActiveThreadViewport,
+	type PresentedSessionPane,
+} from "@/features/panel/thread-viewport";
+import type {
+	CollapsedGroupPart,
+	ThreadMessageLike,
+	ToolCallPart,
+} from "@/lib/api";
+
+const SESSION_ID = "e2e-streaming-footer-overlap";
+const TOOL_STEPS = 18;
+
+function makeTool(toolIndex: number): ToolCallPart {
+	return {
+		type: "tool-call",
+		toolCallId: `tool-${toolIndex}`,
+		toolName: "Bash",
+		args: {
+			command: `sed -n '${toolIndex},${toolIndex + 8}p' src/features/panel/thread-viewport.tsx`,
+		},
+		argsText: "",
+		result:
+			toolIndex % 2 === 0
+				? `line ${toolIndex}\nline ${toolIndex + 1}\nline ${toolIndex + 2}`
+				: undefined,
+		streamingStatus: toolIndex === TOOL_STEPS - 1 ? "running" : "done",
+	};
+}
+
+function makeCollapsedGroup(visibleTools: number): CollapsedGroupPart {
+	return {
+		type: "collapsed-group",
+		id: "group-shell-tools",
+		category: "shell",
+		active: true,
+		summary: `Running ${visibleTools} read-only commands...`,
+		tools: Array.from({ length: visibleTools }, (_, index) => makeTool(index)),
+	};
+}
+
+function makeFillerMessage(index: number): ThreadMessageLike {
+	return {
+		id: `filler-${index}`,
+		role: index % 3 === 0 ? "user" : "assistant",
+		content:
+			index % 3 === 0
+				? [
+						{
+							type: "text",
+							id: `filler-${index}-text`,
+							text: `Filler prompt ${index}: keep this thread long enough to force virtualization.`,
+						},
+					]
+				: [
+						{
+							type: "text",
+							id: `filler-${index}-reply`,
+							text: `Historical reply ${index}. This row exists only to push the panel past the non-virtualized threshold.`,
+						},
+					],
+	};
+}
+
+function buildMessages(visibleTools: number): ThreadMessageLike[] {
+	const history = Array.from({ length: 14 }, (_, index) =>
+		makeFillerMessage(index),
+	);
+	return [
+		...history,
+		{
+			id: "streaming-assistant",
+			role: "assistant",
+			streaming: true,
+			content: [
+				{
+					type: "text",
+					id: "streaming-text",
+					text: "我已经拿到关键证据了：丢了。",
+				},
+				makeCollapsedGroup(visibleTools),
+			],
+		},
+	];
+}
+
+export function StreamingFooterOverlapScenario() {
+	const [visibleTools, setVisibleTools] = useState(2);
+
+	useEffect(() => {
+		const intervalId = window.setInterval(() => {
+			setVisibleTools((current) =>
+				current >= TOOL_STEPS ? TOOL_STEPS : current + 1,
+			);
+		}, 140);
+		return () => window.clearInterval(intervalId);
+	}, []);
+
+	const pane = useMemo<PresentedSessionPane>(
+		() => ({
+			sessionId: SESSION_ID,
+			messages: buildMessages(visibleTools),
+			sending: true,
+			hasLoaded: true,
+			presentationState: "presented",
+		}),
+		[visibleTools],
+	);
+
+	return (
+		<div className="flex h-screen flex-col bg-background text-foreground">
+			<div className="border-b border-border/50 px-4 py-3">
+				<h1 className="text-sm font-medium">
+					Streaming Footer Overlap Scenario
+				</h1>
+				<p className="text-xs text-muted-foreground">
+					Virtualized thread + expanding collapsed tool group + active footer
+				</p>
+			</div>
+			<div className="flex min-h-0 flex-1">
+				<div className="flex min-h-0 flex-1 flex-col">
+					<div className="flex items-center gap-2 border-b border-border/40 px-4 py-2 text-xs text-muted-foreground">
+						<span data-testid="visible-tool-count">{visibleTools}</span>
+						<span>visible tools</span>
+					</div>
+					<ActiveThreadViewport hasSession pane={pane} />
+				</div>
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## What changed
- prevent the active streaming footer from overlapping live assistant output while collapsed tool groups expand
- keep streaming rows pinned to the larger of their estimated and measured heights until layout catches up
- add unit coverage for the row-height and estimator logic plus a WebKit Playwright regression scenario/test

## Why
Long-running tool groups could outgrow the virtualized row height estimate during streaming, which let the loading/timer footer slide on top of the assistant row. This keeps the footer below the live content while the row is still streaming.

## Test notes
- bun x vitest run src/features/panel/thread-viewport.test.ts src/lib/message-layout-estimator.test.ts
- bun x playwright test e2e/tests/streaming-footer-overlap.spec.ts
