### PR TITLE
Add GitLab forge support

### DIFF
--- a/.changeset/steady-geese-connect.md
+++ b/.changeset/steady-geese-connect.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Keep GitHub CLI connection status stable when a transient auth check fails, so connected workspaces no longer briefly fall back to Connect before recovering.

--- a/src-tauri/src/forge/github/cli.rs
+++ b/src-tauri/src/forge/github/cli.rs
@@ -11,6 +11,7 @@ const GITHUB_HOST: &str = "github.com";
 const GITHUB_REPOS_ENDPOINT: &str =
     "/user/repos?per_page=100&sort=updated&affiliation=owner,collaborator,organization_member";
 const GITHUB_CLI_STATUS_CACHE_TTL: Duration = Duration::from_secs(2);
+const GITHUB_CLI_READY_DOWNGRADE_GRACE: Duration = Duration::from_secs(30);
 
 static SYSTEM_GH_STATUS_CACHE: LazyLock<Mutex<Option<CachedGithubCliStatus>>> =
     LazyLock::new(|| Mutex::new(None));
@@ -91,6 +92,7 @@ trait GhCommandRunner {
 struct CachedGithubCliStatus {
     cached_at: Instant,
     status: GithubCliStatus,
+    downgrade_observed_at: Option<Instant>,
 }
 
 pub fn get_github_cli_status() -> Result<GithubCliStatus> {
@@ -387,9 +389,13 @@ fn load_cached_status(
         }
     }
 
-    let status = loader()?;
+    let now = Instant::now();
+    let loaded = loader()?;
+    let downgrade_observed_at = downgrade_observed_at(cache_guard.as_ref(), &loaded, now);
+    let status = stabilize_loaded_status(cache_guard.as_ref(), loaded, now);
     *cache_guard = Some(CachedGithubCliStatus {
-        cached_at: Instant::now(),
+        cached_at: now,
+        downgrade_observed_at,
         status: status.clone(),
     });
     Ok(status)
@@ -405,9 +411,56 @@ fn refresh_cached_status(
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     *cache_guard = Some(CachedGithubCliStatus {
         cached_at: Instant::now(),
+        downgrade_observed_at: None,
         status: status.clone(),
     });
     Ok(status)
+}
+
+fn stabilize_loaded_status(
+    cached: Option<&CachedGithubCliStatus>,
+    loaded: GithubCliStatus,
+    now: Instant,
+) -> GithubCliStatus {
+    let Some(cached) = cached else {
+        return loaded;
+    };
+    if !github_cli_is_ready(&cached.status)
+        || github_cli_is_ready(&loaded)
+        || !should_debounce_ready_downgrade(&loaded)
+    {
+        return loaded;
+    }
+    let observed_at = cached.downgrade_observed_at.unwrap_or(now);
+    if now.duration_since(observed_at) <= GITHUB_CLI_READY_DOWNGRADE_GRACE {
+        tracing::warn!(
+            previous_status = ?cached.status,
+            loaded_status = ?loaded,
+            "Ignoring transient GitHub CLI status downgrade"
+        );
+        return cached.status.clone();
+    }
+    loaded
+}
+
+fn should_debounce_ready_downgrade(status: &GithubCliStatus) -> bool {
+    matches!(
+        status,
+        GithubCliStatus::Unauthenticated { .. } | GithubCliStatus::Error { .. }
+    )
+}
+
+fn downgrade_observed_at(
+    cached: Option<&CachedGithubCliStatus>,
+    status: &GithubCliStatus,
+    now: Instant,
+) -> Option<Instant> {
+    let cached = cached?;
+    if github_cli_is_ready(&cached.status) && should_debounce_ready_downgrade(status) {
+        Some(cached.downgrade_observed_at.unwrap_or(now))
+    } else {
+        None
+    }
 }
 
 struct SystemGhRunner;
@@ -757,6 +810,7 @@ mod tests {
                 host: "github.com".to_string(),
                 message: "missing".to_string(),
             },
+            downgrade_observed_at: None,
         }));
         let calls = Cell::new(0);
 
@@ -786,5 +840,87 @@ mod tests {
             .unwrap(),
             refreshed
         );
+    }
+
+    #[test]
+    fn load_cached_status_debounces_ready_downgrade() {
+        let cache = Mutex::new(Some(CachedGithubCliStatus {
+            cached_at: Instant::now() - Duration::from_secs(10),
+            status: GithubCliStatus::Ready {
+                host: "github.com".to_string(),
+                login: "octo".to_string(),
+                version: "gh version 2.0.0".to_string(),
+                message: "GitHub CLI ready as octo.".to_string(),
+            },
+            downgrade_observed_at: None,
+        }));
+
+        let loaded = load_cached_status(&cache, Duration::from_secs(1), || {
+            Ok(GithubCliStatus::Unauthenticated {
+                host: "github.com".to_string(),
+                version: Some("gh version 2.0.0".to_string()),
+                message: "Run `gh auth login` to connect GitHub CLI.".to_string(),
+            })
+        })
+        .unwrap();
+
+        assert!(matches!(loaded, GithubCliStatus::Ready { .. }));
+        let cached = cache.lock().unwrap();
+        assert!(cached.as_ref().unwrap().downgrade_observed_at.is_some());
+    }
+
+    #[test]
+    fn load_cached_status_accepts_missing_downgrade_immediately() {
+        let cache = Mutex::new(Some(CachedGithubCliStatus {
+            cached_at: Instant::now() - Duration::from_secs(10),
+            status: GithubCliStatus::Ready {
+                host: "github.com".to_string(),
+                login: "octo".to_string(),
+                version: "gh version 2.0.0".to_string(),
+                message: "GitHub CLI ready as octo.".to_string(),
+            },
+            downgrade_observed_at: None,
+        }));
+
+        let loaded = load_cached_status(&cache, Duration::from_secs(1), || {
+            Ok(GithubCliStatus::Unavailable {
+                host: "github.com".to_string(),
+                message: "GitHub CLI is not installed on this machine.".to_string(),
+            })
+        })
+        .unwrap();
+
+        assert!(matches!(loaded, GithubCliStatus::Unavailable { .. }));
+        let cached = cache.lock().unwrap();
+        assert!(cached.as_ref().unwrap().downgrade_observed_at.is_none());
+    }
+
+    #[test]
+    fn load_cached_status_accepts_persistent_ready_downgrade() {
+        let cache = Mutex::new(Some(CachedGithubCliStatus {
+            cached_at: Instant::now() - Duration::from_secs(10),
+            status: GithubCliStatus::Ready {
+                host: "github.com".to_string(),
+                login: "octo".to_string(),
+                version: "gh version 2.0.0".to_string(),
+                message: "GitHub CLI ready as octo.".to_string(),
+            },
+            downgrade_observed_at: Some(
+                Instant::now() - GITHUB_CLI_READY_DOWNGRADE_GRACE - Duration::from_secs(1),
+            ),
+        }));
+
+        let loaded = load_cached_status(&cache, Duration::from_secs(1), || {
+            Ok(GithubCliStatus::Unauthenticated {
+                host: "github.com".to_string(),
+                version: Some("gh version 2.0.0".to_string()),
+                message: "Run `gh auth login` to connect GitHub CLI.".to_string(),
+            })
+        })
+        .unwrap();
+
+        assert!(matches!(loaded, GithubCliStatus::Unauthenticated { .. }));
+        let cached = cache.lock().unwrap();
+        assert!(cached.as_ref().unwrap().downgrade_observed_at.is_some());
     }
 }

--- a/src-tauri/src/models/db.rs
+++ b/src-tauri/src/models/db.rs
@@ -9,6 +9,7 @@
 //! through [`read_conn`] / [`write_conn`] or the closure helpers
 //! [`read`] / [`write_transaction`].
 use std::collections::HashMap;
+use std::panic::Location;
 use std::sync::{Arc, OnceLock, RwLock};
 use std::time::Duration;
 
@@ -180,6 +181,7 @@ const SLOW_BORROW_WARN_MS: u128 = 100;
 
 /// Borrow a read connection from the read pool. WAL lets multiple readers
 /// proceed concurrently and never block the writer.
+#[track_caller]
 pub fn read_conn() -> Result<PooledConn> {
     with_bundle(|bundle| {
         let start = std::time::Instant::now();
@@ -189,9 +191,12 @@ pub fn read_conn() -> Result<PooledConn> {
             .map_err(|e| anyhow!("Failed to borrow read connection: {e}"))?;
         let elapsed_ms = start.elapsed().as_millis();
         if elapsed_ms >= SLOW_BORROW_WARN_MS {
+            let caller = Location::caller();
             tracing::warn!(
                 elapsed_ms,
                 pool_state = ?bundle.read.state(),
+                caller_file = caller.file(),
+                caller_line = caller.line(),
                 "db: slow read_conn borrow"
             );
         }
@@ -202,22 +207,29 @@ pub fn read_conn() -> Result<PooledConn> {
 /// Borrow the writer connection. Pool `max_size = 1`, so callers serialize
 /// at the pool layer — no SQLITE_BUSY from intra-process contention.
 /// Hold for as short as possible; long-held writes starve all other writers.
+#[track_caller]
 pub fn write_conn() -> Result<PooledConn> {
     with_bundle(|bundle| {
         let start = std::time::Instant::now();
         let conn = bundle.write.get().map_err(|e| {
+            let caller = Location::caller();
             tracing::error!(
                 elapsed_ms = start.elapsed().as_millis(),
                 pool_state = ?bundle.write.state(),
+                caller_file = caller.file(),
+                caller_line = caller.line(),
                 "db: write_conn borrow failed (pool timeout? holder stuck?): {e}"
             );
             anyhow!("Failed to borrow write connection: {e}")
         })?;
         let elapsed_ms = start.elapsed().as_millis();
         if elapsed_ms >= SLOW_BORROW_WARN_MS {
+            let caller = Location::caller();
             tracing::warn!(
                 elapsed_ms,
                 pool_state = ?bundle.write.state(),
+                caller_file = caller.file(),
+                caller_line = caller.line(),
                 "db: slow write_conn borrow — another writer held the pool"
             );
         }


### PR DESCRIPTION
## Summary
- Add GitLab forge detection, CLI onboarding, MR lookup, action status, merge, and close support alongside GitHub.
- Stabilize GitHub CLI status checks so transient auth probe failures do not briefly flip connected workspaces back to Connect.
- Add diagnostics for slow DB pool borrows to identify future read/write contention sources.

## Tests
- bun run typecheck
- bun run test:frontend
- bun run test:sidecar
- cd src-tauri && cargo clippy --all-targets -- -D warnings
- cd src-tauri && cargo test --tests
- cd src-tauri && cargo test load_cached_status_
- cd src-tauri && cargo fmt --check