### PR TITLE
Fix chat file link navigation and unknown API error details

### DIFF
--- a/.changeset/bright-parrots-share.md
+++ b/.changeset/bright-parrots-share.md
@@ -1,0 +1,7 @@
+---
+"helmor": patch
+---
+
+Improve error visibility and file navigation in chat responses:
+- Let local file references in assistant messages open directly in Helmor's in-app editor at the referenced line when the file is inside the current workspace.
+- Preserve specific Claude API errors like unexpected socket disconnects instead of collapsing them into a generic "unknown error" notice.

--- a/src-tauri/src/pipeline/accumulator/mod.rs
+++ b/src-tauri/src/pipeline/accumulator/mod.rs
@@ -158,7 +158,35 @@ pub struct StreamAccumulator {
 /// label. Both Claude `assistant.error` and (in the future) any other
 /// turn-level failure surface route through this — the rendered SystemNotice
 /// is the same shape across providers, so the frontend never branches.
-fn assistant_error_message(category: &str) -> String {
+fn assistant_error_fallback_text(value: &Value) -> Option<String> {
+    value
+        .get("message")
+        .and_then(|message| message.get("content"))
+        .and_then(Value::as_array)
+        .and_then(|blocks| {
+            blocks.iter().find_map(|block| {
+                block
+                    .get("type")
+                    .and_then(Value::as_str)
+                    .filter(|ty| *ty == "text")
+                    .and_then(|_| block.get("text"))
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|text| !text.is_empty())
+                    .map(str::to_string)
+            })
+        })
+        .or_else(|| {
+            value
+                .get("text")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|text| !text.is_empty())
+                .map(str::to_string)
+        })
+}
+
+fn assistant_error_message(category: &str, value: &Value) -> String {
     match category {
         "rate_limit" => "Rate limited by Anthropic API",
         "max_output_tokens" => "Output truncated: max output tokens reached",
@@ -166,7 +194,12 @@ fn assistant_error_message(category: &str) -> String {
         "authentication_failed" => "Authentication failed: please re-authenticate",
         "invalid_request" => "Invalid request: malformed payload",
         "server_error" => "Anthropic API server error (5xx)",
-        "unknown" => "Assistant turn ended in an unknown error state",
+        "unknown" => {
+            if let Some(message) = assistant_error_fallback_text(value) {
+                return message;
+            }
+            "Assistant turn ended in an unknown error state"
+        }
         other => return format!("Assistant error: {other}"),
     }
     .to_string()
@@ -938,7 +971,7 @@ impl StreamAccumulator {
 
         // Turn-level failure category → error envelope.
         if let Some(category) = value.get("error").and_then(Value::as_str) {
-            let label = assistant_error_message(category);
+            let label = assistant_error_message(category, value);
             let synthetic = serde_json::json!({
                 "type": "error",
                 "message": label,

--- a/src-tauri/tests/pipeline_scenarios.rs
+++ b/src-tauri/tests/pipeline_scenarios.rs
@@ -716,6 +716,19 @@ fn asst_empty_content_fallback() {
     assert_yaml_snapshot!(run_normalized(msgs));
 }
 
+#[test]
+fn asst_unknown_error_prefers_message_text() {
+    let msgs = vec![assistant_json(
+        "a1",
+        json!([{
+            "type": "text",
+            "text": "API Error: The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()"
+        }]),
+        Some(json!({ "error": "unknown" })),
+    )];
+    assert_yaml_snapshot!(run_normalized(msgs));
+}
+
 // ============================================================================
 // 6. System messages
 // ============================================================================

--- a/src-tauri/tests/snapshots/pipeline_scenarios__asst_unknown_error_prefers_message_text.snap
+++ b/src-tauri/tests/snapshots/pipeline_scenarios__asst_unknown_error_prefers_message_text.snap
@@ -1,0 +1,14 @@
+---
+source: tests/pipeline_scenarios.rs
+expression: run_normalized(msgs)
+---
+- role: assistant
+  id: msg-1
+  content_length: 1
+  content:
+    - type: text
+      text: "API Error: The socket connection was closed unexpe... `verbose: true` in the second argument to fetch()[len:134]"
+  status:
+    type: complete
+    reason: stop
+  streaming: ~

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -930,6 +930,56 @@ function AppShell({
 		],
 	);
 
+	const handleOpenFileReference = useCallback(
+		(path: string, line?: number, column?: number) => {
+			if (!workspaceRootPath) {
+				pushWorkspaceToast(
+					"Open a workspace with a resolved root path before using the in-app editor.",
+					"Editor unavailable",
+				);
+				return;
+			}
+
+			if (!isPathWithinRoot(path, workspaceRootPath)) {
+				pushWorkspaceToast(
+					"Only files inside the current workspace can be opened in the in-app editor.",
+					"File unavailable",
+				);
+				return;
+			}
+
+			if (
+				editorSession?.path !== path &&
+				!confirmDiscardEditorChanges("open another file")
+			) {
+				return;
+			}
+
+			if (selectedWorkspaceId) {
+				triggerWorkspaceFetch(selectedWorkspaceId);
+			}
+
+			setWorkspaceViewMode("editor");
+			setEditorSession((current) => ({
+				kind: "file",
+				path,
+				line,
+				column,
+				dirty: current?.path === path ? current.dirty : false,
+				originalText: current?.path === path ? current.originalText : undefined,
+				modifiedText: current?.path === path ? current.modifiedText : undefined,
+				mtimeMs: current?.path === path ? current.mtimeMs : undefined,
+			}));
+		},
+		[
+			confirmDiscardEditorChanges,
+			editorSession?.path,
+			pushWorkspaceToast,
+			selectedWorkspaceId,
+			workspaceRootPath,
+		],
+	);
+
 	const handleEditorSessionChange = useCallback(
 		(session: EditorSessionState) => {
 			setEditorSession(session);
@@ -2079,6 +2129,8 @@ function AppShell({
 												onQueuePendingPromptForSession={
 													queuePendingPromptForSession
 												}
+												workspaceRootPath={workspaceRootPath}
+												onOpenFileReference={handleOpenFileReference}
 												headerLeading={
 													sidebarCollapsed ? (
 														<>

--- a/src/components/streamdown-components.tsx
+++ b/src/components/streamdown-components.tsx
@@ -28,6 +28,9 @@ import {
 	TableHeader,
 	TableRow,
 } from "@/components/ui/table";
+import { useFileLinkContext } from "@/features/panel/message-components/file-link-context";
+import { isPathWithinRoot } from "@/lib/editor-session";
+import { parseLocalFileLink } from "@/lib/local-file-link";
 import { cn } from "@/lib/utils";
 
 // ---------------------------------------------------------------------------
@@ -182,6 +185,8 @@ export function StreamdownAnchor({
 	className?: string;
 	href?: string;
 } & Record<string, unknown>) {
+	const { openInEditor, workspaceRootPath } = useFileLinkContext();
+
 	const handleClick = async (event: MouseEvent<HTMLAnchorElement>) => {
 		if (!href) {
 			return;
@@ -197,6 +202,17 @@ export function StreamdownAnchor({
 			event.shiftKey ||
 			event.altKey
 		) {
+			return;
+		}
+
+		const localTarget = parseLocalFileLink(href, workspaceRootPath);
+		if (
+			localTarget &&
+			openInEditor &&
+			isPathWithinRoot(localTarget.path, workspaceRootPath)
+		) {
+			event.preventDefault();
+			openInEditor(localTarget.path, localTarget.line, localTarget.column);
 			return;
 		}
 

--- a/src/features/conversation/index.tsx
+++ b/src/features/conversation/index.tsx
@@ -12,6 +12,7 @@ import type {
 	DeferredToolResponseOptions,
 } from "@/features/composer/deferred-tool";
 import { WorkspacePanelContainer } from "@/features/panel/container";
+import { FileLinkProvider } from "@/features/panel/message-components/file-link-context";
 import type { PullRequestInfo } from "@/lib/api";
 import type { ResolvedComposerInsertRequest } from "@/lib/composer-insert";
 import { insertRequestMatchesComposer } from "@/lib/composer-insert";
@@ -71,6 +72,8 @@ type WorkspaceConversationContainerProps = {
 		modelId?: string | null;
 		permissionMode?: string | null;
 	}) => void;
+	workspaceRootPath?: string | null;
+	onOpenFileReference?: (path: string, line?: number, column?: number) => void;
 };
 
 export const WorkspaceConversationContainer = memo(
@@ -96,6 +99,8 @@ export const WorkspaceConversationContainer = memo(
 		pendingInsertRequests = [],
 		onPendingInsertRequestsConsumed,
 		onQueuePendingPromptForSession,
+		workspaceRootPath,
+		onOpenFileReference,
 	}: WorkspaceConversationContainerProps) {
 		const [composerModelSelections, setComposerModelSelections] = useState<
 			Record<string, string>
@@ -278,7 +283,12 @@ export const WorkspaceConversationContainer = memo(
 			);
 
 		return (
-			<>
+			<FileLinkProvider
+				value={{
+					openInEditor: onOpenFileReference,
+					workspaceRootPath,
+				}}
+			>
 				<WorkspacePanelContainer
 					selectedWorkspaceId={selectedWorkspaceId}
 					displayedWorkspaceId={displayedWorkspaceId}
@@ -338,7 +348,7 @@ export const WorkspaceConversationContainer = memo(
 						/>
 					</div>
 				</div>
-			</>
+			</FileLinkProvider>
 		);
 	},
 );

--- a/src/features/panel/message-components/file-link-context.tsx
+++ b/src/features/panel/message-components/file-link-context.tsx
@@ -1,0 +1,14 @@
+import { createContext, useContext } from "react";
+
+type FileLinkContextValue = {
+	workspaceRootPath?: string | null;
+	openInEditor?: (path: string, line?: number, column?: number) => void;
+};
+
+const FileLinkContext = createContext<FileLinkContextValue>({});
+
+export const FileLinkProvider = FileLinkContext.Provider;
+
+export function useFileLinkContext(): FileLinkContextValue {
+	return useContext(FileLinkContext);
+}

--- a/src/lib/local-file-link.test.ts
+++ b/src/lib/local-file-link.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { parseLocalFileLink } from "./local-file-link";
+
+describe("parseLocalFileLink", () => {
+	it("parses absolute file links with GitHub-style line fragments", () => {
+		expect(
+			parseLocalFileLink(
+				"/Users/liangeqiang/project/src/App.tsx#L161C4",
+				"/Users/liangeqiang/project",
+			),
+		).toEqual({
+			path: "/Users/liangeqiang/project/src/App.tsx",
+			line: 161,
+			column: 4,
+		});
+	});
+
+	it("parses absolute file links with trailing line and column", () => {
+		expect(
+			parseLocalFileLink(
+				"/Users/liangeqiang/project/src/App.tsx:42:7",
+				"/Users/liangeqiang/project",
+			),
+		).toEqual({
+			path: "/Users/liangeqiang/project/src/App.tsx",
+			line: 42,
+			column: 7,
+		});
+	});
+
+	it("resolves workspace-relative file links", () => {
+		expect(
+			parseLocalFileLink("src-tauri/src/lib.rs#L12", "/tmp/helmor"),
+		).toEqual({
+			path: "/tmp/helmor/src-tauri/src/lib.rs",
+			line: 12,
+		});
+	});
+
+	it("ignores external urls", () => {
+		expect(
+			parseLocalFileLink("https://example.com/src/App.tsx#L10", "/tmp/helmor"),
+		).toBeNull();
+	});
+
+	it("requires a workspace root for relative paths", () => {
+		expect(parseLocalFileLink("src/App.tsx#L10")).toBeNull();
+	});
+});

--- a/src/lib/local-file-link.ts
+++ b/src/lib/local-file-link.ts
@@ -1,0 +1,101 @@
+export type LocalFileLinkTarget = {
+	path: string;
+	line?: number;
+	column?: number;
+};
+
+type ParsedHashLocation = {
+	line?: number;
+	column?: number;
+};
+
+const EXTERNAL_SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
+const LINE_HASH_RE = /^#L(\d+)(?:C(\d+))?$/i;
+const TRAILING_LOCATION_RE = /^(.*?):(\d+)(?::(\d+))?$/;
+
+export function parseLocalFileLink(
+	href: string,
+	workspaceRootPath?: string | null,
+): LocalFileLinkTarget | null {
+	const trimmedHref = href.trim();
+	if (!trimmedHref || EXTERNAL_SCHEME_RE.test(trimmedHref)) {
+		return null;
+	}
+
+	const [rawPathPart, rawHash = ""] = splitHash(trimmedHref);
+	const decodedPath = safeDecode(rawPathPart);
+	const hashLocation = parseHashLocation(rawHash);
+	const pathWithLocation = parseTrailingLocation(decodedPath);
+	const path = resolvePath(pathWithLocation.path, workspaceRootPath);
+
+	if (!path) {
+		return null;
+	}
+
+	return {
+		path,
+		line: pathWithLocation.line ?? hashLocation.line,
+		column: pathWithLocation.column ?? hashLocation.column,
+	};
+}
+
+function splitHash(href: string): [string, string?] {
+	const hashIndex = href.indexOf("#");
+	if (hashIndex === -1) {
+		return [href];
+	}
+	return [href.slice(0, hashIndex), href.slice(hashIndex)];
+}
+
+function safeDecode(value: string): string {
+	try {
+		return decodeURIComponent(value);
+	} catch {
+		return value;
+	}
+}
+
+function parseHashLocation(hash: string): ParsedHashLocation {
+	const match = LINE_HASH_RE.exec(hash);
+	if (!match) {
+		return {};
+	}
+	return {
+		line: Number(match[1]),
+		column: match[2] ? Number(match[2]) : undefined,
+	};
+}
+
+function parseTrailingLocation(path: string): LocalFileLinkTarget {
+	const match = TRAILING_LOCATION_RE.exec(path);
+	if (!match) {
+		return { path };
+	}
+	return {
+		path: match[1],
+		line: Number(match[2]),
+		column: match[3] ? Number(match[3]) : undefined,
+	};
+}
+
+function resolvePath(
+	path: string,
+	workspaceRootPath?: string | null,
+): string | null {
+	if (!path) {
+		return null;
+	}
+	if (path.startsWith("/")) {
+		return normalizePath(path);
+	}
+	if (!workspaceRootPath) {
+		return null;
+	}
+	return normalizePath(
+		`${workspaceRootPath.replace(/\/+$/, "")}/${path.replace(/^\.?\//, "")}`,
+	);
+}
+
+function normalizePath(path: string): string {
+	return path.replace(/\\/g, "/");
+}


### PR DESCRIPTION
## What changed
- route local file references in assistant chat output into Helmor's in-app editor when the target is inside the current workspace
- add local file link parsing coverage for absolute, relative, and line/column-qualified paths
- preserve unknown Claude API error text when the provider returns a specific message instead of collapsing it into a generic notice
- add the matching pipeline snapshot and changeset entry

## Why
Assistant responses already include file references and provider error details, but the UI was treating those links like external URLs and the pipeline was discarding useful unknown-error text. This keeps users inside the app when jumping to referenced files and surfaces the actual failure message when the provider gives one.

## Test notes
- `bun x vitest run src/lib/local-file-link.test.ts`
- `cargo test --test pipeline_scenarios asst_unknown_error_prefers_message_text`
- commit hooks also passed `biome check --write`, `cargo fmt`, and `cargo clippy -- -D warnings`

## Follow-up
- broader frontend or integration coverage for end-to-end editor navigation from rendered assistant markdown would still be useful