### PR TITLE
fix(composer): remove one-frame white flash on Plan button toggle

### DIFF
--- a/.changeset/plan-button-no-white-flash.md
+++ b/.changeset/plan-button-no-white-flash.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix a one-frame white flash when toggling the composer's Plan button — the muted off-state now fades smoothly to and from the green on-state instead of briefly brightening at the start of the animation.

--- a/src/features/composer/index.tsx
+++ b/src/features/composer/index.tsx
@@ -764,8 +764,8 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 										className={cn(
 											`gap-1 px-1.5 text-[11px] ${composerToolbarTriggerClassName}`,
 											permissionMode === "plan"
-												? "text-plan hover:bg-accent/60 hover:text-plan"
-												: "text-muted-foreground opacity-55",
+												? "text-plan hover:text-plan"
+												: "text-muted-foreground/55 hover:text-muted-foreground/55",
 										)}
 										onClick={() =>
 											onChangePermissionMode(


### PR DESCRIPTION
## Summary

Fixes a one-frame white flash when toggling the composer's Plan button. The muted off-state now fades smoothly to and from the green on-state instead of briefly brightening at the start of the animation.

## What changed

- `src/features/composer/index.tsx`: replaced the `opacity-55` modifier with `text-muted-foreground/55` (and a matching hover variant) on the Plan toggle's off-state, and dropped the `hover:bg-accent/60` hover background on the on-state. The previous `opacity-55` applied to the whole element animated independently of the color transition, producing a brief full-opacity (white-ish) frame as the button switched modes.

## Why

The flash was visually jarring on every Plan toggle. Driving the muted look through the text color's alpha channel (rather than a separate `opacity` rule) keeps everything inside the same color transition, so the toggle now cross-fades cleanly.

## Test notes

- Manually verified in `bun run dev`: rapidly toggling the Plan button no longer flashes white between states.
- No logic changes; purely a class-level styling tweak. Frontend lint runs via the pre-commit hook.