### PR TITLE
fix: use last-iteration tokens for context-usage ring

### DIFF
--- a/.changeset/honest-rings-count.md
+++ b/.changeset/honest-rings-count.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix the composer's context-usage ring pinning at 100% after a single tool-heavy turn on Claude — the ring now reflects the actual end-of-turn context fill instead of cumulative per-call token usage.

--- a/sidecar/src/context-usage.test.ts
+++ b/sidecar/src/context-usage.test.ts
@@ -6,7 +6,7 @@ import {
 } from "./context-usage";
 
 describe("buildClaudeStoredMeta", () => {
-	it("derives used/max/percentage from result.usage + modelUsage", () => {
+	it("derives used/max/percentage from usage when iterations is absent", () => {
 		const meta = buildClaudeStoredMeta({
 			type: "result",
 			usage: {
@@ -24,6 +24,72 @@ describe("buildClaudeStoredMeta", () => {
 			maxTokens: 1_000_000,
 			percentage: 2.54,
 		});
+	});
+
+	it("prefers last message iteration over cumulative usage", () => {
+		// Real-shape payload lifted from a session where `usage` summed
+		// to ~1.1M (42 iterations, cache_read accumulated) but the actual
+		// end-of-turn context was only ~78k.
+		const meta = buildClaudeStoredMeta({
+			type: "result",
+			usage: {
+				input_tokens: 340,
+				cache_creation_input_tokens: 75_098,
+				cache_read_input_tokens: 1_008_704,
+				output_tokens: 18_132,
+			},
+			iterations: [
+				{
+					type: "message",
+					input_tokens: 1,
+					cache_creation_input_tokens: 2_468,
+					cache_read_input_tokens: 72_630,
+					output_tokens: 3_056,
+				},
+			],
+			modelUsage: {
+				"claude-opus-4-7[1m]": { contextWindow: 1_000_000 },
+			},
+		});
+		expect(meta).toEqual({
+			usedTokens: 78_155,
+			maxTokens: 1_000_000,
+			percentage: 7.82,
+		});
+	});
+
+	it("uses the LAST entry when iterations has multiple message entries", () => {
+		const meta = buildClaudeStoredMeta({
+			usage: { input_tokens: 999_999 },
+			iterations: [
+				{ type: "message", input_tokens: 10_000, output_tokens: 0 },
+				{ type: "message", input_tokens: 20_000, output_tokens: 0 },
+				{ type: "message", input_tokens: 42_000, output_tokens: 0 },
+			],
+			modelUsage: { foo: { contextWindow: 1_000_000 } },
+		});
+		expect(meta?.usedTokens).toBe(42_000);
+	});
+
+	it("skips a trailing compaction iteration to find the last message", () => {
+		const meta = buildClaudeStoredMeta({
+			usage: { input_tokens: 999_999 },
+			iterations: [
+				{ type: "message", input_tokens: 50_000, output_tokens: 0 },
+				{ type: "compaction", input_tokens: 8_000 },
+			],
+			modelUsage: { foo: { contextWindow: 1_000_000 } },
+		});
+		expect(meta?.usedTokens).toBe(50_000);
+	});
+
+	it("falls back to usage when iterations is an empty array", () => {
+		const meta = buildClaudeStoredMeta({
+			usage: { input_tokens: 5_000, output_tokens: 100 },
+			iterations: [],
+			modelUsage: { foo: { contextWindow: 200_000 } },
+		});
+		expect(meta?.usedTokens).toBe(5_100);
 	});
 
 	it("picks the largest contextWindow across multiple modelUsage entries", () => {

--- a/sidecar/src/context-usage.ts
+++ b/sidecar/src/context-usage.ts
@@ -29,9 +29,12 @@ function computePercentage(used: number, max: number): number {
 }
 
 /**
- * Build the persisted meta from any Claude terminal `result` message
- * (success OR error — both carry usage). Returns null when usage data
- * is missing so the sidecar can skip emitting.
+ * Persisted meta from a Claude terminal `result` (success or error).
+ * Returns null when usage data is missing.
+ *
+ * Tokens come from `iterations[last]`, not top-level `usage` — `usage`
+ * is a cumulative per-call counter and overshoots the window on
+ * tool-heavy turns. See SDK's `BetaIterationsUsage` docs.
  */
 export function buildClaudeStoredMeta(
 	result: unknown,
@@ -44,11 +47,12 @@ export function buildClaudeStoredMeta(
 	> | null;
 	if (!usage || !modelUsage) return null;
 
+	const source = pickLastMessageIteration(root.iterations) ?? usage;
 	const used =
-		num(usage.input_tokens) +
-		num(usage.cache_creation_input_tokens) +
-		num(usage.cache_read_input_tokens) +
-		num(usage.output_tokens);
+		num(source.input_tokens) +
+		num(source.cache_creation_input_tokens) +
+		num(source.cache_read_input_tokens) +
+		num(source.output_tokens);
 
 	let max = 0;
 	for (const entry of Object.values(modelUsage)) {
@@ -63,6 +67,22 @@ export function buildClaudeStoredMeta(
 		maxTokens: max,
 		percentage: computePercentage(usedClamped, max),
 	};
+}
+
+// Last `message` iteration, skipping trailing compaction entries.
+function pickLastMessageIteration(
+	raw: unknown,
+): Record<string, unknown> | null {
+	if (!Array.isArray(raw)) return null;
+	for (let i = raw.length - 1; i >= 0; i--) {
+		const entry = raw[i];
+		if (!entry || typeof entry !== "object") continue;
+		const obj = entry as Record<string, unknown>;
+		const t = obj.type;
+		if (typeof t === "string" && t !== "message") continue;
+		return obj;
+	}
+	return null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- The composer's context-usage ring could pin at 100% after a single tool-heavy Claude turn because it summed the top-level `result.usage` counters, which accumulate across every SDK iteration (cache reads in particular balloon on tool-heavy turns).
- Switch `buildClaudeStoredMeta` to read tokens from the last `message` entry of `result.iterations` (skipping trailing `compaction` entries), falling back to cumulative `usage` only when iterations isn't present. This matches the SDK's `BetaIterationsUsage` semantics and reflects actual end-of-turn context fill.
- Added regression tests covering: real-shape cumulative-vs-iteration payload (~1.1M cumulative vs ~78k actual), multi-entry iteration picking the last one, trailing compaction skip, and empty-iterations fallback.

## Why
Users were seeing the ring stuck at 100% mid-session even though plenty of context was free. Root cause: `usage` is per-call cumulative, not end-of-turn, so cache_read alone would push us over the window after a few tool rounds.

## Test plan
- [x] `cd sidecar && bun test src/context-usage.test.ts`
- [ ] Manual: run a tool-heavy Claude turn and confirm the ring settles at the real context percentage rather than 100%.