### PR TITLE
style(chrome): nudge macOS traffic lights down 2px

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -31,7 +31,7 @@
 				"titleBarStyle": "Overlay",
 				"trafficLightPosition": {
 					"x": 12,
-					"y": 21
+					"y": 19
 				},
 				"hiddenTitle": true,
 				"center": true,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -31,7 +31,7 @@
 				"titleBarStyle": "Overlay",
 				"trafficLightPosition": {
 					"x": 12,
-					"y": 22
+					"y": 18
 				},
 				"hiddenTitle": true,
 				"center": true,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -31,7 +31,7 @@
 				"titleBarStyle": "Overlay",
 				"trafficLightPosition": {
 					"x": 12,
-					"y": 18
+					"y": 21
 				},
 				"hiddenTitle": true,
 				"center": true,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -31,7 +31,7 @@
 				"titleBarStyle": "Overlay",
 				"trafficLightPosition": {
 					"x": 12,
-					"y": 20
+					"y": 22
 				},
 				"hiddenTitle": true,
 				"center": true,


### PR DESCRIPTION
## Summary

- Shift `trafficLightPosition.y` from `20` to `22` in `src-tauri/tauri.conf.json` to better vertically center the macOS window controls within the overlay title bar.

## Test plan

- [ ] `bun run dev` (required — `tauri.conf.json` is only read at window creation, HMR won't pick it up)
- [ ] Verify traffic lights sit 2px lower than before on the main window
- [ ] Confirm the drag region (`data-tauri-drag-region` areas) still aligns and doesn't overlap the buttons