### PR TITLE
Clear unread on hidden sessions so workspace dot doesn't stick

### DIFF
--- a/src-tauri/src/commands/tests/unread_state.rs
+++ b/src-tauri/src/commands/tests/unread_state.rs
@@ -235,3 +235,41 @@ fn mark_session_read_preserves_workspace_unread_while_other_sessions_stay_unread
     // Workspace flag must stay because the second session still has unread.
     assert_eq!(workspace_unread, 1);
 }
+
+#[test]
+fn hide_session_clears_its_unread_and_drops_workspace_flag() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let harness = ArchiveTestHarness::new(true);
+    let connection = Connection::open(crate::data_dir::db_path().unwrap()).unwrap();
+
+    // Only session in the workspace has unread; workspace flag is derived on.
+    connection
+        .execute(
+            "UPDATE sessions SET unread_count = 3 WHERE id = ?1",
+            [&harness.session_id],
+        )
+        .unwrap();
+    connection
+        .execute(
+            "UPDATE workspaces SET unread = 1 WHERE id = ?1",
+            [&harness.workspace_id],
+        )
+        .unwrap();
+
+    sessions::hide_session(&harness.session_id).unwrap();
+
+    let (session_unread, workspace_unread): (i64, i64) = connection
+        .query_row(
+            "SELECT (SELECT unread_count FROM sessions WHERE id = ?1), (SELECT unread FROM workspaces WHERE id = ?2)",
+            (&harness.session_id, &harness.workspace_id),
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+
+    // Hidden session's unread must be wiped (the user can't reach it).
+    assert_eq!(session_unread, 0);
+    // And the workspace flag should drop because nothing is unread any more.
+    assert_eq!(workspace_unread, 0);
+}

--- a/src-tauri/src/models/sessions.rs
+++ b/src-tauri/src/models/sessions.rs
@@ -488,6 +488,11 @@ pub fn hide_session(session_id: &str) -> Result<()> {
         )
         .with_context(|| format!("Failed to hide session {session_id}"))?;
 
+    // A hidden session can no longer contribute to the workspace unread dot —
+    // the user can't reach it to clear it. Drop its unread_count so the
+    // workspace flag can fall off too when this was the last unread session.
+    mark_session_read_in_transaction(&transaction, session_id)?;
+
     // If this was the workspace's active session, switch to the next visible one
     let current_active: Option<String> = transaction
         .query_row(


### PR DESCRIPTION
## Summary
- When a session is hidden, its `unread_count` is now zeroed out as part of the same transaction. The user can't reach a hidden session to clear it, so without this the workspace's derived `has_unread` stayed on indefinitely.
- Reuses `mark_session_read_in_transaction` inside `hide_session` so the existing `clear_workspace_unread_if_no_session_unread_in_transaction` propagation also drops the workspace flag when the hidden session was the last unread one.
- Follow-up to #174.

## Test plan
- [x] `cargo test unread_state` (7/7 pass, including new `hide_session_clears_its_unread_and_drops_workspace_flag`)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [ ] Manual: in dev, add a new session → bump it unread → hide it → workspace dot drops; then unhide → stays read (expected)