### PR TITLE
feat: show timestamp only on turn-end system row

### DIFF
--- a/.changeset/quiet-system-timestamps.md
+++ b/.changeset/quiet-system-timestamps.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Show relative timestamps only on the turn-end row in the chat thread so errors and other system notices no longer carry a redundant "N minutes ago".

--- a/src-tauri/src/pipeline/adapter/labels.rs
+++ b/src-tauri/src/pipeline/adapter/labels.rs
@@ -26,6 +26,23 @@ pub(super) fn make_system(msg: &IntermediateMessage, text: &str) -> ThreadMessag
     }
 }
 
+/// Turn-end system row (Claude `result` / Codex `turn.completed`).
+/// Tagged with a `:turn-result` part id so the frontend can single it out
+/// as the only system row that renders a timestamp.
+pub(super) fn make_turn_result_system(msg: &IntermediateMessage, text: &str) -> ThreadMessageLike {
+    ThreadMessageLike {
+        role: MessageRole::System,
+        id: Some(msg.id.clone()),
+        created_at: Some(msg.created_at.clone()),
+        content: vec![ExtendedMessagePart::Basic(MessagePart::Text {
+            id: format!("{}:turn-result", msg.id),
+            text: text.to_string(),
+        })],
+        status: None,
+        streaming: None,
+    }
+}
+
 pub(super) fn make_system_notice(
     msg: &IntermediateMessage,
     part: MessagePart,

--- a/src-tauri/src/pipeline/adapter/mod.rs
+++ b/src-tauri/src/pipeline/adapter/mod.rs
@@ -39,6 +39,7 @@ use grouping::{
 use labels::{
     build_error_label, build_rate_limit_notice, build_result_label, build_subagent_notice,
     build_system_label, build_system_notice, extract_fallback, make_system, make_system_notice,
+    make_turn_result_system,
 };
 
 use super::types::{
@@ -104,7 +105,7 @@ fn convert_flat(messages: &[IntermediateMessage]) -> Vec<ThreadMessageLike> {
         if msg_type == Some("result") {
             let label = build_result_label(parsed);
             if !label.is_empty() {
-                result.push(make_system(msg, &label));
+                result.push(make_turn_result_system(msg, &label));
             }
             i += 1;
             continue;
@@ -318,7 +319,7 @@ fn convert_flat(messages: &[IntermediateMessage]) -> Vec<ThreadMessageLike> {
         if matches!(msg_type, Some("turn/completed") | Some("turn.completed")) {
             let label = build_result_label(parsed);
             if !label.is_empty() {
-                result.push(make_system(msg, &label));
+                result.push(make_turn_result_system(msg, &label));
             }
             i += 1;
             continue;

--- a/src/features/panel/message-components/system-message.tsx
+++ b/src/features/panel/message-components/system-message.tsx
@@ -121,13 +121,11 @@ function MessageTimestamp({ createdAt }: { createdAt?: string }) {
 	);
 }
 
+// Only the turn-end row (Claude `result` / Codex `turn.completed`) gets a
+// timestamp — the adapter tags its text part id with `:turn-result`.
 function shouldShowTimestamp(parts: MessagePart[]) {
-	const compactNoticeLabels = new Set([
-		"Compacting context",
-		"Context compacted",
-	]);
-	return !parts.some(
-		(part) => isSystemNoticePart(part) && compactNoticeLabels.has(part.label),
+	return parts.some(
+		(part) => isTextPart(part) && part.id.endsWith(":turn-result"),
 	);
 }
 


### PR DESCRIPTION
## Summary
- Only the turn-end system row (Claude `result` / Codex `turn.completed`) now renders a relative timestamp in the chat thread — errors, notices, and other system rows no longer carry a redundant "N minutes ago".
- Adapter tags the turn-end row with a `:turn-result` text part id via a new `make_turn_result_system` helper; the frontend's `shouldShowTimestamp` keys off that tag instead of the old compact-notice denylist.
- Includes a patch-level changeset.

## Why
The previous logic suppressed timestamps only for the two compaction notices, leaking a relative time onto every other system row (errors, subagent notices, rate-limit messages, etc.). Timestamps are really only meaningful on the turn boundary, so the adapter now marks that row explicitly and the renderer opts-in instead of maintaining an ever-growing denylist.

## Test plan
- [ ] `bun run test:rust` — pipeline snapshots still pass (turn-result rows now carry the `:turn-result` part id).
- [ ] `bun run dev` — in a live thread, confirm only the final turn row shows a relative timestamp; error/system notice rows do not.