### PR TITLE
fix: make context usage model-aware

### DIFF
--- a/.changeset/model-aware-context-usage.md
+++ b/.changeset/model-aware-context-usage.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Make the composer context-usage percentage model-aware so it does not show stale or misleading window percentages after model switches or mixed Claude model usage.

--- a/sidecar/src/claude-session-manager.ts
+++ b/sidecar/src/claude-session-manager.ts
@@ -602,7 +602,7 @@ export class ClaudeSessionManager implements SessionManager {
 					// Bail on the first one we see; any steer() still in its
 					// image-load await will find `promptSource.closed` via
 					// the finally block below and return false.
-					const meta = buildClaudeStoredMeta(message);
+					const meta = buildClaudeStoredMeta(message, model ?? "");
 					if (meta) {
 						emitter.contextUsageUpdated(
 							requestId,
@@ -1036,7 +1036,7 @@ export class ClaudeSessionManager implements SessionManager {
 		const live = this.sessions.get(helmorSessionId);
 		if (live) {
 			const raw = await live.query.getContextUsage();
-			return JSON.stringify(buildClaudeRichMeta(raw));
+			return JSON.stringify(buildClaudeRichMeta(raw, model));
 		}
 
 		// Slow path: spawn a transient Query. `resume` is optional — when
@@ -1095,7 +1095,7 @@ export class ClaudeSessionManager implements SessionManager {
 
 		try {
 			const raw = await q.getContextUsage();
-			return JSON.stringify(buildClaudeRichMeta(raw));
+			return JSON.stringify(buildClaudeRichMeta(raw, model));
 		} catch (err) {
 			if (timedOut) {
 				throw new Error(

--- a/sidecar/src/codex-app-server-manager.ts
+++ b/sidecar/src/codex-app-server-manager.ts
@@ -99,6 +99,8 @@ interface AppServerContext {
 	 *  the frontend pipeline/UI until after the synthetic user_prompt
 	 *  event lands. Microtask FIFO preserves their relative ordering. */
 	notificationGate: Promise<void> | null;
+	/** Last send's model id; Codex usage notifications omit it. */
+	lastSentModel: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -232,6 +234,8 @@ export class CodexAppServerManager implements SessionManager {
 			permissionMode,
 			effectiveFastMode,
 		);
+		// Codex usage notifications do not include a model id.
+		if (model) ctx.lastSentModel = model;
 
 		// Codex, unlike Claude, has no `additionalDirectoriesForClaudeMd`
 		// equivalent — `sandboxPolicy.writableRoots` only grants write
@@ -339,7 +343,7 @@ export class CodexAppServerManager implements SessionManager {
 					const tokenUsage = deepGet(n.params, "tokenUsage");
 					if (tokenUsage && typeof tokenUsage === "object") {
 						try {
-							const meta = buildCodexStoredMeta(tokenUsage);
+							const meta = buildCodexStoredMeta(tokenUsage, ctx.lastSentModel);
 							if (meta) {
 								emitter.contextUsageUpdated(
 									requestId,
@@ -837,6 +841,7 @@ export class CodexAppServerManager implements SessionManager {
 			activeRequestId: null,
 			activeEmitter: null,
 			notificationGate: null,
+			lastSentModel: model ?? "",
 		};
 
 		this.sessions.set(sessionId, ctx);

--- a/sidecar/src/context-usage.test.ts
+++ b/sidecar/src/context-usage.test.ts
@@ -5,77 +5,166 @@ import {
 	buildCodexStoredMeta,
 } from "./context-usage";
 
+const CLAUDE_MODEL = "claude-opus-4-7[1m]";
+const CODEX_MODEL = "gpt-5.1-codex";
+
 describe("buildClaudeStoredMeta", () => {
-	it("derives used/max/percentage from result.usage + modelUsage", () => {
-		const meta = buildClaudeStoredMeta({
-			type: "result",
-			usage: {
-				input_tokens: 6,
-				cache_creation_input_tokens: 12_267,
-				cache_read_input_tokens: 13_101,
-				output_tokens: 10,
+	it("derives used/max/percentage + stamps modelId", () => {
+		const meta = buildClaudeStoredMeta(
+			{
+				type: "result",
+				usage: {
+					input_tokens: 6,
+					cache_creation_input_tokens: 12_267,
+					cache_read_input_tokens: 13_101,
+					output_tokens: 10,
+				},
+				modelUsage: {
+					[CLAUDE_MODEL]: { contextWindow: 1_000_000 },
+				},
 			},
-			modelUsage: {
-				"claude-opus-4-7[1m]": { contextWindow: 1_000_000 },
-			},
-		});
+			CLAUDE_MODEL,
+		);
 		expect(meta).toEqual({
+			modelId: CLAUDE_MODEL,
 			usedTokens: 25_384,
 			maxTokens: 1_000_000,
 			percentage: 2.54,
 		});
 	});
 
-	it("picks the largest contextWindow across multiple modelUsage entries", () => {
-		const meta = buildClaudeStoredMeta({
-			usage: { input_tokens: 100, output_tokens: 50 },
-			modelUsage: {
-				"haiku-4-5": { contextWindow: 200_000 },
-				"claude-opus-4-7[1m]": { contextWindow: 1_000_000 },
+	it("uses the modelId-matched contextWindow across multiple modelUsage entries", () => {
+		const meta = buildClaudeStoredMeta(
+			{
+				usage: { input_tokens: 100, output_tokens: 50 },
+				modelUsage: {
+					"claude-sonnet-4-5": { contextWindow: 200_000 },
+					"claude-opus-4-7[1m]": { contextWindow: 1_000_000 },
+				},
 			},
-		});
+			"claude-sonnet-4-5",
+		);
+		expect(meta?.maxTokens).toBe(200_000);
+	});
+
+	it("falls back to matching the top-level usage tokens when modelId is an alias", () => {
+		const meta = buildClaudeStoredMeta(
+			{
+				usage: {
+					input_tokens: 10,
+					cache_creation_input_tokens: 13_412,
+					cache_read_input_tokens: 114_791,
+					output_tokens: 954,
+				},
+				modelUsage: {
+					"claude-haiku-4-5-20251001": {
+						inputTokens: 378,
+						outputTokens: 15,
+						cacheCreationInputTokens: 0,
+						cacheReadInputTokens: 0,
+						contextWindow: 200_000,
+					},
+					"claude-opus-4-7[1m]": {
+						inputTokens: 10,
+						outputTokens: 954,
+						cacheCreationInputTokens: 13_412,
+						cacheReadInputTokens: 114_791,
+						contextWindow: 1_000_000,
+					},
+				},
+			},
+			"opus",
+		);
 		expect(meta?.maxTokens).toBe(1_000_000);
+		expect(meta?.usedTokens).toBe(129_167);
+	});
+
+	it("returns null for ambiguous multi-model usage without a match", () => {
+		const meta = buildClaudeStoredMeta(
+			{
+				usage: { input_tokens: 100, output_tokens: 50 },
+				modelUsage: {
+					"haiku-4-5": {
+						inputTokens: 1,
+						outputTokens: 2,
+						contextWindow: 200_000,
+					},
+					[CLAUDE_MODEL]: {
+						inputTokens: 3,
+						outputTokens: 4,
+						contextWindow: 1_000_000,
+					},
+				},
+			},
+			"alias-with-no-direct-entry",
+		);
+		expect(meta).toBeNull();
 	});
 
 	it("clamps used at maxTokens when sum exceeds the window", () => {
-		const meta = buildClaudeStoredMeta({
-			usage: { input_tokens: 1_200_000, output_tokens: 0 },
-			modelUsage: { foo: { contextWindow: 1_000_000 } },
-		});
+		const meta = buildClaudeStoredMeta(
+			{
+				usage: { input_tokens: 1_200_000, output_tokens: 0 },
+				modelUsage: { foo: { contextWindow: 1_000_000 } },
+			},
+			CLAUDE_MODEL,
+		);
 		expect(meta?.usedTokens).toBe(1_000_000);
 		expect(meta?.percentage).toBe(100);
 	});
 
 	it("returns null when usage is missing", () => {
-		expect(buildClaudeStoredMeta({ modelUsage: {} })).toBeNull();
+		expect(buildClaudeStoredMeta({ modelUsage: {} }, CLAUDE_MODEL)).toBeNull();
 	});
 
 	it("returns null when modelUsage is missing", () => {
 		expect(
-			buildClaudeStoredMeta({ usage: { input_tokens: 10, output_tokens: 1 } }),
+			buildClaudeStoredMeta(
+				{ usage: { input_tokens: 10, output_tokens: 1 } },
+				CLAUDE_MODEL,
+			),
 		).toBeNull();
 	});
 
 	it("returns null on an empty turn (zero tokens)", () => {
 		expect(
-			buildClaudeStoredMeta({
-				usage: { input_tokens: 0, output_tokens: 0 },
-				modelUsage: { foo: { contextWindow: 1_000_000 } },
-			}),
+			buildClaudeStoredMeta(
+				{
+					usage: { input_tokens: 0, output_tokens: 0 },
+					modelUsage: { foo: { contextWindow: 1_000_000 } },
+				},
+				CLAUDE_MODEL,
+			),
 		).toBeNull();
+	});
+
+	it("accepts empty-string modelId (caller didn't specify) without crashing", () => {
+		const meta = buildClaudeStoredMeta(
+			{
+				usage: { input_tokens: 1000, output_tokens: 10 },
+				modelUsage: { foo: { contextWindow: 1_000_000 } },
+			},
+			"",
+		);
+		expect(meta?.modelId).toBe("");
+		expect(meta?.usedTokens).toBe(1010);
 	});
 
 	it("accepts error-result turns (same usage/modelUsage shape)", () => {
 		// SDKResultError has the same usage/modelUsage fields as
 		// SDKResultSuccess — so error turns get their usage persisted too.
-		const meta = buildClaudeStoredMeta({
-			type: "result",
-			subtype: "error_max_turns",
-			is_error: true,
-			usage: { input_tokens: 5000, output_tokens: 100 },
-			modelUsage: { "claude-sonnet-4-5": { contextWindow: 200_000 } },
-		});
+		const meta = buildClaudeStoredMeta(
+			{
+				type: "result",
+				subtype: "error_max_turns",
+				is_error: true,
+				usage: { input_tokens: 5000, output_tokens: 100 },
+				modelUsage: { "claude-sonnet-4-5": { contextWindow: 200_000 } },
+			},
+			"claude-sonnet-4-5",
+		);
 		expect(meta).toEqual({
+			modelId: "claude-sonnet-4-5",
 			usedTokens: 5100,
 			maxTokens: 200_000,
 			percentage: 2.55,
@@ -84,19 +173,23 @@ describe("buildClaudeStoredMeta", () => {
 });
 
 describe("buildClaudeRichMeta", () => {
-	it("maps SDK response to the rich shape, drops Free space + color", () => {
-		const rich = buildClaudeRichMeta({
-			totalTokens: 1500,
-			maxTokens: 200_000,
-			percentage: 0.75,
-			isAutoCompactEnabled: true,
-			categories: [
-				{ name: "Messages", tokens: 800, color: "#f00" },
-				{ name: "System tools", tokens: 700, color: "#0f0" },
-				{ name: "Free space", tokens: 198_500, color: "#fff" },
-			],
-		});
+	it("maps SDK response + stamps modelId, drops Free space + color", () => {
+		const rich = buildClaudeRichMeta(
+			{
+				totalTokens: 1500,
+				maxTokens: 200_000,
+				percentage: 0.75,
+				isAutoCompactEnabled: true,
+				categories: [
+					{ name: "Messages", tokens: 800, color: "#f00" },
+					{ name: "System tools", tokens: 700, color: "#0f0" },
+					{ name: "Free space", tokens: 198_500, color: "#fff" },
+				],
+			},
+			CLAUDE_MODEL,
+		);
 		expect(rich).toEqual({
+			modelId: CLAUDE_MODEL,
 			usedTokens: 1500,
 			maxTokens: 200_000,
 			percentage: 0.75,
@@ -109,24 +202,31 @@ describe("buildClaudeRichMeta", () => {
 	});
 
 	it("tolerates a missing categories array", () => {
-		const rich = buildClaudeRichMeta({
-			totalTokens: 100,
-			maxTokens: 1000,
-			percentage: 10,
-		});
+		const rich = buildClaudeRichMeta(
+			{
+				totalTokens: 100,
+				maxTokens: 1000,
+				percentage: 10,
+			},
+			CLAUDE_MODEL,
+		);
 		expect(rich.categories).toEqual([]);
 		expect(rich.isAutoCompactEnabled).toBe(false);
 	});
 });
 
 describe("buildCodexStoredMeta", () => {
-	it("uses last.totalTokens as the numerator (not total.totalTokens)", () => {
-		const meta = buildCodexStoredMeta({
-			modelContextWindow: 400_000,
-			last: { totalTokens: 12_000 },
-			total: { totalTokens: 50_000 },
-		});
+	it("uses last.totalTokens as the numerator + stamps modelId", () => {
+		const meta = buildCodexStoredMeta(
+			{
+				modelContextWindow: 400_000,
+				last: { totalTokens: 12_000 },
+				total: { totalTokens: 50_000 },
+			},
+			CODEX_MODEL,
+		);
 		expect(meta).toEqual({
+			modelId: CODEX_MODEL,
 			usedTokens: 12_000,
 			maxTokens: 400_000,
 			percentage: 3,
@@ -134,23 +234,39 @@ describe("buildCodexStoredMeta", () => {
 	});
 
 	it("falls back to total.totalTokens when last is absent", () => {
-		const meta = buildCodexStoredMeta({
-			modelContextWindow: 400_000,
-			total: { totalTokens: 8000 },
-		});
+		const meta = buildCodexStoredMeta(
+			{
+				modelContextWindow: 400_000,
+				total: { totalTokens: 8000 },
+			},
+			CODEX_MODEL,
+		);
 		expect(meta?.usedTokens).toBe(8000);
 	});
 
 	it("clamps used at maxTokens when it exceeds the window", () => {
-		const meta = buildCodexStoredMeta({
-			modelContextWindow: 200_000,
-			last: { totalTokens: 250_000 },
-		});
+		const meta = buildCodexStoredMeta(
+			{
+				modelContextWindow: 200_000,
+				last: { totalTokens: 250_000 },
+			},
+			CODEX_MODEL,
+		);
 		expect(meta?.usedTokens).toBe(200_000);
 		expect(meta?.percentage).toBe(100);
 	});
 
 	it("returns null when there is nothing meaningful to persist", () => {
-		expect(buildCodexStoredMeta({ last: { totalTokens: 0 } })).toBeNull();
+		expect(
+			buildCodexStoredMeta({ last: { totalTokens: 0 } }, CODEX_MODEL),
+		).toBeNull();
+	});
+
+	it("stamps empty-string modelId without crashing", () => {
+		const meta = buildCodexStoredMeta(
+			{ modelContextWindow: 100_000, last: { totalTokens: 1000 } },
+			"",
+		);
+		expect(meta?.modelId).toBe("");
 	});
 });

--- a/sidecar/src/context-usage.ts
+++ b/sidecar/src/context-usage.ts
@@ -1,11 +1,11 @@
 // Context-usage meta builders — one shape for both providers.
 //
-// Written into `sessions.context_usage_meta` at turn end. No model
-// stamping, no provider source: the frontend doesn't gate on either.
-// Window size comes from whatever the sidecar last reported; if the
-// user switched models, the next turn overwrites it.
+// Written into `sessions.context_usage_meta` at turn end. `modelId`
+// lets the frontend hide stale percentages after a model switch.
 
 export type StoredContextUsageMeta = {
+	/** Empty only for legacy rows or unknown callers. */
+	readonly modelId: string;
 	readonly usedTokens: number;
 	readonly maxTokens: number;
 	readonly percentage: number;
@@ -28,6 +28,38 @@ function computePercentage(used: number, max: number): number {
 	return Math.round(raw * 100) / 100;
 }
 
+function matchesClaudeUsage(
+	entry: Record<string, unknown>,
+	usage: Record<string, unknown>,
+): boolean {
+	return (
+		num(entry.inputTokens) === num(usage.input_tokens) &&
+		num(entry.outputTokens) === num(usage.output_tokens) &&
+		num(entry.cacheCreationInputTokens) ===
+			num(usage.cache_creation_input_tokens) &&
+		num(entry.cacheReadInputTokens) === num(usage.cache_read_input_tokens)
+	);
+}
+
+function selectClaudeModelUsage(
+	modelUsage: Record<string, Record<string, unknown>>,
+	usage: Record<string, unknown>,
+	modelId: string,
+): Record<string, unknown> | null {
+	const direct = modelId ? modelUsage[modelId] : undefined;
+	if (direct) return direct;
+
+	const matching = Object.values(modelUsage).filter((entry) =>
+		matchesClaudeUsage(entry, usage),
+	);
+	const [matched] = matching;
+	if (matching.length === 1 && matched) return matched;
+
+	const entries = Object.values(modelUsage);
+	const [only] = entries;
+	return entries.length === 1 && only ? only : null;
+}
+
 /**
  * Build the persisted meta from any Claude terminal `result` message
  * (success OR error — both carry usage). Returns null when usage data
@@ -35,6 +67,7 @@ function computePercentage(used: number, max: number): number {
  */
 export function buildClaudeStoredMeta(
 	result: unknown,
+	modelId: string,
 ): StoredContextUsageMeta | null {
 	const root = (result ?? {}) as Record<string, unknown>;
 	const usage = (root.usage ?? null) as Record<string, unknown> | null;
@@ -50,15 +83,13 @@ export function buildClaudeStoredMeta(
 		num(usage.cache_read_input_tokens) +
 		num(usage.output_tokens);
 
-	let max = 0;
-	for (const entry of Object.values(modelUsage)) {
-		const cw = num(entry?.contextWindow);
-		if (cw > max) max = cw;
-	}
+	const selectedUsage = selectClaudeModelUsage(modelUsage, usage, modelId);
+	const max = num(selectedUsage?.contextWindow);
 	if (max <= 0 || used <= 0) return null;
 
 	const usedClamped = Math.min(used, max);
 	return {
+		modelId,
 		usedTokens: usedClamped,
 		maxTokens: max,
 		percentage: computePercentage(usedClamped, max),
@@ -69,7 +100,10 @@ export function buildClaudeStoredMeta(
  * Reduce `SDKControlGetContextUsageResponse` to the rich shape for the
  * hover popover. Filters the "Free space" pseudo-category.
  */
-export function buildClaudeRichMeta(raw: unknown): ClaudeRichContextUsage {
+export function buildClaudeRichMeta(
+	raw: unknown,
+	modelId: string,
+): ClaudeRichContextUsage {
 	const root = (raw ?? {}) as Record<string, unknown>;
 	const rawCategories = Array.isArray(root.categories) ? root.categories : [];
 	const used = num(root.totalTokens);
@@ -78,6 +112,7 @@ export function buildClaudeRichMeta(raw: unknown): ClaudeRichContextUsage {
 	const percentage =
 		sdkPct > 0 ? Math.round(sdkPct * 100) / 100 : computePercentage(used, max);
 	return {
+		modelId,
 		usedTokens: used,
 		maxTokens: max,
 		percentage,
@@ -100,10 +135,12 @@ export function buildClaudeRichMeta(raw: unknown): ClaudeRichContextUsage {
  * Build the persisted meta from a Codex `thread/tokenUsage/updated`
  * payload. `usedTokens` = `last.totalTokens` (context fill for the
  * most recent turn, not the cumulative billing counter). `maxTokens` =
- * `modelContextWindow`.
+ * `modelContextWindow`. Codex notifications don't carry a model id, so
+ * the caller stamps the active turn's model id.
  */
 export function buildCodexStoredMeta(
 	tokenUsage: unknown,
+	modelId: string,
 ): StoredContextUsageMeta | null {
 	const root = (tokenUsage ?? {}) as Record<string, unknown>;
 	const last = (root.last ?? null) as Record<string, unknown> | null;
@@ -114,6 +151,7 @@ export function buildCodexStoredMeta(
 
 	const usedClamped = max > 0 ? Math.min(used, max) : used;
 	return {
+		modelId,
 		usedTokens: usedClamped,
 		maxTokens: max,
 		percentage: computePercentage(usedClamped, max),

--- a/sidecar/src/session-manager.ts
+++ b/sidecar/src/session-manager.ts
@@ -36,11 +36,8 @@ export interface ListSlashCommandsParams {
 /**
  * Ad-hoc context-usage query for the hover popover. `providerSessionId`
  * is the SDK's own session id (what `resume:` takes) — used when no live
- * `Query` is held for this helmor session. `model` mirrors the composer's
- * current selection — required because the window size is model-specific
- * AND the persisted meta's `model` is compared against it for the
- * match/tokens-only UX decision. `cwd` is the workspace root so the
- * spawn loads the right project settings.
+ * `Query` is held for this helmor session. `model` is the composer's
+ * current model id; `cwd` lets the transient query load project settings.
  */
 export interface GetContextUsageParams {
 	readonly helmorSessionId: string;

--- a/sidecar/test/claude-session-manager.test.ts
+++ b/sidecar/test/claude-session-manager.test.ts
@@ -241,7 +241,7 @@ describe("ClaudeSessionManager.sendMessage", () => {
 		expect(last).toEqual({ id: "REQ-1", type: "end" });
 	});
 
-	test("emits contextUsageUpdated from the terminal result's usage + modelUsage", async () => {
+	test("emits contextUsageUpdated from the terminal result's usage + modelUsage, stamping the requested modelId", async () => {
 		const sdkMessages = [
 			{
 				type: "result",
@@ -266,7 +266,7 @@ describe("ClaudeSessionManager.sendMessage", () => {
 			{
 				sessionId: "helmor-sess-ctx",
 				prompt: "hi",
-				model: undefined,
+				model: "claude-opus-4-7[1m]",
 				cwd: undefined,
 				resume: undefined,
 				permissionMode: undefined,
@@ -282,6 +282,7 @@ describe("ClaudeSessionManager.sendMessage", () => {
 		expect(ctxUsage?.sessionId).toBe("helmor-sess-ctx");
 		const meta = JSON.parse(ctxUsage?.meta as string);
 		expect(meta).toEqual({
+			modelId: "claude-opus-4-7[1m]",
 			usedTokens: 25_384,
 			maxTokens: 1_000_000,
 			// 25384 / 1_000_000 * 100 rounded to 2 decimals.
@@ -368,6 +369,7 @@ describe("ClaudeSessionManager.sendMessage", () => {
 		expect(getContextUsageCalls).toBe(1);
 		const meta = JSON.parse(json);
 		expect(meta).toEqual({
+			modelId: "claude-opus-4-7",
 			usedTokens: 1500,
 			maxTokens: 200_000,
 			percentage: 0.75,
@@ -406,6 +408,7 @@ describe("ClaudeSessionManager.sendMessage", () => {
 		});
 
 		const meta = JSON.parse(json);
+		expect(meta.modelId).toBe("claude-opus-4-7");
 		expect(meta.usedTokens).toBe(42_000);
 		expect(meta.maxTokens).toBe(1_000_000);
 		// Assert the transient query was configured with resume + model so
@@ -446,7 +449,7 @@ describe("ClaudeSessionManager.sendMessage", () => {
 			{
 				sessionId: "helmor-sess-err",
 				prompt: "hi",
-				model: undefined,
+				model: "claude-sonnet-4-5",
 				cwd: undefined,
 				resume: undefined,
 				permissionMode: undefined,
@@ -459,6 +462,7 @@ describe("ClaudeSessionManager.sendMessage", () => {
 		const ctxUsage = captured.find((e) => e.type === "contextUsageUpdated");
 		expect(ctxUsage).toBeDefined();
 		const meta = JSON.parse(ctxUsage?.meta as string);
+		expect(meta.modelId).toBe("claude-sonnet-4-5");
 		expect(meta.usedTokens).toBe(5100);
 		expect(meta.maxTokens).toBe(200_000);
 	});

--- a/sidecar/test/codex-app-server-manager.test.ts
+++ b/sidecar/test/codex-app-server-manager.test.ts
@@ -401,6 +401,8 @@ describe("CodexAppServerManager", () => {
 		expect(ctxUsage?.id).toBe("REQ-usage");
 		const meta = JSON.parse(ctxUsage?.meta as string);
 		expect(meta).toEqual({
+			// Stamped from the sendMessage param, not the notification.
+			modelId: "gpt-5.4",
 			usedTokens: 17_500,
 			maxTokens: 400_000,
 			percentage: 4.38,

--- a/src-tauri/src/agents/queries.rs
+++ b/src-tauri/src/agents/queries.rs
@@ -1000,8 +1000,7 @@ fn fetch_models_for_provider(
 pub struct GetLiveContextUsageRequest {
     pub session_id: String,
     pub provider_session_id: Option<String>,
-    /// CLI model id — required by the sidecar; it stamps this into the
-    /// returned rich meta for the ring's model-match check.
+    /// Model id used by the sidecar and stamped into the returned meta.
     pub model: String,
     pub cwd: Option<String>,
 }

--- a/src/features/composer/context-usage-ring/index.test.tsx
+++ b/src/features/composer/context-usage-ring/index.test.tsx
@@ -29,7 +29,13 @@ vi.mock("@/lib/api", async () => {
 
 import { ContextUsageRing } from "./index";
 
-function Harness({ sessionId }: { sessionId: string }) {
+function Harness({
+	sessionId,
+	composerModelId = "gpt-5.4",
+}: {
+	sessionId: string;
+	composerModelId?: string | null;
+}) {
 	const queryClient = createHelmorQueryClient();
 	queryClient.setDefaultOptions({ queries: { retry: false } });
 	return (
@@ -40,7 +46,7 @@ function Harness({ sessionId }: { sessionId: string }) {
 				providerSessionId={null}
 				cwd={null}
 				agentType="codex"
-				richFetchModel={null}
+				composerModelId={composerModelId}
 				alwaysShow={true}
 			/>
 		</QueryClientProvider>
@@ -82,9 +88,11 @@ describe("ContextUsageRing end-to-end with UI sync bridge", () => {
 	it("refetches baseline from DB when contextUsageChanged fires, then re-renders with new %", async () => {
 		// First read: no usage persisted yet (new session pre-turn).
 		apiMockState.getSessionContextUsage.mockResolvedValueOnce(null);
-		// Second read (after event): new meta from turn end.
+		// Second read (after event): new meta from turn end. modelId stamp
+		// matches the composer's current model so display resolves to `full`.
 		apiMockState.getSessionContextUsage.mockResolvedValueOnce(
 			JSON.stringify({
+				modelId: "gpt-5.4",
 				usedTokens: 23_363,
 				maxTokens: 950_000,
 				percentage: 2.46,
@@ -127,7 +135,12 @@ describe("ContextUsageRing end-to-end with UI sync bridge", () => {
 
 	it("does not refetch when contextUsageChanged is for a different session", async () => {
 		apiMockState.getSessionContextUsage.mockResolvedValue(
-			JSON.stringify({ usedTokens: 10, maxTokens: 100, percentage: 10 }),
+			JSON.stringify({
+				modelId: "gpt-5.4",
+				usedTokens: 10,
+				maxTokens: 100,
+				percentage: 10,
+			}),
 		);
 
 		render(<Harness sessionId="session-abc" />);
@@ -146,5 +159,26 @@ describe("ContextUsageRing end-to-end with UI sync bridge", () => {
 		// Give any potential refetch a tick to fire, then assert it didn't.
 		await new Promise((resolve) => setTimeout(resolve, 20));
 		expect(apiMockState.getSessionContextUsage).toHaveBeenCalledTimes(1);
+	});
+
+	it("degrades to tokensOnly aria-label when composer's model differs from the recorded one", async () => {
+		apiMockState.getSessionContextUsage.mockResolvedValue(
+			JSON.stringify({
+				modelId: "gpt-5.4",
+				usedTokens: 23_363,
+				maxTokens: 950_000,
+				percentage: 2.46,
+			}),
+		);
+
+		const { findByRole, queryByRole } = render(
+			<Harness
+				sessionId="session-mismatch"
+				composerModelId="gpt-5.5-preview"
+			/>,
+		);
+
+		await findByRole("button", { name: "Context usage" });
+		expect(queryByRole("button", { name: /2%/i })).toBeNull();
 	});
 });

--- a/src/features/composer/context-usage-ring/index.tsx
+++ b/src/features/composer/context-usage-ring/index.tsx
@@ -30,10 +30,8 @@ type Props = {
 	cwd: string | null;
 	/** Only Claude supports the rich hover breakdown. */
 	agentType: "claude" | "codex" | null;
-	/** Composer's current model — needed to spawn the transient Query
-	 *  for the rich hover fetch (window size is model-specific). NOT
-	 *  used for display gating. */
-	richFetchModel: string | null;
+	/** Composer's current model id; used for rich fetches and stale checks. */
+	composerModelId: string | null;
 	alwaysShow: boolean;
 	disabled?: boolean;
 	className?: string;
@@ -46,19 +44,13 @@ const RING_CIRCUM = 2 * Math.PI * RING_RADIUS;
 const HOVER_OPEN_DELAY_MS = 180;
 const HOVER_CLOSE_DELAY_MS = 80;
 
-// Two streams feed this ring:
-//
-//   * Baseline (always on): sidecar writes `StoredContextUsageMeta` into
-//     `sessions.context_usage_meta` at turn end; `use-ui-sync-bridge`
-//     invalidates → observer refetches. Drives ring visual.
-//   * Rich (hover-only, Claude): user hovers → ad-hoc
-//     `q.getContextUsage()` → categories + auto-compact note overlay.
+// Baseline comes from DB; Claude rich details are fetched on hover.
 export function ContextUsageRing({
 	sessionId,
 	providerSessionId,
 	cwd,
 	agentType,
-	richFetchModel,
+	composerModelId,
 	alwaysShow,
 	disabled,
 	className,
@@ -79,27 +71,25 @@ export function ContextUsageRing({
 	const [open, setOpen] = useState(false);
 
 	const isClaude = agentType === "claude";
-	// Rich fetch gated on `providerSessionId` — a session with no turn
-	// yet has no Claude session id to resume, and we don't want to pay
-	// the transient-Query spin-up cost to show baseline-only data.
+	// No provider session means there is nothing useful to resume.
 	const { data: richJson = null, isFetching: richFetching } = useQuery(
 		claudeRichContextUsageQueryOptions({
 			sessionId,
 			providerSessionId,
-			model: richFetchModel,
+			model: composerModelId,
 			cwd,
 			enabled:
 				open &&
 				isClaude &&
-				richFetchModel !== null &&
+				composerModelId !== null &&
 				providerSessionId !== null,
 		}),
 	);
 	const rich = useMemo(() => parseClaudeRichMeta(richJson), [richJson]);
 
 	const display = useMemo(
-		() => resolveContextUsageDisplay(baseline, rich),
-		[baseline, rich],
+		() => resolveContextUsageDisplay(baseline, rich, composerModelId),
+		[baseline, rich, composerModelId],
 	);
 
 	const hasCodexRateLimits =

--- a/src/features/composer/context-usage-ring/parse.test.ts
+++ b/src/features/composer/context-usage-ring/parse.test.ts
@@ -10,6 +10,8 @@ import {
 	type StoredContextUsageMeta,
 } from "./parse";
 
+const CLAUDE_MODEL = "claude-opus-4-7[1m]";
+
 describe("parseStoredMeta", () => {
 	it("returns null for empty / null / unparseable input", () => {
 		expect(parseStoredMeta(null)).toBeNull();
@@ -19,38 +21,60 @@ describe("parseStoredMeta", () => {
 		expect(parseStoredMeta("{}")).toBeNull();
 	});
 
-	it("parses the baseline shape", () => {
+	it("parses the baseline shape including modelId", () => {
 		const meta = parseStoredMeta(
 			JSON.stringify({
+				modelId: CLAUDE_MODEL,
 				usedTokens: 25_384,
 				maxTokens: 1_000_000,
 				percentage: 2.5384,
 			}),
 		);
 		expect(meta).toEqual({
+			modelId: CLAUDE_MODEL,
 			usedTokens: 25_384,
 			maxTokens: 1_000_000,
 			percentage: 2.5384,
 		});
 	});
 
+	it("tolerates a row with no modelId (legacy) as empty string", () => {
+		const meta = parseStoredMeta(
+			JSON.stringify({
+				usedTokens: 100,
+				maxTokens: 1000,
+				percentage: 10,
+			}),
+		);
+		expect(meta?.modelId).toBe("");
+	});
+
 	it("computes percentage from used/max when not provided", () => {
 		const meta = parseStoredMeta(
-			JSON.stringify({ usedTokens: 500, maxTokens: 1000 }),
+			JSON.stringify({
+				modelId: "m",
+				usedTokens: 500,
+				maxTokens: 1000,
+			}),
 		);
 		expect(meta?.percentage).toBe(50);
 	});
 
 	it("returns null when used or max is missing", () => {
-		expect(parseStoredMeta(JSON.stringify({ usedTokens: 100 }))).toBeNull();
-		expect(parseStoredMeta(JSON.stringify({ maxTokens: 1000 }))).toBeNull();
+		expect(
+			parseStoredMeta(JSON.stringify({ modelId: "m", usedTokens: 100 })),
+		).toBeNull();
+		expect(
+			parseStoredMeta(JSON.stringify({ modelId: "m", maxTokens: 1000 })),
+		).toBeNull();
 	});
 });
 
 describe("parseClaudeRichMeta", () => {
-	it("parses the rich shape", () => {
+	it("parses the rich shape including modelId", () => {
 		const rich = parseClaudeRichMeta(
 			JSON.stringify({
+				modelId: CLAUDE_MODEL,
 				usedTokens: 1500,
 				maxTokens: 200_000,
 				percentage: 0.75,
@@ -59,6 +83,7 @@ describe("parseClaudeRichMeta", () => {
 			}),
 		);
 		expect(rich).toEqual({
+			modelId: CLAUDE_MODEL,
 			usedTokens: 1500,
 			maxTokens: 200_000,
 			percentage: 0.75,
@@ -75,20 +100,24 @@ describe("parseClaudeRichMeta", () => {
 });
 
 describe("resolveContextUsageDisplay", () => {
-	const baseline: StoredContextUsageMeta = {
+	const baselineClaude: StoredContextUsageMeta = {
+		modelId: CLAUDE_MODEL,
 		usedTokens: 50_000,
 		maxTokens: 200_000,
 		percentage: 25,
 	};
 
 	it("returns `empty` when baseline + rich are both null", () => {
-		expect(resolveContextUsageDisplay(null, null)).toEqual({ kind: "empty" });
+		expect(resolveContextUsageDisplay(null, null, CLAUDE_MODEL)).toEqual({
+			kind: "empty",
+		});
 	});
 
-	it("returns `full` from baseline alone", () => {
-		const res = resolveContextUsageDisplay(baseline, null);
+	it("returns `full` when baseline model matches composer", () => {
+		const res = resolveContextUsageDisplay(baselineClaude, null, CLAUDE_MODEL);
 		expect(res).toEqual({
 			kind: "full",
+			modelId: CLAUDE_MODEL,
 			usedTokens: 50_000,
 			maxTokens: 200_000,
 			percentage: 25,
@@ -97,15 +126,49 @@ describe("resolveContextUsageDisplay", () => {
 		});
 	});
 
-	it("rich overrides baseline when both present", () => {
+	it("returns `tokensOnly` when composer switched to a different model", () => {
+		const res = resolveContextUsageDisplay(
+			baselineClaude,
+			null,
+			"claude-sonnet-4-5",
+		);
+		expect(res).toEqual({
+			kind: "tokensOnly",
+			recordedModelId: CLAUDE_MODEL,
+			usedTokens: 50_000,
+		});
+	});
+
+	it("treats null composerModelId as match (avoids flash of tokensOnly during mount)", () => {
+		const res = resolveContextUsageDisplay(baselineClaude, null, null);
+		expect(res.kind).toBe("full");
+	});
+
+	it("legacy baseline (empty modelId) degrades to tokensOnly when composer has a model", () => {
+		const legacy: StoredContextUsageMeta = {
+			modelId: "",
+			usedTokens: 10_000,
+			maxTokens: 200_000,
+			percentage: 5,
+		};
+		const res = resolveContextUsageDisplay(legacy, null, CLAUDE_MODEL);
+		expect(res).toEqual({
+			kind: "tokensOnly",
+			recordedModelId: "",
+			usedTokens: 10_000,
+		});
+	});
+
+	it("rich overrides baseline values when both present and model matches", () => {
 		const rich: ClaudeRichContextUsage = {
+			modelId: CLAUDE_MODEL,
 			usedTokens: 60_000,
 			maxTokens: 200_000,
 			percentage: 30,
 			isAutoCompactEnabled: true,
 			categories: [{ name: "Messages", tokens: 60_000 }],
 		};
-		const res = resolveContextUsageDisplay(baseline, rich);
+		const res = resolveContextUsageDisplay(baselineClaude, rich, CLAUDE_MODEL);
 		expect(res.kind).toBe("full");
 		if (res.kind !== "full") throw new Error("unreachable");
 		expect(res.usedTokens).toBe(60_000);
@@ -114,8 +177,11 @@ describe("resolveContextUsageDisplay", () => {
 	});
 
 	it("computes ring tier from percentage", () => {
-		const near: StoredContextUsageMeta = { ...baseline, percentage: 85 };
-		const res = resolveContextUsageDisplay(near, null);
+		const near: StoredContextUsageMeta = {
+			...baselineClaude,
+			percentage: 85,
+		};
+		const res = resolveContextUsageDisplay(near, null, CLAUDE_MODEL);
 		if (res.kind !== "full") throw new Error("unreachable");
 		expect(res.tier).toBe("danger");
 	});

--- a/src/features/composer/context-usage-ring/parse.ts
+++ b/src/features/composer/context-usage-ring/parse.ts
@@ -1,17 +1,15 @@
-// Parses `context_usage_meta` JSON (and Codex rate-limits JSON) into
-// display-ready shapes for the ring + popover. One shape per source;
-// no model matching, no legacy fallback — sidecar always writes the
-// current format.
+// Display-ready parsing for context usage and Codex rate limits.
+// Percentages are only trusted when the stored model matches the composer.
 
 /** Baseline: written at turn end by both Claude and Codex. */
 export type StoredContextUsageMeta = {
+	readonly modelId: string;
 	readonly usedTokens: number;
 	readonly maxTokens: number;
 	readonly percentage: number;
 };
 
-/** Claude-only rich breakdown from `q.getContextUsage()`. Fetched live
- *  on hover. */
+/** Claude-only breakdown fetched live on hover. */
 export type ClaudeRichContextUsage = StoredContextUsageMeta & {
 	readonly isAutoCompactEnabled: boolean;
 	readonly categories: ReadonlyArray<{ name: string; tokens: number }>;
@@ -26,11 +24,17 @@ export function ringTier(percentage: number): RingTier {
 	return "default";
 }
 
-/** Ring display. `rich` is set when Claude's hover fetch has resolved. */
+/** Ring display state. */
 export type DisplayResolution =
 	| { readonly kind: "empty" }
 	| {
+			readonly kind: "tokensOnly";
+			readonly recordedModelId: string;
+			readonly usedTokens: number;
+	  }
+	| {
 			readonly kind: "full";
+			readonly modelId: string;
 			readonly usedTokens: number;
 			readonly maxTokens: number;
 			readonly percentage: number;
@@ -38,15 +42,28 @@ export type DisplayResolution =
 			readonly rich: ClaudeRichContextUsage | null;
 	  };
 
-/** Rich overrides baseline when present (same units, strictly fresher). */
+/** Rich overrides baseline; model mismatches degrade to tokens-only. */
 export function resolveContextUsageDisplay(
 	baseline: StoredContextUsageMeta | null,
 	rich: ClaudeRichContextUsage | null,
+	composerModelId: string | null,
 ): DisplayResolution {
 	const effective = rich ?? baseline;
 	if (!effective) return { kind: "empty" };
+
+	const matches =
+		composerModelId === null || effective.modelId === composerModelId;
+	if (!matches) {
+		return {
+			kind: "tokensOnly",
+			recordedModelId: effective.modelId,
+			usedTokens: effective.usedTokens,
+		};
+	}
+
 	return {
 		kind: "full",
+		modelId: effective.modelId,
 		usedTokens: effective.usedTokens,
 		maxTokens: effective.maxTokens,
 		percentage: effective.percentage,
@@ -90,6 +107,7 @@ export function parseStoredMeta(
 	const max = asNumber(root.maxTokens);
 	if (used === null || max === null) return null;
 	return {
+		modelId: typeof root.modelId === "string" ? root.modelId : "",
 		usedTokens: used,
 		maxTokens: max,
 		percentage: asNumber(root.percentage) ?? clampPercent(used, max),
@@ -122,6 +140,7 @@ export function parseClaudeRichMeta(
 		categories.push({ name, tokens });
 	}
 	return {
+		modelId: typeof root.modelId === "string" ? root.modelId : "",
 		usedTokens: used,
 		maxTokens: max,
 		percentage: asNumber(root.percentage) ?? clampPercent(used, max),

--- a/src/features/composer/context-usage-ring/popover-parts.tsx
+++ b/src/features/composer/context-usage-ring/popover-parts.tsx
@@ -35,6 +35,18 @@ export function UsageHeader({
 	);
 }
 
+/** Header for token counts without a trusted window size. */
+export function TokensOnlyHeader({ usedTokens }: { usedTokens: number }) {
+	return (
+		<div className="flex items-center justify-between">
+			<div className="text-[14px] font-semibold text-foreground">Context</div>
+			<div className="text-[12px] tabular-nums text-muted-foreground">
+				Used <span className="text-foreground">{formatTokens(usedTokens)}</span>
+			</div>
+		</div>
+	);
+}
+
 /** Compact percentage: 1 decimal under 10%, integer above. Strips ".0". */
 function formatPercentage(value: number): string {
 	if (!Number.isFinite(value) || value <= 0) return "0%";

--- a/src/features/composer/context-usage-ring/popover.tsx
+++ b/src/features/composer/context-usage-ring/popover.tsx
@@ -5,6 +5,7 @@ import {
 	CategoryList,
 	Divider,
 	LimitRow,
+	TokensOnlyHeader,
 	UsageBar,
 	UsageHeader,
 } from "./popover-parts";
@@ -39,7 +40,9 @@ export function ContextUsagePopoverContent({
 
 	return (
 		<div className="flex flex-col gap-3 px-1 py-1">
-			{display.kind === "full" ? (
+			{display.kind === "tokensOnly" ? (
+				<TokensOnlyHeader usedTokens={display.usedTokens} />
+			) : display.kind === "full" ? (
 				<>
 					<UsageHeader
 						used={display.usedTokens}

--- a/src/features/composer/index.tsx
+++ b/src/features/composer/index.tsx
@@ -730,10 +730,7 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 								<ContextUsageRing
 									sessionId={sessionId}
 									providerSessionId={providerSessionId}
-									// Only used to spawn the transient Query for
-									// the Claude rich hover fetch; the ring
-									// display itself never reads it.
-									richFetchModel={selectedModel?.cliModel ?? null}
+									composerModelId={selectedModel?.id ?? null}
 									cwd={workspaceRootPath}
 									agentType={agentType}
 									alwaysShow={alwaysShowContextUsage}


### PR DESCRIPTION
## Summary
- Stamp context usage metadata with the active model id for Claude and Codex
- Hide stale context window percentages after composer model switches
- Preserve origin/main iteration-based Claude token accounting during merge

## Verification
- cd sidecar && bun test src/context-usage.test.ts
- pre-commit hooks passed: Biome, rustfmt, Clippy