### PR TITLE
perf(db): reduce writer round-trips and skip pool path resolution on hot paths

### DIFF
--- a/.changeset/snappier-db-under-load.md
+++ b/.changeset/snappier-db-under-load.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Make switching into large sessions snappier and reduce database contention during heavy streaming.

--- a/src-tauri/src/agents/streaming/mod.rs
+++ b/src-tauri/src/agents/streaming/mod.rs
@@ -454,11 +454,18 @@ pub(super) fn stream_via_sidecar(
                             pipeline_state.accumulator.append_aborted_notice();
                         }
 
+                        // Borrow writer once for both turn persistence and the
+                        // terminal finalize. drain_output between the two uses
+                        // is purely in-memory, so holding the writer pool slot
+                        // across it is cheap and halves the writer round-trips
+                        // per terminal event.
+                        let writer = exchange_ctx
+                            .as_ref()
+                            .and_then(|_| crate::models::db::write_conn().ok());
+
                         // Persist remaining turns and sync their UUIDs back
                         // into collected[] so streaming IDs = DB IDs.
-                        if let (Some(ctx), Some(conn)) =
-                            (&exchange_ctx, &crate::models::db::write_conn().ok())
-                        {
+                        if let (Some(ctx), Some(conn)) = (exchange_ctx.as_ref(), writer.as_ref()) {
                             let model_str = pipeline_state.accumulator.resolved_model().to_string();
                             while persisted_turn_count < pipeline_state.accumulator.turns_len() {
                                 match persist_turn_message(
@@ -484,9 +491,7 @@ pub(super) fn stream_via_sidecar(
                         if !output.assistant_text.is_empty() {
                             resolved_model = output.resolved_model.clone();
                         }
-                        if let (Some(ctx), Some(conn)) =
-                            (&exchange_ctx, &crate::models::db::write_conn().ok())
-                        {
+                        if let (Some(ctx), Some(conn)) = (exchange_ctx.as_ref(), writer.as_ref()) {
                             if is_aborted {
                                 match finalize_session_metadata(
                                     conn,
@@ -526,6 +531,7 @@ pub(super) fn stream_via_sidecar(
                                 "Failed to borrow writer for finalize — reporting persisted=false"
                             );
                         }
+                        drop(writer);
 
                         // Final render with DB-synced IDs so the frontend
                         // cache matches what the historical loader returns.
@@ -620,9 +626,14 @@ pub(super) fn stream_via_sidecar(
                     if let Some(pipeline_state) = pipeline.as_mut() {
                         pipeline_state.accumulator.flush_pending();
 
-                        if let (Some(ctx), Some(conn)) =
-                            (&exchange_ctx, &crate::models::db::write_conn().ok())
-                        {
+                        // Single writer borrow covers turn persistence and
+                        // the exit-plan message write below; only an
+                        // in-memory `resolved_model` read sits between them.
+                        let writer = exchange_ctx
+                            .as_ref()
+                            .and_then(|_| crate::models::db::write_conn().ok());
+
+                        if let (Some(ctx), Some(conn)) = (exchange_ctx.as_ref(), writer.as_ref()) {
                             let model_str = pipeline_state.accumulator.resolved_model().to_string();
                             while persisted_turn_count < pipeline_state.accumulator.turns_len() {
                                 match persist_turn_message(
@@ -646,7 +657,7 @@ pub(super) fn stream_via_sidecar(
                         let resolved_model =
                             pipeline_state.accumulator.resolved_model().to_string();
                         let persisted_metadata = if let (Some(ctx), Some(conn)) =
-                            (&exchange_ctx, &crate::models::db::write_conn().ok())
+                            (exchange_ctx.as_ref(), writer.as_ref())
                         {
                             persist_exit_plan_message(
                                 conn,
@@ -660,6 +671,7 @@ pub(super) fn stream_via_sidecar(
                         } else {
                             None
                         };
+                        drop(writer);
                         let (msg_id, created_at) = persisted_metadata.unwrap_or_default();
                         let plan_message = build_exit_plan_review_message(
                             (!msg_id.is_empty()).then_some(msg_id),
@@ -704,9 +716,14 @@ pub(super) fn stream_via_sidecar(
                     if let Some(mut pipeline_state) = pipeline.take() {
                         pipeline_state.accumulator.flush_pending();
 
-                        if let (Some(ctx), Some(conn)) =
-                            (&exchange_ctx, &crate::models::db::write_conn().ok())
-                        {
+                        // Borrow writer once for both turn persist and the
+                        // deferred-finalize. The pipeline_state.finish()
+                        // between them is purely in-memory.
+                        let writer = exchange_ctx
+                            .as_ref()
+                            .and_then(|_| crate::models::db::write_conn().ok());
+
+                        if let (Some(ctx), Some(conn)) = (exchange_ctx.as_ref(), writer.as_ref()) {
                             let model_str = pipeline_state.accumulator.resolved_model().to_string();
                             while persisted_turn_count < pipeline_state.accumulator.turns_len() {
                                 match persist_turn_message(
@@ -734,9 +751,7 @@ pub(super) fn stream_via_sidecar(
                         resolved_model = pipeline_state.accumulator.resolved_model().to_string();
                         final_messages = pipeline_state.finish();
 
-                        if let (Some(ctx), Some(conn)) =
-                            (&exchange_ctx, &crate::models::db::write_conn().ok())
-                        {
+                        if let (Some(ctx), Some(conn)) = (exchange_ctx.as_ref(), writer.as_ref()) {
                             if let Err(error) = finalize_session_metadata(
                                 conn,
                                 ctx,
@@ -750,6 +765,7 @@ pub(super) fn stream_via_sidecar(
                                 );
                             }
                         }
+                        drop(writer);
                     }
 
                     match turn_session.handle_deferred_tool_use(

--- a/src-tauri/src/bin/gen_pipeline_fixture.rs
+++ b/src-tauri/src/bin/gen_pipeline_fixture.rs
@@ -145,7 +145,7 @@ fn load_session_records(session_id: &str) -> Result<Vec<HistoricalRecord>> {
         "SELECT id, role, content, created_at \
          FROM session_messages \
          WHERE session_id = ?1 \
-         ORDER BY COALESCE(julianday(sent_at), julianday(created_at)) ASC, rowid ASC",
+         ORDER BY sent_at ASC, rowid ASC",
     )?;
 
     let rows = stmt.query_map([session_id], |row| {

--- a/src-tauri/src/models/db.rs
+++ b/src-tauri/src/models/db.rs
@@ -142,7 +142,21 @@ pub fn init_pools() -> Result<()> {
 /// Ensure pools exist and point at the current `HELMOR_DATA_DIR`. Rebuilds
 /// transparently if the data dir has changed (tests) or if pools were
 /// never built (first call).
+///
+/// Prod fast path skips `db_path()` resolution: pools are built once at
+/// startup and never swapped. Tests still resolve every call so they can
+/// hot-swap `HELMOR_DATA_DIR`.
 fn with_bundle<T>(f: impl FnOnce(&PoolBundle) -> Result<T>) -> Result<T> {
+    #[cfg(not(test))]
+    {
+        let guard = pool_slot()
+            .read()
+            .map_err(|_| anyhow!("pool lock poisoned"))?;
+        if let Some(bundle) = guard.as_ref() {
+            return f(bundle);
+        }
+    }
+
     let current_path = crate::data_dir::db_path()?;
 
     {
@@ -183,6 +197,10 @@ const SLOW_BORROW_WARN_MS: u128 = 100;
 /// proceed concurrently and never block the writer.
 #[track_caller]
 pub fn read_conn() -> Result<PooledConn> {
+    // Capture caller OUTSIDE the closure: `#[track_caller]` only propagates
+    // across the direct call boundary, so calling `Location::caller()`
+    // inside `with_bundle`'s closure would resolve to db.rs itself.
+    let caller = Location::caller();
     with_bundle(|bundle| {
         let start = std::time::Instant::now();
         let conn = bundle
@@ -191,7 +209,6 @@ pub fn read_conn() -> Result<PooledConn> {
             .map_err(|e| anyhow!("Failed to borrow read connection: {e}"))?;
         let elapsed_ms = start.elapsed().as_millis();
         if elapsed_ms >= SLOW_BORROW_WARN_MS {
-            let caller = Location::caller();
             tracing::warn!(
                 elapsed_ms,
                 pool_state = ?bundle.read.state(),
@@ -209,10 +226,10 @@ pub fn read_conn() -> Result<PooledConn> {
 /// Hold for as short as possible; long-held writes starve all other writers.
 #[track_caller]
 pub fn write_conn() -> Result<PooledConn> {
+    let caller = Location::caller();
     with_bundle(|bundle| {
         let start = std::time::Instant::now();
         let conn = bundle.write.get().map_err(|e| {
-            let caller = Location::caller();
             tracing::error!(
                 elapsed_ms = start.elapsed().as_millis(),
                 pool_state = ?bundle.write.state(),
@@ -224,7 +241,6 @@ pub fn write_conn() -> Result<PooledConn> {
         })?;
         let elapsed_ms = start.elapsed().as_millis();
         if elapsed_ms >= SLOW_BORROW_WARN_MS {
-            let caller = Location::caller();
             tracing::warn!(
                 elapsed_ms,
                 pool_state = ?bundle.write.state(),

--- a/src-tauri/src/models/sessions.rs
+++ b/src-tauri/src/models/sessions.rs
@@ -146,9 +146,7 @@ fn list_session_historical_records_with_connection(
               sm.created_at
             FROM session_messages sm
             WHERE sm.session_id = ?1
-            ORDER BY
-              COALESCE(julianday(sm.sent_at), julianday(sm.created_at)) ASC,
-              sm.rowid ASC
+            ORDER BY sm.sent_at ASC, sm.rowid ASC
             "#,
     )?;
 


### PR DESCRIPTION
## Summary

Two small but high-impact perf wins around the SQLite layer that were showing up while watching Helmor logs under heavy streaming.

- **`agents/streaming/mod.rs`** — In each terminal-event branch (final result, exit-plan, deferred tool-use), the code was borrowing a writer from the pool twice: once for turn persistence, then again for the finalize / exit-plan write. The work between the two borrows is purely in-memory (resolved-model read, `pipeline_state.finish()`, `drain_output`), so we now grab the writer once and reuse it, halving the writer round-trips per terminal event.
- **`models/db.rs`** — `with_bundle` was calling `data_dir::db_path()?` on every connection borrow so tests could hot-swap `HELMOR_DATA_DIR`. In prod the pools are built once at startup and never swapped, so we add a `#[cfg(not(test))]` fast path that skips the path resolution and just hands back the existing bundle. Also fixes a subtle bug where `Location::caller()` was called inside the `with_bundle` closure — `#[track_caller]` only propagates one call deep, so the captured caller was always `db.rs` itself; now we capture it in the outer `read_conn`/`write_conn` frame.
- **`models/sessions.rs` + `bin/gen_pipeline_fixture.rs`** — Historical-load query was sorting by `COALESCE(julianday(sent_at), julianday(created_at))`, which forces SQLite to compute `julianday()` per row and defeats any index on `sent_at`. `sent_at` is now always populated, so we sort on it directly. Faster session switching, especially for large sessions.

## Why

Showed up while reviewing logs — slow-borrow warnings during streaming finalize, and noticeably sluggish first-paint when switching into multi-thousand-message sessions.

## Test notes

- `cargo clippy --all-targets -- -D warnings` is clean (pre-commit hook ran it).
- `cargo fmt` clean.
- Pipeline snapshot tests should be unaffected — query change is ordering-equivalent now that `sent_at` is always populated, and the streaming changes are purely a borrow-lifetime refactor with no behavioral diff.
- Worth a manual smoke: stream a long session, switch sessions, confirm no regressions in message ordering or finalize behavior.