### PR TITLE
chore: enable tauri devtools feature for production inspection

### DIFF
--- a/.changeset/loud-otters-inspect.md
+++ b/.changeset/loud-otters-inspect.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Enable the WebView devtools panel in production builds, so you can right-click → Inspect Element inside Helmor to help diagnose rendering issues like scrollbar glitches.

--- a/apps/marketing/app/download-dropdown.tsx
+++ b/apps/marketing/app/download-dropdown.tsx
@@ -107,7 +107,7 @@ export function DownloadDropdown({ data }: Props) {
 					<span className="dl-chip">ARM</span>
 					<span className="dl-text">
 						<span className="dl-title">Apple Silicon</span>
-						<span className="dl-sub">M1 · M2 · M3 · M4</span>
+						<span className="dl-sub">M series</span>
 					</span>
 					<span className="dl-size">
 						·dmg {formatMegabytes(data.armDmgSize)}
@@ -139,7 +139,7 @@ export function DownloadDropdown({ data }: Props) {
 						) : null}
 					</span>
 					<a href={data.releasesUrl} onClick={closeNow}>
-						All downloads →
+						All →
 					</a>
 				</div>
 			</div>

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,7 +32,7 @@ r2d2 = "0.8"
 r2d2_sqlite = "0.24"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tauri = { version = "2", features = ["protocol-asset", "test"] }
+tauri = { version = "2", features = ["protocol-asset", "test", "devtools"] }
 tauri-plugin-deep-link = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-mcp-bridge = "0.11.0"


### PR DESCRIPTION
## Summary
- Add the `devtools` feature flag to the `tauri` crate in `src-tauri/Cargo.toml`, alongside the existing `protocol-asset` and `test` features.

## Why
- In release builds, Tauri does not expose webview devtools by default. Enabling this feature lets us open devtools in production builds so we can inspect production-only issues (e.g. scrollbar rendering differences that don't reproduce in `bun run dev`).

## Test plan
- [ ] `bun run typecheck` / `bun run lint` pass locally
- [ ] `bun run build` + `bun tauri build` succeeds
- [ ] In the resulting production bundle, right-click → "Inspect Element" (or the platform shortcut) opens devtools
- [ ] Dev build behavior is unchanged