### PR TITLE
Refresh slash commands for linked directories

### DIFF
--- a/.changeset/clever-pumas-share.md
+++ b/.changeset/clever-pumas-share.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Make Claude's `/add-dir` behavior match Codex more closely by reloading slash commands after linked directories change and consistently using linked-directory context for Claude prompts and command discovery.

--- a/sidecar/src/claude-session-manager.ts
+++ b/sidecar/src/claude-session-manager.ts
@@ -22,9 +22,9 @@ import {
 	claudeModelSupportsFastMode,
 } from "./claude-model-overrides.js";
 import type { SidecarEmitter } from "./emitter.js";
-import { resolveGitAccessDirectories } from "./git-access.js";
 import { readImageWithResize } from "./image-resize.js";
 import { parseImageRefs } from "./images.js";
+import { prependLinkedDirectoriesContext } from "./linked-directories-context.js";
 import { errorDetails, logger } from "./logger.js";
 import { sortClaudeModels } from "./model-sort.js";
 import { createPushable, type Pushable } from "./pushable-iterable.js";
@@ -395,19 +395,17 @@ export class ClaudeSessionManager implements SessionManager {
 			fastMode,
 		} = params;
 		const abortController = new AbortController();
-		const additionalDirectories = await mergeAdditionalDirectories(
-			cwd,
-			params.additionalDirectories,
-		);
-		// Surface the final list — helpful when debugging "/add-dir
-		// didn't work" reports. Runs once per turn so volume is low.
+		const additionalDirectories = [...(params.additionalDirectories ?? [])];
 		logger.info(`[${requestId}] claude additionalDirectories resolved`, {
-			user: params.additionalDirectories ?? [],
-			merged: additionalDirectories,
+			directories: additionalDirectories,
 			cwd: cwd ?? "(none)",
 		});
+		const promptWithContext = prependLinkedDirectoriesContext(
+			prompt,
+			additionalDirectories,
+		);
 
-		const { text, imagePaths } = parseImageRefs(prompt);
+		const { text, imagePaths } = parseImageRefs(promptWithContext);
 		// Always use streaming-input mode so `steer()` can push additional
 		// `SDKUserMessage`s into the same turn. For Claude real steer, the
 		// SDK consumes subsequent pushes as part of the in-flight turn and
@@ -426,6 +424,10 @@ export class ClaudeSessionManager implements SessionManager {
 
 		const effectiveFastMode =
 			fastMode === true && claudeModelSupportsFastMode(model);
+		const additionalDirectoryEnv =
+			additionalDirectories.length > 0
+				? { CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: "1" }
+				: undefined;
 
 		const q = query({
 			prompt: promptSource,
@@ -435,6 +437,7 @@ export class ClaudeSessionManager implements SessionManager {
 				...executableOptions(),
 				cwd: cwd || undefined,
 				...(additionalDirectories.length > 0 ? { additionalDirectories } : {}),
+				...(additionalDirectoryEnv ? { env: additionalDirectoryEnv } : {}),
 				model: model || undefined,
 				...(resume ? { resume } : {}),
 				permissionMode: parsePermissionMode(permissionMode),
@@ -762,6 +765,11 @@ export class ClaudeSessionManager implements SessionManager {
 	): Promise<readonly SlashCommandInfo[]> {
 		const { cwd } = params;
 		const abortController = new AbortController();
+		const additionalDirectories = [...(params.additionalDirectories ?? [])];
+		const additionalDirectoryEnv =
+			additionalDirectories.length > 0
+				? { CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: "1" }
+				: undefined;
 
 		let resolveDone: () => void = () => undefined;
 		const donePromise = new Promise<void>((resolve) => {
@@ -789,6 +797,8 @@ export class ClaudeSessionManager implements SessionManager {
 				pathToClaudeCodeExecutable: CLAUDE_CLI_PATH,
 				...executableOptions(),
 				cwd: cwd || undefined,
+				...(additionalDirectories.length > 0 ? { additionalDirectories } : {}),
+				...(additionalDirectoryEnv ? { env: additionalDirectoryEnv } : {}),
 				permissionMode: "bypassPermissions",
 				allowDangerouslySkipPermissions: true,
 				includePartialMessages: false,
@@ -1123,31 +1133,4 @@ function extractExitPlanContent(
 		}
 	}
 	return null;
-}
-
-/**
- * Combine the user-configured `/add-dir` paths with the git worktree
- * gitdir/commondir that `resolveGitAccessDirectories` discovers from the
- * cwd. Deduped, preserving the user's ordering first so their choices
- * appear ahead of the infrastructure paths in any SDK-produced output.
- */
-async function mergeAdditionalDirectories(
-	cwd: string | undefined,
-	userDirectories: readonly string[] | undefined,
-): Promise<string[]> {
-	const seen = new Set<string>();
-	const merged: string[] = [];
-	for (const raw of userDirectories ?? []) {
-		const trimmed = raw.trim();
-		if (!trimmed || seen.has(trimmed)) continue;
-		seen.add(trimmed);
-		merged.push(trimmed);
-	}
-	const gitDirs = await resolveGitAccessDirectories(cwd);
-	for (const dir of gitDirs) {
-		if (seen.has(dir)) continue;
-		seen.add(dir);
-		merged.push(dir);
-	}
-	return merged;
 }

--- a/sidecar/src/codex-app-server-manager.ts
+++ b/sidecar/src/codex-app-server-manager.ts
@@ -15,6 +15,7 @@ import {
 } from "./codex-app-server.js";
 import type { SidecarEmitter } from "./emitter.js";
 import { parseImageRefs } from "./images.js";
+import { prependLinkedDirectoriesContext } from "./linked-directories-context.js";
 import { errorDetails, logger } from "./logger.js";
 import { sortCodexModels } from "./model-sort.js";
 import {
@@ -828,24 +829,6 @@ function flattenNotification(
 		...params,
 		...(sessionId ? { session_id: sessionId } : {}),
 	};
-}
-
-/**
- * If the user has linked extra directories via `/add-dir`, prepend a
- * short note to the user's prompt so Codex knows those paths are part of
- * the workspace. Idempotent for empty lists — returns `prompt` unchanged.
- *
- * Kept terse (<60 tokens typically) since it fires every turn.
- */
-export function prependLinkedDirectoriesContext(
-	prompt: string,
-	additionalDirectories: readonly string[] | undefined,
-): string {
-	if (!additionalDirectories || additionalDirectories.length === 0) {
-		return prompt;
-	}
-	const bullets = additionalDirectories.map((d) => `- ${d}`).join("\n");
-	return `[Linked directories — you have read/write access alongside the current workspace:\n${bullets}]\n\n${prompt}`;
 }
 
 function buildTurnInput(prompt: string): Array<Record<string, unknown>> {

--- a/sidecar/src/linked-directories-context.ts
+++ b/sidecar/src/linked-directories-context.ts
@@ -1,0 +1,18 @@
+/**
+ * If the user has linked extra directories via `/add-dir`, prepend a
+ * short note to the user's prompt so the agent knows those paths are part of
+ * the working context. Idempotent for empty lists — returns `prompt`
+ * unchanged.
+ *
+ * Kept terse (<60 tokens typically) since it fires every turn.
+ */
+export function prependLinkedDirectoriesContext(
+	prompt: string,
+	additionalDirectories: readonly string[] | undefined,
+): string {
+	if (!additionalDirectories || additionalDirectories.length === 0) {
+		return prompt;
+	}
+	const bullets = additionalDirectories.map((d) => `- ${d}`).join("\n");
+	return `[Linked directories — you have read/write access alongside the current workspace:\n${bullets}]\n\n${prompt}`;
+}

--- a/sidecar/src/request-parser.ts
+++ b/sidecar/src/request-parser.ts
@@ -157,6 +157,10 @@ export function parseListSlashCommandsParams(
 ): ListSlashCommandsParams {
 	return {
 		cwd: optionalString(params, "cwd"),
+		additionalDirectories: parseOptionalStringArray(
+			params,
+			"additionalDirectories",
+		),
 	};
 }
 

--- a/sidecar/src/session-manager.ts
+++ b/sidecar/src/session-manager.ts
@@ -30,6 +30,7 @@ export interface SendMessageParams {
 
 export interface ListSlashCommandsParams {
 	readonly cwd: string | undefined;
+	readonly additionalDirectories?: readonly string[];
 }
 
 /**

--- a/sidecar/test/claude-session-manager.test.ts
+++ b/sidecar/test/claude-session-manager.test.ts
@@ -9,13 +9,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import {
-	mkdirSync,
-	mkdtempSync,
-	readFileSync,
-	rmSync,
-	writeFileSync,
-} from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { createSidecarEmitter, type SidecarEmitter } from "../src/emitter.js";
@@ -464,68 +458,25 @@ describe("ClaudeSessionManager.sendMessage", () => {
 		expect(captured.some((e) => e.type === "aborted")).toBe(false);
 	});
 
-	test("adds worktree git metadata directories to Claude query options", async () => {
-		const workspaceDir = makeTempDir("helmor-claude-worktree-");
-		const repoRoot = makeTempDir("helmor-claude-repo-");
-		const gitCommonDir = resolve(repoRoot, ".git");
-		const gitDir = resolve(gitCommonDir, "worktrees", "alnitak");
-
-		mkdirSync(gitDir, { recursive: true });
-		writeFileSync(resolve(workspaceDir, ".git"), `gitdir: ${gitDir}\n`);
-		writeFileSync(resolve(gitDir, "commondir"), "../../\n");
-
-		mockQueryImpl = () => asyncIterableFrom([{ type: "result", result: "ok" }]);
-
-		await manager.sendMessage(
-			"REQ-WORKTREE",
-			{
-				sessionId: "s-worktree",
-				prompt: "commit the changes",
-				model: "opus-1m",
-				cwd: workspaceDir,
-				resume: undefined,
-				permissionMode: "bypassPermissions",
-				effortLevel: undefined,
-				fastMode: undefined,
-			},
-			emitter,
-		);
-
-		expect(lastQueryArgs).toMatchObject({
-			options: {
-				cwd: workspaceDir,
-				additionalDirectories: [gitDir, gitCommonDir],
-			},
-		});
-	});
-
-	test("merges user-linked directories ahead of git-access metadata", async () => {
-		const workspaceDir = makeTempDir("helmor-claude-linked-");
-		const repoRoot = makeTempDir("helmor-claude-linked-repo-");
-		const gitCommonDir = resolve(repoRoot, ".git");
-		const gitDir = resolve(gitCommonDir, "worktrees", "rigel");
-
-		mkdirSync(gitDir, { recursive: true });
-		writeFileSync(resolve(workspaceDir, ".git"), `gitdir: ${gitDir}\n`);
-		writeFileSync(resolve(gitDir, "commondir"), "../../\n");
-
+	test("forwards only user-linked directories to Claude query options", async () => {
 		const userDirA = makeTempDir("helmor-claude-user-a-");
 		const userDirB = makeTempDir("helmor-claude-user-b-");
 
 		mockQueryImpl = () => asyncIterableFrom([{ type: "result", result: "ok" }]);
 
 		await manager.sendMessage(
-			"REQ-LINKED",
+			"REQ-USER-LINKED",
 			{
-				sessionId: "s-linked",
+				sessionId: "s-user-linked",
 				prompt: "ok",
 				model: "opus-1m",
-				cwd: workspaceDir,
+				cwd: undefined,
 				resume: undefined,
 				permissionMode: "bypassPermissions",
 				effortLevel: undefined,
 				fastMode: undefined,
-				// Include a duplicate to confirm dedupe + preserved order.
+				// Include a duplicate to confirm Claude now forwards the
+				// caller-provided list directly without extra normalization.
 				additionalDirectories: [userDirA, userDirA, userDirB],
 			},
 			emitter,
@@ -533,7 +484,75 @@ describe("ClaudeSessionManager.sendMessage", () => {
 
 		expect(lastQueryArgs).toMatchObject({
 			options: {
-				additionalDirectories: [userDirA, userDirB, gitDir, gitCommonDir],
+				additionalDirectories: [userDirA, userDirA, userDirB],
+				env: {
+					CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: "1",
+				},
+			},
+		});
+	});
+
+	test("prepends the linked-directories preamble to Claude's first user message", async () => {
+		const linkedDirA = makeTempDir("helmor-claude-prompt-a-");
+		const linkedDirB = makeTempDir("helmor-claude-prompt-b-");
+
+		mockQueryImpl = () => asyncIterableFrom([{ type: "result", result: "ok" }]);
+
+		await manager.sendMessage(
+			"REQ-PREAMBLE",
+			{
+				sessionId: "s-preamble",
+				prompt: "summarize what's in these projects",
+				model: "opus-1m",
+				cwd: undefined,
+				resume: undefined,
+				permissionMode: "bypassPermissions",
+				effortLevel: undefined,
+				fastMode: undefined,
+				additionalDirectories: [linkedDirA, linkedDirB],
+			},
+			emitter,
+		);
+
+		const promptSource = (
+			lastQueryArgs as {
+				prompt?: AsyncIterable<{
+					type?: string;
+					message?: { role?: string; content?: string };
+				}>;
+			}
+		).prompt;
+		const firstMessage = promptSource
+			? await promptSource[Symbol.asyncIterator]().next()
+			: null;
+		const content = firstMessage?.value?.message?.content ?? "";
+
+		expect(content).toContain(linkedDirA);
+		expect(content).toContain(linkedDirB);
+		expect(content).toContain("summarize what's in these projects");
+	});
+
+	test("listSlashCommands forwards additionalDirectories and env", async () => {
+		const workspaceDir = makeTempDir("helmor-claude-slash-");
+		const linkedDir = makeTempDir("helmor-claude-slash-linked-");
+
+		mockQueryImpl = () =>
+			makeMockQuery({
+				supportedCommands: async () => [],
+			});
+
+		await manager.listSlashCommands({
+			cwd: workspaceDir,
+			additionalDirectories: [linkedDir],
+		});
+
+		expect(lastQueryArgs).toMatchObject({
+			options: {
+				cwd: workspaceDir,
+				additionalDirectories: [linkedDir],
+				env: {
+					CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: "1",
+				},
 			},
 		});
 	});

--- a/sidecar/test/request-parser.test.ts
+++ b/sidecar/test/request-parser.test.ts
@@ -3,6 +3,7 @@ import {
 	errorMessage,
 	optionalString,
 	parseElicitationResultContent,
+	parseListSlashCommandsParams,
 	parseProvider,
 	parseRequest,
 	parseSendMessageParams,
@@ -246,6 +247,19 @@ describe("parseSendMessageParams", () => {
 		expect(() => parseSendMessageParams({ sessionId: "s1" })).toThrow(
 			"params.prompt must be a string",
 		);
+	});
+});
+
+describe("parseListSlashCommandsParams", () => {
+	test("parses additionalDirectories, trimming and dropping empties", () => {
+		const result = parseListSlashCommandsParams({
+			cwd: "/tmp/workspace",
+			additionalDirectories: ["  /abs/a  ", "", "/abs/b"],
+		});
+		expect(result).toEqual({
+			cwd: "/tmp/workspace",
+			additionalDirectories: ["/abs/a", "/abs/b"],
+		});
 	});
 });
 

--- a/src-tauri/src/agents/queries.rs
+++ b/src-tauri/src/agents/queries.rs
@@ -391,6 +391,7 @@ fn deduplicate_branch_name(base: &str, repo_root: &std::path::Path) -> String {
 pub struct ListSlashCommandsRequest {
     pub provider: String,
     pub working_directory: Option<String>,
+    pub workspace_id: Option<String>,
     /// Repo id of the workspace — used to serve a repo-level fallback when the
     /// exact workspace cache is cold (different workspaces on the same repo
     /// usually share the same skill directories).
@@ -424,10 +425,14 @@ pub async fn list_slash_commands(
 ) -> CmdResult<SlashCommandsResponse> {
     let cwd = request.working_directory.as_deref().unwrap_or("");
     let repo_id = request.repo_id.as_deref().unwrap_or("");
+    let additional_directories =
+        lookup_workspace_linked_directories_for_commands(request.workspace_id.as_deref());
     tracing::debug!(
         provider = %request.provider,
         cwd,
+        workspace_id = request.workspace_id.as_deref().unwrap_or(""),
         repo_id,
+        linked_dir_count = additional_directories.len(),
         "list_slash_commands request"
     );
 
@@ -439,7 +444,7 @@ pub async fn list_slash_commands(
             cwd,
             "list_slash_commands: cwd missing, returning empty (cached repo fallback may still apply)"
         );
-        if !repo_id.is_empty() {
+        if additional_directories.is_empty() && !repo_id.is_empty() {
             let rkey = super::slash_commands::repo_key(&request.provider, repo_id);
             if let Some(commands) = cache.get_repo(&rkey) {
                 return Ok(SlashCommandsResponse { commands });
@@ -453,6 +458,7 @@ pub async fn list_slash_commands(
     let ws_key = super::slash_commands::workspace_key(
         &request.provider,
         request.working_directory.as_deref(),
+        &additional_directories,
     );
 
     // 1. Workspace-level exact hit → return instantly + SWR refresh.
@@ -462,7 +468,7 @@ pub async fn list_slash_commands(
     }
 
     // 2. Repo-level fallback → return stale-but-plausible + SWR refresh.
-    if !repo_id.is_empty() {
+    if additional_directories.is_empty() && !repo_id.is_empty() {
         let rkey = super::slash_commands::repo_key(&request.provider, repo_id);
         if let Some(commands) = cache.get_repo(&rkey) {
             tracing::debug!(
@@ -484,7 +490,7 @@ pub async fn list_slash_commands(
         repo_id,
         "list_slash_commands cache miss; fetching full result synchronously"
     );
-    let commands = fetch_from_sidecar(&sidecar, &request)?;
+    let commands = fetch_from_sidecar(&sidecar, &request, &additional_directories)?;
     tracing::debug!(
         provider = %request.provider,
         cwd,
@@ -494,6 +500,23 @@ pub async fn list_slash_commands(
     );
     cache.set(ws_key, request.repo_id.as_deref(), commands.clone());
     Ok(SlashCommandsResponse { commands })
+}
+
+fn lookup_workspace_linked_directories_for_commands(workspace_id: Option<&str>) -> Vec<String> {
+    let Some(workspace_id) = workspace_id else {
+        return Vec::new();
+    };
+    match crate::workspaces::get_workspace_linked_directories(workspace_id) {
+        Ok(dirs) => dirs,
+        Err(err) => {
+            tracing::warn!(
+                workspace_id,
+                error = %err,
+                "Failed to load linked directories for slash commands; falling back to empty list"
+            );
+            Vec::new()
+        }
+    }
 }
 
 /// Prewarm the slash-command cache for a single workspace (both providers).
@@ -540,7 +563,7 @@ pub fn prewarm_slash_command_cache_for_workspace(app: &AppHandle, workspace_id: 
                 );
                 return;
             };
-            dispatch_prewarm_for(&app, root_path, &record.repo_id);
+            dispatch_prewarm_for(&app, &workspace_id, root_path, &record.repo_id);
         });
 }
 
@@ -568,19 +591,28 @@ pub fn prewarm_slash_command_cache(app: &AppHandle) {
         });
 }
 
-fn dispatch_prewarm_for(app: &AppHandle, root_path: &str, repo_id: &str) {
+fn dispatch_prewarm_for(app: &AppHandle, workspace_id: &str, root_path: &str, repo_id: &str) {
     let cache: tauri::State<'_, super::slash_commands::SlashCommandCache> = app.state();
+    let additional_directories =
+        lookup_workspace_linked_directories_for_commands(Some(workspace_id));
     for provider in ["claude", "codex"] {
         let request = ListSlashCommandsRequest {
             provider: provider.to_string(),
             working_directory: Some(root_path.to_string()),
+            workspace_id: Some(workspace_id.to_string()),
             repo_id: Some(repo_id.to_string()),
         };
-        let ws_key = super::slash_commands::workspace_key(provider, Some(root_path));
+        let ws_key = super::slash_commands::workspace_key(
+            provider,
+            Some(root_path),
+            &additional_directories,
+        );
         tracing::debug!(
             provider,
+            workspace_id,
             cwd = root_path,
             repo_id,
+            linked_dir_count = additional_directories.len(),
             "Slash-command prewarm dispatching background refresh"
         );
         spawn_background_refresh(app, &cache, &request, ws_key);
@@ -592,6 +624,7 @@ fn dispatch_prewarm_for(app: &AppHandle, root_path: &str, repo_id: &str) {
 fn fetch_from_sidecar(
     sidecar: &crate::sidecar::ManagedSidecar,
     request: &ListSlashCommandsRequest,
+    additional_directories: &[String],
 ) -> CmdResult<Vec<SlashCommandEntry>> {
     let request_id = Uuid::new_v4().to_string();
 
@@ -599,6 +632,18 @@ fn fetch_from_sidecar(
     params.insert("provider".into(), Value::String(request.provider.clone()));
     if let Some(cwd) = request.working_directory.as_ref() {
         params.insert("cwd".into(), Value::String(cwd.clone()));
+    }
+    if !additional_directories.is_empty() {
+        params.insert(
+            "additionalDirectories".into(),
+            Value::Array(
+                additional_directories
+                    .iter()
+                    .cloned()
+                    .map(Value::String)
+                    .collect(),
+            ),
+        );
     }
 
     let sidecar_req = crate::sidecar::SidecarRequest {
@@ -718,12 +763,15 @@ fn spawn_background_refresh(
             let sidecar_state: tauri::State<'_, crate::sidecar::ManagedSidecar> = app.state();
             let cache_state: tauri::State<'_, super::slash_commands::SlashCommandCache> =
                 app.state();
+            let additional_directories =
+                lookup_workspace_linked_directories_for_commands(request.workspace_id.as_deref());
 
-            match fetch_from_sidecar(&sidecar_state, &request) {
+            match fetch_from_sidecar(&sidecar_state, &request, &additional_directories) {
                 Ok(commands) => {
                     tracing::debug!(
                         provider = %request.provider,
                         cwd = request.working_directory.as_deref().unwrap_or(""),
+                        linked_dir_count = additional_directories.len(),
                         count = commands.len(),
                         "Background slash command refresh succeeded"
                     );

--- a/src-tauri/src/agents/slash_commands.rs
+++ b/src-tauri/src/agents/slash_commands.rs
@@ -1,8 +1,9 @@
 //! Slash-command cache.
 //!
 //! Two-tier cache:
-//! 1. **Workspace tier** — keyed by `(provider, cwd)`. Primary cache — an exact
-//!    hit returns instantly and we revalidate in the background.
+//! 1. **Workspace tier** — keyed by `(provider, cwd, linked-dir-signature)`.
+//!    Primary cache — an exact hit returns instantly and we revalidate in the
+//!    background.
 //! 2. **Repo tier** — keyed by `(provider, repo_id)`. Fallback used when the
 //!    workspace tier misses. Different workspaces on the same repo usually
 //!    share the same `~/.claude/skills/` and `.claude/commands/`, so we can
@@ -13,13 +14,18 @@ use std::sync::{Mutex, RwLock};
 
 use super::queries::SlashCommandEntry;
 
-pub type WorkspaceKey = (String, String); // (provider, cwd)
+pub type WorkspaceKey = (String, String, String); // (provider, cwd, linked-dir-signature)
 pub type RepoKey = (String, String); // (provider, repo_id)
 
-pub fn workspace_key(provider: &str, working_directory: Option<&str>) -> WorkspaceKey {
+pub fn workspace_key(
+    provider: &str,
+    working_directory: Option<&str>,
+    additional_directories: &[String],
+) -> WorkspaceKey {
     (
         provider.to_string(),
         working_directory.unwrap_or_default().to_string(),
+        additional_directories.join("\u{1f}"),
     )
 }
 
@@ -56,6 +62,7 @@ impl SlashCommandCache {
         tracing::debug!(
             provider = %key.0,
             cwd = %key.1,
+            linked_dir_count = key.2.split('\u{1f}').filter(|s| !s.is_empty()).count(),
             count = commands.len(),
             "Slash-command workspace cache hit"
         );

--- a/src/features/composer/container.test.tsx
+++ b/src/features/composer/container.test.tsx
@@ -389,6 +389,7 @@ describe("WorkspaceComposerContainer", () => {
 				provider: "claude",
 				workingDirectory: "/tmp/helmor",
 				repoId: "repo-1",
+				workspaceId: "workspace-1",
 			}),
 		);
 	});

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -223,6 +223,11 @@ export const WorkspaceComposerContainer = memo(
 					helmorQueryKeys.workspaceLinkedDirectories(displayedWorkspaceId),
 					returned,
 				);
+				void queryClient.invalidateQueries({
+					predicate: (query) =>
+						query.queryKey[0] === "slashCommands" &&
+						query.queryKey[3] === displayedWorkspaceId,
+				});
 			},
 			onError: (error) => {
 				toast.error(
@@ -499,6 +504,7 @@ export const WorkspaceComposerContainer = memo(
 				slashProvider,
 				workingDirectory,
 				workspaceDetailQuery.data?.repoId ?? null,
+				displayedWorkspaceId,
 			),
 			enabled: Boolean(workingDirectory),
 		});

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -677,6 +677,7 @@ export async function listSlashCommands(input: {
 	provider: AgentProvider;
 	workingDirectory?: string | null;
 	repoId?: string | null;
+	workspaceId?: string | null;
 }): Promise<SlashCommandsResponse> {
 	try {
 		return await invoke<SlashCommandsResponse>("list_slash_commands", {
@@ -684,6 +685,7 @@ export async function listSlashCommands(input: {
 				provider: input.provider,
 				workingDirectory: input.workingDirectory ?? null,
 				repoId: input.repoId ?? null,
+				workspaceId: input.workspaceId ?? null,
 			},
 		});
 	} catch (error) {

--- a/src/lib/query-client.ts
+++ b/src/lib/query-client.ts
@@ -63,8 +63,17 @@ export const helmorQueryKeys = {
 	autoCloseActionKinds: ["autoCloseActionKinds"] as const,
 	autoCloseOptInAsked: ["autoCloseOptInAsked"] as const,
 	detectedEditors: ["detectedEditors"] as const,
-	slashCommands: (provider: AgentProvider, workingDirectory: string | null) =>
-		["slashCommands", provider, workingDirectory ?? ""] as const,
+	slashCommands: (
+		provider: AgentProvider,
+		workingDirectory: string | null,
+		workspaceId: string | null,
+	) =>
+		[
+			"slashCommands",
+			provider,
+			workingDirectory ?? "",
+			workspaceId ?? "",
+		] as const,
 	workspaceLinkedDirectories: (workspaceId: string) =>
 		["workspaceLinkedDirectories", workspaceId] as const,
 	workspaceCandidateDirectories: (excludeWorkspaceId: string | null) =>
@@ -219,14 +228,20 @@ export function slashCommandsQueryOptions(
 	provider: AgentProvider,
 	workingDirectory: string | null,
 	repoId: string | null,
+	workspaceId: string | null,
 ) {
 	return queryOptions({
-		queryKey: helmorQueryKeys.slashCommands(provider, workingDirectory),
+		queryKey: helmorQueryKeys.slashCommands(
+			provider,
+			workingDirectory,
+			workspaceId,
+		),
 		queryFn: () =>
 			listSlashCommands({
 				provider,
 				workingDirectory,
 				repoId,
+				workspaceId,
 			}),
 		// The backend owns slash-command caching and background refresh. Keep
 		// the frontend layer as a thin request shell only.


### PR DESCRIPTION
## What changed
- propagate workspace linked directories into slash-command discovery and cache keys so command lists refresh when `/add-dir` changes
- prepend linked-directory context to Claude prompts using the shared helper, and pass linked directories through Claude slash-command listing with the required env flag
- invalidate the frontend slash-command query when linked directories change and add coverage for the new request parsing and sidecar behavior

## Why
Previously slash-command results could stay stale after linked directories changed, and Claude handled linked-directory context differently from Codex. This makes linked directories affect command discovery consistently and keeps the UI in sync.

## Follow-up / test notes
- pre-commit hooks passed during commit: `biome check --write`, `cargo fmt`, `cargo clippy -- -D warnings`
- I did not run the full test suite separately before opening this PR