### PR TITLE
feat: add Codex /compact context compaction support

### DIFF
--- a/.changeset/neat-codex-compact.md
+++ b/.changeset/neat-codex-compact.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Add Codex context compaction support so Codex chats can run `/compact` from the composer and show a context-compacted notice when the provider finishes.

--- a/sidecar/src/codex-app-server-manager.ts
+++ b/sidecar/src/codex-app-server-manager.ts
@@ -245,6 +245,7 @@ export class CodexAppServerManager implements SessionManager {
 			prompt,
 			resolvedAdditionalDirectories,
 		);
+		const isCompactCommand = prompt.trim() === "/compact";
 		const input = buildTurnInput(promptWithContext);
 		const turnStartParams: Record<string, unknown> = {
 			threadId: ctx.providerThreadId,
@@ -391,6 +392,13 @@ export class CodexAppServerManager implements SessionManager {
 						ctx.turnReject = null;
 					}
 				}
+
+				if (n.method === "thread/compacted") {
+					ctx.activeTurnId = null;
+					ctx.turnResolve?.();
+					ctx.turnResolve = null;
+					ctx.turnReject = null;
+				}
 			};
 
 			const handleRequest = async (req: JsonRpcRequest) => {
@@ -449,8 +457,20 @@ export class CodexAppServerManager implements SessionManager {
 			ctx.server.setHandlers(handleNotification, handleRequest);
 			ctx.server.setActiveRequestId(requestId);
 
-			ctx.server
-				.sendRequest("turn/start", turnStartParams)
+			if (isCompactCommand && !ctx.providerThreadId) {
+				reject(new Error("Cannot compact before a Codex thread has started"));
+				return;
+			}
+
+			const requestPromise = isCompactCommand
+				? ctx.server.sendRequest(
+						"thread/compact/start",
+						{ threadId: ctx.providerThreadId },
+						20_000,
+					)
+				: ctx.server.sendRequest("turn/start", turnStartParams);
+
+			requestPromise
 				.then((response) => {
 					const turnId = deepGet(response, "turn", "id");
 					if (typeof turnId === "string") {
@@ -458,7 +478,10 @@ export class CodexAppServerManager implements SessionManager {
 					}
 				})
 				.catch((err) => {
-					logger.error("turn/start failed", errorDetails(err));
+					logger.error(
+						`${isCompactCommand ? "thread/compact/start" : "turn/start"} failed`,
+						errorDetails(err),
+					);
 					reject(err);
 				});
 		}).finally(() => {

--- a/src-tauri/src/pipeline/accumulator/codex.rs
+++ b/src-tauri/src/pipeline/accumulator/codex.rs
@@ -288,6 +288,9 @@ fn dispatch_item(acc: &mut StreamAccumulator, raw_line: &str, value: &Value, per
         Some("plan") => {
             handle_plan_item(acc, raw_line, item, item_id.as_deref(), persist);
         }
+        Some("context_compaction") => {
+            handle_context_compaction_item(acc, raw_line, item, item_id.as_deref(), persist);
+        }
         Some("error") => {
             handle_error_item(acc, raw_line, item, persist);
         }
@@ -801,6 +804,70 @@ fn handle_plan_item(
     }
 }
 
+fn handle_context_compaction_item(
+    acc: &mut StreamAccumulator,
+    raw_line: &str,
+    item: &Value,
+    item_id: Option<&str>,
+    persist: bool,
+) {
+    let body = item
+        .get("summary")
+        .or_else(|| item.get("text"))
+        .or_else(|| item.get("content"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let subtype = if persist {
+        "codex_compacted"
+    } else {
+        "codex_compacting"
+    };
+    let synthetic = serde_json::json!({
+        "type": "system",
+        "subtype": subtype,
+        "summary": body,
+    });
+    let synthetic_str = serde_json::to_string(&synthetic).unwrap_or_default();
+    let prefix = if persist {
+        "codex-compaction"
+    } else {
+        "codex-compacting"
+    };
+    let compaction_id = item_id
+        .map(|id| format!("{prefix}:{id}"))
+        .unwrap_or_else(|| format!("{prefix}:{}", acc.line_count));
+    acc.collect_or_replace(
+        &synthetic_str,
+        &synthetic,
+        MessageRole::System,
+        Some(compaction_id.clone()),
+    );
+
+    if persist {
+        acc.turns.push(CollectedTurn {
+            id: compaction_id,
+            role: MessageRole::System,
+            content_json: raw_line.to_string(),
+        });
+    }
+}
+
+pub(super) fn handle_thread_compacted(acc: &mut StreamAccumulator, _raw_line: &str, value: &Value) {
+    let synthetic = serde_json::json!({
+        "type": "system",
+        "subtype": "codex_compacted",
+        "thread_id": value.get("threadId").or_else(|| value.get("thread_id")),
+    });
+    let synthetic_str = synthetic.to_string();
+    let id = format!("codex-thread-compacted:{}", acc.line_count);
+    acc.collect_message(&synthetic_str, &synthetic, MessageRole::System, Some(&id));
+    acc.turns.push(CollectedTurn {
+        id,
+        role: MessageRole::System,
+        content_json: synthetic_str,
+    });
+}
+
 /// Handle `turn/plan/updated`: map plan steps to a TodoList via synthetic
 /// `TodoWrite` tool_use. Uses a stable override_id so each update replaces
 /// the previous.
@@ -958,6 +1025,7 @@ fn normalize_item_type(t: &str) -> &str {
         "todoList" | "todo_list" => "todo_list",
         "reasoning" => "reasoning",
         "plan" => "plan",
+        "contextCompaction" | "context_compaction" => "context_compaction",
         "error" => "error",
         other => other,
     }

--- a/src-tauri/src/pipeline/accumulator/mod.rs
+++ b/src-tauri/src/pipeline/accumulator/mod.rs
@@ -462,6 +462,10 @@ impl StreamAccumulator {
                 self.codex_turn_started_at = Some(now_ms());
                 PushOutcome::NoOp
             }
+            Some("thread/compacted") => {
+                codex::handle_thread_compacted(self, raw_line, value);
+                PushOutcome::Finalized
+            }
             Some("thread/started") => {
                 if let Some(tid) = value
                     .get("thread")

--- a/src-tauri/src/pipeline/adapter/codex_items.rs
+++ b/src-tauri/src/pipeline/adapter/codex_items.rs
@@ -16,7 +16,7 @@ use serde_json::Value;
 use super::blocks::parse_codex_todolist_items;
 use crate::pipeline::types::{
     ExtendedMessagePart, IntermediateMessage, MessagePart, MessageRole, MessageStatus,
-    PlanAllowedPrompt, ThreadMessageLike,
+    NoticeSeverity, PlanAllowedPrompt, ThreadMessageLike,
 };
 
 /// Render a single `item.completed` IntermediateMessage. Pushes 0 or 1
@@ -58,6 +58,7 @@ pub(super) fn render_item_completed(
         Some("web_search") => render_web_search(msg, item, result),
         Some("mcp_tool_call") => render_mcp_tool_call(msg, item, result),
         Some("plan") => render_plan(msg, item, result),
+        Some("context_compaction") => render_context_compaction(msg, item, result),
         _ => {}
     }
 }
@@ -104,6 +105,33 @@ fn render_command_execution(
             status_type: "complete".to_string(),
             reason: Some("stop".to_string()),
         }),
+        streaming: None,
+    });
+}
+
+fn render_context_compaction(
+    msg: &IntermediateMessage,
+    item: &Value,
+    result: &mut Vec<ThreadMessageLike>,
+) {
+    let body = item
+        .get("summary")
+        .or_else(|| item.get("text"))
+        .or_else(|| item.get("content"))
+        .and_then(Value::as_str)
+        .filter(|s| !s.trim().is_empty())
+        .map(str::to_string);
+    result.push(ThreadMessageLike {
+        role: MessageRole::System,
+        id: Some(msg.id.clone()),
+        created_at: Some(msg.created_at.clone()),
+        content: vec![ExtendedMessagePart::Basic(MessagePart::SystemNotice {
+            id: format!("{}:notice", msg.id),
+            severity: NoticeSeverity::Info,
+            label: "Context compacted".to_string(),
+            body,
+        })],
+        status: None,
         streaming: None,
     });
 }

--- a/src-tauri/src/pipeline/adapter/labels.rs
+++ b/src-tauri/src/pipeline/adapter/labels.rs
@@ -200,6 +200,22 @@ pub(super) fn build_system_notice(parsed: Option<&Value>, msg_id: &str) -> Optio
             })
         }
         "compact_boundary" => Some(build_compact_boundary_notice(parsed, msg_id)),
+        "codex_compacting" => Some(MessagePart::SystemNotice {
+            id: notice_part_id(msg_id),
+            severity: NoticeSeverity::Info,
+            label: "Compacting context".to_string(),
+            body: None,
+        }),
+        "codex_compacted" => Some(MessagePart::SystemNotice {
+            id: notice_part_id(msg_id),
+            severity: NoticeSeverity::Info,
+            label: "Context compacted".to_string(),
+            body: parsed
+                .get("summary")
+                .and_then(Value::as_str)
+                .filter(|s| !s.trim().is_empty())
+                .map(str::to_string),
+        }),
         "api_retry" => Some(build_api_retry_notice(parsed, msg_id)),
         _ => None,
     }

--- a/src-tauri/tests/fixtures/streams/codex/context-compaction-item.jsonl
+++ b/src-tauri/tests/fixtures/streams/codex/context-compaction-item.jsonl
@@ -1,0 +1,4 @@
+{"type":"thread/started","thread":{"id":"codex-compact-thread"},"session_id":"codex-compact-thread"}
+{"type":"item/started","item":{"id":"compact-item-1","type":"contextCompaction"},"threadId":"codex-compact-thread","turnId":"compact-turn-1"}
+{"type":"item/completed","item":{"id":"compact-item-1","type":"contextCompaction"},"threadId":"codex-compact-thread","turnId":"compact-turn-1"}
+{"type":"turn/completed","turn":{"id":"compact-turn-1","status":"completed"},"usage":{"input_tokens":100,"output_tokens":8},"threadId":"codex-compact-thread"}

--- a/src-tauri/tests/fixtures/streams/codex/thread-compacted.jsonl
+++ b/src-tauri/tests/fixtures/streams/codex/thread-compacted.jsonl
@@ -1,0 +1,2 @@
+{"type":"thread/started","thread":{"id":"codex-thread-compacted"},"session_id":"codex-thread-compacted"}
+{"type":"thread/compacted","threadId":"codex-thread-compacted"}

--- a/src-tauri/tests/snapshots/pipeline_streams__stream_replay@codex__context-compaction-item.jsonl.snap
+++ b/src-tauri/tests/snapshots/pipeline_streams__stream_replay@codex__context-compaction-item.jsonl.snap
@@ -1,0 +1,40 @@
+---
+source: tests/pipeline_streams.rs
+expression: snapshot
+input_file: tests/fixtures/streams/codex/context-compaction-item.jsonl
+---
+line_count: 4
+checkpoint_count: 2
+checkpoints:
+  - line_index: 2
+    event_type: item/completed
+    roles:
+      - system
+      - system
+    last_part_types:
+      - system-notice
+  - line_index: 3
+    event_type: turn/completed
+    roles:
+      - system
+      - system
+    last_part_types:
+      - system-notice
+final_state:
+  message_count: 2
+  roles:
+    - system
+    - system
+  total_parts: 2
+persisted_turns:
+  turn_count: 1
+  total_blocks: 0
+  turns:
+    - role: system
+      block_types: []
+historical_render:
+  message_count: 1
+  messages:
+    - role: system
+      part_types:
+        - system-notice

--- a/src-tauri/tests/snapshots/pipeline_streams__stream_replay@codex__thread-compacted.jsonl.snap
+++ b/src-tauri/tests/snapshots/pipeline_streams__stream_replay@codex__thread-compacted.jsonl.snap
@@ -1,0 +1,31 @@
+---
+source: tests/pipeline_streams.rs
+expression: snapshot
+input_file: tests/fixtures/streams/codex/thread-compacted.jsonl
+---
+line_count: 2
+checkpoint_count: 1
+checkpoints:
+  - line_index: 1
+    event_type: thread/compacted
+    roles:
+      - system
+    last_part_types:
+      - system-notice
+final_state:
+  message_count: 1
+  roles:
+    - system
+  total_parts: 1
+persisted_turns:
+  turn_count: 1
+  total_blocks: 0
+  turns:
+    - role: system
+      block_types: []
+historical_render:
+  message_count: 1
+  messages:
+    - role: system
+      part_types:
+        - system-notice

--- a/src-tauri/tests/stable_part_ids.rs
+++ b/src-tauri/tests/stable_part_ids.rs
@@ -15,6 +15,7 @@ mod common;
 
 use common::*;
 use helmor_lib::pipeline::types::{ExtendedMessagePart, MessagePart};
+use helmor_lib::pipeline::PipelineEmit;
 use serde_json::{json, Value};
 
 /// Feed an event and return the fully rendered thread snapshot.
@@ -46,6 +47,15 @@ fn last_text_id(messages: &[ThreadMessageLike]) -> Option<String> {
     for part in &last.content {
         if let ExtendedMessagePart::Basic(MessagePart::Text { id, .. }) = part {
             return Some(id.clone());
+        }
+    }
+    None
+}
+
+fn first_system_notice(message: &ThreadMessageLike) -> Option<(String, String)> {
+    for part in &message.content {
+        if let ExtendedMessagePart::Basic(MessagePart::SystemNotice { id, label, .. }) = part {
+            return Some((id.clone(), label.clone()));
         }
     }
     None
@@ -429,4 +439,44 @@ fn codex_reasoning_id_roundtrips_through_historical_reload() {
         live_id, hist_id,
         "Codex reasoning part id must survive the live → DB → historical round-trip",
     );
+}
+
+#[test]
+fn codex_context_compaction_renders_started_and_completed_notices() {
+    let mut pipeline = MessagePipeline::new("codex", "codex-mini", "ctx", "sess");
+
+    let started = json!({
+        "type": "item/started",
+        "item": {
+            "id": "compact_1",
+            "type": "contextCompaction"
+        }
+    });
+    let started_line = serde_json::to_string(&started).unwrap();
+    let partial = match pipeline.push_event(&started, &started_line) {
+        PipelineEmit::Partial(message) => message,
+        _ => panic!("context compaction start should emit a streaming notice"),
+    };
+    let (started_part_id, started_label) =
+        first_system_notice(&partial).expect("started notice should render");
+    assert_eq!(started_label, "Compacting context");
+
+    let completed = json!({
+        "type": "item/completed",
+        "item": {
+            "id": "compact_1",
+            "type": "contextCompaction"
+        }
+    });
+    let completed_line = serde_json::to_string(&completed).unwrap();
+    let messages = match pipeline.push_event(&completed, &completed_line) {
+        PipelineEmit::Full(messages) => messages,
+        _ => panic!("context compaction completion should emit a full render"),
+    };
+    let notices: Vec<(String, String)> = messages.iter().filter_map(first_system_notice).collect();
+
+    assert_eq!(notices.len(), 2);
+    assert_eq!(notices[0].1, "Compacting context");
+    assert_eq!(notices[1].1, "Context compacted");
+    assert_ne!(started_part_id, notices[1].0);
 }

--- a/src/features/composer/container.test.tsx
+++ b/src/features/composer/container.test.tsx
@@ -32,6 +32,7 @@ const composerMockState = vi.hoisted(() => ({
 		name: string;
 		description: string;
 		source: string;
+		providers?: readonly string[] | null;
 	}>,
 	lastLinkedDirectories: [] as readonly string[],
 	lastOnRemoveLinkedDirectory: null as RemoveHandler | null,
@@ -53,6 +54,7 @@ vi.mock("./index", async () => {
 				name: string;
 				description: string;
 				source: string;
+				providers?: readonly string[] | null;
 			}[];
 			linkedDirectories?: readonly string[];
 			onRemoveLinkedDirectory?: RemoveHandler;
@@ -605,7 +607,10 @@ describe("WorkspaceComposerContainer", () => {
 	});
 
 	describe("/add-dir integration", () => {
-		function renderWithLinkedDirs(linked: string[]) {
+		function renderWithLinkedDirs(
+			linked: string[],
+			displayedSessionId = "session-1",
+		) {
 			// Returning the list from the API mock — not setQueryData —
 			// so the background refetch (`staleTime: 0`) doesn't overwrite
 			// the seeded value with the default setup.ts mock.
@@ -627,7 +632,7 @@ describe("WorkspaceComposerContainer", () => {
 				<QueryClientProvider client={queryClient}>
 					<WorkspaceComposerContainer
 						displayedWorkspaceId="workspace-1"
-						displayedSessionId="session-1"
+						displayedSessionId={displayedSessionId}
 						disabled={false}
 						sending={false}
 						sendError={null}
@@ -682,6 +687,28 @@ describe("WorkspaceComposerContainer", () => {
 				name: "add-dir",
 				description: "Link extra directories to this workspace",
 				source: "client-action",
+			});
+		});
+
+		it("adds a built-in /compact command for Codex sessions", async () => {
+			apiMockState.listSlashCommands.mockResolvedValue({
+				commands: [],
+				isComplete: true,
+			});
+
+			renderWithLinkedDirs([], "session-2");
+
+			await waitFor(() => {
+				expect(composerMockState.lastSlashCommands.map((c) => c.name)).toEqual([
+					"add-dir",
+					"compact",
+				]);
+			});
+			expect(composerMockState.lastSlashCommands[1]).toEqual({
+				name: "compact",
+				description: "Compact this Codex thread's context",
+				source: "builtin",
+				providers: ["codex"],
 			});
 		});
 

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -57,17 +57,25 @@ const EMPTY_CANDIDATE_DIRECTORIES: readonly CandidateDirectory[] = [];
 const EMPTY_QUEUE_ITEMS: readonly QueuedSubmit[] = [];
 
 /**
- * Host-app built-in slash commands. Prepended to the agent-supplied list
- * so they always appear at the top of the popup. `source: "client-action"`
- * tells the plugin to fire an in-app handler instead of inserting the
- * command as prompt text.
+ * Host-app slash commands. Prepended to the agent-supplied list so they
+ * always appear at the top of the popup.
  */
+const ADD_DIR_COMMAND: SlashCommandEntry = {
+	name: "add-dir",
+	description: "Link extra directories to this workspace",
+	source: "client-action",
+};
+
+const CODEX_COMPACT_COMMAND: SlashCommandEntry = {
+	name: "compact",
+	description: "Compact this Codex thread's context",
+	source: "builtin",
+	providers: ["codex"],
+};
+
 const BUILTIN_CLIENT_COMMANDS: readonly SlashCommandEntry[] = [
-	{
-		name: "add-dir",
-		description: "Link extra directories to this workspace",
-		source: "client-action",
-	},
+	ADD_DIR_COMMAND,
+	CODEX_COMPACT_COMMAND,
 ];
 
 type WorkspaceComposerContainerProps = {
@@ -515,8 +523,14 @@ export const WorkspaceComposerContainer = memo(
 		// show at the top of the popup, even before the agent-supplied list
 		// has loaded.
 		const slashCommands = useMemo<readonly SlashCommandEntry[]>(
-			() => [...BUILTIN_CLIENT_COMMANDS, ...agentSlashCommands],
-			[agentSlashCommands],
+			() => [
+				...BUILTIN_CLIENT_COMMANDS.filter(
+					(command) =>
+						!command.providers || command.providers.includes(slashProvider),
+				),
+				...agentSlashCommands,
+			],
+			[agentSlashCommands, slashProvider],
 		);
 		// Pending only (`isPending`) covers the very first fetch with no data
 		// yet; once we have data, `isFetching` covers background refetches but

--- a/src/features/conversation/hooks/use-streaming.ts
+++ b/src/features/conversation/hooks/use-streaming.ts
@@ -1167,13 +1167,15 @@ export function useConversationStreaming({
 				typeof currentSession?.title === "string"
 					? currentSession.title
 					: undefined;
+			const isCompactCommand = trimmedPrompt === "/compact";
 			const isFirstUserMessage =
 				(currentThread ?? []).every((message) => message.role !== "user") &&
 				(currentTitle == null || currentTitle === "Untitled");
 			const repoPreferences = repoId ? await loadRepoPreferences(repoId) : null;
-			const finalPrompt = isFirstUserMessage
-				? prependGeneralPreferencePrompt(trimmedPrompt, repoPreferences)
-				: trimmedPrompt;
+			const finalPrompt =
+				isFirstUserMessage && !isCompactCommand
+					? prependGeneralPreferencePrompt(trimmedPrompt, repoPreferences)
+					: trimmedPrompt;
 			const now = new Date().toISOString();
 			const userMessageId = crypto.randomUUID();
 			const optimisticUserMessage = createLiveThreadMessage({
@@ -1184,7 +1186,7 @@ export function useConversationStreaming({
 				files: filePaths,
 			});
 			let titleSeed: string | null = null;
-			if (isFirstUserMessage) {
+			if (isFirstUserMessage && !isCompactCommand) {
 				titleSeed = buildTitleSeed(trimmedPrompt);
 				seedSessionTitle(targetSessionId, targetWorkspaceId, titleSeed);
 				void renameSession(targetSessionId, titleSeed).catch((error) => {

--- a/src/features/panel/message-components.test.tsx
+++ b/src/features/panel/message-components.test.tsx
@@ -193,6 +193,34 @@ describe("MemoConversationMessage plan review", () => {
 		expect(writeTextMock).toHaveBeenCalledWith("Real assistant reply");
 	});
 
+	it("hides timestamps on Codex compact status notices", () => {
+		vi.setSystemTime(new Date("2026-04-12T12:01:00.000Z"));
+		const systemMessage: ThreadMessageLike = {
+			id: "compact-start",
+			role: "system",
+			createdAt: "2026-04-12T12:00:00.000Z",
+			content: [
+				{
+					type: "system-notice",
+					id: "compact-start:notice",
+					severity: "info",
+					label: "Compacting context",
+				},
+			],
+		};
+
+		render(
+			<MemoConversationMessage
+				message={systemMessage}
+				sessionId="session-1"
+				itemIndex={1}
+			/>,
+		);
+
+		expect(screen.getByText("Compacting context")).toBeInTheDocument();
+		expect(screen.queryByText("1 minute ago")).not.toBeInTheDocument();
+	});
+
 	it("copies a user message from the bubble action slot", () => {
 		const userMessage: ThreadMessageLike = {
 			id: "user-copy-source",

--- a/src/features/panel/message-components/system-message.tsx
+++ b/src/features/panel/message-components/system-message.tsx
@@ -41,7 +41,7 @@ function SystemNotice({ part }: { part: SystemNoticePart }) {
 				? "text-chart-5"
 				: "text-chart-3";
 	return (
-		<span className="inline-flex items-center gap-1 whitespace-nowrap">
+		<span className="inline-flex min-h-4 items-center gap-1 whitespace-nowrap leading-none">
 			<Icon className={cn("size-3 shrink-0", iconClass)} strokeWidth={1.8} />
 			<span>{part.label}</span>
 			{part.body ? (
@@ -111,11 +111,23 @@ function MessageTimestamp({ createdAt }: { createdAt?: string }) {
 	if (Number.isNaN(date.getTime())) return null;
 	return (
 		<>
-			<span className="mx-0.5 text-[11px] text-muted-foreground/60">•</span>
-			<span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
+			<span className="inline-flex h-4 items-center text-[11px] leading-none text-muted-foreground/60">
+				•
+			</span>
+			<span className="inline-flex h-4 shrink-0 items-center text-[11px] leading-none tabular-nums text-muted-foreground">
 				{formatDistanceToNow(date, { addSuffix: true })}
 			</span>
 		</>
+	);
+}
+
+function shouldShowTimestamp(parts: MessagePart[]) {
+	const compactNoticeLabels = new Set([
+		"Compacting context",
+		"Context compacted",
+	]);
+	return !parts.some(
+		(part) => isSystemNoticePart(part) && compactNoticeLabels.has(part.label),
 	);
 }
 
@@ -138,7 +150,7 @@ export function ChatSystemMessage({
 			data-message-role="system"
 			className="group/sys flex min-w-0 items-center gap-1.5"
 		>
-			<div className="py-1 text-[11px] text-muted-foreground">
+			<div className="flex min-w-0 items-center gap-1.5 py-1 text-[11px] leading-none text-muted-foreground">
 				{parts.map((part, index) => {
 					if (isSystemNoticePart(part)) {
 						return <SystemNotice key={index} part={part} />;
@@ -151,8 +163,10 @@ export function ChatSystemMessage({
 					}
 					return null;
 				})}
+				{shouldShowTimestamp(parts) ? (
+					<MessageTimestamp createdAt={message.createdAt} />
+				) : null}
 			</div>
-			<MessageTimestamp createdAt={message.createdAt} />
 			<CopyMessageButton
 				message={copyTarget}
 				className="size-5 shrink-0 text-muted-foreground/30 opacity-0 hover:text-muted-foreground group-hover/sys:opacity-100"

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -634,6 +634,7 @@ export type SlashCommandEntry = {
 	name: string;
 	description: string;
 	argumentHint?: string | null;
+	providers?: AgentProvider[] | null;
 	/**
 	 * - `builtin` / `skill`: command is forwarded to the agent SDK as text.
 	 * - `client-action`: selecting the entry runs a host-app handler instead


### PR DESCRIPTION
## Summary

- Adds a Codex-only `/compact` built-in slash command in the composer that sends a `thread/compact/start` JSON-RPC to the Codex app server and resolves the turn on `thread/compacted`.
- Teaches the pipeline accumulator + adapter to recognize Codex `context_compaction` items and `thread/compacted` notifications, rendering "Compacting context" / "Context compacted" system notices in the conversation.
- Skips the first-message title seed + general-preference prompt prepend when the user's prompt is `/compact`, so compaction doesn't masquerade as a real first turn.
- Extends `SlashCommandEntry` with an optional `providers` filter so built-ins can be gated per-agent (Codex here).

## Why

Codex threads grow unbounded without a client-triggered way to summarize context. This wires the official Codex app-server compaction API end-to-end — composer → sidecar → pipeline → UI — matching the Claude `/compact` UX.

## Test plan

- [x] `bun run test:rust` — new `codex_context_compaction_renders_started_and_completed_notices` unit test plus two new stream-replay fixtures (`codex/context-compaction-item.jsonl`, `codex/thread-compacted.jsonl`) with committed snapshots.
- [x] `bun run test:frontend` — new composer test asserts the Codex `/compact` entry only appears for Codex sessions.
- [x] Manual: run a Codex session, type `/compact`, confirm the "Compacting context" → "Context compacted" notices render and the turn resolves.