### PR TITLE
chore: bump package name in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "helmor11111",
+	"name": "helmor11111222",
 	"description": "The local-first IDE for coding agent orchestration.",
 	"private": true,
 	"version": "0.6.3",


### PR DESCRIPTION
## Summary
- Renames the `name` field in `package.json` from `helmor11111` to `helmor11111222`.

## Why
- Carries over an unpushed local commit on `natllian/eukelade` so it can land via `nathan/testing`.

## Test plan
- [ ] `bun install` still resolves cleanly with the new package name.
- [ ] `bun run build` succeeds.
- [ ] No downstream tooling references the old `name` literal.

## Follow-ups
- The original commit message was `"1"`; consider squashing on merge to a clearer message.