### PR TITLE
fix: hide duplicate local command notices

### DIFF
--- a/.changeset/quiet-command-notices.md
+++ b/.changeset/quiet-command-notices.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Hide duplicate Claude local command completion notices so finished shell tasks no longer appear as top-level subagent messages.

--- a/src-tauri/src/pipeline/accumulator/mod.rs
+++ b/src-tauri/src/pipeline/accumulator/mod.rs
@@ -134,6 +134,7 @@ pub struct StreamAccumulator {
     /// `__part_id` indices when the SDK delivers finalized blocks in
     /// separate per-block `assistant` events (delta-style).
     cur_asst_block_count: usize,
+    local_bash_task_refs: HashSet<String>,
     // ── Codex state ──────────────────────────────────────────────────
     /// Per-item delta accumulation for Codex App Server streaming.
     codex_items: HashMap<String, codex::CodexItemState>,
@@ -299,6 +300,7 @@ impl StreamAccumulator {
             cur_asst_blocks: Vec::new(),
             cur_asst_template: None,
             cur_asst_block_count: 0,
+            local_bash_task_refs: HashSet::new(),
             codex_items: codex::new_item_states(),
             codex_partial_idx: None,
             codex_turn_started_at: None,
@@ -1040,9 +1042,18 @@ impl StreamAccumulator {
                 return;
             }
         }
-        // `local_bash` task_* events duplicate the accompanying Bash tool
-        // call — drop before they enter the render / persistence path.
-        if crate::pipeline::event_filter::is_suppressed_local_bash_task(value) {
+        // `local_bash` task_* events duplicate the accompanying Bash tool.
+        // Claude omits `task_type` on the later notification, so remember
+        // refs from the start event and apply them to the completion event.
+        if crate::pipeline::event_filter::is_explicit_local_bash_task(value) {
+            crate::pipeline::event_filter::remember_task_refs(
+                value,
+                &mut self.local_bash_task_refs,
+            );
+            return;
+        }
+        if crate::pipeline::event_filter::is_local_bash_task_ref(value, &self.local_bash_task_refs)
+        {
             return;
         }
         self.collect_message(raw_line, value, MessageRole::System, None);

--- a/src-tauri/src/pipeline/accumulator/tests.rs
+++ b/src-tauri/src/pipeline/accumulator/tests.rs
@@ -128,6 +128,33 @@ fn claude_local_bash_task_events_are_dropped() {
 }
 
 #[test]
+fn claude_local_bash_notification_without_task_type_is_dropped() {
+    let mut acc = StreamAccumulator::new("claude", "opus");
+    let started = json!({
+        "type": "system",
+        "subtype": "task_started",
+        "task_id": "task_bash",
+        "task_type": "local_bash",
+        "tool_use_id": "toolu_bash_1",
+        "description": "bun x vitest run src/foo.test.ts",
+    });
+    acc.push_event(&started, &started.to_string());
+
+    let notification = json!({
+        "type": "system",
+        "subtype": "task_notification",
+        "task_id": "task_bash",
+        "tool_use_id": "toolu_bash_1",
+        "status": "completed",
+        "output_file": "",
+        "summary": "bun x vitest run src/foo.test.ts",
+    });
+    acc.push_event(&notification, &notification.to_string());
+
+    assert!(acc.collected().is_empty());
+}
+
+#[test]
 fn claude_local_agent_task_events_still_render() {
     // The real subagent lifecycle (`task_type: "local_agent"`) still
     // enters `collected[]` so the adapter can fold it under the parent

--- a/src-tauri/src/pipeline/event_filter.rs
+++ b/src-tauri/src/pipeline/event_filter.rs
@@ -4,7 +4,7 @@
 //! - `accumulator::push_event` reads `SUPPRESSED_EVENT_TYPES` and drops
 //!   matching top-level events before any handler runs (NoOp).
 //! - `accumulator::handle_claude_system` reads `SUPPRESSED_SYSTEM_SUBTYPES`
-//!   + `is_suppressed_local_bash_task` on live ingest.
+//!   + local-bash task helpers on live ingest.
 //! - `adapter::convert_system_msg` reads the same pair on historical
 //!   reload, so old persisted noise rows from earlier code versions
 //!   render with the same rules as new turns.
@@ -79,15 +79,40 @@ pub(crate) fn is_suppressed_system_subtype(subtype: &str) -> bool {
 /// `local_agent` task events are left untouched — those are the real
 /// subagent lifecycle, and whether/how to render them is handled
 /// further down the pipeline.
-pub(crate) fn is_suppressed_local_bash_task(value: &Value) -> bool {
+pub(crate) fn is_claude_task_lifecycle(value: &Value) -> bool {
     let Some(subtype) = value.get("subtype").and_then(Value::as_str) else {
         return false;
     };
-    if !matches!(
+    matches!(
         subtype,
         "task_started" | "task_progress" | "task_notification"
-    ) {
-        return false;
+    )
+}
+
+pub(crate) fn is_explicit_local_bash_task(value: &Value) -> bool {
+    is_claude_task_lifecycle(value)
+        && value.get("task_type").and_then(Value::as_str) == Some("local_bash")
+}
+
+pub(crate) fn is_suppressed_local_bash_task(value: &Value) -> bool {
+    is_explicit_local_bash_task(value)
+}
+
+pub(crate) fn task_refs(value: &Value) -> impl Iterator<Item = &str> {
+    ["task_id", "tool_use_id"]
+        .into_iter()
+        .filter_map(|key| value.get(key).and_then(Value::as_str))
+}
+
+pub(crate) fn is_local_bash_task_ref(
+    value: &Value,
+    known_refs: &std::collections::HashSet<String>,
+) -> bool {
+    is_claude_task_lifecycle(value) && task_refs(value).any(|id| known_refs.contains(id))
+}
+
+pub(crate) fn remember_task_refs(value: &Value, refs: &mut std::collections::HashSet<String>) {
+    for id in task_refs(value) {
+        refs.insert(id.to_string());
     }
-    value.get("task_type").and_then(Value::as_str) == Some("local_bash")
 }


### PR DESCRIPTION
## What changed
- Track Claude local bash task refs from explicit `local_bash` lifecycle events.
- Suppress later matching task notifications even when Claude omits `task_type`.
- Add regression coverage and a patch changeset.

## Why
Claude can emit a completion notification for local shell work without `task_type`, which let duplicate command completion notices render as top-level subagent messages. Remembering the task/tool refs keeps those duplicate local command lifecycle events out of rendering and persistence.

## Follow-up / test notes
- `cd src-tauri && cargo test claude_local_bash_notification_without_task_type_is_dropped`
- Pre-commit hook ran `cargo fmt --manifest-path src-tauri/Cargo.toml --all` and `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`.
