### PR TITLE
Remove workspace context scaffolding and archive preservation

### DIFF
--- a/.changeset/fair-pans-invite.md
+++ b/.changeset/fair-pans-invite.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Remove the unused workspace `.context` scaffold and stop preserving it during archive, restore, and import flows.

--- a/src-tauri/src/cli/args.rs
+++ b/src-tauri/src/cli/args.rs
@@ -248,7 +248,7 @@ pub enum WorkspaceAction {
         #[arg(name = "ref")]
         workspace_ref: String,
     },
-    /// Archive a workspace — removes the worktree, keeps `.context`.
+    /// Archive a workspace — removes the worktree and preserves restore metadata.
     Archive {
         #[arg(name = "ref")]
         workspace_ref: String,

--- a/src-tauri/src/commands/system_commands.rs
+++ b/src-tauri/src/commands/system_commands.rs
@@ -381,11 +381,7 @@ pub async fn dev_reset_all_data(app: tauri::AppHandle) -> CmdResult<DevResetResu
         // --- Filesystem cleanup (best-effort) ----------------------------
         let mut dirs_removed = Vec::new();
 
-        let dirs_to_clear = [
-            data_dir.join("workspaces"),
-            data_dir.join("archived-contexts"),
-            data_dir.join("paste-cache"),
-        ];
+        let dirs_to_clear = [data_dir.join("workspaces"), data_dir.join("paste-cache")];
 
         for dir in &dirs_to_clear {
             if dir.is_dir() {

--- a/src-tauri/src/commands/tests/archive_restore.rs
+++ b/src-tauri/src/commands/tests/archive_restore.rs
@@ -8,7 +8,7 @@ use tauri::{
 };
 
 #[test]
-fn restore_workspace_recreates_worktree_and_context() {
+fn restore_workspace_recreates_worktree() {
     let _guard = TEST_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -22,12 +22,6 @@ fn restore_workspace_recreates_worktree_and_context() {
     assert!(harness.source_repo_root().exists());
     assert!(harness.workspace_dir().join(".git").exists());
     assert!(harness.workspace_dir().join("tracked.txt").exists());
-    assert!(harness.workspace_dir().join(".context/notes.md").exists());
-    assert!(harness
-        .workspace_dir()
-        .join(".context/attachments/evidence.txt")
-        .exists());
-    assert!(!harness.archived_context_dir().exists());
 
     let connection = Connection::open(crate::data_dir::db_path().unwrap()).unwrap();
     let state: String = connection
@@ -42,7 +36,7 @@ fn restore_workspace_recreates_worktree_and_context() {
 }
 
 #[test]
-fn archive_workspace_moves_context_and_removes_worktree() {
+fn archive_workspace_removes_worktree() {
     let _guard = TEST_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -53,11 +47,6 @@ fn archive_workspace_moves_context_and_removes_worktree() {
     assert_eq!(response.archived_workspace_id, harness.workspace_id);
     assert_eq!(response.archived_state, WorkspaceState::Archived);
     assert!(!harness.workspace_dir().exists());
-    assert!(harness.archived_context_dir().join("notes.md").exists());
-    assert!(harness
-        .archived_context_dir()
-        .join("attachments/evidence.txt")
-        .exists());
 
     let worktree_list = git_ops::run_git(
         [
@@ -85,14 +74,13 @@ fn archive_workspace_moves_context_and_removes_worktree() {
 }
 
 #[test]
-fn permanently_delete_archived_workspace_removes_db_rows_and_context() {
+fn permanently_delete_archived_workspace_removes_db_rows() {
     let _guard = TEST_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     let harness = ArchiveTestHarness::new();
 
     workspaces::archive_workspace_impl(&harness.workspace_id).unwrap();
-    assert!(harness.archived_context_dir().exists());
 
     workspaces::permanently_delete_workspace(&harness.workspace_id).unwrap();
 
@@ -122,7 +110,6 @@ fn permanently_delete_archived_workspace_removes_db_rows_and_context() {
     assert_eq!(workspace_count, 0);
     assert_eq!(session_count, 0);
     assert_eq!(message_count, 0);
-    assert!(!harness.archived_context_dir().exists());
 }
 
 #[test]
@@ -177,7 +164,6 @@ fn prepare_archive_plan_is_read_only() {
     let _plan = workspaces::prepare_archive_plan(&harness.workspace_id).unwrap();
 
     assert!(harness.workspace_dir().exists());
-    assert!(!harness.archived_context_dir().exists());
 
     let connection = Connection::open(crate::data_dir::db_path().unwrap()).unwrap();
     let state: String = connection
@@ -333,10 +319,6 @@ fn restore_workspace_fails_when_archive_commit_missing() {
         .unwrap();
     assert_eq!(state, "archived");
     assert!(
-        harness.archived_context_dir().exists(),
-        "Archived context dir should be untouched on bail-out"
-    );
-    assert!(
         !harness.workspace_dir().exists(),
         "Workspace dir should not be materialized when restore bails"
     );
@@ -353,7 +335,6 @@ fn restore_workspace_cleans_up_when_db_update_fails() {
 
     assert!(error.to_string().contains("update workspace restore state"));
     assert!(!harness.workspace_dir().exists());
-    assert!(harness.archived_context_dir().exists());
 }
 
 #[test]
@@ -367,12 +348,6 @@ fn archive_workspace_cleans_up_when_db_update_fails() {
 
     assert!(error.to_string().contains("update workspace archive state"));
     assert!(harness.workspace_dir().exists());
-    assert!(harness.workspace_dir().join(".context/notes.md").exists());
-    assert!(harness
-        .workspace_dir()
-        .join(".context/attachments/evidence.txt")
-        .exists());
-    assert!(!harness.archived_context_dir().exists());
 
     let connection = Connection::open(crate::data_dir::db_path().unwrap()).unwrap();
     let state: String = connection

--- a/src-tauri/src/commands/tests/support.rs
+++ b/src-tauri/src/commands/tests/support.rs
@@ -89,12 +89,6 @@ impl RestoreTestHarness {
         let session_id = "session-1".to_string();
         let branch = "feature/restore-target".to_string();
 
-        let archived_ctx =
-            crate::data_dir::archived_context_dir(&repo_name, &directory_name).unwrap();
-        fs::create_dir_all(archived_ctx.join("attachments")).unwrap();
-        fs::write(archived_ctx.join("notes.md"), "archived notes").unwrap();
-        fs::write(archived_ctx.join("attachments/evidence.txt"), "evidence").unwrap();
-
         let ws_dir = crate::data_dir::workspace_dir(&repo_name, &directory_name).unwrap();
         fs::create_dir_all(ws_dir.parent().unwrap()).unwrap();
 
@@ -123,10 +117,6 @@ impl RestoreTestHarness {
             directory_name,
             branch,
         }
-    }
-
-    pub(crate) fn archived_context_dir(&self) -> PathBuf {
-        crate::data_dir::archived_context_dir(&self.repo_name, &self.directory_name).unwrap()
     }
 
     pub(crate) fn workspace_dir(&self) -> PathBuf {
@@ -184,11 +174,6 @@ impl ArchiveTestHarness {
         )
         .unwrap();
 
-        let archived_ctx_parent = crate::data_dir::archived_contexts_dir()
-            .unwrap()
-            .join(&repo_name);
-        fs::create_dir_all(&archived_ctx_parent).unwrap();
-
         let ws_parent = crate::data_dir::workspaces_dir().unwrap().join(&repo_name);
         fs::create_dir_all(&ws_parent).unwrap();
 
@@ -209,13 +194,6 @@ impl ArchiveTestHarness {
         let workspace_dir = crate::data_dir::workspace_dir(&repo_name, &directory_name).unwrap();
         git_ops::point_branch_to_commit(&source_repo_root, &branch, &head_commit).unwrap();
         git_ops::create_worktree(&source_repo_root, &workspace_dir, &branch).unwrap();
-        fs::create_dir_all(workspace_dir.join(".context/attachments")).unwrap();
-        fs::write(workspace_dir.join(".context/notes.md"), "ready notes").unwrap();
-        fs::write(
-            workspace_dir.join(".context/attachments/evidence.txt"),
-            "ready evidence",
-        )
-        .unwrap();
 
         Self {
             _test_dir: test_dir,
@@ -226,10 +204,6 @@ impl ArchiveTestHarness {
             directory_name,
             head_commit,
         }
-    }
-
-    pub(crate) fn archived_context_dir(&self) -> PathBuf {
-        crate::data_dir::archived_context_dir(&self.repo_name, &self.directory_name).unwrap()
     }
 
     pub(crate) fn workspace_dir(&self) -> PathBuf {

--- a/src-tauri/src/commands/tests/workspace_creation.rs
+++ b/src-tauri/src/commands/tests/workspace_creation.rs
@@ -26,9 +26,6 @@ fn create_workspace_from_repo_creates_ready_workspace_and_initial_session() {
 
     let workspace_dir = harness.workspace_dir(&response.directory_name);
     assert!(workspace_dir.join(".git").exists());
-    assert!(workspace_dir.join(".context/notes.md").exists());
-    assert!(workspace_dir.join(".context/todos.md").exists());
-    assert!(workspace_dir.join(".context/attachments").is_dir());
 
     let connection = Connection::open(harness.db_path()).unwrap();
     let (state, branch, initialization_parent_branch, intended_target_branch, active_session_id): (
@@ -261,9 +258,8 @@ fn finalize_workspace_transitions_initializing_to_ready_and_creates_worktree() {
     assert_eq!(finalized.workspace_id, prepared.workspace_id);
     assert_eq!(finalized.final_state, WorkspaceState::Ready);
 
-    // Worktree + scaffold exist after Phase 2.
+    // Worktree exists after Phase 2.
     assert!(workspace_dir.join(".git").exists());
-    assert!(workspace_dir.join(".context/notes.md").exists());
 
     // DB row flipped to ready.
     let connection = Connection::open(harness.db_path()).unwrap();

--- a/src-tauri/src/commands/workspace_commands.rs
+++ b/src-tauri/src/commands/workspace_commands.rs
@@ -36,7 +36,7 @@ pub async fn prepare_workspace_from_repo(
 }
 
 /// Phase 2: slow (~200ms-2s) materialization. Creates the git worktree,
-/// scaffolds `.context`, probes `helmor.json` for a setup script, and flips
+/// probes `helmor.json` for a setup script, and flips
 /// the workspace row from `initializing` to `ready` / `setup_pending`. On
 /// failure, the workspace + session rows are deleted and the worktree is
 /// cleaned up so the user can retry.

--- a/src-tauri/src/data_dir.rs
+++ b/src-tauri/src/data_dir.rs
@@ -52,15 +52,6 @@ pub fn workspaces_dir() -> Result<PathBuf> {
     Ok(dir)
 }
 
-/// Returns the archived-contexts directory inside the data dir.
-pub fn archived_contexts_dir() -> Result<PathBuf> {
-    let dir = data_dir()?.join("archived-contexts");
-    if !dir.exists() {
-        fs::create_dir_all(&dir).context("Failed to create archived-contexts directory")?;
-    }
-    Ok(dir)
-}
-
 /// Returns the logs directory inside the data dir.
 pub fn logs_dir() -> Result<PathBuf> {
     let dir = data_dir()?.join("logs");
@@ -149,7 +140,6 @@ fn dirs_home() -> Option<PathBuf> {
 pub fn ensure_directory_structure() -> Result<()> {
     data_dir()?;
     workspaces_dir()?;
-    archived_contexts_dir()?;
     logs_dir()?;
     run_dir()?;
     Ok(())
@@ -158,13 +148,6 @@ pub fn ensure_directory_structure() -> Result<()> {
 /// Returns the workspace directory for a given repo + workspace.
 pub fn workspace_dir(repo_name: &str, directory_name: &str) -> Result<PathBuf> {
     Ok(workspaces_dir()?.join(repo_name).join(directory_name))
-}
-
-/// Returns the archived context directory for a given repo + workspace.
-pub fn archived_context_dir(repo_name: &str, directory_name: &str) -> Result<PathBuf> {
-    Ok(archived_contexts_dir()?
-        .join(repo_name)
-        .join(directory_name))
 }
 
 /// Returns a human-readable description of the data mode.

--- a/src-tauri/src/import.rs
+++ b/src-tauri/src/import.rs
@@ -442,7 +442,7 @@ fn import_workspace_db_records(conn: &Connection, workspace_id: &str) -> Result<
     }))
 }
 
-/// Phase 2: Set up filesystem for an imported workspace (git worktree + context files).
+/// Phase 2: Set up filesystem for an imported workspace.
 #[allow(clippy::too_many_arguments)]
 fn setup_workspace_filesystem(
     workspace_id: &str,
@@ -455,7 +455,7 @@ fn setup_workspace_filesystem(
     helmor_data_dir: &Path,
 ) -> Result<()> {
     if state != "archived" {
-        // Active workspace: create git worktree, then copy .context/
+        // Active workspace: create the git worktree.
         let workspace_dir = crate::data_dir::workspace_dir(repo_name, directory_name)?;
 
         if !workspace_dir.exists() {
@@ -501,53 +501,6 @@ fn setup_workspace_filesystem(
                 Err(e) => {
                     tracing::error!(directory_name, "Failed to open DB to update branch: {e}");
                 }
-            }
-        }
-
-        // Copy .context/ after the worktree exists.
-        if let Some(root) = conductor_root {
-            let context_src = root
-                .join("workspaces")
-                .join(repo_name)
-                .join(directory_name)
-                .join(".context");
-            let context_dst = workspace_dir.join(".context");
-
-            if context_src.is_dir() {
-                // Overwrite if exists — ensures clean state on re-import
-                if context_dst.exists() {
-                    std::fs::remove_dir_all(&context_dst).ok();
-                }
-                std::fs::create_dir_all(context_dst.parent().unwrap_or(&workspace_dir)).ok();
-                helpers::copy_dir_all(&context_src, &context_dst).with_context(|| {
-                    format!("Failed to copy .context from {}", context_src.display())
-                })?;
-            }
-        }
-    } else {
-        // Archived workspace: copy archived-contexts/
-        if let Some(root) = conductor_root {
-            let archive_src = root
-                .join("archived-contexts")
-                .join(repo_name)
-                .join(directory_name);
-            let archive_dst = helmor_data_dir
-                .join("archived-contexts")
-                .join(repo_name)
-                .join(directory_name);
-
-            if archive_src.is_dir() {
-                // Overwrite if exists — ensures clean state on re-import
-                if archive_dst.exists() {
-                    std::fs::remove_dir_all(&archive_dst).ok();
-                }
-                std::fs::create_dir_all(archive_dst.parent().unwrap_or(helmor_data_dir)).ok();
-                helpers::copy_dir_all(&archive_src, &archive_dst).with_context(|| {
-                    format!(
-                        "Failed to copy archived context from {}",
-                        archive_src.display()
-                    )
-                })?;
             }
         }
     }

--- a/src-tauri/src/workspace/helpers.rs
+++ b/src-tauri/src/workspace/helpers.rs
@@ -3,7 +3,7 @@ use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use std::{
     collections::HashMap,
     fs,
-    path::{Path, PathBuf},
+    path::Path,
     sync::{LazyLock, Mutex},
 };
 
@@ -294,33 +294,6 @@ pub fn copy_symlink(source: &Path, destination: &Path) -> Result<()> {
             destination.display()
         )
     })
-}
-
-// ---- Workspace scaffolding helpers ----
-
-pub fn write_file_if_missing(path: &Path, contents: &str) -> Result<()> {
-    if path.exists() {
-        return Ok(());
-    }
-
-    fs::write(path, contents)
-        .with_context(|| format!("Failed to write scaffold file {}", path.display()))
-}
-
-pub fn create_workspace_context_scaffold(workspace_dir: &Path) -> Result<()> {
-    let context_dir = workspace_dir.join(".context");
-    let attachments_dir = context_dir.join("attachments");
-    fs::create_dir_all(&attachments_dir).with_context(|| {
-        format!(
-            "Failed to create workspace context scaffold under {}",
-            context_dir.display()
-        )
-    })?;
-
-    write_file_if_missing(&context_dir.join("notes.md"), "# Notes\n")?;
-    write_file_if_missing(&context_dir.join("todos.md"), "# Todos\n")?;
-
-    Ok(())
 }
 
 // ---- Branch / directory name helpers ----
@@ -617,19 +590,6 @@ pub fn allocate_directory_name_with_conn(
     }
 
     bail!("Unable to allocate a workspace name")
-}
-
-// ---- Archive helpers ----
-
-pub fn staged_archive_context_dir(archived_context_dir: &Path) -> PathBuf {
-    archived_context_dir.with_file_name(format!(
-        ".{}-restore-staged-{}",
-        archived_context_dir
-            .file_name()
-            .and_then(|value| value.to_str())
-            .unwrap_or("workspace"),
-        uuid::Uuid::new_v4()
-    ))
 }
 
 #[cfg(test)]

--- a/src-tauri/src/workspace/lifecycle.rs
+++ b/src-tauri/src/workspace/lifecycle.rs
@@ -188,8 +188,8 @@ pub fn prepare_workspace_from_repo_impl(repo_id: &str) -> Result<PrepareWorkspac
     })
 }
 
-/// Phase 2 of workspace creation: creates the git worktree, seeds the
-/// `.context` scaffold, probes `helmor.json` for a setup script, and
+/// Phase 2 of workspace creation: creates the git worktree, probes
+/// `helmor.json` for a setup script, and
 /// upgrades the workspace row from `Initializing` to `Ready` /
 /// `SetupPending`. On failure, cleans up the worktree + DB rows so the
 /// caller can surface the error without leaving a broken workspace
@@ -254,7 +254,6 @@ pub fn finalize_workspace_from_repo_impl(workspace_id: &str) -> Result<FinalizeW
             }
         };
 
-        helpers::create_workspace_context_scaffold(&workspace_dir)?;
         // Defer setup to the frontend inspector: if a script is configured AND
         // the user opted into auto-run, the workspace starts in "setup_pending"
         // and the UI auto-triggers it. Otherwise we go straight to Ready and
@@ -362,7 +361,6 @@ pub struct ArchivePreparedPlan {
     repo_root: PathBuf,
     branch: String,
     workspace_dir: PathBuf,
-    archived_context_dir: PathBuf,
 }
 
 fn is_archive_eligible_state(state: WorkspaceState) -> bool {
@@ -490,15 +488,6 @@ pub fn prepare_archive_plan(workspace_id: &str) -> Result<ArchivePreparedPlan> {
         );
     }
 
-    let archived_context_dir =
-        crate::data_dir::archived_context_dir(&record.repo_name, &record.directory_name)?;
-    if archived_context_dir.exists() {
-        bail!(
-            "Archived context target already exists at {}",
-            archived_context_dir.display()
-        );
-    }
-
     tracing::debug!(
         workspace_id,
         elapsed_ms = timing.elapsed().as_millis(),
@@ -509,7 +498,6 @@ pub fn prepare_archive_plan(workspace_id: &str) -> Result<ArchivePreparedPlan> {
         repo_root,
         branch,
         workspace_dir,
-        archived_context_dir,
     })
 }
 
@@ -526,7 +514,6 @@ pub fn execute_archive_plan(plan: &ArchivePreparedPlan) -> Result<ArchiveWorkspa
     let repo_root = &plan.repo_root;
     let branch = &plan.branch;
     let workspace_dir = &plan.workspace_dir;
-    let archived_context_dir = &plan.archived_context_dir;
     let workspace_id = &plan.workspace_id;
     let timing = std::time::Instant::now();
     let git_started = std::time::Instant::now();
@@ -547,34 +534,8 @@ pub fn execute_archive_plan(plan: &ArchivePreparedPlan) -> Result<ArchiveWorkspa
         "Archive hook finished"
     );
 
-    fs::create_dir_all(archived_context_dir.parent().with_context(|| {
-        format!(
-            "Archived context target has no parent: {}",
-            archived_context_dir.display()
-        )
-    })?)
-    .with_context(|| {
-        format!(
-            "Failed to create archived context parent directory for {}",
-            archived_context_dir.display()
-        )
-    })?;
-
-    let workspace_context_dir = workspace_dir.join(".context");
-    let staged_archive_dir = helpers::staged_archive_context_dir(archived_context_dir);
-    let context_copy_started = std::time::Instant::now();
-    create_staged_archive_context(&workspace_context_dir, &staged_archive_dir)?;
-    tracing::info!(
-        workspace_id,
-        elapsed_ms = context_copy_started.elapsed().as_millis(),
-        "Archive context staging finished"
-    );
-
     let remove_worktree_started = std::time::Instant::now();
-    if let Err(error) = git_ops::remove_worktree(repo_root, workspace_dir) {
-        let _ = fs::remove_dir_all(&staged_archive_dir);
-        return Err(error);
-    }
+    git_ops::remove_worktree(repo_root, workspace_dir)?;
     tracing::info!(
         workspace_id,
         elapsed_ms = remove_worktree_started.elapsed().as_millis(),
@@ -599,35 +560,11 @@ pub fn execute_archive_plan(plan: &ArchivePreparedPlan) -> Result<ArchiveWorkspa
         "Archive: branch delete finished"
     );
 
-    if let Err(error) = fs::rename(&staged_archive_dir, archived_context_dir) {
-        cleanup_failed_archive(
-            repo_root,
-            workspace_dir,
-            &workspace_context_dir,
-            branch,
-            &archive_commit,
-            &staged_archive_dir,
-            archived_context_dir,
-        );
-        bail!(
-            "Failed to move archived context into {}: {error}",
-            archived_context_dir.display()
-        );
-    }
-
     let db_started = std::time::Instant::now();
     if let Err(error) =
         workspace_models::update_archived_workspace_state(workspace_id, &archive_commit)
     {
-        cleanup_failed_archive(
-            repo_root,
-            workspace_dir,
-            &workspace_context_dir,
-            branch,
-            &archive_commit,
-            &staged_archive_dir,
-            archived_context_dir,
-        );
+        cleanup_failed_archive(repo_root, workspace_dir, branch, &archive_commit);
         return Err(error);
     }
 
@@ -653,7 +590,6 @@ struct RestorePreflightData {
     branch: String,
     archive_commit: String,
     workspace_dir: PathBuf,
-    archived_context_dir: PathBuf,
 }
 
 fn restore_workspace_preflight(workspace_id: &str) -> Result<RestorePreflightData> {
@@ -676,16 +612,6 @@ fn restore_workspace_preflight(workspace_id: &str) -> Result<RestorePreflightDat
         .with_context(|| format!("Workspace {workspace_id} is missing archive_commit"))?;
 
     let workspace_dir = crate::data_dir::workspace_dir(&record.repo_name, &record.directory_name)?;
-    let archived_context_dir =
-        crate::data_dir::archived_context_dir(&record.repo_name, &record.directory_name)?;
-    if !archived_context_dir.is_dir() {
-        bail_coded!(
-            ErrorCode::WorkspaceBroken,
-            "Archived context directory is missing at {}",
-            archived_context_dir.display()
-        );
-    }
-
     git_ops::ensure_git_repository(&repo_root)?;
     git_ops::verify_commit_exists(&repo_root, &archive_commit)?;
 
@@ -694,7 +620,6 @@ fn restore_workspace_preflight(workspace_id: &str) -> Result<RestorePreflightDat
         branch,
         archive_commit,
         workspace_dir,
-        archived_context_dir,
     })
 }
 
@@ -747,7 +672,6 @@ pub fn restore_workspace_impl(
         branch,
         archive_commit,
         workspace_dir,
-        archived_context_dir,
     } = restore_workspace_preflight(workspace_id)?;
 
     if workspace_dir.exists() {
@@ -807,17 +731,9 @@ pub fn restore_workspace_impl(
 
     git_ops::create_worktree(&repo_root, &workspace_dir, &actual_branch)?;
 
-    let staged_archive_dir = helpers::staged_archive_context_dir(&archived_context_dir);
     if actual_branch != branch {
         let conn = db::write_conn().map_err(|error| {
-            cleanup_failed_restore(
-                &repo_root,
-                &workspace_dir,
-                None,
-                &staged_archive_dir,
-                &archived_context_dir,
-                &actual_branch,
-            );
+            cleanup_failed_restore(&repo_root, &workspace_dir, &actual_branch);
             error.context("Failed to open DB to persist restored branch name")
         })?;
         conn.execute(
@@ -825,63 +741,16 @@ pub fn restore_workspace_impl(
             rusqlite::params![actual_branch, workspace_id],
         )
         .map_err(|error| {
-            cleanup_failed_restore(
-                &repo_root,
-                &workspace_dir,
-                None,
-                &staged_archive_dir,
-                &archived_context_dir,
-                &actual_branch,
-            );
+            cleanup_failed_restore(&repo_root, &workspace_dir, &actual_branch);
             anyhow::anyhow!("Failed to persist restored branch name in DB: {error}")
         })?;
-    }
-
-    fs::rename(&archived_context_dir, &staged_archive_dir).map_err(|error| {
-        cleanup_failed_restore(
-            &repo_root,
-            &workspace_dir,
-            None,
-            &staged_archive_dir,
-            &archived_context_dir,
-            &actual_branch,
-        );
-        anyhow::anyhow!(
-            "Failed to stage archived context {}: {error}",
-            archived_context_dir.display()
-        )
-    })?;
-
-    let workspace_context_dir = workspace_dir.join(".context");
-    if let Err(error) = helpers::copy_dir_all(&staged_archive_dir, &workspace_context_dir) {
-        cleanup_failed_restore(
-            &repo_root,
-            &workspace_dir,
-            Some(&workspace_context_dir),
-            &staged_archive_dir,
-            &archived_context_dir,
-            &actual_branch,
-        );
-        return Err(error);
     }
 
     if let Err(error) =
         workspace_models::update_restored_workspace_state(workspace_id, target_branch_override)
     {
-        cleanup_failed_restore(
-            &repo_root,
-            &workspace_dir,
-            Some(&workspace_context_dir),
-            &staged_archive_dir,
-            &archived_context_dir,
-            &actual_branch,
-        );
+        cleanup_failed_restore(&repo_root, &workspace_dir, &actual_branch);
         return Err(error);
-    }
-
-    if let Err(error) = fs::remove_dir_all(&staged_archive_dir) {
-        let _ = fs::rename(&staged_archive_dir, &archived_context_dir);
-        tracing::error!(dir = %staged_archive_dir.display(), "Failed to delete staged archived context: {error}");
     }
 
     let branch_rename = if actual_branch != branch {
@@ -919,85 +788,23 @@ fn cleanup_failed_created_workspace(
     let _ = workspace_models::delete_workspace_and_session_rows(workspace_id);
 }
 
-fn cleanup_failed_restore(
-    repo_root: &Path,
-    workspace_dir: &Path,
-    workspace_context_dir: Option<&Path>,
-    staged_archive_dir: &Path,
-    archived_context_dir: &Path,
-    branch: &str,
-) {
-    if let Some(context_dir) = workspace_context_dir {
-        let _ = fs::remove_dir_all(context_dir);
-    }
-
+fn cleanup_failed_restore(repo_root: &Path, workspace_dir: &Path, branch: &str) {
     let _ = git_ops::remove_worktree(repo_root, workspace_dir);
     let _ = fs::remove_dir_all(workspace_dir);
     let _ = git_ops::remove_branch(repo_root, branch);
-
-    if staged_archive_dir.exists() && !archived_context_dir.exists() {
-        let _ = fs::rename(staged_archive_dir, archived_context_dir);
-    }
 }
 
 fn cleanup_failed_archive(
     repo_root: &Path,
     workspace_dir: &Path,
-    workspace_context_dir: &Path,
     branch: &str,
     archive_commit: &str,
-    staged_archive_dir: &Path,
-    archived_context_dir: &Path,
 ) {
-    if archived_context_dir.exists() && !staged_archive_dir.exists() {
-        let _ = fs::rename(archived_context_dir, staged_archive_dir);
-    }
-
     let _ = git_ops::point_branch_to_commit(repo_root, branch, archive_commit);
 
     if !workspace_dir.exists() {
         let _ = git_ops::create_worktree(repo_root, workspace_dir, branch);
     }
-
-    if staged_archive_dir.exists() {
-        let _ = fs::remove_dir_all(workspace_context_dir);
-        let _ = helpers::copy_dir_contents(staged_archive_dir, workspace_context_dir);
-        let _ = fs::remove_dir_all(staged_archive_dir);
-    }
-}
-
-fn create_staged_archive_context(
-    workspace_context_dir: &Path,
-    staged_archive_dir: &Path,
-) -> Result<()> {
-    if staged_archive_dir.exists() {
-        bail!(
-            "Archive staging directory already exists at {}",
-            staged_archive_dir.display()
-        );
-    }
-
-    fs::create_dir_all(staged_archive_dir).with_context(|| {
-        format!(
-            "Failed to create archive staging directory {}",
-            staged_archive_dir.display()
-        )
-    })?;
-
-    if workspace_context_dir.is_dir() {
-        if let Err(error) = helpers::copy_dir_contents(workspace_context_dir, staged_archive_dir) {
-            let _ = fs::remove_dir_all(staged_archive_dir);
-            return Err(error);
-        }
-    } else if workspace_context_dir.exists() {
-        let _ = fs::remove_dir_all(staged_archive_dir);
-        bail!(
-            "Workspace context path is not a directory: {}",
-            workspace_context_dir.display()
-        );
-    }
-
-    Ok(())
 }
 
 /// Resolve the setup script command string from DB or project config.

--- a/src-tauri/src/workspace/workspaces.rs
+++ b/src-tauri/src/workspace/workspaces.rs
@@ -703,8 +703,8 @@ pub fn record_to_detail(record: WorkspaceRecord) -> WorkspaceDetail {
 /// Called once at startup so that externally-deleted directories don't cause
 /// repeated errors (e.g. git-status polling a missing path every 10 s).
 ///
-/// Archived workspaces are excluded — their worktree is intentionally gone, but
-/// their archived `.context` and session history must be preserved.
+/// Archived workspaces are excluded — their worktree is intentionally gone and
+/// the archived DB row must be preserved.
 pub fn purge_orphaned_workspaces() -> Result<usize> {
     let connection = db::read_conn()?;
     let mut stmt = connection.prepare(
@@ -756,8 +756,7 @@ pub fn purge_orphaned_workspaces() -> Result<usize> {
 }
 
 /// Permanently delete a workspace and all its data (sessions, messages)
-/// from the database, plus any filesystem artifacts (worktree directory,
-/// archived context).
+/// from the database, plus any filesystem artifacts (worktree directory).
 pub fn permanently_delete_workspace(workspace_id: &str) -> Result<()> {
     let mut connection = db::write_conn()?;
 
@@ -804,23 +803,11 @@ pub fn permanently_delete_workspace(workspace_id: &str) -> Result<()> {
     db::remove_workspace_lock(workspace_id);
 
     // Filesystem cleanup (best-effort)
-    if let Some((repo_name, directory_name, state)) = record {
+    if let Some((repo_name, directory_name, _state)) = record {
         // Remove worktree directory
         if let Ok(ws_dir) = crate::data_dir::workspace_dir(&repo_name, &directory_name) {
             if ws_dir.is_dir() {
                 std::fs::remove_dir_all(&ws_dir).ok();
-            }
-        }
-        // Remove archived context
-        if state == WorkspaceState::Archived {
-            if let Ok(data_dir) = crate::data_dir::data_dir() {
-                let archived = data_dir
-                    .join("archived-contexts")
-                    .join(&repo_name)
-                    .join(&directory_name);
-                if archived.is_dir() {
-                    std::fs::remove_dir_all(&archived).ok();
-                }
             }
         }
     }
@@ -859,20 +846,10 @@ mod tests {
             },
         );
 
-        // Simulate post-archive on-disk state: archived context exists, worktree
-        // does not.
-        let archived_ctx = env.root.join("archived-contexts/demo/alpha");
-        fs::create_dir_all(&archived_ctx).unwrap();
-        fs::write(archived_ctx.join("notes.md"), "preserved").unwrap();
-
         let purged = purge_orphaned_workspaces().unwrap();
 
         assert_eq!(purged, 0, "archived workspace must not be purged");
         assert_eq!(count_workspaces(&env), 1, "DB row must remain");
-        assert!(
-            archived_ctx.join("notes.md").exists(),
-            "archived context files must remain on disk"
-        );
     }
 
     #[test]

--- a/src/features/settings/panels/dev-tools.tsx
+++ b/src/features/settings/panels/dev-tools.tsx
@@ -42,8 +42,8 @@ export function DevToolsPanel() {
 				</div>
 				<div className="mt-1 text-[12px] leading-snug text-muted-foreground">
 					Delete all workspaces, sessions, messages, and repositories from the
-					development database. Filesystem artefacts (worktrees,
-					archived-contexts, paste-cache) will also be removed.
+					development database. Filesystem artefacts (worktrees, paste-cache)
+					will also be removed.
 				</div>
 				{dataDir && (
 					<div className="mt-2 text-[11px] text-muted-foreground/70">

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1477,7 +1477,7 @@ export async function prepareWorkspaceFromRepo(
 
 /**
  * Phase 2 of workspace creation. Slow (~200ms-2s): creates the git
- * worktree, scaffolds `.context`, probes `helmor.json`, and flips the
+ * worktree, probes `helmor.json`, and flips the
  * workspace row from `initializing` to `ready` / `setup_pending`. On
  * failure, the workspace row is cleaned up automatically.
  */


### PR DESCRIPTION
## What changed
- remove workspace `.context` scaffolding from workspace creation and restore/archive flows
- drop archived-context filesystem handling from data-dir setup, import, dev reset, and permanent deletion paths
- update Rust tests, API/docs copy, settings copy, and add a patch changeset for the behavior change

## Why
The `.context` scaffold and archived-context preservation path are no longer used, but they still add branching, filesystem work, and cleanup logic throughout the workspace lifecycle. Removing them simplifies workspace state transitions and reduces dead maintenance surface area.

## Follow-up / test notes
- `bun run typecheck`
- `bun run test:rust`