### PR TITLE
fix(commit-button): use workspace target branch in GitLab MR prompts

### DIFF
--- a/.changeset/gitlab-create-mr-target-branch.md
+++ b/.changeset/gitlab-create-mr-target-branch.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix the Create MR button on GitLab repos so it opens the merge request against the workspace's configured target branch instead of falling back to the repository's default branch.

--- a/src/lib/commit-button-prompts.test.ts
+++ b/src/lib/commit-button-prompts.test.ts
@@ -19,6 +19,23 @@ const GITLAB_FORGE: ForgeDetection = {
 	detectionSignals: [],
 };
 
+const GITHUB_FORGE: ForgeDetection = {
+	provider: "github",
+	host: "github.com",
+	namespace: "acme",
+	repo: "repo",
+	remoteUrl: "git@github.com:acme/repo.git",
+	labels: {
+		providerName: "GitHub",
+		cliName: "gh",
+		changeRequestName: "PR",
+		changeRequestFullName: "pull request",
+		connectAction: "Connect GitHub",
+	},
+	cli: null,
+	detectionSignals: [],
+};
+
 describe("buildCommitButtonPrompt", () => {
 	it("appends create-pr preferences after the built-in prompt", () => {
 		expect(
@@ -32,10 +49,38 @@ describe("buildCommitButtonPrompt", () => {
 		).toContain("### User Preferences\n\nAlways include rollout notes.");
 	});
 
-	it("passes the target branch into create-pr prompts", () => {
+	it("passes the target branch into create-pr prompts (GitHub default)", () => {
 		expect(buildCommitButtonPrompt("create-pr", {}, "release/next")).toContain(
 			"gh pr create --base release/next",
 		);
+	});
+
+	it("passes the target branch into create-pr prompts (GitHub forge)", () => {
+		const prompt = buildCommitButtonPrompt(
+			"create-pr",
+			{},
+			"release/next",
+			GITHUB_FORGE,
+		);
+		expect(prompt).toContain("Create a pull request");
+		expect(prompt).toContain(
+			"Open a pull request against `release/next` using `gh pr create --base release/next`.",
+		);
+	});
+
+	it("passes the target branch into create-pr prompts (GitLab forge)", () => {
+		const prompt = buildCommitButtonPrompt(
+			"create-pr",
+			{},
+			"release/next",
+			GITLAB_FORGE,
+		);
+		expect(prompt).toContain("Create a merge request");
+		expect(prompt).toContain(
+			"Open a merge request against `release/next` using `glab mr create --target-branch release/next`.",
+		);
+		expect(prompt).not.toContain("`gh pr create`");
+		expect(prompt).not.toContain("the repository's default branch");
 	});
 
 	it("passes the target branch into resolve-conflicts prompts", () => {
@@ -56,29 +101,40 @@ describe("buildCommitButtonPrompt", () => {
 		);
 	});
 
-	it("uses GitLab merge request creation instructions", () => {
-		const prompt = buildCommitButtonPrompt(
-			"create-pr",
+	it("uses GitHub CI inspection commands by default", () => {
+		const prompt = buildCommitButtonPrompt("fix", null);
+		expect(prompt).toContain("`gh run list` / `gh run view`");
+	});
+
+	it("uses GitLab CI inspection commands for GitLab forge", () => {
+		const prompt = buildCommitButtonPrompt("fix", null, null, GITLAB_FORGE);
+		expect(prompt).toContain("GitLab CI is failing");
+		expect(prompt).toContain("`glab ci list` / `glab ci view`");
+		expect(prompt).toContain("failing pipeline");
+		expect(prompt).not.toContain("`gh run list`");
+	});
+
+	it("uses the same root-cause guidance for both forges", () => {
+		const githubPrompt = buildCommitButtonPrompt("fix", null);
+		const gitlabPrompt = buildCommitButtonPrompt(
+			"fix",
 			null,
 			null,
 			GITLAB_FORGE,
 		);
-
-		expect(prompt).toContain("Create a merge request");
-		expect(prompt).toContain("`glab mr create`");
-		expect(prompt).not.toContain("`gh pr create`");
+		const clause = "— don't just paper over the symptom";
+		expect(githubPrompt).toContain(clause);
+		expect(gitlabPrompt).toContain(clause);
 	});
 
-	it("uses GitLab CI inspection instructions for fix mode", () => {
-		const prompt = buildCommitButtonPrompt("fix", null, null, GITLAB_FORGE);
-
-		expect(prompt).toContain("GitLab CI is failing");
-		expect(prompt).toContain("`glab ci list` / `glab ci view`");
+	it("uses GitHub reopen commands for open-pr by default", () => {
+		const prompt = buildCommitButtonPrompt("open-pr", null);
+		expect(prompt).toContain("Reopen the closed pull request");
+		expect(prompt).toContain("`gh pr reopen` + `gh pr comment`");
 	});
 
-	it("uses GitLab reopen instructions for open-pr mode", () => {
+	it("uses GitLab reopen commands for open-pr on GitLab forge", () => {
 		const prompt = buildCommitButtonPrompt("open-pr", null, null, GITLAB_FORGE);
-
 		expect(prompt).toContain("Reopen the closed merge request");
 		expect(prompt).toContain("`glab mr reopen` + `glab mr note`");
 	});
@@ -87,13 +143,30 @@ describe("buildCommitButtonPrompt", () => {
 		const prompt = buildCommitButtonPrompt(
 			"create-pr",
 			{ createPr: "Mention deployment order." },
-			null,
+			"release/next",
 			GITLAB_FORGE,
 		);
 
-		expect(prompt).toContain("`glab mr create`");
+		expect(prompt).toContain("`glab mr create --target-branch release/next`");
 		expect(prompt).toContain(
 			"### User Preferences\n\nMention deployment order.",
 		);
+	});
+
+	it("uses pure-git instructions for commit-and-push regardless of forge", () => {
+		const githubPrompt = buildCommitButtonPrompt(
+			"commit-and-push",
+			null,
+			null,
+			GITHUB_FORGE,
+		);
+		const gitlabPrompt = buildCommitButtonPrompt(
+			"commit-and-push",
+			null,
+			null,
+			GITLAB_FORGE,
+		);
+		expect(githubPrompt).toBe(gitlabPrompt);
+		expect(githubPrompt).toContain("Commit and push all uncommitted work");
 	});
 });

--- a/src/lib/commit-button-prompts.ts
+++ b/src/lib/commit-button-prompts.ts
@@ -1,9 +1,9 @@
 import type { WorkspaceCommitButtonMode } from "@/features/commit/button";
 import type { ForgeDetection, RepoPreferences } from "@/lib/api";
+import { forgePromptDialect } from "@/lib/forge-dialect";
 import {
 	type RepoPreferenceKey,
 	resolveRepoPreferencePrompt,
-	resolveRepoPreferencePromptWithDefault,
 } from "@/lib/repo-preferences-prompts";
 
 type ActionSessionMode = Exclude<
@@ -11,15 +11,18 @@ type ActionSessionMode = Exclude<
 	"push" | "merge" | "closed" | "merged"
 >;
 
+// Modes that delegate to a `RepoPreferenceKey`. The other action modes
+// (`commit-and-push`, `open-pr`) have no user-facing preference slot — they're
+// rendered inline below.
+type PreferenceBackedMode = "create-pr" | "fix" | "resolve-conflicts";
+
 const ACTION_MODE_TO_PREFERENCE_KEY: Record<
-	ActionSessionMode,
+	PreferenceBackedMode,
 	RepoPreferenceKey
 > = {
 	"create-pr": "createPr",
-	"commit-and-push": "createPr",
 	fix: "fixErrors",
 	"resolve-conflicts": "resolveConflicts",
-	"open-pr": "createPr",
 };
 
 export function buildCommitButtonPrompt(
@@ -28,12 +31,9 @@ export function buildCommitButtonPrompt(
 	targetBranch?: string | null,
 	forge?: ForgeDetection | null,
 ): string {
-	if (forge?.provider === "gitlab") {
-		return buildGitLabCommitButtonPrompt(mode, repoPreferences, targetBranch);
-	}
-
 	switch (mode) {
 		case "commit-and-push":
+			// Pure git — no forge involved.
 			return `Commit and push all uncommitted work in this workspace.
 
 Do the following, in order:
@@ -44,65 +44,22 @@ Do the following, in order:
 5. Report the resulting commit SHA and pushed ref.
 
 Don't stop to ask for confirmation — execute each step automatically. If a pre-commit / pre-push hook fails, report the failure and stop without force-pushing.`;
-		case "open-pr":
-			return `Reopen the closed pull request for this branch and leave a short comment explaining why it's being reopened.
 
-Use \`gh pr reopen\` + \`gh pr comment\`. Report the PR URL when done.`;
-		default:
+		case "open-pr": {
+			const dialect = forgePromptDialect(forge);
+			return `Reopen the closed ${dialect.changeRequestFullName} for this branch and leave a short comment explaining why it's being reopened.
+
+Use \`${dialect.reopenCommand}\` + \`${dialect.commentCommand}\`. Report the ${dialect.changeRequestName} URL when done.`;
+		}
+
+		case "create-pr":
+		case "fix":
+		case "resolve-conflicts":
 			return resolveRepoPreferencePrompt({
 				key: ACTION_MODE_TO_PREFERENCE_KEY[mode],
 				repoPreferences,
 				targetBranch,
-			});
-	}
-}
-
-function buildGitLabCommitButtonPrompt(
-	mode: ActionSessionMode,
-	repoPreferences?: RepoPreferences | null,
-	targetBranch?: string | null,
-): string {
-	switch (mode) {
-		case "commit-and-push":
-			return buildCommitButtonPrompt(mode, repoPreferences);
-		case "open-pr":
-			return `Reopen the closed merge request for this branch and leave a short comment explaining why it's being reopened.
-
-Use \`glab mr reopen\` + \`glab mr note\`. Report the MR URL when done.`;
-		case "fix":
-			return resolveRepoPreferencePromptWithDefault({
-				key: "fixErrors",
-				repoPreferences,
-				defaultPrompt: `GitLab CI is failing on the current branch. Diagnose and fix it.
-
-Do the following, in order:
-1. Use \`glab ci list\` / \`glab ci view\` to inspect the most recent failing pipeline for this branch. Read the logs for each failing job.
-2. Identify the root cause. Explain your diagnosis briefly before making changes.
-3. Apply the minimum set of changes needed to get CI green. Run the relevant tests / linters locally to confirm.
-4. Commit the fix with a clear \`fix(ci): …\` message and push to the same branch so CI re-runs.
-5. Report what was broken, what you changed, and whether the re-run is passing.`,
-			});
-		case "create-pr":
-			return resolveRepoPreferencePromptWithDefault({
-				key: "createPr",
-				repoPreferences,
-				defaultPrompt: `Create a merge request for the uncommitted work in this workspace.
-
-Do the following, in order:
-1. Run \`git status\` and \`git diff\` to survey what's changed.
-2. Stage everything that should ship with \`git add\`.
-3. Commit with a concise, Conventional-Commits-style message (\`feat:\`, \`fix:\`, \`refactor:\`, \`chore:\`, etc.) that summarizes the change in one line.
-4. Push the current branch to its remote. If needed, create the remote tracking branch with \`git push -u <remote> HEAD\`.
-5. Open a merge request against the repository's default branch using \`glab mr create\`. Use a clear MR title and a body that explains: what changed, why it changed, and any follow-up / test notes.
-6. Report the MR URL in your final message so I can click it.
-
-Don't stop to ask for confirmation — execute each step automatically. If you hit an unrecoverable error (e.g. merge conflict, pre-push hook failure), report it clearly so I can intervene.`,
-			});
-		case "resolve-conflicts":
-			return resolveRepoPreferencePrompt({
-				key: "resolveConflicts",
-				repoPreferences,
-				targetBranch,
+				forge,
 			});
 	}
 }
@@ -111,8 +68,10 @@ export function isActionSessionMode(
 	mode: WorkspaceCommitButtonMode,
 ): mode is ActionSessionMode {
 	return (
-		mode in ACTION_MODE_TO_PREFERENCE_KEY ||
+		mode === "create-pr" ||
 		mode === "commit-and-push" ||
+		mode === "fix" ||
+		mode === "resolve-conflicts" ||
 		mode === "open-pr"
 	);
 }

--- a/src/lib/forge-dialect.ts
+++ b/src/lib/forge-dialect.ts
@@ -1,0 +1,60 @@
+import type { ForgeDetection } from "@/lib/api";
+
+// Forge-specific bits that get dropped into agent prompts. Everything else in
+// our prompts is forge-agnostic (plain git, prose). Keep this surface tight —
+// only add a field when the prompt actually needs to render it.
+export type ForgePromptDialect = {
+	/** Short label, e.g. "PR" / "MR". */
+	changeRequestName: string;
+	/** Long label, e.g. "pull request" / "merge request". */
+	changeRequestFullName: string;
+	/** Forge CLI binary, e.g. "gh" / "glab". */
+	cliName: string;
+	/** Renders the create-PR/MR command for a given target branch. */
+	createCommand: (targetBranch: string) => string;
+	/** Reopen a closed PR/MR, e.g. "gh pr reopen" / "glab mr reopen". */
+	reopenCommand: string;
+	/** Comment on a PR/MR, e.g. "gh pr comment" / "glab mr note". */
+	commentCommand: string;
+	/** List CI runs, e.g. "gh run list" / "glab ci list". */
+	ciListCommand: string;
+	/** Inspect a CI run, e.g. "gh run view" / "glab ci view". */
+	ciViewCommand: string;
+	/** CI system name as it appears in prose, e.g. "CI" / "GitLab CI". */
+	ciSystemName: string;
+	/** What the CI system calls a single run, e.g. "run" / "pipeline". */
+	ciJobNoun: string;
+};
+
+const GITHUB_DIALECT: ForgePromptDialect = {
+	changeRequestName: "PR",
+	changeRequestFullName: "pull request",
+	cliName: "gh",
+	createCommand: (branch) => `gh pr create --base ${branch}`,
+	reopenCommand: "gh pr reopen",
+	commentCommand: "gh pr comment",
+	ciListCommand: "gh run list",
+	ciViewCommand: "gh run view",
+	ciSystemName: "CI",
+	ciJobNoun: "run",
+};
+
+const GITLAB_DIALECT: ForgePromptDialect = {
+	changeRequestName: "MR",
+	changeRequestFullName: "merge request",
+	cliName: "glab",
+	createCommand: (branch) => `glab mr create --target-branch ${branch}`,
+	reopenCommand: "glab mr reopen",
+	commentCommand: "glab mr note",
+	ciListCommand: "glab ci list",
+	ciViewCommand: "glab ci view",
+	ciSystemName: "GitLab CI",
+	ciJobNoun: "pipeline",
+};
+
+/** Pick the prompt dialect for the given forge. Falls back to GitHub. */
+export function forgePromptDialect(
+	forge?: ForgeDetection | null,
+): ForgePromptDialect {
+	return forge?.provider === "gitlab" ? GITLAB_DIALECT : GITHUB_DIALECT;
+}

--- a/src/lib/repo-preferences-prompts.test.ts
+++ b/src/lib/repo-preferences-prompts.test.ts
@@ -1,9 +1,27 @@
 import { describe, expect, it } from "vitest";
+import type { ForgeDetection } from "./api";
 import {
 	prependGeneralPreferencePrompt,
 	resolveRepoPreferencePreview,
 	resolveRepoPreferencePrompt,
 } from "./repo-preferences-prompts";
+
+const GITLAB_FORGE: ForgeDetection = {
+	provider: "gitlab",
+	host: "gitlab.example.com",
+	namespace: "acme",
+	repo: "repo",
+	remoteUrl: "git@gitlab.example.com:acme/repo.git",
+	labels: {
+		providerName: "GitLab",
+		cliName: "glab",
+		changeRequestName: "MR",
+		changeRequestFullName: "merge request",
+		connectAction: "Connect GitLab",
+	},
+	cli: null,
+	detectionSignals: [],
+};
 
 describe("repo preference prompts", () => {
 	const targetRefPlaceholder = "$" + "{TARGET_REF}";
@@ -11,6 +29,15 @@ describe("repo preference prompts", () => {
 
 	it("leaves the general preview empty when no override exists", () => {
 		expect(resolveRepoPreferencePreview("general", {})).toBe("");
+	});
+
+	it("uses generic prose in the create-pr preview", () => {
+		// Preview has no live workspace context — keep the original generic
+		// wording rather than substituting placeholders into the template.
+		const preview = resolveRepoPreferencePreview("createPr", {});
+		expect(preview).toContain("this workspace's target branch");
+		expect(preview).toContain("`gh pr create`");
+		expect(preview).not.toContain("<target-branch>");
 	});
 
 	it("appends the override after the target-specific create-pr prompt", () => {
@@ -23,7 +50,7 @@ describe("repo preference prompts", () => {
 		).toContain("### User Preferences\n\nShip it exactly this way.");
 	});
 
-	it("uses the workspace target branch in the create-pr prompt", () => {
+	it("uses the workspace target branch in the create-pr prompt (GitHub default)", () => {
 		expect(
 			resolveRepoPreferencePrompt({
 				key: "createPr",
@@ -35,6 +62,19 @@ describe("repo preference prompts", () => {
 		);
 	});
 
+	it("uses the GitLab dialect in the create-pr prompt when forge is GitLab", () => {
+		const prompt = resolveRepoPreferencePrompt({
+			key: "createPr",
+			repoPreferences: {},
+			targetBranch: "develop",
+			forge: GITLAB_FORGE,
+		});
+		expect(prompt).toContain("Create a merge request");
+		expect(prompt).toContain(
+			"Open a merge request against `develop` using `glab mr create --target-branch develop`.",
+		);
+	});
+
 	it("throws instead of falling back when create-pr has no target branch", () => {
 		expect(() =>
 			resolveRepoPreferencePrompt({
@@ -42,6 +82,15 @@ describe("repo preference prompts", () => {
 				repoPreferences: {},
 			}),
 		).toThrow("Missing workspace target branch for createPr prompt.");
+	});
+
+	it("uses the GitLab dialect in the fix-errors prompt when forge is GitLab", () => {
+		const prompt = resolveRepoPreferencePrompt({
+			key: "fixErrors",
+			repoPreferences: {},
+			forge: GITLAB_FORGE,
+		});
+		expect(prompt).toContain("`glab ci list` / `glab ci view`");
 	});
 
 	it("renders the dynamic resolve-conflicts fallback", () => {

--- a/src/lib/repo-preferences-prompts.ts
+++ b/src/lib/repo-preferences-prompts.ts
@@ -1,4 +1,8 @@
-import type { RepoPreferences } from "@/lib/api";
+import type { ForgeDetection, RepoPreferences } from "@/lib/api";
+import {
+	type ForgePromptDialect,
+	forgePromptDialect,
+} from "@/lib/forge-dialect";
 
 const TARGET_REF_PLACEHOLDER = "$" + "{TARGET_REF}";
 const DIRTY_WORKTREE_PLACEHOLDER = "$" + "{DIRTY_WORKTREE}";
@@ -16,6 +20,7 @@ type ResolveRepoPreferencePromptArgs = {
 	targetBranch?: string | null;
 	targetRef?: string | null;
 	dirtyWorktree?: boolean;
+	forge?: ForgeDetection | null;
 };
 
 const DEFAULT_BRANCH_RENAME_PROMPT = `When you generate the branch name segment for a new chat:
@@ -27,7 +32,14 @@ const DEFAULT_BRANCH_RENAME_PROMPT = `When you generate the branch name segment 
 
 const CUSTOM_PREFERENCES_INTRO = `IMPORTANT: The following are the user's custom preferences. These preferences take precedence over any default guidelines or instructions provided above. When there is a conflict, always follow the user's preferences.`;
 
-const DEFAULT_CREATE_PR_PROMPT = `Create a pull request for the uncommitted work in this workspace.
+// Used to render `DEFAULT_REPO_PREFERENCE_PROMPTS`, which feeds the settings
+// preview pane. The user has no live workspace context there, so the preview
+// uses generic prose ("this workspace's target branch") rather than the
+// dynamic templates. The `fixErrors` preview can come from the template
+// directly because there's no per-workspace data needed there.
+const PREVIEW_DIALECT = forgePromptDialect(null);
+
+const CREATE_PR_PREVIEW = `Create a pull request for the uncommitted work in this workspace.
 
 Do the following, in order:
 1. Run \`git status\` and \`git diff\` to survey what's changed.
@@ -39,7 +51,7 @@ Do the following, in order:
 
 Don't stop to ask for confirmation — execute each step automatically. If you hit an unrecoverable error (e.g. merge conflict, pre-push hook failure), report it clearly so I can intervene.`;
 
-const DEFAULT_RESOLVE_CONFLICTS_PROMPT = `This branch has merge conflicts with its target branch. Resolve them.
+const RESOLVE_CONFLICTS_PREVIEW = `This branch has merge conflicts with its target branch. Resolve them.
 
 Do the following, in order:
 1. Use this workspace's configured target branch as the branch to resolve against.
@@ -51,23 +63,71 @@ Do the following, in order:
 
 If a conflict is too ambiguous to resolve automatically, stop and ask.`;
 
+function createPrPrompt(
+	dialect: ForgePromptDialect,
+	targetBranch?: string | null,
+): string {
+	const branch = requireTargetBranch("createPr", targetBranch);
+	return `Create a ${dialect.changeRequestFullName} for the uncommitted work in this workspace.
+
+Do the following, in order:
+1. Run \`git status\` and \`git diff\` to survey what's changed.
+2. Stage everything that should ship with \`git add\`.
+3. Commit with a concise, Conventional-Commits-style message (\`feat:\`, \`fix:\`, \`refactor:\`, \`chore:\`, etc.) that summarizes the change in one line.
+4. Push the current branch to its remote. If needed, create the remote tracking branch with \`git push -u <remote> HEAD\`.
+5. Open a ${dialect.changeRequestFullName} against \`${branch}\` using \`${dialect.createCommand(branch)}\`. Use a clear ${dialect.changeRequestName} title and a body that explains: what changed, why it changed, and any follow-up / test notes.
+6. Report the ${dialect.changeRequestName} URL in your final message so I can click it.
+
+Don't stop to ask for confirmation — execute each step automatically. If you hit an unrecoverable error (e.g. merge conflict, pre-push hook failure), report it clearly so I can intervene.`;
+}
+
+function fixErrorsPrompt(dialect: ForgePromptDialect): string {
+	return `${dialect.ciSystemName} is failing on the current branch. Diagnose and fix it.
+
+Do the following, in order:
+1. Use \`${dialect.ciListCommand}\` / \`${dialect.ciViewCommand}\` to inspect the most recent failing ${dialect.ciJobNoun} for this branch. Read the logs for each failing job.
+2. Identify the root cause — don't just paper over the symptom. Explain your diagnosis briefly before making changes.
+3. Apply the minimum set of changes needed to get CI green. Run the relevant tests / linters locally to confirm.
+4. Commit the fix with a clear \`fix(ci): …\` message and push to the same branch so CI re-runs.
+5. Report what was broken, what you changed, and whether the re-run is passing.`;
+}
+
+function resolveConflictsPrompt({
+	targetBranch,
+	targetRef,
+	dirtyWorktree,
+}: Pick<
+	ResolveRepoPreferencePromptArgs,
+	"targetBranch" | "targetRef" | "dirtyWorktree"
+>): string {
+	if (targetRef) {
+		return dirtyWorktree
+			? `Commit uncommitted changes, then merge ${targetRef} into this branch. Then push.`
+			: `Merge ${targetRef} into this branch. Then push.`;
+	}
+
+	const branch = requireTargetBranch("resolveConflicts", targetBranch);
+
+	return `This branch has merge conflicts with \`${branch}\`, this workspace's target branch. Resolve them.
+
+Do the following, in order:
+1. Fetch the latest \`${branch}\` from its remote.
+2. Rebase or merge \`${branch}\` into the current branch.
+3. Resolve each conflict, preserving intent from both sides where possible. Explain your resolution choices briefly in the session.
+4. Run the relevant tests locally to confirm nothing broke.
+5. Commit the resolution and push.
+6. Report the conflicted files and how you resolved them.
+
+If a conflict is too ambiguous to resolve automatically, stop and ask.`;
+}
+
 export const DEFAULT_REPO_PREFERENCE_PROMPTS: Record<
 	RepoPreferenceKey,
 	string
 > = {
-	createPr: DEFAULT_CREATE_PR_PROMPT,
-
-	fixErrors: `CI is failing on the current branch. Diagnose and fix it.
-
-Do the following, in order:
-1. Use \`gh run list\` / \`gh run view\` to inspect the most recent failing run for this branch. Read the logs for each failing job.
-2. Identify the root cause — don't just paper over the symptom. Explain your diagnosis briefly before making changes.
-3. Apply the minimum set of changes needed to get CI green. Run the relevant tests / linters locally to confirm.
-4. Commit the fix with a clear \`fix(ci): …\` message and push to the same branch so CI re-runs.
-5. Report what was broken, what you changed, and whether the re-run is passing.`,
-
-	resolveConflicts: DEFAULT_RESOLVE_CONFLICTS_PROMPT,
-
+	createPr: CREATE_PR_PREVIEW,
+	fixErrors: fixErrorsPrompt(PREVIEW_DIALECT),
+	resolveConflicts: RESOLVE_CONFLICTS_PREVIEW,
 	branchRename: DEFAULT_BRANCH_RENAME_PROMPT,
 	general: "",
 };
@@ -128,50 +188,6 @@ function requireTargetBranch(
 	return branch;
 }
 
-function createPrPrompt(targetBranch?: string | null): string {
-	const branch = requireTargetBranch("createPr", targetBranch);
-	return `Create a pull request for the uncommitted work in this workspace.
-
-Do the following, in order:
-1. Run \`git status\` and \`git diff\` to survey what's changed.
-2. Stage everything that should ship with \`git add\`.
-3. Commit with a concise, Conventional-Commits-style message (\`feat:\`, \`fix:\`, \`refactor:\`, \`chore:\`, etc.) that summarizes the change in one line.
-4. Push the current branch to its remote. If needed, create the remote tracking branch with \`git push -u <remote> HEAD\`.
-5. Open a pull request against \`${branch}\` using \`gh pr create --base ${branch}\`. Use a clear PR title and a body that explains: what changed, why it changed, and any follow-up / test notes.
-6. Report the PR URL in your final message so I can click it.
-
-Don't stop to ask for confirmation — execute each step automatically. If you hit an unrecoverable error (e.g. merge conflict, pre-push hook failure), report it clearly so I can intervene.`;
-}
-
-function resolveConflictsPrompt({
-	targetBranch,
-	targetRef,
-	dirtyWorktree,
-}: Pick<
-	ResolveRepoPreferencePromptArgs,
-	"targetBranch" | "targetRef" | "dirtyWorktree"
->): string {
-	if (targetRef) {
-		return dirtyWorktree
-			? `Commit uncommitted changes, then merge ${targetRef} into this branch. Then push.`
-			: `Merge ${targetRef} into this branch. Then push.`;
-	}
-
-	const branch = requireTargetBranch("resolveConflicts", targetBranch);
-
-	return `This branch has merge conflicts with \`${branch}\`, this workspace's target branch. Resolve them.
-
-Do the following, in order:
-1. Fetch the latest \`${branch}\` from its remote.
-2. Rebase or merge \`${branch}\` into the current branch.
-3. Resolve each conflict, preserving intent from both sides where possible. Explain your resolution choices briefly in the session.
-4. Run the relevant tests locally to confirm nothing broke.
-5. Commit the resolution and push.
-6. Report the conflicted files and how you resolved them.
-
-If a conflict is too ambiguous to resolve automatically, stop and ask.`;
-}
-
 export function resolveRepoPreferencePreview(
 	key: RepoPreferenceKey,
 	repoPreferences?: RepoPreferences | null,
@@ -188,6 +204,7 @@ export function resolveRepoPreferencePrompt({
 	targetBranch,
 	targetRef,
 	dirtyWorktree = false,
+	forge,
 }: ResolveRepoPreferencePromptArgs): string {
 	const override = repoPreferenceOverride(key, repoPreferences);
 	const targetPlaceholderValue = targetRef ?? targetBranch ?? null;
@@ -201,39 +218,28 @@ export function resolveRepoPreferencePrompt({
 					)
 			: override;
 
-	if (key === "resolveConflicts") {
-		return appendUserPreferences(
-			resolveConflictsPrompt({ targetBranch, targetRef, dirtyWorktree }),
-			resolvedOverride,
-		);
+	switch (key) {
+		case "resolveConflicts":
+			return appendUserPreferences(
+				resolveConflictsPrompt({ targetBranch, targetRef, dirtyWorktree }),
+				resolvedOverride,
+			);
+		case "createPr":
+			return appendUserPreferences(
+				createPrPrompt(forgePromptDialect(forge), targetBranch),
+				resolvedOverride,
+			);
+		case "fixErrors":
+			return appendUserPreferences(
+				fixErrorsPrompt(forgePromptDialect(forge)),
+				resolvedOverride,
+			);
+		default:
+			return appendUserPreferences(
+				DEFAULT_REPO_PREFERENCE_PROMPTS[key],
+				resolvedOverride,
+			);
 	}
-
-	if (key === "createPr") {
-		return appendUserPreferences(
-			createPrPrompt(targetBranch),
-			resolvedOverride,
-		);
-	}
-
-	return appendUserPreferences(
-		DEFAULT_REPO_PREFERENCE_PROMPTS[key],
-		resolvedOverride,
-	);
-}
-
-export function resolveRepoPreferencePromptWithDefault({
-	key,
-	defaultPrompt,
-	repoPreferences,
-}: {
-	key: RepoPreferenceKey;
-	defaultPrompt: string;
-	repoPreferences?: RepoPreferences | null;
-}): string {
-	return appendUserPreferences(
-		defaultPrompt,
-		repoPreferenceOverride(key, repoPreferences),
-	);
 }
 
 export function prependGeneralPreferencePrompt(


### PR DESCRIPTION
## Summary

- The GitLab Create MR button was opening merge requests against the repository's default branch instead of the workspace's configured target branch. This patch fixes that and unifies the GitHub/GitLab prompt paths along the way.
- Adds a new `src/lib/forge-dialect.ts` that captures all forge-specific prompt bits (CLI name, change-request labels, create/reopen/comment/CI commands) in one place.
- Refactors `commit-button-prompts.ts` and `repo-preferences-prompts.ts` to consume the dialect: GitHub/GitLab now share one code path, no more divergent `buildGitLabCommitButtonPrompt` branch.
- Splits the settings-pane "preview" copy from the live workspace prompt (`CREATE_PR_PREVIEW`, `RESOLVE_CONFLICTS_PREVIEW`) so previews can stay generic while live prompts get the actual target branch substituted in.

## Why

The bug was a regression of the "use workspace target branch" feature on GitLab — only the GitHub branch had been wired up. The straightforward fix would have been to add a target-branch parameter to the GitLab branch, but the GitHub/GitLab paths had drifted and were ~50% duplicated. Pulling forge-specific strings into a `ForgePromptDialect` value lets both forges share the same prompt skeleton and makes future forge additions (or string tweaks) a one-line change.

## Test plan

- [x] `bun run test:frontend` covers expanded coverage in `commit-button-prompts.test.ts` and `repo-preferences-prompts.test.ts` (GitHub default + GitLab forge variants for create-pr, fix, open-pr, commit-and-push).
- [ ] Manual: with a GitLab repo connected, click Create MR and confirm the agent prompt references `glab mr create --target-branch <workspace-target>`.
- [ ] Manual: with a GitHub repo, confirm Create PR still resolves to `gh pr create --base <workspace-target>` (no behavior change expected).
- [ ] Manual: spot-check the settings preview pane still renders generic prose (no `<target-branch>` placeholder leakage).