### PR TITLE
Preserve workspaces with missing directories

### DIFF
--- a/.changeset/calm-worktrees-heal.md
+++ b/.changeset/calm-worktrees-heal.md
@@ -1,0 +1,8 @@
+---
+"helmor": patch
+---
+
+Improve recovery when a workspace directory disappears outside Helmor:
+- Preserve chat history by moving missing workspaces to the archive instead of deleting their records.
+- Let archived workspaces without an archive snapshot restore from their target branch, with an in-app notice explaining the fallback.
+- Reduce repeated git, file, and inspector errors for missing worktrees while still offering an explicit permanent delete action when recovery is needed.

--- a/src-tauri/src/agents.rs
+++ b/src-tauri/src/agents.rs
@@ -239,10 +239,17 @@ fn resolve_stream_working_directory(
         if let Some(session_id) = request.helmor_session_id.as_deref() {
             if let Some(workspace_dir) = resolve_resume_working_directory(session_id)? {
                 if !workspace_dir.is_dir() {
-                    return Err(anyhow::anyhow!(
-                        "Workspace directory not found for resumed session: {}",
-                        workspace_dir.display()
-                    ));
+                    // Tag as `WorkspaceBroken` so the frontend toast can
+                    // offer "Permanently Delete" + default-keep-history,
+                    // matching the non-resume path in resolve_working_directory.
+                    return Err(
+                        crate::error::coded(crate::error::ErrorCode::WorkspaceBroken).context(
+                            format!(
+                                "Workspace directory is missing for resumed session: {}",
+                                workspace_dir.display()
+                            ),
+                        ),
+                    );
                 }
                 return Ok(workspace_dir);
             }
@@ -890,7 +897,11 @@ mod tests {
         let error = resolve_stream_working_directory(&request).unwrap_err();
         assert!(error
             .to_string()
-            .contains("Workspace directory not found for resumed session"),);
+            .contains("Workspace directory is missing for resumed session"),);
+        assert_eq!(
+            crate::error::extract_code(&error),
+            crate::error::ErrorCode::WorkspaceBroken,
+        );
 
         std::env::remove_var("HELMOR_DATA_DIR");
     }

--- a/src-tauri/src/agents/support.rs
+++ b/src-tauri/src/agents/support.rs
@@ -52,9 +52,20 @@ pub(super) fn parse_codex_output(
 pub(super) fn resolve_working_directory(provided: Option<&str>) -> Result<PathBuf> {
     if let Some(path) = non_empty(provided) {
         let directory = PathBuf::from(path);
-        if directory.is_dir() {
-            return Ok(directory);
+        // Provided path MUST exist — silently falling back to the helmor
+        // process's cwd would spawn the agent CLI in `/` (or the app bundle)
+        // and pollute session_messages with nonsense output. Tag the error
+        // with `WorkspaceBroken` so the frontend can offer "Permanently
+        // Delete" instead of a generic failure toast.
+        if !directory.is_dir() {
+            return Err(
+                crate::error::coded(crate::error::ErrorCode::WorkspaceBroken).context(format!(
+                    "Workspace directory is missing: {}",
+                    directory.display()
+                )),
+            );
         }
+        return Ok(directory);
     }
 
     std::env::current_dir().context("Failed to resolve working directory")

--- a/src-tauri/src/commands/editor_commands.rs
+++ b/src-tauri/src/commands/editor_commands.rs
@@ -1,8 +1,6 @@
 use anyhow::Context;
 
-use crate::{
-    editor_files, git_ops, models::workspaces as workspace_models, workspace_state::WorkspaceState,
-};
+use crate::{editor_files, git_ops, models::workspaces as workspace_models};
 
 use super::common::{run_blocking, CmdResult};
 
@@ -91,29 +89,44 @@ pub async fn get_workspace_git_action_status(
     run_blocking(move || {
         let record = workspace_models::load_workspace_record_by_id(&workspace_id)?
             .with_context(|| format!("Workspace not found: {workspace_id}"))?;
-        // A workspace that hasn't finished Phase 2 has no worktree on disk —
-        // running `git status` against it would error. A freshly-created
-        // workspace always starts clean (0 uncommitted, 0 conflicts, in sync
-        // with its base branch, not yet pushed), so short-circuit to the
-        // canonical "fresh" status. The frontend paints the same values
-        // post-ready, so the state transition causes zero visual change.
-        if record.state == WorkspaceState::Initializing {
-            return Ok(git_ops::WorkspaceGitActionStatus {
-                uncommitted_count: 0,
-                conflict_count: 0,
-                sync_target_branch: record
-                    .intended_target_branch
-                    .clone()
-                    .or_else(|| record.default_branch.clone()),
-                sync_status: git_ops::WorkspaceSyncStatus::UpToDate,
-                behind_target_count: 0,
-                remote_tracking_ref: None,
-                ahead_of_remote_count: 0,
-                push_status: git_ops::WorkspacePushStatus::Unpublished,
-            });
+        let quiet_status = || git_ops::WorkspaceGitActionStatus {
+            uncommitted_count: 0,
+            conflict_count: 0,
+            sync_target_branch: record
+                .intended_target_branch
+                .clone()
+                .or_else(|| record.default_branch.clone()),
+            sync_status: git_ops::WorkspaceSyncStatus::UpToDate,
+            behind_target_count: 0,
+            remote_tracking_ref: None,
+            ahead_of_remote_count: 0,
+            push_status: git_ops::WorkspacePushStatus::Unpublished,
+        };
+        // Non-operational workspaces (Initializing / Archived) have no live
+        // worktree to inspect — Initializing because Phase 2 hasn't run yet,
+        // Archived because the worktree has been removed. Running `git status`
+        // against them would either error or return stale data. Short-circuit
+        // to the canonical "fresh/quiet" status; the frontend can't take any
+        // action on them anyway.
+        if !record.state.is_operational() {
+            return Ok(quiet_status());
         }
         let workspace_dir =
             crate::data_dir::workspace_dir(&record.repo_name, &record.directory_name)?;
+        // Defensive: if the worktree directory was removed externally (e.g.
+        // user `rm -rf`ed it while the row is still `ready`), return quiet
+        // status rather than erroring on every poll. User-triggered paths
+        // (stage/unstage/send message) are where we surface WorkspaceBroken;
+        // this poll is invisible and stays silent. Logged as warn (not debug)
+        // so release builds still show the anomaly.
+        if !workspace_dir.is_dir() {
+            tracing::warn!(
+                workspace_id = %workspace_id,
+                path = %workspace_dir.display(),
+                "worktree missing during git-status poll; returning quiet status",
+            );
+            return Ok(quiet_status());
+        }
         let remote = record.remote.as_deref();
         let target_branch = record
             .intended_target_branch

--- a/src-tauri/src/commands/tests/archive_restore.rs
+++ b/src-tauri/src/commands/tests/archive_restore.rs
@@ -36,6 +36,33 @@ fn restore_workspace_recreates_worktree() {
 }
 
 #[test]
+fn restore_workspace_without_archive_commit_uses_target_branch() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let harness = RestoreTestHarness::new();
+    let connection = Connection::open(crate::data_dir::db_path().unwrap()).unwrap();
+    connection
+        .execute(
+            "UPDATE workspaces SET archive_commit = NULL WHERE id = ?1",
+            [&harness.workspace_id],
+        )
+        .unwrap();
+
+    let response = workspaces::restore_workspace_impl(&harness.workspace_id, None).unwrap();
+
+    assert_eq!(
+        response.restored_from_target_branch.as_deref(),
+        Some("main")
+    );
+    assert_eq!(
+        fs::read_to_string(harness.workspace_dir().join("tracked.txt")).unwrap(),
+        "main"
+    );
+    assert_eq!(response.restored_state, WorkspaceState::Ready);
+}
+
+#[test]
 fn archive_workspace_removes_worktree() {
     let _guard = TEST_LOCK
         .lock()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -93,11 +93,17 @@ pub fn run() {
                 "Helmor started"
             );
 
-            // Purge workspaces whose directory was deleted outside the app.
+            // Reconcile workspaces whose directory was deleted outside the
+            // app: degrade them to `archived` so chat history is preserved
+            // (users can find the messages in the archive list and choose
+            // to Permanently Delete there). Never auto-destroys data.
             match workspace::workspaces::purge_orphaned_workspaces() {
                 Ok(0) => {}
-                Ok(n) => tracing::info!(count = n, "Purged orphaned workspaces"),
-                Err(e) => tracing::warn!("Failed to purge orphaned workspaces: {e:#}"),
+                Ok(n) => tracing::info!(
+                    count = n,
+                    "Degraded orphaned workspaces to archived (chat history preserved)"
+                ),
+                Err(e) => tracing::warn!("Failed to reconcile orphaned workspaces: {e:#}"),
             }
 
             // Clear rows stuck in `initializing` state past the cutoff —

--- a/src-tauri/src/workspace/files/changes.rs
+++ b/src-tauri/src/workspace/files/changes.rs
@@ -11,17 +11,32 @@ use super::{
     support::allowed_workspace_roots,
     types::{EditorFileListItem, EditorFilePrefetchItem, EditorFilesWithContentResponse},
 };
-use crate::{db, git_ops, workspace_state};
+use crate::{
+    bail_coded, db,
+    error::{AnyhowCodedExt, ErrorCode},
+    git_ops, workspace_state,
+};
 
 const MAX_PREFETCH_BYTES: u64 = 1_048_576;
 
 pub fn list_workspace_changes(workspace_root_path: &str) -> Result<Vec<EditorFileListItem>> {
     let workspace_root = Path::new(workspace_root_path);
-    if !workspace_root.is_absolute() || !workspace_root.is_dir() {
+    if !workspace_root.is_absolute() {
         bail!(
-            "Workspace root is not a valid directory: {}",
+            "Workspace root must be an absolute path: {}",
             workspace_root.display()
         );
+    }
+    if !workspace_root.is_dir() {
+        // Workspace dir vanished externally (deleted / archive cleanup /
+        // repo moved). The inspector polls this on a fixed interval — if
+        // we bailed, every tick would log an error. Return empty changes
+        // silently; the selection layer is responsible for reconciling.
+        tracing::warn!(
+            path = %workspace_root.display(),
+            "workspace root missing; returning empty change list",
+        );
+        return Ok(Vec::new());
     }
 
     let target_ref = resolve_target_ref(workspace_root)?;
@@ -170,9 +185,19 @@ fn validate_workspace_relative_path(
     relative_path: &str,
 ) -> Result<(PathBuf, PathBuf)> {
     let workspace_root = PathBuf::from(workspace_root_path);
-    if !workspace_root.is_absolute() || !workspace_root.is_dir() {
+    if !workspace_root.is_absolute() {
         bail!(
-            "Workspace root is not a valid directory: {}",
+            "Workspace root must be an absolute path: {}",
+            workspace_root.display()
+        );
+    }
+    // Directory vanished (archived, deleted externally, repo moved). Tag
+    // the error so the frontend can offer "Permanently Delete" rather than
+    // a generic red toast with no recovery action.
+    if !workspace_root.is_dir() {
+        bail_coded!(
+            ErrorCode::WorkspaceBroken,
+            "Workspace directory is missing: {}",
             workspace_root.display()
         );
     }
@@ -191,11 +216,15 @@ fn validate_workspace_relative_path(
         bail!("Relative path must not contain parent traversal: {relative_path}");
     }
 
-    let canonical_root = workspace_root.canonicalize().with_context(|| {
-        format!(
-            "Failed to canonicalize workspace root: {}",
-            workspace_root.display()
-        )
+    let canonical_root = workspace_root.canonicalize().map_err(|error| {
+        // canonicalize only fails here if the directory was removed between
+        // the is_dir() check above and now (TOCTOU). Same recovery action.
+        anyhow::Error::new(error)
+            .context(format!(
+                "Failed to canonicalize workspace root: {}",
+                workspace_root.display()
+            ))
+            .with_code(ErrorCode::WorkspaceBroken)
     })?;
     let workspace_roots = allowed_workspace_roots()?;
     if !workspace_roots

--- a/src-tauri/src/workspace/files/editor.rs
+++ b/src-tauri/src/workspace/files/editor.rs
@@ -15,22 +15,31 @@ use super::{
         EditorFileWriteResponse, EditorFilesWithContentResponse,
     },
 };
+use crate::{
+    bail_coded,
+    error::{AnyhowCodedExt, ErrorCode},
+};
 
 const MAX_EDITOR_FILE_ITEMS: usize = 24;
 const MAX_PREFETCH_BYTES: u64 = 1_048_576;
 
-/// Read a file at a given git ref. Returns `None` when the path doesn't exist in that ref.
+/// Read a file at a given git ref. Returns `None` when the path doesn't
+/// exist in that ref, or when the workspace itself has vanished (e.g. the
+/// user deleted the worktree while an old diff view was still open).
 pub fn read_file_at_ref(
     workspace_root_path: &str,
     file_path: &str,
     git_ref: &str,
 ) -> Result<Option<String>> {
     let workspace_root = Path::new(workspace_root_path);
-    if !workspace_root.is_absolute() || !workspace_root.is_dir() {
+    if !workspace_root.is_absolute() {
         bail!(
-            "Workspace root is not a valid directory: {}",
+            "Workspace root must be an absolute path: {}",
             workspace_root.display()
         );
+    }
+    if !workspace_root.is_dir() {
+        return Ok(None);
     }
 
     let abs = Path::new(file_path);
@@ -47,9 +56,25 @@ pub fn read_file_at_ref(
 }
 
 pub fn read_editor_file(path: &str) -> Result<EditorFileReadResponse> {
-    let resolved_path = resolve_allowed_path(Path::new(path), true)?;
-    let metadata = fs::metadata(&resolved_path)
-        .with_context(|| format!("Failed to stat editor file {}", resolved_path.display()))?;
+    let resolved_path = resolve_allowed_path(Path::new(path), false)?;
+    let metadata = match fs::metadata(&resolved_path) {
+        Ok(metadata) => metadata,
+        // File or any parent component vanished after the open — treat as
+        // broken workspace so the frontend offers a recovery action rather
+        // than a bare "no such file" toast.
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Err(anyhow::Error::new(error)
+                .context(format!(
+                    "Editor file no longer exists: {}",
+                    resolved_path.display()
+                ))
+                .with_code(ErrorCode::WorkspaceBroken));
+        }
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("Failed to stat editor file {}", resolved_path.display()))
+        }
+    };
 
     if !metadata.is_file() {
         bail!("Editor target is not a file: {}", resolved_path.display());
@@ -72,9 +97,24 @@ pub fn read_editor_file(path: &str) -> Result<EditorFileReadResponse> {
 }
 
 pub fn write_editor_file(path: &str, content: &str) -> Result<EditorFileWriteResponse> {
-    let resolved_path = resolve_allowed_path(Path::new(path), true)?;
-    let metadata = fs::metadata(&resolved_path)
-        .with_context(|| format!("Failed to stat editor file {}", resolved_path.display()))?;
+    let resolved_path = resolve_allowed_path(Path::new(path), false)?;
+    let metadata = match fs::metadata(&resolved_path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            // Target file or parent dir vanished between open and save.
+            // Bail with a recoverable code; the editor should prompt to
+            // reload / save elsewhere rather than surface a plain error.
+            bail_coded!(
+                ErrorCode::WorkspaceBroken,
+                "Cannot save: {} no longer exists on disk",
+                resolved_path.display()
+            );
+        }
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("Failed to stat editor file {}", resolved_path.display()))
+        }
+    };
 
     if !metadata.is_file() {
         bail!("Editor target is not a file: {}", resolved_path.display());
@@ -119,7 +159,9 @@ pub fn stat_editor_file(path: &str) -> Result<EditorFileStatResponse> {
 }
 
 pub fn list_editor_files(workspace_root_path: &str) -> Result<Vec<EditorFileListItem>> {
-    let workspace_root = resolve_workspace_root(workspace_root_path)?;
+    let Some(workspace_root) = resolve_workspace_root_optional(workspace_root_path)? else {
+        return Ok(Vec::new());
+    };
     let mut discovered_files = Vec::<PathBuf>::new();
     collect_editor_files(&workspace_root, &workspace_root, &mut discovered_files)?;
     discovered_files.sort_by(|left, right| {
@@ -132,7 +174,9 @@ pub fn list_editor_files(workspace_root_path: &str) -> Result<Vec<EditorFileList
 }
 
 pub fn list_workspace_files(workspace_root_path: &str) -> Result<Vec<EditorFileListItem>> {
-    let workspace_root = resolve_workspace_root(workspace_root_path)?;
+    let Some(workspace_root) = resolve_workspace_root_optional(workspace_root_path)? else {
+        return Ok(Vec::new());
+    };
     let mut discovered_files = Vec::<PathBuf>::new();
     collect_workspace_files_for_mention(&workspace_root, &mut discovered_files)?;
     discovered_files.sort_by(|left, right| {
@@ -152,19 +196,26 @@ pub fn list_editor_files_with_content(
     Ok(EditorFilesWithContentResponse { items, prefetched })
 }
 
-fn resolve_workspace_root(workspace_root_path: &str) -> Result<PathBuf> {
-    let workspace_root = resolve_allowed_path(Path::new(workspace_root_path), true)?;
-    let metadata = fs::metadata(&workspace_root)
-        .with_context(|| format!("Failed to stat workspace root {}", workspace_root.display()))?;
-
-    if !metadata.is_dir() {
-        bail!(
-            "Workspace root is not a directory: {}",
-            workspace_root.display()
-        );
+/// Best-effort variant for read-only listers. Returns `None` if the
+/// workspace directory has vanished (deleted externally, archived, etc.)
+/// so callers surface an empty list instead of a red toast. Real errors
+/// (permission denied, path outside allowed roots, malformed arg) still
+/// propagate.
+fn resolve_workspace_root_optional(workspace_root_path: &str) -> Result<Option<PathBuf>> {
+    let workspace_root = resolve_allowed_path(Path::new(workspace_root_path), false)?;
+    match fs::metadata(&workspace_root) {
+        Ok(metadata) if metadata.is_dir() => Ok(Some(workspace_root)),
+        Ok(_) => Ok(None),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            tracing::warn!(
+                path = %workspace_root.display(),
+                "workspace root missing; returning empty file list",
+            );
+            Ok(None)
+        }
+        Err(error) => Err(error)
+            .with_context(|| format!("Failed to stat workspace root {}", workspace_root.display())),
     }
-
-    Ok(workspace_root)
 }
 
 fn build_list_items(

--- a/src-tauri/src/workspace/files/support.rs
+++ b/src-tauri/src/workspace/files/support.rs
@@ -25,14 +25,14 @@ pub(super) fn resolve_allowed_path(path: &Path, require_existing: bool) -> Resul
 
     let workspace_roots = allowed_workspace_roots()?;
 
-    if workspace_roots.is_empty() {
-        bail!("No workspace roots are available for in-app editing");
-    }
-
     if workspace_roots
         .iter()
         .any(|workspace_root| normalized_path.starts_with(workspace_root))
     {
+        return Ok(normalized_path);
+    }
+
+    if path_is_inside_known_workspace(path)? {
         return Ok(normalized_path);
     }
 
@@ -42,29 +42,58 @@ pub(super) fn resolve_allowed_path(path: &Path, require_existing: bool) -> Resul
     )
 }
 
+pub(super) fn path_is_inside_known_workspace(path: &Path) -> Result<bool> {
+    if !path.is_absolute() {
+        return Ok(false);
+    }
+    let normalized_path = canonicalize_missing_path(path)?;
+
+    for record in workspace_models::load_workspace_records()? {
+        let Ok(workspace_dir) =
+            crate::data_dir::workspace_dir(&record.repo_name, &record.directory_name)
+        else {
+            continue;
+        };
+        let Ok(normalized_root) = canonicalize_missing_path(&workspace_dir) else {
+            continue;
+        };
+        if normalized_path.starts_with(normalized_root) {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
 pub(super) fn allowed_workspace_roots() -> Result<Vec<PathBuf>> {
     let mut workspace_roots = Vec::new();
 
     for record in workspace_models::load_workspace_records()? {
-        let workspace_dir =
+        let Ok(workspace_dir) =
             crate::data_dir::workspace_dir(&record.repo_name, &record.directory_name)
-                .with_context(|| {
-                    format!(
-                        "Failed to resolve workspace directory for {}/{}",
-                        record.repo_name, record.directory_name
-                    )
-                })?;
+        else {
+            // Malformed repo/directory name — skip rather than nuke the whole
+            // picker. Not user-actionable.
+            continue;
+        };
 
         if !workspace_dir.is_dir() {
             continue;
         }
 
-        workspace_roots.push(workspace_dir.canonicalize().with_context(|| {
-            format!(
-                "Failed to resolve workspace root {}",
-                workspace_dir.display()
-            )
-        })?);
+        // canonicalize can fail if a parent component vanishes mid-iteration
+        // (symlink chain broken, etc.). One broken workspace must not take
+        // the whole picker down — skip and keep going.
+        match workspace_dir.canonicalize() {
+            Ok(path) => workspace_roots.push(path),
+            Err(error) => {
+                tracing::warn!(
+                    path = %workspace_dir.display(),
+                    error = %error,
+                    "skipping unresolvable workspace root",
+                );
+            }
+        }
     }
 
     workspace_roots.sort();
@@ -83,13 +112,28 @@ pub(super) fn collect_workspace_files_for_mention(
         return Ok(());
     }
 
-    let mut entries = fs::read_dir(current_dir)
-        .with_context(|| {
-            format!(
-                "Failed to read workspace directory {}",
-                current_dir.display()
-            )
-        })?
+    let read_dir = match fs::read_dir(current_dir) {
+        Ok(iter) => iter,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            // Subdir vanished between walk start and descent (git checkout,
+            // rm -rf, etc.). Skip silently rather than aborting the whole
+            // walk — one missing dir shouldn't break the @-mention picker.
+            tracing::warn!(
+                path = %current_dir.display(),
+                "skipping missing workspace subdir during mention walk",
+            );
+            return Ok(());
+        }
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!(
+                    "Failed to read workspace directory {}",
+                    current_dir.display()
+                )
+            })
+        }
+    };
+    let mut entries = read_dir
         .collect::<std::result::Result<Vec<_>, _>>()
         .with_context(|| {
             format!(
@@ -258,13 +302,25 @@ pub(super) fn collect_editor_files(
         return Ok(());
     }
 
-    let mut entries = fs::read_dir(current_dir)
-        .with_context(|| {
-            format!(
-                "Failed to read workspace directory {}",
-                current_dir.display()
-            )
-        })?
+    let read_dir = match fs::read_dir(current_dir) {
+        Ok(iter) => iter,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            tracing::warn!(
+                path = %current_dir.display(),
+                "skipping missing workspace subdir during editor walk",
+            );
+            return Ok(());
+        }
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!(
+                    "Failed to read workspace directory {}",
+                    current_dir.display()
+                )
+            })
+        }
+    };
+    let mut entries = read_dir
         .collect::<std::result::Result<Vec<_>, _>>()
         .with_context(|| {
             format!(

--- a/src-tauri/src/workspace/files/tests/editor_files.rs
+++ b/src-tauri/src/workspace/files/tests/editor_files.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use crate::data_dir::TEST_ENV_LOCK as TEST_LOCK;
+use crate::error::{extract_code, ErrorCode};
 
 use super::{
     canonicalize_missing_path, list_editor_files, list_workspace_files, read_editor_file,
@@ -82,6 +83,31 @@ fn list_editor_files_returns_existing_workspace_files() {
     assert!(files
         .iter()
         .all(|file| Path::new(&file.absolute_path).is_file()));
+}
+
+#[test]
+fn list_editor_files_returns_empty_when_workspace_root_is_missing() {
+    let _lock = TEST_LOCK.lock().unwrap_or_else(|error| error.into_inner());
+    let harness = EditorFilesHarness::new();
+    fs::remove_dir_all(&harness.workspace_dir).unwrap();
+
+    let files = list_editor_files(harness.workspace_dir.to_str().unwrap()).unwrap();
+
+    assert!(files.is_empty());
+}
+
+#[test]
+fn read_editor_file_marks_missing_workspace_as_broken() {
+    let _lock = TEST_LOCK.lock().unwrap_or_else(|error| error.into_inner());
+    let harness = EditorFilesHarness::new();
+    let file = harness.workspace_dir.join("src").join("App.tsx");
+    fs::create_dir_all(file.parent().unwrap()).unwrap();
+    fs::write(&file, "export const app = true;\n").unwrap();
+    fs::remove_dir_all(&harness.workspace_dir).unwrap();
+
+    let error = read_editor_file(file.to_str().unwrap()).unwrap_err();
+
+    assert_eq!(extract_code(&error), ErrorCode::WorkspaceBroken);
 }
 
 #[test]

--- a/src-tauri/src/workspace/lifecycle.rs
+++ b/src-tauri/src/workspace/lifecycle.rs
@@ -28,6 +28,7 @@ pub struct RestoreWorkspaceResponse {
     /// suffixed branch instead. The frontend uses this to surface an
     /// informational toast so the rename never happens silently.
     pub branch_rename: Option<BranchRename>,
+    pub restored_from_target_branch: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -588,7 +589,9 @@ pub fn execute_archive_plan(plan: &ArchivePreparedPlan) -> Result<ArchiveWorkspa
 struct RestorePreflightData {
     repo_root: PathBuf,
     branch: String,
-    archive_commit: String,
+    archive_commit: Option<String>,
+    target_branch: String,
+    remote: String,
     workspace_dir: PathBuf,
 }
 
@@ -607,18 +610,25 @@ fn restore_workspace_preflight(workspace_id: &str) -> Result<RestorePreflightDat
     let branch = helpers::non_empty(&record.branch)
         .map(ToOwned::to_owned)
         .with_context(|| format!("Workspace {workspace_id} is missing branch"))?;
-    let archive_commit = helpers::non_empty(&record.archive_commit)
-        .map(ToOwned::to_owned)
-        .with_context(|| format!("Workspace {workspace_id} is missing archive_commit"))?;
+    let archive_commit = helpers::non_empty(&record.archive_commit).map(ToOwned::to_owned);
+    let target_branch = helpers::non_empty(&record.intended_target_branch)
+        .or_else(|| helpers::non_empty(&record.default_branch))
+        .unwrap_or("main")
+        .to_string();
+    let remote = record.remote.unwrap_or_else(|| "origin".to_string());
 
     let workspace_dir = crate::data_dir::workspace_dir(&record.repo_name, &record.directory_name)?;
     git_ops::ensure_git_repository(&repo_root)?;
-    git_ops::verify_commit_exists(&repo_root, &archive_commit)?;
+    if let Some(archive_commit) = archive_commit.as_deref() {
+        git_ops::verify_commit_exists(&repo_root, archive_commit)?;
+    }
 
     Ok(RestorePreflightData {
         repo_root,
         branch,
         archive_commit,
+        target_branch,
+        remote,
         workspace_dir,
     })
 }
@@ -671,8 +681,13 @@ pub fn restore_workspace_impl(
         repo_root,
         branch,
         archive_commit,
+        target_branch: stored_target_branch,
+        remote,
         workspace_dir,
     } = restore_workspace_preflight(workspace_id)?;
+    let target_branch = target_branch_override
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or(stored_target_branch.as_str());
 
     if workspace_dir.exists() {
         std::fs::remove_dir_all(&workspace_dir).with_context(|| {
@@ -709,13 +724,22 @@ pub fn restore_workspace_impl(
         branch.clone()
     };
 
-    git_ops::verify_commit_exists(&repo_root, &archive_commit).with_context(|| {
-        format!(
-            "Archive commit {archive_commit} no longer exists in {} \
-             (likely garbage-collected). Cannot restore.",
-            repo_root.display()
-        )
-    })?;
+    let (start_point, restored_from_target_branch) = match archive_commit.as_deref() {
+        Some(commit) => {
+            git_ops::verify_commit_exists(&repo_root, commit).with_context(|| {
+                format!(
+                    "Archive commit {commit} no longer exists in {} \
+                     (likely garbage-collected). Cannot restore.",
+                    repo_root.display()
+                )
+            })?;
+            (commit.to_string(), None)
+        }
+        None => (
+            resolve_restore_target_start_point(&repo_root, &remote, target_branch)?,
+            Some(target_branch.to_string()),
+        ),
+    };
 
     git_ops::run_git(
         [
@@ -723,11 +747,21 @@ pub fn restore_workspace_impl(
             &repo_root.display().to_string(),
             "branch",
             &actual_branch,
-            &archive_commit,
+            &start_point,
         ],
         None,
     )
-    .with_context(|| format!("Failed to create branch {actual_branch} from {archive_commit}"))?;
+    .with_context(|| format!("Failed to create branch {actual_branch} from {start_point}"))?;
+    let _ = git_ops::run_git(
+        [
+            "-C",
+            &repo_root.display().to_string(),
+            "branch",
+            "--unset-upstream",
+            &actual_branch,
+        ],
+        None,
+    );
 
     git_ops::create_worktree(&repo_root, &workspace_dir, &actual_branch)?;
 
@@ -767,7 +801,26 @@ pub fn restore_workspace_impl(
         restored_state: WorkspaceState::Ready,
         selected_workspace_id: workspace_id.to_string(),
         branch_rename,
+        restored_from_target_branch,
     })
+}
+
+fn resolve_restore_target_start_point(
+    repo_root: &Path,
+    remote: &str,
+    target_branch: &str,
+) -> Result<String> {
+    if git_ops::verify_branch_exists(repo_root, target_branch).is_ok() {
+        return Ok(target_branch.to_string());
+    }
+
+    if git_ops::verify_remote_ref_exists(repo_root, remote, target_branch)? {
+        return Ok(format!("{remote}/{target_branch}"));
+    }
+
+    bail!(
+        "Cannot restore workspace without an archive commit: target branch {target_branch} was not found"
+    );
 }
 
 fn cleanup_failed_created_workspace(

--- a/src-tauri/src/workspace/workspaces.rs
+++ b/src-tauri/src/workspace/workspaces.rs
@@ -704,23 +704,31 @@ pub fn record_to_detail(record: WorkspaceRecord) -> WorkspaceDetail {
     }
 }
 
-/// Remove DB records for workspaces whose directory no longer exists on disk.
+/// Degrade operational workspaces whose directory no longer exists on disk
+/// to the `archived` state — preserving all chat history (sessions +
+/// session_messages) so the user can still find their conversations.
 ///
-/// Called once at startup so that externally-deleted directories don't cause
-/// repeated errors (e.g. git-status polling a missing path every 10 s).
+/// Called once at startup so that externally-deleted directories don't
+/// cause repeated errors (e.g. git-status polling a missing path every
+/// 10 s). The legacy behavior here was `permanently_delete_workspace`,
+/// which silently destroyed `session_messages` rows — never acceptable:
+/// a user may have rm -rf'd the worktree but still wants the chat history.
 ///
-/// Archived workspaces are excluded — their worktree is intentionally gone and
-/// the archived DB row must be preserved.
+/// Archived rows are never touched (the worktree being gone is by design
+/// for those; their state is already correct).
+///
+/// Returns the number of workspaces that were degraded.
 pub fn purge_orphaned_workspaces() -> Result<usize> {
     let connection = db::read_conn()?;
-    let mut stmt = connection.prepare(
+    let mut stmt = connection.prepare(&format!(
         "SELECT w.id, r.name, w.directory_name, w.state
          FROM workspaces w
          JOIN repos r ON r.id = w.repository_id
-         WHERE w.state != ?1",
-    )?;
+         WHERE w.state {}",
+        crate::workspace_state::OPERATIONAL_FILTER
+    ))?;
     let orphans: Vec<(String, String, String, WorkspaceState)> = stmt
-        .query_map([WorkspaceState::Archived], |row| {
+        .query_map([], |row| {
             Ok((
                 row.get::<_, String>(0)?,
                 row.get::<_, String>(1)?,
@@ -735,30 +743,65 @@ pub fn purge_orphaned_workspaces() -> Result<usize> {
                 .unwrap_or(false)
         })
         .collect();
+    // Release the read connection so `degrade_workspace_to_archived`
+    // (which takes a write conn) doesn't deadlock on SQLite.
+    drop(stmt);
+    drop(connection);
 
     let mut count = 0;
     for (id, repo_name, dir_name, state) in &orphans {
-        // Defense in depth: even if the SQL filter ever regresses, never purge
-        // an archived workspace (the worktree being gone is by design).
+        // Defense in depth: even if the SQL filter ever regresses, never
+        // re-archive something that's already archived.
         if *state == WorkspaceState::Archived {
             tracing::warn!(
                 workspace_id = %id,
-                "Skipping archived workspace in orphan purge"
+                "Skipping archived workspace in orphan reconcile"
             );
             continue;
         }
-        if let Err(e) = permanently_delete_workspace(id) {
-            tracing::warn!(workspace_id = %id, "Failed to purge orphaned workspace: {e:#}");
-        } else {
-            count += 1;
-            tracing::info!(
-                workspace_id = %id,
-                path = %format!("{}/{}", repo_name, dir_name),
-                "Purged orphaned workspace (directory missing)"
-            );
+        match degrade_workspace_to_archived(id) {
+            Ok(true) => {
+                count += 1;
+                tracing::info!(
+                    workspace_id = %id,
+                    path = %format!("{}/{}", repo_name, dir_name),
+                    "Degraded orphaned workspace to archived (directory missing; chat history preserved)"
+                );
+            }
+            Ok(false) => {
+                // Another thread got there first (already archived).
+            }
+            Err(e) => {
+                tracing::warn!(
+                    workspace_id = %id,
+                    "Failed to degrade orphaned workspace: {e:#}"
+                );
+            }
         }
     }
     Ok(count)
+}
+
+/// Flip a single workspace row from its current operational state to
+/// `archived`, without touching sessions / session_messages. Used by
+/// [`purge_orphaned_workspaces`] to reconcile workspaces whose worktree
+/// vanished externally. Idempotent: returns `Ok(false)` if the row is
+/// not operational or doesn't exist.
+pub fn degrade_workspace_to_archived(workspace_id: &str) -> Result<bool> {
+    let connection = db::write_conn()?;
+    let rows = connection
+        .execute(
+            &format!(
+                "UPDATE workspaces
+             SET state = 'archived',
+                 updated_at = datetime('now')
+             WHERE id = ?1 AND state {}",
+                crate::workspace_state::OPERATIONAL_FILTER
+            ),
+            [workspace_id],
+        )
+        .context("Failed to degrade workspace to archived")?;
+    Ok(rows > 0)
 }
 
 /// Permanently delete a workspace and all its data (sessions, messages)
@@ -835,6 +878,26 @@ mod tests {
             .unwrap() as usize
     }
 
+    fn workspace_state(env: &TestEnv, id: &str) -> Option<String> {
+        env.db_connection()
+            .query_row("SELECT state FROM workspaces WHERE id = ?1", [id], |row| {
+                row.get::<_, String>(0)
+            })
+            .ok()
+    }
+
+    fn count_session_messages(env: &TestEnv, workspace_id: &str) -> i64 {
+        env.db_connection()
+            .query_row(
+                "SELECT COUNT(*) FROM session_messages sm
+                 JOIN sessions s ON s.id = sm.session_id
+                 WHERE s.workspace_id = ?1",
+                [workspace_id],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap()
+    }
+
     #[test]
     fn purge_skips_archived_even_when_worktree_missing() {
         let env = TestEnv::new("purge-archived");
@@ -854,12 +917,16 @@ mod tests {
 
         let purged = purge_orphaned_workspaces().unwrap();
 
-        assert_eq!(purged, 0, "archived workspace must not be purged");
+        assert_eq!(purged, 0, "archived workspace must not be re-archived");
         assert_eq!(count_workspaces(&env), 1, "DB row must remain");
+        assert_eq!(
+            workspace_state(&env, "w-archived").as_deref(),
+            Some("archived")
+        );
     }
 
     #[test]
-    fn purge_removes_ready_workspace_with_missing_dir() {
+    fn purge_degrades_ready_workspace_with_missing_dir_to_archived() {
         let env = TestEnv::new("purge-ready");
         let conn = env.db_connection();
         insert_repo(&conn, "r1", "demo", None);
@@ -874,12 +941,67 @@ mod tests {
                 intended_target_branch: None,
             },
         );
+        // Simulate a session with chat history so we can verify it survives.
+        conn.execute(
+            "INSERT INTO sessions (id, workspace_id, status, title) VALUES ('s1', 'w-ready', 'idle', 'Test')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO session_messages (id, session_id, sent_at, content) VALUES ('m1', 's1', datetime('now'), '{}')",
+            [],
+        )
+        .unwrap();
+        assert_eq!(count_session_messages(&env, "w-ready"), 1);
         // No worktree dir created — simulates external deletion.
 
-        let purged = purge_orphaned_workspaces().unwrap();
+        let degraded = purge_orphaned_workspaces().unwrap();
 
-        assert_eq!(purged, 1, "ready workspace with missing dir must be purged");
-        assert_eq!(count_workspaces(&env), 0);
+        assert_eq!(
+            degraded, 1,
+            "ready workspace with missing dir must be degraded"
+        );
+        assert_eq!(
+            count_workspaces(&env),
+            1,
+            "DB row must be preserved, not deleted"
+        );
+        assert_eq!(
+            workspace_state(&env, "w-ready").as_deref(),
+            Some("archived"),
+            "state must flip to archived"
+        );
+        assert_eq!(
+            count_session_messages(&env, "w-ready"),
+            1,
+            "chat history must survive the degrade",
+        );
+    }
+
+    #[test]
+    fn purge_does_not_degrade_initializing_workspace_with_missing_dir() {
+        let env = TestEnv::new("purge-initializing");
+        let conn = env.db_connection();
+        insert_repo(&conn, "r1", "demo", None);
+        insert_workspace(
+            &conn,
+            &WorkspaceFixture {
+                id: "w-initializing",
+                repo_id: "r1",
+                directory_name: "delta",
+                state: WorkspaceState::Initializing.as_str(),
+                branch: Some("feature/delta"),
+                intended_target_branch: None,
+            },
+        );
+
+        let degraded = purge_orphaned_workspaces().unwrap();
+
+        assert_eq!(degraded, 0);
+        assert_eq!(
+            workspace_state(&env, "w-initializing").as_deref(),
+            Some("initializing"),
+        );
     }
 
     #[test]
@@ -905,5 +1027,6 @@ mod tests {
 
         assert_eq!(purged, 0);
         assert_eq!(count_workspaces(&env), 1);
+        assert_eq!(workspace_state(&env, "w-live").as_deref(), Some("ready"));
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -695,7 +695,10 @@ function AppShell({
 	// button's mode derivation — shared cache with inspector's actions.tsx.
 	const workspacePrActionStatusQuery = useQuery({
 		...workspacePrActionStatusQueryOptions(selectedWorkspaceId ?? "__none__"),
-		enabled: isIdentityConnected && selectedWorkspaceId !== null,
+		enabled:
+			isIdentityConnected &&
+			selectedWorkspaceId !== null &&
+			selectedWorkspaceDetail?.state !== "archived",
 	});
 	const workspacePrActionStatus = workspacePrActionStatusQuery.data ?? null;
 

--- a/src/features/conversation/hooks/use-streaming.ts
+++ b/src/features/conversation/hooks/use-streaming.ts
@@ -30,6 +30,7 @@ import {
 	stopAgentStream,
 } from "@/lib/api";
 import type { ComposerCustomTag } from "@/lib/composer-insert";
+import { extractError, isRecoverableByPurge } from "@/lib/errors";
 import {
 	agentModelSectionsQueryOptions,
 	helmorQueryKeys,
@@ -47,6 +48,7 @@ import {
 } from "@/lib/session-thread-cache";
 import type { FollowUpBehavior } from "@/lib/settings";
 import type { SubmitQueueApi } from "@/lib/use-submit-queue";
+import { showWorkspaceBrokenToast } from "@/lib/workspace-broken-toast";
 import {
 	createLiveThreadMessage,
 	findModelOption,
@@ -939,7 +941,17 @@ export function useConversationStreaming({
 				);
 			} catch (error) {
 				console.error("[conversation] deferred tool response:", error);
-				const errorMsg = error instanceof Error ? error.message : String(error);
+				const { code, message: errorMsg } = extractError(
+					error,
+					"Failed to resume agent stream.",
+				);
+				if (isRecoverableByPurge(code) && displayedWorkspaceId) {
+					showWorkspaceBrokenToast({
+						workspaceId: displayedWorkspaceId,
+						pushToast,
+						queryClient,
+					});
+				}
 				setPendingDeferredByContext((current) => ({
 					...current,
 					[contextKey]: deferred,
@@ -1463,7 +1475,17 @@ export function useConversationStreaming({
 				);
 			} catch (error) {
 				console.error("[conversation] invoke error:", error);
-				const errorMsg = error instanceof Error ? error.message : String(error);
+				const { code, message: errorMsg } = extractError(
+					error,
+					"Failed to send message.",
+				);
+				if (isRecoverableByPurge(code) && displayedWorkspaceId) {
+					showWorkspaceBrokenToast({
+						workspaceId: displayedWorkspaceId,
+						pushToast,
+						queryClient,
+					});
+				}
 				setSendErrorsByContext((current) => ({
 					...current,
 					[contextKey]: errorMsg,

--- a/src/features/inspector/index.tsx
+++ b/src/features/inspector/index.tsx
@@ -164,6 +164,7 @@ export function WorkspaceInspectorSidebar({
 
 			<ActionsSection
 				workspaceId={workspaceId ?? null}
+				workspaceState={workspaceState ?? null}
 				repoId={repoId ?? null}
 				workspaceRemote={workspaceRemote ?? null}
 				sectionRef={actionsRef}

--- a/src/features/inspector/sections/actions.tsx
+++ b/src/features/inspector/sections/actions.tsx
@@ -93,6 +93,7 @@ const EMPTY_PR_ACTION_STATUS: WorkspacePrActionStatus = {
 
 type ActionsSectionProps = {
 	workspaceId: string | null;
+	workspaceState?: string | null;
 	repoId?: string | null;
 	workspaceRemote?: string | null;
 	sectionRef?: React.RefObject<HTMLElement | null>;
@@ -139,6 +140,7 @@ function buildSyncResolutionPrompt(
 
 export function ActionsSection({
 	workspaceId,
+	workspaceState,
 	repoId,
 	workspaceRemote,
 	sectionRef,
@@ -153,13 +155,16 @@ export function ActionsSection({
 }: ActionsSectionProps) {
 	const queryClient = useQueryClient();
 	const [syncPending, setSyncPending] = useState(false);
+	// Archived workspaces have no live worktree — polling git/PR status every
+	// 10s would spam errors. App.tsx mirrors this guard.
+	const isArchived = workspaceState === "archived";
 	const gitStatusQuery = useQuery({
 		...workspaceGitActionStatusQueryOptions(workspaceId ?? "__none__"),
-		enabled: workspaceId !== null,
+		enabled: workspaceId !== null && !isArchived,
 	});
 	const prStatusQuery = useQuery({
 		...workspacePrActionStatusQueryOptions(workspaceId ?? "__none__"),
-		enabled: workspaceId !== null,
+		enabled: workspaceId !== null && !isArchived,
 	});
 	const gitStatus = gitStatusQuery.data ?? EMPTY_GIT_ACTION_STATUS;
 	const prStatus = prStatusQuery.data ?? EMPTY_PR_ACTION_STATUS;

--- a/src/features/inspector/sections/changes.tsx
+++ b/src/features/inspector/sections/changes.tsx
@@ -32,8 +32,11 @@ import {
 	unstageWorkspaceFile,
 } from "@/lib/api";
 import type { DiffOpenOptions, InspectorFileItem } from "@/lib/editor-session";
+import { extractError, isRecoverableByPurge } from "@/lib/errors";
 import { helmorQueryKeys } from "@/lib/query-client";
 import { cn } from "@/lib/utils";
+import { showWorkspaceBrokenToast } from "@/lib/workspace-broken-toast";
+import { useWorkspaceToast } from "@/lib/workspace-toast-context";
 import { GitSectionHeader } from "./git-section-header";
 
 const STATUS_COLORS: Record<InspectorFileItem["status"], string> = {
@@ -155,6 +158,28 @@ export function ChangesSection({
 		}
 	}, [queryClient, workspaceId, workspaceRootPath]);
 
+	const pushToast = useWorkspaceToast();
+	// Surface backend mutation failures (which used to be silently
+	// swallowed). If the workspace is broken, show a persistent toast
+	// with "Permanently Delete" — never auto-deletes. Dismiss preserves
+	// the chat history (the startup reconcile has archived the row so
+	// the user can still find it).
+	const surfaceChangeError = useCallback(
+		(action: string, error: unknown) => {
+			const { code, message } = extractError(error, `Failed to ${action}.`);
+			if (isRecoverableByPurge(code) && workspaceId) {
+				showWorkspaceBrokenToast({
+					workspaceId,
+					pushToast,
+					queryClient,
+				});
+				return;
+			}
+			pushToast(message, `Unable to ${action}`, "destructive");
+		},
+		[pushToast, queryClient, workspaceId],
+	);
+
 	const stageFile = useCallback(
 		async (relativePath: string) => {
 			if (!workspaceRootPath) {
@@ -162,11 +187,13 @@ export function ChangesSection({
 			}
 			try {
 				await stageWorkspaceFile(workspaceRootPath, relativePath);
+			} catch (error) {
+				surfaceChangeError("stage file", error);
 			} finally {
 				invalidateChanges();
 			}
 		},
-		[invalidateChanges, workspaceRootPath],
+		[invalidateChanges, surfaceChangeError, workspaceRootPath],
 	);
 	const unstageFile = useCallback(
 		async (relativePath: string) => {
@@ -175,11 +202,13 @@ export function ChangesSection({
 			}
 			try {
 				await unstageWorkspaceFile(workspaceRootPath, relativePath);
+			} catch (error) {
+				surfaceChangeError("unstage file", error);
 			} finally {
 				invalidateChanges();
 			}
 		},
-		[invalidateChanges, workspaceRootPath],
+		[invalidateChanges, surfaceChangeError, workspaceRootPath],
 	);
 	const stageAll = useCallback(async () => {
 		if (!workspaceRootPath) {
@@ -190,10 +219,17 @@ export function ChangesSection({
 			for (const path of paths) {
 				await stageWorkspaceFile(workspaceRootPath, path);
 			}
+		} catch (error) {
+			surfaceChangeError("stage files", error);
 		} finally {
 			invalidateChanges();
 		}
-	}, [invalidateChanges, unstagedChanges, workspaceRootPath]);
+	}, [
+		invalidateChanges,
+		surfaceChangeError,
+		unstagedChanges,
+		workspaceRootPath,
+	]);
 	const unstageAll = useCallback(async () => {
 		if (!workspaceRootPath) {
 			return;
@@ -203,10 +239,12 @@ export function ChangesSection({
 			for (const path of paths) {
 				await unstageWorkspaceFile(workspaceRootPath, path);
 			}
+		} catch (error) {
+			surfaceChangeError("unstage files", error);
 		} finally {
 			invalidateChanges();
 		}
-	}, [invalidateChanges, stagedChanges, workspaceRootPath]);
+	}, [invalidateChanges, stagedChanges, surfaceChangeError, workspaceRootPath]);
 
 	const discardFile = useCallback(
 		async (relativePath: string) => {
@@ -215,11 +253,13 @@ export function ChangesSection({
 			}
 			try {
 				await discardWorkspaceFile(workspaceRootPath, relativePath);
+			} catch (error) {
+				surfaceChangeError("discard changes", error);
 			} finally {
 				invalidateChanges();
 			}
 		},
-		[invalidateChanges, workspaceRootPath],
+		[invalidateChanges, surfaceChangeError, workspaceRootPath],
 	);
 
 	const handleCommitButtonClick = useCallback(async () => {

--- a/src/features/navigation/hooks/use-controller.test.tsx
+++ b/src/features/navigation/hooks/use-controller.test.tsx
@@ -264,6 +264,7 @@ describe("useWorkspacesSidebarController archive flow", () => {
 			restoredState: "ready",
 			selectedWorkspaceId: "ws-1",
 			branchRename: null,
+			restoredFromTargetBranch: null,
 		});
 	});
 

--- a/src/features/navigation/hooks/use-controller.ts
+++ b/src/features/navigation/hooks/use-controller.ts
@@ -385,6 +385,13 @@ export function useWorkspacesSidebarController({
 			return;
 		}
 
+		// Only restore archived workspaces if they were the live selection
+		// (runtime state). Never auto-restore archived from persisted
+		// `lastWorkspaceId` — the directory may be gone, which would spam
+		// git/editor errors on every poll. Fall through to an active group.
+		const isInActiveGroups = (id: string) =>
+			groups.some((group) => group.rows.some((row) => row.id === id));
+
 		let nextWorkspaceId: string | null;
 		if (
 			selectedWorkspaceId &&
@@ -393,7 +400,7 @@ export function useWorkspacesSidebarController({
 			nextWorkspaceId = selectedWorkspaceId;
 		} else if (
 			settings.lastWorkspaceId &&
-			hasWorkspaceId(settings.lastWorkspaceId, groups, archivedSummaries)
+			isInActiveGroups(settings.lastWorkspaceId)
 		) {
 			nextWorkspaceId = settings.lastWorkspaceId;
 		} else {
@@ -1122,6 +1129,20 @@ export function useWorkspacesSidebarController({
 		[handleDeleteWorkspace, pushWorkspaceToast],
 	);
 
+	const notifyTargetBranchRestore = useCallback(
+		(targetBranch: string | null) => {
+			if (!targetBranch) {
+				return;
+			}
+			pushWorkspaceToast(
+				`No archive commit was available, so the workspace was restored from "${targetBranch}".`,
+				"Restored from target branch",
+				"default",
+			);
+		},
+		[pushWorkspaceToast],
+	);
+
 	// Keep the forward-ref used by `pushWorkspaceErrorToast` in sync.
 	useEffect(() => {
 		handleDeleteWorkspaceRef.current = handleDeleteWorkspace;
@@ -1307,6 +1328,7 @@ export function useWorkspacesSidebarController({
 					.then((response) => {
 						prefetchWorkspace(workspaceId);
 						onSelectWorkspace(workspaceId);
+						notifyTargetBranchRestore(response.restoredFromTargetBranch);
 						if (response.branchRename) {
 							notifyBranchRename(response.branchRename);
 						}
@@ -1373,6 +1395,7 @@ export function useWorkspacesSidebarController({
 					if (response.branchRename) {
 						notifyBranchRename(response.branchRename);
 					}
+					notifyTargetBranchRestore(response.restoredFromTargetBranch);
 				})
 				.catch((error) => {
 					queryClient.setQueryData(
@@ -1396,6 +1419,7 @@ export function useWorkspacesSidebarController({
 			beginSidebarMutation,
 			endSidebarMutation,
 			notifyBranchRename,
+			notifyTargetBranchRestore,
 			onSelectWorkspace,
 			pendingCreations,
 			prefetchWorkspace,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -306,6 +306,7 @@ export type RestoreWorkspaceResponse = {
 	 * instead. The frontend uses this to surface an informational toast so
 	 * the rename never happens silently. */
 	branchRename: { original: string; actual: string } | null;
+	restoredFromTargetBranch: string | null;
 };
 
 export type ArchiveWorkspaceResponse = {

--- a/src/lib/workspace-broken-toast.ts
+++ b/src/lib/workspace-broken-toast.ts
@@ -1,0 +1,67 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { permanentlyDeleteWorkspace } from "@/lib/api";
+import { extractError } from "@/lib/errors";
+import { helmorQueryKeys } from "@/lib/query-client";
+import type { PushWorkspaceToast } from "@/lib/workspace-toast-context";
+
+type ShowWorkspaceBrokenToastArgs = {
+	workspaceId: string;
+	pushToast: PushWorkspaceToast;
+	queryClient: QueryClient;
+	description?: string;
+};
+
+/**
+ * Pop a persistent, destructive toast for a workspace whose directory has
+ * vanished on disk. The default action is "Dismiss" (chat history stays
+ * in the archive list); the explicit "Permanently Delete" action nukes
+ * the DB row + messages only after the user confirms. Never auto-deletes.
+ *
+ * Shared between inspector mutation failures and send-message failures so
+ * the recovery UX is identical wherever `ErrorCode::WorkspaceBroken`
+ * surfaces.
+ */
+export function showWorkspaceBrokenToast({
+	workspaceId,
+	pushToast,
+	queryClient,
+	description,
+}: ShowWorkspaceBrokenToastArgs): void {
+	pushToast(
+		description ??
+			"The chat history is preserved in the archive. Permanently delete to remove it for good.",
+		"Workspace directory is missing",
+		"destructive",
+		{
+			persistent: true,
+			action: {
+				label: "Permanently Delete",
+				destructive: true,
+				onClick: () => {
+					void permanentlyDeleteWorkspace(workspaceId)
+						.then(() => {
+							void queryClient.invalidateQueries({
+								queryKey: helmorQueryKeys.workspaceGroups,
+							});
+							void queryClient.invalidateQueries({
+								queryKey: helmorQueryKeys.archivedWorkspaces,
+							});
+							void queryClient.removeQueries({
+								queryKey: helmorQueryKeys.workspaceDetail(workspaceId),
+							});
+							void queryClient.removeQueries({
+								queryKey: helmorQueryKeys.workspaceSessions(workspaceId),
+							});
+						})
+						.catch((error) => {
+							const { message } = extractError(
+								error,
+								"Failed to delete workspace.",
+							);
+							pushToast(message, "Unable to delete workspace", "destructive");
+						});
+				},
+			},
+		},
+	);
+}


### PR DESCRIPTION
## What changed
- Preserve chat history when a workspace directory disappears by archiving the workspace record instead of permanently deleting it.
- Return quieter file/git status results for missing worktrees and surface a persistent recovery toast with an explicit permanent-delete action where needed.
- Allow archived workspaces without an archive commit to restore from the target branch and notify the user about that fallback.

## Why
Externally deleted worktree directories could previously trigger repeated backend/UI errors and, during startup reconciliation, remove workspace records and chat history. This keeps history recoverable while still giving users a clear cleanup path.

## Tests
- Pre-commit hook passed: Biome, cargo fmt, and cargo clippy with `-D warnings`.
- Added/updated Rust and frontend tests for missing worktree handling and restore response shape.