### PR TITLE
fix: activate adjacent session after closing tab

### DIFF
--- a/.changeset/calm-tabs-close.md
+++ b/.changeset/calm-tabs-close.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix session tab closing so Helmor activates the tab to the right, falls back to the left, and keeps the current tab active when closing a background session.

--- a/src-tauri/src/models/sessions.rs
+++ b/src-tauri/src/models/sessions.rs
@@ -100,6 +100,39 @@ pub fn list_session_historical_records(session_id: &str) -> Result<Vec<Historica
     list_session_historical_records_with_connection(&connection, session_id)
 }
 
+fn adjacent_visible_session_id(
+    transaction: &Transaction<'_>,
+    workspace_id: &str,
+    session_id: &str,
+) -> Result<Option<String>> {
+    let mut statement = transaction.prepare(
+        r#"
+            SELECT id FROM sessions
+            WHERE workspace_id = ?1 AND COALESCE(is_hidden, 0) = 0
+            ORDER BY datetime(created_at) ASC
+            "#,
+    )?;
+    let visible_session_ids = statement
+        .query_map([workspace_id], |row| row.get::<_, String>(0))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+
+    let Some(index) = visible_session_ids
+        .iter()
+        .position(|candidate| candidate == session_id)
+    else {
+        return Ok(None);
+    };
+
+    Ok(visible_session_ids
+        .get(index + 1)
+        .or_else(|| {
+            index
+                .checked_sub(1)
+                .and_then(|prev| visible_session_ids.get(prev))
+        })
+        .cloned())
+}
+
 fn list_session_historical_records_with_connection(
     connection: &Connection,
     session_id: &str,
@@ -429,6 +462,21 @@ pub fn hide_session(session_id: &str) -> Result<()> {
         )
         .with_context(|| format!("Failed to find session {session_id}"))?;
 
+    // If this was the workspace's active session, switch to its right neighbor,
+    // falling back to the left neighbor when closing the rightmost tab.
+    let current_active: Option<String> = transaction
+        .query_row(
+            "SELECT active_session_id FROM workspaces WHERE id = ?1",
+            [&workspace_id],
+            |row| row.get(0),
+        )
+        .context("Failed to read active session for workspace")?;
+    let next_session_id = if current_active.as_deref() == Some(session_id) {
+        adjacent_visible_session_id(&transaction, &workspace_id, session_id)?
+    } else {
+        None
+    };
+
     transaction
         .execute(
             "UPDATE sessions SET is_hidden = 1 WHERE id = ?1",
@@ -441,29 +489,7 @@ pub fn hide_session(session_id: &str) -> Result<()> {
     // workspace flag can fall off too when this was the last unread session.
     mark_session_read_in_transaction(&transaction, session_id)?;
 
-    // If this was the workspace's active session, switch to the next visible one
-    let current_active: Option<String> = transaction
-        .query_row(
-            "SELECT active_session_id FROM workspaces WHERE id = ?1",
-            [&workspace_id],
-            |row| row.get(0),
-        )
-        .context("Failed to read active session for workspace")?;
-
     if current_active.as_deref() == Some(session_id) {
-        let next_session_id: Option<String> = transaction
-            .query_row(
-                r#"
-                SELECT id FROM sessions
-                WHERE workspace_id = ?1 AND COALESCE(is_hidden, 0) = 0
-                ORDER BY datetime(created_at) ASC
-                LIMIT 1
-                "#,
-                [&workspace_id],
-                |row| row.get(0),
-            )
-            .ok();
-
         transaction
             .execute(
                 "UPDATE workspaces SET active_session_id = ?1 WHERE id = ?2",
@@ -501,6 +527,24 @@ pub fn delete_session(session_id: &str) -> Result<()> {
         )
         .ok();
 
+    let current_active: Option<String> = if let Some(ws_id) = &workspace_id {
+        transaction
+            .query_row(
+                "SELECT active_session_id FROM workspaces WHERE id = ?1",
+                [ws_id],
+                |row| row.get(0),
+            )
+            .ok()
+    } else {
+        None
+    };
+    let next_session_id = match (&workspace_id, current_active.as_deref()) {
+        (Some(ws_id), Some(active_id)) if active_id == session_id => {
+            adjacent_visible_session_id(&transaction, ws_id, session_id)?
+        }
+        _ => None,
+    };
+
     transaction
         .execute(
             "DELETE FROM session_messages WHERE session_id = ?1",
@@ -511,14 +555,14 @@ pub fn delete_session(session_id: &str) -> Result<()> {
         .execute("DELETE FROM sessions WHERE id = ?1", [session_id])
         .context("Failed to delete session")?;
 
-    // Clear active_session_id if it pointed to the deleted session
+    // If this was active, persist the same right-then-left tab fallback as the UI.
     if let Some(ws_id) = &workspace_id {
         transaction
             .execute(
-                "UPDATE workspaces SET active_session_id = NULL WHERE id = ?1 AND active_session_id = ?2",
-                (ws_id, session_id),
+                "UPDATE workspaces SET active_session_id = ?1 WHERE id = ?2 AND active_session_id = ?3",
+                (next_session_id.as_deref(), ws_id, session_id),
             )
-            .context("Failed to clear active session")?;
+            .context("Failed to update active session")?;
     }
 
     transaction
@@ -666,7 +710,19 @@ mod tests {
     fn seed_two_sessions(conn: &Connection) {
         seed_with_active_session(conn);
         conn.execute(
+            "UPDATE sessions SET created_at = '2026-01-01T00:00:00', updated_at = '2026-01-01T00:00:00' WHERE id = 's1'",
+            [],
+        ).unwrap();
+        conn.execute(
             "INSERT INTO sessions (id, workspace_id, status, title, created_at, updated_at) VALUES ('s2', 'w1', 'idle', 'Second Session', '2026-01-02T00:00:00', '2026-01-02T00:00:00')",
+            [],
+        ).unwrap();
+    }
+
+    fn seed_three_sessions(conn: &Connection) {
+        seed_two_sessions(conn);
+        conn.execute(
+            "INSERT INTO sessions (id, workspace_id, status, title, created_at, updated_at) VALUES ('s3', 'w1', 'idle', 'Third Session', '2026-01-03T00:00:00', '2026-01-03T00:00:00')",
             [],
         ).unwrap();
     }
@@ -753,6 +809,26 @@ mod tests {
     }
 
     #[test]
+    fn adjacent_visible_session_prefers_right_then_left() {
+        let (mut conn, _dir) = test_db();
+        seed_three_sessions(&conn);
+        let transaction = conn.transaction().unwrap();
+
+        assert_eq!(
+            adjacent_visible_session_id(&transaction, "w1", "s1").unwrap(),
+            Some("s2".to_string())
+        );
+        assert_eq!(
+            adjacent_visible_session_id(&transaction, "w1", "s2").unwrap(),
+            Some("s3".to_string())
+        );
+        assert_eq!(
+            adjacent_visible_session_id(&transaction, "w1", "s3").unwrap(),
+            Some("s2".to_string())
+        );
+    }
+
+    #[test]
     fn delete_session_clears_active_session_id() {
         let (conn, _dir) = test_db();
         seed_with_active_session(&conn);
@@ -770,6 +846,35 @@ mod tests {
 
         assert_eq!(get_active_session_id(&conn, "w1"), None);
         assert_eq!(count_sessions(&conn, "w1"), 0);
+    }
+
+    #[test]
+    fn delete_active_session_switches_to_adjacent_visible_session() {
+        let (mut conn, _dir) = test_db();
+        seed_three_sessions(&conn);
+        conn.execute(
+            "UPDATE workspaces SET active_session_id = 's2' WHERE id = 'w1'",
+            [],
+        )
+        .unwrap();
+
+        let transaction = conn.transaction().unwrap();
+        let next_session_id = adjacent_visible_session_id(&transaction, "w1", "s2").unwrap();
+        transaction
+            .execute("DELETE FROM session_messages WHERE session_id = 's2'", [])
+            .unwrap();
+        transaction
+            .execute("DELETE FROM sessions WHERE id = 's2'", [])
+            .unwrap();
+        transaction
+            .execute(
+                "UPDATE workspaces SET active_session_id = ?1 WHERE id = 'w1' AND active_session_id = 's2'",
+                [next_session_id.as_deref()],
+            )
+            .unwrap();
+        transaction.commit().unwrap();
+
+        assert_eq!(get_active_session_id(&conn, "w1"), Some("s3".to_string()));
     }
 
     #[test]

--- a/src/App.shortcuts.test.tsx
+++ b/src/App.shortcuts.test.tsx
@@ -284,6 +284,18 @@ function expectSelectedSession(title: string) {
 	expect(getSessionTab(title)).toHaveAttribute("aria-selected", "true");
 }
 
+function getSessionCloseButton(title: string) {
+	const closeButton = getSessionTab(title).querySelector(
+		'[aria-label="Close session"]',
+	);
+
+	if (!closeButton) {
+		throw new Error(`Unable to find close button for "${title}".`);
+	}
+
+	return closeButton as HTMLElement;
+}
+
 function expectSelectedWorkspace(title: string) {
 	expect(screen.getByRole("button", { name: title })).toHaveClass(
 		"workspace-row-selected",
@@ -323,12 +335,12 @@ function emitTauriEvent(eventName: string) {
 	}
 }
 
-async function renderAppReady() {
+async function renderAppReady(expectedSessionTitle = "Done session 1") {
 	render(<App />);
 
 	await waitFor(() => {
 		expectSelectedWorkspace("Done workspace");
-		expectSelectedSession("Done session 1");
+		expectSelectedSession(expectedSessionTitle);
 	});
 }
 
@@ -718,6 +730,106 @@ describe("App global navigation shortcuts", () => {
 		});
 		expect(apiMocks.hideSession).toHaveBeenCalledWith("session-done-1");
 		expect(apiMocks.deleteSession).not.toHaveBeenCalled();
+	});
+
+	it("selects the right session after closing a middle session", async () => {
+		runtimeSessionFixtures[WORKSPACE_IDS.done] = [
+			{
+				id: "session-done-1",
+				title: "Done session 1",
+				active: true,
+			},
+			{
+				id: "session-done-2",
+				title: "Done session 2",
+				active: false,
+			},
+			{
+				id: "session-done-3",
+				title: "Done session 3",
+				active: false,
+			},
+		];
+
+		await renderAppReady();
+		await userEvent.click(getSessionTab("Done session 2"));
+		await waitFor(() => {
+			expectSelectedSession("Done session 2");
+		});
+
+		fireEvent.keyDown(window, {
+			key: "w",
+			metaKey: true,
+		});
+
+		await waitFor(() => {
+			expectSelectedSession("Done session 3");
+		});
+		expect(apiMocks.hideSession).toHaveBeenCalledWith("session-done-2");
+	});
+
+	it("selects the left session after closing the rightmost session", async () => {
+		runtimeSessionFixtures[WORKSPACE_IDS.done] = [
+			{
+				id: "session-done-1",
+				title: "Done session 1",
+				active: true,
+			},
+			{
+				id: "session-done-2",
+				title: "Done session 2",
+				active: false,
+			},
+			{
+				id: "session-done-3",
+				title: "Done session 3",
+				active: false,
+			},
+		];
+
+		await renderAppReady();
+		await userEvent.click(getSessionTab("Done session 3"));
+		await waitFor(() => {
+			expectSelectedSession("Done session 3");
+		});
+
+		fireEvent.keyDown(window, {
+			key: "w",
+			metaKey: true,
+		});
+
+		await waitFor(() => {
+			expectSelectedSession("Done session 2");
+		});
+		expect(apiMocks.hideSession).toHaveBeenCalledWith("session-done-3");
+	});
+
+	it("keeps the active session when closing an inactive session tab", async () => {
+		runtimeSessionFixtures[WORKSPACE_IDS.done] = [
+			{
+				id: "session-done-1",
+				title: "Done session 1",
+				active: true,
+			},
+			{
+				id: "session-done-2",
+				title: "Done session 2",
+				active: false,
+			},
+			{
+				id: "session-done-3",
+				title: "Done session 3",
+				active: false,
+			},
+		];
+
+		await renderAppReady();
+		await userEvent.click(getSessionCloseButton("Done session 2"));
+
+		await waitFor(() => {
+			expect(apiMocks.hideSession).toHaveBeenCalledWith("session-done-2");
+		});
+		expectSelectedSession("Done session 1");
 	});
 
 	it("quits silently on a Rust-emitted quit-requested event when nothing is in flight", async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1520,6 +1520,7 @@ function AppShell({
 			workspace,
 			sessions,
 			session,
+			activateAdjacent: true,
 			onSessionsChanged: () => {
 				void Promise.all([
 					queryClient.invalidateQueries({

--- a/src/features/panel/header.tsx
+++ b/src/features/panel/header.tsx
@@ -230,6 +230,7 @@ export const WorkspacePanelHeader = memo(function WorkspacePanelHeader({
 					workspace,
 					sessions,
 					session: targetSession,
+					activateAdjacent: targetSession.id === selectedSessionId,
 					provider: sessionDisplayProviders?.[targetSession.id] ?? null,
 					onSessionsChanged,
 				});
@@ -241,6 +242,7 @@ export const WorkspacePanelHeader = memo(function WorkspacePanelHeader({
 				workspace,
 				sessions,
 				sessionId,
+				activateAdjacent: sessionId === selectedSessionId,
 				onSelectSession,
 				onSessionsChanged,
 				pushToast,
@@ -252,6 +254,7 @@ export const WorkspacePanelHeader = memo(function WorkspacePanelHeader({
 			onSessionsChanged,
 			pushToast,
 			queryClient,
+			selectedSessionId,
 			sessionDisplayProviders,
 			sessions,
 			workspace,
@@ -325,6 +328,11 @@ export const WorkspacePanelHeader = memo(function WorkspacePanelHeader({
 	const handleCancelRename = useCallback(() => {
 		setEditingSessionId(null);
 		setEditingTitle("");
+	}, []);
+
+	const stopTabActionPointerDown = useCallback((event: React.PointerEvent) => {
+		event.preventDefault();
+		event.stopPropagation();
 	}, []);
 
 	return (
@@ -636,6 +644,7 @@ export const WorkspacePanelHeader = memo(function WorkspacePanelHeader({
 																<span
 																	role="button"
 																	aria-label="Rename session"
+																	onPointerDown={stopTabActionPointerDown}
 																	onClick={(event) =>
 																		handleStartRename(session, event)
 																	}
@@ -646,6 +655,7 @@ export const WorkspacePanelHeader = memo(function WorkspacePanelHeader({
 																<span
 																	role="button"
 																	aria-label="Close session"
+																	onPointerDown={stopTabActionPointerDown}
 																	onClick={(event) =>
 																		handleHideSession(session.id, event)
 																	}

--- a/src/features/panel/session-close.ts
+++ b/src/features/panel/session-close.ts
@@ -16,16 +16,30 @@ type CloseWorkspaceSessionOptions = {
 	workspace: WorkspaceDetail;
 	sessions: WorkspaceSessionSummary[];
 	sessionId: string;
+	activateAdjacent?: boolean;
 	onSelectSession?: (sessionId: string) => void;
 	onSessionsChanged?: () => void;
 	pushToast?: PushWorkspaceToast;
 };
+
+function findAdjacentSessionId(
+	sessions: WorkspaceSessionSummary[],
+	sessionId: string,
+) {
+	const index = sessions.findIndex((session) => session.id === sessionId);
+	if (index === -1) {
+		return null;
+	}
+
+	return sessions[index + 1]?.id ?? sessions[index - 1]?.id ?? null;
+}
 
 export async function closeWorkspaceSession({
 	queryClient,
 	workspace,
 	sessions,
 	sessionId,
+	activateAdjacent = false,
 	onSelectSession,
 	onSessionsChanged,
 	pushToast,
@@ -38,6 +52,9 @@ export async function closeWorkspaceSession({
 
 	const isEmptySession = isNewSession(targetSession);
 	const isClosingLastVisibleSession = sessions.length === 1;
+	const adjacentSessionId = activateAdjacent
+		? findAdjacentSessionId(sessions, sessionId)
+		: null;
 
 	try {
 		if (isClosingLastVisibleSession) {
@@ -91,6 +108,42 @@ export async function closeWorkspaceSession({
 		} else {
 			await hideSession(sessionId);
 		}
+
+		if (adjacentSessionId) {
+			const adjacentSession =
+				sessions.find((session) => session.id === adjacentSessionId) ?? null;
+
+			queryClient.setQueryData(
+				helmorQueryKeys.workspaceDetail(workspace.id),
+				(current: WorkspaceDetail | null | undefined) => {
+					const base = current ?? workspace;
+					if (!base) {
+						return base;
+					}
+
+					return {
+						...base,
+						activeSessionId: adjacentSessionId,
+						activeSessionTitle: adjacentSession?.title ?? "Untitled",
+						activeSessionAgentType: adjacentSession?.agentType ?? null,
+						activeSessionStatus: adjacentSession?.status ?? "idle",
+						sessionCount: Math.max(0, base.sessionCount - 1),
+					};
+				},
+			);
+			queryClient.setQueryData(
+				helmorQueryKeys.workspaceSessions(workspace.id),
+				(current: WorkspaceSessionSummary[] | undefined) =>
+					(current ?? sessions)
+						.filter((session) => session.id !== sessionId)
+						.map((session) => ({
+							...session,
+							active: session.id === adjacentSessionId,
+						})),
+			);
+			onSelectSession?.(adjacentSessionId);
+		}
+
 		onSessionsChanged?.();
 		return true;
 	} catch (error) {

--- a/src/features/panel/use-confirm-session-close.tsx
+++ b/src/features/panel/use-confirm-session-close.tsx
@@ -17,6 +17,7 @@ export type SessionCloseRequest = {
 	workspace: WorkspaceDetail;
 	sessions: WorkspaceSessionSummary[];
 	session: WorkspaceSessionSummary;
+	activateAdjacent?: boolean;
 	// Display-provider override (from sessionDisplayProviders). Falls back
 	// to `session.agentType` for label and stop call.
 	provider?: string | null;
@@ -55,6 +56,7 @@ export function useConfirmSessionClose({
 				workspace: request.workspace,
 				sessions: request.sessions,
 				sessionId: request.session.id,
+				activateAdjacent: request.activateAdjacent,
 				onSelectSession,
 				onSessionsChanged: request.onSessionsChanged,
 				pushToast,


### PR DESCRIPTION
## What changed
- Select the tab to the right after closing the active session, falling back to the leftmost available neighbor when closing the rightmost tab.
- Keep the current active tab selected when closing a background session.
- Persist the same adjacent-session fallback in Rust hide/delete session flows and cover it with frontend and Rust tests.
- Added a patch changeset for the behavior fix.

## Why
Closing tabs should match normal tab-strip behavior and keep frontend selection plus persisted workspace state in sync.

## Tests
- bun x vitest run src/App.shortcuts.test.tsx
- cd src-tauri && cargo test models::sessions::tests
- Pre-commit hook: biome check, cargo fmt, cargo clippy -- -D warnings