### PR TITLE
style: refine markdown, code block, and sidebar selection styling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -167,12 +167,38 @@ body {
 }
 
 .assistant-markdown-scale {
+	--assistant-paragraph-line-height: 1.82;
 	line-height: 1.5;
 }
 
+.assistant-markdown-scale p,
 .assistant-markdown-scale [data-streamdown="paragraph"],
 .assistant-markdown-scale [data-streamdown="list-item"] {
-	line-height: 1.5;
+	line-height: var(--assistant-paragraph-line-height);
+}
+
+.assistant-markdown-scale
+	[data-streamdown="ordered-list"]
+	> [data-streamdown="list-item"]::marker {
+	color: var(--muted-foreground);
+}
+
+.assistant-markdown-scale
+	:is([data-streamdown="ordered-list"], [data-streamdown="unordered-list"]) {
+	padding-inline-start: 0.25rem;
+}
+
+.assistant-markdown-scale
+	:is([data-streamdown="ordered-list"], [data-streamdown="unordered-list"])
+	> [data-streamdown="list-item"] {
+	padding-top: 0.125rem;
+	padding-bottom: 0.125rem;
+}
+
+.conversation-streamdown
+	> :is(p, [data-streamdown="paragraph"])
+	+ :is([data-streamdown="ordered-list"], [data-streamdown="unordered-list"]) {
+	margin-top: 0.75rem;
 }
 
 .assistant-markdown-scale [data-streamdown="heading-1"],
@@ -182,7 +208,7 @@ body {
 .assistant-markdown-scale [data-streamdown="heading-5"],
 .assistant-markdown-scale [data-streamdown="heading-6"] {
 	margin: 0;
-	color: var(--foreground);
+	color: inherit;
 }
 
 .assistant-markdown-scale [data-streamdown="heading-1"] {
@@ -218,6 +244,9 @@ body {
 
 .assistant-markdown-scale [data-streamdown="inline-code"] {
 	font-size: 0.88em;
+	background: transparent;
+	border: 1px solid
+		color-mix(in oklch, var(--muted) 87%, var(--muted-foreground) 13%);
 }
 
 .assistant-markdown-scale [data-streamdown="code-block"] {
@@ -419,9 +448,17 @@ body {
 	}
 }
 
+.conversation-body-text {
+	color: var(--conversation-body-foreground);
+}
+
+.workspace-row-selected {
+	background: var(--workspace-sidebar-selected-bg);
+}
+
 /* Streamdown theme overrides — minimal, no !important */
 .conversation-streamdown {
-	color: var(--foreground);
+	color: var(--conversation-body-foreground);
 }
 
 .conversation-streamdown [data-sd-animate] {
@@ -452,6 +489,9 @@ body {
  */
 .conversation-streamdown :not(pre) > code {
 	font-size: inherit;
+	background: transparent;
+	border: 1px solid
+		color-mix(in oklch, var(--muted) 87%, var(--muted-foreground) 13%);
 }
 
 /* Table layout for assistant markdown */

--- a/src/App.shortcuts.test.tsx
+++ b/src/App.shortcuts.test.tsx
@@ -286,7 +286,9 @@ function expectSelectedSession(title: string) {
 }
 
 function expectSelectedWorkspace(title: string) {
-	expect(screen.getByRole("button", { name: title })).toHaveClass("bg-accent");
+	expect(screen.getByRole("button", { name: title })).toHaveClass(
+		"workspace-row-selected",
+	);
 }
 
 function pressGlobalShortcut(
@@ -580,7 +582,7 @@ describe("App global navigation shortcuts", () => {
 		// assertion we actually care about.
 		expect(
 			screen.getByRole("button", { name: "Review workspace" }),
-		).not.toHaveClass("bg-accent");
+		).not.toHaveClass("workspace-row-selected");
 	});
 
 	it("navigates through archived workspaces after the active workspace list even while Archived stays collapsed", async () => {

--- a/src/components/ai/code-block.test.tsx
+++ b/src/components/ai/code-block.test.tsx
@@ -1,0 +1,40 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { CodeBlock, CodeBlockCopyButton } from "./code-block";
+
+afterEach(() => {
+	cleanup();
+});
+
+describe("CodeBlock", () => {
+	it("uses floating actions when no language is provided", () => {
+		const { container } = render(
+			<CodeBlock code="mutation 持续未完成 → 32.5s 后超时，共 10 次调用">
+				<CodeBlockCopyButton />
+			</CodeBlock>,
+		);
+
+		expect(
+			container.querySelector('[data-code-block-actions="header"]'),
+		).toBeNull();
+		expect(
+			container.querySelector('[data-code-block-actions="floating"]'),
+		).not.toBeNull();
+		expect(screen.getByRole("button")).toBeInTheDocument();
+	});
+
+	it("keeps header actions when a language is provided", () => {
+		const { container } = render(
+			<CodeBlock code="const value = 1;" language="ts">
+				<CodeBlockCopyButton />
+			</CodeBlock>,
+		);
+
+		expect(
+			container.querySelector('[data-code-block-actions="header"]'),
+		).not.toBeNull();
+		expect(
+			container.querySelector('[data-code-block-actions="floating"]'),
+		).toBeNull();
+	});
+});

--- a/src/components/ai/code-block.tsx
+++ b/src/components/ai/code-block.tsx
@@ -75,6 +75,8 @@ export const CodeBlock = ({
 	const [darkHtml, setDarkHtml] = useState(() => plainHtml(code));
 	const resolvedLanguage = useMemo(() => resolveLanguage(language), [language]);
 	const isPlain = variant === "plain";
+	const hasHeaderActions = !isPlain && Boolean(language);
+	const hasFloatingActions = !isPlain && !language && Boolean(children);
 
 	useEffect(() => {
 		let cancelled = false;
@@ -142,7 +144,11 @@ export const CodeBlock = ({
 
 	const codePadding = isPlain
 		? "[&>pre]:p-3.5"
-		: "[&>pre]:px-3.5 [&>pre]:pb-3.5 [&>pre]:pt-1";
+		: hasHeaderActions
+			? "[&>pre]:px-3.5 [&>pre]:pb-3.5 [&>pre]:pt-1"
+			: hasFloatingActions
+				? "[&>pre]:px-3.5 [&>pre]:py-3.5 [&>pre]:pr-11"
+				: "[&>pre]:p-3.5";
 	const wrapClasses = wrapLines
 		? "overflow-x-hidden overflow-y-hidden [&>pre]:whitespace-pre-wrap [&>pre]:break-words [&_code]:whitespace-pre-wrap [&_code]:break-words"
 		: "overflow-x-auto overflow-y-hidden [&>pre]:min-w-full";
@@ -160,20 +166,27 @@ export const CodeBlock = ({
 				)}
 				{...props}
 			>
-				{isPlain ? null : (
-					<div className="flex items-center justify-between gap-2 px-3 pt-1.5">
-						{language ? (
-							<span className="truncate font-mono text-[10px] leading-none tracking-wide text-muted-foreground/50 uppercase select-none">
-								{language}
-							</span>
-						) : (
-							<span />
-						)}
+				{hasHeaderActions ? (
+					<div
+						data-code-block-actions="header"
+						className="flex items-center justify-between gap-2 px-3 pt-1.5"
+					>
+						<span className="truncate font-mono text-[10px] leading-none tracking-wide text-muted-foreground/50 uppercase select-none">
+							{language}
+						</span>
 						<div className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
 							{children}
 						</div>
 					</div>
-				)}
+				) : null}
+				{hasFloatingActions ? (
+					<div
+						data-code-block-actions="floating"
+						className="absolute top-2 right-2 z-10 flex items-center gap-0.5"
+					>
+						{children}
+					</div>
+				) : null}
 				<div className="relative">
 					<div
 						className={cn(codeBase, codePadding, wrapClasses, "dark:hidden")}

--- a/src/components/streamdown-components.tsx
+++ b/src/components/streamdown-components.tsx
@@ -54,7 +54,9 @@ export function StreamdownTable({
 				<TableCopyDropdown />
 				<TableDownloadDropdown />
 			</div>
-			<Table className={cn("text-[11px]", className)}>{children}</Table>
+			<div className="overflow-hidden rounded-md border border-border/70">
+				<Table className={cn("text-[0.9em]", className)}>{children}</Table>
+			</div>
 		</div>
 	);
 }
@@ -97,7 +99,12 @@ export function StreamdownTableHead({
 	className?: string;
 }) {
 	return (
-		<TableHead className={cn("h-8 text-[11px] font-semibold", className)}>
+		<TableHead
+			className={cn(
+				"h-8 border-r border-border/60 bg-muted/35 text-[0.9em] font-semibold last:border-r-0",
+				className,
+			)}
+		>
 			{children}
 		</TableHead>
 	);
@@ -111,7 +118,12 @@ export function StreamdownTableCell({
 	className?: string;
 }) {
 	return (
-		<TableCell className={cn("py-1.5 text-[11px]", className)}>
+		<TableCell
+			className={cn(
+				"border-r border-border/60 py-1.5 text-[0.9em] last:border-r-0",
+				className,
+			)}
+		>
 			{children}
 		</TableCell>
 	);

--- a/src/features/navigation/row-item.tsx
+++ b/src/features/navigation/row-item.tsx
@@ -45,7 +45,7 @@ const rowVariants = cva(
 	{
 		variants: {
 			active: {
-				true: "bg-accent text-foreground",
+				true: "workspace-row-selected text-foreground",
 				false: "text-foreground/80 hover:bg-accent/60",
 			},
 		},

--- a/src/features/panel/message-components/user-message.tsx
+++ b/src/features/panel/message-components/user-message.tsx
@@ -125,7 +125,7 @@ export function ChatUserMessage({ message }: { message: RenderedMessage }) {
 			className="flex min-w-0 justify-end"
 		>
 			<div
-				className="max-w-[75%] overflow-hidden rounded-md bg-accent/35 px-3 py-2 leading-7 text-foreground"
+				className="conversation-body-text max-w-[75%] overflow-hidden rounded-md bg-accent/55 px-3 py-2 leading-7"
 				style={{ fontSize: `${settings.fontSize}px` }}
 			>
 				<p className="whitespace-pre-wrap break-words">

--- a/src/styles/color-theme.css
+++ b/src/styles/color-theme.css
@@ -4,6 +4,7 @@
 	/* Official shadcn/ui radix-nova neutral theme */
 	--background: oklch(1 0 0);
 	--foreground: oklch(0.145 0 0);
+	--conversation-body-foreground: rgb(44, 40, 38);
 	--card: oklch(1 0 0);
 	--card-foreground: oklch(0.145 0 0);
 	--popover: oklch(1 0 0);
@@ -31,6 +32,11 @@
 	--sidebar-primary-foreground: oklch(0.985 0 0);
 	--sidebar-accent: oklch(0.97 0 0);
 	--sidebar-accent-foreground: oklch(0.205 0 0);
+	--workspace-sidebar-selected-bg: color-mix(
+		in oklch,
+		var(--sidebar-accent) 98.5%,
+		var(--sidebar-foreground) 1.5%
+	);
 	--sidebar-border: oklch(0.922 0 0);
 	--sidebar-ring: oklch(0.708 0 0);
 	--workspace-sidebar-status-done: color-mix(
@@ -109,6 +115,7 @@
 	/* Official shadcn/ui radix-nova neutral theme */
 	--background: oklch(0.165 0 0);
 	--foreground: oklch(0.985 0 0);
+	--conversation-body-foreground: rgb(234, 232, 230);
 	--card: oklch(0.205 0 0);
 	--card-foreground: oklch(0.985 0 0);
 	--popover: oklch(0.205 0 0);
@@ -136,6 +143,11 @@
 	--sidebar-primary-foreground: oklch(0.985 0 0);
 	--sidebar-accent: oklch(0.269 0 0);
 	--sidebar-accent-foreground: oklch(0.985 0 0);
+	--workspace-sidebar-selected-bg: color-mix(
+		in oklch,
+		var(--sidebar-accent) 98.5%,
+		var(--sidebar-foreground) 1.5%
+	);
 	--sidebar-border: oklch(1 0 0 / 10%);
 	--sidebar-ring: oklch(0.556 0 0);
 	--workspace-sidebar-status-done: color-mix(


### PR DESCRIPTION
## Summary

- Increase paragraph line-height in assistant markdown (new `--assistant-paragraph-line-height: 1.82`) and polish list spacing/indentation/markers.
- Refresh inline-code styling with a transparent bg + subtle `color-mix` border for both `.assistant-markdown-scale` and `.conversation-streamdown`.
- Rework streamdown tables: rounded outer border, muted header row, per-cell dividers, and `0.9em` sizing for better proportionality.
- Introduce `--conversation-body-foreground` tokens (light/dark) and apply via a new `.conversation-body-text` helper to conversation body and user message bubbles; also bumps user-bubble bg from `accent/35` → `accent/55`.
- Add `--workspace-sidebar-selected-bg` token + `.workspace-row-selected` class so the navigation row's active state reads as a distinct tint instead of reusing `bg-accent`.

## Why

Tightens typography and visual hierarchy in the chat surface:
- Longer line-height makes multi-paragraph assistant responses easier to read.
- Table styling previously relied on an 11px hardcoded font + no borders, which looked cramped and unstructured.
- Sidebar selection shared `bg-accent` with hover, making the active workspace hard to distinguish at a glance.
- Pulling conversation/sidebar colors into theme tokens keeps light/dark parity and centralizes future tweaks.

## Test plan

- [ ] Visual check: assistant markdown paragraphs, ordered/unordered lists, inline code, headings
- [ ] Visual check: streamdown tables render with rounded border, header tint, column dividers
- [ ] Visual check: user message bubble color in light and dark themes
- [ ] Visual check: workspace sidebar active row distinguishable from hover in both themes
- [ ] `bun run lint` / `bun run typecheck`