### PR TITLE
fix: preserve cached model catalog on startup

### DIFF
--- a/.changeset/blue-pears-wait.md
+++ b/.changeset/blue-pears-wait.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Keep the model picker populated from the last good startup cache and only overwrite that cache after a successful model refresh, so reopening Helmor no longer flashes an empty "Select model" state before the catalog loads.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -217,6 +217,9 @@ function MainApp() {
 							if (key[0] === "slashCommands") {
 								return false;
 							}
+							if (key[0] === "agentModelSections") {
+								return false;
+							}
 							// Workspace lists are fast local DB queries — always
 							// load fresh to avoid "ghost workspace" errors on startup.
 							if (

--- a/src/lib/model-catalog-cache.ts
+++ b/src/lib/model-catalog-cache.ts
@@ -1,0 +1,43 @@
+import type { AgentModelSection } from "./api";
+
+const MODEL_CATALOG_CACHE_KEY = "helmor-agent-model-sections";
+
+function canUseLocalStorage(): boolean {
+	return (
+		typeof window !== "undefined" && typeof window.localStorage !== "undefined"
+	);
+}
+
+export function hasUsableAgentModelSections(
+	sections: readonly AgentModelSection[] | null | undefined,
+): boolean {
+	return (sections ?? []).some((section) => section.options.length > 0);
+}
+
+export function readCachedAgentModelSections():
+	| AgentModelSection[]
+	| undefined {
+	if (!canUseLocalStorage()) return undefined;
+	try {
+		const raw = window.localStorage.getItem(MODEL_CATALOG_CACHE_KEY);
+		if (!raw) return undefined;
+		const parsed = JSON.parse(raw) as AgentModelSection[];
+		return hasUsableAgentModelSections(parsed) ? parsed : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+export function writeCachedAgentModelSections(
+	sections: readonly AgentModelSection[],
+): void {
+	if (!canUseLocalStorage() || !hasUsableAgentModelSections(sections)) return;
+	try {
+		window.localStorage.setItem(
+			MODEL_CATALOG_CACHE_KEY,
+			JSON.stringify(sections),
+		);
+	} catch {
+		// ignore
+	}
+}

--- a/src/lib/query-client.ts
+++ b/src/lib/query-client.ts
@@ -27,6 +27,11 @@ import {
 	type PullRequestInfo,
 	type WorkspacePrActionStatus,
 } from "./api";
+import {
+	hasUsableAgentModelSections,
+	readCachedAgentModelSections,
+	writeCachedAgentModelSections,
+} from "./model-catalog-cache";
 
 const SESSION_STALE_TIME = 10 * 60_000;
 const CHANGES_STALE_TIME = 3_000;
@@ -156,9 +161,19 @@ export function repositoriesQueryOptions() {
 }
 
 export function agentModelSectionsQueryOptions() {
+	const cached = readCachedAgentModelSections();
 	return queryOptions({
 		queryKey: helmorQueryKeys.agentModelSections,
-		queryFn: loadAgentModelSections,
+		queryFn: async () => {
+			const fresh = await loadAgentModelSections();
+			if (hasUsableAgentModelSections(fresh)) {
+				writeCachedAgentModelSections(fresh);
+				return fresh;
+			}
+			return cached ?? fresh;
+		},
+		initialData: cached,
+		initialDataUpdatedAt: cached ? Date.now() : undefined,
 		staleTime: Infinity,
 		refetchOnWindowFocus: false,
 		retry: 2,


### PR DESCRIPTION
## What changed
- keep the `agentModelSections` query out of the startup invalidation sweep so the model picker does not discard cached data on launch
- seed the query from a localStorage-backed last-good cache and only overwrite that cache after a successful refresh with usable model options
- add a changeset for the model picker startup fix

## Why
Reopening Helmor could briefly show an empty `Select model` state before the catalog finished loading. This keeps the previous valid model list available during startup and avoids replacing it with empty data.

## Follow-up / test notes
- Tests not run manually in this workspace
- Commit hooks ran Biome on staged frontend files during commit