### PR TITLE
feat: clone repository from git URL via sidebar

### DIFF
--- a/.changeset/clone-from-url.md
+++ b/.changeset/clone-from-url.md
@@ -1,0 +1,8 @@
+---
+"helmor": minor
+---
+
+Ship a sidebar clone flow and a couple of readability polish fixes:
+- Add "Clone from URL" to the Workspaces add-repository menu so you can paste a Git URL, pick a clone location, and have Helmor clone and import the repository as a new workspace in one step.
+- Fix sidebar workspace titles clipping descenders (g / j / p / q / y) at the bottom edge when the app is zoomed out.
+- Restore vertical rhythm around assistant markdown headings and add a touch of horizontal breathing room to inline code in chat messages.

--- a/src-tauri/src/commands/repository_commands.rs
+++ b/src-tauri/src/commands/repository_commands.rs
@@ -28,6 +28,15 @@ pub async fn add_repository_from_local_path(
 }
 
 #[tauri::command]
+pub async fn clone_repository_from_url(
+    git_url: String,
+    clone_directory: String,
+) -> CmdResult<repos::AddRepositoryResponse> {
+    let _lock = db::WORKSPACE_MUTATION_LOCK.lock().await;
+    run_blocking(move || repos::clone_repository_from_url(&git_url, &clone_directory)).await
+}
+
+#[tauri::command]
 pub async fn update_repository_default_branch(
     app: AppHandle,
     repo_id: String,

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -58,6 +58,12 @@ pub enum WorkspacePushStatus {
 /// the calling blocking-pool worker indefinitely.
 pub const GIT_NETWORK_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Hard upper bound on `git clone`. Cloning large repositories over a slow
+/// network regularly exceeds the 30s `GIT_NETWORK_TIMEOUT`, so use a more
+/// generous cap here while still preventing the blocking pool from being
+/// parked indefinitely on a stalled remote.
+pub const GIT_CLONE_TIMEOUT: Duration = Duration::from_secs(300);
+
 pub fn run_git<I, S>(args: I, current_dir: Option<&Path>) -> Result<String>
 where
     I: IntoIterator<Item = S>,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -168,6 +168,7 @@ pub fn run() {
             commands::github_commands::get_github_identity_session,
             commands::workspace_commands::get_workspace,
             commands::repository_commands::add_repository_from_local_path,
+            commands::repository_commands::clone_repository_from_url,
             commands::github_commands::list_github_accessible_repositories,
             commands::workspace_commands::list_archived_workspaces,
             commands::repository_commands::list_repositories,

--- a/src-tauri/src/models/repos.rs
+++ b/src-tauri/src/models/repos.rs
@@ -711,6 +711,69 @@ pub fn resolve_repository_from_local_path(folder_path: &str) -> Result<ResolvedR
     })
 }
 
+pub fn clone_repository_from_url(
+    git_url: &str,
+    clone_directory: &str,
+) -> Result<AddRepositoryResponse> {
+    let url = git_url.trim();
+    if url.is_empty() {
+        bail!("Git URL is required.");
+    }
+
+    let parent = Path::new(clone_directory.trim());
+    if !parent.exists() {
+        bail!(
+            "Clone location does not exist: {}. Please choose an existing directory.",
+            parent.display()
+        );
+    }
+    if !parent.is_dir() {
+        bail!("Clone location is not a directory: {}", parent.display());
+    }
+
+    let repo_name = infer_repo_name_from_url(url)
+        .with_context(|| format!("Unable to derive a repository name from URL: {url}"))?;
+    let target_dir = parent.join(&repo_name);
+
+    if target_dir.exists() {
+        bail!(
+            "Target directory already exists: {}. Please remove it or choose a different clone location.",
+            target_dir.display()
+        );
+    }
+
+    let target_arg = target_dir.display().to_string();
+    let clone_result = git_ops::run_git_with_timeout(
+        ["clone", "--", url, target_arg.as_str()],
+        Some(parent),
+        git_ops::GIT_CLONE_TIMEOUT,
+    );
+
+    if let Err(error) = clone_result {
+        // git may have partially created the target directory before failing.
+        // Best-effort cleanup so the user can retry without hitting the
+        // "target directory already exists" branch above.
+        if target_dir.exists() {
+            let _ = fs::remove_dir_all(&target_dir);
+        }
+        return Err(error.context("Failed to clone repository"));
+    }
+
+    add_repository_from_local_path(&target_dir.display().to_string())
+}
+
+fn infer_repo_name_from_url(url: &str) -> Option<String> {
+    let trimmed = url.trim().trim_end_matches('/');
+    let without_git = trimmed.strip_suffix(".git").unwrap_or(trimmed);
+    let last = without_git.rsplit(['/', ':']).next()?;
+    let cleaned = last.trim();
+    if cleaned.is_empty() {
+        None
+    } else {
+        Some(cleaned.to_string())
+    }
+}
+
 pub fn add_repository_from_local_path(folder_path: &str) -> Result<AddRepositoryResponse> {
     // Fast duplicate check: only needs git root path, no network calls.
     let normalized_root_path = resolve_git_root_path(folder_path)?;

--- a/src/App.add-repo.test.tsx
+++ b/src/App.add-repo.test.tsx
@@ -275,6 +275,9 @@ describe("App add repository flow", () => {
 		await screen.findByRole("main", { name: "Application shell" });
 
 		await user.click(screen.getByRole("button", { name: "Add repository" }));
+		await user.click(
+			await screen.findByRole("menuitem", { name: "Open project" }),
+		);
 
 		await waitFor(() => {
 			expect(dialogMocks.open).toHaveBeenCalledWith({
@@ -310,6 +313,9 @@ describe("App add repository flow", () => {
 		await screen.findByRole("main", { name: "Application shell" });
 
 		await user.click(screen.getByRole("button", { name: "Add repository" }));
+		await user.click(
+			await screen.findByRole("menuitem", { name: "Open project" }),
+		);
 
 		await waitFor(() => {
 			expect(dialogMocks.open).toHaveBeenCalled();
@@ -332,6 +338,9 @@ describe("App add repository flow", () => {
 		await screen.findByRole("main", { name: "Application shell" });
 
 		await user.click(screen.getByRole("button", { name: "Add repository" }));
+		await user.click(
+			await screen.findByRole("menuitem", { name: "Open project" }),
+		);
 
 		await waitFor(() => {
 			expect(apiMocks.addRepositoryFromLocalPath).toHaveBeenCalledWith(
@@ -352,6 +361,9 @@ describe("App add repository flow", () => {
 		await screen.findByRole("main", { name: "Application shell" });
 
 		await user.click(screen.getByRole("button", { name: "Add repository" }));
+		await user.click(
+			await screen.findByRole("menuitem", { name: "Open project" }),
+		);
 
 		await waitFor(() => {
 			expect(

--- a/src/App.css
+++ b/src/App.css
@@ -207,30 +207,39 @@ body {
 .assistant-markdown-scale [data-streamdown="heading-4"],
 .assistant-markdown-scale [data-streamdown="heading-5"],
 .assistant-markdown-scale [data-streamdown="heading-6"] {
-	margin: 0;
+	margin: 1.4em 0 0.4em;
 	color: inherit;
 }
 
+.assistant-markdown-scale [data-streamdown="heading-1"]:first-child,
+.assistant-markdown-scale [data-streamdown="heading-2"]:first-child,
+.assistant-markdown-scale [data-streamdown="heading-3"]:first-child,
+.assistant-markdown-scale [data-streamdown="heading-4"]:first-child,
+.assistant-markdown-scale [data-streamdown="heading-5"]:first-child,
+.assistant-markdown-scale [data-streamdown="heading-6"]:first-child {
+	margin-top: 0;
+}
+
 .assistant-markdown-scale [data-streamdown="heading-1"] {
-	font-size: 1.12em;
-	line-height: 1.24;
+	font-size: 1.35em;
+	line-height: 1.3;
 }
 
 .assistant-markdown-scale [data-streamdown="heading-2"] {
-	font-size: 1.06em;
-	line-height: 1.28;
+	font-size: 1.2em;
+	line-height: 1.32;
 }
 
 .assistant-markdown-scale [data-streamdown="heading-3"] {
-	font-size: 1.02em;
-	line-height: 1.34;
+	font-size: 1.1em;
+	line-height: 1.36;
 }
 
 .assistant-markdown-scale [data-streamdown="heading-4"],
 .assistant-markdown-scale [data-streamdown="heading-5"],
 .assistant-markdown-scale [data-streamdown="heading-6"] {
-	font-size: 0.98em;
-	line-height: 1.38;
+	font-size: 1em;
+	line-height: 1.4;
 }
 
 .assistant-markdown-scale [data-streamdown="list"] {
@@ -247,6 +256,7 @@ body {
 	background: transparent;
 	border: 1px solid
 		color-mix(in oklch, var(--muted) 87%, var(--muted-foreground) 13%);
+	margin: 0 2px;
 }
 
 .assistant-markdown-scale [data-streamdown="code-block"] {
@@ -492,6 +502,7 @@ body {
 	background: transparent;
 	border: 1px solid
 		color-mix(in oklch, var(--muted) 87%, var(--muted-foreground) 13%);
+	margin: 0 2px;
 }
 
 /* Table layout for assistant markdown */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2170,13 +2170,13 @@ function AppShell({
 																		>
 																			<EditorIcon
 																				editorId={editor.id}
-																				className="size-3.5 shrink-0"
+																				className="shrink-0"
 																			/>
 																			<span className="flex-1">
 																				{editor.name}
 																			</span>
 																			{editor.id === preferredEditor.id && (
-																				<Check className="ml-auto size-3 text-muted-foreground" />
+																				<Check className="ml-auto text-muted-foreground" />
 																			)}
 																		</DropdownMenuItem>
 																	))}

--- a/src/components/ai/open-in-chat.tsx
+++ b/src/components/ai/open-in-chat.tsx
@@ -258,7 +258,7 @@ export const OpenInChatGPT = (props: OpenInChatGPTProps) => {
 			>
 				<span className="shrink-0">{providers.chatgpt.icon}</span>
 				<span className="flex-1">{providers.chatgpt.title}</span>
-				<ExternalLinkIcon className="size-4 shrink-0" />
+				<ExternalLinkIcon className="shrink-0" />
 			</a>
 		</DropdownMenuItem>
 	);
@@ -279,7 +279,7 @@ export const OpenInClaude = (props: OpenInClaudeProps) => {
 			>
 				<span className="shrink-0">{providers.claude.icon}</span>
 				<span className="flex-1">{providers.claude.title}</span>
-				<ExternalLinkIcon className="size-4 shrink-0" />
+				<ExternalLinkIcon className="shrink-0" />
 			</a>
 		</DropdownMenuItem>
 	);
@@ -300,7 +300,7 @@ export const OpenInT3 = (props: OpenInT3Props) => {
 			>
 				<span className="shrink-0">{providers.t3.icon}</span>
 				<span className="flex-1">{providers.t3.title}</span>
-				<ExternalLinkIcon className="size-4 shrink-0" />
+				<ExternalLinkIcon className="shrink-0" />
 			</a>
 		</DropdownMenuItem>
 	);
@@ -321,7 +321,7 @@ export const OpenInScira = (props: OpenInSciraProps) => {
 			>
 				<span className="shrink-0">{providers.scira.icon}</span>
 				<span className="flex-1">{providers.scira.title}</span>
-				<ExternalLinkIcon className="size-4 shrink-0" />
+				<ExternalLinkIcon className="shrink-0" />
 			</a>
 		</DropdownMenuItem>
 	);
@@ -342,7 +342,7 @@ export const OpenInv0 = (props: OpenInv0Props) => {
 			>
 				<span className="shrink-0">{providers.v0.icon}</span>
 				<span className="flex-1">{providers.v0.title}</span>
-				<ExternalLinkIcon className="size-4 shrink-0" />
+				<ExternalLinkIcon className="shrink-0" />
 			</a>
 		</DropdownMenuItem>
 	);
@@ -363,7 +363,7 @@ export const OpenInCursor = (props: OpenInCursorProps) => {
 			>
 				<span className="shrink-0">{providers.cursor.icon}</span>
 				<span className="flex-1">{providers.cursor.title}</span>
-				<ExternalLinkIcon className="size-4 shrink-0" />
+				<ExternalLinkIcon className="shrink-0" />
 			</a>
 		</DropdownMenuItem>
 	);

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,7 +1,17 @@
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
 import { CheckIcon, ChevronRightIcon } from "lucide-react";
 import type * as React from "react";
+import { createContext, useContext } from "react";
 import { cn } from "@/lib/utils";
+
+type DropdownMenuSize = "default" | "sm";
+
+const DropdownMenuSizeContext = createContext<DropdownMenuSize>("default");
+
+const dropdownMenuItemSizeClasses: Record<DropdownMenuSize, string> = {
+	default: "gap-1.5 py-1 text-sm [&_svg:not([class*='size-'])]:size-4",
+	sm: "gap-1 py-1 text-xs leading-[14px] [&_svg:not([class*='size-'])]:size-3",
+};
 
 function DropdownMenu({
 	...props
@@ -32,22 +42,28 @@ function DropdownMenuContent({
 	className,
 	align = "start",
 	sideOffset = 4,
+	size = "sm",
 	...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content> & {
+	size?: DropdownMenuSize;
+}) {
 	return (
-		<DropdownMenuPrimitive.Portal>
-			<DropdownMenuPrimitive.Content
-				data-slot="dropdown-menu-content"
-				sideOffset={sideOffset}
-				align={align}
-				onWheel={(e) => e.stopPropagation()}
-				className={cn(
-					"z-50 max-h-(--radix-dropdown-menu-content-available-height) w-(--radix-dropdown-menu-trigger-width) min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:overflow-hidden data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
-					className,
-				)}
-				{...props}
-			/>
-		</DropdownMenuPrimitive.Portal>
+		<DropdownMenuSizeContext.Provider value={size}>
+			<DropdownMenuPrimitive.Portal>
+				<DropdownMenuPrimitive.Content
+					data-slot="dropdown-menu-content"
+					data-size={size}
+					sideOffset={sideOffset}
+					align={align}
+					onWheel={(e) => e.stopPropagation()}
+					className={cn(
+						"z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-24 origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:overflow-hidden data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+						className,
+					)}
+					{...props}
+				/>
+			</DropdownMenuPrimitive.Portal>
+		</DropdownMenuSizeContext.Provider>
 	);
 }
 
@@ -68,13 +84,15 @@ function DropdownMenuItem({
 	inset?: boolean;
 	variant?: "default" | "destructive";
 }) {
+	const size = useContext(DropdownMenuSizeContext);
 	return (
 		<DropdownMenuPrimitive.Item
 			data-slot="dropdown-menu-item"
 			data-inset={inset}
 			data-variant={variant}
 			className={cn(
-				"group/dropdown-menu-item relative flex cursor-pointer items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
+				"group/dropdown-menu-item relative flex cursor-pointer items-center rounded-md px-1.5 outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 data-[variant=destructive]:*:[svg]:text-destructive",
+				dropdownMenuItemSizeClasses[size],
 				className,
 			)}
 			{...props}
@@ -91,12 +109,14 @@ function DropdownMenuCheckboxItem({
 }: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem> & {
 	inset?: boolean;
 }) {
+	const size = useContext(DropdownMenuSizeContext);
 	return (
 		<DropdownMenuPrimitive.CheckboxItem
 			data-slot="dropdown-menu-checkbox-item"
 			data-inset={inset}
 			className={cn(
-				"relative flex cursor-pointer items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				"relative flex cursor-pointer items-center rounded-md pr-8 pl-1.5 outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+				dropdownMenuItemSizeClasses[size],
 				className,
 			)}
 			checked={checked}
@@ -134,12 +154,14 @@ function DropdownMenuRadioItem({
 }: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem> & {
 	inset?: boolean;
 }) {
+	const size = useContext(DropdownMenuSizeContext);
 	return (
 		<DropdownMenuPrimitive.RadioItem
 			data-slot="dropdown-menu-radio-item"
 			data-inset={inset}
 			className={cn(
-				"relative flex cursor-pointer items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				"relative flex cursor-pointer items-center rounded-md pr-8 pl-1.5 outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+				dropdownMenuItemSizeClasses[size],
 				className,
 			)}
 			{...props}
@@ -220,12 +242,14 @@ function DropdownMenuSubTrigger({
 }: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
 	inset?: boolean;
 }) {
+	const size = useContext(DropdownMenuSizeContext);
 	return (
 		<DropdownMenuPrimitive.SubTrigger
 			data-slot="dropdown-menu-sub-trigger"
 			data-inset={inset}
 			className={cn(
-				"flex cursor-pointer items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				"flex cursor-pointer items-center rounded-md px-1.5 outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0",
+				dropdownMenuItemSizeClasses[size],
 				className,
 			)}
 			{...props}

--- a/src/features/commit/button.tsx
+++ b/src/features/commit/button.tsx
@@ -374,7 +374,6 @@ export function WorkspaceCommitButton({
 					<DropdownMenuItem
 						key={item.id}
 						onClick={() => runAction(item.onClick)}
-						className="text-[11px]"
 					>
 						{item.label}
 					</DropdownMenuItem>

--- a/src/features/composer/index.tsx
+++ b/src/features/composer/index.tsx
@@ -574,9 +574,9 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 															<div className="flex items-center gap-3">
 																<span className="text-muted-foreground">
 																	{option.provider === "codex" ? (
-																		<OpenAIIcon className="size-[13px]" />
+																		<OpenAIIcon />
 																	) : (
-																		<ClaudeIcon className="size-[13px]" />
+																		<ClaudeIcon />
 																	)}
 																</span>
 																<span className="font-mono tabular-nums">
@@ -787,7 +787,7 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 });
 
 function EffortBrainIcon({ level }: { level: string }) {
-	const cls = "size-4 shrink-0";
+	const cls = "shrink-0";
 
 	if (level === "minimal") {
 		return (

--- a/src/features/navigation/clone-from-url-dialog.tsx
+++ b/src/features/navigation/clone-from-url-dialog.tsx
@@ -108,19 +108,26 @@ export function CloneFromUrlDialog({
 				onOpenChange(nextOpen);
 			}}
 		>
-			<DialogContent className="sm:max-w-md">
+			<DialogContent className="gap-3 p-4 sm:max-w-sm">
 				<DialogHeader>
-					<DialogTitle>Clone from URL</DialogTitle>
+					<DialogTitle className="text-[13px] font-medium tracking-[-0.01em]">
+						Clone from URL
+					</DialogTitle>
 				</DialogHeader>
 				<form
 					onSubmit={(event) => {
 						event.preventDefault();
 						void handleSubmit();
 					}}
-					className="flex flex-col gap-4"
+					className="flex flex-col gap-3"
 				>
-					<div className="flex flex-col gap-1.5">
-						<Label htmlFor="clone-git-url">Git URL</Label>
+					<div className="flex flex-col gap-1">
+						<Label
+							htmlFor="clone-git-url"
+							className="text-[12px] font-medium tracking-[-0.01em]"
+						>
+							Git URL
+						</Label>
 						<Input
 							id="clone-git-url"
 							type="text"
@@ -132,11 +139,17 @@ export function CloneFromUrlDialog({
 							autoCorrect="off"
 							spellCheck={false}
 							disabled={isSubmitting}
+							className="h-7 text-[13px] md:text-[13px]"
 						/>
 					</div>
-					<div className="flex flex-col gap-1.5">
-						<Label htmlFor="clone-location">Clone location</Label>
-						<div className="flex items-center gap-2">
+					<div className="flex flex-col gap-1">
+						<Label
+							htmlFor="clone-location"
+							className="text-[12px] font-medium tracking-[-0.01em]"
+						>
+							Clone location
+						</Label>
+						<div className="flex items-center gap-1.5">
 							<Input
 								id="clone-location"
 								type="text"
@@ -149,10 +162,12 @@ export function CloneFromUrlDialog({
 								autoCorrect="off"
 								spellCheck={false}
 								disabled={isSubmitting}
+								className="h-7 text-[13px] md:text-[13px]"
 							/>
 							<Button
 								type="button"
 								variant="outline"
+								size="sm"
 								onClick={() => {
 									void handleBrowse();
 								}}
@@ -163,12 +178,15 @@ export function CloneFromUrlDialog({
 						</div>
 					</div>
 					{errorMessage ? (
-						<p role="alert" className="text-destructive text-xs leading-snug">
+						<p
+							role="alert"
+							className="text-destructive text-[12px] leading-snug"
+						>
 							{errorMessage}
 						</p>
 					) : null}
-					<div className="flex justify-end">
-						<Button type="submit" disabled={!canSubmit}>
+					<div className="flex justify-end pt-0.5">
+						<Button type="submit" size="sm" disabled={!canSubmit}>
 							{isSubmitting ? (
 								<>
 									<LoaderCircle className="animate-spin" strokeWidth={2.1} />

--- a/src/features/navigation/clone-from-url-dialog.tsx
+++ b/src/features/navigation/clone-from-url-dialog.tsx
@@ -1,0 +1,186 @@
+import { open } from "@tauri-apps/plugin-dialog";
+import { LoaderCircle } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { describeUnknownError } from "@/lib/workspace-helpers";
+
+type SubmitArgs = {
+	gitUrl: string;
+	cloneDirectory: string;
+};
+
+type CloneFromUrlDialogProps = {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	defaultCloneDirectory: string | null;
+	onSubmit: (args: SubmitArgs) => Promise<void>;
+};
+
+export function CloneFromUrlDialog({
+	open: isOpen,
+	onOpenChange,
+	defaultCloneDirectory,
+	onSubmit,
+}: CloneFromUrlDialogProps) {
+	const [gitUrl, setGitUrl] = useState("");
+	const [cloneDirectory, setCloneDirectory] = useState("");
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [errorMessage, setErrorMessage] = useState<string | null>(null);
+	// Track whether the user has explicitly edited the location so the default
+	// only seeds the field once per open session — reopening after a manual
+	// change shouldn't wipe their choice.
+	const cloneDirectoryTouchedRef = useRef(false);
+
+	useEffect(() => {
+		if (!isOpen) {
+			return;
+		}
+		setIsSubmitting(false);
+		setErrorMessage(null);
+		if (!cloneDirectoryTouchedRef.current) {
+			setCloneDirectory(defaultCloneDirectory ?? "");
+		}
+	}, [isOpen, defaultCloneDirectory]);
+
+	const handleBrowse = useCallback(async () => {
+		try {
+			const selection = await open({
+				directory: true,
+				multiple: false,
+				defaultPath: cloneDirectory || defaultCloneDirectory || undefined,
+			});
+			const selected = Array.isArray(selection) ? selection[0] : selection;
+			if (selected) {
+				cloneDirectoryTouchedRef.current = true;
+				setCloneDirectory(selected);
+			}
+		} catch (error) {
+			setErrorMessage(
+				describeUnknownError(error, "Unable to open the folder picker."),
+			);
+		}
+	}, [cloneDirectory, defaultCloneDirectory]);
+
+	const trimmedUrl = gitUrl.trim();
+	const trimmedDirectory = cloneDirectory.trim();
+	const canSubmit =
+		trimmedUrl.length > 0 && trimmedDirectory.length > 0 && !isSubmitting;
+
+	const handleSubmit = useCallback(async () => {
+		if (!canSubmit) {
+			return;
+		}
+		setIsSubmitting(true);
+		setErrorMessage(null);
+		try {
+			await onSubmit({
+				gitUrl: trimmedUrl,
+				cloneDirectory: trimmedDirectory,
+			});
+			setGitUrl("");
+			setCloneDirectory("");
+			cloneDirectoryTouchedRef.current = false;
+			onOpenChange(false);
+		} catch (error) {
+			setErrorMessage(
+				describeUnknownError(error, "Unable to clone repository."),
+			);
+		} finally {
+			setIsSubmitting(false);
+		}
+	}, [canSubmit, onOpenChange, onSubmit, trimmedDirectory, trimmedUrl]);
+
+	return (
+		<Dialog
+			open={isOpen}
+			onOpenChange={(nextOpen) => {
+				if (isSubmitting && !nextOpen) {
+					return;
+				}
+				onOpenChange(nextOpen);
+			}}
+		>
+			<DialogContent className="sm:max-w-md">
+				<DialogHeader>
+					<DialogTitle>Clone from URL</DialogTitle>
+				</DialogHeader>
+				<form
+					onSubmit={(event) => {
+						event.preventDefault();
+						void handleSubmit();
+					}}
+					className="flex flex-col gap-4"
+				>
+					<div className="flex flex-col gap-1.5">
+						<Label htmlFor="clone-git-url">Git URL</Label>
+						<Input
+							id="clone-git-url"
+							type="text"
+							value={gitUrl}
+							onChange={(event) => setGitUrl(event.target.value)}
+							placeholder="https://github.com/user/repo.git"
+							autoFocus
+							autoComplete="off"
+							autoCorrect="off"
+							spellCheck={false}
+							disabled={isSubmitting}
+						/>
+					</div>
+					<div className="flex flex-col gap-1.5">
+						<Label htmlFor="clone-location">Clone location</Label>
+						<div className="flex items-center gap-2">
+							<Input
+								id="clone-location"
+								type="text"
+								value={cloneDirectory}
+								onChange={(event) => {
+									cloneDirectoryTouchedRef.current = true;
+									setCloneDirectory(event.target.value);
+								}}
+								autoComplete="off"
+								autoCorrect="off"
+								spellCheck={false}
+								disabled={isSubmitting}
+							/>
+							<Button
+								type="button"
+								variant="outline"
+								onClick={() => {
+									void handleBrowse();
+								}}
+								disabled={isSubmitting}
+							>
+								Browse…
+							</Button>
+						</div>
+					</div>
+					{errorMessage ? (
+						<p role="alert" className="text-destructive text-xs leading-snug">
+							{errorMessage}
+						</p>
+					) : null}
+					<div className="flex justify-end">
+						<Button type="submit" disabled={!canSubmit}>
+							{isSubmitting ? (
+								<>
+									<LoaderCircle className="animate-spin" strokeWidth={2.1} />
+									Cloning…
+								</>
+							) : (
+								"Clone repository"
+							)}
+						</Button>
+					</div>
+				</form>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/src/features/navigation/container.tsx
+++ b/src/features/navigation/container.tsx
@@ -34,17 +34,22 @@ export const WorkspacesSidebarContainer = memo(
 			archivedRows,
 			availableRepositories,
 			creatingWorkspaceRepoId,
+			cloneDefaultDirectory,
 			groups,
 			handleAddRepository,
 			handleArchiveWorkspace,
+			handleCloneFromUrl,
 			handleCreateWorkspaceFromRepo,
 			handleDeleteWorkspace,
 			handleMarkWorkspaceUnread,
+			handleOpenCloneDialog,
 			handleRestoreWorkspace,
 			handleSelectWorkspace,
 			handleSetManualStatus,
 			handleTogglePin,
+			isCloneDialogOpen,
 			prefetchWorkspace,
+			setIsCloneDialogOpen,
 		} = useWorkspacesSidebarController({
 			selectedWorkspaceId,
 			onSelectWorkspace,
@@ -65,6 +70,11 @@ export const WorkspacesSidebarContainer = memo(
 				onAddRepository={() => {
 					void handleAddRepository();
 				}}
+				onOpenCloneDialog={handleOpenCloneDialog}
+				isCloneDialogOpen={isCloneDialogOpen}
+				onCloneDialogOpenChange={setIsCloneDialogOpen}
+				cloneDefaultDirectory={cloneDefaultDirectory}
+				onSubmitClone={handleCloneFromUrl}
 				onSelectWorkspace={handleSelectWorkspace}
 				onPrefetchWorkspace={prefetchWorkspace}
 				onCreateWorkspace={(repoId) => {

--- a/src/features/navigation/hooks/use-controller.ts
+++ b/src/features/navigation/hooks/use-controller.ts
@@ -2,7 +2,9 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { open } from "@tauri-apps/plugin-dialog";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
+	type AddRepositoryResponse,
 	addRepositoryFromLocalPath,
+	cloneRepositoryFromUrl,
 	type DerivedStatus,
 	finalizeWorkspaceFromRepo,
 	listenArchiveExecutionFailed,
@@ -81,6 +83,10 @@ export function useWorkspacesSidebarController({
 	const queryClient = useQueryClient();
 	const { settings } = useSettings();
 	const [addingRepository, setAddingRepository] = useState(false);
+	const [isCloneDialogOpen, setIsCloneDialogOpen] = useState(false);
+	const [cloneDefaultDirectory, setCloneDefaultDirectory] = useState<
+		string | null
+	>(null);
 	const [creatingWorkspaceRepoId, setCreatingWorkspaceRepoId] = useState<
 		string | null
 	>(null);
@@ -931,6 +937,28 @@ export function useWorkspacesSidebarController({
 		],
 	);
 
+	const applyAddRepositoryResponse = useCallback(
+		async (response: AddRepositoryResponse) => {
+			await refetchNavigation();
+			prefetchWorkspace(response.selectedWorkspaceId);
+			onSelectWorkspace(response.selectedWorkspaceId);
+
+			if (!response.createdRepository) {
+				pushWorkspaceToast(
+					"Switched to the existing workspace.",
+					"Repository already added",
+					"default",
+				);
+			}
+		},
+		[
+			onSelectWorkspace,
+			prefetchWorkspace,
+			pushWorkspaceToast,
+			refetchNavigation,
+		],
+	);
+
 	const handleAddRepository = useCallback(async () => {
 		if (addingRepository) {
 			return;
@@ -940,6 +968,7 @@ export function useWorkspacesSidebarController({
 
 		try {
 			const defaults = await loadAddRepositoryDefaults();
+			setCloneDefaultDirectory(defaults.lastCloneDirectory ?? null);
 			const selection = await open({
 				directory: true,
 				multiple: false,
@@ -952,17 +981,7 @@ export function useWorkspacesSidebarController({
 			}
 
 			const response = await addRepositoryFromLocalPath(selectedPath);
-			await refetchNavigation();
-			prefetchWorkspace(response.selectedWorkspaceId);
-			onSelectWorkspace(response.selectedWorkspaceId);
-
-			if (!response.createdRepository) {
-				pushWorkspaceToast(
-					"Switched to the existing workspace.",
-					"Repository already added",
-					"default",
-				);
-			}
+			await applyAddRepositoryResponse(response);
 		} catch (error) {
 			pushWorkspaceToast(
 				describeUnknownError(error, "Unable to add repository."),
@@ -970,13 +989,29 @@ export function useWorkspacesSidebarController({
 		} finally {
 			setAddingRepository(false);
 		}
-	}, [
-		addingRepository,
-		onSelectWorkspace,
-		prefetchWorkspace,
-		pushWorkspaceToast,
-		refetchNavigation,
-	]);
+	}, [addingRepository, applyAddRepositoryResponse, pushWorkspaceToast]);
+
+	const handleOpenCloneDialog = useCallback(() => {
+		setIsCloneDialogOpen(true);
+		// Lazy-load the last-used clone directory so the dialog pre-fills it.
+		// Errors here are non-fatal — the dialog still works without a default.
+		void loadAddRepositoryDefaults()
+			.then((defaults) => {
+				setCloneDefaultDirectory(defaults.lastCloneDirectory ?? null);
+			})
+			.catch(() => {
+				/* swallow: dialog will just have an empty default */
+			});
+	}, []);
+
+	const handleCloneFromUrl = useCallback(
+		async (args: { gitUrl: string; cloneDirectory: string }) => {
+			const response = await cloneRepositoryFromUrl(args);
+			await applyAddRepositoryResponse(response);
+			setCloneDefaultDirectory(args.cloneDirectory);
+		},
+		[applyAddRepositoryResponse],
+	);
 
 	const handleDeleteWorkspace = useCallback(
 		(workspaceId: string) => {
@@ -1409,17 +1444,22 @@ export function useWorkspacesSidebarController({
 		archivedRows,
 		availableRepositories: repositoriesQuery.data ?? [],
 		creatingWorkspaceRepoId,
+		cloneDefaultDirectory,
 		groups,
 		handleAddRepository,
 		handleArchiveWorkspace,
+		handleCloneFromUrl,
 		handleCreateWorkspaceFromRepo,
 		handleDeleteWorkspace,
 		handleMarkWorkspaceUnread,
+		handleOpenCloneDialog,
 		handleRestoreWorkspace,
 		handleSelectWorkspace,
 		handleSetManualStatus,
 		handleTogglePin,
+		isCloneDialogOpen,
 		prefetchWorkspace,
+		setIsCloneDialogOpen,
 	};
 }
 

--- a/src/features/navigation/index.tsx
+++ b/src/features/navigation/index.tsx
@@ -2,7 +2,9 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import {
 	Archive,
 	ChevronRight,
+	Folder,
 	FolderPlus,
+	Globe,
 	LoaderCircle,
 	Plus,
 } from "lucide-react";
@@ -24,6 +26,12 @@ import {
 	CommandList,
 } from "@/components/ui/command";
 import { CommandPopoverContent } from "@/components/ui/command-popover";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Popover, PopoverAnchor } from "@/components/ui/popover";
 import {
 	Tooltip,
@@ -38,6 +46,7 @@ import type {
 } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import { WorkspaceAvatar } from "./avatar";
+import { CloneFromUrlDialog } from "./clone-from-url-dialog";
 import {
 	createInitialSectionOpenState,
 	readStoredSectionOpenState,
@@ -93,6 +102,11 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 	interactionRequiredWorkspaceIds,
 	creatingWorkspaceRepoId,
 	onAddRepository,
+	onOpenCloneDialog,
+	isCloneDialogOpen,
+	onCloneDialogOpenChange,
+	cloneDefaultDirectory,
+	onSubmitClone,
 	onSelectWorkspace,
 	onPrefetchWorkspace,
 	onCreateWorkspace,
@@ -115,6 +129,14 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 	interactionRequiredWorkspaceIds?: Set<string>;
 	creatingWorkspaceRepoId?: string | null;
 	onAddRepository?: () => void;
+	onOpenCloneDialog?: () => void;
+	isCloneDialogOpen?: boolean;
+	onCloneDialogOpenChange?: (open: boolean) => void;
+	cloneDefaultDirectory?: string | null;
+	onSubmitClone?: (args: {
+		gitUrl: string;
+		cloneDirectory: string;
+	}) => Promise<void>;
 	onSelectWorkspace?: (workspaceId: string) => void;
 	onPrefetchWorkspace?: (workspaceId: string) => void;
 	onCreateWorkspace?: (repoId: string) => void;
@@ -451,6 +473,17 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 
 	return (
 		<div className="flex h-full min-h-0 flex-col overflow-hidden">
+			<CloneFromUrlDialog
+				open={isCloneDialogOpen ?? false}
+				onOpenChange={(nextOpen) => onCloneDialogOpenChange?.(nextOpen)}
+				defaultCloneDirectory={cloneDefaultDirectory ?? null}
+				onSubmit={async (args) => {
+					if (!onSubmitClone) {
+						return;
+					}
+					await onSubmitClone(args);
+				}}
+			/>
 			<div
 				data-slot="window-safe-top"
 				className="flex h-9 shrink-0 items-center pr-3"
@@ -465,8 +498,8 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 				</h2>
 
 				<div className="flex items-center gap-1 text-muted-foreground">
-					<Tooltip>
-						<TooltipTrigger asChild>
+					<DropdownMenu>
+						<DropdownMenuTrigger asChild>
 							<Button
 								type="button"
 								aria-label="Add repository"
@@ -481,14 +514,6 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 										? "cursor-not-allowed opacity-60"
 										: undefined,
 								)}
-								onClick={() => {
-									if (addRepositoryBusy || createBusy || workspaceActionsBusy) {
-										return;
-									}
-
-									setIsRepoPickerOpen(false);
-									onAddRepository?.();
-								}}
 							>
 								{addRepositoryBusy ? (
 									<LoaderCircle className="animate-spin" strokeWidth={2.1} />
@@ -496,15 +521,28 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 									<FolderPlus strokeWidth={2} />
 								)}
 							</Button>
-						</TooltipTrigger>
-						<TooltipContent
-							side="top"
-							sideOffset={8}
-							className="flex h-[22px] items-center rounded-md px-1.5 text-[11px] leading-none"
-						>
-							<span>Add repository</span>
-						</TooltipContent>
-					</Tooltip>
+						</DropdownMenuTrigger>
+						<DropdownMenuContent align="end" className="min-w-40">
+							<DropdownMenuItem
+								onSelect={() => {
+									setIsRepoPickerOpen(false);
+									onAddRepository?.();
+								}}
+							>
+								<Folder strokeWidth={2} />
+								<span>Open project</span>
+							</DropdownMenuItem>
+							<DropdownMenuItem
+								onSelect={() => {
+									setIsRepoPickerOpen(false);
+									onOpenCloneDialog?.();
+								}}
+							>
+								<Globe strokeWidth={2} />
+								<span>Clone from URL</span>
+							</DropdownMenuItem>
+						</DropdownMenuContent>
+					</DropdownMenu>
 
 					<Popover open={isRepoPickerOpen} onOpenChange={setIsRepoPickerOpen}>
 						<PopoverAnchor asChild>

--- a/src/features/navigation/row-item.tsx
+++ b/src/features/navigation/row-item.tsx
@@ -231,7 +231,10 @@ export const WorkspaceRowItem = memo(
 						)}
 						<span
 							className={cn(
-								"truncate leading-none",
+								// leading-tight (1.25) instead of leading-none so descenders
+								// (g/j/p/q/y) aren't clipped by truncate's overflow:hidden
+								// when the page is zoomed out (Cmd+-).
+								"truncate leading-tight",
 								selected
 									? row.hasUnread
 										? "font-semibold text-foreground"

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1541,6 +1541,13 @@ export async function addRepositoryFromLocalPath(
 	});
 }
 
+export async function cloneRepositoryFromUrl(args: {
+	gitUrl: string;
+	cloneDirectory: string;
+}): Promise<AddRepositoryResponse> {
+	return invoke<AddRepositoryResponse>("clone_repository_from_url", args);
+}
+
 export async function markSessionRead(
 	sessionId: string,
 ): Promise<MarkWorkspaceReadResponse> {


### PR DESCRIPTION
## Summary

Adds a "Clone from URL" flow to the sidebar's add-repository affordance so users can pull a remote git repo into Helmor without needing to clone it separately first.

- **New backend command** `clone_repository_from_url(git_url, clone_directory)` in `src-tauri/src/commands/repository_commands.rs` — clones into `<clone_directory>/<inferred-name>`, best-effort cleans up a partial target on failure, then reuses the existing `add_repository_from_local_path` path. Backed by a new `GIT_CLONE_TIMEOUT = 300s` in `git/ops.rs` so large repos over slow networks aren't killed by the 30s network timeout.
- **New frontend dialog** `src/features/navigation/clone-from-url-dialog.tsx` and wiring in `features/navigation/{container,index,hooks/use-controller}.tsx`. Pre-fills the clone directory from the last-used value in add-repo defaults.
- **Sidebar affordance change**: the `+` button next to "Workspaces" is now a `DropdownMenu` with two options — `Open project` (existing local-path flow) and `Clone from URL` (new). Icons from `lucide-react` (`Folder`, `Globe`).
- **`DropdownMenu` size variant**: added a `size` prop (`default` | `sm`, default `sm`) with context-propagated item sizing so smaller menus (sidebar, composer) render at `text-xs`/`size-3` icons, and dropped now-redundant per-site size classes in `App.tsx`, `open-in-chat.tsx`, `composer/index.tsx`, `commit/button.tsx`.
- **Test updates**: existing `App.add-repo.test.tsx` flows now click the `Open project` menu item after opening the dropdown, matching the new UX.

## Why

Cloning a repo then pointing Helmor at the folder is an unnecessary two-step for a very common action. Folding it into the same affordance keeps discoverability high without cluttering the sidebar header.

## Test plan

- [ ] `bun run typecheck`
- [ ] `bun run test` (frontend + sidecar + rust)
- [ ] `bun run lint`
- [ ] Manual: click `+` in sidebar → `Clone from URL` → paste a public repo URL → confirm repo appears and workspace auto-selects
- [ ] Manual: retry with an already-cloned target directory and confirm the error message is actionable
- [ ] Manual: `Open project` path still works unchanged