### PR TITLE
Confirm before closing running chats

### DIFF
--- a/.changeset/brisk-pets-arrive.md
+++ b/.changeset/brisk-pets-arrive.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Warn before closing a session while its chat is still running, and stop the in-flight response if you choose to close it anyway.

--- a/src/features/panel/header.tsx
+++ b/src/features/panel/header.tsx
@@ -42,6 +42,7 @@ import {
 	prefetchRemoteRefs,
 	renameSession,
 	renameWorkspaceBranch,
+	stopAgentStream,
 	unhideSession,
 	updateIntendedTargetBranch,
 	type WorkspaceDetail,
@@ -54,6 +55,7 @@ import {
 	type WorkspaceBranchTone,
 } from "@/lib/workspace-helpers";
 import { useWorkspaceToast } from "@/lib/workspace-toast-context";
+import { RunningSessionCloseDialog } from "./running-session-close-dialog";
 import { seedNewSessionInCache } from "./session-cache";
 import { closeWorkspaceSession } from "./session-close";
 
@@ -121,6 +123,18 @@ export const WorkspacePanelHeader = memo(function WorkspacePanelHeader({
 	const [branchCopied, setBranchCopied] = useState(false);
 	const tabsScrollRef = useRef<HTMLDivElement>(null);
 	const [hasRightOverflow, setHasRightOverflow] = useState(false);
+	const [confirmCloseSessionId, setConfirmCloseSessionId] = useState<
+		string | null
+	>(null);
+	const [confirmCloseLoading, setConfirmCloseLoading] = useState(false);
+
+	const confirmCloseSession =
+		sessions.find((session) => session.id === confirmCloseSessionId) ?? null;
+	const confirmCloseProvider =
+		(confirmCloseSession
+			? (sessionDisplayProviders?.[confirmCloseSession.id] ??
+				confirmCloseSession.agentType)
+			: null) ?? null;
 
 	const updateOverflow = useCallback(() => {
 		const el = tabsScrollRef.current;
@@ -213,6 +227,11 @@ export const WorkspacePanelHeader = memo(function WorkspacePanelHeader({
 				return;
 			}
 
+			if (sendingSessionIds?.has(sessionId)) {
+				setConfirmCloseSessionId(sessionId);
+				return;
+			}
+
 			await closeWorkspaceSession({
 				queryClient,
 				workspace,
@@ -228,10 +247,56 @@ export const WorkspacePanelHeader = memo(function WorkspacePanelHeader({
 			onSessionsChanged,
 			pushToast,
 			queryClient,
+			sendingSessionIds,
 			sessions,
 			workspace,
 		],
 	);
+
+	const handleConfirmCloseSession = useCallback(async () => {
+		if (!workspace || !confirmCloseSession) {
+			return;
+		}
+
+		const provider =
+			sessionDisplayProviders?.[confirmCloseSession.id] ??
+			confirmCloseSession.agentType ??
+			undefined;
+
+		setConfirmCloseLoading(true);
+		try {
+			await stopAgentStream(confirmCloseSession.id, provider);
+		} catch (error) {
+			pushToast(
+				error instanceof Error ? error.message : String(error),
+				"Unable to stop chat",
+				"destructive",
+			);
+			setConfirmCloseLoading(false);
+			return;
+		}
+
+		setConfirmCloseSessionId(null);
+		setConfirmCloseLoading(false);
+		await closeWorkspaceSession({
+			queryClient,
+			workspace,
+			sessions,
+			sessionId: confirmCloseSession.id,
+			onSelectSession,
+			onSessionsChanged,
+			pushToast,
+		});
+	}, [
+		confirmCloseSession,
+		onSelectSession,
+		onSessionsChanged,
+		pushToast,
+		queryClient,
+		sessionDisplayProviders,
+		sessions,
+		workspace,
+	]);
 
 	const handleToggleHistory = useCallback(
 		async (open: boolean) => {
@@ -728,6 +793,18 @@ export const WorkspacePanelHeader = memo(function WorkspacePanelHeader({
 					</DropdownMenuContent>
 				</DropdownMenu>
 			</div>
+			<RunningSessionCloseDialog
+				open={confirmCloseSession !== null}
+				agentLabel={confirmCloseProvider === "codex" ? "Codex" : "Claude"}
+				loading={confirmCloseLoading}
+				onOpenChange={(open) => {
+					if (confirmCloseLoading || open) {
+						return;
+					}
+					setConfirmCloseSessionId(null);
+				}}
+				onConfirm={() => void handleConfirmCloseSession()}
+			/>
 		</header>
 	);
 });

--- a/src/features/panel/running-session-close-dialog.test.tsx
+++ b/src/features/panel/running-session-close-dialog.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { RunningSessionCloseDialog } from "./running-session-close-dialog";
+
+describe("RunningSessionCloseDialog", () => {
+	it("renders the running-chat confirmation copy", () => {
+		render(
+			<RunningSessionCloseDialog
+				open
+				agentLabel="Claude"
+				onOpenChange={vi.fn()}
+				onConfirm={vi.fn()}
+			/>,
+		);
+
+		expect(screen.getByText("Close running chat?")).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				"This chat is currently running. Closing it will cancel Claude.",
+			),
+		).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: "Close anyway" }),
+		).toBeInTheDocument();
+	});
+
+	it("blocks dismiss while loading", async () => {
+		const user = userEvent.setup();
+		const onOpenChange = vi.fn();
+
+		render(
+			<RunningSessionCloseDialog
+				open
+				agentLabel="Codex"
+				loading
+				onOpenChange={onOpenChange}
+				onConfirm={vi.fn()}
+			/>,
+		);
+
+		await user.click(screen.getByRole("button", { name: "Cancel" }));
+		expect(onOpenChange).not.toHaveBeenCalled();
+	});
+});

--- a/src/features/panel/running-session-close-dialog.tsx
+++ b/src/features/panel/running-session-close-dialog.tsx
@@ -1,0 +1,29 @@
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+
+type RunningSessionCloseDialogProps = {
+	open: boolean;
+	agentLabel: string;
+	loading?: boolean;
+	onOpenChange: (open: boolean) => void;
+	onConfirm: () => void;
+};
+
+export function RunningSessionCloseDialog({
+	open,
+	agentLabel,
+	loading = false,
+	onOpenChange,
+	onConfirm,
+}: RunningSessionCloseDialogProps) {
+	return (
+		<ConfirmDialog
+			open={open}
+			onOpenChange={onOpenChange}
+			title="Close running chat?"
+			description={`This chat is currently running. Closing it will cancel ${agentLabel}.`}
+			confirmLabel="Close anyway"
+			onConfirm={onConfirm}
+			loading={loading}
+		/>
+	);
+}


### PR DESCRIPTION
## What changed
- add a confirmation dialog when closing a session whose chat is still running
- stop the in-flight Codex or Claude stream before closing the session when the user confirms
- add a focused frontend test for the new dialog copy and loading behavior
- include a patch changeset for the user-facing behavior change

## Why
Closing an active session could abruptly terminate a running response without warning. This makes the close action explicit and ensures the active stream is cancelled intentionally before the session disappears.

## Follow-up / test notes
- Tested with `bun x vitest run src/features/panel/running-session-close-dialog.test.tsx`
- I did not run the full frontend or Tauri test suites for this PR.