### PR TITLE
fix: prevent stuck sessions from DB contention and stalled sidecars

### DIFF
--- a/.changeset/swift-tigers-persist.md
+++ b/.changeset/swift-tigers-persist.md
@@ -1,0 +1,7 @@
+---
+"helmor": patch
+---
+
+Fix stuck sessions caused by SQLite contention and unresponsive sidecars:
+- Eliminate the "database is locked" failures that could interrupt session actions (marking read, pinning, renaming) while an AI turn was actively writing to the DB.
+- Detect a frozen or disconnected sidecar via heartbeat and surface a retry-able error instead of leaving the session stuck in a streaming state.

--- a/sidecar/src/emitter.ts
+++ b/sidecar/src/emitter.ts
@@ -48,6 +48,16 @@ export type SteeredEvent = {
 
 export type PongEvent = { readonly id: string; readonly type: "pong" };
 
+/**
+ * Liveness ping — emitted every ~15s while a stream is active. Used by the
+ * Rust side to detect a hung/frozen sidecar vs. one that's legitimately
+ * waiting on a long-running tool. Carries no payload; only presence matters.
+ */
+export type HeartbeatEvent = {
+	readonly id: string;
+	readonly type: "heartbeat";
+};
+
 export type TitleGeneratedEvent = {
 	readonly id: string;
 	readonly type: "titleGenerated";
@@ -140,6 +150,7 @@ export type SidecarControlEvent =
 	| StoppedEvent
 	| SteeredEvent
 	| PongEvent
+	| HeartbeatEvent
 	| TitleGeneratedEvent
 	| SlashCommandsListedEvent
 	| PermissionRequestEvent
@@ -170,6 +181,7 @@ export interface SidecarEmitter {
 		reason?: string,
 	): void;
 	pong(requestId: string): void;
+	heartbeat(requestId: string): void;
 	titleGenerated(
 		requestId: string,
 		title: string,
@@ -257,6 +269,7 @@ export function createSidecarEmitter(
 				...(reason ? { reason } : {}),
 			}),
 		pong: (requestId) => write({ id: requestId, type: "pong" }),
+		heartbeat: (requestId) => write({ id: requestId, type: "heartbeat" }),
 		titleGenerated: (requestId, title, branchName) =>
 			write({ id: requestId, type: "titleGenerated", title, branchName }),
 		slashCommandsListed: (requestId, commands) =>

--- a/sidecar/src/index.ts
+++ b/sidecar/src/index.ts
@@ -45,6 +45,34 @@ const emitter = createSidecarEmitter((event) => {
 });
 
 // ---------------------------------------------------------------------------
+// Heartbeat — emit a lightweight keepalive every 15s for every in-flight
+// stream request. Rust's streaming loop uses its absence (no event for
+// >45s) to distinguish "sidecar frozen" from "AI legitimately running a
+// long tool call". Heartbeats carry no payload beyond the request id.
+// ---------------------------------------------------------------------------
+
+const HEARTBEAT_INTERVAL_MS = 15_000;
+const activeStreamIds = new Set<string>();
+let heartbeatTickCount = 0;
+
+setInterval(() => {
+	heartbeatTickCount++;
+	if (activeStreamIds.size === 0) return;
+	// Log every tick at debug so the logs show heartbeats are flowing.
+	logger.debug(
+		`heartbeat tick #${heartbeatTickCount} for ${activeStreamIds.size} active stream(s)`,
+		{ ids: [...activeStreamIds] },
+	);
+	for (const id of activeStreamIds) {
+		try {
+			emitter.heartbeat(id);
+		} catch {
+			// stdout closed — nothing to do
+		}
+	}
+}, HEARTBEAT_INTERVAL_MS).unref();
+
+// ---------------------------------------------------------------------------
 // Global error recovery — the sidecar must never crash from unhandled errors.
 // Log to stderr so Rust can capture it, emit a protocol error event so any
 // in-flight request gets notified, and keep the process alive.
@@ -80,6 +108,10 @@ async function handleSendMessage(
 	id: string,
 	params: Record<string, unknown>,
 ): Promise<void> {
+	activeStreamIds.add(id);
+	logger.debug(
+		`[${id}] stream tracking: +1 (now ${activeStreamIds.size} active)`,
+	);
 	try {
 		const provider = parseProvider(params.provider);
 		const sendParams = parseSendMessageParams(params);
@@ -99,6 +131,11 @@ async function handleSendMessage(
 		const msg = errorMessage(err);
 		logger.error(`[${id}] sendMessage FAILED: ${msg}`, errorDetails(err));
 		emitter.error(id, msg);
+	} finally {
+		activeStreamIds.delete(id);
+		logger.debug(
+			`[${id}] stream tracking: -1 (now ${activeStreamIds.size} active)`,
+		);
 	}
 }
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1804,6 +1804,8 @@ dependencies = [
  "libc",
  "notify",
  "notify-debouncer-full",
+ "r2d2",
+ "r2d2_sqlite",
  "rand 0.10.0",
  "reqwest 0.12.28",
  "rusqlite",
@@ -3753,6 +3755,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "r2d2"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
+dependencies = [
+ "log",
+ "parking_lot",
+ "scheduled-thread-pool",
+]
+
+[[package]]
+name = "r2d2_sqlite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a982edf65c129796dba72f8775b292ef482b40d035e827a9825b3bc07ccc5f2"
+dependencies = [
+ "r2d2",
+ "rusqlite",
+ "uuid",
+]
+
+[[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4234,6 +4258,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "scheduled-thread-pool"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]
@@ -5910,6 +5943,7 @@ checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
+ "rand 0.10.0",
  "serde_core",
  "wasm-bindgen",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,6 +28,8 @@ clap_complete = "4"
 rand = "0.10.0"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 rusqlite = { version = "0.31", features = ["bundled", "backup"] }
+r2d2 = "0.8"
+r2d2_sqlite = "0.24"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri = { version = "2", features = ["protocol-asset", "test"] }

--- a/src-tauri/src/agents.rs
+++ b/src-tauri/src/agents.rs
@@ -29,9 +29,8 @@ pub use self::streaming::{
 };
 
 use self::persistence::{
-    finalize_session_metadata, open_write_connection, persist_error_message,
-    persist_exit_plan_message, persist_result_and_finalize, persist_turn_message,
-    persist_user_message,
+    finalize_session_metadata, persist_error_message, persist_exit_plan_message,
+    persist_result_and_finalize, persist_turn_message, persist_user_message,
 };
 use self::streaming::stream_via_sidecar;
 use self::support::{resolve_resume_working_directory, resolve_working_directory};
@@ -741,6 +740,8 @@ mod tests {
             "INSERT INTO workspaces (id, repository_id, directory_name, state) VALUES ('w1', 'r1', 'test', 'ready')",
             [],
         ).unwrap();
+        drop(conn);
+        crate::models::db::init_pools().expect("failed to init test DB pools");
         db_path
     }
 

--- a/src-tauri/src/agents/persistence.rs
+++ b/src-tauri/src/agents/persistence.rs
@@ -310,10 +310,6 @@ fn finalize_session_metadata_in_transaction(
     Ok(())
 }
 
-pub(super) fn open_write_connection() -> Result<Connection> {
-    crate::models::db::open_connection(true)
-}
-
 fn current_timestamp_string() -> Result<String> {
     crate::models::db::current_timestamp()
 }

--- a/src-tauri/src/agents/queries.rs
+++ b/src-tauri/src/agents/queries.rs
@@ -1,6 +1,5 @@
 use std::sync::Mutex;
 
-use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tauri::{AppHandle, Manager};
@@ -45,7 +44,7 @@ pub async fn generate_session_title(
     request: GenerateSessionTitleRequest,
 ) -> CmdResult<GenerateSessionTitleResponse> {
     let connection =
-        open_write_connection().map_err(|e| anyhow::anyhow!("Failed to open DB: {e}"))?;
+        crate::models::db::read_conn().map_err(|e| anyhow::anyhow!("Failed to open DB: {e}"))?;
     let (current_title, action_kind): (String, Option<super::ActionKind>) = connection
         .query_row(
             "SELECT title, action_kind FROM sessions WHERE id = ?1",
@@ -212,8 +211,8 @@ pub async fn generate_session_title(
     let mut title_renamed = false;
     if should_generate_title {
         if let Some(ref title) = generated_title {
-            let connection =
-                open_write_connection().map_err(|e| anyhow::anyhow!("Failed to open DB: {e}"))?;
+            let connection = crate::models::db::read_conn()
+                .map_err(|e| anyhow::anyhow!("Failed to open DB: {e}"))?;
             let latest_title: String = connection
                 .query_row(
                     "SELECT title FROM sessions WHERE id = ?1",
@@ -251,13 +250,13 @@ pub async fn generate_session_title(
         {
             // Acquire per-workspace lock so concurrent title-gens serialise
             // their branch renames instead of racing on `git branch -m`.
-            let ws_lock = crate::models::db::workspace_mutation_lock(&workspace_id);
+            let ws_lock = crate::models::db::workspace_fs_mutation_lock(&workspace_id);
             let _guard = ws_lock.lock().await;
 
             // Re-read branch under lock to avoid TOCTOU: if another title-gen
             // already renamed the branch, we'll see the updated value and skip.
-            let connection =
-                open_write_connection().map_err(|e| anyhow::anyhow!("Failed to open DB: {e}"))?;
+            let connection = crate::models::db::read_conn()
+                .map_err(|e| anyhow::anyhow!("Failed to open DB: {e}"))?;
             let old_branch: Option<String> = connection
                 .query_row(
                     "SELECT branch FROM workspaces WHERE id = ?1",
@@ -786,10 +785,6 @@ fn spawn_background_refresh(
             cache_state.finish_refresh(&refresh_key);
         })
         .ok();
-}
-
-fn open_write_connection() -> Result<rusqlite::Connection> {
-    crate::models::db::open_connection(true)
 }
 
 // ---------------------------------------------------------------------------

--- a/src-tauri/src/agents/streaming.rs
+++ b/src-tauri/src/agents/streaming.rs
@@ -1,7 +1,82 @@
 use std::collections::HashMap;
 use std::path::Path;
+use std::sync::mpsc::RecvTimeoutError;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
+
+/// Maximum time we wait between sidecar events before declaring the sidecar
+/// dead. The sidecar emits a `heartbeat` event every 15s for every active
+/// stream; 45s = 3× heartbeat interval tolerates a single missed tick from
+/// GC / busy system without false positives. A long-running tool call (e.g.
+/// `bash: pytest` for 20 minutes) is fine because heartbeats keep flowing
+/// regardless of what the AI is doing.
+const HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(45);
+
+/// Persist an error message and finalize the session after an abnormal
+/// stream exit (heartbeat timeout, channel disconnect). Returns `true` iff
+/// the session row was successfully transitioned to `idle`.
+///
+/// Kept as a free fn so both the timeout/disconnect match arms and the
+/// regression tests can drive the same code path.
+pub(crate) fn cleanup_abnormal_stream_exit(
+    rid: &str,
+    exchange_ctx: Option<&ExchangeContext>,
+    resolved_model: &str,
+    user_message: &str,
+    effort_level: Option<&str>,
+    permission_mode: Option<&str>,
+) -> bool {
+    let Some(ctx) = exchange_ctx else {
+        tracing::debug!(
+            rid = %rid,
+            "cleanup_abnormal_stream_exit: no exchange_ctx — nothing to finalize"
+        );
+        return false;
+    };
+    let conn = match crate::models::db::write_conn() {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::error!(
+                rid = %rid,
+                session_id = %ctx.helmor_session_id,
+                "cleanup_abnormal_stream_exit: write_conn borrow failed — session may be stuck: {e}"
+            );
+            return false;
+        }
+    };
+
+    let err_persist_ok = match persist_error_message(&conn, ctx, resolved_model, user_message) {
+        Ok(_) => true,
+        Err(error) => {
+            tracing::error!(
+                rid = %rid,
+                session_id = %ctx.helmor_session_id,
+                "cleanup_abnormal_stream_exit: persist_error_message failed: {error}"
+            );
+            false
+        }
+    };
+
+    match finalize_session_metadata(&conn, ctx, "idle", effort_level, permission_mode) {
+        Ok(_) => {
+            tracing::debug!(
+                rid = %rid,
+                session_id = %ctx.helmor_session_id,
+                err_persist_ok,
+                "cleanup_abnormal_stream_exit: session finalized to idle"
+            );
+            true
+        }
+        Err(error) => {
+            tracing::error!(
+                rid = %rid,
+                session_id = %ctx.helmor_session_id,
+                "cleanup_abnormal_stream_exit: finalize_session_metadata failed: {error}"
+            );
+            false
+        }
+    }
+}
 
 use rusqlite::params;
 use serde_json::{json, Value};
@@ -13,9 +88,9 @@ use crate::pipeline::types::{
 };
 
 use super::{
-    finalize_session_metadata, open_write_connection, persist_error_message,
-    persist_exit_plan_message, persist_result_and_finalize, persist_turn_message,
-    persist_user_message, AgentSendRequest, AgentStreamEvent, CmdResult, ExchangeContext,
+    finalize_session_metadata, persist_error_message, persist_exit_plan_message,
+    persist_result_and_finalize, persist_turn_message, persist_user_message, AgentSendRequest,
+    AgentStreamEvent, CmdResult, ExchangeContext,
 };
 
 #[derive(Debug, Clone)]
@@ -320,7 +395,7 @@ pub fn lookup_workspace_linked_directories(helmor_session_id: Option<&str>) -> V
     let Some(hsid) = helmor_session_id else {
         return Vec::new();
     };
-    let conn = match open_write_connection() {
+    let conn = match crate::models::db::read_conn() {
         Ok(c) => c,
         Err(err) => {
             tracing::warn!(
@@ -387,7 +462,7 @@ pub(super) fn stream_via_sidecar(
 
     let resume_session_id = request.session_id.clone().or_else(|| {
         request.helmor_session_id.as_deref().and_then(|hsid| {
-            let conn = open_write_connection().ok()?;
+            let conn = crate::models::db::read_conn().ok()?;
             let (stored_sid, stored_provider): (Option<String>, Option<String>) = conn
                 .query_row(
                     "SELECT provider_session_id, agent_type FROM sessions WHERE id = ?1",
@@ -481,9 +556,21 @@ pub(super) fn stream_via_sidecar(
     let user_message_id_copy = request.user_message_id.clone();
     let files_copy = request.files.clone().unwrap_or_default();
     let resume_only = request.resume_only;
+    let sidecar_session_id_copy = sidecar_session_id.clone();
     let rid = request_id.clone();
 
     tauri::async_runtime::spawn_blocking(move || {
+        let stream_started_at = Instant::now();
+        tracing::info!(
+            rid = %rid,
+            helmor_session_id = ?hsid_copy,
+            sidecar_session_id = %sidecar_session_id_copy,
+            provider = %provider,
+            model = %model_copy.cli_model,
+            resume_only,
+            "stream: event loop starting"
+        );
+
         let sidecar_state: tauri::State<'_, crate::sidecar::ManagedSidecar> = app.state();
         let active_streams_state: tauri::State<'_, ActiveStreams> = app.state();
         let mut resolved_session_id: Option<String> = resume_session_id.clone();
@@ -498,17 +585,16 @@ pub(super) fn stream_via_sidecar(
             )
         });
         let mut event_count: u64 = 0;
+        let mut heartbeat_count: u64 = 0;
 
         let mut exchange_ctx: Option<ExchangeContext> = None;
         let mut persisted_turn_count: usize = 0;
-        let db_conn = if hsid_copy.is_some() {
-            open_write_connection().ok()
-        } else {
-            None
-        };
         let mut persisted_exit_plan_review: Option<ThreadMessageLike> = None;
 
-        if let (Some(hsid), Some(conn)) = (&hsid_copy, &db_conn) {
+        // Short-borrow only. The single-writer pool (max_size=1) is shared
+        // with every other write in the app; a long-held handle here would
+        // block pin/unpin/mark-read/rename for the entire turn.
+        if let Some(hsid) = &hsid_copy {
             let ctx = ExchangeContext {
                 helmor_session_id: hsid.clone(),
                 turn_id: Uuid::new_v4().to_string(),
@@ -520,32 +606,116 @@ pub(super) fn stream_via_sidecar(
                     .unwrap_or_else(|| Uuid::new_v4().to_string()),
             };
 
-            // Persist fast_mode toggle to session
-            if let Err(e) = conn.execute(
-                "UPDATE sessions SET fast_mode = ?1 WHERE id = ?2",
-                rusqlite::params![fast_mode, &ctx.helmor_session_id],
-            ) {
-                tracing::error!(rid = %rid, "Failed to update fast_mode: {e}");
-            }
+            match crate::models::db::write_conn() {
+                Ok(conn) => {
+                    if let Err(e) = conn.execute(
+                        "UPDATE sessions SET fast_mode = ?1 WHERE id = ?2",
+                        rusqlite::params![fast_mode, &ctx.helmor_session_id],
+                    ) {
+                        tracing::error!(rid = %rid, "Failed to update fast_mode: {e}");
+                    }
 
-            if resume_only {
-                exchange_ctx = Some(ctx);
-            } else {
-                match persist_user_message(conn, &ctx, &prompt_copy, &files_copy) {
-                    Ok(()) => {
-                        tracing::debug!(rid = %rid, "User message persisted to DB");
+                    if resume_only {
                         exchange_ctx = Some(ctx);
+                    } else {
+                        match persist_user_message(&conn, &ctx, &prompt_copy, &files_copy) {
+                            Ok(()) => {
+                                tracing::debug!(rid = %rid, "User message persisted to DB");
+                                exchange_ctx = Some(ctx);
+                            }
+                            Err(error) => {
+                                tracing::error!(rid = %rid, "Failed to persist user message: {error}");
+                            }
+                        }
                     }
-                    Err(error) => {
-                        tracing::error!(rid = %rid, "Failed to persist user message: {error}");
-                    }
+                }
+                Err(e) => {
+                    tracing::error!(rid = %rid, "Failed to borrow write conn for initial persist: {e}");
                 }
             }
         }
 
         tracing::debug!(rid = %rid, "Waiting for sidecar events...");
 
-        for event in rx.iter() {
+        loop {
+            let event = match rx.recv_timeout(HEARTBEAT_TIMEOUT) {
+                Ok(ev) => ev,
+                Err(err @ (RecvTimeoutError::Timeout | RecvTimeoutError::Disconnected)) => {
+                    let (reason_log, user_message, should_stop_sidecar) = match err {
+                        RecvTimeoutError::Timeout => (
+                            format!(
+                                "heartbeat lost for {:?} — treating stream as dead",
+                                HEARTBEAT_TIMEOUT
+                            ),
+                            format!(
+                                "Sidecar stopped responding (no heartbeat for {:?}). You can retry the request.",
+                                HEARTBEAT_TIMEOUT,
+                            ),
+                            true,
+                        ),
+                        RecvTimeoutError::Disconnected => (
+                            "sidecar channel disconnected".to_string(),
+                            "Sidecar connection was lost. You can retry the request.".to_string(),
+                            // Channel already closed — stopSession would most
+                            // likely fail, and if the sidecar already died
+                            // the request isn't running anyway.
+                            false,
+                        ),
+                    };
+                    tracing::error!(rid = %rid, "{reason_log}");
+
+                    if should_stop_sidecar {
+                        let stop_req = crate::sidecar::SidecarRequest {
+                            id: Uuid::new_v4().to_string(),
+                            method: "stopSession".to_string(),
+                            params: serde_json::json!({
+                                "sessionId": sidecar_session_id_copy,
+                                "provider": provider,
+                            }),
+                        };
+                        if let Err(e) = sidecar_state.send(&stop_req) {
+                            tracing::warn!(rid = %rid, "stopSession during abnormal exit failed: {e}");
+                        }
+                    }
+
+                    let resolved_model = pipeline
+                        .as_ref()
+                        .map(|p| p.accumulator.resolved_model().to_string())
+                        .unwrap_or_else(|| model_copy.cli_model.to_string());
+                    let persisted = cleanup_abnormal_stream_exit(
+                        &rid,
+                        exchange_ctx.as_ref(),
+                        &resolved_model,
+                        &user_message,
+                        effort_copy.as_deref(),
+                        permission_mode_copy.as_deref(),
+                    );
+
+                    tracing::info!(
+                        rid = %rid,
+                        event_count,
+                        heartbeat_count,
+                        elapsed_ms = stream_started_at.elapsed().as_millis(),
+                        persisted,
+                        has_exchange_ctx = exchange_ctx.is_some(),
+                        "stream: abnormal exit — finalized"
+                    );
+                    let _ = on_event.send(AgentStreamEvent::Error {
+                        message: user_message,
+                        persisted,
+                        internal: true,
+                    });
+                    break;
+                }
+            };
+
+            // Heartbeats are keepalives only — do not advance pipeline state.
+            if event.event_type() == "heartbeat" {
+                heartbeat_count += 1;
+                tracing::trace!(rid = %rid, heartbeat_count, "heartbeat");
+                continue;
+            }
+
             event_count += 1;
 
             // Claude's authoritative session_id comes only from `system.init`.
@@ -572,7 +742,9 @@ pub(super) fn stream_via_sidecar(
                                 provider_session_id = sid,
                                 "Skipping provider session persistence for resume-only stream"
                             );
-                        } else if let (Some(ctx), Some(conn)) = (&exchange_ctx, &db_conn) {
+                        } else if let (Some(ctx), Some(conn)) =
+                            (&exchange_ctx, &crate::models::db::write_conn().ok())
+                        {
                             if let Err(error) = conn.execute(
                                 "UPDATE sessions SET provider_session_id = ?2, agent_type = ?3 WHERE id = ?1",
                                 params![ctx.helmor_session_id, sid, ctx.model_provider],
@@ -603,7 +775,11 @@ pub(super) fn stream_via_sidecar(
                     };
                     let status = if is_aborted { "aborted" } else { "idle" };
 
-                    let persisted = exchange_ctx.is_some();
+                    // Tracks whether the FINAL finalize (persist_result_and_finalize
+                    // for end, finalize_session_metadata for aborted) succeeded.
+                    // Turn-message failures don't flip this back to false — the
+                    // frontend uses `persisted` as "end state is durable in DB".
+                    let mut persisted = false;
                     let mut resolved_model = model_copy.cli_model.to_string();
 
                     if let Some(mut pipeline_state) = pipeline.take() {
@@ -621,7 +797,9 @@ pub(super) fn stream_via_sidecar(
 
                         // Persist remaining turns and sync their UUIDs back
                         // into collected[] so streaming IDs = DB IDs.
-                        if let (Some(ctx), Some(conn)) = (&exchange_ctx, &db_conn) {
+                        if let (Some(ctx), Some(conn)) =
+                            (&exchange_ctx, &crate::models::db::write_conn().ok())
+                        {
                             let model_str = pipeline_state.accumulator.resolved_model().to_string();
                             while persisted_turn_count < pipeline_state.accumulator.turns_len() {
                                 match persist_turn_message(
@@ -647,20 +825,25 @@ pub(super) fn stream_via_sidecar(
                         if !output.assistant_text.is_empty() {
                             resolved_model = output.resolved_model.clone();
                         }
-                        if let (Some(ctx), Some(conn)) = (&exchange_ctx, &db_conn) {
+                        if let (Some(ctx), Some(conn)) =
+                            (&exchange_ctx, &crate::models::db::write_conn().ok())
+                        {
                             if is_aborted {
-                                if let Err(error) = finalize_session_metadata(
+                                match finalize_session_metadata(
                                     conn,
                                     ctx,
                                     status,
                                     effort_copy.as_deref(),
                                     permission_mode_copy.as_deref(),
                                 ) {
-                                    tracing::error!(rid = %rid, "Failed to finalize exchange: {error}");
+                                    Ok(_) => persisted = true,
+                                    Err(error) => {
+                                        tracing::error!(rid = %rid, "Failed to finalize exchange: {error}");
+                                    }
                                 }
                             } else {
                                 let preassigned = pipeline_state.accumulator.take_result_id();
-                                if let Err(error) = persist_result_and_finalize(
+                                match persist_result_and_finalize(
                                     conn,
                                     ctx,
                                     &output.resolved_model,
@@ -672,9 +855,17 @@ pub(super) fn stream_via_sidecar(
                                     status,
                                     preassigned,
                                 ) {
-                                    tracing::error!(rid = %rid, "Failed to finalize exchange: {error}");
+                                    Ok(_) => persisted = true,
+                                    Err(error) => {
+                                        tracing::error!(rid = %rid, "Failed to finalize exchange: {error}");
+                                    }
                                 }
                             }
+                        } else if exchange_ctx.is_some() {
+                            tracing::error!(
+                                rid = %rid,
+                                "Failed to borrow writer for finalize — reporting persisted=false"
+                            );
                         }
 
                         // Final render with DB-synced IDs so the frontend
@@ -688,6 +879,16 @@ pub(super) fn stream_via_sidecar(
                         });
                     }
 
+                    tracing::info!(
+                        rid = %rid,
+                        outcome = if is_aborted { "aborted" } else { "done" },
+                        event_count,
+                        heartbeat_count,
+                        persisted_turn_count,
+                        elapsed_ms = stream_started_at.elapsed().as_millis(),
+                        persisted,
+                        "stream: terminal event received"
+                    );
                     let _ = if let Some(reason) = reason {
                         on_event.send(AgentStreamEvent::Aborted {
                             provider: provider.clone(),
@@ -762,7 +963,9 @@ pub(super) fn stream_via_sidecar(
                     if let Some(pipeline_state) = pipeline.as_mut() {
                         pipeline_state.accumulator.flush_pending();
 
-                        if let (Some(ctx), Some(conn)) = (&exchange_ctx, &db_conn) {
+                        if let (Some(ctx), Some(conn)) =
+                            (&exchange_ctx, &crate::models::db::write_conn().ok())
+                        {
                             let model_str = pipeline_state.accumulator.resolved_model().to_string();
                             while persisted_turn_count < pipeline_state.accumulator.turns_len() {
                                 match persist_turn_message(
@@ -785,20 +988,21 @@ pub(super) fn stream_via_sidecar(
 
                         let resolved_model =
                             pipeline_state.accumulator.resolved_model().to_string();
-                        let persisted_metadata =
-                            if let (Some(ctx), Some(conn)) = (&exchange_ctx, &db_conn) {
-                                persist_exit_plan_message(
-                                    conn,
-                                    ctx,
-                                    &resolved_model,
-                                    &tool_use_id,
-                                    "ExitPlanMode",
-                                    &tool_input,
-                                )
-                                .ok()
-                            } else {
-                                None
-                            };
+                        let persisted_metadata = if let (Some(ctx), Some(conn)) =
+                            (&exchange_ctx, &crate::models::db::write_conn().ok())
+                        {
+                            persist_exit_plan_message(
+                                conn,
+                                ctx,
+                                &resolved_model,
+                                &tool_use_id,
+                                "ExitPlanMode",
+                                &tool_input,
+                            )
+                            .ok()
+                        } else {
+                            None
+                        };
                         let (msg_id, created_at) = persisted_metadata.unwrap_or_default();
                         persisted_exit_plan_review = Some(build_exit_plan_review_message(
                             (!msg_id.is_empty()).then_some(msg_id),
@@ -841,7 +1045,9 @@ pub(super) fn stream_via_sidecar(
                     if let Some(mut pipeline_state) = pipeline.take() {
                         pipeline_state.accumulator.flush_pending();
 
-                        if let (Some(ctx), Some(conn)) = (&exchange_ctx, &db_conn) {
+                        if let (Some(ctx), Some(conn)) =
+                            (&exchange_ctx, &crate::models::db::write_conn().ok())
+                        {
                             let model_str = pipeline_state.accumulator.resolved_model().to_string();
                             while persisted_turn_count < pipeline_state.accumulator.turns_len() {
                                 match persist_turn_message(
@@ -873,7 +1079,9 @@ pub(super) fn stream_via_sidecar(
                             messages: final_messages,
                         });
 
-                        if let (Some(ctx), Some(conn)) = (&exchange_ctx, &db_conn) {
+                        if let (Some(ctx), Some(conn)) =
+                            (&exchange_ctx, &crate::models::db::write_conn().ok())
+                        {
                             if let Err(error) = finalize_session_metadata(
                                 conn,
                                 ctx,
@@ -971,7 +1179,9 @@ pub(super) fn stream_via_sidecar(
                     tracing::debug!(rid = %rid, internal, "Sidecar error: {message}");
                     let mut persisted = false;
 
-                    if let (Some(ctx), Some(conn)) = (&exchange_ctx, &db_conn) {
+                    if let (Some(ctx), Some(conn)) =
+                        (&exchange_ctx, &crate::models::db::write_conn().ok())
+                    {
                         let resolved_model = pipeline
                             .as_ref()
                             .map(|pipeline_state| {
@@ -997,6 +1207,15 @@ pub(super) fn stream_via_sidecar(
                         }
                     }
 
+                    tracing::info!(
+                        rid = %rid,
+                        event_count,
+                        heartbeat_count,
+                        elapsed_ms = stream_started_at.elapsed().as_millis(),
+                        persisted,
+                        internal,
+                        "stream: error event — finalized"
+                    );
                     let _ = on_event.send(AgentStreamEvent::Error {
                         message,
                         persisted,
@@ -1010,7 +1229,9 @@ pub(super) fn stream_via_sidecar(
                         if let Some(pipeline_state) = pipeline.as_mut() {
                             let emit = pipeline_state.push_event(&event.raw, &line);
 
-                            if let (Some(ctx), Some(conn)) = (&exchange_ctx, &db_conn) {
+                            if let (Some(ctx), Some(conn)) =
+                                (&exchange_ctx, &crate::models::db::write_conn().ok())
+                            {
                                 let model_str =
                                     pipeline_state.accumulator.resolved_model().to_string();
                                 while persisted_turn_count < pipeline_state.accumulator.turns_len()
@@ -1054,7 +1275,14 @@ pub(super) fn stream_via_sidecar(
             }
         }
 
-        tracing::debug!(rid = %rid, event_count, "Event loop exited");
+        tracing::info!(
+            rid = %rid,
+            event_count,
+            heartbeat_count,
+            persisted_turn_count,
+            elapsed_ms = stream_started_at.elapsed().as_millis(),
+            "stream: event loop exited, cleaning up subscription"
+        );
         sidecar_state.unsubscribe(&rid);
         active_streams_state.unregister(&rid);
     });
@@ -1447,6 +1675,127 @@ working_directory: /tmp/helmor
                     lookup_workspace_linked_directories(Some("s-4")),
                     vec!["/abs/a".to_string(), "/abs/b".to_string()],
                 );
+            });
+        }
+    }
+
+    // ---- cleanup_abnormal_stream_exit ------------------------------------
+
+    mod cleanup_abnormal_exit {
+        use super::*;
+        use crate::agents::ExchangeContext;
+
+        fn with_session<F: FnOnce()>(session_status: &str, f: F) {
+            let dir = tempfile::tempdir().unwrap();
+            let _guard = crate::data_dir::TEST_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            std::env::set_var("HELMOR_DATA_DIR", dir.path());
+            crate::data_dir::ensure_directory_structure().unwrap();
+
+            let db_path = crate::data_dir::db_path().unwrap();
+            let conn = rusqlite::Connection::open(&db_path).unwrap();
+            crate::schema::ensure_schema(&conn).unwrap();
+            conn.execute(
+                "INSERT INTO repos (id, name, default_branch) VALUES ('r-1', 'r', 'main')",
+                [],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO workspaces (id, repository_id, directory_name, state, derived_status)
+                 VALUES ('w-1', 'r-1', 'd', 'ready', 'in-progress')",
+                [],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO sessions (id, workspace_id, status, title) VALUES (?1, 'w-1', ?2, 't')",
+                rusqlite::params!["s-1", session_status],
+            )
+            .unwrap();
+            drop(conn);
+
+            f();
+
+            std::env::remove_var("HELMOR_DATA_DIR");
+        }
+
+        fn ctx() -> ExchangeContext {
+            ExchangeContext {
+                helmor_session_id: "s-1".to_string(),
+                turn_id: "turn-1".to_string(),
+                model_id: "opus".to_string(),
+                model_provider: "claude".to_string(),
+                assistant_sdk_message_id: "sdk-1".to_string(),
+                user_message_id: "user-1".to_string(),
+            }
+        }
+
+        fn session_status() -> String {
+            crate::models::db::read_conn()
+                .unwrap()
+                .query_row("SELECT status FROM sessions WHERE id = 's-1'", [], |r| {
+                    r.get::<_, String>(0)
+                })
+                .unwrap()
+        }
+
+        fn error_message_count() -> i64 {
+            crate::models::db::read_conn()
+                .unwrap()
+                .query_row(
+                    "SELECT COUNT(*) FROM session_messages
+                     WHERE session_id = 's-1' AND content LIKE '%sidecar%'",
+                    [],
+                    |r| r.get::<_, i64>(0),
+                )
+                .unwrap()
+        }
+
+        #[test]
+        fn finalizes_session_to_idle_and_persists_error_message() {
+            with_session("streaming", || {
+                let persisted = cleanup_abnormal_stream_exit(
+                    "rid-1",
+                    Some(&ctx()),
+                    "opus",
+                    "sidecar dead, retry",
+                    None,
+                    None,
+                );
+                assert!(persisted, "expected persisted=true on successful finalize");
+                assert_eq!(session_status(), "idle");
+                assert_eq!(error_message_count(), 1);
+            });
+        }
+
+        #[test]
+        fn returns_false_and_does_not_touch_db_when_exchange_ctx_is_none() {
+            with_session("streaming", || {
+                let persisted =
+                    cleanup_abnormal_stream_exit("rid-2", None, "opus", "sidecar dead", None, None);
+                assert!(!persisted);
+                // Session must remain in streaming state — nothing happened.
+                assert_eq!(session_status(), "streaming");
+                assert_eq!(error_message_count(), 0);
+            });
+        }
+
+        #[test]
+        fn returns_false_when_session_row_does_not_exist() {
+            with_session("streaming", || {
+                let mut bad_ctx = ctx();
+                bad_ctx.helmor_session_id = "nonexistent".to_string();
+                let persisted = cleanup_abnormal_stream_exit(
+                    "rid-3",
+                    Some(&bad_ctx),
+                    "opus",
+                    "sidecar dead",
+                    None,
+                    None,
+                );
+                // finalize_session_metadata fails when no row matches; helper
+                // must report the session as NOT persisted rather than lying.
+                assert!(!persisted);
             });
         }
     }

--- a/src-tauri/src/agents/support.rs
+++ b/src-tauri/src/agents/support.rs
@@ -61,7 +61,7 @@ pub(super) fn resolve_working_directory(provided: Option<&str>) -> Result<PathBu
 }
 
 pub(super) fn resolve_resume_working_directory(session_id: &str) -> Result<Option<PathBuf>> {
-    let connection = crate::models::db::open_connection(false)
+    let connection = crate::models::db::read_conn()
         .context("Failed to open DB while resolving resume workspace")?;
     let workspace_info: Option<(String, String)> = connection
         .query_row(

--- a/src-tauri/src/cli/session.rs
+++ b/src-tauri/src/cli/session.rs
@@ -235,7 +235,7 @@ fn update_settings(
 ) -> Result<()> {
     let workspace_id = service::resolve_workspace_ref(workspace_ref)?;
     let session_id = refs::resolve_session_ref(&workspace_id, session)?;
-    let conn = crate::models::db::open_connection(true)?;
+    let conn = crate::models::db::write_conn()?;
     conn.execute(
         r#"
         UPDATE sessions SET

--- a/src-tauri/src/cli/settings.rs
+++ b/src-tauri/src/cli/settings.rs
@@ -38,7 +38,7 @@ fn set(key: &str, value: &str, cli: &Cli) -> Result<()> {
 }
 
 fn list(all: bool, cli: &Cli) -> Result<()> {
-    let conn = crate::models::db::open_connection(false)?;
+    let conn = crate::models::db::read_conn()?;
     let mut stmt = if all {
         conn.prepare("SELECT key, value FROM settings ORDER BY key ASC")?
     } else {
@@ -62,7 +62,7 @@ fn list(all: bool, cli: &Cli) -> Result<()> {
 }
 
 fn delete(key: &str, cli: &Cli) -> Result<()> {
-    let conn = crate::models::db::open_connection(true)?;
+    let conn = crate::models::db::write_conn()?;
     let removed = conn.execute("DELETE FROM settings WHERE key = ?1", params![key])?;
     if removed == 0 {
         bail!("No setting with key '{key}'");

--- a/src-tauri/src/commands/repository_commands.rs
+++ b/src-tauri/src/commands/repository_commands.rs
@@ -32,7 +32,7 @@ pub async fn clone_repository_from_url(
     git_url: String,
     clone_directory: String,
 ) -> CmdResult<repos::AddRepositoryResponse> {
-    let _lock = db::WORKSPACE_MUTATION_LOCK.lock().await;
+    let _lock = db::WORKSPACE_FS_MUTATION_LOCK.lock().await;
     run_blocking(move || repos::clone_repository_from_url(&git_url, &clone_directory)).await
 }
 

--- a/src-tauri/src/commands/repository_commands.rs
+++ b/src-tauri/src/commands/repository_commands.rs
@@ -23,7 +23,7 @@ pub async fn get_add_repository_defaults() -> CmdResult<repos::AddRepositoryDefa
 pub async fn add_repository_from_local_path(
     folder_path: String,
 ) -> CmdResult<repos::AddRepositoryResponse> {
-    let _lock = db::WORKSPACE_MUTATION_LOCK.lock().await;
+    let _lock = db::WORKSPACE_FS_MUTATION_LOCK.lock().await;
     run_blocking(move || repos::add_repository_from_local_path(&folder_path)).await
 }
 
@@ -96,6 +96,6 @@ pub async fn update_repo_preferences(
 
 #[tauri::command]
 pub async fn delete_repository(repo_id: String) -> CmdResult<()> {
-    let _lock = db::WORKSPACE_MUTATION_LOCK.lock().await;
+    let _lock = db::WORKSPACE_FS_MUTATION_LOCK.lock().await;
     run_blocking(move || repos::delete_repository_cascade(&repo_id)).await
 }

--- a/src-tauri/src/commands/session_commands.rs
+++ b/src-tauri/src/commands/session_commands.rs
@@ -70,14 +70,12 @@ pub async fn list_hidden_sessions(
 
 #[tauri::command]
 pub async fn mark_session_read(session_id: String) -> CmdResult<()> {
-    let _lock = db::WORKSPACE_MUTATION_LOCK.lock().await;
-    Ok(sessions::mark_session_read(&session_id)?)
+    run_blocking(move || sessions::mark_session_read(&session_id)).await
 }
 
 #[tauri::command]
 pub async fn mark_session_unread(session_id: String) -> CmdResult<()> {
-    let _lock = db::WORKSPACE_MUTATION_LOCK.lock().await;
-    Ok(sessions::mark_session_unread(&session_id)?)
+    run_blocking(move || sessions::mark_session_unread(&session_id)).await
 }
 
 #[tauri::command]
@@ -88,7 +86,7 @@ pub async fn update_session_settings(
     permission_mode: Option<String>,
 ) -> CmdResult<()> {
     run_blocking(move || {
-        let connection = db::open_connection(true)?;
+        let connection = db::write_conn()?;
         connection
             .execute(
                 r#"

--- a/src-tauri/src/commands/settings_commands.rs
+++ b/src-tauri/src/commands/settings_commands.rs
@@ -7,7 +7,7 @@ use super::common::{run_blocking, CmdResult};
 #[tauri::command]
 pub async fn get_app_settings() -> CmdResult<std::collections::HashMap<String, String>> {
     run_blocking(|| {
-        let conn = db::open_connection(false)?;
+        let conn = db::read_conn()?;
         let mut stmt = conn
             .prepare(
                 "SELECT key, value FROM settings WHERE key LIKE 'app.%' OR key LIKE 'branch_prefix_%'",

--- a/src-tauri/src/commands/system_commands.rs
+++ b/src-tauri/src/commands/system_commands.rs
@@ -357,7 +357,7 @@ pub async fn dev_reset_all_data(app: tauri::AppHandle) -> CmdResult<DevResetResu
         tracing::warn!(dir = %data_dir.display(), "DEV RESET: wiping all data");
 
         // --- Database cleanup (single transaction) -----------------------
-        let mut conn = db::open_connection(true)?;
+        let mut conn = db::write_conn()?;
         let tx = conn
             .transaction()
             .context("Failed to start dev-reset transaction")?;

--- a/src-tauri/src/commands/tests/support.rs
+++ b/src-tauri/src/commands/tests/support.rs
@@ -14,6 +14,7 @@ impl TestDataDir {
             std::env::temp_dir().join(format!("helmor-test-{name}-{}", uuid::Uuid::new_v4()));
         std::env::set_var("HELMOR_DATA_DIR", root.display().to_string());
         crate::data_dir::ensure_directory_structure().unwrap();
+        crate::models::db::init_pools().expect("failed to init test DB pools");
         Self { root }
     }
 

--- a/src-tauri/src/commands/workspace_commands.rs
+++ b/src-tauri/src/commands/workspace_commands.rs
@@ -28,7 +28,7 @@ pub async fn prepare_workspace_from_repo(
     repo_id: String,
 ) -> CmdResult<workspaces::PrepareWorkspaceResponse> {
     let result = {
-        let _lock = db::WORKSPACE_MUTATION_LOCK.lock().await;
+        let _lock = db::WORKSPACE_FS_MUTATION_LOCK.lock().await;
         run_blocking(move || workspaces::prepare_workspace_from_repo_impl(&repo_id)).await?
     };
     notify_workspace_changed_in_background(app);
@@ -45,7 +45,7 @@ pub async fn finalize_workspace_from_repo(
     app: AppHandle,
     workspace_id: String,
 ) -> CmdResult<workspaces::FinalizeWorkspaceResponse> {
-    let ws_lock = db::workspace_mutation_lock(&workspace_id);
+    let ws_lock = db::workspace_fs_mutation_lock(&workspace_id);
     let _lock = ws_lock.lock().await;
     let result = {
         let workspace_id = workspace_id.clone();
@@ -64,7 +64,7 @@ pub async fn create_workspace_from_repo(
     repo_id: String,
 ) -> CmdResult<workspaces::CreateWorkspaceResponse> {
     let result = {
-        let _lock = db::WORKSPACE_MUTATION_LOCK.lock().await;
+        let _lock = db::WORKSPACE_FS_MUTATION_LOCK.lock().await;
         run_blocking(move || workspaces::create_workspace_from_repo_impl(&repo_id)).await?
     };
     notify_workspace_changed_in_background(app);
@@ -101,23 +101,17 @@ pub async fn get_workspace(workspace_id: String) -> CmdResult<workspaces::Worksp
 
 #[tauri::command]
 pub async fn mark_workspace_unread(workspace_id: String) -> CmdResult<()> {
-    let ws_lock = db::workspace_mutation_lock(&workspace_id);
-    let _lock = ws_lock.lock().await;
-    Ok(workspaces::mark_workspace_unread(&workspace_id)?)
+    run_blocking(move || workspaces::mark_workspace_unread(&workspace_id)).await
 }
 
 #[tauri::command]
 pub async fn pin_workspace(workspace_id: String) -> CmdResult<()> {
-    let ws_lock = db::workspace_mutation_lock(&workspace_id);
-    let _lock = ws_lock.lock().await;
-    Ok(workspaces::pin_workspace(&workspace_id)?)
+    run_blocking(move || workspaces::pin_workspace(&workspace_id)).await
 }
 
 #[tauri::command]
 pub async fn unpin_workspace(workspace_id: String) -> CmdResult<()> {
-    let ws_lock = db::workspace_mutation_lock(&workspace_id);
-    let _lock = ws_lock.lock().await;
-    Ok(workspaces::unpin_workspace(&workspace_id)?)
+    run_blocking(move || workspaces::unpin_workspace(&workspace_id)).await
 }
 
 #[tauri::command]
@@ -125,12 +119,7 @@ pub async fn set_workspace_manual_status(
     workspace_id: String,
     status: Option<DerivedStatus>,
 ) -> CmdResult<()> {
-    let ws_lock = db::workspace_mutation_lock(&workspace_id);
-    let _lock = ws_lock.lock().await;
-    Ok(workspaces::set_workspace_manual_status(
-        &workspace_id,
-        status,
-    )?)
+    run_blocking(move || workspaces::set_workspace_manual_status(&workspace_id, status)).await
 }
 
 /// `/add-dir` feature: list the extra directories the user has linked to
@@ -149,8 +138,6 @@ pub async fn set_workspace_linked_directories(
     workspace_id: String,
     directories: Vec<String>,
 ) -> CmdResult<Vec<String>> {
-    let ws_lock = db::workspace_mutation_lock(&workspace_id);
-    let _lock = ws_lock.lock().await;
     let workspace_id_clone = workspace_id.clone();
     let result = run_blocking(move || {
         workspaces::set_workspace_linked_directories(&workspace_id_clone, directories)
@@ -188,7 +175,7 @@ pub async fn rename_workspace_branch(
     workspace_id: String,
     new_branch: String,
 ) -> CmdResult<()> {
-    let ws_lock = db::workspace_mutation_lock(&workspace_id);
+    let ws_lock = db::workspace_fs_mutation_lock(&workspace_id);
     let _lock = ws_lock.lock().await;
     run_blocking(move || workspaces::rename_workspace_branch(&workspace_id, &new_branch)).await?;
     git_watcher::notify_workspace_changed(&app);
@@ -201,7 +188,7 @@ pub async fn update_intended_target_branch(
     workspace_id: String,
     target_branch: String,
 ) -> CmdResult<workspaces::UpdateIntendedTargetBranchResponse> {
-    let ws_lock = db::workspace_mutation_lock(&workspace_id);
+    let ws_lock = db::workspace_fs_mutation_lock(&workspace_id);
     let _lock = ws_lock.lock().await;
     let result = run_blocking(move || {
         workspaces::update_intended_target_branch(&workspace_id, &target_branch)
@@ -234,7 +221,7 @@ pub async fn prefetch_remote_refs(
 pub async fn sync_workspace_with_target_branch(
     workspace_id: String,
 ) -> CmdResult<workspaces::SyncWorkspaceTargetResponse> {
-    let ws_lock = db::workspace_mutation_lock(&workspace_id);
+    let ws_lock = db::workspace_fs_mutation_lock(&workspace_id);
     let _lock = ws_lock.lock().await;
     run_blocking(move || workspaces::sync_workspace_with_target_branch(&workspace_id)).await
 }
@@ -243,7 +230,7 @@ pub async fn sync_workspace_with_target_branch(
 pub async fn push_workspace_to_remote(
     workspace_id: String,
 ) -> CmdResult<workspaces::PushWorkspaceToRemoteResponse> {
-    let ws_lock = db::workspace_mutation_lock(&workspace_id);
+    let ws_lock = db::workspace_fs_mutation_lock(&workspace_id);
     let _lock = ws_lock.lock().await;
     run_blocking(move || workspaces::push_workspace_to_remote(&workspace_id)).await
 }
@@ -254,7 +241,7 @@ pub async fn restore_workspace(
     workspace_id: String,
     target_branch_override: Option<String>,
 ) -> CmdResult<workspaces::RestoreWorkspaceResponse> {
-    let ws_lock = db::workspace_mutation_lock(&workspace_id);
+    let ws_lock = db::workspace_fs_mutation_lock(&workspace_id);
     let _lock = ws_lock.lock().await;
     let result = run_blocking(move || {
         workspaces::restore_workspace_impl(&workspace_id, target_branch_override.as_deref())
@@ -305,7 +292,7 @@ pub async fn validate_archive_workspace(
 
 #[tauri::command]
 pub async fn permanently_delete_workspace(app: AppHandle, workspace_id: String) -> CmdResult<()> {
-    let ws_lock = db::workspace_mutation_lock(&workspace_id);
+    let ws_lock = db::workspace_fs_mutation_lock(&workspace_id);
     let _lock = ws_lock.lock().await;
     let manager = app.state::<git_watcher::GitWatcherManager>();
     manager.unwatch(&workspace_id);

--- a/src-tauri/src/git/watcher.rs
+++ b/src-tauri/src/git/watcher.rs
@@ -549,7 +549,7 @@ fn do_triggered_fetch(workspace_id: &str) -> Result<()> {
 
 /// Returns (workspace_dir, remote, branch, repo_id).
 fn lookup_fetch_target(workspace_id: &str) -> Result<(PathBuf, String, String, String)> {
-    let connection = db::open_connection(false)?;
+    let connection = db::read_conn()?;
     let sql = format!(
         "SELECT r.name, w.directory_name, r.remote,
                 COALESCE(w.intended_target_branch, r.default_branch), r.id
@@ -651,7 +651,7 @@ fn update_branch_in_db(
     old_branch: Option<&str>,
     new_branch: &str,
 ) -> Result<()> {
-    let connection = db::open_connection(true)?;
+    let connection = db::write_conn()?;
     let rows = match old_branch {
         Some(old) => connection.execute(
             &format!(
@@ -681,7 +681,7 @@ fn update_branch_in_db(
 // -- DB helper --
 
 fn load_watchable_workspaces() -> Result<Vec<WatchableWorkspace>> {
-    let connection = db::open_connection(false)?;
+    let connection = db::read_conn()?;
     let mut stmt = connection.prepare(
         "SELECT w.id, r.name, w.directory_name, w.branch, w.state,
                 r.remote, COALESCE(w.intended_target_branch, r.default_branch), r.id

--- a/src-tauri/src/import.rs
+++ b/src-tauri/src/import.rs
@@ -513,7 +513,7 @@ fn setup_workspace_filesystem(
                 })?;
 
             // Update branch in DB (best-effort, DB is already committed)
-            match crate::models::db::open_connection(true) {
+            match crate::models::db::write_conn() {
                 Ok(conn) => {
                     if let Err(e) = conn.execute(
                         "UPDATE workspaces SET branch = ?1 WHERE id = ?2",
@@ -578,7 +578,7 @@ fn setup_workspace_filesystem(
 
     // Rewrite attachment paths
     if let Some(root) = conductor_root {
-        let conn = crate::models::db::open_connection(true)?;
+        let conn = crate::models::db::write_conn()?;
         rewrite_attachment_paths(
             &conn,
             workspace_id,
@@ -602,7 +602,7 @@ fn setup_workspace_filesystem(
 }
 
 fn delete_imported_workspace_records(workspace_id: &str) -> Result<()> {
-    let conn = crate::models::db::open_connection(true)?;
+    let conn = crate::models::db::write_conn()?;
     conn.execute_batch("BEGIN IMMEDIATE")
         .context("Failed to start cleanup transaction")?;
 
@@ -1474,7 +1474,7 @@ mod tests {
             "expected source branch resolution failure, got {:?}",
             result.errors
         );
-        let conn = crate::models::db::open_connection(true).unwrap();
+        let conn = crate::models::db::write_conn().unwrap();
         let workspace_count: i64 = conn
             .query_row("SELECT count(*) FROM workspaces WHERE id = 'w1'", [], |r| {
                 r.get(0)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -40,6 +40,7 @@ use tauri::Manager;
 
 /// Initialise the database schema (call once at startup).
 pub fn schema_init(conn: &rusqlite::Connection) {
+    db::init_connection(conn, true).expect("Failed to apply PRAGMA init");
     schema::ensure_schema(conn).expect("Failed to initialize database schema");
 }
 
@@ -74,10 +75,17 @@ pub fn run() {
             let logs_dir = data_dir::logs_dir()?;
             logging::init(&logs_dir)?;
 
-            // Initialize database schema
+            // Initialize database schema. We apply the same PRAGMA init as
+            // the pools to get WAL mode persisted to the file before any
+            // pool connection opens.
             let db_path = data_dir::db_path()?;
             let connection = rusqlite::Connection::open(&db_path)?;
+            db::init_connection(&connection, true)?;
             schema::ensure_schema(&connection)?;
+            drop(connection);
+
+            // Build read/write connection pools (must happen after schema).
+            db::init_pools()?;
 
             tracing::info!(
                 mode = data_dir::data_mode_label(),

--- a/src-tauri/src/models/db.rs
+++ b/src-tauri/src/models/db.rs
@@ -1,45 +1,38 @@
+//! DB connection pools + unified API.
+//!
+//! Two pools match SQLite's concurrency model:
+//!   - read pool  (size = 8) — WAL readers run fully concurrently
+//!   - write pool (size = 1) — single-writer executor; app-layer queue
+//!     eliminates SQLITE_BUSY
+//!
+//! Initialise once at startup via [`init_pools`]. All DB access goes
+//! through [`read_conn`] / [`write_conn`] or the closure helpers
+//! [`read`] / [`write_transaction`].
 use std::collections::HashMap;
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, OnceLock, RwLock};
+use std::time::Duration;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use chrono::{SecondsFormat, Utc};
-use rusqlite::{Connection, OpenFlags};
+use r2d2::{Pool, PooledConnection};
+use r2d2_sqlite::SqliteConnectionManager;
+use rusqlite::{Connection, OpenFlags, Transaction};
 use tauri::async_runtime::Mutex;
 
-/// Serializes any operation that mutates a workspace's filesystem state
-/// (worktree creation/removal/reset) along with its DB row, so concurrent
-/// commands can't interleave a half-applied filesystem change with a DB
-/// update.
-///
-/// This is a `tokio::sync::Mutex` (re-exported via `tauri::async_runtime`)
-/// rather than `std::sync::Mutex` so that it can be `.lock().await`-ed
-/// directly inside async Tauri commands without needing to wrap the
-/// acquisition in `spawn_blocking`. The background `refresh_remote_and_realign`
-/// thread (spawned via `std::thread::spawn`, NOT a Tokio runtime worker)
-/// uses `.blocking_lock()` instead.
-///
-/// Retained for commands that don't target a specific existing workspace
-/// (e.g. `add_repository_from_local_path`, `create_workspace_from_repo`).
-/// Commands that operate on a known workspace should prefer the per-workspace
-/// lock from [`workspace_mutation_lock`].
-pub static WORKSPACE_MUTATION_LOCK: Mutex<()> = Mutex::const_new(());
+pub type PooledConn = PooledConnection<SqliteConnectionManager>;
 
-/// Per-workspace mutation lock map. Each workspace gets its own
-/// `tokio::sync::Mutex` so that heavy git operations on one workspace
-/// (e.g. `git reset --hard` inside `update_intended_target_branch`) do not
-/// block unrelated commands on other workspaces.
-///
-/// The outer `std::sync::Mutex` protects the `HashMap` itself and is held
-/// only for the brief map lookup / insertion — never across I/O.
+/// Serializes FS-mutating operations on a workspace (worktree creation /
+/// removal / reset) together with the DB row update, so concurrent commands
+/// can't interleave a half-applied filesystem change with a DB update.
+pub static WORKSPACE_FS_MUTATION_LOCK: Mutex<()> = Mutex::const_new(());
+
+/// Per-workspace FS-mutation lock map (see [`WORKSPACE_FS_MUTATION_LOCK`]).
 fn per_workspace_locks() -> &'static std::sync::Mutex<HashMap<String, Arc<Mutex<()>>>> {
     static MAP: OnceLock<std::sync::Mutex<HashMap<String, Arc<Mutex<()>>>>> = OnceLock::new();
     MAP.get_or_init(|| std::sync::Mutex::new(HashMap::new()))
 }
 
-/// Return a shareable handle to the per-workspace mutation lock for
-/// `workspace_id`. The returned `Arc<Mutex<()>>` can be `.lock().await`-ed
-/// from async Tauri commands or `.blocking_lock()`-ed from std threads.
-pub fn workspace_mutation_lock(workspace_id: &str) -> Arc<Mutex<()>> {
+pub fn workspace_fs_mutation_lock(workspace_id: &str) -> Arc<Mutex<()>> {
     let mut map = per_workspace_locks()
         .lock()
         .expect("per-workspace lock map poisoned");
@@ -48,42 +41,325 @@ pub fn workspace_mutation_lock(workspace_id: &str) -> Arc<Mutex<()>> {
         .clone()
 }
 
-/// Remove the per-workspace mutation lock for a deleted workspace so the
-/// static map does not grow unboundedly.
 pub fn remove_workspace_lock(workspace_id: &str) {
     if let Ok(mut map) = per_workspace_locks().lock() {
         map.remove(workspace_id);
     }
 }
 
-/// Open a connection to the Helmor database.
-pub fn open_connection(writable: bool) -> Result<Connection> {
-    let db_path = crate::data_dir::db_path()?;
-    let flags = if writable {
-        OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_NO_MUTEX
-    } else {
-        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX
-    };
+// ── Pools ────────────────────────────────────────────────────────────────
 
-    open_connection_with_flags(&db_path, flags, writable)
+struct PoolBundle {
+    path: std::path::PathBuf,
+    read: Pool<SqliteConnectionManager>,
+    write: Pool<SqliteConnectionManager>,
 }
 
-/// Open a connection with explicit path and flags.
-pub fn open_connection_with_flags(
-    path: &std::path::Path,
-    flags: OpenFlags,
-    set_busy_timeout: bool,
-) -> Result<Connection> {
-    let connection = Connection::open_with_flags(path, flags)?;
+/// RwLock-wrapped so tests can transparently rebuild the pools when they
+/// swap `HELMOR_DATA_DIR`. In production [`init_pools`] runs once and the
+/// lock sees a single writer forever.
+fn pool_slot() -> &'static RwLock<Option<PoolBundle>> {
+    static P: OnceLock<RwLock<Option<PoolBundle>>> = OnceLock::new();
+    P.get_or_init(|| RwLock::new(None))
+}
 
-    if set_busy_timeout {
-        connection.busy_timeout(std::time::Duration::from_secs(3))?;
+const READ_POOL_SIZE: u32 = 8;
+const WRITE_POOL_SIZE: u32 = 1;
+const POOL_GET_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Unified per-connection initialization. Applied by both pools and by any
+/// ad-hoc `Connection::open` sites (schema init, tests, import).
+///
+/// Writable-only PRAGMAs (journal_mode, synchronous, busy_timeout) are
+/// skipped on read-only connections: SQLite can't rewrite the journal
+/// header from a read-only handle, and busy_timeout is moot for readers
+/// in WAL mode (readers never block). `journal_mode=WAL` only needs to be
+/// set ONCE per DB file (it persists), done on the first writable open.
+pub fn init_connection(conn: &Connection, writable: bool) -> rusqlite::Result<()> {
+    // Read-compatible PRAGMAs — safe and useful on either handle type.
+    conn.pragma_update(None, "temp_store", "MEMORY")?;
+    conn.pragma_update(None, "cache_size", -20_000)?; // 20 MiB
+    conn.pragma_update(None, "mmap_size", 268_435_456i64)?; // 256 MiB
+
+    if writable {
+        // journal_mode is persisted to the DB file on first set; idempotent here.
+        conn.pragma_update(None, "journal_mode", "WAL")?;
+        conn.pragma_update(None, "synchronous", "NORMAL")?;
+        conn.busy_timeout(Duration::from_secs(3))?;
+        // TODO(tech-debt): enable foreign_keys=ON once an orphan-cleanup migration lands.
     }
 
-    Ok(connection)
+    conn.set_prepared_statement_cache_capacity(256);
+    Ok(())
 }
 
-/// Get the current UTC timestamp without opening a throwaway SQLite connection.
+fn build_bundle(path: std::path::PathBuf) -> Result<PoolBundle> {
+    let write_mgr = SqliteConnectionManager::file(&path)
+        .with_flags(
+            OpenFlags::SQLITE_OPEN_READ_WRITE
+                | OpenFlags::SQLITE_OPEN_CREATE
+                | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )
+        .with_init(|c| init_connection(c, true));
+    let write = Pool::builder()
+        .max_size(WRITE_POOL_SIZE)
+        .connection_timeout(POOL_GET_TIMEOUT)
+        .build(write_mgr)
+        .map_err(|e| anyhow!("Failed to build write pool: {e}"))?;
+
+    let read_mgr = SqliteConnectionManager::file(&path)
+        .with_flags(OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX)
+        .with_init(|c| init_connection(c, false));
+    let read = Pool::builder()
+        .max_size(READ_POOL_SIZE)
+        .connection_timeout(POOL_GET_TIMEOUT)
+        .build(read_mgr)
+        .map_err(|e| anyhow!("Failed to build read pool: {e}"))?;
+
+    Ok(PoolBundle { path, read, write })
+}
+
+/// Initialise both pools against the current `HELMOR_DATA_DIR`. Called once
+/// during app startup. In tests, [`read_conn`] / [`write_conn`] auto-rebuild
+/// the pools whenever the data dir changes, so individual test helpers
+/// don't need to remember to call this.
+pub fn init_pools() -> Result<()> {
+    let path = crate::data_dir::db_path()?;
+    tracing::info!(
+        path = %path.display(),
+        read_pool_size = READ_POOL_SIZE,
+        write_pool_size = WRITE_POOL_SIZE,
+        "db: initialising pools"
+    );
+    let bundle = build_bundle(path)?;
+    *pool_slot()
+        .write()
+        .map_err(|_| anyhow!("pool lock poisoned"))? = Some(bundle);
+    Ok(())
+}
+
+/// Ensure pools exist and point at the current `HELMOR_DATA_DIR`. Rebuilds
+/// transparently if the data dir has changed (tests) or if pools were
+/// never built (first call).
+fn with_bundle<T>(f: impl FnOnce(&PoolBundle) -> Result<T>) -> Result<T> {
+    let current_path = crate::data_dir::db_path()?;
+
+    {
+        let guard = pool_slot()
+            .read()
+            .map_err(|_| anyhow!("pool lock poisoned"))?;
+        if let Some(bundle) = guard.as_ref() {
+            if bundle.path == current_path {
+                return f(bundle);
+            }
+        }
+    }
+
+    // Slow path: need to (re)build. Double-check under the write lock.
+    let mut guard = pool_slot()
+        .write()
+        .map_err(|_| anyhow!("pool lock poisoned"))?;
+    if guard
+        .as_ref()
+        .map(|b| b.path != current_path)
+        .unwrap_or(true)
+    {
+        tracing::debug!(
+            path = %current_path.display(),
+            "db: rebuilding pool bundle (first access or HELMOR_DATA_DIR changed)"
+        );
+        *guard = Some(build_bundle(current_path)?);
+    }
+    f(guard.as_ref().expect("pool bundle just initialised"))
+}
+
+/// Log any pool borrow that takes longer than this. Below the threshold we
+/// stay silent to avoid flooding the hot streaming path; above it, the
+/// delay is a signal that another caller is holding the writer too long.
+const SLOW_BORROW_WARN_MS: u128 = 100;
+
+/// Borrow a read connection from the read pool. WAL lets multiple readers
+/// proceed concurrently and never block the writer.
+pub fn read_conn() -> Result<PooledConn> {
+    with_bundle(|bundle| {
+        let start = std::time::Instant::now();
+        let conn = bundle
+            .read
+            .get()
+            .map_err(|e| anyhow!("Failed to borrow read connection: {e}"))?;
+        let elapsed_ms = start.elapsed().as_millis();
+        if elapsed_ms >= SLOW_BORROW_WARN_MS {
+            tracing::warn!(
+                elapsed_ms,
+                pool_state = ?bundle.read.state(),
+                "db: slow read_conn borrow"
+            );
+        }
+        Ok(conn)
+    })
+}
+
+/// Borrow the writer connection. Pool `max_size = 1`, so callers serialize
+/// at the pool layer — no SQLITE_BUSY from intra-process contention.
+/// Hold for as short as possible; long-held writes starve all other writers.
+pub fn write_conn() -> Result<PooledConn> {
+    with_bundle(|bundle| {
+        let start = std::time::Instant::now();
+        let conn = bundle.write.get().map_err(|e| {
+            tracing::error!(
+                elapsed_ms = start.elapsed().as_millis(),
+                pool_state = ?bundle.write.state(),
+                "db: write_conn borrow failed (pool timeout? holder stuck?): {e}"
+            );
+            anyhow!("Failed to borrow write connection: {e}")
+        })?;
+        let elapsed_ms = start.elapsed().as_millis();
+        if elapsed_ms >= SLOW_BORROW_WARN_MS {
+            tracing::warn!(
+                elapsed_ms,
+                pool_state = ?bundle.write.state(),
+                "db: slow write_conn borrow — another writer held the pool"
+            );
+        }
+        Ok(conn)
+    })
+}
+
+/// Run a read-only closure with a pool-borrowed connection.
+#[allow(dead_code)]
+pub fn read<F, T>(f: F) -> Result<T>
+where
+    F: FnOnce(&Connection) -> Result<T>,
+{
+    let conn = read_conn()?;
+    f(&conn)
+}
+
+/// Run a write closure inside a transaction. Commits on Ok, rolls back on Err.
+#[allow(dead_code)]
+pub fn write_transaction<F, T>(f: F) -> Result<T>
+where
+    F: FnOnce(&Transaction) -> Result<T>,
+{
+    let mut conn = write_conn()?;
+    let tx = conn.transaction()?;
+    let result = f(&tx)?;
+    tx.commit()?;
+    Ok(result)
+}
+
+// ── Utilities ────────────────────────────────────────────────────────────
+
+/// Current UTC timestamp in RFC 3339 / millisecond precision.
 pub fn current_timestamp() -> Result<String> {
     Ok(Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+
+    fn test_env() -> crate::testkit::TestEnv {
+        crate::testkit::TestEnv::new("pool")
+    }
+
+    #[test]
+    fn write_pool_serializes_concurrent_writers_without_sqlite_busy() {
+        // Regression for the locked-DB storm: with max_size=1, concurrent
+        // writers must queue at the pool layer and never surface SQLITE_BUSY.
+        let _env = test_env();
+        write_conn()
+            .unwrap()
+            .execute_batch("CREATE TABLE counters (id INTEGER PRIMARY KEY, v INTEGER)")
+            .unwrap();
+        write_conn()
+            .unwrap()
+            .execute("INSERT INTO counters (id, v) VALUES (1, 0)", [])
+            .unwrap();
+
+        let handles: Vec<_> = (0..16)
+            .map(|_| {
+                thread::spawn(|| {
+                    for _ in 0..25 {
+                        let conn = write_conn().expect("pool borrow");
+                        conn.execute("UPDATE counters SET v = v + 1 WHERE id = 1", [])
+                            .expect("no SQLITE_BUSY");
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        let final_v: i64 = read_conn()
+            .unwrap()
+            .query_row("SELECT v FROM counters WHERE id = 1", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(final_v, 16 * 25);
+    }
+
+    #[test]
+    fn streaming_short_borrow_leaves_writer_available() {
+        // Regression for the reviewer's Finding 1: as long as streaming
+        // short-borrows the writer, unrelated writes must still acquire the
+        // single writer without hitting the 30s connection_timeout.
+        let _env = test_env();
+        write_conn()
+            .unwrap()
+            .execute_batch("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+            .unwrap();
+
+        // Simulate a long-running stream that *briefly* borrows the writer
+        // per-event, without ever holding it across iterations.
+        let streaming = thread::spawn(|| {
+            for i in 0..50 {
+                let conn = write_conn().expect("streaming per-event borrow");
+                conn.execute("INSERT INTO t (id) VALUES (?1)", [i]).unwrap();
+                drop(conn);
+                thread::sleep(std::time::Duration::from_millis(2));
+            }
+        });
+
+        // Concurrently, an unrelated write (e.g. mark_session_read) must
+        // succeed without waiting anywhere near the pool timeout.
+        let start = std::time::Instant::now();
+        for i in 100..110 {
+            write_conn()
+                .expect("unrelated write should not starve")
+                .execute("INSERT INTO t (id) VALUES (?1)", [i])
+                .unwrap();
+        }
+        let elapsed = start.elapsed();
+        streaming.join().unwrap();
+
+        assert!(
+            elapsed < std::time::Duration::from_secs(5),
+            "unrelated writes starved by streaming: {:?}",
+            elapsed,
+        );
+    }
+
+    #[test]
+    fn read_pool_connection_is_read_only() {
+        // Regression for the reviewer's Finding 4: the read-pool handle
+        // must actually reject writes, so callers can't accidentally route
+        // writes through the read pool.
+        let _env = test_env();
+        write_conn()
+            .unwrap()
+            .execute_batch("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+            .unwrap();
+
+        let conn = read_conn().unwrap();
+        let err = conn
+            .execute("INSERT INTO t (id) VALUES (1)", [])
+            .unwrap_err();
+        let msg = err.to_string().to_lowercase();
+        assert!(
+            msg.contains("read-only") || msg.contains("readonly"),
+            "expected read-only rejection, got: {msg}",
+        );
+    }
 }

--- a/src-tauri/src/models/repos.rs
+++ b/src-tauri/src/models/repos.rs
@@ -63,7 +63,7 @@ pub(crate) struct RepositoryRecord {
 }
 
 pub fn list_repositories() -> Result<Vec<RepositoryCreateOption>> {
-    let connection = db::open_connection(false)?;
+    let connection = db::read_conn()?;
     let mut statement = connection
         .prepare(
             r#"
@@ -103,7 +103,7 @@ pub fn list_repositories() -> Result<Vec<RepositoryCreateOption>> {
 }
 
 pub(crate) fn load_repository_by_id(repo_id: &str) -> Result<Option<RepositoryRecord>> {
-    let connection = db::open_connection(false)?;
+    let connection = db::read_conn()?;
     let mut statement = connection
         .prepare(
             r#"
@@ -137,7 +137,7 @@ pub(crate) fn load_repository_by_id(repo_id: &str) -> Result<Option<RepositoryRe
 }
 
 pub(crate) fn load_repository_by_root_path(root_path: &str) -> Result<Option<RepositoryRecord>> {
-    let connection = db::open_connection(false)?;
+    let connection = db::read_conn()?;
     if let Some(repository) = query_repository_by_root_path(&connection, root_path)? {
         return Ok(Some(repository));
     }
@@ -245,7 +245,7 @@ fn query_repository_candidates_by_name(
 }
 
 pub(crate) fn insert_repository(repository: &ResolvedRepositoryInput) -> Result<String> {
-    let connection = db::open_connection(true)?;
+    let connection = db::write_conn()?;
     let next_display_order: i64 = connection
         .query_row(
             "SELECT COALESCE(MAX(display_order), 0) + 1 FROM repos",
@@ -315,7 +315,7 @@ pub fn update_repository_remote(
         })?;
     let new_remote_url = resolve_repository_remote_url(&repo_root, remote).ok();
 
-    let connection = db::open_connection(true)?;
+    let connection = db::write_conn()?;
     let updated = connection
         .execute(
             "UPDATE repos SET remote = ?1, default_branch = ?2, remote_url = ?3, updated_at = datetime('now') WHERE id = ?4",
@@ -371,7 +371,7 @@ pub fn list_repo_remotes(repo_id: &str) -> Result<Vec<String>> {
 }
 
 pub fn update_repository_default_branch(repo_id: &str, default_branch: &str) -> Result<()> {
-    let connection = db::open_connection(true)?;
+    let connection = db::write_conn()?;
     let updated = connection
         .execute(
             "UPDATE repos SET default_branch = ?1, updated_at = datetime('now') WHERE id = ?2",
@@ -444,7 +444,7 @@ pub fn load_repo_scripts(repo_id: &str, workspace_id: Option<&str>) -> Result<Re
 
     // Priority 3: DB values — picked up by `pick_script` when the project
     // config doesn't provide a value.
-    let connection = db::open_connection(false)?;
+    let connection = db::read_conn()?;
     let mut statement = connection
         .prepare("SELECT setup_script, run_script, archive_script FROM repos WHERE id = ?1")
         .with_context(|| format!("Failed to prepare script lookup for {repo_id}"))?;
@@ -537,7 +537,7 @@ pub fn update_repo_scripts(
     run_script: Option<&str>,
     archive_script: Option<&str>,
 ) -> Result<()> {
-    let connection = db::open_connection(true)?;
+    let connection = db::write_conn()?;
     let updated = connection
         .execute(
             "UPDATE repos SET setup_script = ?1, run_script = ?2, archive_script = ?3, updated_at = datetime('now') WHERE id = ?4",
@@ -553,7 +553,7 @@ pub fn update_repo_scripts(
 }
 
 pub fn load_repo_preferences(repo_id: &str) -> Result<RepoPreferences> {
-    let connection = db::open_connection(false)?;
+    let connection = db::read_conn()?;
     let mut statement = connection
         .prepare(
             r#"
@@ -583,7 +583,7 @@ pub fn load_repo_preferences(repo_id: &str) -> Result<RepoPreferences> {
 }
 
 pub fn update_repo_preferences(repo_id: &str, preferences: &RepoPreferences) -> Result<()> {
-    let connection = db::open_connection(true)?;
+    let connection = db::write_conn()?;
     let updated = connection
         .execute(
             r#"
@@ -623,7 +623,7 @@ fn normalize_repo_preference(value: Option<&str>) -> Option<String> {
 }
 
 pub(crate) fn delete_repository(repo_id: &str) -> Result<()> {
-    let connection = db::open_connection(true)?;
+    let connection = db::write_conn()?;
     let deleted_rows = connection
         .execute("DELETE FROM repos WHERE id = ?1", [repo_id])
         .with_context(|| format!("Failed to delete repository {repo_id}"))?;
@@ -637,7 +637,7 @@ pub(crate) fn delete_repository(repo_id: &str) -> Result<()> {
 
 /// Delete a repository and all related data (workspaces, sessions, messages, etc.)
 pub fn delete_repository_cascade(repo_id: &str) -> Result<()> {
-    let mut connection = db::open_connection(true)?;
+    let mut connection = db::write_conn()?;
     let tx = connection
         .transaction()
         .context("Failed to start delete repository transaction")?;

--- a/src-tauri/src/models/sessions.rs
+++ b/src-tauri/src/models/sessions.rs
@@ -58,7 +58,7 @@ pub struct SessionAttachmentRecord {
 }
 
 pub fn list_workspace_sessions(workspace_id: &str) -> Result<Vec<WorkspaceSessionSummary>> {
-    let connection = db::open_connection(false)?;
+    let connection = db::read_conn()?;
     let active_session_id: Option<String> = connection.query_row(
         "SELECT active_session_id FROM workspaces WHERE id = ?1",
         [workspace_id],
@@ -131,7 +131,7 @@ pub fn list_workspace_sessions(workspace_id: &str) -> Result<Vec<WorkspaceSessio
 }
 
 pub fn list_session_historical_records(session_id: &str) -> Result<Vec<HistoricalRecord>> {
-    let connection = db::open_connection(false)?;
+    let connection = db::read_conn()?;
     list_session_historical_records_with_connection(&connection, session_id)
 }
 
@@ -175,7 +175,7 @@ fn list_session_historical_records_with_connection(
 }
 
 pub fn list_session_attachments(session_id: &str) -> Result<Vec<SessionAttachmentRecord>> {
-    let connection = db::open_connection(false)?;
+    let connection = db::read_conn()?;
     let mut statement = connection.prepare(
         r#"
             SELECT
@@ -221,7 +221,7 @@ pub fn list_session_attachments(session_id: &str) -> Result<Vec<SessionAttachmen
 // ---- Session read/unread functions ----
 
 pub fn mark_session_read(session_id: &str) -> Result<()> {
-    let mut connection = db::open_connection(true)?;
+    let mut connection = db::write_conn()?;
     let transaction = connection
         .transaction()
         .context("Failed to start mark-read transaction")?;
@@ -234,7 +234,7 @@ pub fn mark_session_read(session_id: &str) -> Result<()> {
 }
 
 pub fn mark_session_unread(session_id: &str) -> Result<()> {
-    let mut connection = db::open_connection(true)?;
+    let mut connection = db::write_conn()?;
     let transaction = connection
         .transaction()
         .context("Failed to start mark-unread transaction")?;
@@ -366,7 +366,7 @@ pub fn create_session(
     action_kind: Option<ActionKind>,
     permission_mode: Option<&str>,
 ) -> Result<CreateSessionResponse> {
-    let mut connection = db::open_connection(true)?;
+    let mut connection = db::write_conn()?;
 
     // `model` is left NULL on create: the frontend owns model selection via
     // `settings.defaultModelId` (kept valid by `useEnsureDefaultModel`), and
@@ -438,7 +438,7 @@ pub fn create_session(
 
 /// Read the `model` column from a session row.
 pub fn get_session_model(session_id: &str) -> Result<Option<String>> {
-    let conn = db::open_connection(false)?;
+    let conn = db::read_conn()?;
     let model: Option<String> = conn
         .query_row(
             "SELECT model FROM sessions WHERE id = ?1",
@@ -450,7 +450,7 @@ pub fn get_session_model(session_id: &str) -> Result<Option<String>> {
 }
 
 pub fn rename_session(session_id: &str, title: &str) -> Result<()> {
-    let connection = db::open_connection(true)?;
+    let connection = db::write_conn()?;
 
     let updated_rows = connection
         .execute(
@@ -467,7 +467,7 @@ pub fn rename_session(session_id: &str, title: &str) -> Result<()> {
 }
 
 pub fn hide_session(session_id: &str) -> Result<()> {
-    let mut connection = db::open_connection(true)?;
+    let mut connection = db::write_conn()?;
     let transaction = connection
         .transaction()
         .context("Failed to start hide-session transaction")?;
@@ -530,7 +530,7 @@ pub fn hide_session(session_id: &str) -> Result<()> {
 }
 
 pub fn unhide_session(session_id: &str) -> Result<()> {
-    let connection = db::open_connection(true)?;
+    let connection = db::write_conn()?;
     connection
         .execute(
             "UPDATE sessions SET is_hidden = 0 WHERE id = ?1",
@@ -541,7 +541,7 @@ pub fn unhide_session(session_id: &str) -> Result<()> {
 }
 
 pub fn delete_session(session_id: &str) -> Result<()> {
-    let mut connection = db::open_connection(true)?;
+    let mut connection = db::write_conn()?;
     let transaction = connection.transaction()?;
 
     // Resolve workspace before deleting, so we can fix active_session_id
@@ -586,7 +586,7 @@ pub fn delete_session(session_id: &str) -> Result<()> {
 }
 
 pub fn list_hidden_sessions(workspace_id: &str) -> Result<Vec<WorkspaceSessionSummary>> {
-    let connection = db::open_connection(false)?;
+    let connection = db::read_conn()?;
     let mut statement = connection
         .prepare(
             r#"

--- a/src-tauri/src/models/settings.rs
+++ b/src-tauri/src/models/settings.rs
@@ -10,7 +10,7 @@ pub struct BranchPrefixSettings {
 }
 
 pub fn load_setting_value(key: &str) -> Result<Option<String>> {
-    let connection = db::open_connection(false)?;
+    let connection = db::read_conn()?;
     let mut statement = connection
         .prepare("SELECT value FROM settings WHERE key = ?1")
         .with_context(|| format!("Failed to prepare settings lookup for {key}"))?;
@@ -27,7 +27,7 @@ pub fn load_setting_value(key: &str) -> Result<Option<String>> {
 }
 
 pub fn upsert_setting_value(key: &str, value: &str) -> Result<()> {
-    let connection = db::open_connection(true)?;
+    let connection = db::write_conn()?;
     connection
         .execute(
             r#"
@@ -45,7 +45,7 @@ pub fn upsert_setting_value(key: &str, value: &str) -> Result<()> {
 }
 
 pub fn delete_setting_value(key: &str) -> Result<()> {
-    let connection = db::open_connection(true)?;
+    let connection = db::write_conn()?;
     connection
         .execute("DELETE FROM settings WHERE key = ?1", [key])
         .with_context(|| format!("Failed to delete setting {key}"))?;
@@ -98,7 +98,7 @@ pub fn save_auto_close_opt_in_asked(kinds: &[crate::agents::ActionKind]) -> Resu
 }
 
 pub fn load_branch_prefix_settings() -> Result<BranchPrefixSettings> {
-    let connection = db::open_connection(false)?;
+    let connection = db::read_conn()?;
     let mut statement = connection
         .prepare(
             "SELECT key, value FROM settings WHERE key IN ('branch_prefix_type', 'branch_prefix_custom')",

--- a/src-tauri/src/models/workspaces.rs
+++ b/src-tauri/src/models/workspaces.rs
@@ -109,7 +109,7 @@ pub const WORKSPACE_RECORD_SQL: &str = r#"
 "#;
 
 pub fn load_workspace_records() -> Result<Vec<WorkspaceRecord>> {
-    let connection = db::open_connection(false)?;
+    let connection = db::read_conn()?;
     let sql = format!(
         "{WORKSPACE_RECORD_SQL} ORDER BY datetime(w.created_at) DESC, datetime(w.updated_at) DESC, w.id DESC"
     );
@@ -121,7 +121,7 @@ pub fn load_workspace_records() -> Result<Vec<WorkspaceRecord>> {
 }
 
 pub fn load_workspace_record_by_id(workspace_id: &str) -> Result<Option<WorkspaceRecord>> {
-    let connection = db::open_connection(false)?;
+    let connection = db::read_conn()?;
     let mut statement =
         connection.prepare(format!("{WORKSPACE_RECORD_SQL} WHERE w.id = ?1").as_str())?;
 
@@ -134,7 +134,7 @@ pub fn load_workspace_record_by_id(workspace_id: &str) -> Result<Option<Workspac
 }
 
 pub fn load_archived_workspace_records() -> Result<Vec<WorkspaceRecord>> {
-    let connection = db::open_connection(false)?;
+    let connection = db::read_conn()?;
     let mut statement = connection
         .prepare(&format!(
             // Archived list sorts by `updated_at DESC` so the most recently
@@ -160,7 +160,7 @@ pub(crate) fn insert_initializing_workspace_and_session(
     default_branch: &str,
     timestamp: &str,
 ) -> Result<()> {
-    let mut connection = db::open_connection(true)?;
+    let mut connection = db::write_conn()?;
     let transaction = connection
         .transaction()
         .context("Failed to start create-workspace transaction")?;
@@ -233,7 +233,7 @@ pub(crate) fn update_workspace_initialization_metadata(
     initialization_files_copied: i64,
     timestamp: &str,
 ) -> Result<()> {
-    let connection = db::open_connection(true)?;
+    let connection = db::write_conn()?;
     let updated_rows = connection
         .execute(
             r#"
@@ -260,7 +260,7 @@ pub(crate) fn update_workspace_state(
     state: WorkspaceState,
     timestamp: &str,
 ) -> Result<()> {
-    let connection = db::open_connection(true)?;
+    let connection = db::write_conn()?;
     let updated_rows = connection
         .execute(
             "UPDATE workspaces SET state = ?2, updated_at = ?3 WHERE id = ?1",
@@ -276,7 +276,7 @@ pub(crate) fn update_workspace_state(
 }
 
 pub(crate) fn delete_workspace_and_session_rows(workspace_id: &str) -> Result<()> {
-    let mut connection = db::open_connection(true)?;
+    let mut connection = db::write_conn()?;
     let transaction = connection
         .transaction()
         .context("Failed to start create cleanup transaction")?;
@@ -317,7 +317,7 @@ pub(crate) fn delete_workspace_and_session_rows(workspace_id: &str) -> Result<()
 pub(crate) fn list_initializing_workspaces_older_than(
     max_age_seconds: i64,
 ) -> Result<Vec<OrphanedInitializingWorkspace>> {
-    let connection = db::open_connection(false)?;
+    let connection = db::read_conn()?;
     let cutoff = format!("datetime('now', '-{} seconds')", max_age_seconds.max(0));
     let sql = format!("{WORKSPACE_RECORD_SQL} WHERE w.state = ?1 AND w.created_at < {cutoff}",);
     let mut statement = connection.prepare(&sql)?;
@@ -342,7 +342,7 @@ pub(crate) fn update_archived_workspace_state(
     workspace_id: &str,
     archive_commit: &str,
 ) -> Result<()> {
-    let mut connection = db::open_connection(true)?;
+    let mut connection = db::write_conn()?;
     let transaction = connection
         .transaction()
         .context("Failed to start archive transaction")?;
@@ -381,7 +381,7 @@ pub(crate) fn update_restored_workspace_state(
     workspace_context_dir: &Path,
     target_branch_override: Option<&str>,
 ) -> Result<()> {
-    let mut connection = db::open_connection(true)?;
+    let mut connection = db::write_conn()?;
     let transaction = connection
         .transaction()
         .context("Failed to start restore transaction")?;

--- a/src-tauri/src/service.rs
+++ b/src-tauri/src/service.rs
@@ -184,7 +184,7 @@ pub fn send_message(
     if is_app_running() {
         // Persist user message so the app's conversation container
         // shows the optimistic user bubble right away.
-        let conn = crate::models::db::open_connection(true)?;
+        let conn = crate::models::db::write_conn()?;
         let timestamp = crate::models::db::current_timestamp()?;
         let user_msg_id = Uuid::new_v4().to_string();
         let turn_id = Uuid::new_v4().to_string();
@@ -281,7 +281,7 @@ pub fn send_message(
         .context("Failed to send request to sidecar")?;
 
     // 6. Persist user message + set session streaming
-    let conn = crate::models::db::open_connection(true)?;
+    let conn = crate::models::db::write_conn()?;
     let timestamp = crate::models::db::current_timestamp()?;
     let turn_id = Uuid::new_v4().to_string();
     let user_msg_id = Uuid::new_v4().to_string();
@@ -552,7 +552,7 @@ pub fn insert_pending_cli_send(
     model_id: Option<&str>,
     permission_mode: Option<&str>,
 ) -> Result<String> {
-    let conn = crate::models::db::open_connection(true)?;
+    let conn = crate::models::db::write_conn()?;
     let id = Uuid::new_v4().to_string();
     conn.execute(
         r#"INSERT INTO pending_cli_sends (id, workspace_id, session_id, prompt, model_id, permission_mode)
@@ -566,7 +566,7 @@ pub fn insert_pending_cli_send(
 /// Read and delete all pending sends in one atomic operation.
 /// Returns them oldest-first so the App processes them in order.
 pub fn drain_pending_cli_sends() -> Result<Vec<PendingCliSend>> {
-    let conn = crate::models::db::open_connection(true)?;
+    let conn = crate::models::db::write_conn()?;
     let mut stmt = conn.prepare(
         "SELECT id, workspace_id, session_id, prompt, model_id, permission_mode, created_at
          FROM pending_cli_sends ORDER BY datetime(created_at) ASC",

--- a/src-tauri/src/testkit.rs
+++ b/src-tauri/src/testkit.rs
@@ -35,7 +35,14 @@ impl TestEnv {
         crate::data_dir::ensure_directory_structure().expect("failed to create test dirs");
 
         let connection = Connection::open(crate::data_dir::db_path().unwrap()).unwrap();
+        crate::models::db::init_connection(&connection, true)
+            .expect("failed to apply PRAGMA init in test env");
         crate::schema::ensure_schema(&connection).expect("failed to init test DB schema");
+        drop(connection);
+
+        // Rebuild pools against the fresh tempdir. `init_pools` is re-entrant
+        // so back-to-back tests each get their own isolated pools.
+        crate::models::db::init_pools().expect("failed to init test DB pools");
 
         Self { root, _lock: lock }
     }
@@ -43,8 +50,8 @@ impl TestEnv {
     pub fn db_connection(&self) -> Connection {
         let path = crate::data_dir::db_path().unwrap();
         let conn = Connection::open(&path).unwrap();
-        conn.busy_timeout(std::time::Duration::from_secs(3))
-            .unwrap();
+        crate::models::db::init_connection(&conn, true)
+            .expect("failed to apply PRAGMA init on test connection");
         conn
     }
 }

--- a/src-tauri/src/workspace/branching.rs
+++ b/src-tauri/src/workspace/branching.rs
@@ -106,7 +106,7 @@ pub fn rename_workspace_branch(workspace_id: &str, new_branch: &str) -> Result<(
 
     git_ops::rename_branch(repo_root_path, old_branch, new_branch)?;
 
-    let connection = db::open_connection(true)?;
+    let connection = db::write_conn()?;
     if let Err(db_err) = connection.execute(
         "UPDATE workspaces SET branch = ?1 WHERE id = ?2",
         (new_branch, workspace_id),
@@ -159,7 +159,7 @@ pub fn update_intended_target_branch_local(
     target_branch: &str,
 ) -> Result<UpdateIntendedTargetBranchInternal> {
     {
-        let connection = db::open_connection(true)?;
+        let connection = db::write_conn()?;
         let updated_rows = connection
             .execute(
                 &format!(
@@ -181,7 +181,7 @@ pub fn update_intended_target_branch_local(
     let post_reset_sha = try_realign_local_branch(&record, target_branch)?;
 
     if post_reset_sha.is_some() {
-        let connection = db::open_connection(true)?;
+        let connection = db::write_conn()?;
         connection
             .execute(
                 "UPDATE workspaces SET initialization_parent_branch = ?2 WHERE id = ?1",
@@ -269,7 +269,7 @@ pub fn refresh_remote_and_realign(
         return Ok(false);
     }
 
-    let ws_lock = db::workspace_mutation_lock(workspace_id);
+    let ws_lock = db::workspace_fs_mutation_lock(workspace_id);
     let _lock = ws_lock.blocking_lock();
 
     let Some(fresh_record) = workspace_models::load_workspace_record_by_id(workspace_id)? else {

--- a/src-tauri/src/workspace/files/changes.rs
+++ b/src-tauri/src/workspace/files/changes.rs
@@ -288,7 +288,7 @@ pub(super) fn query_workspace_target(
 
 fn lookup_workspace_target(workspace_root: &Path) -> Option<(String, String)> {
     let (repo_name, dir_name) = parse_workspace_path(workspace_root)?;
-    let conn = db::open_connection(false).ok()?;
+    let conn = db::read_conn().ok()?;
     query_workspace_target(&conn, repo_name, dir_name)
 }
 

--- a/src-tauri/src/workspace/helpers.rs
+++ b/src-tauri/src/workspace/helpers.rs
@@ -566,7 +566,7 @@ fn resolve_github_login() -> Result<Option<String>> {
 }
 
 pub fn allocate_directory_name_for_repo(repo_id: &str) -> Result<String> {
-    let connection = crate::db::open_connection(false)?;
+    let connection = crate::db::read_conn()?;
     allocate_directory_name_with_conn(&connection, repo_id)
 }
 

--- a/src-tauri/src/workspace/lifecycle.rs
+++ b/src-tauri/src/workspace/lifecycle.rs
@@ -813,7 +813,7 @@ pub fn restore_workspace_impl(
 
     let staged_archive_dir = helpers::staged_archive_context_dir(&archived_context_dir);
     if actual_branch != branch {
-        let conn = db::open_connection(true).map_err(|error| {
+        let conn = db::write_conn().map_err(|error| {
             cleanup_failed_restore(
                 &repo_root,
                 &workspace_dir,

--- a/src-tauri/src/workspace/workspaces.rs
+++ b/src-tauri/src/workspace/workspaces.rs
@@ -227,7 +227,7 @@ pub fn get_workspace(workspace_id: &str) -> Result<WorkspaceDetail> {
 // ---- Read / unread ----
 
 pub fn mark_workspace_read(workspace_id: &str) -> Result<()> {
-    let mut connection = db::open_connection(true)?;
+    let mut connection = db::write_conn()?;
     let transaction = connection
         .transaction()
         .context("Failed to start workspace-read transaction")?;
@@ -256,7 +256,7 @@ pub fn mark_workspace_read(workspace_id: &str) -> Result<()> {
 }
 
 pub fn mark_workspace_unread(workspace_id: &str) -> Result<()> {
-    let mut connection = db::open_connection(true)?;
+    let mut connection = db::write_conn()?;
     let transaction = connection
         .transaction()
         .context("Failed to start workspace-unread transaction")?;
@@ -269,7 +269,7 @@ pub fn mark_workspace_unread(workspace_id: &str) -> Result<()> {
 }
 
 pub fn pin_workspace(workspace_id: &str) -> Result<()> {
-    let connection = db::open_connection(true)?;
+    let connection = db::write_conn()?;
     connection
         .execute(
             "UPDATE workspaces SET pinned_at = datetime('now'), updated_at = datetime('now') WHERE id = ?1",
@@ -280,7 +280,7 @@ pub fn pin_workspace(workspace_id: &str) -> Result<()> {
 }
 
 pub fn unpin_workspace(workspace_id: &str) -> Result<()> {
-    let connection = db::open_connection(true)?;
+    let connection = db::write_conn()?;
     connection
         .execute(
             "UPDATE workspaces SET pinned_at = NULL, updated_at = datetime('now') WHERE id = ?1",
@@ -294,7 +294,7 @@ pub fn set_workspace_manual_status(
     workspace_id: &str,
     status: Option<DerivedStatus>,
 ) -> Result<()> {
-    let connection = db::open_connection(true)?;
+    let connection = db::write_conn()?;
     connection
         .execute(
             "UPDATE workspaces SET manual_status = ?2, updated_at = datetime('now') WHERE id = ?1",
@@ -310,7 +310,7 @@ pub fn set_workspace_manual_status(
 // Schema pre-dates the feature (Conductor import compatibility); we own it now.
 
 pub fn get_workspace_linked_directories(workspace_id: &str) -> Result<Vec<String>> {
-    let connection = db::open_connection(false)?;
+    let connection = db::read_conn()?;
     let raw: Option<String> = connection
         .query_row(
             "SELECT linked_directory_paths FROM workspaces WHERE id = ?1",
@@ -394,7 +394,7 @@ pub fn set_workspace_linked_directories(
     } else {
         Some(serde_json::to_string(&normalized).context("Failed to encode linked directories")?)
     };
-    let connection = db::open_connection(true)?;
+    let connection = db::write_conn()?;
     let updated = connection
         .execute(
             "UPDATE workspaces SET linked_directory_paths = ?2, updated_at = datetime('now') WHERE id = ?1",
@@ -716,7 +716,7 @@ pub fn record_to_detail(record: WorkspaceRecord) -> WorkspaceDetail {
 /// Archived workspaces are excluded — their worktree is intentionally gone, but
 /// their archived `.context` and session history must be preserved.
 pub fn purge_orphaned_workspaces() -> Result<usize> {
-    let connection = db::open_connection(false)?;
+    let connection = db::read_conn()?;
     let mut stmt = connection.prepare(
         "SELECT w.id, r.name, w.directory_name, w.state
          FROM workspaces w
@@ -769,7 +769,7 @@ pub fn purge_orphaned_workspaces() -> Result<usize> {
 /// attachments, diff_comments) from the database, plus any filesystem
 /// artifacts (worktree directory, archived context).
 pub fn permanently_delete_workspace(workspace_id: &str) -> Result<()> {
-    let mut connection = db::open_connection(true)?;
+    let mut connection = db::write_conn()?;
 
     // Load workspace info for filesystem cleanup
     let record: Option<(String, String, WorkspaceState)> = connection


### PR DESCRIPTION
## What changed
- serialized SQLite writes through a single-writer r2d2 pool while routing read-only queries through a read pool
- updated streaming persistence to short-borrow the writer so session actions are not blocked for an entire AI turn
- added sidecar heartbeats and timeout handling so frozen or disconnected sidecars fail cleanly instead of leaving sessions stuck
- renamed the filesystem mutation lock usage in the clone-from-URL path to match the refactor and added a changeset for the patch

## Why
Active AI turns could hold the database in a way that caused `database is locked` failures for unrelated session actions, and a stalled sidecar could leave the UI stuck in a streaming state. This branch makes those failure modes deterministic and recoverable.

## Follow-up / test notes
- Branch was already clean and pushed before PR creation; there was no additional uncommitted work to stage or commit in this workspace.
- I did not run the test suite in this PR creation step.