### PR TITLE
feat: show shine border on workspace avatar when run script is running

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -352,7 +352,7 @@ body {
 		50% {
 			background-position: 100% 100%;
 		}
-		100% {
+		to {
 			background-position: 0% 0%;
 		}
 	}

--- a/src/components/ui/shine-border.tsx
+++ b/src/components/ui/shine-border.tsx
@@ -1,13 +1,32 @@
-import type { CSSProperties, HTMLAttributes } from "react";
+"use client";
+
+import type * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-type ShineBorderProps = HTMLAttributes<HTMLDivElement> & {
+interface ShineBorderProps extends React.HTMLAttributes<HTMLDivElement> {
+	/**
+	 * Width of the border in pixels
+	 * @default 1
+	 */
 	borderWidth?: number;
+	/**
+	 * Duration of the animation in seconds
+	 * @default 14
+	 */
 	duration?: number;
+	/**
+	 * Color of the border, can be a single color or an array of colors
+	 * @default "#000000"
+	 */
 	shineColor?: string | string[];
-};
+}
 
+/**
+ * Shine Border
+ *
+ * An animated background border effect component with configurable properties.
+ */
 export function ShineBorder({
 	borderWidth = 1,
 	duration = 14,
@@ -22,22 +41,20 @@ export function ShineBorder({
 				{
 					"--border-width": `${borderWidth}px`,
 					"--duration": `${duration}s`,
-					backgroundImage: `radial-gradient(transparent, transparent, ${
+					backgroundImage: `radial-gradient(transparent,transparent, ${
 						Array.isArray(shineColor) ? shineColor.join(",") : shineColor
-					}, transparent, transparent)`,
+					},transparent,transparent)`,
 					backgroundSize: "300% 300%",
-					clipPath: "inset(0 0 var(--border-width) 0 round inherit)",
-					mask: "linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)",
-					WebkitMask:
-						"linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)",
+					mask: `linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)`,
+					WebkitMask: `linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)`,
 					WebkitMaskComposite: "xor",
 					maskComposite: "exclude",
 					padding: "var(--border-width)",
 					...style,
-				} as CSSProperties
+				} as React.CSSProperties
 			}
 			className={cn(
-				"pointer-events-none absolute inset-0 size-full rounded-[inherit] motion-safe:animate-shine will-change-[background-position]",
+				"motion-safe:animate-shine pointer-events-none absolute inset-0 size-full rounded-[inherit] will-change-[background-position]",
 				className,
 			)}
 			{...props}

--- a/src/features/navigation/avatar.tsx
+++ b/src/features/navigation/avatar.tsx
@@ -5,6 +5,7 @@ import {
 	AvatarFallback,
 	AvatarImage,
 } from "@/components/ui/avatar";
+import { ShineBorder } from "@/components/ui/shine-border";
 import { cn } from "@/lib/utils";
 
 function initialsFromLabel(label?: string | null) {
@@ -44,6 +45,7 @@ export const WorkspaceAvatar = memo(function WorkspaceAvatar({
 	fallbackClassName,
 	badgeClassName,
 	badgeAriaLabel,
+	isRunning,
 }: {
 	repoIconSrc?: string | null;
 	repoInitials?: string | null;
@@ -53,6 +55,7 @@ export const WorkspaceAvatar = memo(function WorkspaceAvatar({
 	fallbackClassName?: string;
 	badgeClassName?: string | null;
 	badgeAriaLabel?: string;
+	isRunning?: boolean;
 }) {
 	const fallback = (
 		repoInitials?.trim() || initialsFromLabel(repoName || title)
@@ -99,11 +102,24 @@ export const WorkspaceAvatar = memo(function WorkspaceAvatar({
 					{fallback}
 				</AvatarFallback>
 			) : null}
+			{isRunning ? (
+				<ShineBorder
+					borderWidth={1}
+					duration={6}
+					shineColor={["#A07CFE", "#FE8FB5", "#FFBE7B"]}
+					style={{
+						inset: "-2px",
+						width: "calc(100% + 4px)",
+						height: "calc(100% + 4px)",
+						borderRadius: "6px",
+					}}
+				/>
+			) : null}
 			{badgeClassName ? (
 				<AvatarBadge
 					aria-label={badgeAriaLabel}
 					className={cn(
-						"bottom-auto -top-0.5 size-1.5 border-0 ring-2 ring-sidebar",
+						"bottom-auto -top-0.5 z-10 size-1.5 border-0 ring-2 ring-sidebar",
 						badgeClassName,
 					)}
 				/>

--- a/src/features/navigation/row-item.tsx
+++ b/src/features/navigation/row-item.tsx
@@ -9,7 +9,7 @@ import {
 	RotateCcw,
 	Trash2,
 } from "lucide-react";
-import { memo, useEffect } from "react";
+import { memo, useEffect, useState } from "react";
 import { HelmorThinkingIndicator } from "@/components/helmor-thinking-indicator";
 import { Button } from "@/components/ui/button";
 import {
@@ -28,6 +28,10 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
+import {
+	getScriptState,
+	subscribeStatus,
+} from "@/features/inspector/script-store";
 import type { DerivedStatus, WorkspaceRow } from "@/lib/api";
 import { recordSidebarRowRender } from "@/lib/dev-render-debug";
 import { cn } from "@/lib/utils";
@@ -78,6 +82,26 @@ export type WorkspaceRowItemProps = {
 	workspaceActionsDisabled?: boolean;
 };
 
+/**
+ * Subscribes to this workspace's `run`-script status via the module-level
+ * script-store used by the inspector. Returns true only while the script is
+ * actively executing (not "idle" or "exited"). Per-row subscription keeps the
+ * re-render fan-out narrow — only rows whose status flipped re-render.
+ */
+function useIsRunScriptRunning(workspaceId: string): boolean {
+	const [running, setRunning] = useState(
+		() => getScriptState(workspaceId, "run")?.status === "running",
+	);
+	useEffect(() => {
+		// Re-sync when the row is reused for a different workspace (virtual list).
+		setRunning(getScriptState(workspaceId, "run")?.status === "running");
+		return subscribeStatus(workspaceId, "run", (status) => {
+			setRunning(status === "running");
+		});
+	}, [workspaceId]);
+	return running;
+}
+
 export const WorkspaceRowItem = memo(
 	function WorkspaceRowItem({
 		row,
@@ -101,6 +125,7 @@ export const WorkspaceRowItem = memo(
 		useEffect(() => {
 			recordSidebarRowRender(row.id);
 		});
+		const isRunScriptRunning = useIsRunScriptRunning(row.id);
 		const actionLabel =
 			row.state === "archived" ? "Restore workspace" : "Archive workspace";
 		const isArchiving = archivingWorkspaceIds?.has(row.id) ?? false;
@@ -189,6 +214,7 @@ export const WorkspaceRowItem = memo(
 						title={displayTitle}
 						badgeClassName={showStatusDot ? statusDotClassName : null}
 						badgeAriaLabel={statusDotLabel ?? undefined}
+						isRunning={isRunScriptRunning}
 					/>
 					{/* Fade is on an inner wrapper so the avatar's overflowing badge isn't clipped by mask-image. */}
 					<div className="row-content-fade flex min-w-0 flex-1 items-center gap-2">


### PR DESCRIPTION
## Summary

- Add an animated `ShineBorder` around the workspace avatar whenever that workspace's inspector `run` script is in the `running` state, giving users an at-a-glance indicator in the sidebar.
- Refactor `ShineBorder` to match the canonical `magicui` API (JSDoc'd props, `"use client"`, `React.CSSProperties`) and drop the hard-coded `clipPath` so the border can render fully around arbitrary containers.
- Subscribe each sidebar row to script status via `script-store` (`getScriptState` + `subscribeStatus`) so only rows whose running state flips re-render — no sidebar-wide fan-out.
- Minor: rename the final `@keyframes shine` stop from `100%` to `to` for consistency, and bump the avatar status dot to `z-10` so it stays above the new border.

## Why

Previously there was no sidebar signal that a workspace's `run` script was actively executing — you had to open the inspector to check. The glow makes active workspaces immediately scannable.

## Test plan

- [ ] Start a `run` script on a workspace → avatar shows the animated multi-color border.
- [ ] Stop / exit the script → border disappears.
- [ ] Switch script to a different workspace (virtual-list row reuse) → border tracks the correct row.
- [ ] Status dot (unread / archived / etc.) still renders on top of the avatar, not clipped by the border.
- [ ] `motion-safe:animate-shine` respects reduced-motion preference.