### PR TITLE
fix: prefer per-message iterations from usage for context meter

### DIFF
--- a/.changeset/quiet-cycles-count.md
+++ b/.changeset/quiet-cycles-count.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix Claude context usage so Helmor uses the latest per-message SDK token totals instead of inflated cumulative usage when updating the composer meter.

--- a/sidecar/src/context-usage.test.ts
+++ b/sidecar/src/context-usage.test.ts
@@ -42,6 +42,39 @@ describe("buildClaudeStoredMeta", () => {
 					cache_creation_input_tokens: 75_098,
 					cache_read_input_tokens: 1_008_704,
 					output_tokens: 18_132,
+					iterations: [
+						{
+							type: "message",
+							input_tokens: 1,
+							cache_creation_input_tokens: 2_468,
+							cache_read_input_tokens: 72_630,
+							output_tokens: 3_056,
+						},
+					],
+				},
+				modelUsage: {
+					[CLAUDE_MODEL]: { contextWindow: 1_000_000 },
+				},
+			},
+			CLAUDE_MODEL,
+		);
+		expect(meta).toEqual({
+			modelId: CLAUDE_MODEL,
+			usedTokens: 78_155,
+			maxTokens: 1_000_000,
+			percentage: 7.82,
+		});
+	});
+
+	it("accepts legacy top-level iterations", () => {
+		const meta = buildClaudeStoredMeta(
+			{
+				type: "result",
+				usage: {
+					input_tokens: 340,
+					cache_creation_input_tokens: 75_098,
+					cache_read_input_tokens: 1_008_704,
+					output_tokens: 18_132,
 				},
 				iterations: [
 					{

--- a/sidecar/src/context-usage.ts
+++ b/sidecar/src/context-usage.ts
@@ -80,7 +80,10 @@ export function buildClaudeStoredMeta(
 	> | null;
 	if (!usage || !modelUsage) return null;
 
-	const source = pickLastMessageIteration(root.iterations) ?? usage;
+	const source =
+		pickLastMessageIteration(usage.iterations) ??
+		pickLastMessageIteration(root.iterations) ??
+		usage;
 	const used =
 		num(source.input_tokens) +
 		num(source.cache_creation_input_tokens) +


### PR DESCRIPTION
## Summary

- `buildClaudeStoredMeta` now prefers the latest per-message iteration from `usage.iterations` (the SDK's current shape) before falling back to the legacy top-level `root.iterations`, and finally to the cumulative `usage` totals.
- This keeps the composer's context-window meter aligned with what the model actually sees on the current turn, instead of the inflated cumulative cache-read/cache-creation numbers that the SDK reports in `result.usage`.

## Why

The Claude Agent SDK started nesting `iterations` under `usage` instead of at the top level of the result event. Our previous implementation only looked at `root.iterations`, so it silently fell through to the cumulative `usage` — which sums every turn's cache reads/creates — and made the meter show ~100% very early. Reading `usage.iterations` first restores per-turn accuracy while still honoring older payloads.

## Test plan

- [x] `bun run test:sidecar` — added a new test covering the `usage.iterations` path and renamed the existing one to cover the legacy top-level `iterations` fallback.