### PR TITLE
feat(marketing): on-demand ISR revalidation for release publishes

### DIFF
--- a/.github/workflows/refresh-marketing.yml
+++ b/.github/workflows/refresh-marketing.yml
@@ -1,0 +1,50 @@
+name: Refresh marketing site
+
+# Calls the marketing site's on-demand ISR revalidation endpoint so
+# helmor.ai reflects a new version within seconds of a release going live,
+# instead of waiting for the 3600s ISR window in `apps/marketing/lib/github.ts`.
+#
+# Triggered on `release.published` (covers both "push tag → tauri-action
+# creates published release" and "manually flip draft → published" flows).
+# Intentionally NOT tied to publish.yml: that workflow uses a 2-way matrix
+# and may run in draft mode where `/releases/latest` returns nothing.
+#
+# `workflow_dispatch` is kept for first-time verification and manual recovery.
+#
+# Failure mode: if this workflow fails, the 3600s ISR fallback still works --
+# helmor.ai is at worst ~1 hour stale, never broken.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+concurrency:
+  group: refresh-marketing
+  cancel-in-progress: false
+
+jobs:
+  revalidate:
+    # Skip prereleases (marketing site only tracks stable latest). `workflow_dispatch`
+    # has no release payload, so this condition must allow it through.
+    if: github.event_name == 'workflow_dispatch' || github.event.release.prerelease == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Call revalidate endpoint
+        env:
+          SECRET: ${{ secrets.HELMOR_MARKETING_REVALIDATE_SECRET }}
+        # curl --fail makes non-2xx return an exit code; --retry handles
+        # transient Vercel cold starts. The secret is passed via env and
+        # injected into a header (never argv or URL) to keep it out of
+        # process listings and access logs.
+        run: |
+          if [ -z "${SECRET}" ]; then
+            echo "HELMOR_MARKETING_REVALIDATE_SECRET is not set"
+            exit 1
+          fi
+          curl --fail --silent --show-error \
+            --retry 3 --retry-delay 10 --retry-connrefused \
+            -X POST "https://helmor.ai/api/revalidate" \
+            -H "x-revalidate-secret: ${SECRET}" \
+            -H "content-type: application/json"

--- a/apps/marketing/app/api/revalidate/route.ts
+++ b/apps/marketing/app/api/revalidate/route.ts
@@ -1,0 +1,58 @@
+/**
+ * On-demand ISR revalidation webhook for the marketing site.
+ *
+ * Triggered by `.github/workflows/refresh-marketing.yml` on GitHub Release
+ * `published` events, so helmor.ai reflects new versions within seconds
+ * instead of waiting for the hourly `revalidate: 3600` window in
+ * `app/page.tsx` + `lib/github.ts`.
+ *
+ * Security:
+ *   - Shared secret `HELMOR_MARKETING_REVALIDATE_SECRET` must match on both
+ *     sides (Vercel env var + GitHub Actions secret).
+ *   - Secret is read from the `x-revalidate-secret` HEADER (never query
+ *     string), compared via `crypto.timingSafeEqual` to avoid timing attacks.
+ *   - Fail-closed: if the env var is missing, we return 500 rather than
+ *     silently allowing unauthenticated revalidation.
+ *
+ * Failure mode: if this route ever breaks, the existing 3600s ISR in
+ * `app/page.tsx` still auto-refreshes the page. Worst case is ~1 hour stale.
+ */
+
+import crypto from "node:crypto";
+import { revalidatePath } from "next/cache";
+import { NextResponse } from "next/server";
+
+// `crypto.timingSafeEqual` needs Node runtime. Default is Node in Next 15
+// App Router, but declare it explicitly so future regressions surface.
+export const runtime = "nodejs";
+// The route itself must not be cached -- every hit is a control-plane call.
+export const dynamic = "force-dynamic";
+
+export async function POST(req: Request): Promise<NextResponse> {
+	const expected = process.env.HELMOR_MARKETING_REVALIDATE_SECRET;
+	if (!expected) {
+		return NextResponse.json(
+			{ ok: false, error: "not_configured" },
+			{ status: 500 },
+		);
+	}
+
+	const provided = req.headers.get("x-revalidate-secret") ?? "";
+	const a = Buffer.from(provided);
+	const b = Buffer.from(expected);
+	if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) {
+		return NextResponse.json({ ok: false }, { status: 401 });
+	}
+
+	try {
+		// Only the home page pulls from GitHub. Scope = "page" avoids
+		// invalidating layouts we don't own.
+		revalidatePath("/", "page");
+		return NextResponse.json({ ok: true, revalidated: "/" });
+	} catch {
+		return NextResponse.json(
+			{ ok: false, error: "revalidate_failed" },
+			{ status: 500 },
+		);
+	}
+}


### PR DESCRIPTION
## Summary

- Add `POST /api/revalidate` on the marketing site: secret-authenticated (timing-safe), Node runtime, calls `revalidatePath(\"/\", \"page\")`. Fails closed if the env var is missing.
- Add `.github/workflows/refresh-marketing.yml` that fires on `release.published` (plus manual `workflow_dispatch`), filters out prereleases, and `curl`s the endpoint with retry. Secret travels in a header via env var — never argv, never query string.

helmor.ai now reflects a new version within seconds of a release going live instead of waiting on the hourly ISR window in ``apps/marketing/lib/github.ts``. The existing 3600s ISR fallback is preserved — if this webhook ever fails, the site is still auto-refreshed on the hourly schedule (worst case ~1 hour stale).

## Required config before merge

Set the shared secret in both places (same value, generated via ``openssl rand -hex 32``):

- Vercel → marketing project → Settings → Environment Variables → ``HELMOR_MARKETING_REVALIDATE_SECRET`` (Production; mark Sensitive)
- GitHub → repo Settings → Secrets and variables → Actions → ``HELMOR_MARKETING_REVALIDATE_SECRET``

## Test plan

After merge + Vercel deploy:

- [ ] ``curl -i -X POST https://helmor.ai/api/revalidate`` → ``401``
- [ ] ``curl -i -X POST https://helmor.ai/api/revalidate -H \"x-revalidate-secret: wrong\"`` → ``401``
- [ ] ``curl -i https://helmor.ai/api/revalidate`` → ``405``
- [ ] ``curl -i -X POST https://helmor.ai/api/revalidate -H \"x-revalidate-secret: \$SECRET\"`` → ``200 {\"ok\":true,\"revalidated\":\"/\"}``
- [ ] GitHub Actions → Refresh marketing site → Run workflow (main) → green
- [ ] Observe ``curl -sI https://helmor.ai/ | grep x-vercel-cache`` flipping MISS → HIT with fresh ``age``