### PR TITLE
Add a per-repo auto-run toggle for setup scripts

### DIFF
--- a/.changeset/short-pandas-dance.md
+++ b/.changeset/short-pandas-dance.md
@@ -1,0 +1,5 @@
+---
+"helmor": minor
+---
+
+Add a per-repository Auto-run toggle for setup scripts so new workspaces can either run setup immediately on creation or stay ready for manual setup from the Setup tab.

--- a/src-tauri/src/commands/repository_commands.rs
+++ b/src-tauri/src/commands/repository_commands.rs
@@ -96,6 +96,11 @@ pub async fn update_repo_scripts(
 }
 
 #[tauri::command]
+pub async fn update_repo_auto_run_setup(repo_id: String, enabled: bool) -> CmdResult<()> {
+    run_blocking(move || repos::update_repo_auto_run_setup(&repo_id, enabled)).await
+}
+
+#[tauri::command]
 pub async fn update_repo_preferences(
     repo_id: String,
     preferences: repos::RepoPreferences,

--- a/src-tauri/src/commands/tests/workspace_creation.rs
+++ b/src-tauri/src/commands/tests/workspace_creation.rs
@@ -87,17 +87,18 @@ fn create_workspace_from_repo_creates_ready_workspace_and_initial_session() {
 }
 
 #[test]
-fn create_workspace_from_repo_defers_setup_when_script_configured() {
+fn create_workspace_from_repo_defers_setup_when_script_configured_by_default() {
     let _guard = TEST_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     let harness = CreateTestHarness::new();
 
+    // Setup script configured. auto_run_setup defaults to true (DB default
+    // 1), so the workspace defers to the frontend inspector for auto-run.
     harness.commit_repo_files(&[("helmor.json", r#"{"scripts":{"setup":"echo hello"}}"#)]);
 
     let response = workspaces::create_workspace_from_repo_impl(&harness.repo_id).unwrap();
 
-    // Setup script detected → deferred to frontend inspector.
     assert_eq!(response.created_state, WorkspaceState::SetupPending);
 
     let connection = Connection::open(harness.db_path()).unwrap();
@@ -109,6 +110,22 @@ fn create_workspace_from_repo_defers_setup_when_script_configured() {
         )
         .unwrap();
     assert_eq!(state, "setup_pending");
+}
+
+#[test]
+fn create_workspace_from_repo_stays_ready_when_auto_run_setup_disabled() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let harness = CreateTestHarness::new();
+
+    harness.commit_repo_files(&[("helmor.json", r#"{"scripts":{"setup":"echo hello"}}"#)]);
+    repos::update_repo_auto_run_setup(&harness.repo_id, false).unwrap();
+
+    let response = workspaces::create_workspace_from_repo_impl(&harness.repo_id).unwrap();
+
+    // User opted out → workspace lands in Ready; setup runs manually.
+    assert_eq!(response.created_state, WorkspaceState::Ready);
 }
 
 #[test]
@@ -267,12 +284,32 @@ fn finalize_workspace_reports_setup_pending_when_helmor_json_has_setup() {
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     let harness = CreateTestHarness::new();
 
+    // Default behavior: auto_run_setup=true, helmor.json sets a setup script
+    // → workspace defers to frontend inspector.
     harness.commit_repo_files(&[("helmor.json", r#"{"scripts":{"setup":"echo hi"}}"#)]);
 
     let prepared = workspaces::prepare_workspace_from_repo_impl(&harness.repo_id).unwrap();
     let finalized = workspaces::finalize_workspace_from_repo_impl(&prepared.workspace_id).unwrap();
 
     assert_eq!(finalized.final_state, WorkspaceState::SetupPending);
+}
+
+#[test]
+fn finalize_workspace_stays_ready_when_helmor_json_has_setup_but_auto_run_disabled() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let harness = CreateTestHarness::new();
+
+    harness.commit_repo_files(&[("helmor.json", r#"{"scripts":{"setup":"echo hi"}}"#)]);
+    repos::update_repo_auto_run_setup(&harness.repo_id, false).unwrap();
+
+    let prepared = workspaces::prepare_workspace_from_repo_impl(&harness.repo_id).unwrap();
+    let finalized = workspaces::finalize_workspace_from_repo_impl(&prepared.workspace_id).unwrap();
+
+    // User opted out → setup script is configured but the workspace lands
+    // in Ready; user must run setup manually.
+    assert_eq!(finalized.final_state, WorkspaceState::Ready);
 }
 
 #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -187,6 +187,7 @@ pub fn run() {
             commands::repository_commands::load_repo_scripts,
             commands::repository_commands::load_repo_preferences,
             commands::repository_commands::update_repo_scripts,
+            commands::repository_commands::update_repo_auto_run_setup,
             commands::repository_commands::update_repo_preferences,
             commands::repository_commands::delete_repository,
             commands::script_commands::execute_repo_script,

--- a/src-tauri/src/models/repos.rs
+++ b/src-tauri/src/models/repos.rs
@@ -60,6 +60,9 @@ pub(crate) struct RepositoryRecord {
     pub setup_script: Option<String>,
     #[allow(dead_code)] // Queried separately via RepoScripts; kept here for completeness.
     pub run_script: Option<String>,
+    /// Auto-run the setup script when a workspace is created.
+    /// Defaults to true; users disable it from repo settings.
+    pub auto_run_setup: bool,
 }
 
 pub fn list_repositories() -> Result<Vec<RepositoryCreateOption>> {
@@ -107,7 +110,7 @@ pub(crate) fn load_repository_by_id(repo_id: &str) -> Result<Option<RepositoryRe
     let mut statement = connection
         .prepare(
             r#"
-            SELECT id, name, remote, default_branch, root_path, setup_script, run_script
+            SELECT id, name, remote, default_branch, root_path, setup_script, run_script, auto_run_setup
             FROM repos
             WHERE id = ?1
             "#,
@@ -124,6 +127,7 @@ pub(crate) fn load_repository_by_id(repo_id: &str) -> Result<Option<RepositoryRe
                 root_path: row.get(4)?,
                 setup_script: row.get(5)?,
                 run_script: row.get(6)?,
+                auto_run_setup: row.get::<_, Option<i64>>(7)?.unwrap_or(1) != 0,
             })
         })
         .with_context(|| format!("Failed to query repository {repo_id}"))?;
@@ -175,7 +179,7 @@ fn query_repository_by_root_path(
     let mut statement = connection
         .prepare(
             r#"
-            SELECT id, name, remote, default_branch, root_path, setup_script, run_script
+            SELECT id, name, remote, default_branch, root_path, setup_script, run_script, auto_run_setup
             FROM repos
             WHERE root_path = ?1
             ORDER BY created_at ASC
@@ -194,6 +198,7 @@ fn query_repository_by_root_path(
                 root_path: row.get(4)?,
                 setup_script: row.get(5)?,
                 run_script: row.get(6)?,
+                auto_run_setup: row.get::<_, Option<i64>>(7)?.unwrap_or(1) != 0,
             })
         })
         .with_context(|| format!("Failed to query repository row for {root_path}"))?;
@@ -214,7 +219,7 @@ fn query_repository_candidates_by_name(
     let mut statement = connection
         .prepare(
             r#"
-            SELECT id, name, remote, default_branch, root_path, setup_script, run_script
+            SELECT id, name, remote, default_branch, root_path, setup_script, run_script, auto_run_setup
             FROM repos
             WHERE name = ?1 OR root_path LIKE ?2
             ORDER BY created_at ASC
@@ -234,6 +239,7 @@ fn query_repository_candidates_by_name(
                 root_path: row.get(4)?,
                 setup_script: row.get(5)?,
                 run_script: row.get(6)?,
+                auto_run_setup: row.get::<_, Option<i64>>(7)?.unwrap_or(1) != 0,
             })
         })
         .with_context(|| format!("Failed to query repository candidates for {repository_name}"))?;
@@ -393,6 +399,9 @@ pub struct RepoScripts {
     pub setup_from_project: bool,
     pub run_from_project: bool,
     pub archive_from_project: bool,
+    /// Auto-run setup on workspace creation. DB-only — not configurable
+    /// from `helmor.json`. Defaults to true.
+    pub auto_run_setup: bool,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -444,15 +453,18 @@ pub fn load_repo_scripts(repo_id: &str, workspace_id: Option<&str>) -> Result<Re
     // config doesn't provide a value.
     let connection = db::read_conn()?;
     let mut statement = connection
-        .prepare("SELECT setup_script, run_script, archive_script FROM repos WHERE id = ?1")
+        .prepare(
+            "SELECT setup_script, run_script, archive_script, auto_run_setup FROM repos WHERE id = ?1",
+        )
         .with_context(|| format!("Failed to prepare script lookup for {repo_id}"))?;
 
-    let (db_setup, db_run, db_archive) = statement
+    let (db_setup, db_run, db_archive, auto_run_setup) = statement
         .query_row([repo_id], |row| {
             Ok((
                 row.get::<_, Option<String>>(0)?,
                 row.get::<_, Option<String>>(1)?,
                 row.get::<_, Option<String>>(2)?,
+                row.get::<_, Option<i64>>(3)?.unwrap_or(1) != 0,
             ))
         })
         .with_context(|| format!("Repository not found: {repo_id}"))?;
@@ -473,6 +485,7 @@ pub fn load_repo_scripts(repo_id: &str, workspace_id: Option<&str>) -> Result<Re
         setup_from_project,
         run_from_project,
         archive_from_project,
+        auto_run_setup,
     })
 }
 
@@ -542,6 +555,24 @@ pub fn update_repo_scripts(
             rusqlite::params![setup_script, run_script, archive_script, repo_id],
         )
         .with_context(|| format!("Failed to update scripts for {repo_id}"))?;
+
+    if updated != 1 {
+        bail!("Repository not found: {repo_id}");
+    }
+
+    Ok(())
+}
+
+/// Persist the user opt-in flag that controls whether the setup script
+/// auto-runs on workspace creation.
+pub fn update_repo_auto_run_setup(repo_id: &str, enabled: bool) -> Result<()> {
+    let connection = db::write_conn()?;
+    let updated = connection
+        .execute(
+            "UPDATE repos SET auto_run_setup = ?1, updated_at = datetime('now') WHERE id = ?2",
+            rusqlite::params![if enabled { 1 } else { 0 }, repo_id],
+        )
+        .with_context(|| format!("Failed to update auto_run_setup for {repo_id}"))?;
 
     if updated != 1 {
         bail!("Repository not found: {repo_id}");

--- a/src-tauri/src/schema.rs
+++ b/src-tauri/src/schema.rs
@@ -350,6 +350,18 @@ fn run_migrations(connection: &Connection) -> Result<()> {
             .context("Failed to add context_usage_meta column")?;
     }
 
+    // Migration: toggle for auto-running the setup script on workspace
+    // creation. Default 1 (on) — preserves the pre-feature behavior for
+    // existing repos and is the most common case. Users opt out per-repo
+    // when they prefer to run setup manually from the inspector.
+    // Nullable so the conductor-import path (which copies rows without
+    // specifying this column) can leave it NULL; reads treat NULL as on.
+    if has_table(connection, "repos") && !has_column(connection, "repos", "auto_run_setup") {
+        connection
+            .execute_batch("ALTER TABLE repos ADD COLUMN auto_run_setup INTEGER DEFAULT 1")
+            .context("Failed to add auto_run_setup column")?;
+    }
+
     drop_dead_schema(connection)?;
 
     // Migration: remap legacy "opus-1m" model ID — the CLI no longer accepts it.
@@ -379,6 +391,7 @@ CREATE TABLE IF NOT EXISTS repos (
     hidden INTEGER DEFAULT 0,
     custom_prompt_fix_errors TEXT,
     custom_prompt_resolve_merge_conflicts TEXT,
+    auto_run_setup INTEGER DEFAULT 1,
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );

--- a/src-tauri/src/workspace/lifecycle.rs
+++ b/src-tauri/src/workspace/lifecycle.rs
@@ -170,6 +170,7 @@ pub fn prepare_workspace_from_repo_impl(repo_id: &str) -> Result<PrepareWorkspac
                 setup_from_project: false,
                 run_from_project: false,
                 archive_from_project: false,
+                auto_run_setup: true,
             }
         }
     };
@@ -254,8 +255,10 @@ pub fn finalize_workspace_from_repo_impl(workspace_id: &str) -> Result<FinalizeW
         };
 
         helpers::create_workspace_context_scaffold(&workspace_dir)?;
-        // Defer setup to the frontend inspector: if a script is configured,
-        // the workspace starts in "setup_pending" and the UI auto-triggers it.
+        // Defer setup to the frontend inspector: if a script is configured AND
+        // the user opted into auto-run, the workspace starts in "setup_pending"
+        // and the UI auto-triggers it. Otherwise we go straight to Ready and
+        // the user runs setup manually from the inspector when they want.
         let has_setup = match resolve_setup_hook(&repository, &workspace_dir) {
             Ok(Some(s)) if !s.trim().is_empty() => true,
             Ok(_) => false,
@@ -264,7 +267,7 @@ pub fn finalize_workspace_from_repo_impl(workspace_id: &str) -> Result<FinalizeW
                 false
             }
         };
-        let final_state = if has_setup {
+        let final_state = if has_setup && repository.auto_run_setup {
             WorkspaceState::SetupPending
         } else {
             WorkspaceState::Ready

--- a/src/App.create.test.tsx
+++ b/src/App.create.test.tsx
@@ -69,6 +69,7 @@ describe("App create workspace flow", () => {
 			setupFromProject: false,
 			runFromProject: false,
 			archiveFromProject: false,
+			autoRunSetup: true,
 		});
 		apiMocks.listRepositories.mockReset();
 		apiMocks.createWorkspaceFromRepo.mockReset();

--- a/src/App.unread-reclick.test.tsx
+++ b/src/App.unread-reclick.test.tsx
@@ -96,6 +96,7 @@ describe("App unread — re-click selected workspace clears dot", () => {
 			setupFromProject: false,
 			runFromProject: false,
 			archiveFromProject: false,
+			autoRunSetup: true,
 		});
 
 		// Before create: empty sidebar.

--- a/src/features/navigation/hooks/use-controller.test.tsx
+++ b/src/features/navigation/hooks/use-controller.test.tsx
@@ -420,6 +420,7 @@ describe("useWorkspacesSidebarController archive flow", () => {
 				setupFromProject: false,
 				runFromProject: false,
 				archiveFromProject: false,
+				autoRunSetup: true,
 			},
 		});
 		apiMocks.finalizeWorkspaceFromRepo.mockImplementation(
@@ -519,6 +520,7 @@ describe("useWorkspacesSidebarController archive flow", () => {
 				setupFromProject: false,
 				runFromProject: false,
 				archiveFromProject: false,
+				autoRunSetup: true,
 			},
 		});
 		// Keep Phase 2 suspended so we can assert the Phase 1 painted state
@@ -697,6 +699,7 @@ describe("useWorkspacesSidebarController archive flow", () => {
 				setupFromProject: false,
 				runFromProject: false,
 				archiveFromProject: false,
+				autoRunSetup: true,
 			},
 		});
 		apiMocks.finalizeWorkspaceFromRepo.mockImplementation(
@@ -807,6 +810,7 @@ describe("useWorkspacesSidebarController archive flow", () => {
 				setupFromProject: false,
 				runFromProject: false,
 				archiveFromProject: false,
+				autoRunSetup: true,
 			},
 		});
 		apiMocks.finalizeWorkspaceFromRepo.mockRejectedValue(

--- a/src/features/panel/container.test.tsx
+++ b/src/features/panel/container.test.tsx
@@ -253,6 +253,7 @@ describe("WorkspacePanelContainer loading semantics", () => {
 			setupFromProject: false,
 			runFromProject: false,
 			archiveFromProject: false,
+			autoRunSetup: true,
 		});
 		apiMocks.loadWorkspaceDetail.mockImplementation((workspaceId?: string) =>
 			Promise.resolve(createWorkspaceDetail(workspaceId)),

--- a/src/features/settings/panels/repository-settings.tsx
+++ b/src/features/settings/panels/repository-settings.tsx
@@ -1,5 +1,11 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Check, ChevronDown, GitBranch, Trash2 } from "lucide-react";
+import {
+	Check,
+	ChevronDown,
+	GitBranch,
+	HelpCircle,
+	Trash2,
+} from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { BranchPickerPopover } from "@/components/branch-picker";
 import { Button } from "@/components/ui/button";
@@ -15,6 +21,7 @@ import {
 	PopoverContent,
 	PopoverTrigger,
 } from "@/components/ui/popover";
+import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import {
 	Tooltip,
@@ -29,6 +36,7 @@ import {
 	loadRepoScripts,
 	prefetchRemoteRefs,
 	type RepositoryCreateOption,
+	updateRepoAutoRunSetup,
 	updateRepoScripts,
 	updateRepositoryDefaultBranch,
 	updateRepositoryRemote,
@@ -233,6 +241,7 @@ function ScriptField({
 	locked,
 	lockedMessage,
 	onChange,
+	headerRight,
 }: {
 	label: string;
 	description: string;
@@ -241,6 +250,7 @@ function ScriptField({
 	locked: boolean;
 	lockedMessage: string;
 	onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+	headerRight?: React.ReactNode;
 }) {
 	const textarea = (
 		<Textarea
@@ -255,9 +265,16 @@ function ScriptField({
 
 	return (
 		<div>
-			<div className="text-[12px] font-medium text-app-foreground">{label}</div>
-			<div className="mt-0.5 text-[11px] text-muted-foreground">
-				{description}
+			<div className="flex items-start justify-between gap-3">
+				<div className="min-w-0">
+					<div className="text-[12px] font-medium text-app-foreground">
+						{label}
+					</div>
+					<div className="mt-0.5 text-[11px] text-muted-foreground">
+						{description}
+					</div>
+				</div>
+				{headerRight && <div className="shrink-0">{headerRight}</div>}
 			</div>
 			{locked ? (
 				<TooltipProvider>
@@ -295,6 +312,7 @@ function ScriptsSection({
 	const [setupScript, setSetupScript] = useState("");
 	const [runScript, setRunScript] = useState("");
 	const [archiveScript, setArchiveScript] = useState("");
+	const [autoRunSetup, setAutoRunSetup] = useState(false);
 	const initialized = useRef(false);
 
 	useEffect(() => {
@@ -305,6 +323,7 @@ function ScriptsSection({
 		if (shouldSyncSetup) setSetupScript(data.setupScript ?? "");
 		if (shouldSyncRun) setRunScript(data.runScript ?? "");
 		if (shouldSyncArchive) setArchiveScript(data.archiveScript ?? "");
+		if (!initialized.current) setAutoRunSetup(data.autoRunSetup);
 		if (!setupLocked && !runLocked && !archiveLocked) {
 			initialized.current = true;
 		}
@@ -363,6 +382,20 @@ function ScriptsSection({
 		[setupScript, runScript, save],
 	);
 
+	const handleAutoRunSetupChange = useCallback(
+		(checked: boolean) => {
+			setAutoRunSetup(checked);
+			void updateRepoAutoRunSetup(repoId, checked).then(() => {
+				void queryClient.invalidateQueries({
+					queryKey: ["repoScripts", repoId],
+				});
+			});
+		},
+		[repoId, queryClient],
+	);
+
+	const setupHasScript = !!setupScript.trim();
+
 	return (
 		<div className="rounded-xl border border-app-border/30 bg-app-base/20 px-5 py-4">
 			<div className="text-[13px] font-medium leading-snug text-app-foreground">
@@ -375,12 +408,40 @@ function ScriptsSection({
 			<div className="mt-4 space-y-4">
 				<ScriptField
 					label="Setup script"
-					description="Runs when a new workspace is created"
+					description="Available from the Setup tab in any workspace"
 					placeholder="e.g., npm install"
 					value={setupScript}
 					locked={setupLocked}
 					lockedMessage="Set by this workspace's helmor.json — edit it there"
 					onChange={handleSetupChange}
+					headerRight={
+						<div className="flex items-center gap-1.5">
+							<span className="text-[11px] font-medium text-muted-foreground">
+								Auto-run
+							</span>
+							<TooltipProvider>
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<HelpCircle
+											className="size-3 cursor-help text-muted-foreground/70"
+											strokeWidth={1.8}
+										/>
+									</TooltipTrigger>
+									<TooltipContent side="top" className="max-w-[240px]">
+										On by default — setup runs automatically as soon as a
+										workspace is created. Turn off to run it manually from the
+										Setup tab.
+									</TooltipContent>
+								</Tooltip>
+							</TooltipProvider>
+							<Switch
+								checked={autoRunSetup}
+								onCheckedChange={handleAutoRunSetupChange}
+								disabled={!setupHasScript}
+								aria-label="Auto-run setup script on workspace creation"
+							/>
+						</div>
+					}
 				/>
 				<ScriptField
 					label="Run script"

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2061,6 +2061,8 @@ export type RepoScripts = {
 	setupFromProject: boolean;
 	runFromProject: boolean;
 	archiveFromProject: boolean;
+	/** Auto-run the setup script on workspace creation. Defaults to true. */
+	autoRunSetup: boolean;
 };
 
 export type RepoPreferences = {
@@ -2113,6 +2115,13 @@ export async function updateRepoScripts(
 		runScript,
 		archiveScript,
 	});
+}
+
+export async function updateRepoAutoRunSetup(
+	repoId: string,
+	enabled: boolean,
+): Promise<void> {
+	await invoke("update_repo_auto_run_setup", { repoId, enabled });
 }
 
 export async function loadRepoPreferences(


### PR DESCRIPTION
## What changed
- added a per-repository `auto_run_setup` flag, migration, and Tauri command/API plumbing
- updated workspace creation so repos with setup scripts only enter `setup_pending` when auto-run is enabled
- added a repository settings toggle and kept related frontend/Rust tests in sync

## Why
Some repositories need a setup script available but should not run it automatically every time a workspace is created. This keeps the existing default behavior while letting users opt into manual setup from the Setup tab.

## Test notes
- `bun x vitest run src/App.create.test.tsx src/App.unread-reclick.test.tsx src/features/navigation/hooks/use-controller.test.tsx src/features/panel/container.test.tsx`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib commands::tests::workspace_creation`