### PR TITLE
fix(navigation): keep pinned and unarchived rows stable in sidebar list

### DIFF
--- a/.changeset/solid-shrimps-notice.md
+++ b/.changeset/solid-shrimps-notice.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Keep pinned workspaces in the pinned section and place unarchived workspaces directly into their final newest-first position so the sidebar no longer jumps when the list refreshes.

--- a/src-tauri/src/models/workspaces.rs
+++ b/src-tauri/src/models/workspaces.rs
@@ -33,6 +33,7 @@ pub struct WorkspaceRecord {
     pub session_count: i64,
     pub message_count: i64,
     pub remote: Option<String>,
+    pub created_at: String,
 }
 
 pub const WORKSPACE_RECORD_SQL: &str = r#"
@@ -81,7 +82,8 @@ pub const WORKSPACE_RECORD_SQL: &str = r#"
       w.archive_commit,
       COALESCE(ss.session_count, 0) AS session_count,
       COALESCE(ms.message_count, 0) AS message_count,
-      r.remote
+      r.remote,
+      w.created_at
     FROM workspaces w
     JOIN repos r ON r.id = w.repository_id
     LEFT JOIN sessions s ON s.id = w.active_session_id
@@ -387,5 +389,6 @@ fn workspace_record_from_row(row: &Row<'_>) -> rusqlite::Result<WorkspaceRecord>
         session_count: row.get(23)?,
         message_count: row.get(24)?,
         remote: row.get(25)?,
+        created_at: row.get(26)?,
     })
 }

--- a/src-tauri/src/workspace/workspaces.rs
+++ b/src-tauri/src/workspace/workspaces.rs
@@ -57,6 +57,7 @@ pub struct WorkspaceSidebarRow {
     pub pinned_at: Option<String>,
     pub session_count: i64,
     pub message_count: i64,
+    pub created_at: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -89,8 +90,10 @@ pub struct WorkspaceSummary {
     pub active_session_agent_type: Option<String>,
     pub active_session_status: Option<String>,
     pub pr_title: Option<String>,
+    pub pinned_at: Option<String>,
     pub session_count: i64,
     pub message_count: i64,
+    pub created_at: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -618,6 +621,7 @@ pub fn record_to_sidebar_row(record: WorkspaceRecord) -> WorkspaceSidebarRow {
         pinned_at: record.pinned_at,
         session_count: record.session_count,
         message_count: record.message_count,
+        created_at: record.created_at,
     }
 }
 
@@ -643,8 +647,10 @@ pub fn record_to_summary(record: WorkspaceRecord) -> WorkspaceSummary {
         active_session_agent_type: record.active_session_agent_type,
         active_session_status: record.active_session_status,
         pr_title: record.pr_title,
+        pinned_at: record.pinned_at,
         session_count: record.session_count,
         message_count: record.message_count,
+        created_at: record.created_at,
     }
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -112,6 +112,7 @@ import {
 	type ThemeMode,
 	useSettings,
 } from "./lib/settings";
+import { flushSidebarListsIfIdle } from "./lib/sidebar-mutation-gate";
 import { useOsNotifications } from "./lib/use-os-notifications";
 import {
 	recomputeWorkspaceDetailUnread,
@@ -526,14 +527,14 @@ function AppShell({
 
 		void markSessionRead(sessionId)
 			.then(() => {
-				const invalidations = [
-					queryClient.invalidateQueries({
-						queryKey: helmorQueryKeys.workspaceGroups,
-					}),
-					queryClient.invalidateQueries({
-						queryKey: helmorQueryKeys.archivedWorkspaces,
-					}),
-				];
+				// Skip sidebar-list invalidations while a sidebar mutation
+				// (archive/restore/create/delete/pin) is in flight: the server
+				// state is mid-transition and a refetch here would overwrite
+				// the optimistic cache with a stale snapshot, bouncing the row
+				// back to its pre-mutation position. The mutation owner flushes
+				// these lists in its own `.finally`.
+				flushSidebarListsIfIdle(queryClient);
+				const invalidations: Promise<void>[] = [];
 				if (workspaceId) {
 					invalidations.push(
 						queryClient.invalidateQueries({
@@ -1400,22 +1401,19 @@ function AppShell({
 			// sidebar workspace dot and the dock badge.
 			if (!isCurrentSession) {
 				void markSessionUnread(sessionId)
-					.then(() =>
-						Promise.all([
-							queryClient.invalidateQueries({
-								queryKey: helmorQueryKeys.workspaceGroups,
-							}),
-							queryClient.invalidateQueries({
-								queryKey: helmorQueryKeys.archivedWorkspaces,
-							}),
+					.then(() => {
+						// Same rationale as the mark-read path — defer the
+						// sidebar-list flush when a mutation owns the cache.
+						flushSidebarListsIfIdle(queryClient);
+						return Promise.all([
 							queryClient.invalidateQueries({
 								queryKey: helmorQueryKeys.workspaceDetail(workspaceId),
 							}),
 							queryClient.invalidateQueries({
 								queryKey: helmorQueryKeys.workspaceSessions(workspaceId),
 							}),
-						]),
-					)
+						]);
+					})
 					.catch((error) => {
 						console.error("[app] mark session unread on completion:", error);
 					});

--- a/src/features/navigation/hooks/use-controller.test.tsx
+++ b/src/features/navigation/hooks/use-controller.test.tsx
@@ -13,6 +13,7 @@ import type {
 } from "@/lib/api";
 import { helmorQueryKeys } from "@/lib/query-client";
 import { DEFAULT_SETTINGS, SettingsContext } from "@/lib/settings";
+import { resetSidebarMutationGate } from "@/lib/sidebar-mutation-gate";
 import { useWorkspacesSidebarController } from "./use-controller";
 
 const apiMocks = vi.hoisted(() => {
@@ -170,8 +171,10 @@ function makeArchivedSummary(id: string): WorkspaceSummary {
 		activeSessionAgentType: null,
 		activeSessionStatus: null,
 		prTitle: null,
+		pinnedAt: null,
 		sessionCount: 0,
 		messageCount: 0,
+		createdAt: "2024-01-01T00:00:00Z",
 	};
 }
 
@@ -231,6 +234,7 @@ function createWrapper(queryClient: QueryClient) {
 
 describe("useWorkspacesSidebarController archive flow", () => {
 	beforeEach(() => {
+		resetSidebarMutationGate();
 		vi.clearAllMocks();
 		apiMocks.loadWorkspaceGroups.mockResolvedValue(workspaceGroups);
 		apiMocks.loadArchivedWorkspaces.mockResolvedValue([]);

--- a/src/features/navigation/hooks/use-controller.ts
+++ b/src/features/navigation/hooks/use-controller.ts
@@ -38,11 +38,18 @@ import {
 } from "@/lib/query-client";
 import { useSettings } from "@/lib/settings";
 import {
+	beginSidebarMutation as gateBeginSidebarMutation,
+	endSidebarMutation as gateEndSidebarMutation,
+	flushSidebarLists as gateFlushSidebarLists,
+	isSidebarMutationInFlight,
+} from "@/lib/sidebar-mutation-gate";
+import {
 	createOptimisticCreatingWorkspaceDetail,
 	describeUnknownError,
 	findInitialWorkspaceId,
 	findReplacementWorkspaceIdAfterRemoval,
 	hasWorkspaceId,
+	insertRowByCreatedAtDesc,
 	rowToWorkspaceSummary,
 	summaryToArchivedRow,
 	workspaceGroupIdFromStatus,
@@ -108,7 +115,6 @@ export function useWorkspacesSidebarController({
 			}
 		>
 	>(() => new Map());
-	const sidebarMutationCountRef = useRef(0);
 	// Live mirror of `selectedWorkspaceId` so async callbacks (Phase 2
 	// finalize catch, archive/restore handlers, etc.) can read the
 	// current selection rather than a stale closure snapshot.
@@ -116,24 +122,16 @@ export function useWorkspacesSidebarController({
 	selectedWorkspaceIdRef.current = selectedWorkspaceId;
 
 	const flushSidebarLists = useCallback(() => {
-		void queryClient.invalidateQueries({
-			queryKey: helmorQueryKeys.workspaceGroups,
-		});
-		void queryClient.invalidateQueries({
-			queryKey: helmorQueryKeys.archivedWorkspaces,
-		});
+		gateFlushSidebarLists(queryClient);
 	}, [queryClient]);
 
 	const beginSidebarMutation = useCallback(() => {
-		sidebarMutationCountRef.current += 1;
+		gateBeginSidebarMutation();
 	}, []);
 
 	const endSidebarMutation = useCallback(() => {
-		sidebarMutationCountRef.current = Math.max(
-			0,
-			sidebarMutationCountRef.current - 1,
-		);
-		if (sidebarMutationCountRef.current === 0) {
+		gateEndSidebarMutation();
+		if (!isSidebarMutationInFlight()) {
 			flushSidebarLists();
 		}
 	}, [flushSidebarLists]);
@@ -476,7 +474,7 @@ export function useWorkspacesSidebarController({
 					queryKey: helmorQueryKeys.workspaceSessions(workspaceId),
 				}),
 			]);
-			if (!opts?.skipSidebarFlush && sidebarMutationCountRef.current === 0) {
+			if (!opts?.skipSidebarFlush && !isSidebarMutationInFlight()) {
 				flushSidebarLists();
 			}
 		},
@@ -600,12 +598,11 @@ export function useWorkspacesSidebarController({
 					pinnedAt: currentlyPinned ? null : new Date().toISOString(),
 				};
 
-				const targetGroupId = currentlyPinned
-					? workspaceGroupIdFromStatus(
-							updatedRow.manualStatus,
-							updatedRow.derivedStatus,
-						)
-					: "pinned";
+				const targetGroupId = workspaceGroupIdFromStatus(
+					updatedRow.manualStatus,
+					updatedRow.derivedStatus,
+					updatedRow.pinnedAt,
+				);
 
 				return withoutRow.map((group) =>
 					group.id === targetGroupId
@@ -1341,12 +1338,19 @@ export function useWorkspacesSidebarController({
 			const targetGroupId = workspaceGroupIdFromStatus(
 				archivedSummary.manualStatus,
 				archivedSummary.derivedStatus,
+				archivedSummary.pinnedAt,
 			);
+			// Sorted insert by createdAt DESC so the row lands where the server
+			// will place it on refetch — avoids the reorder flicker we'd get from
+			// unconditionally prepending.
 			queryClient.setQueryData(helmorQueryKeys.workspaceGroups, (current) =>
 				Array.isArray(current)
 					? (current as typeof groups).map((group) =>
 							group.id === targetGroupId
-								? { ...group, rows: [placeholderRow, ...group.rows] }
+								? {
+										...group,
+										rows: insertRowByCreatedAtDesc(group.rows, placeholderRow),
+									}
 								: group,
 						)
 					: current,
@@ -1497,6 +1501,7 @@ function createPreparedWorkspaceRow(
 		pinnedAt: null,
 		sessionCount: 1,
 		messageCount: 0,
+		createdAt: new Date().toISOString(),
 	};
 }
 

--- a/src/features/navigation/sidebar-projection.test.ts
+++ b/src/features/navigation/sidebar-projection.test.ts
@@ -48,8 +48,10 @@ function makeArchivedSummary(id: string): WorkspaceSummary {
 		activeSessionAgentType: null,
 		activeSessionStatus: null,
 		prTitle: null,
+		pinnedAt: null,
 		sessionCount: 0,
 		messageCount: 0,
+		createdAt: "2024-01-01T00:00:00Z",
 	};
 }
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -73,6 +73,9 @@ export type WorkspaceRow = {
 	pinnedAt?: string | null;
 	sessionCount?: number;
 	messageCount?: number;
+	/** ISO-8601 timestamp — present for rows coming from the backend; absent
+	 * for ad-hoc optimistic rows that haven't been given one. */
+	createdAt?: string;
 };
 
 export type WorkspaceGroup = {
@@ -144,8 +147,10 @@ export type WorkspaceSummary = {
 	activeSessionAgentType?: string | null;
 	activeSessionStatus?: string | null;
 	prTitle?: string | null;
+	pinnedAt?: string | null;
 	sessionCount?: number;
 	messageCount?: number;
+	createdAt: string;
 };
 
 export type RepositoryCreateOption = {

--- a/src/lib/sidebar-mutation-gate.test.ts
+++ b/src/lib/sidebar-mutation-gate.test.ts
@@ -1,0 +1,67 @@
+import { QueryClient } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	beginSidebarMutation,
+	endSidebarMutation,
+	flushSidebarLists,
+	flushSidebarListsIfIdle,
+	isSidebarMutationInFlight,
+	resetSidebarMutationGate,
+} from "./sidebar-mutation-gate";
+
+describe("sidebar-mutation-gate", () => {
+	let queryClient: QueryClient;
+	let invalidateSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		resetSidebarMutationGate();
+		queryClient = new QueryClient();
+		invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+	});
+
+	afterEach(() => {
+		resetSidebarMutationGate();
+	});
+
+	it("starts with no mutation in flight", () => {
+		expect(isSidebarMutationInFlight()).toBe(false);
+	});
+
+	it("tracks begin/end pairs", () => {
+		beginSidebarMutation();
+		expect(isSidebarMutationInFlight()).toBe(true);
+		beginSidebarMutation();
+		expect(isSidebarMutationInFlight()).toBe(true);
+		endSidebarMutation();
+		expect(isSidebarMutationInFlight()).toBe(true);
+		endSidebarMutation();
+		expect(isSidebarMutationInFlight()).toBe(false);
+	});
+
+	it("clamps counter at zero", () => {
+		endSidebarMutation();
+		endSidebarMutation();
+		expect(isSidebarMutationInFlight()).toBe(false);
+		beginSidebarMutation();
+		expect(isSidebarMutationInFlight()).toBe(true);
+	});
+
+	it("flushSidebarLists always invalidates both queries", () => {
+		flushSidebarLists(queryClient);
+		expect(invalidateSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it("flushSidebarListsIfIdle invalidates when counter is 0", () => {
+		flushSidebarListsIfIdle(queryClient);
+		expect(invalidateSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it("flushSidebarListsIfIdle skips invalidate when a mutation is in flight", () => {
+		beginSidebarMutation();
+		flushSidebarListsIfIdle(queryClient);
+		expect(invalidateSpy).not.toHaveBeenCalled();
+		endSidebarMutation();
+		flushSidebarListsIfIdle(queryClient);
+		expect(invalidateSpy).toHaveBeenCalledTimes(2);
+	});
+});

--- a/src/lib/sidebar-mutation-gate.ts
+++ b/src/lib/sidebar-mutation-gate.ts
@@ -1,0 +1,48 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { helmorQueryKeys } from "./query-client";
+
+// Module-level counter: any code path about to mutate the sidebar lists
+// (archive, restore, create, delete, pin) wraps the async work in
+// begin/endSidebarMutation. While the counter is non-zero, concurrent
+// callers (mark-session-read, etc.) must NOT force a refetch of
+// workspaceGroups / archivedWorkspaces — the backend state is still
+// mid-transition and a refetch would overwrite the optimistic cache with
+// a stale snapshot, causing the row to flicker back to its pre-mutation
+// position before settling.
+let pending = 0;
+
+export function beginSidebarMutation(): void {
+	pending += 1;
+}
+
+export function endSidebarMutation(): void {
+	pending = Math.max(0, pending - 1);
+}
+
+export function isSidebarMutationInFlight(): boolean {
+	return pending > 0;
+}
+
+/** Unconditional flush — used by the owner of the mutation when it
+ * completes (counter has hit 0) and wants the server to reconcile. */
+export function flushSidebarLists(queryClient: QueryClient): void {
+	void queryClient.invalidateQueries({
+		queryKey: helmorQueryKeys.workspaceGroups,
+	});
+	void queryClient.invalidateQueries({
+		queryKey: helmorQueryKeys.archivedWorkspaces,
+	});
+}
+
+/** Gated flush — safe for concurrent callers (mark-read, etc.) that want
+ * to reconcile the sidebar only when no mutation is mid-flight. */
+export function flushSidebarListsIfIdle(queryClient: QueryClient): void {
+	if (pending > 0) return;
+	flushSidebarLists(queryClient);
+}
+
+/** Test-only: reset the counter between test cases so leaked mutations
+ * from one test don't gate flushes in the next. */
+export function resetSidebarMutationGate(): void {
+	pending = 0;
+}

--- a/src/lib/workspace-helpers.test.ts
+++ b/src/lib/workspace-helpers.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, it } from "vitest";
-import type { AgentModelSection, WorkspaceSessionSummary } from "./api";
+import type {
+	AgentModelSection,
+	WorkspaceRow,
+	WorkspaceSessionSummary,
+} from "./api";
 import {
 	clampEffort,
 	clampEffortToModel,
 	findModelOption,
 	getWorkspaceBranchTone,
 	inferDefaultModelId,
+	insertRowByCreatedAtDesc,
 	isNewSession,
 	resolveSessionDisplayProvider,
 	resolveSessionSelectedModelId,
@@ -149,6 +154,71 @@ describe("workspaceGroupIdFromStatus", () => {
 
 	it("falls back to derived when manual is null", () => {
 		expect(workspaceGroupIdFromStatus(null, "review")).toBe("review");
+	});
+
+	it("routes pinned rows to the pinned group regardless of status", () => {
+		expect(
+			workspaceGroupIdFromStatus("done", "backlog", "2024-01-01T00:00:00Z"),
+		).toBe("pinned");
+	});
+
+	it("ignores a null/empty pinnedAt", () => {
+		expect(workspaceGroupIdFromStatus("done", null, null)).toBe("done");
+		expect(workspaceGroupIdFromStatus("done", null, undefined)).toBe("done");
+	});
+});
+
+describe("insertRowByCreatedAtDesc", () => {
+	const row = (id: string, createdAt?: string): WorkspaceRow => ({
+		id,
+		title: id,
+		...(createdAt ? { createdAt } : {}),
+	});
+
+	it("inserts at the correct position to preserve DESC order", () => {
+		const rows = [
+			row("a", "2024-03-01T00:00:00Z"),
+			row("b", "2024-02-01T00:00:00Z"),
+			row("c", "2024-01-01T00:00:00Z"),
+		];
+		const inserted = insertRowByCreatedAtDesc(
+			rows,
+			row("new", "2024-02-15T00:00:00Z"),
+		);
+		expect(inserted.map((r) => r.id)).toEqual(["a", "new", "b", "c"]);
+	});
+
+	it("appends when new row is the oldest", () => {
+		const rows = [
+			row("a", "2024-03-01T00:00:00Z"),
+			row("b", "2024-02-01T00:00:00Z"),
+		];
+		const inserted = insertRowByCreatedAtDesc(
+			rows,
+			row("new", "2023-01-01T00:00:00Z"),
+		);
+		expect(inserted.map((r) => r.id)).toEqual(["a", "b", "new"]);
+	});
+
+	it("prepends when new row is the newest", () => {
+		const rows = [
+			row("a", "2024-03-01T00:00:00Z"),
+			row("b", "2024-02-01T00:00:00Z"),
+		];
+		const inserted = insertRowByCreatedAtDesc(
+			rows,
+			row("new", "2025-01-01T00:00:00Z"),
+		);
+		expect(inserted.map((r) => r.id)).toEqual(["new", "a", "b"]);
+	});
+
+	it("treats a missing createdAt as newest", () => {
+		const rows = [
+			row("a", "2024-03-01T00:00:00Z"),
+			row("b", "2024-02-01T00:00:00Z"),
+		];
+		const inserted = insertRowByCreatedAtDesc(rows, row("new"));
+		expect(inserted.map((r) => r.id)).toEqual(["new", "a", "b"]);
 	});
 });
 

--- a/src/lib/workspace-helpers.ts
+++ b/src/lib/workspace-helpers.ts
@@ -135,15 +135,18 @@ export function findWorkspaceRowById(
 
 /**
  * Map a workspace's status (manual takes precedence over derived) to the
- * sidebar group id it belongs in. Mirrors `helpers::group_id_from_status`
- * in the Rust backend so that optimistic UI placement matches what the
- * canonical query will return on the next invalidation — no flicker as the
- * row jumps groups when the real data lands.
+ * sidebar group id it belongs in. Mirrors `list_workspace_groups` in the
+ * Rust backend: pinned rows go to the `pinned` group regardless of status,
+ * otherwise status decides. Matching the backend here means optimistic UI
+ * placement lands in the same group the next query invalidation will put
+ * the row into — no cross-group flicker when real data arrives.
  */
 export function workspaceGroupIdFromStatus(
 	manualStatus: string | null | undefined,
 	derivedStatus: string | null | undefined,
-): "done" | "review" | "progress" | "backlog" | "canceled" {
+	pinnedAt?: string | null | undefined,
+): "pinned" | "done" | "review" | "progress" | "backlog" | "canceled" {
+	if (pinnedAt) return "pinned";
 	const raw = (manualStatus ?? derivedStatus ?? "").trim().toLowerCase();
 	switch (raw) {
 		case "done":
@@ -159,6 +162,26 @@ export function workspaceGroupIdFromStatus(
 		default:
 			return "progress";
 	}
+}
+
+/**
+ * Insert `row` into `rows` preserving `createdAt DESC` order (matching the
+ * backend's `ORDER BY datetime(created_at) DESC` for non-archived groups).
+ * Used for optimistic insertions — placing the row in its final spot avoids
+ * the reorder flicker that happens when the refetch returns and re-sorts.
+ *
+ * Rows without a `createdAt` are treated as newest (sort to the front), so
+ * freshly-created workspaces still land at the top as before.
+ */
+export function insertRowByCreatedAtDesc(
+	rows: WorkspaceRow[],
+	row: WorkspaceRow,
+): WorkspaceRow[] {
+	const key = (r: WorkspaceRow): string => r.createdAt ?? "\uFFFF";
+	const incoming = key(row);
+	const index = rows.findIndex((existing) => key(existing) < incoming);
+	if (index === -1) return [...rows, row];
+	return [...rows.slice(0, index), row, ...rows.slice(index)];
 }
 
 export type WorkspaceBranchTone =
@@ -312,8 +335,10 @@ export function summaryToArchivedRow(summary: WorkspaceSummary): WorkspaceRow {
 		activeSessionAgentType: summary.activeSessionAgentType ?? null,
 		activeSessionStatus: summary.activeSessionStatus ?? null,
 		prTitle: summary.prTitle ?? null,
+		pinnedAt: summary.pinnedAt ?? null,
 		sessionCount: summary.sessionCount,
 		messageCount: summary.messageCount,
+		createdAt: summary.createdAt,
 	};
 }
 
@@ -406,8 +431,10 @@ export function rowToWorkspaceSummary(
 		activeSessionAgentType: row.activeSessionAgentType ?? null,
 		activeSessionStatus: row.activeSessionStatus ?? null,
 		prTitle: row.prTitle ?? null,
+		pinnedAt: row.pinnedAt ?? null,
 		sessionCount: row.sessionCount,
 		messageCount: row.messageCount,
+		createdAt: row.createdAt ?? new Date().toISOString(),
 		...overrides,
 	};
 }


### PR DESCRIPTION
## Summary

- Gate sidebar-list invalidations behind a shared module-level counter (`src/lib/sidebar-mutation-gate.ts`). Archive/restore/pin/create/delete own the list during their mutation; concurrent callers (mark-read, mark-unread) now call `flushSidebarListsIfIdle` and skip the refetch while a mutation is mid-flight, so the server never overwrites the optimistic cache mid-transition.
- Do an optimistic sorted insert when unarchiving: `insertRowByCreatedAtDesc` places the row in its final `createdAt DESC` spot instead of prepending, so the row doesn't visibly shift when the refetch lands.
- Teach `workspaceGroupIdFromStatus` about `pinnedAt` so pinned rows always route to the `pinned` group, matching the backend's `list_workspace_groups` partition. Toggling a pin now updates the row in place without bouncing through its status group.
- Surface `created_at` on `WorkspaceRecord` / `WorkspaceSidebarRow` / `WorkspaceSummary` and `pinned_at` on `WorkspaceSummary` so the frontend has the fields it needs to compute the sorted insert and pinned routing.

## Why

The sidebar used to flicker on unarchive and pin: the optimistic row would land in the wrong group or at the wrong position, then snap to its real spot when the background query finished. Two root causes — (1) unrelated callers like "mark session read" invalidated `workspaceGroups` while a mutation's optimistic cache was still the source of truth, and (2) optimistic inserts didn't match the backend's sort. Fixing both makes the transitions visually stable.

## Test plan

- [ ] `bun run test` (frontend + sidecar + rust) passes
- [ ] `bun run lint` passes (biome + clippy)
- [ ] Manually verify: archive a workspace, then unarchive — row stays put while list refetches
- [ ] Manually verify: pin/unpin a workspace — row moves to/from pinned group without flicker
- [ ] Manually verify: receiving messages on a non-current session while an archive/restore is in flight no longer bounces the optimistic row back