### PR TITLE
feat: persist thinking-block duration so "Thought for N seconds" survives reloads

### DIFF
--- a/src-tauri/src/pipeline/accumulator/mod.rs
+++ b/src-tauri/src/pipeline/accumulator/mod.rs
@@ -17,7 +17,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde_json::Value;
 
-fn now_ms() -> f64 {
+pub(super) fn now_ms() -> f64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
@@ -88,6 +88,17 @@ pub struct StreamAccumulator {
     fallback_text: String,
     /// Fallback flat delta thinking text.
     fallback_thinking: String,
+    /// Wall-clock ms at which each thinking block started streaming. Keyed
+    /// by the block's stable `__part_id` (`{turn_id}:blk:{index}`). Populated
+    /// at `content_block_start` and consumed when the block is finalized
+    /// (assistant event or content_block_stop) to derive `__duration_ms`.
+    /// Survives `finalize_blocks` because the block's live state is cleared
+    /// mid-turn — the duration needs to outlive that clear.
+    pub(super) thinking_start_ms: HashMap<String, f64>,
+    /// Computed duration for each thinking block by `__part_id`. Set once
+    /// at finalization and then stamped onto both the live partial and the
+    /// collected assistant message for persistence.
+    pub(super) thinking_duration_ms: HashMap<String, u64>,
     /// Stable timestamp for the current streaming partial.
     partial_created_at: Option<String>,
     /// DB UUID for the currently in-flight assistant turn. Minted on first
@@ -240,6 +251,8 @@ impl StreamAccumulator {
             fallback_thinking: String::new(),
             partial_created_at: None,
             active_turn_id: None,
+            thinking_start_ms: HashMap::new(),
+            thinking_duration_ms: HashMap::new(),
             line_count: 0,
             turns: Vec::new(),
             session_id: None,
@@ -830,7 +843,21 @@ impl StreamAccumulator {
                     } else {
                         format!("{turn_id}:blk:{}", self.cur_asst_block_count + i)
                     };
-                    obj.insert("__part_id".to_string(), Value::String(part_id));
+                    obj.insert("__part_id".to_string(), Value::String(part_id.clone()));
+
+                    // The `assistant` event marks a thinking block as
+                    // complete (the SDK ships it here fully populated).
+                    // content_block_stop usually arrives AFTER this event,
+                    // so this is the earliest point at which we can stamp
+                    // a duration. `finalize_thinking_duration` is
+                    // idempotent: if content_block_stop happens to beat
+                    // the assistant event, the value set there wins.
+                    if obj.get("type").and_then(Value::as_str) == Some("thinking") {
+                        streaming::finalize_thinking_duration(self, &part_id);
+                        if let Some(duration) = self.thinking_duration_ms.get(&part_id).copied() {
+                            obj.insert("__duration_ms".to_string(), Value::Number(duration.into()));
+                        }
+                    }
                 }
             }
             if cumulative_snapshot {

--- a/src-tauri/src/pipeline/accumulator/streaming.rs
+++ b/src-tauri/src/pipeline/accumulator/streaming.rs
@@ -101,6 +101,13 @@ fn handle_block_start(acc: &mut StreamAccumulator, event: &Value) {
             );
         }
         "thinking" => {
+            // Stamp the start ms so we can derive "Thought for N seconds"
+            // when the block finalizes (either via content_block_stop OR
+            // via the `assistant` event, whichever arrives first — in the
+            // real SDK the `assistant` event usually wins).
+            acc.thinking_start_ms
+                .entry(part_id.clone())
+                .or_insert_with(super::now_ms);
             acc.blocks.insert(
                 index,
                 StreamingBlock::Thinking {
@@ -181,6 +188,16 @@ fn handle_block_delta(acc: &mut StreamAccumulator, event: &Value) {
 
 fn handle_block_stop(acc: &mut StreamAccumulator, event: &Value) {
     let index = event.get("index").and_then(Value::as_u64).unwrap_or(0) as usize;
+    // Snapshot the thinking block's id + start ms BEFORE the mutable borrow
+    // so we can record the derived duration back into the accumulator below
+    // without juggling two &mut borrows of `acc`.
+    let thinking_finalize: Option<String> =
+        if let Some(StreamingBlock::Thinking { id, .. }) = acc.blocks.get(&index) {
+            Some(id.clone())
+        } else {
+            None
+        };
+
     match acc.blocks.get_mut(&index) {
         Some(StreamingBlock::Thinking { done, .. }) => {
             *done = true;
@@ -199,6 +216,26 @@ fn handle_block_stop(acc: &mut StreamAccumulator, event: &Value) {
             *status = "running";
         }
         _ => {}
+    }
+
+    if let Some(part_id) = thinking_finalize {
+        finalize_thinking_duration(acc, &part_id);
+    }
+}
+
+/// Compute `now - start` and store it in `thinking_duration_ms` if we have
+/// a start time and haven't recorded a duration yet. Idempotent — a second
+/// call for the same part id is a no-op so the value matches whichever
+/// event (content_block_stop or assistant-event finalization) arrived first.
+pub(super) fn finalize_thinking_duration(acc: &mut StreamAccumulator, part_id: &str) {
+    if acc.thinking_duration_ms.contains_key(part_id) {
+        return;
+    }
+    if let Some(start) = acc.thinking_start_ms.get(part_id).copied() {
+        let now = super::now_ms();
+        let elapsed = (now - start).max(0.0).round() as u64;
+        acc.thinking_duration_ms
+            .insert(part_id.to_string(), elapsed);
     }
 }
 
@@ -319,12 +356,16 @@ pub(super) fn build_partial_from_blocks(
             }
             StreamingBlock::Thinking { id, text, done } => {
                 if !text.is_empty() {
-                    content_blocks.push(serde_json::json!({
+                    let mut obj = serde_json::json!({
                         "type": "thinking",
                         "thinking": text,
                         "__is_streaming": !done,
                         "__part_id": id,
-                    }));
+                    });
+                    if let Some(duration) = acc.thinking_duration_ms.get(id).copied() {
+                        obj["__duration_ms"] = serde_json::json!(duration);
+                    }
+                    content_blocks.push(obj);
                 }
             }
             StreamingBlock::ToolUse {
@@ -394,11 +435,15 @@ pub(super) fn build_materialized_partial_from_blocks(
             }
             StreamingBlock::Thinking { id, text, .. } => {
                 if !text.is_empty() {
-                    content_blocks.push(serde_json::json!({
+                    let mut obj = serde_json::json!({
                         "type": "thinking",
                         "thinking": text,
                         "__part_id": id,
-                    }));
+                    });
+                    if let Some(duration) = acc.thinking_duration_ms.get(id).copied() {
+                        obj["__duration_ms"] = serde_json::json!(duration);
+                    }
+                    content_blocks.push(obj);
                 }
             }
             StreamingBlock::ToolUse {

--- a/src-tauri/src/pipeline/accumulator/tests.rs
+++ b/src-tauri/src/pipeline/accumulator/tests.rs
@@ -577,6 +577,82 @@ fn delta_assistant_events_with_same_msg_id_append_blocks() {
     assert_eq!(blocks[1]["id"].as_str(), Some("tool_1"));
 }
 
+/// Thinking-block duration (`__duration_ms`) is stamped onto the finalized
+/// block JSON so the frontend can render "Thought for N seconds" without a
+/// client-side timer. Live streaming stamps via `content_block_stop`; the
+/// `assistant` event stamps as a fallback when `stop` arrives later (the
+/// real Claude SDK ordering, confirmed via live trace against the Agent SDK).
+#[test]
+fn thinking_block_duration_stamped_on_finalized_assistant_event() {
+    let mut acc = StreamAccumulator::new("claude", "opus");
+    acc.push_event(
+        &json!({
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "thinking"}
+            }
+        }),
+        "",
+    );
+    acc.push_event(
+        &json!({
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "thinking_delta", "thinking": "hmm..."}
+            }
+        }),
+        "",
+    );
+    // `assistant` arrives BEFORE content_block_stop (real SDK ordering).
+    let asst = json!({
+        "type": "assistant",
+        "message": {
+            "id": "msg_1",
+            "role": "assistant",
+            "content": [{"type": "thinking", "thinking": "hmm..."}]
+        }
+    });
+    acc.push_event(&asst, &asst.to_string());
+    acc.flush_pending();
+
+    let turn = acc.turn_at(0);
+    let parsed: serde_json::Value = serde_json::from_str(&turn.content_json).unwrap();
+    let block = &parsed["message"]["content"][0];
+    assert_eq!(block["type"].as_str(), Some("thinking"));
+    assert!(
+        block
+            .get("__duration_ms")
+            .and_then(|v| v.as_u64())
+            .is_some(),
+        "assistant event must stamp __duration_ms onto the thinking block for persistence"
+    );
+
+    // Adapter should surface this as `duration_ms` on the Reasoning part.
+    let messages = acc.snapshot("ctx", "sess");
+    let rendered = crate::pipeline::adapter::convert(&messages);
+    let reasoning_duration = rendered
+        .iter()
+        .flat_map(|m| m.content.iter())
+        .find_map(|p| {
+            if let crate::pipeline::types::ExtendedMessagePart::Basic(
+                crate::pipeline::types::MessagePart::Reasoning { duration_ms, .. },
+            ) = p
+            {
+                *duration_ms
+            } else {
+                None
+            }
+        });
+    assert!(
+        reasoning_duration.is_some(),
+        "adapter must plumb __duration_ms into MessagePart::Reasoning.duration_ms"
+    );
+}
+
 /// Different msg_id should still REPLACE, not append. Pins the boundary
 /// case so a future "always append" mistake gets caught.
 #[test]

--- a/src-tauri/src/pipeline/adapter/blocks.rs
+++ b/src-tauri/src/pipeline/adapter/blocks.rs
@@ -97,10 +97,12 @@ pub(super) fn parse_assistant_parts(parsed: Option<&Value>, msg_id: &str) -> Vec
                         .get("__is_streaming")
                         .and_then(Value::as_bool)
                         .unwrap_or(false);
+                    let duration_ms = obj.get("__duration_ms").and_then(Value::as_u64);
                     parts.push(MessagePart::Reasoning {
                         id: resolve_part_id(obj, msg_id, idx),
                         text: text.to_string(),
                         streaming: if is_streaming { Some(true) } else { None },
+                        duration_ms,
                     });
                 }
             }
@@ -109,6 +111,7 @@ pub(super) fn parse_assistant_parts(parsed: Option<&Value>, msg_id: &str) -> Vec
                     id: resolve_part_id(obj, msg_id, idx),
                     text: "[Thinking redacted]".to_string(),
                     streaming: None,
+                    duration_ms: None,
                 });
             }
             "text" => {

--- a/src-tauri/src/pipeline/adapter/codex_items.rs
+++ b/src-tauri/src/pipeline/adapter/codex_items.rs
@@ -138,6 +138,7 @@ fn render_reasoning(msg: &IntermediateMessage, item: &Value, result: &mut Vec<Th
                     id: format!("{}:blk:0", msg.id),
                     text: text.to_string(),
                     streaming: None,
+                    duration_ms: None,
                 })],
                 status: Some(MessageStatus {
                     status_type: "complete".to_string(),

--- a/src-tauri/src/pipeline/collapse.rs
+++ b/src-tauri/src/pipeline/collapse.rs
@@ -343,6 +343,7 @@ mod tests {
             id: format!("r-{t}"),
             text: t.to_string(),
             streaming: None,
+            duration_ms: None,
         })
     }
 

--- a/src-tauri/src/pipeline/types.rs
+++ b/src-tauri/src/pipeline/types.rs
@@ -119,13 +119,20 @@ pub enum MessagePart {
     Text { id: String, text: String },
 
     /// Extended thinking / reasoning block.
-    #[serde(rename = "reasoning")]
+    #[serde(rename = "reasoning", rename_all = "camelCase")]
     Reasoning {
         id: String,
         text: String,
         /// Per-part streaming state — only the active thinking block is streaming.
         #[serde(skip_serializing_if = "Option::is_none")]
         streaming: Option<bool>,
+        /// Elapsed ms from block start to finalization. Populated by the
+        /// accumulator when the SDK's `assistant` event (or
+        /// `content_block_stop`) lands — whichever arrives first. Persisted
+        /// into the block JSON so historical reloads keep the
+        /// "Thought for N seconds" label without needing a client-side timer.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        duration_ms: Option<u64>,
     },
 
     /// Tool invocation with optional result.

--- a/src-tauri/tests/thinking_block_replay.rs
+++ b/src-tauri/tests/thinking_block_replay.rs
@@ -1,0 +1,149 @@
+//! Replay the real Claude Agent SDK NDJSON dump captured at
+//! `/tmp/claude-sdk-test/events.ndjson` and print what the pipeline
+//! actually emits at each stage. Run with:
+//!
+//!   cargo test --manifest-path src-tauri/Cargo.toml \
+//!     --test thinking_block_replay -- --nocapture
+//!
+//! Not a pass/fail gate — exists to expose where `streaming`,
+//! `durationMs`, and part-id flow diverge from the raw SDK stream.
+
+use helmor_lib::pipeline::accumulator::StreamAccumulator;
+use helmor_lib::pipeline::adapter::convert;
+use helmor_lib::pipeline::types::{ExtendedMessagePart, MessagePart};
+use serde_json::Value;
+use std::fs;
+
+fn variant_tag(part: &ExtendedMessagePart) -> &'static str {
+    match part {
+        ExtendedMessagePart::Basic(MessagePart::Text { .. }) => "Text",
+        ExtendedMessagePart::Basic(MessagePart::Reasoning { .. }) => "Reasoning",
+        ExtendedMessagePart::Basic(MessagePart::ToolCall { .. }) => "ToolCall",
+        ExtendedMessagePart::Basic(MessagePart::Image { .. }) => "Image",
+        ExtendedMessagePart::Basic(MessagePart::TodoList { .. }) => "TodoList",
+        ExtendedMessagePart::Basic(MessagePart::SystemNotice { .. }) => "SystemNotice",
+        ExtendedMessagePart::Basic(MessagePart::PlanReview { .. }) => "PlanReview",
+        ExtendedMessagePart::Basic(MessagePart::PromptSuggestion { .. }) => "PromptSuggestion",
+        ExtendedMessagePart::CollapsedGroup(_) => "CollapsedGroup",
+        _ => "Other",
+    }
+}
+
+#[test]
+fn replay_real_sdk_dump() {
+    let path = "/tmp/claude-sdk-test/events.ndjson";
+    let Ok(contents) = fs::read_to_string(path) else {
+        eprintln!("skip: no dump at {path}");
+        return;
+    };
+
+    let mut acc = StreamAccumulator::new("claude", "claude-sonnet-4-5");
+    let mut line_no = 0usize;
+
+    for raw_line in contents.lines() {
+        line_no += 1;
+        let value: Value = match serde_json::from_str(raw_line) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("line {line_no}: parse err {e}");
+                continue;
+            }
+        };
+        let outcome = acc.push_event(&value, raw_line);
+
+        let evt_type = value.get("type").and_then(Value::as_str).unwrap_or("?");
+        let inner_evt = value
+            .get("event")
+            .and_then(|e| e.get("type"))
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        let delta_t = value
+            .get("event")
+            .and_then(|e| e.get("delta"))
+            .and_then(|d| d.get("type"))
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        let idx = value
+            .get("event")
+            .and_then(|e| e.get("index"))
+            .and_then(Value::as_u64);
+
+        eprintln!(
+            "[{line_no:02}] outcome={outcome:?} type={evt_type} evt={inner_evt} delta={delta_t} idx={idx:?}"
+        );
+
+        // After each event, dump what a live partial or collected slice
+        // looks like for thinking blocks.
+        let partial = acc.build_partial("ctx", "sess");
+        if let Some(p) = partial {
+            dump_thinking_state("partial", &p.parsed);
+        }
+        for (i, m) in acc.collected().iter().enumerate() {
+            dump_thinking_state(&format!("collected[{i}]"), &m.parsed);
+        }
+    }
+
+    // Finalize and show the end-state render
+    acc.flush_pending();
+
+    eprintln!("\n=== final render (after flush) ===");
+    let messages = acc.collected().to_vec();
+    let rendered = convert(&messages);
+    for (i, m) in rendered.iter().enumerate() {
+        eprintln!(
+            "msg[{i}] role={:?} streaming={:?} parts={}",
+            m.role,
+            m.streaming,
+            m.content.len()
+        );
+        for (j, part) in m.content.iter().enumerate() {
+            match part {
+                ExtendedMessagePart::Basic(MessagePart::Reasoning {
+                    id,
+                    streaming,
+                    duration_ms,
+                    text,
+                }) => {
+                    eprintln!(
+                        "  [{j}] Reasoning id={id} streaming={streaming:?} duration_ms={duration_ms:?} text_len={}",
+                        text.len()
+                    );
+                }
+                ExtendedMessagePart::Basic(MessagePart::Text { id, text }) => {
+                    eprintln!("  [{j}] Text id={id} len={}", text.len());
+                }
+                other => {
+                    eprintln!("  [{j}] {}", variant_tag(other));
+                }
+            }
+        }
+    }
+}
+
+fn dump_thinking_state(label: &str, parsed: &Option<Value>) {
+    let Some(parsed) = parsed else { return };
+    let Some(blocks) = parsed
+        .get("message")
+        .and_then(|m| m.get("content"))
+        .and_then(Value::as_array)
+    else {
+        return;
+    };
+    for (i, b) in blocks.iter().enumerate() {
+        let Some(obj) = b.as_object() else { continue };
+        if obj.get("type").and_then(Value::as_str) != Some("thinking") {
+            continue;
+        }
+        let part_id = obj.get("__part_id").and_then(Value::as_str).unwrap_or("-");
+        let is_streaming = obj.get("__is_streaming").and_then(Value::as_bool);
+        let duration = obj.get("__duration_ms").and_then(Value::as_u64);
+        let text_len = obj
+            .get("thinking")
+            .and_then(Value::as_str)
+            .map(str::len)
+            .unwrap_or(0);
+        eprintln!(
+            "    {label}[{i}] thinking part_id={part_id} streaming={is_streaming:?} duration_ms={duration:?} text_len={text_len}"
+        );
+    }
+}

--- a/src/components/ai/reasoning.tsx
+++ b/src/components/ai/reasoning.tsx
@@ -48,8 +48,10 @@ export const Reasoning = memo(
 		children,
 		...props
 	}: ReasoningProps) => {
-		// Historical (non-streaming) blocks start collapsed to avoid re-opening on remount.
-		const resolvedDefaultOpen = defaultOpen ?? isStreaming;
+		// Always default to open — users asked us NOT to auto-collapse
+		// completed thinking blocks. Callers can still pass `defaultOpen={false}`
+		// explicitly, or control `open` via the parent.
+		const resolvedDefaultOpen = defaultOpen ?? true;
 
 		const [isOpen, setIsOpen] = useControllableState({
 			prop: open,

--- a/src/features/panel/message-components/assistant-message.tsx
+++ b/src/features/panel/message-components/assistant-message.tsx
@@ -162,8 +162,20 @@ export function ChatAssistantMessage({
 					);
 				}
 				if (isReasoningPart(part)) {
+					// Backend-stamped duration (ms); prefer over client-side
+					// timer so historical reloads and immediate-finalize turns
+					// (where `isStreaming` is false on first mount) still show
+					// "Thought for N seconds".
+					const durationSeconds =
+						typeof part.durationMs === "number"
+							? Math.max(1, Math.ceil(part.durationMs / 1000))
+							: undefined;
 					return (
-						<Reasoning key={key} isStreaming={part.streaming === true}>
+						<Reasoning
+							key={key}
+							isStreaming={part.streaming === true}
+							duration={durationSeconds}
+						>
 							<ReasoningTrigger />
 							<ReasoningContent fontSize={settings.fontSize}>
 								{part.text}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1591,6 +1591,10 @@ export type ReasoningPart = {
 	text: string;
 	/** Per-part streaming state — only the active thinking block is streaming. */
 	streaming?: boolean;
+	/** Elapsed ms from block start to finalization, stamped by the Rust
+	 *  accumulator. Persisted, so historical reloads keep the "Thought for
+	 *  N seconds" label without needing a client-side timer. */
+	durationMs?: number;
 };
 export type ToolCallPart = {
 	type: "tool-call";

--- a/src/lib/structural-equality.ts
+++ b/src/lib/structural-equality.ts
@@ -61,7 +61,11 @@ export function partStructurallyEqual(
 		}
 		case "reasoning": {
 			const rb = b as Extract<MessagePart, { type: "reasoning" }>;
-			return a.text === rb.text && a.streaming === rb.streaming;
+			return (
+				a.text === rb.text &&
+				a.streaming === rb.streaming &&
+				a.durationMs === rb.durationMs
+			);
 		}
 		case "tool-call": {
 			const tb = b as ToolCallPart;


### PR DESCRIPTION
## Summary

- Stamp an elapsed `__duration_ms` onto each thinking block in the Rust `StreamAccumulator` when the block finalizes (whichever of `content_block_stop` or the SDK `assistant` event arrives first), and plumb it through the adapter as `MessagePart::Reasoning.duration_ms` / `ReasoningPart.durationMs` on the frontend.
- Teach `assistant-message.tsx` to pass the backend-stamped duration into `<Reasoning>` as seconds so the "Thought for N seconds" label shows up on historical reloads and on turns where the reasoning block is already complete on first mount.
- Default `<Reasoning>` to open (instead of only when streaming). Users asked us to stop auto-collapsing completed thinking blocks; callers can still pass `defaultOpen={false}` or control `open` explicitly.
- Include `durationMs` in `partStructurallyEqual` for reasoning parts so the duration stamp actually propagates through the React Query / structural-equality cache.

## Why

Previously "Thought for N seconds" relied on a client-side timer that only ran while the block was actively streaming. Historical reloads and fast-finalizing turns lost the label entirely, because by the time React mounted the block it was already non-streaming. Moving the measurement to the accumulator (which sees block start + finalization timestamps directly) fixes both cases and keeps the label stable across reloads since the value is persisted in the session_messages content JSON.

## Test plan

- [x] `cargo test --manifest-path src-tauri/Cargo.toml` — new `thinking_block_duration_stamped_on_finalized_assistant_event` unit test covers the assistant-event-before-content_block_stop ordering (matches the real SDK behavior).
- [ ] Manual: trigger a thinking turn in the app and confirm the label renders live AND after reloading the session.
- [ ] Manual: reload an older session that has a completed thinking block and confirm the label now appears (new sessions only — historical DB rows won't have `__duration_ms`).
- [ ] New `src-tauri/tests/thinking_block_replay.rs` is a diagnostic (not a gate); it replays a real NDJSON dump if present at `/tmp/claude-sdk-test/events.ndjson` and skips otherwise.