### PR TITLE
Fix delayed git sync status after target branch switch

### DIFF
--- a/.changeset/quick-foxes-sync.md
+++ b/.changeset/quick-foxes-sync.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Refresh the inspector's Actions panel immediately after switching target branch, so the sync-with-remote row shows the new ahead/behind numbers right away instead of lagging up to ten seconds behind.

--- a/src/features/panel/header.tsx
+++ b/src/features/panel/header.tsx
@@ -505,6 +505,12 @@ export const WorkspacePanelHeader = memo(function WorkspacePanelHeader({
 										void updateIntendedTargetBranch(workspace.id, branch)
 											.then(({ reset }) => {
 												onWorkspaceChanged?.();
+												// Recompute sync status vs. new target now; don't wait for 10s poll.
+												void queryClient.invalidateQueries({
+													queryKey: helmorQueryKeys.workspaceGitActionStatus(
+														workspace.id,
+													),
+												});
 												if (workspace.rootPath) {
 													void queryClient.invalidateQueries({
 														queryKey: helmorQueryKeys.workspaceChanges(


### PR DESCRIPTION
## What changed
- invalidate the workspace git action status query immediately after changing a workspace target branch
- add a patch changeset describing the inspector Actions panel refresh behavior

## Why
The sync-with-remote row could show stale ahead/behind counts for up to ten seconds after switching the target branch because it was waiting on the polling interval instead of recomputing immediately.

## Follow-up / test notes
- Tests not run locally; this is a small frontend query invalidation change
- The change is intended to make the inspector update immediately after a target-branch switch