### PR TITLE
chore: rename package to helmor111

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "helmor",
+	"name": "helmor111",
 	"description": "The local-first IDE for coding agent orchestration.",
 	"private": true,
 	"version": "0.6.3",


### PR DESCRIPTION
## What
Renames the npm package field in `package.json` from `helmor` to `helmor111`.

## Why
Pushing the in-progress change from this workspace as requested.

## Test notes
- No code paths exercise the package `name` field at runtime, so no functional impact expected.
- CI (biome / clippy / vitest / cargo test) should still pass unchanged.

> Heads up: please double-check whether `helmor111` is the intended package name before merging — it looks like it may have been a placeholder.