### PR TITLE
fix: suppress local bash task notices

### DIFF
--- a/.changeset/calm-subagents-explain.md
+++ b/.changeset/calm-subagents-explain.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Stop rendering mislabeled "Subagent started / completed" rows next to long-running Bash commands — those came from Claude's per-bash lifecycle notices and duplicated the Bash tool call itself.

--- a/src-tauri/src/pipeline/accumulator/mod.rs
+++ b/src-tauri/src/pipeline/accumulator/mod.rs
@@ -134,7 +134,6 @@ pub struct StreamAccumulator {
     /// `__part_id` indices when the SDK delivers finalized blocks in
     /// separate per-block `assistant` events (delta-style).
     cur_asst_block_count: usize,
-
     // ── Codex state ──────────────────────────────────────────────────
     /// Per-item delta accumulation for Codex App Server streaming.
     codex_items: HashMap<String, codex::CodexItemState>,
@@ -1040,6 +1039,11 @@ impl StreamAccumulator {
             if crate::pipeline::event_filter::is_suppressed_system_subtype(subtype) {
                 return;
             }
+        }
+        // `local_bash` task_* events duplicate the accompanying Bash tool
+        // call — drop before they enter the render / persistence path.
+        if crate::pipeline::event_filter::is_suppressed_local_bash_task(value) {
+            return;
         }
         self.collect_message(raw_line, value, MessageRole::System, None);
     }

--- a/src-tauri/src/pipeline/accumulator/tests.rs
+++ b/src-tauri/src/pipeline/accumulator/tests.rs
@@ -106,6 +106,47 @@ fn accumulate_tool_use_blocks() {
 }
 
 #[test]
+fn claude_local_bash_task_events_are_dropped() {
+    // `task_type: "local_bash"` is Claude wrapping a single Bash command
+    // with its own task_started / task_notification. The `tool_use_id`
+    // points at the Bash tool, which doesn't serve as a subagent parent,
+    // so these notices would render as mislabeled "Subagent started /
+    // completed" siblings next to the real Bash tool call. Drop them.
+    let mut acc = StreamAccumulator::new("claude", "opus");
+    for subtype in ["task_started", "task_progress", "task_notification"] {
+        let event = json!({
+            "type": "system",
+            "subtype": subtype,
+            "task_id": "task_bash",
+            "task_type": "local_bash",
+            "tool_use_id": "toolu_bash_1",
+            "description": "cargo test -p helmor",
+        });
+        acc.push_event(&event, &event.to_string());
+    }
+    assert!(acc.collected().is_empty());
+}
+
+#[test]
+fn claude_local_agent_task_events_still_render() {
+    // The real subagent lifecycle (`task_type: "local_agent"`) still
+    // enters `collected[]` so the adapter can fold it under the parent
+    // Task tool call (or render it as an orphan sibling when the parent
+    // isn't in the current view).
+    let mut acc = StreamAccumulator::new("claude", "opus");
+    let event = json!({
+        "type": "system",
+        "subtype": "task_started",
+        "task_id": "task_agent",
+        "task_type": "local_agent",
+        "tool_use_id": "toolu_agent_1",
+        "description": "Explore frontend",
+    });
+    acc.push_event(&event, &event.to_string());
+    assert_eq!(acc.collected().len(), 1);
+}
+
+#[test]
 fn handle_assistant_stamps_thinking_block_as_just_finished_live() {
     // When the SDK's finalized `assistant` event arrives, the accumulator
     // must mark thinking blocks with `__is_streaming: false` and a

--- a/src-tauri/src/pipeline/adapter/mod.rs
+++ b/src-tauri/src/pipeline/adapter/mod.rs
@@ -501,6 +501,11 @@ fn convert_system_msg(msg: &IntermediateMessage, out: &mut Vec<ThreadMessageLike
             return;
         }
     }
+    if let Some(value) = parsed {
+        if super::event_filter::is_suppressed_local_bash_task(value) {
+            return;
+        }
+    }
     if let Some(part) = build_subagent_notice(sub, parsed, &msg.id) {
         // Mark with `child:<tool_use_id>:<msg_id>` so the parent-grouping
         // pass folds these notices into the corresponding Task tool

--- a/src-tauri/src/pipeline/adapter/tests.rs
+++ b/src-tauri/src/pipeline/adapter/tests.rs
@@ -197,7 +197,7 @@ fn system_init_skipped_subagent_renders_as_notice() {
         ),
     ];
     let result = convert(&messages);
-    // task_progress now renders as a SystemNotice; init stays silent.
+    // task_progress renders as a SystemNotice; init stays silent.
     assert_eq!(result.len(), 2);
     assert_eq!(result[0].role, MessageRole::System);
     assert!(matches!(
@@ -989,6 +989,26 @@ fn subagent_task_started_renders_as_notice_with_child_id() {
         other => panic!("expected SystemNotice, got {other:?}"),
     }
     assert_eq!(result[0].id.as_deref(), Some("child:task_xyz:sn1"));
+}
+
+#[test]
+fn local_bash_task_events_are_dropped() {
+    // `task_type: local_bash` wraps a single Bash command — the Bash
+    // tool call already renders the command, so dropping the notice
+    // avoids a mislabeled "Subagent started/completed" sibling row.
+    let messages = vec![im(
+        "sn1",
+        "assistant",
+        json!({
+            "type": "system",
+            "subtype": "task_started",
+            "task_type": "local_bash",
+            "tool_use_id": "toolu_bash_1",
+            "description": "cargo test",
+        }),
+    )];
+    let result = convert(&messages);
+    assert!(result.is_empty());
 }
 
 // ---------------------------------------------------------------------------

--- a/src-tauri/src/pipeline/event_filter.rs
+++ b/src-tauri/src/pipeline/event_filter.rs
@@ -4,12 +4,14 @@
 //! - `accumulator::push_event` reads `SUPPRESSED_EVENT_TYPES` and drops
 //!   matching top-level events before any handler runs (NoOp).
 //! - `accumulator::handle_claude_system` reads `SUPPRESSED_SYSTEM_SUBTYPES`
-//!   on live ingest.
-//! - `adapter::convert_system_msg` reads `SUPPRESSED_SYSTEM_SUBTYPES`
-//!   on historical reload, so old persisted noise rows from earlier
-//!   code versions render with the same rules as new turns.
+//!   + `is_suppressed_local_bash_task` on live ingest.
+//! - `adapter::convert_system_msg` reads the same pair on historical
+//!   reload, so old persisted noise rows from earlier code versions
+//!   render with the same rules as new turns.
 //!
 //! Comment out a line to start surfacing that event again.
+
+use serde_json::Value;
 
 /// Top-level event types (Claude or Codex) that should be silently
 /// dropped before any handler runs. The dispatch arms downstream still
@@ -43,9 +45,9 @@ pub(crate) const SUPPRESSED_SYSTEM_SUBTYPES: &[&str] = &[
     // Status pings (`{status: 'compacting' | null}`) — comment out to
     // surface the compacting indicator.
     "status",
-    // Dead arm — `task_completed` is not in `@anthropic-ai/claude-agent-sdk`
-    // v0.2.111's `.d.ts`. The real lifecycle uses `task_notification`.
-    // Listed here defensively in case the SDK ever revives it.
+    // Dead arm — not in `@anthropic-ai/claude-agent-sdk` v0.2.111's
+    // `.d.ts`. The real lifecycle uses `task_notification`. Listed
+    // defensively in case the SDK ever revives it.
     "task_completed",
     // ── To start showing one of these, comment out its line: ─────────
     // "task_started",         // subagent started
@@ -63,4 +65,29 @@ pub(crate) fn is_suppressed_event_type(event_type: &str) -> bool {
 
 pub(crate) fn is_suppressed_system_subtype(subtype: &str) -> bool {
     SUPPRESSED_SYSTEM_SUBTYPES.contains(&subtype)
+}
+
+/// `task_type: "local_bash"` lifecycle events are Claude wrapping a
+/// single Bash command with its own started/progress/completed notices.
+/// The `tool_use_id` on them points at the Bash tool call — which our
+/// grouping pass doesn't treat as a parent — so they'd render as flat
+/// "Subagent started / completed" siblings (mislabeled — these are not
+/// subagents) right next to the real Bash tool call that already shows
+/// the command. Pure duplication; drop them on both live ingest and
+/// historical reload.
+///
+/// `local_agent` task events are left untouched — those are the real
+/// subagent lifecycle, and whether/how to render them is handled
+/// further down the pipeline.
+pub(crate) fn is_suppressed_local_bash_task(value: &Value) -> bool {
+    let Some(subtype) = value.get("subtype").and_then(Value::as_str) else {
+        return false;
+    };
+    if !matches!(
+        subtype,
+        "task_started" | "task_progress" | "task_notification"
+    ) {
+        return false;
+    }
+    value.get("task_type").and_then(Value::as_str) == Some("local_bash")
 }


### PR DESCRIPTION
## What changed
- Dropped Claude `local_bash` task lifecycle notices during live accumulation and historical adapter conversion.
- Added focused accumulator and adapter coverage for `local_bash` suppression while preserving `local_agent` subagent notices.
- Added a patch changeset.

## Why
Claude emits per-bash `task_*` system events that duplicate the real Bash tool call and were rendering as mislabeled subagent rows.

## Tests
- `cd src-tauri && cargo test --test pipeline_scenarios --test pipeline_fixtures --test pipeline_streams`
- Commit hook: `cargo fmt --manifest-path src-tauri/Cargo.toml --all`
- Commit hook: `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`