### PR TITLE
fix: reset commit button to idle when PR-creation session is aborted

### DIFF
--- a/.changeset/swift-pandas-recover.md
+++ b/.changeset/swift-pandas-recover.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix the Create PR button getting stuck on "Creating…" after aborting the PR-creation session; it now returns to idle so the action can be retried.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -434,6 +434,12 @@ function AppShell({
 	const [settledSessionIds, setSettledSessionIds] = useState<Set<string>>(
 		() => new Set(),
 	);
+	// Sessions that terminated via abort (stop stream) rather than normal
+	// completion. Used by the commit lifecycle to return the button to idle
+	// when the user aborts an action session (e.g. Create PR).
+	const [abortedSessionIds, setAbortedSessionIds] = useState<Set<string>>(
+		() => new Set(),
+	);
 	const [interactionRequiredSessions, setInteractionRequiredSessions] =
 		useState<Map<string, string>>(() => new Map());
 	const interactionRequiredSessionIds = useMemo(
@@ -1383,6 +1389,7 @@ function AppShell({
 		workspacePrActionStatus,
 		workspaceGitActionStatus,
 		completedSessionIds: settledSessionIds,
+		abortedSessionIds,
 		interactionRequiredSessionIds,
 		sendingSessionIds,
 		onSelectSession: handleSelectSession,
@@ -1431,6 +1438,15 @@ function AppShell({
 		},
 		[notify, queryClient],
 	);
+
+	const handleSessionAborted = useCallback((sessionId: string) => {
+		setAbortedSessionIds((prev) => {
+			if (prev.has(sessionId)) return prev;
+			const next = new Set(prev);
+			next.add(sessionId);
+			return next;
+		});
+	}, []);
 
 	const lastInteractionCountsRef = useRef<Map<string, number>>(new Map());
 	const handleInteractionSessionsChange = useCallback(
@@ -2151,6 +2167,7 @@ function AppShell({
 													interactionRequiredSessionIds
 												}
 												onSessionCompleted={handleSessionCompleted}
+												onSessionAborted={handleSessionAborted}
 												workspacePrInfo={workspacePrInfo}
 												pendingPromptForSession={pendingPromptForSession}
 												onPendingPromptConsumed={handlePendingPromptConsumed}

--- a/src/features/commit/hooks/use-commit-lifecycle.test.tsx
+++ b/src/features/commit/hooks/use-commit-lifecycle.test.tsx
@@ -206,6 +206,81 @@ describe("useWorkspaceCommitLifecycle", () => {
 		});
 	});
 
+	it("clears the lifecycle when the tracked action session is aborted", async () => {
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false } },
+		});
+
+		const selectedWorkspaceIdRef = { current: "workspace-1" };
+		const onSelectSession = vi.fn();
+
+		const { result, rerender } = renderHook(
+			({
+				completedSessionIds,
+				abortedSessionIds,
+				sendingSessionIds,
+			}: {
+				completedSessionIds: Set<string>;
+				abortedSessionIds: Set<string>;
+				sendingSessionIds: Set<string>;
+			}) =>
+				useWorkspaceCommitLifecycle({
+					queryClient,
+					selectedWorkspaceId: "workspace-1",
+					selectedWorkspaceIdRef,
+					selectedRepoId: "repo-1",
+					workspaceManualStatus: null,
+					workspacePrInfo: null,
+					workspacePrActionStatus: EMPTY_PR_ACTION_STATUS,
+					workspaceGitActionStatus: EMPTY_GIT_ACTION_STATUS,
+					completedSessionIds,
+					abortedSessionIds,
+					interactionRequiredSessionIds: new Set<string>(),
+					sendingSessionIds,
+					onSelectSession,
+				}),
+			{
+				initialProps: {
+					completedSessionIds: new Set<string>(),
+					abortedSessionIds: new Set<string>(),
+					sendingSessionIds: new Set<string>(),
+				},
+				wrapper: createWrapper(queryClient),
+			},
+		);
+
+		await act(async () => {
+			await result.current.handleInspectorCommitAction("create-pr");
+		});
+
+		expect(result.current.commitButtonState).toBe("busy");
+
+		act(() => {
+			result.current.handlePendingPromptConsumed();
+		});
+
+		// Session starts streaming.
+		rerender({
+			completedSessionIds: new Set<string>(),
+			abortedSessionIds: new Set<string>(),
+			sendingSessionIds: new Set(["session-action"]),
+		});
+
+		// User aborts: session leaves sendingSessionIds and enters
+		// abortedSessionIds without ever reaching completedSessionIds.
+		rerender({
+			completedSessionIds: new Set<string>(),
+			abortedSessionIds: new Set(["session-action"]),
+			sendingSessionIds: new Set<string>(),
+		});
+
+		await waitFor(() => {
+			expect(result.current.commitButtonState).toBe("idle");
+		});
+		expect(apiMocks.lookupWorkspacePr).not.toHaveBeenCalled();
+		expect(apiMocks.setWorkspaceManualStatus).not.toHaveBeenCalled();
+	});
+
 	it("pushes directly without creating an action session", async () => {
 		const queryClient = new QueryClient({
 			defaultOptions: {

--- a/src/features/commit/hooks/use-commit-lifecycle.ts
+++ b/src/features/commit/hooks/use-commit-lifecycle.ts
@@ -92,6 +92,7 @@ export function useWorkspaceCommitLifecycle({
 	workspacePrActionStatus,
 	workspaceGitActionStatus,
 	completedSessionIds,
+	abortedSessionIds,
 	interactionRequiredSessionIds,
 	sendingSessionIds,
 	onSelectSession,
@@ -106,6 +107,7 @@ export function useWorkspaceCommitLifecycle({
 	workspacePrActionStatus: WorkspacePrActionStatus | null;
 	workspaceGitActionStatus: WorkspaceGitActionStatus | null;
 	completedSessionIds: Set<string>;
+	abortedSessionIds?: Set<string>;
 	interactionRequiredSessionIds: Set<string>;
 	sendingSessionIds: Set<string>;
 	onSelectSession: (sessionId: string | null) => void;
@@ -355,6 +357,7 @@ export function useWorkspaceCommitLifecycle({
 		console.log("[commitButton] action-session settlement check", {
 			sendingIds: Array.from(sendingSessionIds),
 			completedIds: Array.from(completedSessionIds),
+			abortedIds: abortedSessionIds ? Array.from(abortedSessionIds) : [],
 			interactionRequiredIds: Array.from(interactionRequiredSessionIds),
 			lifecyclePhase: current?.phase ?? null,
 			trackedSessionId: current?.trackedSessionId ?? null,
@@ -366,6 +369,19 @@ export function useWorkspaceCommitLifecycle({
 		if (current.phase !== "creating" && current.phase !== "streaming") return;
 
 		const trackedSessionId = current.trackedSessionId;
+
+		// Aborted sessions clear the lifecycle — no PR was created, so the
+		// button returns to idle rather than proceeding to verify.
+		if (abortedSessionIds?.has(trackedSessionId)) {
+			console.log(
+				"[commitButton] tracked session aborted — clearing lifecycle",
+			);
+			hasObservedSendingRef.current = false;
+			completedSessionHandledRef.current = null;
+			setCommitLifecycle(null);
+			return;
+		}
+
 		const isSending = sendingSessionIds.has(trackedSessionId);
 		if (isSending) {
 			console.log("[commitButton] tracked session is streaming");
@@ -435,6 +451,7 @@ export function useWorkspaceCommitLifecycle({
 		})();
 	}, [
 		completedSessionIds,
+		abortedSessionIds,
 		interactionRequiredSessionIds,
 		pushToast,
 		refreshWorkspaceRemoteStatus,

--- a/src/features/conversation/hooks/use-streaming.ts
+++ b/src/features/conversation/hooks/use-streaming.ts
@@ -134,6 +134,7 @@ type UseConversationStreamingArgs = {
 		interactionCounts: Map<string, number>,
 	) => void;
 	onSessionCompleted?: (sessionId: string, workspaceId: string) => void;
+	onSessionAborted?: (sessionId: string, workspaceId: string) => void;
 };
 
 export function useConversationStreaming({
@@ -149,6 +150,7 @@ export function useConversationStreaming({
 	onSendingSessionsChange,
 	onInteractionSessionsChange,
 	onSessionCompleted,
+	onSessionAborted,
 }: UseConversationStreamingArgs) {
 	const queryClient = useQueryClient();
 	const pushToast = useWorkspaceToast();
@@ -268,6 +270,8 @@ export function useConversationStreaming({
 	onInteractionSessionsChangeRef.current = onInteractionSessionsChange;
 	const onSessionCompletedRef = useRef(onSessionCompleted);
 	onSessionCompletedRef.current = onSessionCompleted;
+	const onSessionAbortedRef = useRef(onSessionAborted);
+	onSessionAbortedRef.current = onSessionAborted;
 	useLayoutEffect(() => {
 		const workspaceIds = new Set<string>();
 		for (const [, workspaceId] of sendingWorkspaceMapRef.current) {
@@ -884,6 +888,11 @@ export function useConversationStreaming({
 								if (sid && displayedWorkspaceId) {
 									onSessionCompletedRef.current?.(sid, displayedWorkspaceId);
 								}
+							} else if (event.kind === "aborted") {
+								const sid = event.sessionId ?? displayedSessionId;
+								if (sid && displayedWorkspaceId) {
+									onSessionAbortedRef.current?.(sid, displayedWorkspaceId);
+								}
 							}
 
 							void queryClient.invalidateQueries({
@@ -1401,6 +1410,11 @@ export function useConversationStreaming({
 								const sid = event.sessionId ?? targetSessionId;
 								if (sid && targetWorkspaceId) {
 									onSessionCompletedRef.current?.(sid, targetWorkspaceId);
+								}
+							} else if (event.kind === "aborted") {
+								const sid = event.sessionId ?? targetSessionId;
+								if (sid && targetWorkspaceId) {
+									onSessionAbortedRef.current?.(sid, targetWorkspaceId);
 								}
 							}
 

--- a/src/features/conversation/index.tsx
+++ b/src/features/conversation/index.tsx
@@ -48,6 +48,7 @@ type WorkspaceConversationContainerProps = {
 	) => void;
 	interactionRequiredSessionIds?: Set<string>;
 	onSessionCompleted?: (sessionId: string, workspaceId: string) => void;
+	onSessionAborted?: (sessionId: string, workspaceId: string) => void;
 	workspacePrInfo?: PullRequestInfo | null;
 	headerActions?: React.ReactNode;
 	headerLeading?: React.ReactNode;
@@ -93,6 +94,7 @@ export const WorkspaceConversationContainer = memo(
 		onInteractionSessionsChange,
 		interactionRequiredSessionIds,
 		onSessionCompleted,
+		onSessionAborted,
 		workspacePrInfo = null,
 		headerActions,
 		headerLeading,
@@ -168,6 +170,7 @@ export const WorkspaceConversationContainer = memo(
 			onSendingWorkspacesChange,
 			onInteractionSessionsChange,
 			onSessionCompleted,
+			onSessionAborted,
 		});
 
 		const queueItems = displayedSessionId


### PR DESCRIPTION
## Summary
- Fix the Create PR button staying stuck on "Creating…" after the user aborts the PR-creation session — it now returns to idle so the action can be retried.
- Thread a new `onSessionAborted` callback from `useConversationStreaming` up through `WorkspaceConversationContainer` to `AppShell`, which tracks aborted sessions in a new `abortedSessionIds` set.
- `useWorkspaceCommitLifecycle` consumes that set: when the tracked action session appears in `abortedSessionIds`, it clears the lifecycle instead of proceeding to the verify/PR-lookup phase.

## Why
Previously the commit lifecycle only reacted to `completedSessionIds` / `sendingSessionIds`. Aborted sessions leave `sendingSessionIds` without ever entering `completedSessionIds`, so the lifecycle stayed in `streaming` forever and the button was frozen on "Creating…". Treating abort as a distinct terminal signal lets the lifecycle unwind cleanly without triggering a spurious PR lookup.

## Test plan
- [x] `bun run test:frontend` — new `use-commit-lifecycle` test covers the abort path
- [ ] Manual: kick off Create PR, hit stop while it's streaming, confirm the button returns to idle and can be retried