### PR TITLE
Handle archived workspaces without a worktree

### DIFF
--- a/.changeset/archived-workspaces-safe-status.md
+++ b/.changeset/archived-workspaces-safe-status.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Archived workspaces now report safe git status values instead of trying to inspect a removed worktree, and the editor action is hidden until a workspace has a root path again.

--- a/src-tauri/src/commands/editor_commands.rs
+++ b/src-tauri/src/commands/editor_commands.rs
@@ -91,26 +91,41 @@ pub async fn get_workspace_git_action_status(
     run_blocking(move || {
         let record = workspace_models::load_workspace_record_by_id(&workspace_id)?
             .with_context(|| format!("Workspace not found: {workspace_id}"))?;
-        // A workspace that hasn't finished Phase 2 has no worktree on disk —
-        // running `git status` against it would error. A freshly-created
-        // workspace always starts clean (0 uncommitted, 0 conflicts, in sync
-        // with its base branch, not yet pushed), so short-circuit to the
-        // canonical "fresh" status. The frontend paints the same values
-        // post-ready, so the state transition causes zero visual change.
-        if record.state == WorkspaceState::Initializing {
-            return Ok(git_ops::WorkspaceGitActionStatus {
-                uncommitted_count: 0,
-                conflict_count: 0,
-                sync_target_branch: record
-                    .intended_target_branch
-                    .clone()
-                    .or_else(|| record.default_branch.clone()),
-                sync_status: git_ops::WorkspaceSyncStatus::UpToDate,
-                behind_target_count: 0,
-                remote_tracking_ref: None,
-                ahead_of_remote_count: 0,
-                push_status: git_ops::WorkspacePushStatus::Unpublished,
-            });
+        // Workspaces without a live worktree must never hit the filesystem for
+        // local git status. Initializing workspaces haven't finished Phase 2
+        // yet; archived workspaces intentionally removed their worktree.
+        match record.state {
+            WorkspaceState::Initializing => {
+                return Ok(git_ops::WorkspaceGitActionStatus {
+                    uncommitted_count: 0,
+                    conflict_count: 0,
+                    sync_target_branch: record
+                        .intended_target_branch
+                        .clone()
+                        .or_else(|| record.default_branch.clone()),
+                    sync_status: git_ops::WorkspaceSyncStatus::UpToDate,
+                    behind_target_count: 0,
+                    remote_tracking_ref: None,
+                    ahead_of_remote_count: 0,
+                    push_status: git_ops::WorkspacePushStatus::Unpublished,
+                });
+            }
+            WorkspaceState::Archived => {
+                return Ok(git_ops::WorkspaceGitActionStatus {
+                    uncommitted_count: 0,
+                    conflict_count: 0,
+                    sync_target_branch: record
+                        .intended_target_branch
+                        .clone()
+                        .or_else(|| record.default_branch.clone()),
+                    sync_status: git_ops::WorkspaceSyncStatus::Unknown,
+                    behind_target_count: 0,
+                    remote_tracking_ref: None,
+                    ahead_of_remote_count: 0,
+                    push_status: git_ops::WorkspacePushStatus::Unknown,
+                });
+            }
+            _ => {}
         }
         let workspace_dir =
             crate::data_dir::workspace_dir(&record.repo_name, &record.directory_name)?;

--- a/src-tauri/src/commands/tests/archive_restore.rs
+++ b/src-tauri/src/commands/tests/archive_restore.rs
@@ -94,6 +94,31 @@ fn archive_workspace_moves_context_and_removes_worktree() {
 }
 
 #[test]
+fn git_action_status_returns_safe_defaults_for_archived_workspace() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let harness = ArchiveTestHarness::new(true);
+
+    workspaces::archive_workspace_impl(&harness.workspace_id).unwrap();
+    assert!(!harness.workspace_dir().exists());
+
+    let status = tauri::async_runtime::block_on(
+        crate::commands::editor_commands::get_workspace_git_action_status(
+            harness.workspace_id.clone(),
+        ),
+    )
+    .expect("get_workspace_git_action_status should succeed for archived workspace");
+
+    assert_eq!(status.uncommitted_count, 0);
+    assert_eq!(status.conflict_count, 0);
+    assert_eq!(status.behind_target_count, 0);
+    assert_eq!(status.ahead_of_remote_count, 0);
+    assert_eq!(status.sync_status, git_ops::WorkspaceSyncStatus::Unknown);
+    assert_eq!(status.push_status, git_ops::WorkspacePushStatus::Unknown);
+}
+
+#[test]
 fn permanently_delete_archived_workspace_removes_db_rows_and_context() {
     let _guard = TEST_LOCK
         .lock()

--- a/src-tauri/src/workspace/scripts.rs
+++ b/src-tauri/src/workspace/scripts.rs
@@ -438,13 +438,13 @@ pub(crate) fn run_script_with_shell(
                         let _ = ch.send(ScriptEvent::Stdout { data });
                     }
                     Err(e) => {
-                        // EIO is expected when the child exits and slave closes.
-                        if e.raw_os_error() != Some(libc::EIO) {
-                            tracing::debug!(error = %e, "PTY read error");
-                        }
                         if e.kind() == std::io::ErrorKind::WouldBlock {
                             std::thread::sleep(PTY_POLL_INTERVAL);
                             continue;
+                        }
+                        // EIO is expected when the child exits and slave closes.
+                        if e.raw_os_error() != Some(libc::EIO) {
+                            tracing::debug!(error = %e, "PTY read error");
                         }
                         break;
                     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1989,6 +1989,7 @@ function AppShell({
 												}
 												headerActions={
 													selectedWorkspaceId &&
+													workspaceRootPath &&
 													installedEditors.length > 0 &&
 													preferredEditor ? (
 														<div className="flex items-center">

--- a/src/features/navigation/hooks/use-controller.test.tsx
+++ b/src/features/navigation/hooks/use-controller.test.tsx
@@ -11,7 +11,10 @@ import type {
 	WorkspaceSessionSummary,
 	WorkspaceSummary,
 } from "@/lib/api";
-import { helmorQueryKeys } from "@/lib/query-client";
+import {
+	helmorQueryKeys,
+	workspaceDetailQueryOptions,
+} from "@/lib/query-client";
 import { DEFAULT_SETTINGS, SettingsContext } from "@/lib/settings";
 import { useWorkspacesSidebarController } from "./use-controller";
 
@@ -318,6 +321,47 @@ describe("useWorkspacesSidebarController archive flow", () => {
 		expect(result.current.archivedRows.map((row) => row.id)).toContain("ws-1");
 		expect(onSelectWorkspace).toHaveBeenCalledWith("ws-2");
 		expect(pushWorkspaceToast).not.toHaveBeenCalled();
+	});
+
+	it("optimistically clears the archived workspace root path from detail cache", async () => {
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false } },
+		});
+		const onSelectWorkspace = vi.fn();
+		const pushWorkspaceToast = vi.fn();
+
+		const { result } = renderHook(
+			() =>
+				useWorkspacesSidebarController({
+					selectedWorkspaceId: "ws-1",
+					onSelectWorkspace,
+					pushWorkspaceToast,
+				}),
+			{ wrapper: createWrapper(queryClient) },
+		);
+
+		await waitFor(() => {
+			expect(result.current.groups[0]?.rows).toHaveLength(2);
+		});
+		await queryClient.ensureQueryData(workspaceDetailQueryOptions("ws-1"));
+
+		act(() => {
+			result.current.handleArchiveWorkspace("ws-1");
+		});
+
+		await waitFor(() => {
+			expect(apiMocks.prepareArchiveWorkspace).toHaveBeenCalledWith("ws-1");
+		});
+
+		expect(
+			queryClient.getQueryData<WorkspaceDetail | null>(
+				helmorQueryKeys.workspaceDetail("ws-1"),
+			),
+		).toMatchObject({
+			id: "ws-1",
+			state: "archived",
+			rootPath: null,
+		});
 	});
 
 	it("consecutive archives advance to the next sidebar row instead of jumping to archived", async () => {

--- a/src/features/navigation/hooks/use-controller.ts
+++ b/src/features/navigation/hooks/use-controller.ts
@@ -100,6 +100,9 @@ export function useWorkspacesSidebarController({
 	const [pendingArchives, setPendingArchives] = useState<
 		Map<string, PendingArchiveEntry>
 	>(() => new Map());
+	const archivedWorkspaceDetailRollbackRef = useRef<
+		Map<string, WorkspaceDetail | null>
+	>(new Map());
 	const [pendingCreations, setPendingCreations] = useState<
 		Map<
 			string,
@@ -229,6 +232,20 @@ export function useWorkspacesSidebarController({
 
 	const rollbackArchivedWorkspace = useCallback(
 		(workspaceId: string, error: unknown, fallbackMessage: string) => {
+			const previousDetail =
+				archivedWorkspaceDetailRollbackRef.current.get(workspaceId);
+			archivedWorkspaceDetailRollbackRef.current.delete(workspaceId);
+			if (previousDetail !== undefined) {
+				queryClient.setQueryData(
+					helmorQueryKeys.workspaceDetail(workspaceId),
+					previousDetail,
+				);
+			} else {
+				void queryClient.invalidateQueries({
+					queryKey: helmorQueryKeys.workspaceDetail(workspaceId),
+				});
+			}
+
 			updateArchivingWorkspaceId(workspaceId, false);
 			let rollback: PendingArchiveEntry | null = null;
 			setPendingArchives((current) => {
@@ -253,7 +270,12 @@ export function useWorkspacesSidebarController({
 				fallbackMessage,
 			);
 		},
-		[flushSidebarLists, pushWorkspaceErrorToast, updateArchivingWorkspaceId],
+		[
+			flushSidebarLists,
+			pushWorkspaceErrorToast,
+			queryClient,
+			updateArchivingWorkspaceId,
+		],
 	);
 
 	useEffect(() => {
@@ -282,6 +304,7 @@ export function useWorkspacesSidebarController({
 			if (disposed) {
 				return;
 			}
+			archivedWorkspaceDetailRollbackRef.current.delete(payload.workspaceId);
 			setPendingArchives((current) => {
 				const existing = current.get(payload.workspaceId);
 				if (!existing || existing.stage === "confirmed") {
@@ -299,6 +322,12 @@ export function useWorkspacesSidebarController({
 			});
 			void queryClient.invalidateQueries({
 				queryKey: helmorQueryKeys.archivedWorkspaces,
+			});
+			void queryClient.invalidateQueries({
+				queryKey: helmorQueryKeys.workspaceDetail(payload.workspaceId),
+			});
+			void queryClient.invalidateQueries({
+				queryKey: helmorQueryKeys.workspaceGitActionStatus(payload.workspaceId),
 			});
 		}).then((cleanup) => {
 			if (disposed) {
@@ -1335,6 +1364,20 @@ export function useWorkspacesSidebarController({
 				}
 
 				const sortTimestamp = Date.now();
+				const detailKey = helmorQueryKeys.workspaceDetail(workspaceId);
+				const previousDetail =
+					queryClient.getQueryData<WorkspaceDetail | null>(detailKey) ?? null;
+				archivedWorkspaceDetailRollbackRef.current.set(
+					workspaceId,
+					previousDetail,
+				);
+				if (previousDetail) {
+					queryClient.setQueryData<WorkspaceDetail | null>(detailKey, {
+						...previousDetail,
+						state: "archived",
+						rootPath: null,
+					});
+				}
 				const pendingArchive: PendingArchiveEntry = {
 					row: {
 						...moved.row,


### PR DESCRIPTION
What changed:
- Treat archived workspaces as worktree-free in `get_workspace_git_action_status`, returning safe defaults instead of probing the filesystem.
- Update the archive flow to optimistically clear cached workspace details, restore them on rollback, and invalidate related queries when the archive is confirmed.
- Hide the editor header action when the selected workspace has no root path.
- Add coverage for archived workspace git status handling.

Why:
- Archived workspaces intentionally remove their local worktree, so the UI and backend must not assume the path still exists or try to run git status against it.

Tests:
- `bun x vitest run src/features/navigation/hooks/use-controller.test.tsx`
- `cargo test git_action_status_returns_safe_defaults_for_archived_workspace`
- Pre-commit hooks also ran `biome check --write`, `cargo fmt`, and `cargo clippy -- -D warnings`.