### PR TITLE
fix: deliver Claude ask-user answers

### DIFF
--- a/.changeset/calm-owls-answer.md
+++ b/.changeset/calm-owls-answer.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix Claude's AskUserQuestion so the answer you pick in the UI actually reaches the assistant when you submit.

--- a/sidecar/src/claude-session-manager.ts
+++ b/sidecar/src/claude-session-manager.ts
@@ -358,6 +358,11 @@ export class ClaudeSessionManager implements SessionManager {
 		this.pruneExpiredDeferredToolResponses();
 		const resolved = this.deferredToolResponses.get(toolUseID);
 		if (resolved) {
+			// Consume once: the SDK invokes the hook exactly once per
+			// tool_use lifecycle before executing the tool, so leaving the
+			// resolution in the map only risks stale reads if the same
+			// toolUseID is re-evaluated within TTL (5 min).
+			this.deferredToolResponses.delete(toolUseID);
 			return {
 				hookSpecificOutput: {
 					hookEventName: "PreToolUse",
@@ -406,21 +411,31 @@ export class ClaudeSessionManager implements SessionManager {
 		);
 
 		const { text, imagePaths } = parseImageRefs(promptWithContext);
-		// Always use streaming-input mode so `steer()` can push additional
-		// `SDKUserMessage`s into the same turn. For Claude real steer, the
-		// SDK consumes subsequent pushes as part of the in-flight turn and
-		// emits ONE final `result` — so bail-on-first-result semantics are
-		// unchanged.
+		// Resume-only streams (AskUserQuestion answer submission) arrive with
+		// `prompt === ""` — the Rust command layer rejects empty prompts in
+		// every other case (see `agents.rs: "Prompt cannot be empty"`), so
+		// this check is unambiguous. In that path we pass `""` as a plain
+		// string to `query()` (pre-Steer shape) so the SDK replays the
+		// session and re-invokes PreToolUse for the pending tool_use, which
+		// is how the stored `deferredToolResponses` resolution reaches
+		// Claude. Pushing a synthetic `{ role: "user", content: "" }` into
+		// the pushable — what streaming-input mode would do — makes the SDK
+		// treat it as a new empty user turn and skip that re-evaluation.
 		const promptSource = createPushable<SDKUserMessage>();
-		const initialMessage =
-			imagePaths.length === 0
-				? ({
-						type: "user",
-						message: { role: "user", content: text },
-						parent_tool_use_id: null,
-					} as SDKUserMessage)
-				: await buildUserMessageWithImages(text, imagePaths);
-		promptSource.push(initialMessage);
+		const isResumeOnly = text === "" && imagePaths.length === 0;
+		if (isResumeOnly) {
+			promptSource.close();
+		} else {
+			const initialMessage =
+				imagePaths.length === 0
+					? ({
+							type: "user",
+							message: { role: "user", content: text },
+							parent_tool_use_id: null,
+						} as SDKUserMessage)
+					: await buildUserMessageWithImages(text, imagePaths);
+			promptSource.push(initialMessage);
+		}
 
 		const effectiveFastMode =
 			fastMode === true && claudeModelSupportsFastMode(model);
@@ -430,7 +445,7 @@ export class ClaudeSessionManager implements SessionManager {
 				: undefined;
 
 		const q = query({
-			prompt: promptSource,
+			prompt: isResumeOnly ? "" : promptSource,
 			options: {
 				abortController,
 				pathToClaudeCodeExecutable: CLAUDE_CLI_PATH,

--- a/sidecar/test/claude-session-manager.test.ts
+++ b/sidecar/test/claude-session-manager.test.ts
@@ -39,6 +39,13 @@ type MockQueryResult = AsyncIterable<unknown> & {
 	close?: () => void;
 };
 
+type MockHookFn = (
+	input: { hook_event_name: string; tool_name: string },
+	toolUseID: string,
+) => Promise<{
+	hookSpecificOutput?: Record<string, unknown>;
+}>;
+
 type MockQueryImpl = (options: {
 	prompt?: unknown;
 	options?: {
@@ -54,6 +61,9 @@ type MockQueryImpl = (options: {
 			},
 			options: { signal: AbortSignal },
 		) => Promise<{ action: string; content?: Record<string, unknown> }>;
+		hooks?: {
+			PreToolUse?: Array<{ hooks: MockHookFn[] }>;
+		};
 	};
 }) => MockQueryResult;
 
@@ -629,6 +639,84 @@ describe("ClaudeSessionManager.sendMessage", () => {
 			},
 		});
 		expect(captured[2]).toEqual({ id: "REQ-DEFER", type: "end" });
+	});
+
+	// Regression for AskUserQuestion answer delivery: the Steer commit
+	// (1e0d07b) forced every sendMessage through streaming-input mode, which
+	// made resume-only streams push a synthetic `{ role: "user", content: "" }`
+	// into the SDK. Claude treated that as a new empty user turn and skipped
+	// re-invoking the PreToolUse hook, so the user's answer (stored in
+	// `deferredToolResponses`) never reached Claude. This test pins the fix:
+	// empty prompt => pass `""` (string) to `query()` so the hook re-fires.
+	test("empty prompt: query() gets string prompt and PreToolUse hook surfaces the stored resolution", async () => {
+		manager.resolveDeferredTool("tool-ask-1", "allow", undefined, {
+			questions: [{ question: "Which path should we take?", options: [] }],
+			answers: { "Which path should we take?": "Option A" },
+		});
+
+		let hookOutput: unknown = null;
+		mockQueryImpl = (queryArgs) => {
+			const hook = queryArgs.options?.hooks?.PreToolUse?.[0]?.hooks?.[0];
+			// Simulate the SDK re-invoking PreToolUse for the pending tool_use
+			// on resume. The real SDK does this inside its replay loop before
+			// executing the deferred tool.
+			if (hook) {
+				void (async () => {
+					hookOutput = await hook(
+						{
+							hook_event_name: "PreToolUse",
+							tool_name: "AskUserQuestion",
+						},
+						"tool-ask-1",
+					);
+				})();
+			}
+			return makeMockQuery({
+				stream: [
+					{
+						type: "result",
+						session_id: "sdk-session-resume",
+						subtype: "success",
+						is_error: false,
+						result: "done",
+					},
+				],
+			});
+		};
+
+		await manager.sendMessage(
+			"REQ-RESUME",
+			{
+				sessionId: "helmor-sess-defer",
+				prompt: "",
+				model: undefined,
+				cwd: undefined,
+				resume: "sdk-session-resume",
+				permissionMode: undefined,
+				effortLevel: undefined,
+				fastMode: undefined,
+			},
+			emitter,
+		);
+
+		// Pre-Steer shape: plain empty string. If this ever becomes an object
+		// (pushable / iterable), AskUserQuestion answers stop reaching Claude.
+		expect(typeof (lastQueryArgs as { prompt?: unknown } | null)?.prompt).toBe(
+			"string",
+		);
+		expect((lastQueryArgs as { prompt: string }).prompt).toBe("");
+
+		await waitForCondition(() => hookOutput !== null, "hook invocation");
+		expect(hookOutput).toEqual({
+			hookSpecificOutput: {
+				hookEventName: "PreToolUse",
+				permissionDecision: "allow",
+				updatedInput: {
+					questions: [{ question: "Which path should we take?", options: [] }],
+					answers: { "Which path should we take?": "Option A" },
+				},
+			},
+		});
 	});
 
 	test("stops after a successful result and ignores trailing SDK noise", async () => {


### PR DESCRIPTION
## What changed
- Resume-only Claude AskUserQuestion submissions now call `query()` with an empty string prompt so the SDK replays the pending tool use and re-runs `PreToolUse`.
- Deferred tool responses are consumed after being surfaced to avoid stale reuse within the TTL window.
- Added a sidecar regression test covering empty-prompt resume delivery.
- Added a patch changeset.

## Why
After the streaming-input steer change, submitting an AskUserQuestion answer pushed an empty synthetic user turn, causing Claude to skip the pending `PreToolUse` re-evaluation and never receive the selected answer.

## Test notes
- Pre-commit hook ran `biome check --write --error-on-warnings` on staged TS files during commit.
- Not run separately: full sidecar/frontend/Rust test suites.