### PR TITLE
fix: keep deferred approval actions enabled while waiting

### DIFF
--- a/.changeset/bright-forks-help.md
+++ b/.changeset/bright-forks-help.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix approval prompts so Allow and Deny stay clickable while the agent is waiting, and remove the unused optional reason field from that approval UI.

--- a/src/features/composer/deferred-tool-panel/generic-panel.tsx
+++ b/src/features/composer/deferred-tool-panel/generic-panel.tsx
@@ -1,29 +1,31 @@
-import { Check, MessageSquareMore, Settings2, X } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { Check, Settings2, X } from "lucide-react";
+import { useMemo } from "react";
 import { CodeBlock } from "@/components/ai/code-block";
 import { Button } from "@/components/ui/button";
-import {
-	InteractionFooter,
-	InteractionHeader,
-	InteractionOptionalInput,
-} from "../interaction";
+import { InteractionFooter, InteractionHeader } from "../interaction";
 import { DeferredToolCard, type DeferredToolPanelProps } from "./shared";
 
-/**
- * If the tool looks shell-shaped (Bash tool with a `command` string),
- * render the command with bash highlighting. Everything else falls back
- * to a JSON view of `toolInput` with JSON highlighting.
- */
+function looksLikeCommand(
+	toolName: string,
+	toolInput: Record<string, unknown>,
+) {
+	const lowerName = toolName.toLowerCase();
+	return (
+		typeof toolInput.command === "string" &&
+		toolInput.command.length > 0 &&
+		(lowerName === "bash" || lowerName === "shell" || lowerName === "exec")
+	);
+}
+
 function getCodePreview(deferred: DeferredToolPanelProps["deferred"]): {
 	code: string;
 	language: string;
 } {
-	const lowerName = deferred.toolName.toLowerCase();
 	const command = deferred.toolInput?.command;
 	if (
 		typeof command === "string" &&
 		command.length > 0 &&
-		(lowerName === "bash" || lowerName === "shell" || lowerName === "exec")
+		looksLikeCommand(deferred.toolName, deferred.toolInput)
 	) {
 		return { code: command, language: "bash" };
 	}
@@ -38,12 +40,6 @@ export function GenericDeferredToolPanel({
 	disabled,
 	onResponse,
 }: DeferredToolPanelProps) {
-	const [reason, setReason] = useState("");
-
-	useEffect(() => {
-		setReason("");
-	}, [deferred.toolUseId]);
-
 	const preview = useMemo(() => getCodePreview(deferred), [deferred]);
 
 	return (
@@ -54,8 +50,6 @@ export function GenericDeferredToolPanel({
 				description="This tool needs your approval before it can run."
 				truncateTitle
 			/>
-
-			{/* Tool input — syntax-highlighted via shiki */}
 			<div className="mx-1 max-h-56 overflow-y-auto rounded-xl bg-muted/20">
 				<CodeBlock
 					code={preview.code}
@@ -65,24 +59,12 @@ export function GenericDeferredToolPanel({
 				/>
 			</div>
 
-			<InteractionOptionalInput
-				icon={MessageSquareMore}
-				placeholder="Optional reason"
-				value={reason}
-				onChange={setReason}
-				disabled={disabled}
-			/>
-
 			<InteractionFooter>
 				<Button
 					variant="outline"
 					size="sm"
 					disabled={disabled}
-					onClick={() =>
-						onResponse(deferred, "deny", {
-							...(reason.trim() ? { reason: reason.trim() } : {}),
-						})
-					}
+					onClick={() => onResponse(deferred, "deny")}
 				>
 					<X className="size-3.5" strokeWidth={2} />
 					<span>Deny</span>
@@ -94,7 +76,6 @@ export function GenericDeferredToolPanel({
 					onClick={() =>
 						onResponse(deferred, "allow", {
 							updatedInput: deferred.toolInput,
-							...(reason.trim() ? { reason: reason.trim() } : {}),
 						})
 					}
 				>

--- a/src/features/composer/index.test.tsx
+++ b/src/features/composer/index.test.tsx
@@ -121,6 +121,22 @@ function createAskUserQuestionDeferredTool(): PendingDeferredTool {
 	};
 }
 
+function createGenericDeferredTool(): PendingDeferredTool {
+	return {
+		provider: "claude",
+		modelId: "opus-1m",
+		resolvedModel: "opus-1m",
+		providerSessionId: "provider-session-1",
+		workingDirectory: "/tmp/helmor",
+		permissionMode: "default",
+		toolUseId: "tool-generic-1",
+		toolName: "Bash",
+		toolInput: {
+			command: "git status --short",
+		},
+	};
+}
+
 function createFormElicitation(): PendingElicitation {
 	return {
 		provider: "claude",
@@ -983,6 +999,55 @@ describe("WorkspaceComposer", () => {
 						},
 					},
 				}),
+			}),
+		);
+	});
+
+	it("keeps deferred tool approval buttons enabled while the stream is paused for approval", async () => {
+		const user = userEvent.setup();
+		const queryClient = createHelmorQueryClient();
+		const handleDeferredToolResponse = vi.fn();
+
+		render(
+			<QueryClientProvider client={queryClient}>
+				<WorkspaceComposer
+					contextKey="session:session-1"
+					onSubmit={vi.fn()}
+					disabled={false}
+					submitDisabled={false}
+					sending={true}
+					selectedModelId="opus-1m"
+					modelSections={MODEL_SECTIONS}
+					onSelectModel={vi.fn()}
+					provider="claude"
+					effortLevel="high"
+					onSelectEffort={vi.fn()}
+					permissionMode="acceptEdits"
+					onChangePermissionMode={vi.fn()}
+					restoreImages={[]}
+					restoreFiles={[]}
+					restoreCustomTags={[]}
+					pendingDeferredTool={createGenericDeferredTool()}
+					onDeferredToolResponse={handleDeferredToolResponse}
+				/>
+			</QueryClientProvider>,
+		);
+
+		const allowButton = screen.getByRole("button", { name: "Allow" });
+		const denyButton = screen.getByRole("button", { name: "Deny" });
+
+		expect(allowButton).toBeEnabled();
+		expect(denyButton).toBeEnabled();
+
+		await user.click(allowButton);
+
+		expect(handleDeferredToolResponse).toHaveBeenCalledWith(
+			expect.objectContaining({ toolUseId: "tool-generic-1" }),
+			"allow",
+			expect.objectContaining({
+				updatedInput: {
+					command: "git status --short",
+				},
 			}),
 		);
 	});

--- a/src/features/composer/index.tsx
+++ b/src/features/composer/index.tsx
@@ -409,7 +409,7 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 			) : hasPendingDeferredTool ? (
 				<DeferredToolPanel
 					deferred={pendingDeferredTool!}
-					disabled={disabled || sending}
+					disabled={disabled}
 					onResponse={onDeferredToolResponse}
 				/>
 			) : (


### PR DESCRIPTION
## What changed
- keep the generic deferred tool Allow and Deny buttons enabled while a stream is paused for approval
- remove the unused optional reason field from the generic deferred tool approval UI
- add a composer test covering the paused-for-approval state

## Why
When an agent paused for tool approval, the generic approval buttons were disabled because the composer treated the session as sending. That blocked the user from approving or denying the tool call.

## Test notes
- `bun x vitest run src/features/composer/index.test.tsx`

## Follow-up
- none