### PR TITLE
feat: render codex image generation output inline

### DIFF
--- a/.changeset/tidy-images-glow.md
+++ b/.changeset/tidy-images-glow.md
@@ -1,0 +1,8 @@
+---
+"helmor": minor
+---
+
+Add first-class Codex image output support in chat:
+- Render Codex-generated images inline in assistant messages.
+- Store generated images as managed files instead of large base64 payloads in the session database.
+- Add a chat image context menu for copying images and revealing generated image files in Finder.

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "helmor",

--- a/src-tauri/src/agents/persistence.rs
+++ b/src-tauri/src/agents/persistence.rs
@@ -61,6 +61,10 @@ pub(super) fn persist_turn_message(
     // Use the pre-assigned ID from the turn so streaming and historical
     // message IDs are the same UUID.
     let msg_id = turn.id.clone();
+    let content = crate::image_store::prepare_turn_content_for_persist(
+        &ctx.helmor_session_id,
+        &turn.content_json,
+    )?;
 
     conn.execute(
         r#"
@@ -68,13 +72,7 @@ pub(super) fn persist_turn_message(
               id, session_id, role, content, created_at, sent_at
             ) VALUES (?1, ?2, ?3, ?4, ?5, ?5)
             "#,
-        params![
-            msg_id,
-            ctx.helmor_session_id,
-            turn.role,
-            turn.content_json,
-            now
-        ],
+        params![msg_id, ctx.helmor_session_id, turn.role, content, now],
     )?;
     Ok(msg_id)
 }

--- a/src-tauri/src/commands/system_commands.rs
+++ b/src-tauri/src/commands/system_commands.rs
@@ -254,6 +254,91 @@ pub async fn save_pasted_image(data: String, media_type: String) -> CmdResult<St
     .await
 }
 
+#[tauri::command]
+pub async fn show_image_in_finder(path: String) -> CmdResult<()> {
+    run_blocking(move || {
+        let source = std::path::PathBuf::from(path);
+        if !source.is_file() {
+            return Err(anyhow::anyhow!(
+                "Image file not found: {}",
+                source.display()
+            ));
+        }
+        reveal_file_in_finder(&source).context("Failed to show image in Finder")
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn copy_image_to_clipboard(path: String) -> CmdResult<()> {
+    run_blocking(move || {
+        let source = std::path::PathBuf::from(path);
+        if !source.is_file() {
+            return Err(anyhow::anyhow!(
+                "Image file not found: {}",
+                source.display()
+            ));
+        }
+        copy_image_file_to_clipboard(&source).context("Failed to copy image")
+    })
+    .await
+}
+
+#[cfg(target_os = "macos")]
+fn reveal_file_in_finder(path: &std::path::Path) -> anyhow::Result<()> {
+    std::process::Command::new("open")
+        .arg("-R")
+        .arg(path)
+        .spawn()
+        .map(|_| ())
+        .context("open command failed")
+}
+
+#[cfg(not(target_os = "macos"))]
+fn reveal_file_in_finder(_path: &std::path::Path) -> anyhow::Result<()> {
+    anyhow::bail!("Showing images in Finder is only supported on macOS")
+}
+
+#[cfg(target_os = "macos")]
+fn copy_image_file_to_clipboard(path: &std::path::Path) -> anyhow::Result<()> {
+    let class_name = match path
+        .extension()
+        .and_then(|s| s.to_str())
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("jpg" | "jpeg") => "JPEG picture",
+        Some("gif") => "GIF picture",
+        _ => "«class PNGf»",
+    };
+    let script = format!(
+        "set the clipboard to (read (POSIX file \"{}\") as {class_name})",
+        applescript_escape(&path.to_string_lossy())
+    );
+    let output = std::process::Command::new("osascript")
+        .arg("-e")
+        .arg(script)
+        .output()
+        .context("osascript command failed")?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!(
+            "{}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ))
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn copy_image_file_to_clipboard(_path: &std::path::Path) -> anyhow::Result<()> {
+    anyhow::bail!("Copying images is only supported on macOS")
+}
+
+fn applescript_escape(input: &str) -> String {
+    input.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
 fn base64_decode(input: &str) -> anyhow::Result<Vec<u8>> {
     use base64::Engine;
     base64::engine::general_purpose::STANDARD

--- a/src-tauri/src/data_dir.rs
+++ b/src-tauri/src/data_dir.rs
@@ -70,6 +70,15 @@ pub fn run_dir() -> Result<PathBuf> {
     Ok(dir)
 }
 
+/// Returns the generated images directory inside the data dir.
+pub fn generated_images_dir() -> Result<PathBuf> {
+    let dir = data_dir()?.join("generated-images");
+    if !dir.exists() {
+        fs::create_dir_all(&dir).context("Failed to create generated images directory")?;
+    }
+    Ok(dir)
+}
+
 /// Returns the Conductor source database path for import.
 /// This is the real Conductor database on the local machine.
 pub fn conductor_source_db_path() -> Option<PathBuf> {
@@ -142,6 +151,7 @@ pub fn ensure_directory_structure() -> Result<()> {
     workspaces_dir()?;
     logs_dir()?;
     run_dir()?;
+    generated_images_dir()?;
     Ok(())
 }
 

--- a/src-tauri/src/image_store.rs
+++ b/src-tauri/src/image_store.rs
@@ -1,0 +1,207 @@
+use std::{fs, path::PathBuf};
+
+use anyhow::{Context, Result};
+use base64::Engine;
+use serde_json::Value;
+
+pub fn prepare_turn_content_for_persist(session_id: &str, content_json: &str) -> Result<String> {
+    let Ok(mut parsed) = serde_json::from_str::<Value>(content_json) else {
+        return Ok(content_json.to_string());
+    };
+
+    let Some(item) = parsed.get_mut("item").and_then(Value::as_object_mut) else {
+        return Ok(content_json.to_string());
+    };
+    let item_type = item.get("type").and_then(Value::as_str);
+    if !matches!(item_type, Some("image_generation" | "imageGeneration")) {
+        return Ok(content_json.to_string());
+    }
+
+    let item_id = item
+        .get("id")
+        .and_then(Value::as_str)
+        .map(safe_filename)
+        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+    let result = item
+        .get("result")
+        .and_then(Value::as_str)
+        .filter(|s| !s.trim().is_empty())
+        .map(str::to_string);
+    let source_path = item
+        .get("saved_path")
+        .or_else(|| item.get("savedPath"))
+        .and_then(Value::as_str)
+        .filter(|s| !s.trim().is_empty())
+        .map(PathBuf::from);
+
+    let Some(path) = persist_image_payload(session_id, &item_id, source_path, result.as_deref())?
+    else {
+        return Ok(content_json.to_string());
+    };
+
+    item.remove("result");
+    item.remove("savedPath");
+    item.insert(
+        "saved_path".to_string(),
+        Value::String(path.to_string_lossy().to_string()),
+    );
+
+    Ok(serde_json::to_string(&parsed)?)
+}
+
+fn persist_image_payload(
+    session_id: &str,
+    item_id: &str,
+    source_path: Option<PathBuf>,
+    result: Option<&str>,
+) -> Result<Option<PathBuf>> {
+    let ext = source_path
+        .as_deref()
+        .and_then(path_ext)
+        .or_else(|| result.and_then(data_url_ext))
+        .unwrap_or("png");
+    let dest_dir = crate::data_dir::generated_images_dir()?.join(safe_filename(session_id));
+    fs::create_dir_all(&dest_dir).with_context(|| {
+        format!(
+            "Failed to create generated image dir {}",
+            dest_dir.display()
+        )
+    })?;
+    let dest_path = dest_dir.join(format!("{item_id}.{ext}"));
+
+    if let Some(source) = source_path {
+        if source.is_file() {
+            if source != dest_path {
+                fs::copy(&source, &dest_path).with_context(|| {
+                    format!(
+                        "Failed to copy generated image {} to {}",
+                        source.display(),
+                        dest_path.display()
+                    )
+                })?;
+            }
+            return Ok(Some(dest_path));
+        }
+    }
+
+    let Some(result) = result else {
+        return Ok(None);
+    };
+    let bytes = decode_image_result(result)?;
+    fs::write(&dest_path, bytes)
+        .with_context(|| format!("Failed to write generated image {}", dest_path.display()))?;
+    Ok(Some(dest_path))
+}
+
+fn decode_image_result(result: &str) -> Result<Vec<u8>> {
+    let encoded = result
+        .split_once(',')
+        .filter(|(prefix, _)| prefix.starts_with("data:image/"))
+        .map(|(_, data)| data)
+        .unwrap_or(result);
+
+    base64::engine::general_purpose::STANDARD
+        .decode(encoded.trim())
+        .context("Invalid generated image base64")
+}
+
+fn data_url_ext(result: &str) -> Option<&'static str> {
+    let prefix = result.split_once(',')?.0;
+    if !prefix.starts_with("data:image/") {
+        return None;
+    }
+    match prefix.strip_prefix("data:image/")?.split(';').next()? {
+        "jpeg" | "jpg" => Some("jpg"),
+        "gif" => Some("gif"),
+        "webp" => Some("webp"),
+        "png" => Some("png"),
+        _ => None,
+    }
+}
+
+fn path_ext(path: &std::path::Path) -> Option<&'static str> {
+    match path.extension()?.to_str()?.to_ascii_lowercase().as_str() {
+        "jpg" | "jpeg" => Some("jpg"),
+        "gif" => Some("gif"),
+        "webp" => Some("webp"),
+        "png" => Some("png"),
+        _ => None,
+    }
+}
+
+fn safe_filename(input: &str) -> String {
+    input
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '-' | '_') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_result_and_copies_saved_image() {
+        let _guard = crate::data_dir::TEST_ENV_LOCK.lock().unwrap();
+        let temp = tempfile::tempdir().unwrap();
+        let source = temp.path().join("source.png");
+        fs::write(&source, b"png-bytes").unwrap();
+        std::env::set_var("HELMOR_DATA_DIR", temp.path().join("helmor-data"));
+
+        let content = serde_json::json!({
+            "type": "item.completed",
+            "item": {
+                "id": "ig_1",
+                "type": "image_generation",
+                "result": "large-base64",
+                "saved_path": source,
+            }
+        })
+        .to_string();
+
+        let prepared = prepare_turn_content_for_persist("session/1", &content).unwrap();
+        let parsed: Value = serde_json::from_str(&prepared).unwrap();
+        let item = parsed.get("item").unwrap();
+        assert!(item.get("result").is_none());
+
+        let saved_path = item.get("saved_path").and_then(Value::as_str).unwrap();
+        assert!(saved_path.contains("generated-images/session_1/ig_1.png"));
+        assert_eq!(fs::read(saved_path).unwrap(), b"png-bytes");
+
+        std::env::remove_var("HELMOR_DATA_DIR");
+    }
+
+    #[test]
+    fn writes_base64_when_saved_path_is_missing() {
+        let _guard = crate::data_dir::TEST_ENV_LOCK.lock().unwrap();
+        let temp = tempfile::tempdir().unwrap();
+        std::env::set_var("HELMOR_DATA_DIR", temp.path().join("helmor-data"));
+
+        let content = serde_json::json!({
+            "type": "item.completed",
+            "item": {
+                "id": "ig_2",
+                "type": "image_generation",
+                "result": "cG5nLWJ5dGVz",
+            }
+        })
+        .to_string();
+
+        let prepared = prepare_turn_content_for_persist("session-2", &content).unwrap();
+        let parsed: Value = serde_json::from_str(&prepared).unwrap();
+        let saved_path = parsed
+            .get("item")
+            .and_then(|item| item.get("saved_path"))
+            .and_then(Value::as_str)
+            .unwrap();
+        assert_eq!(fs::read(saved_path).unwrap(), b"png-bytes");
+
+        std::env::remove_var("HELMOR_DATA_DIR");
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ pub mod data_dir;
 pub mod error;
 pub mod forge;
 pub mod git;
+pub mod image_store;
 mod import;
 pub mod logging;
 pub mod mcp;
@@ -268,6 +269,8 @@ pub fn run() {
             commands::conductor_commands::list_conductor_workspaces,
             commands::conductor_commands::import_conductor_workspaces,
             commands::system_commands::save_pasted_image,
+            commands::system_commands::show_image_in_finder,
+            commands::system_commands::copy_image_to_clipboard,
             commands::system_commands::request_quit,
             commands::system_commands::dev_reset_all_data,
             commands::settings_commands::update_app_settings,

--- a/src-tauri/src/pipeline/accumulator/codex.rs
+++ b/src-tauri/src/pipeline/accumulator/codex.rs
@@ -291,6 +291,9 @@ fn dispatch_item(acc: &mut StreamAccumulator, raw_line: &str, value: &Value, per
         Some("context_compaction") => {
             handle_context_compaction_item(acc, raw_line, item, item_id.as_deref(), persist);
         }
+        Some("image_generation") => {
+            handle_image_generation(acc, raw_line, item, item_id.as_deref(), persist);
+        }
         Some("error") => {
             handle_error_item(acc, raw_line, item, persist);
         }
@@ -852,6 +855,37 @@ fn handle_context_compaction_item(
     }
 }
 
+fn handle_image_generation(
+    acc: &mut StreamAccumulator,
+    raw_line: &str,
+    item: &Value,
+    item_id: Option<&str>,
+    persist: bool,
+) {
+    let envelope = serde_json::json!({
+        "type": "item.completed",
+        "item": item,
+    });
+    let s = serde_json::to_string(&envelope).unwrap_or_default();
+    let image_id = item_id
+        .map(|id| format!("codex-image:{id}"))
+        .unwrap_or_else(|| format!("codex-image:{}", acc.line_count));
+    acc.collect_or_replace(
+        &s,
+        &envelope,
+        MessageRole::Assistant,
+        Some(image_id.clone()),
+    );
+
+    if persist {
+        acc.turns.push(CollectedTurn {
+            id: image_id,
+            role: MessageRole::Assistant,
+            content_json: raw_line.to_string(),
+        });
+    }
+}
+
 pub(super) fn handle_thread_compacted(acc: &mut StreamAccumulator, _raw_line: &str, value: &Value) {
     let synthetic = serde_json::json!({
         "type": "system",
@@ -1026,6 +1060,7 @@ fn normalize_item_type(t: &str) -> &str {
         "reasoning" => "reasoning",
         "plan" => "plan",
         "contextCompaction" | "context_compaction" => "context_compaction",
+        "imageGeneration" | "image_generation" => "image_generation",
         "error" => "error",
         other => other,
     }
@@ -1040,6 +1075,7 @@ fn normalize_field_name(name: &str) -> String {
         "processId" => "process_id".to_string(),
         "commandActions" => "command_actions".to_string(),
         "memoryCitation" => "memory_citation".to_string(),
+        "savedPath" => "saved_path".to_string(),
         _ => name.to_string(),
     }
 }

--- a/src-tauri/src/pipeline/adapter/codex_items.rs
+++ b/src-tauri/src/pipeline/adapter/codex_items.rs
@@ -15,7 +15,7 @@ use serde_json::Value;
 
 use super::blocks::parse_codex_todolist_items;
 use crate::pipeline::types::{
-    ExtendedMessagePart, IntermediateMessage, MessagePart, MessageRole, MessageStatus,
+    ExtendedMessagePart, ImageSource, IntermediateMessage, MessagePart, MessageRole, MessageStatus,
     NoticeSeverity, PlanAllowedPrompt, ThreadMessageLike,
 };
 
@@ -59,6 +59,7 @@ pub(super) fn render_item_completed(
         Some("mcp_tool_call") => render_mcp_tool_call(msg, item, result),
         Some("plan") => render_plan(msg, item, result),
         Some("context_compaction") => render_context_compaction(msg, item, result),
+        Some("image_generation") => render_image_generation(msg, item, result),
         _ => {}
     }
 }
@@ -333,6 +334,60 @@ fn render_plan(msg: &IntermediateMessage, item: &Value, result: &mut Vec<ThreadM
             plan: Some(text.to_string()),
             plan_file_path: None,
             allowed_prompts: Vec::<PlanAllowedPrompt>::new(),
+        })],
+        status: Some(MessageStatus {
+            status_type: "complete".to_string(),
+            reason: Some("stop".to_string()),
+        }),
+        streaming: None,
+    });
+}
+
+fn render_image_generation(
+    msg: &IntermediateMessage,
+    item: &Value,
+    result: &mut Vec<ThreadMessageLike>,
+) {
+    let source = if let Some(path) = item
+        .get("saved_path")
+        .or_else(|| item.get("savedPath"))
+        .and_then(Value::as_str)
+        .filter(|s| !s.trim().is_empty())
+    {
+        ImageSource::File {
+            path: path.to_string(),
+        }
+    } else if let Some(raw_result) = item.get("result").and_then(Value::as_str) {
+        let result_value = raw_result.trim();
+        if result_value.is_empty() {
+            return;
+        }
+
+        if result_value.starts_with("data:image/") || result_value.starts_with("http") {
+            ImageSource::Url {
+                url: result_value.to_string(),
+            }
+        } else {
+            ImageSource::Base64 {
+                data: result_value.to_string(),
+            }
+        }
+    } else {
+        return;
+    };
+    let media_type = match &source {
+        ImageSource::Base64 { .. } => Some("image/png".to_string()),
+        ImageSource::Url { .. } | ImageSource::File { .. } => None,
+    };
+
+    result.push(ThreadMessageLike {
+        role: MessageRole::Assistant,
+        id: Some(msg.id.clone()),
+        created_at: Some(msg.created_at.clone()),
+        content: vec![ExtendedMessagePart::Basic(MessagePart::Image {
+            id: format!("{}:blk:0", msg.id),
+            source,
+            media_type,
         })],
         status: Some(MessageStatus {
             status_type: "complete".to_string(),

--- a/src-tauri/src/pipeline/types.rs
+++ b/src-tauri/src/pipeline/types.rs
@@ -241,6 +241,7 @@ impl MessagePart {
 pub enum ImageSource {
     Base64 { data: String },
     Url { url: String },
+    File { path: String },
 }
 
 /// Severity tier for `MessagePart::SystemNotice`. The frontend picks the

--- a/src-tauri/src/service.rs
+++ b/src-tauri/src/service.rs
@@ -491,11 +491,13 @@ fn persist_turn(
 ) -> Result<()> {
     let now = crate::models::db::current_timestamp()?;
     let msg_id = turn.id.clone();
+    let content =
+        crate::image_store::prepare_turn_content_for_persist(session_id, &turn.content_json)?;
     conn.execute(
         r#"INSERT INTO session_messages
            (id, session_id, role, content, created_at, sent_at)
            VALUES (?1, ?2, ?3, ?4, ?5, ?5)"#,
-        params![msg_id, session_id, turn.role, turn.content_json, now],
+        params![msg_id, session_id, turn.role, content, now],
     )?;
     Ok(())
 }

--- a/src-tauri/tests/common/normalize.rs
+++ b/src-tauri/tests/common/normalize.rs
@@ -220,6 +220,7 @@ fn normalize_basic(part: &MessagePart) -> NormPart {
             kind: match source {
                 ImageSource::Base64 { .. } => "base64".to_string(),
                 ImageSource::Url { .. } => "url".to_string(),
+                ImageSource::File { .. } => "file".to_string(),
             },
             media_type: media_type.clone(),
         },

--- a/src-tauri/tests/pipeline_scenarios.rs
+++ b/src-tauri/tests/pipeline_scenarios.rs
@@ -1193,6 +1193,45 @@ fn codex_web_search_with_action_passes_through() {
 }
 
 #[test]
+fn codex_image_generation_renders_as_image() {
+    let parsed = json!({
+        "type": "item.completed",
+        "item": {
+            "id": "img_1",
+            "type": "image_generation",
+            "status": "completed",
+            "revised_prompt": "A small architecture diagram",
+            "result": "iVBORw0KGgo="
+        }
+    });
+    let msgs = vec![make_record(
+        "img1",
+        "assistant",
+        &serde_json::to_string(&parsed).unwrap(),
+    )];
+    assert_yaml_snapshot!(run_normalized(msgs));
+}
+
+#[test]
+fn codex_image_generation_saved_path_renders_as_file_image() {
+    let parsed = json!({
+        "type": "item.completed",
+        "item": {
+            "id": "img_2",
+            "type": "image_generation",
+            "status": "completed",
+            "saved_path": "/tmp/helmor/generated-images/session/img_2.png"
+        }
+    });
+    let msgs = vec![make_record(
+        "img2",
+        "assistant",
+        &serde_json::to_string(&parsed).unwrap(),
+    )];
+    assert_yaml_snapshot!(run_normalized(msgs));
+}
+
+#[test]
 fn codex_mcp_tool_call_renders_as_tool_call() {
     let parsed = json!({
         "type": "item.completed",

--- a/src-tauri/tests/snapshots/pipeline_scenarios__codex_image_generation_renders_as_image.snap
+++ b/src-tauri/tests/snapshots/pipeline_scenarios__codex_image_generation_renders_as_image.snap
@@ -1,0 +1,15 @@
+---
+source: tests/pipeline_scenarios.rs
+expression: run_normalized(msgs)
+---
+- role: assistant
+  id: msg-1
+  content_length: 1
+  content:
+    - type: image
+      kind: base64
+      media_type: image/png
+  status:
+    type: complete
+    reason: stop
+  streaming: ~

--- a/src-tauri/tests/snapshots/pipeline_scenarios__codex_image_generation_saved_path_renders_as_file_image.snap
+++ b/src-tauri/tests/snapshots/pipeline_scenarios__codex_image_generation_saved_path_renders_as_file_image.snap
@@ -1,0 +1,15 @@
+---
+source: tests/pipeline_scenarios.rs
+expression: run_normalized(msgs)
+---
+- role: assistant
+  id: msg-1
+  content_length: 1
+  content:
+    - type: image
+      kind: file
+      media_type: ~
+  status:
+    type: complete
+    reason: stop
+  streaming: ~

--- a/src/features/panel/message-components/content-parts.tsx
+++ b/src/features/panel/message-components/content-parts.tsx
@@ -1,12 +1,23 @@
+import { convertFileSrc } from "@tauri-apps/api/core";
 import {
 	Check,
 	Circle,
 	CircleDot,
 	ClipboardList,
+	Copy,
+	FolderOpen,
 	MessageSquareText,
 } from "lucide-react";
-import { Suspense } from "react";
-import type { ImagePart, PlanReviewPart, TodoListPart } from "@/lib/api";
+import { Suspense, useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { toast } from "sonner";
+import {
+	copyImageToClipboard,
+	type ImagePart,
+	type PlanReviewPart,
+	showImageInFinder,
+	type TodoListPart,
+} from "@/lib/api";
 import { cn } from "@/lib/utils";
 import { LazyStreamdown } from "./streamdown-loader";
 
@@ -107,15 +118,155 @@ export function PlanReviewCard({ part }: { part: PlanReviewPart }) {
 }
 
 export function ImageBlock({ part }: { part: ImagePart }) {
-	const src =
-		part.source.kind === "url"
-			? part.source.url
-			: `data:${part.mediaType ?? "image/png"};base64,${part.source.data}`;
+	const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
+	const src = imageSrc(part);
+	const filePath = part.source.kind === "file" ? part.source.path : null;
+
+	useEffect(() => {
+		if (!menuPosition) return;
+		const close = () => setMenuPosition(null);
+		window.addEventListener("pointerdown", close);
+		window.addEventListener("scroll", close, true);
+		window.addEventListener("resize", close);
+		return () => {
+			window.removeEventListener("pointerdown", close);
+			window.removeEventListener("scroll", close, true);
+			window.removeEventListener("resize", close);
+		};
+	}, [menuPosition]);
+
 	return (
-		<img
-			src={src}
-			alt=""
-			className="my-2 max-h-[420px] max-w-full rounded-md border border-border/40"
-		/>
+		<span className="inline-block max-w-full">
+			<img
+				src={src}
+				alt=""
+				onContextMenu={(event) => {
+					event.preventDefault();
+					setMenuPosition(positionMenu(event));
+				}}
+				className="my-2 max-h-[420px] max-w-full rounded-md border border-border/40"
+			/>
+			{menuPosition
+				? createPortal(
+						<div
+							role="menu"
+							style={{ left: menuPosition.x, top: menuPosition.y }}
+							onContextMenu={(event) => event.preventDefault()}
+							onPointerDown={(event) => event.stopPropagation()}
+							className="fixed z-50 min-w-44 overflow-hidden rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10"
+						>
+							<button
+								type="button"
+								role="menuitem"
+								onClick={() => {
+									setMenuPosition(null);
+									void copyImage(part);
+								}}
+								className={imageMenuItemClassName}
+							>
+								<Copy className="size-4 shrink-0" strokeWidth={1.6} />
+								<span>Copy Image</span>
+							</button>
+							<button
+								type="button"
+								role="menuitem"
+								disabled={!filePath}
+								onClick={() => {
+									if (!filePath) return;
+									setMenuPosition(null);
+									void showInFinder(filePath);
+								}}
+								className={cn(
+									imageMenuItemClassName,
+									!filePath && "cursor-not-allowed opacity-50",
+								)}
+							>
+								<FolderOpen className="size-4 shrink-0" strokeWidth={1.6} />
+								<span>Show in Finder</span>
+							</button>
+						</div>,
+						document.body,
+					)
+				: null}
+		</span>
 	);
+}
+
+type MenuPosition = {
+	x: number;
+	y: number;
+};
+
+const imageMenuItemClassName =
+	"relative flex w-full cursor-pointer items-center gap-1.5 rounded-md px-1.5 py-1 text-left text-sm outline-hidden select-none hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground disabled:pointer-events-none";
+
+function positionMenu(event: React.MouseEvent): MenuPosition {
+	const width = 176;
+	const height = 76;
+	const margin = 8;
+	return {
+		x: Math.max(
+			margin,
+			Math.min(event.clientX, window.innerWidth - width - margin),
+		),
+		y: Math.max(
+			margin,
+			Math.min(event.clientY, window.innerHeight - height - margin),
+		),
+	};
+}
+
+function imageSrc(part: ImagePart) {
+	if (part.source.kind === "url") return part.source.url;
+	if (part.source.kind === "file") return convertFileSrc(part.source.path);
+	return `data:${part.mediaType ?? "image/png"};base64,${part.source.data}`;
+}
+
+async function copyImage(part: ImagePart) {
+	try {
+		if (part.source.kind === "file") {
+			await copyImageToClipboard(part.source.path);
+			toast.success("Image copied");
+			return;
+		}
+
+		await copyImageBlobToClipboard(await imageBlob(part));
+		toast.success("Image copied");
+	} catch (error) {
+		toast.error("Copy failed", { description: String(error) });
+	}
+}
+
+async function showInFinder(path: string) {
+	try {
+		await showImageInFinder(path);
+	} catch (error) {
+		toast.error("Unable to show image in Finder", {
+			description: String(error),
+		});
+	}
+}
+
+async function imageBlob(part: ImagePart) {
+	if (part.source.kind === "base64") {
+		const response = await fetch(imageSrc(part));
+		return response.blob();
+	}
+	if (part.source.kind !== "url") {
+		throw new Error("Image file clipboard is not available.");
+	}
+
+	const response = await fetch(part.source.url);
+	if (!response.ok) {
+		throw new Error(`Unable to load image (${response.status})`);
+	}
+	return response.blob();
+}
+
+async function copyImageBlobToClipboard(blob: Blob) {
+	if (typeof ClipboardItem === "undefined" || !navigator.clipboard?.write) {
+		throw new Error("Image clipboard is not available.");
+	}
+	const type = blob.type || "image/png";
+	await navigator.clipboard.write([new ClipboardItem({ [type]: blob })]);
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1750,7 +1750,8 @@ export type TodoListPart = {
 };
 export type ImageSource =
 	| { kind: "base64"; data: string }
-	| { kind: "url"; url: string };
+	| { kind: "url"; url: string }
+	| { kind: "file"; path: string };
 export type ImagePart = {
 	type: "image";
 	id: string;
@@ -1904,6 +1905,14 @@ export async function savePastedImage(
 	mediaType: string,
 ): Promise<string> {
 	return invoke<string>("save_pasted_image", { data, mediaType });
+}
+
+export async function showImageInFinder(path: string): Promise<void> {
+	await invoke("show_image_in_finder", { path });
+}
+
+export async function copyImageToClipboard(path: string): Promise<void> {
+	await invoke("copy_image_to_clipboard", { path });
 }
 
 /**

--- a/src/lib/structural-equality.ts
+++ b/src/lib/structural-equality.ts
@@ -127,6 +127,12 @@ export function partStructurallyEqual(
 			if (a.source.kind === "base64") {
 				return a.source.data === (ib.source as typeof a.source).data;
 			}
+			if (a.source.kind === "file") {
+				return (
+					a.source.path ===
+					(ib.source as Extract<ImagePart["source"], { kind: "file" }>).path
+				);
+			}
 			return (
 				(a.source as { url: string }).url === (ib.source as { url: string }).url
 			);

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -110,6 +110,7 @@ vi.mock("@tauri-apps/api/webview", () => ({
 // commands the boot path hits; individual tests still mock `./lib/api`
 // directly when they need specific return values.
 vi.mock("@tauri-apps/api/core", () => ({
+	convertFileSrc: vi.fn((path: string) => `asset://localhost${path}`),
 	invoke: vi.fn(async (command: string) => {
 		switch (command) {
 			case "get_github_identity_session":


### PR DESCRIPTION
## Summary
- Render Codex `image_generation` item outputs inline in the assistant thread, including a new `file` `ImageSource` variant for on-disk images.
- Add an `image_store` module that intercepts image turns before persistence, copying `saved_path` files (or decoding `data:` / base64 `result` payloads) into `{data_dir}/generated-images/<session>/<item>.<ext>` and rewriting the stored JSON to reference that file instead of the base64 blob.
- Add a chat image context menu with **Copy Image** and **Show in Finder**, backed by new `copy_image_to_clipboard` / `show_image_in_finder` Tauri commands (AppleScript + `open -R` on macOS).

## Why
Codex app-server emits generated images as item-completed events, but they were previously dropped. Persisting the raw base64 also bloats the session DB and makes the thread reload slow. Writing the image to a managed directory keeps the session DB lean, lets the webview stream the file via `convertFileSrc`, and makes it easy to expose native actions (copy, reveal in Finder).

## Test notes
- `cd src-tauri && cargo test` — covers the new `pipeline_scenarios` cases (`codex_image_generation_renders_as_image`, `codex_image_generation_saved_path_renders_as_file_image`) and the `image_store` unit tests.
- `bun run test:frontend` — the mocked `convertFileSrc` in `src/test/setup.ts` keeps ImageBlock renders working under jsdom.
- Manual: run Codex with an image-generation tool, confirm the image appears inline, right-click and try Copy / Show in Finder.

## Follow-ups
- Copy / Show-in-Finder currently only work on macOS; Windows/Linux paths will need their own implementations.