### PR TITLE
fix: keep queued follow-ups overlayed and show Skill icon

### DIFF
--- a/.changeset/calm-oranges-rest.md
+++ b/.changeset/calm-oranges-rest.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Keep queued follow-up prompts overlaying the composer instead of shrinking the thread, and show a proper icon for streamed Skill entries.

--- a/src/features/composer/container.test.tsx
+++ b/src/features/composer/container.test.tsx
@@ -598,7 +598,12 @@ describe("WorkspaceComposerContainer", () => {
 									imagePaths: [],
 									filePaths: [],
 									customTags: [],
-									model: MODEL_SECTIONS[0].options[0],
+									model: {
+										...MODEL_SECTIONS[0].options[0],
+										effortLevels: [
+											...MODEL_SECTIONS[0].options[0].effortLevels,
+										],
+									},
 									workingDirectory: "/tmp/helmor",
 									effortLevel: "medium",
 									permissionMode: "default",

--- a/src/features/composer/container.test.tsx
+++ b/src/features/composer/container.test.tsx
@@ -1,6 +1,7 @@
 import { QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { createHelmorQueryClient, helmorQueryKeys } from "@/lib/query-client";
 import { DEFAULT_SETTINGS, SettingsContext } from "@/lib/settings";
 
@@ -545,6 +546,78 @@ describe("WorkspaceComposerContainer", () => {
 		const composer = screen.getByTestId("workspace-composer-mock");
 		expect(composer).toHaveAttribute("data-disabled", "false");
 		expect(composer).toHaveAttribute("data-submit-disabled", "false");
+	});
+
+	it("renders queued follow-ups as an overlay above the composer", () => {
+		const queryClient = createHelmorQueryClient();
+		queryClient.setQueryData(
+			helmorQueryKeys.agentModelSections,
+			MODEL_SECTIONS,
+		);
+		queryClient.setQueryData(
+			helmorQueryKeys.workspaceDetail("workspace-1"),
+			WORKSPACE_DETAIL,
+		);
+		queryClient.setQueryData(
+			helmorQueryKeys.workspaceSessions("workspace-1"),
+			WORKSPACE_SESSIONS,
+		);
+
+		render(
+			<TooltipProvider>
+				<QueryClientProvider client={queryClient}>
+					<WorkspaceComposerContainer
+						displayedWorkspaceId="workspace-1"
+						displayedSessionId="session-1"
+						disabled={false}
+						sending={false}
+						sendError={null}
+						restoreDraft={null}
+						restoreImages={[]}
+						restoreFiles={[]}
+						restoreNonce={0}
+						modelSelections={{}}
+						effortLevels={{}}
+						permissionModes={{}}
+						fastModes={{}}
+						onSelectModel={vi.fn()}
+						onSelectEffort={vi.fn()}
+						onChangePermissionMode={vi.fn()}
+						onChangeFastMode={vi.fn()}
+						onSubmit={vi.fn()}
+						queueItems={[
+							{
+								id: "queued-1",
+								context: {
+									sessionId: "session-1",
+									workspaceId: "workspace-1",
+									contextKey: "session:session-1",
+								},
+								payload: {
+									prompt: "Continue",
+									imagePaths: [],
+									filePaths: [],
+									customTags: [],
+									model: MODEL_SECTIONS[0].options[0],
+									workingDirectory: "/tmp/helmor",
+									effortLevel: "medium",
+									permissionMode: "default",
+									fastMode: false,
+								},
+								enqueuedAt: Date.now(),
+							},
+						]}
+						onSteerQueued={vi.fn()}
+						onRemoveQueued={vi.fn()}
+					/>
+				</QueryClientProvider>
+			</TooltipProvider>,
+		);
+
+		const queueList = screen.getByTestId("submit-queue-list");
+		expect(queueList).toHaveClass("pointer-events-auto");
+		expect(queueList.parentElement).toHaveClass("absolute");
+		expect(queueList.parentElement).toHaveClass("bottom-[calc(100%-1px)]");
 	});
 
 	describe("/add-dir integration", () => {

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -728,14 +728,15 @@ export const WorkspaceComposerContainer = memo(
 					/>
 				) : null}
 
-				<SubmitQueueList
-					items={queueItems}
-					onSteer={(id) => onSteerQueued?.(id)}
-					onRemove={(id) => onRemoveQueued?.(id)}
-					disabled={composerUnavailable}
-				/>
-
 				<div className="relative z-10">
+					<div className="pointer-events-none absolute inset-x-0 bottom-[calc(100%-1px)] z-20 flex justify-center">
+						<SubmitQueueList
+							items={queueItems}
+							onSteer={(id) => onSteerQueued?.(id)}
+							onRemove={(id) => onRemoveQueued?.(id)}
+							disabled={composerUnavailable}
+						/>
+					</div>
 					<WorkspaceComposer
 						contextKey={composerContextKey}
 						onSubmit={handleComposerSubmit}

--- a/src/features/composer/submit-queue-list/index.tsx
+++ b/src/features/composer/submit-queue-list/index.tsx
@@ -1,20 +1,4 @@
-/**
- * Vertical stack of queued follow-up messages, rendered above the
- * composer when `followUpBehavior === 'queue'` is active and the user
- * has typed additional messages while a turn is still running. Stacked
- * `ActionRow`s (the same primitive the auto-close banner uses) keep
- * the visual continuous-card look: each row's border collapses into
- * the next, and the bottom row overlaps the composer top edge via
- * `-mb-px`.
- *
- * Every row offers two actions: steer (convert this queued entry into
- * a `steerAgentStream` call and send now, interrupting the active
- * turn), or trash (remove from the local queue — no provider side
- * effect).
- *
- * Renders nothing when the queue for the given session is empty — the
- * composer's outer layout doesn't reserve space.
- */
+/** Queue overlay that sits above the composer without reserving layout space. */
 
 import { Clock, CornerDownLeft, Trash2 } from "lucide-react";
 import { ActionRow } from "@/components/action-row";
@@ -42,7 +26,10 @@ export function SubmitQueueList({
 }: SubmitQueueListProps) {
 	if (items.length === 0) return null;
 	return (
-		<div className="relative z-0 mx-auto -mb-px w-[90%] overflow-hidden rounded-t-2xl border border-b-0 border-secondary/80 bg-background">
+		<div
+			data-testid="submit-queue-list"
+			className="pointer-events-auto relative z-0 mx-auto w-[90%] overflow-hidden rounded-t-2xl border border-b-0 border-secondary/80 bg-background"
+		>
 			{items.map((item, idx) => (
 				<QueueRow
 					key={item.id}

--- a/src/features/panel/message-components/tool-info.test.tsx
+++ b/src/features/panel/message-components/tool-info.test.tsx
@@ -1,6 +1,18 @@
 import { describe, expect, it } from "vitest";
 import { getToolInfo } from "./tool-info";
 
+describe("getToolInfo — Skill", () => {
+	it("renders a dedicated skill icon and name", () => {
+		const info = getToolInfo("Skill", {
+			name: "review-ui",
+		});
+		expect(info.action).toBe("Skill");
+		expect(info.detail).toBe("review-ui");
+		expect(info.icon).not.toBeNull();
+		expect(typeof info.icon).toBe("object");
+	});
+});
+
 describe("getToolInfo — WebSearch", () => {
 	it("search action shows query", () => {
 		const info = getToolInfo("WebSearch", {

--- a/src/features/panel/message-components/tool-info.tsx
+++ b/src/features/panel/message-components/tool-info.tsx
@@ -11,6 +11,7 @@ import {
 	Pencil,
 	Plug,
 	Search,
+	Sparkles,
 	Terminal,
 } from "lucide-react";
 import type { FileChangeInfo, ToolInfo } from "./shared";
@@ -217,6 +218,19 @@ export function getToolInfo(
 				/>
 			),
 			body: text ?? undefined,
+		};
+	}
+
+	if (name === "Skill") {
+		const skillName =
+			str(input.name) ??
+			str(input.skill) ??
+			str(input.command) ??
+			str(input.id);
+		return {
+			action: "Skill",
+			icon: <Sparkles className={neutralToolIconClassName} strokeWidth={1.8} />,
+			detail: skillName ? truncate(skillName, 50) : undefined,
 		};
 	}
 


### PR DESCRIPTION
## What changed
- keeps queued follow-up prompts rendered as an overlay above the composer instead of letting them take layout space and shrink the thread
- adds a dedicated icon mapping for streamed `Skill` tool entries in the message panel
- adds frontend tests covering the queue overlay positioning and `Skill` tool metadata
- includes a patch changeset for the user-visible behavior change

## Why
The queued follow-up UI was affecting the thread layout, which made the composer area expand into the conversation view. Streamed Skill events also lacked a proper icon treatment, so they were less recognizable in the panel.

## Follow-up / test notes
- Tests not run in this session
- Branch was already clean when I started, so there was no uncommitted work to stage or commit; this PR is based on the existing branch commits