### PR TITLE
fix: soften transient failure paths in sidecar, agents, and GitHub client

### DIFF
--- a/.changeset/steady-pr-recover.md
+++ b/.changeset/steady-pr-recover.md
@@ -1,0 +1,8 @@
+---
+"helmor": patch
+---
+
+Tighten up a handful of transient failure paths so they stop surfacing as errors:
+- Retry the slash-command popup once when the Claude SDK tears down its query mid-request, so the `/` menu loads instead of flashing an error.
+- Retry GitHub PR actions (show / merge / close) once on transient TLS and connect errors with a short backoff, so a flaky network doesn't bounce the user out of a commit flow.
+- Stop raising an error when a session is deleted while its title is still being generated in the background.

--- a/sidecar/src/abort.ts
+++ b/sidecar/src/abort.ts
@@ -14,3 +14,16 @@ export function isAbortError(err: unknown): boolean {
 	if (typeof e.message === "string" && /abort/i.test(e.message)) return true;
 	return false;
 }
+
+/**
+ * Detect "Query closed before response received" — a transient Claude SDK
+ * race where the claude-code child is torn down (session swap, child exit)
+ * between a control-protocol request and its reply. Caller retries once.
+ */
+export function isQueryClosedTransient(err: unknown): boolean {
+	if (!err || typeof err !== "object") return false;
+	const msg = (err as { message?: unknown }).message;
+	return (
+		typeof msg === "string" && msg.includes("Query closed before response")
+	);
+}

--- a/sidecar/src/claude-session-manager.ts
+++ b/sidecar/src/claude-session-manager.ts
@@ -16,7 +16,7 @@ import {
 	type SDKMessage,
 	type SDKUserMessage,
 } from "@anthropic-ai/claude-agent-sdk";
-import { isAbortError } from "./abort.js";
+import { isAbortError, isQueryClosedTransient } from "./abort.js";
 import {
 	applyClaudeModelOverrides,
 	claudeModelSupportsFastMode,
@@ -791,6 +791,22 @@ export class ClaudeSessionManager implements SessionManager {
 	 * which lets the iterator return naturally as part of teardown.
 	 */
 	async listSlashCommands(
+		params: ListSlashCommandsParams,
+	): Promise<readonly SlashCommandInfo[]> {
+		// Retry once on "Query closed before response received" — it's a
+		// transient race (claude-code child preempted or torn down between
+		// init and the control-protocol reply), not a real failure.
+		try {
+			return await this.listSlashCommandsOnce(params);
+		} catch (err) {
+			if (isQueryClosedTransient(err)) {
+				return this.listSlashCommandsOnce(params);
+			}
+			throw err;
+		}
+	}
+
+	private async listSlashCommandsOnce(
 		params: ListSlashCommandsParams,
 	): Promise<readonly SlashCommandInfo[]> {
 		const { cwd } = params;

--- a/sidecar/src/logger.ts
+++ b/sidecar/src/logger.ts
@@ -98,8 +98,14 @@ class Logger {
 		this.minLevel = LEVELS[level];
 		this.devStderr = level === "debug";
 
+		// Skip file writes under `bun test`. This singleton is created on first
+		// import, before any test-level env override can fire, so agent-spawned
+		// shells inheriting HELMOR_LOG_DIR from a release helmor would otherwise
+		// pollute ~/helmor/logs. Bun auto-sets NODE_ENV=test.
+		const isTest =
+			process.env.NODE_ENV === "test" || process.env.BUN_TEST === "1";
 		const logDir = process.env.HELMOR_LOG_DIR;
-		if (logDir) {
+		if (logDir && !isTest) {
 			mkdirSync(logDir, { recursive: true });
 			this.primaryPath = `${logDir}/sidecar.jsonl`;
 			this.backupPath = `${logDir}/sidecar.jsonl.1`;

--- a/src-tauri/src/agents/queries.rs
+++ b/src-tauri/src/agents/queries.rs
@@ -1,5 +1,6 @@
 use std::sync::Mutex;
 
+use rusqlite::OptionalExtension;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tauri::{AppHandle, Manager};
@@ -213,13 +214,27 @@ pub async fn generate_session_title(
         if let Some(ref title) = generated_title {
             let connection = crate::models::db::read_conn()
                 .map_err(|e| anyhow::anyhow!("Failed to open DB: {e}"))?;
-            let latest_title: String = connection
+            // Session may have been deleted while title generation was in flight.
+            // Treat as a silent skip — matches the branch re-read a few lines below.
+            let latest_title: Option<String> = connection
                 .query_row(
                     "SELECT title FROM sessions WHERE id = ?1",
                     [&session_id],
                     |row| row.get(0),
                 )
+                .optional()
                 .map_err(|e| anyhow::anyhow!("Failed to re-read session title: {e}"))?;
+            let Some(latest_title) = latest_title else {
+                tracing::debug!(
+                    session_id = %session_id,
+                    "Skipping auto session rename: session deleted during title generation"
+                );
+                return Ok(GenerateSessionTitleResponse {
+                    title: generated_title,
+                    branch_renamed: false,
+                    skipped: false,
+                });
+            };
 
             if can_replace_session_title(&latest_title, request.title_seed.as_deref()) {
                 crate::sessions::rename_session(&session_id, title)

--- a/src-tauri/src/github/graphql.rs
+++ b/src-tauri/src/github/graphql.rs
@@ -135,6 +135,40 @@ impl WorkspacePrActionStatus {
     }
 }
 
+/// Send a blocking HTTP request with up to 2 retries on transient network
+/// failures (TLS handshake, connect, timeout, connection reset). JSON bodies
+/// are always cloneable via `try_clone`; on the rare non-cloneable case we
+/// fall through to a single send.
+fn send_with_retry(
+    builder: reqwest::blocking::RequestBuilder,
+) -> reqwest::Result<reqwest::blocking::Response> {
+    const BACKOFF_MS: [u64; 2] = [200, 500];
+    for &delay in &BACKOFF_MS {
+        let Some(attempt) = builder.try_clone() else {
+            return builder.send();
+        };
+        match attempt.send() {
+            Ok(resp) => return Ok(resp),
+            Err(e) if is_transient_network_error(&e) => {
+                std::thread::sleep(std::time::Duration::from_millis(delay));
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    builder.send()
+}
+
+fn is_transient_network_error(err: &reqwest::Error) -> bool {
+    if err.is_connect() || err.is_timeout() {
+        return true;
+    }
+    let msg = err.to_string().to_lowercase();
+    msg.contains("tls handshake")
+        || msg.contains("handshake eof")
+        || msg.contains("connection reset")
+        || msg.contains("connection closed")
+}
+
 /// Look up the (most recent) pull request matching this workspace's current
 /// branch on GitHub.
 ///
@@ -209,15 +243,16 @@ query($owner: String!, $name: String!, $head: String!) {
         },
     });
 
-    let response = client
-        .post("https://api.github.com/graphql")
-        .header(USER_AGENT, "Helmor")
-        .header(ACCEPT, "application/json")
-        .header(CONTENT_TYPE, "application/json")
-        .header(AUTHORIZATION, format!("Bearer {access_token}"))
-        .json(&body)
-        .send()
-        .context("Failed to reach GitHub GraphQL API")?;
+    let response = send_with_retry(
+        client
+            .post("https://api.github.com/graphql")
+            .header(USER_AGENT, "Helmor")
+            .header(ACCEPT, "application/json")
+            .header(CONTENT_TYPE, "application/json")
+            .header(AUTHORIZATION, format!("Bearer {access_token}"))
+            .json(&body),
+    )
+    .context("Failed to reach GitHub GraphQL API")?;
 
     let status = response.status();
     if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
@@ -461,15 +496,16 @@ query($owner: String!, $name: String!, $head: String!) {
         },
     });
 
-    let response = client
-        .post("https://api.github.com/graphql")
-        .header(USER_AGENT, "Helmor")
-        .header(ACCEPT, "application/json")
-        .header(CONTENT_TYPE, "application/json")
-        .header(AUTHORIZATION, format!("Bearer {access_token}"))
-        .json(&body)
-        .send()
-        .context("Failed to reach GitHub GraphQL API")?;
+    let response = send_with_retry(
+        client
+            .post("https://api.github.com/graphql")
+            .header(USER_AGENT, "Helmor")
+            .header(ACCEPT, "application/json")
+            .header(CONTENT_TYPE, "application/json")
+            .header(AUTHORIZATION, format!("Bearer {access_token}"))
+            .json(&body),
+    )
+    .context("Failed to reach GitHub GraphQL API")?;
 
     let status = response.status();
     if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
@@ -528,15 +564,16 @@ fn query_check_run_detail(
     name: &str,
     check_run_id: i64,
 ) -> Result<GithubCheckRunDetail> {
-    let response = client
-        .get(format!(
-            "https://api.github.com/repos/{owner}/{name}/check-runs/{check_run_id}"
-        ))
-        .header(USER_AGENT, "Helmor")
-        .header(ACCEPT, "application/vnd.github+json")
-        .header(AUTHORIZATION, format!("Bearer {access_token}"))
-        .send()
-        .context("Failed to reach GitHub REST API")?;
+    let response = send_with_retry(
+        client
+            .get(format!(
+                "https://api.github.com/repos/{owner}/{name}/check-runs/{check_run_id}"
+            ))
+            .header(USER_AGENT, "Helmor")
+            .header(ACCEPT, "application/vnd.github+json")
+            .header(AUTHORIZATION, format!("Bearer {access_token}")),
+    )
+    .context("Failed to reach GitHub REST API")?;
 
     let status = response.status();
     if !status.is_success() {
@@ -601,17 +638,18 @@ query($owner: String!, $name: String!, $head: String!) {
         "variables": { "owner": owner, "name": name, "head": branch },
     });
 
-    let id_response: GraphqlEnvelope = client
-        .post("https://api.github.com/graphql")
-        .header(USER_AGENT, "Helmor")
-        .header(ACCEPT, "application/json")
-        .header(CONTENT_TYPE, "application/json")
-        .header(AUTHORIZATION, format!("Bearer {access_token}"))
-        .json(&id_body)
-        .send()
-        .context("Failed to reach GitHub GraphQL API")?
-        .json()
-        .context("Failed to decode GraphQL response")?;
+    let id_response: GraphqlEnvelope = send_with_retry(
+        client
+            .post("https://api.github.com/graphql")
+            .header(USER_AGENT, "Helmor")
+            .header(ACCEPT, "application/json")
+            .header(CONTENT_TYPE, "application/json")
+            .header(AUTHORIZATION, format!("Bearer {access_token}"))
+            .json(&id_body),
+    )
+    .context("Failed to reach GitHub GraphQL API")?
+    .json()
+    .context("Failed to decode GraphQL response")?;
 
     let pr_node_id = id_response
         .data
@@ -635,17 +673,18 @@ mutation($prId: ID!) {
         "variables": { "prId": pr_node_id },
     });
 
-    let merge_response: serde_json::Value = client
-        .post("https://api.github.com/graphql")
-        .header(USER_AGENT, "Helmor")
-        .header(ACCEPT, "application/json")
-        .header(CONTENT_TYPE, "application/json")
-        .header(AUTHORIZATION, format!("Bearer {access_token}"))
-        .json(&merge_body)
-        .send()
-        .context("Failed to call mergePullRequest")?
-        .json()
-        .context("Failed to decode merge response")?;
+    let merge_response: serde_json::Value = send_with_retry(
+        client
+            .post("https://api.github.com/graphql")
+            .header(USER_AGENT, "Helmor")
+            .header(ACCEPT, "application/json")
+            .header(CONTENT_TYPE, "application/json")
+            .header(AUTHORIZATION, format!("Bearer {access_token}"))
+            .json(&merge_body),
+    )
+    .context("Failed to call mergePullRequest")?
+    .json()
+    .context("Failed to decode merge response")?;
 
     if let Some(errors) = merge_response.get("errors") {
         if let Some(arr) = errors.as_array() {
@@ -711,17 +750,18 @@ query($owner: String!, $name: String!, $head: String!) {
         "variables": { "owner": owner, "name": name, "head": branch },
     });
 
-    let id_response: GraphqlEnvelope = client
-        .post("https://api.github.com/graphql")
-        .header(USER_AGENT, "Helmor")
-        .header(ACCEPT, "application/json")
-        .header(CONTENT_TYPE, "application/json")
-        .header(AUTHORIZATION, format!("Bearer {access_token}"))
-        .json(&id_body)
-        .send()
-        .context("Failed to reach GitHub GraphQL API")?
-        .json()
-        .context("Failed to decode GraphQL response")?;
+    let id_response: GraphqlEnvelope = send_with_retry(
+        client
+            .post("https://api.github.com/graphql")
+            .header(USER_AGENT, "Helmor")
+            .header(ACCEPT, "application/json")
+            .header(CONTENT_TYPE, "application/json")
+            .header(AUTHORIZATION, format!("Bearer {access_token}"))
+            .json(&id_body),
+    )
+    .context("Failed to reach GitHub GraphQL API")?
+    .json()
+    .context("Failed to decode GraphQL response")?;
 
     let pr_node_id = id_response
         .data
@@ -744,17 +784,18 @@ mutation($prId: ID!) {
         "variables": { "prId": pr_node_id },
     });
 
-    let close_response: serde_json::Value = client
-        .post("https://api.github.com/graphql")
-        .header(USER_AGENT, "Helmor")
-        .header(ACCEPT, "application/json")
-        .header(CONTENT_TYPE, "application/json")
-        .header(AUTHORIZATION, format!("Bearer {access_token}"))
-        .json(&close_body)
-        .send()
-        .context("Failed to call closePullRequest")?
-        .json()
-        .context("Failed to decode close response")?;
+    let close_response: serde_json::Value = send_with_retry(
+        client
+            .post("https://api.github.com/graphql")
+            .header(USER_AGENT, "Helmor")
+            .header(ACCEPT, "application/json")
+            .header(CONTENT_TYPE, "application/json")
+            .header(AUTHORIZATION, format!("Bearer {access_token}"))
+            .json(&close_body),
+    )
+    .context("Failed to call closePullRequest")?
+    .json()
+    .context("Failed to decode close response")?;
 
     if let Some(errors) = close_response.get("errors") {
         if let Some(arr) = errors.as_array() {

--- a/src-tauri/src/models/sessions.rs
+++ b/src-tauri/src/models/sessions.rs
@@ -216,7 +216,9 @@ pub(crate) fn mark_session_unread_in_transaction(
         )
         .with_context(|| format!("Failed to mark session {session_id} as unread"))?;
 
-    if updated_rows != 1 {
+    // 0 rows = session was deleted mid-flight; benign race, skip silently.
+    // >1 rows = duplicate primary key, genuinely broken schema.
+    if updated_rows > 1 {
         bail!("Session unread update affected {updated_rows} rows for session {session_id}");
     }
 


### PR DESCRIPTION
## Summary

Tighten a handful of transient failure paths so they stop surfacing as user-visible errors:

- **Slash-command popup** — retry `listSlashCommands` once when the Claude SDK throws `Query closed before response received`, a race where the claude-code child is torn down between a control-protocol request and its reply. The `/` menu now loads instead of flashing an error. New `isQueryClosedTransient` helper in `sidecar/src/abort.ts`.
- **GitHub PR actions** — retry show / merge / close / check-run detail once on transient TLS handshake, connect, timeout, and connection-reset errors with a short backoff (200ms, 500ms). A flaky network no longer bounces users out of a commit flow. New `send_with_retry` helper in `src-tauri/src/github/graphql.rs`.
- **Auto session title** — if a session is deleted while its title is still being generated in the background, skip silently instead of raising `Failed to re-read session title`. `queries.rs` now uses `OptionalExtension` on the re-read.
- **Mark session unread** — 0 rows updated is a benign race (session deleted mid-flight); only `>1 rows` remains a real error.
- **Sidecar logger under `bun test`** — skip file writes when `NODE_ENV=test` / `BUN_TEST=1` so agent-spawned shells inheriting `HELMOR_LOG_DIR` from a release helmor don't pollute `~/helmor/logs`.

## Why

All five spots are cases where the product already knew how to recover, but the transient error was being bubbled up as if it were a real failure — degrading trust in the UI during otherwise healthy runs. Changeset `.changeset/steady-pr-recover.md` included.

## Test plan

- [ ] `bun run lint` (biome + clippy)
- [ ] `bun run test` (frontend + sidecar + rust, including `pipeline_*` snapshots)
- [ ] Manually verify `/` slash-command popup still loads cleanly after a session swap
- [ ] Manually verify PR show/merge/close paths still succeed on a healthy network (no regression from the retry wrapper)
- [ ] Manually verify deleting a session mid-title-generation no longer logs an error