### PR TITLE
feat(updater): persist scheduler, add backoff, download progress, install on exit

### DIFF
--- a/.changeset/swift-pandas-hum.md
+++ b/.changeset/swift-pandas-hum.md
@@ -1,0 +1,6 @@
+---
+"helmor": patch
+---
+
+Make in-app updates land faster and feel more transparent
+

--- a/src-tauri/src/forge/cli_status.rs
+++ b/src-tauri/src/forge/cli_status.rs
@@ -400,9 +400,9 @@ mod tests {
     #[test]
     fn parse_glab_login_extracts_username_from_decorated_line() {
         let stderr = concat!(
-            "ngit.hundun.cn\n",
-            "  ✓ Logged in to ngit.hundun.cn as liangeqiang (/Users/liangeqiang/.config/glab-cli/config.yml)\n",
-            "  ✓ Git operations for ngit.hundun.cn configured to use https protocol.\n",
+            "example.cn\n",
+            "  ✓ Logged in to example.cn as liangeqiang (/Users/liangeqiang/.config/glab-cli/config.yml)\n",
+            "  ✓ Git operations for example.cn configured to use https protocol.\n",
             "  ✓ Token found: ********\n",
         );
         assert_eq!(parse_glab_login(stderr), Some("liangeqiang".to_string()),);
@@ -439,7 +439,7 @@ mod tests {
 
     #[test]
     fn looks_like_glab_unauthenticated_recognises_canonical_messages() {
-        let real_world = "X ngit.hundun.cn has not been authenticated with glab. Run `glab auth login --hostname ngit.hundun.cn` to authenticate.";
+        let real_world = "X example.cn has not been authenticated with glab. Run `glab auth login --hostname example.cn` to authenticate.";
         assert!(looks_like_glab_unauthenticated(real_world));
         assert!(looks_like_glab_unauthenticated("401 Unauthorized"));
         assert!(looks_like_glab_unauthenticated("No token found"));

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -338,6 +338,12 @@ pub fn run() {
             api.prevent_exit();
             emit_quit_requested(app_handle);
         }
+        // Install pending update on the way out so the next launch is the
+        // new version. By this point `request_quit` has stopped watchers
+        // and torn down the sidecar, so blocking briefly here is safe.
+        tauri::RunEvent::Exit => {
+            updater::install_pending_on_exit_blocking();
+        }
         _ => {}
     });
 }

--- a/src-tauri/src/updater/config.rs
+++ b/src-tauri/src/updater/config.rs
@@ -11,14 +11,17 @@ const UPDATER_PUBKEY_ENV: Option<&str> = option_env!("HELMOR_UPDATER_PUBKEY");
 const AUTO_UPDATE_ENABLED_KEY: &str = "app.auto_update_enabled";
 const AUTO_UPDATE_ON_LAUNCH_KEY: &str = "app.auto_update_check_on_launch";
 const AUTO_UPDATE_ON_FOCUS_KEY: &str = "app.auto_update_check_on_focus";
-const AUTO_UPDATE_INTERVAL_MINUTES_KEY: &str = "app.auto_update_interval_minutes";
 
 const DEFAULT_AUTO_UPDATE_ENABLED: bool = true;
 const DEFAULT_AUTO_UPDATE_ON_LAUNCH: bool = true;
 const DEFAULT_AUTO_UPDATE_ON_FOCUS: bool = true;
-const DEFAULT_AUTO_UPDATE_INTERVAL_MINUTES: u64 = 360;
-const DEFAULT_FOCUS_TTL_MINUTES: u64 = 30;
-const DEFAULT_FAILURE_BACKOFF_MINUTES: u64 = 15;
+const DEFAULT_AUTO_UPDATE_INTERVAL_MINUTES: u64 = 30;
+const DEFAULT_FOCUS_TTL_MINUTES: u64 = 10;
+
+// Exponential backoff after consecutive failures: 1, 2, 4, 8, 16, 32, 60 (capped).
+const FAILURE_BACKOFF_BASE_MINUTES: u64 = 1;
+const FAILURE_BACKOFF_MAX_MINUTES: u64 = 60;
+const FAILURE_BACKOFF_MAX_SHIFT: u32 = 6;
 
 #[derive(Clone, Debug)]
 pub struct UpdaterConfig {
@@ -45,7 +48,6 @@ pub struct UpdateBehavior {
     pub check_on_focus: bool,
     pub interval: Duration,
     pub focus_ttl: Duration,
-    pub failure_backoff: Duration,
 }
 
 impl UpdateBehavior {
@@ -56,21 +58,28 @@ impl UpdateBehavior {
             load_bool_setting(AUTO_UPDATE_ON_LAUNCH_KEY, DEFAULT_AUTO_UPDATE_ON_LAUNCH);
         let check_on_focus =
             load_bool_setting(AUTO_UPDATE_ON_FOCUS_KEY, DEFAULT_AUTO_UPDATE_ON_FOCUS);
-        let interval_minutes = load_u64_setting(
-            AUTO_UPDATE_INTERVAL_MINUTES_KEY,
-            DEFAULT_AUTO_UPDATE_INTERVAL_MINUTES,
-        )
-        .max(1);
 
         Self {
             auto_update_enabled,
             check_on_launch,
             check_on_focus,
-            interval: Duration::from_secs(interval_minutes.saturating_mul(60)),
+            interval: Duration::from_secs(DEFAULT_AUTO_UPDATE_INTERVAL_MINUTES * 60),
             focus_ttl: Duration::from_secs(DEFAULT_FOCUS_TTL_MINUTES * 60),
-            failure_backoff: Duration::from_secs(DEFAULT_FAILURE_BACKOFF_MINUTES * 60),
         }
     }
+}
+
+/// Compute exponential backoff after `n` consecutive failures.
+/// 1 → 1m, 2 → 2m, 3 → 4m, 4 → 8m, 5 → 16m, 6 → 32m, 7+ → 60m (capped).
+pub fn failure_backoff(consecutive_failures: u32) -> Duration {
+    if consecutive_failures == 0 {
+        return Duration::ZERO;
+    }
+    let shift = (consecutive_failures - 1).min(FAILURE_BACKOFF_MAX_SHIFT);
+    let minutes = FAILURE_BACKOFF_BASE_MINUTES
+        .saturating_mul(1u64 << shift)
+        .min(FAILURE_BACKOFF_MAX_MINUTES);
+    Duration::from_secs(minutes * 60)
 }
 
 fn parse_endpoints(raw: &str) -> anyhow::Result<Vec<Url>> {
@@ -102,10 +111,20 @@ fn load_bool_setting(key: &str, default: bool) -> bool {
         .unwrap_or(default)
 }
 
-fn load_u64_setting(key: &str, default: u64) -> u64 {
-    settings::load_setting_value(key)
-        .ok()
-        .flatten()
-        .and_then(|value| value.trim().parse::<u64>().ok())
-        .unwrap_or(default)
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn failure_backoff_progression() {
+        assert_eq!(failure_backoff(0), Duration::ZERO);
+        assert_eq!(failure_backoff(1), Duration::from_secs(60));
+        assert_eq!(failure_backoff(2), Duration::from_secs(2 * 60));
+        assert_eq!(failure_backoff(3), Duration::from_secs(4 * 60));
+        assert_eq!(failure_backoff(4), Duration::from_secs(8 * 60));
+        assert_eq!(failure_backoff(5), Duration::from_secs(16 * 60));
+        assert_eq!(failure_backoff(6), Duration::from_secs(32 * 60));
+        assert_eq!(failure_backoff(7), Duration::from_secs(60 * 60));
+        assert_eq!(failure_backoff(99), Duration::from_secs(60 * 60));
+    }
 }

--- a/src-tauri/src/updater/events.rs
+++ b/src-tauri/src/updater/events.rs
@@ -25,6 +25,13 @@ pub struct UpdateInfoSnapshot {
     pub release_url: String,
 }
 
+#[derive(Clone, Copy, Debug, Default, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DownloadProgress {
+    pub downloaded: u64,
+    pub total: Option<u64>,
+}
+
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UpdateStatusSnapshot {
@@ -35,6 +42,7 @@ pub struct UpdateStatusSnapshot {
     pub last_error: Option<String>,
     pub last_attempt_at: Option<String>,
     pub downloaded_at: Option<String>,
+    pub progress: Option<DownloadProgress>,
 }
 
 impl UpdateStatusSnapshot {
@@ -47,6 +55,7 @@ impl UpdateStatusSnapshot {
             last_error: None,
             last_attempt_at: None,
             downloaded_at: None,
+            progress: None,
         }
     }
 }

--- a/src-tauri/src/updater/mod.rs
+++ b/src-tauri/src/updater/mod.rs
@@ -8,6 +8,7 @@ mod tests;
 
 pub use events::{UpdateStatusSnapshot, APP_UPDATE_STATUS_EVENT};
 pub use service::{
-    configure, install_downloaded_update, maybe_trigger_on_focus, maybe_trigger_on_resume,
-    snapshot, spawn_interval_worker, spawn_startup_check, trigger_check, CheckReason,
+    configure, install_downloaded_update, install_pending_on_exit_blocking, maybe_trigger_on_focus,
+    maybe_trigger_on_resume, snapshot, spawn_interval_worker, spawn_startup_check, trigger_check,
+    CheckReason,
 };

--- a/src-tauri/src/updater/service.rs
+++ b/src-tauri/src/updater/service.rs
@@ -1,17 +1,22 @@
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::thread;
+use std::time::{Duration, Instant};
 
 use chrono::Utc;
 use tauri::{AppHandle, Emitter, Runtime};
 use tauri_plugin_updater::UpdaterExt;
 
-use super::config::{UpdateBehavior, UpdaterConfig};
+use super::config::{failure_backoff, UpdateBehavior, UpdaterConfig};
 use super::events::{
-    UpdateInfoSnapshot, UpdateStage, UpdateStatusSnapshot, APP_UPDATE_STATUS_EVENT,
+    DownloadProgress, UpdateInfoSnapshot, UpdateStage, UpdateStatusSnapshot,
+    APP_UPDATE_STATUS_EVENT,
 };
-use super::state::{PendingUpdate, UpdateRuntimeState};
+use super::state::{self as persisted, PendingUpdate, UpdateRuntimeState};
 
 static UPDATE_MANAGER: OnceLock<UpdateManager> = OnceLock::new();
+
+const PROGRESS_EMIT_THROTTLE: Duration = Duration::from_millis(200);
+const SCHEDULER_FLOOR: Duration = Duration::from_secs(60);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CheckReason {
@@ -29,12 +34,15 @@ pub struct UpdateManager {
 
 pub fn configure() -> anyhow::Result<()> {
     let config = UpdaterConfig::load()?;
+    let mut initial = UpdateRuntimeState {
+        stage: UpdateStage::Idle,
+        ..UpdateRuntimeState::default()
+    };
+    persisted::load_persisted(&mut initial);
+
     let _ = UPDATE_MANAGER.set(UpdateManager {
         config,
-        state: Mutex::new(UpdateRuntimeState {
-            stage: UpdateStage::Idle,
-            ..UpdateRuntimeState::default()
-        }),
+        state: Mutex::new(initial),
     });
     Ok(())
 }
@@ -50,12 +58,16 @@ pub fn spawn_startup_check<R: Runtime>(app: AppHandle<R>) {
     });
 }
 
+/// Deadline-based interval poller. Sleeps until the next legitimate check
+/// time (last attempt + interval, or last failure + exponential backoff,
+/// whichever is later) instead of waking every 60s and short-circuiting.
 pub fn spawn_interval_worker<R: Runtime>(app: AppHandle<R>) {
     let app_handle = app.clone();
     if let Err(error) = thread::Builder::new()
         .name("app-update-poller".into())
         .spawn(move || loop {
-            thread::sleep(std::time::Duration::from_secs(60));
+            let sleep_dur = compute_sleep_duration();
+            thread::sleep(sleep_dur);
             let app_handle = app_handle.clone();
             tauri::async_runtime::spawn(async move {
                 let _ = trigger_check(app_handle, CheckReason::Interval, false).await;
@@ -123,11 +135,13 @@ pub async fn trigger_check<R: Runtime>(
         state.stage = UpdateStage::Checking;
         state.last_attempt_at = Some(Utc::now());
         state.last_error = None;
+        state.download_progress = None;
+        persisted::persist(&state);
     }
 
     manager.emit_status(&app, &behavior);
 
-    let result = manager.do_check(&app).await;
+    let result = manager.do_check(&app, &behavior).await;
 
     let snapshot = {
         let mut state = manager.state.lock().expect("update state poisoned");
@@ -139,20 +153,27 @@ pub async fn trigger_check<R: Runtime>(
                 state.last_success_at = Some(Utc::now());
                 state.downloaded_at = Some(Utc::now());
                 state.last_error = None;
+                state.consecutive_failures = 0;
                 state.pending_update = Some(pending);
+                state.download_progress = None;
             }
             Ok(None) => {
                 state.stage = UpdateStage::Idle;
                 state.last_success_at = Some(Utc::now());
                 state.last_error = None;
+                state.consecutive_failures = 0;
+                state.download_progress = None;
             }
             Err(error) => {
                 state.stage = UpdateStage::Error;
                 state.last_error = Some(error.to_string());
                 state.last_failure_at = Some(Utc::now());
+                state.consecutive_failures = state.consecutive_failures.saturating_add(1);
+                state.download_progress = None;
             }
         }
 
+        persisted::persist(&state);
         state.snapshot(manager.config.is_configured(), behavior.auto_update_enabled)
     };
 
@@ -194,6 +215,7 @@ pub async fn install_downloaded_update<R: Runtime>(app: AppHandle<R>) -> UpdateS
                 last_error: None,
                 last_attempt_at: None,
                 downloaded_at: None,
+                progress: None,
             }
         }
         Err(error) => {
@@ -208,6 +230,30 @@ pub async fn install_downloaded_update<R: Runtime>(app: AppHandle<R>) -> UpdateS
             let _ = app.emit(APP_UPDATE_STATUS_EVENT, snapshot.clone());
             snapshot
         }
+    }
+}
+
+/// Install the pending update — if any — synchronously. Called from the
+/// Rust event loop's `Exit` handler so the user's next launch is the new
+/// version. Best-effort: any failure just logs (the same bundle will be
+/// re-fetched on the next launch's update check).
+pub fn install_pending_on_exit_blocking() {
+    let Some(manager) = UPDATE_MANAGER.get() else {
+        return;
+    };
+    let pending = match manager.state.lock() {
+        Ok(mut state) => state.pending_update.take(),
+        Err(_) => return,
+    };
+    let Some(pending) = pending else {
+        return;
+    };
+    tracing::info!(
+        version = %pending.info.version,
+        "Installing downloaded update on exit"
+    );
+    if let Err(error) = pending.update.install(&pending.bytes) {
+        tracing::warn!(error = %error, "Failed to install update on exit");
     }
 }
 
@@ -229,6 +275,7 @@ impl UpdateManager {
     async fn do_check<R: Runtime>(
         &self,
         app: &AppHandle<R>,
+        behavior: &UpdateBehavior,
     ) -> anyhow::Result<Option<PendingUpdate>> {
         let mut builder = app.updater_builder();
         builder = builder
@@ -246,15 +293,83 @@ impl UpdateManager {
             let mut state = self.state.lock().expect("update state poisoned");
             state.stage = UpdateStage::Downloading;
             state.pending_update = None;
+            state.download_progress = Some(DownloadProgress::default());
         }
+        self.emit_status(app, behavior);
 
-        let bytes = update.download(|_, _| {}, || {}).await?;
+        // Throttled progress emitter — chunk callback fires per ~16KB read,
+        // re-emitting the full snapshot every chunk would saturate the IPC
+        // channel for no UI benefit.
+        let tracker = Arc::new(Mutex::new(ProgressTracker {
+            downloaded: 0,
+            total: None,
+            last_emit: Instant::now()
+                .checked_sub(PROGRESS_EMIT_THROTTLE)
+                .unwrap_or_else(Instant::now),
+        }));
+
+        let app_for_chunk = app.clone();
+        let behavior_for_chunk = behavior.clone();
+        let tracker_for_chunk = tracker.clone();
+        let on_chunk = move |chunk_len: usize, total: Option<u64>| {
+            let mut t = tracker_for_chunk.lock().expect("progress tracker poisoned");
+            t.downloaded = t.downloaded.saturating_add(chunk_len as u64);
+            t.total = total;
+            let now = Instant::now();
+            if now.duration_since(t.last_emit) < PROGRESS_EMIT_THROTTLE {
+                return;
+            }
+            t.last_emit = now;
+            let progress = DownloadProgress {
+                downloaded: t.downloaded,
+                total: t.total,
+            };
+            drop(t);
+            update_progress_and_emit(&app_for_chunk, &behavior_for_chunk, progress);
+        };
+
+        let app_for_finish = app.clone();
+        let behavior_for_finish = behavior.clone();
+        let tracker_for_finish = tracker.clone();
+        let on_finish = move || {
+            let t = tracker_for_finish
+                .lock()
+                .expect("progress tracker poisoned");
+            let progress = DownloadProgress {
+                downloaded: t.downloaded,
+                total: t.total.or(Some(t.downloaded)),
+            };
+            drop(t);
+            update_progress_and_emit(&app_for_finish, &behavior_for_finish, progress);
+        };
+
+        let bytes = update.download(on_chunk, on_finish).await?;
         Ok(Some(PendingUpdate {
             update,
             bytes,
             info,
         }))
     }
+}
+
+struct ProgressTracker {
+    downloaded: u64,
+    total: Option<u64>,
+    last_emit: Instant,
+}
+
+fn update_progress_and_emit<R: Runtime>(
+    app: &AppHandle<R>,
+    behavior: &UpdateBehavior,
+    progress: DownloadProgress,
+) {
+    let manager = manager();
+    let snapshot = {
+        let mut state = manager.state.lock().expect("update state poisoned");
+        state.download_progress = Some(progress);
+        state.snapshot(manager.config.is_configured(), behavior.auto_update_enabled)
+    };
+    let _ = app.emit(APP_UPDATE_STATUS_EVENT, snapshot);
 }
 
 fn manager() -> &'static UpdateManager {
@@ -279,10 +394,11 @@ fn should_attempt(
     let now = Utc::now();
 
     if let Some(last_failure_at) = state.last_failure_at {
+        let backoff = failure_backoff(state.consecutive_failures);
         if (now - last_failure_at)
             .to_std()
             .ok()
-            .is_some_and(|elapsed| elapsed < behavior.failure_backoff)
+            .is_some_and(|elapsed| elapsed < backoff)
         {
             return false;
         }
@@ -301,6 +417,50 @@ fn should_attempt(
             elapsed_since_attempt.is_none_or(|elapsed| elapsed >= behavior.interval)
         }
     }
+}
+
+/// Compute how long the interval worker should sleep before its next poll.
+/// Reads current state to honor manual checks / focus checks that already
+/// fired during the previous sleep window — e.g. if user just clicked
+/// "Check now", we wait the full interval before firing again.
+fn compute_sleep_duration() -> Duration {
+    let Some(manager) = UPDATE_MANAGER.get() else {
+        return SCHEDULER_FLOOR;
+    };
+    let behavior = UpdateBehavior::load();
+    let state = match manager.state.lock() {
+        Ok(s) => s,
+        Err(_) => return SCHEDULER_FLOOR,
+    };
+
+    let now = Utc::now();
+    let interval_deadline = state
+        .last_attempt_at
+        .map(|t| {
+            t + chrono::Duration::from_std(behavior.interval).unwrap_or(chrono::Duration::zero())
+        })
+        .unwrap_or(now);
+
+    let failure_deadline = if state.consecutive_failures > 0 {
+        state.last_failure_at.map(|t| {
+            t + chrono::Duration::from_std(failure_backoff(state.consecutive_failures))
+                .unwrap_or(chrono::Duration::zero())
+        })
+    } else {
+        None
+    };
+
+    let target = match failure_deadline {
+        Some(f) if f > interval_deadline => f,
+        _ => interval_deadline,
+    };
+
+    drop(state);
+
+    let diff = target - now;
+    diff.to_std()
+        .unwrap_or(SCHEDULER_FLOOR)
+        .max(SCHEDULER_FLOOR)
 }
 
 fn snapshot_from_update(update: &tauri_plugin_updater::Update) -> UpdateInfoSnapshot {

--- a/src-tauri/src/updater/state.rs
+++ b/src-tauri/src/updater/state.rs
@@ -1,7 +1,9 @@
 use chrono::{DateTime, Utc};
 use tauri_plugin_updater::Update;
 
-use super::events::{UpdateInfoSnapshot, UpdateStage, UpdateStatusSnapshot};
+use crate::settings;
+
+use super::events::{DownloadProgress, UpdateInfoSnapshot, UpdateStage, UpdateStatusSnapshot};
 
 #[derive(Clone)]
 pub struct PendingUpdate {
@@ -20,12 +22,16 @@ pub struct UpdateRuntimeState {
     pub downloaded_at: Option<DateTime<Utc>>,
     pub last_success_at: Option<DateTime<Utc>>,
     pub last_failure_at: Option<DateTime<Utc>>,
+    pub consecutive_failures: u32,
+    pub download_progress: Option<DownloadProgress>,
 }
 
 impl UpdateRuntimeState {
     pub fn snapshot(&self, configured: bool, auto_update_enabled: bool) -> UpdateStatusSnapshot {
+        let effective_disabled =
+            !configured || (!auto_update_enabled && self.pending_update.is_none());
         UpdateStatusSnapshot {
-            stage: if !configured || !auto_update_enabled && self.pending_update.is_none() {
+            stage: if effective_disabled {
                 UpdateStage::Disabled
             } else {
                 self.stage
@@ -39,6 +45,68 @@ impl UpdateRuntimeState {
             last_error: self.last_error.clone(),
             last_attempt_at: self.last_attempt_at.map(|value| value.to_rfc3339()),
             downloaded_at: self.downloaded_at.map(|value| value.to_rfc3339()),
+            progress: if matches!(self.stage, UpdateStage::Downloading) {
+                self.download_progress
+            } else {
+                None
+            },
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Persistence — outlive process restarts so the interval scheduler and
+// failure backoff don't reset every launch (that's why every cold-start
+// used to fire a check; with persistence we honor the actual cadence).
+// ---------------------------------------------------------------------------
+
+const KEY_LAST_ATTEMPT_AT: &str = "app.updater.last_attempt_at";
+const KEY_LAST_SUCCESS_AT: &str = "app.updater.last_success_at";
+const KEY_LAST_FAILURE_AT: &str = "app.updater.last_failure_at";
+const KEY_CONSECUTIVE_FAILURES: &str = "app.updater.consecutive_failures";
+
+pub fn load_persisted(state: &mut UpdateRuntimeState) {
+    state.last_attempt_at = load_datetime(KEY_LAST_ATTEMPT_AT);
+    state.last_success_at = load_datetime(KEY_LAST_SUCCESS_AT);
+    state.last_failure_at = load_datetime(KEY_LAST_FAILURE_AT);
+    state.consecutive_failures = load_u32(KEY_CONSECUTIVE_FAILURES);
+}
+
+pub fn persist(state: &UpdateRuntimeState) {
+    save_optional_datetime(KEY_LAST_ATTEMPT_AT, state.last_attempt_at);
+    save_optional_datetime(KEY_LAST_SUCCESS_AT, state.last_success_at);
+    save_optional_datetime(KEY_LAST_FAILURE_AT, state.last_failure_at);
+    save_u32(KEY_CONSECUTIVE_FAILURES, state.consecutive_failures);
+}
+
+fn load_datetime(key: &str) -> Option<DateTime<Utc>> {
+    settings::load_setting_value(key)
+        .ok()
+        .flatten()
+        .and_then(|raw| DateTime::parse_from_rfc3339(raw.trim()).ok())
+        .map(|dt| dt.with_timezone(&Utc))
+}
+
+fn load_u32(key: &str) -> u32 {
+    settings::load_setting_value(key)
+        .ok()
+        .flatten()
+        .and_then(|raw| raw.trim().parse::<u32>().ok())
+        .unwrap_or(0)
+}
+
+fn save_optional_datetime(key: &str, value: Option<DateTime<Utc>>) {
+    let result = match value {
+        Some(dt) => settings::upsert_setting_value(key, &dt.to_rfc3339()),
+        None => settings::delete_setting_value(key),
+    };
+    if let Err(error) = result {
+        tracing::warn!(key, error = %error, "Failed to persist updater state");
+    }
+}
+
+fn save_u32(key: &str, value: u32) {
+    if let Err(error) = settings::upsert_setting_value(key, &value.to_string()) {
+        tracing::warn!(key, error = %error, "Failed to persist updater state");
     }
 }

--- a/src-tauri/src/updater/tests.rs
+++ b/src-tauri/src/updater/tests.rs
@@ -4,7 +4,8 @@
 //! later cross-platform refactors (Phase 2+) cannot regress them silently.
 
 use super::events::{
-    UpdateInfoSnapshot, UpdateStage, UpdateStatusSnapshot, APP_UPDATE_STATUS_EVENT,
+    DownloadProgress, UpdateInfoSnapshot, UpdateStage, UpdateStatusSnapshot,
+    APP_UPDATE_STATUS_EVENT,
 };
 
 #[test]
@@ -61,6 +62,7 @@ fn update_status_snapshot_serializes_camel_case_fields() {
         last_error: Some("network".into()),
         last_attempt_at: Some("2026-04-17T00:00:00Z".into()),
         downloaded_at: None,
+        progress: None,
     };
 
     let value = serde_json::to_value(&snap).unwrap();
@@ -82,4 +84,26 @@ fn app_update_status_event_name_is_stable() {
     // Frontend subscribes via this literal; cross-platform refactors must not
     // rename it.
     assert_eq!(APP_UPDATE_STATUS_EVENT, "app-update-status");
+}
+
+#[test]
+fn download_progress_serializes_camel_case() {
+    let progress = DownloadProgress {
+        downloaded: 12_345,
+        total: Some(50_000),
+    };
+    let value = serde_json::to_value(progress).unwrap();
+    assert_eq!(value["downloaded"], 12_345);
+    assert_eq!(value["total"], 50_000);
+}
+
+#[test]
+fn download_progress_total_unknown_serializes_null() {
+    let progress = DownloadProgress {
+        downloaded: 100,
+        total: None,
+    };
+    let value = serde_json::to_value(progress).unwrap();
+    assert_eq!(value["downloaded"], 100);
+    assert!(value["total"].is_null());
 }

--- a/src/features/settings/panels/app-updates.tsx
+++ b/src/features/settings/panels/app-updates.tsx
@@ -39,6 +39,43 @@ function formatStatusDescription(status: AppUpdateStatus): string {
 	}
 }
 
+function formatBytes(bytes: number): string {
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+	return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function DownloadProgressBar({ status }: { status: AppUpdateStatus }) {
+	if (status.stage !== "downloading") return null;
+	const progress = status.progress;
+	const downloaded = progress?.downloaded ?? 0;
+	const total = progress?.total ?? null;
+	const hasTotal = typeof total === "number" && total > 0;
+	const percent = hasTotal
+		? Math.min(100, Math.round((downloaded / total) * 100))
+		: null;
+
+	return (
+		<div className="mt-2 max-w-[280px]">
+			<div className="h-1 w-full overflow-hidden rounded-full bg-muted/40">
+				{percent !== null ? (
+					<div
+						className="h-full bg-foreground/70 transition-[width] duration-200 ease-out"
+						style={{ width: `${percent}%` }}
+					/>
+				) : (
+					<div className="h-full w-1/3 animate-pulse bg-foreground/50" />
+				)}
+			</div>
+			<div className="mt-1 text-[11px] tabular-nums text-muted-foreground">
+				{hasTotal
+					? `${formatBytes(downloaded)} / ${formatBytes(total)} · ${percent}%`
+					: formatBytes(downloaded)}
+			</div>
+		</div>
+	);
+}
+
 export function AppUpdatesPanel() {
 	const [status, setStatus] = useState<AppUpdateStatus | null>(null);
 	const [checking, setChecking] = useState(false);
@@ -64,6 +101,22 @@ export function AppUpdatesPanel() {
 		};
 	}, []);
 
+	const stage = status?.stage;
+	const isAutoChecking = stage === "checking";
+	const isDownloading = stage === "downloading";
+	const isInstallingStage = stage === "installing";
+	const checkBusy = checking || isAutoChecking;
+	const installBusy = installing || isInstallingStage;
+	const anyBusy = checkBusy || isDownloading || installBusy;
+
+	const checkLabel = isDownloading
+		? "Downloading"
+		: installBusy
+			? "Installing"
+			: checkBusy
+				? "Checking"
+				: "Check now";
+
 	return (
 		<SettingsRow
 			align="start"
@@ -77,6 +130,7 @@ export function AppUpdatesPanel() {
 							{status.update.version}
 						</SettingsNotice>
 					) : null}
+					{status ? <DownloadProgressBar status={status} /> : null}
 				</>
 			}
 		>
@@ -101,14 +155,14 @@ export function AppUpdatesPanel() {
 							})
 							.finally(() => setChecking(false));
 					}}
-					disabled={checking || installing}
+					disabled={anyBusy}
 				>
-					{checking ? (
+					{anyBusy ? (
 						<Loader2 className="size-3.5 animate-spin" />
 					) : (
 						<RefreshCw className="size-3.5" />
 					)}
-					Check now
+					{checkLabel}
 				</Button>
 				{status?.stage === "downloaded" && (
 					<Button
@@ -127,7 +181,7 @@ export function AppUpdatesPanel() {
 								})
 								.finally(() => setInstalling(false));
 						}}
-						disabled={checking || installing}
+						disabled={anyBusy}
 					>
 						Update and restart
 					</Button>

--- a/src/features/updater/use-app-updater.ts
+++ b/src/features/updater/use-app-updater.ts
@@ -57,7 +57,7 @@ function showDownloadedUpdateToast(
 			},
 			"View change log",
 		),
-		duration: Number.POSITIVE_INFINITY,
+		duration: 8000,
 	});
 }
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -462,6 +462,11 @@ export type AppUpdateInfo = {
 	releaseUrl: string;
 };
 
+export type AppUpdateProgress = {
+	downloaded: number;
+	total?: number | null;
+};
+
 export type AppUpdateStatus = {
 	stage: AppUpdateStage;
 	configured: boolean;
@@ -470,6 +475,7 @@ export type AppUpdateStatus = {
 	lastError?: string | null;
 	lastAttemptAt?: string | null;
 	downloadedAt?: string | null;
+	progress?: AppUpdateProgress | null;
 };
 
 const DEFAULT_WORKSPACE_GROUPS: WorkspaceGroup[] = [


### PR DESCRIPTION
## Summary

In-app updates landed too rarely and felt opaque. This change makes the auto-updater both faster to converge and more transparent in flight.

### What changed

**Backend (`src-tauri/src/updater/`)**
- **Persist scheduler state** across launches (`last_attempt_at`, `last_success_at`, `last_failure_at`, `consecutive_failures`) via `settings`. Cold-starts no longer reset the cadence and re-fire a check every launch.
- **Exponential failure backoff**: 1 → 2 → 4 → 8 → 16 → 32 → 60 min (capped). Replaces a flat 15-minute backoff. Resets on success.
- **Deadline-based interval poller**: thread sleeps until the next legitimate check time (interval deadline ∨ failure-backoff deadline) instead of waking every 60 s and short-circuiting. Floor of 60 s.
- **Default poll interval** dropped from 6 h → 30 min; focus TTL from 30 min → 10 min. The settings-overridable interval key was removed (we fix the cadence centrally now).
- **Download progress**: `DownloadProgress { downloaded, total }` is plumbed through the `update.download` callbacks, throttled to one IPC emission per ~200 ms, and surfaced on the status snapshot.
- **Install pending update on exit** via Tauri's `RunEvent::Exit`. After `request_quit` has stopped watchers and torn down the sidecar, we synchronously call `update.install(&bytes)` so the next launch is the new version. Best-effort — failure just logs and the bundle re-downloads next check.

**Frontend**
- New `DownloadProgressBar` in the App Updates settings panel. Shows determinate progress when total is known, otherwise a pulsing indeterminate bar.
- \"Check now\" button now reflects the current stage (`Checking` / `Downloading` / `Installing`) and disables for any in-flight stage.
- Downloaded-update toast duration changed from `Infinity` → 8 s (the panel and on-exit install make a sticky toast unnecessary).

**Misc**
- Sanitized hostnames in `forge/cli_status.rs` test fixtures (internal `ngit.hundun.cn` → `example.cn`).

### Why

The old behavior had three sharp edges:
1. Every cold-start fired a check (state was in-memory only), so cadence was effectively \"once per launch\" rather than the configured interval.
2. A failed check was retried on a flat 15-minute clock — repeated transient errors hammered the endpoint without any backoff curve.
3. Once an update finished downloading, the user had to notice an infinite toast and click \"Update and restart\". With on-exit install, the next quit *is* the install.

### Test notes

- `cargo test` covers the backoff progression (`updater::config::tests::failure_backoff_progression`) and the new `DownloadProgress` serialization shape (`updater/tests.rs`).
- `bun run test` / `cargo clippy --all-targets -- -D warnings` clean.
- Manual:
  - [ ] Launch app, watch Settings → App Updates: trigger a check, verify the progress bar appears during download and the button label cycles `Check now` → `Checking` → `Downloading`.
  - [ ] Force a failure (e.g. block the endpoint), confirm consecutive failures persist across a relaunch and that the next attempt respects the exponential backoff.
  - [ ] With a downloaded update pending, quit the app and confirm the next launch is the new version.