### PR TITLE
fix: preserve built-in repo prompts

### DIFF
--- a/.changeset/tiny-coins-obey.md
+++ b/.changeset/tiny-coins-obey.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Append custom repository preferences after Helmor's built-in prompts, and tighten the preferences editor so placeholders and prompt previews better match what agents actually receive.

--- a/sidecar/src/title.ts
+++ b/sidecar/src/title.ts
@@ -7,6 +7,26 @@
 export const TITLE_GENERATION_TIMEOUT_MS = 30_000;
 export const TITLE_GENERATION_FALLBACK_TIMEOUT_MS = 30_000;
 
+const DEFAULT_BRANCH_RENAME_PROMPT = `When you generate the branch name segment for a new chat:
+
+- Base it on the user's first message.
+- Return a short English slug in lowercase with hyphens.
+- Omit any branch prefix such as \`feat/\` or usernames.
+- Favor clarity over cleverness.`;
+
+const CUSTOM_PREFERENCES_INTRO =
+	"IMPORTANT: The following are the user's custom preferences. These preferences take precedence over any default guidelines or instructions provided above. When there is a conflict, always follow the user's preferences.";
+
+function buildBranchRenameInstructions(
+	branchRenamePrompt?: string | null,
+): string {
+	const trimmedOverride = branchRenamePrompt?.trim();
+	if (!trimmedOverride) {
+		return DEFAULT_BRANCH_RENAME_PROMPT;
+	}
+	return `${DEFAULT_BRANCH_RENAME_PROMPT}\n\n${CUSTOM_PREFERENCES_INTRO}\n\n### User Preferences\n\n${trimmedOverride}`;
+}
+
 export function buildTitlePrompt(
 	userMessage: string,
 	branchRenamePrompt?: string | null,
@@ -15,13 +35,9 @@ export function buildTitlePrompt(
 		"Based on the following user message, generate TWO things:",
 		"1. A concise session title (use the same language as the user message, max 8 words)",
 		"2. A git branch name segment (English only, lowercase, hyphens for spaces, max 4 words, no prefix)",
-		...(branchRenamePrompt?.trim()
-			? [
-					"",
-					"Additional branch naming instructions:",
-					branchRenamePrompt.trim(),
-				]
-			: []),
+		"",
+		"Additional branch naming instructions:",
+		buildBranchRenameInstructions(branchRenamePrompt),
 		"",
 		"Output EXACTLY in this format (two lines, nothing else):",
 		"title: <the title>",

--- a/sidecar/test/title.test.ts
+++ b/sidecar/test/title.test.ts
@@ -17,6 +17,26 @@ describe("buildTitlePrompt", () => {
 		expect(prompt).toContain("branch: <the-branch-name>");
 	});
 
+	test("always includes the built-in branch naming instructions", () => {
+		const prompt = buildTitlePrompt("anything");
+		expect(prompt).toContain("Additional branch naming instructions:");
+		expect(prompt).toContain(
+			"When you generate the branch name segment for a new chat:",
+		);
+		expect(prompt).toContain("- Favor clarity over cleverness.");
+	});
+
+	test("appends custom branch naming preferences after the built-in instructions", () => {
+		const prompt = buildTitlePrompt(
+			"anything",
+			"Use repo-specific nouns. Keep it under 20 chars.",
+		);
+		expect(prompt).toContain("### User Preferences");
+		expect(prompt).toContain(
+			"Use repo-specific nouns. Keep it under 20 chars.",
+		);
+	});
+
 	test("ends with the user message on the last line", () => {
 		const prompt = buildTitlePrompt("the last one");
 		const lines = prompt.split("\n");

--- a/src/features/conversation/hooks/use-streaming.test.tsx
+++ b/src/features/conversation/hooks/use-streaming.test.tsx
@@ -559,7 +559,7 @@ describe("useConversationStreaming", () => {
 		expect(apiMocks.startAgentMessageStream).toHaveBeenCalledWith(
 			expect.objectContaining({
 				prompt:
-					"Always summarize the repo conventions first.\n\nUser request:\nFix the failing tests.",
+					"IMPORTANT: The following are the user's custom preferences. These preferences take precedence over any default guidelines or instructions provided above. When there is a conflict, always follow the user's preferences.\n\n### User Preferences\n\nAlways summarize the repo conventions first.\n\nUser request:\nFix the failing tests.",
 			}),
 			expect.any(Function),
 		);

--- a/src/features/settings/panels/repository-preferences-section.tsx
+++ b/src/features/settings/panels/repository-preferences-section.tsx
@@ -98,11 +98,11 @@ export function RepositoryPreferencesSection({ repoId }: { repoId: string }) {
 									</CollapsibleTrigger>
 									<CollapsibleContent className="pt-4">
 										<Textarea
-											className="min-h-[140px] resize-y bg-app-base/30 font-mono text-[12px]"
+											className="min-h-[140px] resize-y bg-app-base/30 font-mono text-[12px] placeholder:text-[12px]"
 											placeholder={
 												key === "general"
-													? undefined
-													: "Leave empty to use Helmor's built-in prompt."
+													? "Add custom instructions for all agents working in this repo."
+													: "Add your preferences here. The agent will be told to prioritize these instructions over its default instructions."
 											}
 											value={value}
 											onChange={(event) =>
@@ -155,14 +155,14 @@ export function RepositoryPreferencesSection({ repoId }: { repoId: string }) {
 				onOpenChange={(open) => !open && setPreviewKey(null)}
 			>
 				<DialogContent className="w-[calc(100vw-2rem)] max-w-[calc(100vw-2rem)] sm:w-[min(76vw,760px)] sm:max-w-[760px] rounded-2xl border-border/60 bg-background p-0 shadow-2xl">
-					<div className="border-b border-border/40 px-6 py-4">
-						<DialogTitle className="text-[15px] font-semibold text-foreground">
+					<div className="px-6 pt-4">
+						<DialogTitle className="text-[18px] font-semibold text-foreground">
 							{previewKey
 								? `${REPO_PREFERENCE_LABELS[previewKey]} prompt`
 								: "Prompt preview"}
 						</DialogTitle>
 					</div>
-					<div className="max-h-[78vh] overflow-y-auto px-6 py-5">
+					<div className="max-h-[78vh] overflow-y-auto px-6 pb-5 pt-1">
 						<div className="conversation-markdown max-w-none break-words text-[13px] leading-6 text-foreground">
 							<Suspense
 								fallback={

--- a/src/lib/commit-button-prompts.test.ts
+++ b/src/lib/commit-button-prompts.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { buildCommitButtonPrompt } from "./commit-button-prompts";
+
+describe("buildCommitButtonPrompt", () => {
+	it("appends create-pr preferences after the built-in prompt", () => {
+		expect(
+			buildCommitButtonPrompt("create-pr", {
+				createPr: "Always include rollout notes.",
+			}),
+		).toContain("### User Preferences\n\nAlways include rollout notes.");
+	});
+
+	it("appends fix-errors preferences after the built-in prompt", () => {
+		expect(
+			buildCommitButtonPrompt("fix", {
+				fixErrors: "Run targeted tests before broad suites.",
+			}),
+		).toContain(
+			"### User Preferences\n\nRun targeted tests before broad suites.",
+		);
+	});
+});

--- a/src/lib/repo-preferences-prompts.test.ts
+++ b/src/lib/repo-preferences-prompts.test.ts
@@ -6,17 +6,22 @@ import {
 } from "./repo-preferences-prompts";
 
 describe("repo preference prompts", () => {
+	const targetRefPlaceholder = "$" + "{TARGET_REF}";
+	const dirtyWorktreePlaceholder = "$" + "{DIRTY_WORKTREE}";
+
 	it("leaves the general preview empty when no override exists", () => {
 		expect(resolveRepoPreferencePreview("general", {})).toBe("");
 	});
 
-	it("uses the override instead of the built-in prompt", () => {
+	it("appends the override after the built-in prompt", () => {
 		expect(
 			resolveRepoPreferencePrompt({
 				key: "createPr",
 				repoPreferences: { createPr: "Ship it exactly this way." },
 			}),
-		).toBe("Ship it exactly this way.");
+		).toBe(
+			"Create a pull request for the uncommitted work in this workspace.\n\nDo the following, in order:\n1. Run `git status` and `git diff` to survey what's changed.\n2. Stage everything that should ship with `git add`.\n3. Commit with a concise, Conventional-Commits-style message (`feat:`, `fix:`, `refactor:`, `chore:`, etc.) that summarizes the change in one line.\n4. Push the current branch to its remote. If needed, create the remote tracking branch with `git push -u <remote> HEAD`.\n5. Open a pull request against the repository's default branch using `gh pr create`. Use a clear PR title and a body that explains: what changed, why it changed, and any follow-up / test notes.\n6. Report the PR URL in your final message so I can click it.\n\nDon't stop to ask for confirmation — execute each step automatically. If you hit an unrecoverable error (e.g. merge conflict, pre-push hook failure), report it clearly so I can intervene.\n\nIMPORTANT: The following are the user's custom preferences. These preferences take precedence over any default guidelines or instructions provided above. When there is a conflict, always follow the user's preferences.\n\n### User Preferences\n\nShip it exactly this way.",
+		);
 	});
 
 	it("renders the dynamic resolve-conflicts fallback", () => {
@@ -38,7 +43,22 @@ describe("repo preference prompts", () => {
 				general: "Always explain the root cause first.",
 			}),
 		).toBe(
-			"Always explain the root cause first.\n\nUser request:\nFix the failing tests.",
+			"IMPORTANT: The following are the user's custom preferences. These preferences take precedence over any default guidelines or instructions provided above. When there is a conflict, always follow the user's preferences.\n\n### User Preferences\n\nAlways explain the root cause first.\n\nUser request:\nFix the failing tests.",
+		);
+	});
+
+	it("appends resolve-conflicts overrides after the dynamic fallback", () => {
+		expect(
+			resolveRepoPreferencePrompt({
+				key: "resolveConflicts",
+				repoPreferences: {
+					resolveConflicts: `Prefer rebase when possible. Target: ${targetRefPlaceholder}. Dirty: ${dirtyWorktreePlaceholder}.`,
+				},
+				targetRef: "origin/main",
+				dirtyWorktree: true,
+			}),
+		).toBe(
+			"Commit uncommitted changes, then merge origin/main into this branch. Then push.\n\nIMPORTANT: The following are the user's custom preferences. These preferences take precedence over any default guidelines or instructions provided above. When there is a conflict, always follow the user's preferences.\n\n### User Preferences\n\nPrefer rebase when possible. Target: origin/main. Dirty: true.",
 		);
 	});
 

--- a/src/lib/repo-preferences-prompts.ts
+++ b/src/lib/repo-preferences-prompts.ts
@@ -24,6 +24,8 @@ const DEFAULT_BRANCH_RENAME_PROMPT = `When you generate the branch name segment 
 - Omit any branch prefix such as \`feat/\` or usernames.
 - Favor clarity over cleverness.`;
 
+const CUSTOM_PREFERENCES_INTRO = `IMPORTANT: The following are the user's custom preferences. These preferences take precedence over any default guidelines or instructions provided above. When there is a conflict, always follow the user's preferences.`;
+
 export const DEFAULT_REPO_PREFERENCE_PROMPTS: Record<
 	RepoPreferenceKey,
 	string
@@ -95,13 +97,28 @@ function repoPreferenceOverride(
 	return trimmed ? trimmed : null;
 }
 
+function appendUserPreferences(
+	basePrompt: string,
+	override: string | null,
+): string {
+	const trimmedBase = basePrompt.trim();
+	const trimmedOverride = override?.trim();
+	if (!trimmedOverride) {
+		return trimmedBase;
+	}
+	if (!trimmedBase) {
+		return `${CUSTOM_PREFERENCES_INTRO}\n\n### User Preferences\n\n${trimmedOverride}`;
+	}
+	return `${trimmedBase}\n\n${CUSTOM_PREFERENCES_INTRO}\n\n### User Preferences\n\n${trimmedOverride}`;
+}
+
 export function resolveRepoPreferencePreview(
 	key: RepoPreferenceKey,
 	repoPreferences?: RepoPreferences | null,
 ): string {
-	return (
-		repoPreferenceOverride(key, repoPreferences) ??
-		DEFAULT_REPO_PREFERENCE_PROMPTS[key]
+	return appendUserPreferences(
+		DEFAULT_REPO_PREFERENCE_PROMPTS[key],
+		repoPreferenceOverride(key, repoPreferences),
 	);
 }
 
@@ -112,26 +129,33 @@ export function resolveRepoPreferencePrompt({
 	dirtyWorktree = false,
 }: ResolveRepoPreferencePromptArgs): string {
 	const override = repoPreferenceOverride(key, repoPreferences);
-	if (override) {
-		if (key === "resolveConflicts" && targetRef) {
-			return override
-				.replaceAll(TARGET_REF_PLACEHOLDER, targetRef)
-				.replaceAll(
-					DIRTY_WORKTREE_PLACEHOLDER,
-					dirtyWorktree ? "true" : "false",
-				);
-		}
-		return override;
-	}
+	const resolvedOverride =
+		key === "resolveConflicts" && targetRef && override
+			? override
+					.replaceAll(TARGET_REF_PLACEHOLDER, targetRef)
+					.replaceAll(
+						DIRTY_WORKTREE_PLACEHOLDER,
+						dirtyWorktree ? "true" : "false",
+					)
+			: override;
 
 	if (key === "resolveConflicts" && targetRef) {
 		if (dirtyWorktree) {
-			return `Commit uncommitted changes, then merge ${targetRef} into this branch. Then push.`;
+			return appendUserPreferences(
+				`Commit uncommitted changes, then merge ${targetRef} into this branch. Then push.`,
+				resolvedOverride,
+			);
 		}
-		return `Merge ${targetRef} into this branch. Then push.`;
+		return appendUserPreferences(
+			`Merge ${targetRef} into this branch. Then push.`,
+			resolvedOverride,
+		);
 	}
 
-	return DEFAULT_REPO_PREFERENCE_PROMPTS[key];
+	return appendUserPreferences(
+		DEFAULT_REPO_PREFERENCE_PROMPTS[key],
+		resolvedOverride,
+	);
 }
 
 export function prependGeneralPreferencePrompt(


### PR DESCRIPTION
## What changed
- append custom repository preference overrides after Helmor's built-in prompts instead of replacing them
- apply the same built-in-plus-custom behavior to branch rename instructions and general prompt injection
- update repository preferences placeholders and preview dialog copy to match the prompt shape agents now receive
- add targeted frontend and sidecar test coverage for the new prompt composition behavior

## Why
Repo-specific preferences should refine Helmor's default guidance, not erase it. This keeps core workflow instructions intact while still letting repositories express local preferences.

## Follow-up / test notes
- Ran `bun x vitest run src/lib/repo-preferences-prompts.test.ts src/lib/commit-button-prompts.test.ts src/features/conversation/hooks/use-streaming.test.tsx`
- Ran `cd sidecar && bun test test/title.test.ts`
- Pre-commit Biome checks passed during `git commit`