### PR TITLE
feat(onboarding): soften setup failures and skip glab terminal when authed

### DIFF
--- a/.changeset/guided-onboarding-flow.md
+++ b/.changeset/guided-onboarding-flow.md
@@ -1,0 +1,9 @@
+---
+"helmor": minor
+---
+
+Add a guided first-run onboarding flow that walks new users from agent login to a workable workspace:
+- Animated multi-step intro with previews of the Helmor UI, per-step spotlights, and Back / Next navigation between steps.
+- Agent login step that detects active Claude and Codex installations and highlights the provider you're signed into.
+- A "Power up Helmor" step that installs the Helmor CLI and Helmor Skills (Beta) from inside the app, with a live `helmor --help` preview — setup failures don't block onboarding, you can resolve them later from inside Helmor.
+- Repository import step that lets you clone from a URL or add a local path before reaching the main workspace.

--- a/src/features/onboarding/components/setup-item.tsx
+++ b/src/features/onboarding/components/setup-item.tsx
@@ -12,6 +12,7 @@ export function SetupItem({
 	disabled = false,
 	busy = false,
 	ready = false,
+	error,
 }: {
 	icon: ReactNode;
 	label: string;
@@ -21,7 +22,9 @@ export function SetupItem({
 	disabled?: boolean;
 	busy?: boolean;
 	ready?: boolean;
+	error?: ReactNode;
 }) {
+	const hasError = Boolean(error);
 	return (
 		<div
 			role="group"
@@ -36,6 +39,18 @@ export function SetupItem({
 				<p className="mt-0.5 text-xs leading-5 text-muted-foreground">
 					{description}
 				</p>
+				<div
+					aria-hidden={!hasError}
+					className={`grid transition-[grid-template-rows,opacity,margin] duration-500 ease-[cubic-bezier(.22,.82,.2,1)] ${
+						hasError
+							? "mt-1 grid-rows-[1fr] opacity-100"
+							: "mt-0 grid-rows-[0fr] opacity-0"
+					}`}
+				>
+					<div className="overflow-hidden">
+						<p className="text-[11px] leading-4 text-destructive">{error}</p>
+					</div>
+				</div>
 			</div>
 			{ready ? (
 				<ReadyStatus />

--- a/src/features/onboarding/steps/repository-cli-step.tsx
+++ b/src/features/onboarding/steps/repository-cli-step.tsx
@@ -197,7 +197,7 @@ export function RepositoryCliStep({
 		setActiveGitlabPanel("host");
 	}, [clearPoll]);
 
-	const handleGitlabHostSubmit = useCallback(() => {
+	const handleGitlabHostSubmit = useCallback(async () => {
 		const host = normalizeGitlabHost(gitlabHost);
 		if (!host) {
 			toast.error("Enter a GitLab domain.");
@@ -205,10 +205,25 @@ export function RepositoryCliStep({
 		}
 		setGitlabHost(host);
 		setGitlabStatusHost(host);
-		if (gitlab.status?.status === "ready" && gitlab.status.host === host)
-			return;
+		// Probe `glab auth status --hostname <host>` before spawning the terminal —
+		// the domain may already be authenticated, in which case we skip straight
+		// to the ready state instead of forcing the user through `glab auth login`.
+		clearPoll();
+		setWaitingProvider("gitlab");
+		setGitlab((prev) => ({ status: prev.status, checking: true }));
+		try {
+			const status = await refreshStatus("gitlab", host);
+			if (status.status === "ready") {
+				setWaitingProvider(null);
+				setActiveGitlabPanel(null);
+				toast.success(`${status.cliName} connected`);
+				return;
+			}
+		} catch {
+			// Fall through to the terminal so the user can finish auth manually.
+		}
 		openTerminal("gitlab", host);
-	}, [gitlab.status, gitlabHost, openTerminal]);
+	}, [clearPoll, gitlabHost, openTerminal, refreshStatus]);
 
 	return (
 		<section

--- a/src/features/onboarding/steps/skills-step.test.tsx
+++ b/src/features/onboarding/steps/skills-step.test.tsx
@@ -156,7 +156,7 @@ describe("SkillsStep", () => {
 		expect(within(skillsItem).getByText("Ready")).toBeInTheDocument();
 	});
 
-	it("shows the skills setup error and manual command", async () => {
+	it("shows the unified failure hint when skills setup throws", async () => {
 		const user = userEvent.setup();
 		apiMocks.getCliStatus.mockResolvedValue({
 			installed: true,
@@ -165,7 +165,7 @@ describe("SkillsStep", () => {
 			installState: "managed",
 		});
 		apiMocks.installHelmorSkills.mockRejectedValue(
-			new Error("Helmor skills setup failed."),
+			new Error("Helmor skills setup failed with a long stack trace."),
 		);
 
 		render(
@@ -187,11 +187,12 @@ describe("SkillsStep", () => {
 
 		await waitFor(() => {
 			expect(
-				within(skillsItem).getByText("Helmor skills setup failed."),
+				within(skillsItem).getByText(/something went wrong/i),
 			).toBeInTheDocument();
 		});
+		expect(within(skillsItem).getByText(/don't worry/i)).toBeInTheDocument();
 		expect(
-			within(skillsItem).getByText(/npx --yes skills add/),
-		).toBeInTheDocument();
+			within(skillsItem).queryByText(/long stack trace/i),
+		).not.toBeInTheDocument();
 	});
 });

--- a/src/features/onboarding/steps/skills-step.tsx
+++ b/src/features/onboarding/steps/skills-step.tsx
@@ -17,6 +17,9 @@ import {
 import { SetupItem } from "../components/setup-item";
 import type { OnboardingStep } from "../types";
 
+const SETUP_FAILED_MESSAGE =
+	"Something went wrong — don't worry, Helmor will work fine without it.";
+
 export function SkillsStep({
 	step,
 	onBack,
@@ -30,15 +33,10 @@ export function SkillsStep({
 }) {
 	const [isInstallingCli, setIsInstallingCli] = useState(false);
 	const [cliInstalled, setCliInstalled] = useState(false);
-	const [cliInstallError, setCliInstallError] = useState<string | null>(null);
+	const [cliInstallFailed, setCliInstallFailed] = useState(false);
 	const [isInstallingSkills, setIsInstallingSkills] = useState(false);
 	const [skillsInstalled, setSkillsInstalled] = useState(false);
-	const [skillsInstallError, setSkillsInstallError] = useState<string | null>(
-		null,
-	);
-	const [skillsInstallCommand, setSkillsInstallCommand] = useState<
-		string | null
-	>(null);
+	const [skillsInstallFailed, setSkillsInstallFailed] = useState(false);
 
 	useEffect(() => {
 		let cancelled = false;
@@ -47,7 +45,6 @@ export function SkillsStep({
 				if (!cancelled) {
 					setCliInstalled(cliStatus.installState === "managed");
 					setSkillsInstalled(skillsStatus.installed);
-					setSkillsInstallCommand(skillsStatus.command);
 				}
 			})
 			.catch(() => {});
@@ -61,14 +58,13 @@ export function SkillsStep({
 			return;
 		}
 		setIsInstallingCli(true);
-		setCliInstallError(null);
+		setCliInstallFailed(false);
 		try {
 			const status = await installCli();
 			setCliInstalled(status.installState === "managed");
 			toast("Helmor CLI installed.");
-		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error);
-			setCliInstallError(message);
+		} catch {
+			setCliInstallFailed(true);
 		} finally {
 			setIsInstallingCli(false);
 		}
@@ -79,15 +75,13 @@ export function SkillsStep({
 			return;
 		}
 		setIsInstallingSkills(true);
-		setSkillsInstallError(null);
+		setSkillsInstallFailed(false);
 		try {
 			const status = await installHelmorSkills();
 			setSkillsInstalled(status.installed);
-			setSkillsInstallCommand(status.command);
 			toast("Helmor skills installed.");
-		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error);
-			setSkillsInstallError(message);
+		} catch {
+			setSkillsInstallFailed(true);
 		} finally {
 			setIsInstallingSkills(false);
 		}
@@ -192,45 +186,22 @@ Options:
 					<SetupItem
 						icon={<Terminal className="size-5" />}
 						label="Helmor CLI"
-						description={
-							<>
-								Control Helmor from your terminal: create workspaces, send
-								prompts, inspect files, and script repeatable flows.
-								{cliInstallError ? (
-									<span className="mt-1 block text-destructive">
-										{cliInstallError}
-									</span>
-								) : null}
-							</>
-						}
+						description="Control Helmor from your terminal: create workspaces, send prompts, inspect files, and script repeatable flows."
 						actionLabel={isInstallingCli ? "Installing" : "Set up"}
 						onAction={handleInstallCli}
 						busy={isInstallingCli}
 						ready={cliInstalled}
+						error={cliInstallFailed ? SETUP_FAILED_MESSAGE : null}
 					/>
 					<SetupItem
 						icon={<PackageCheck className="size-5" />}
 						label="Helmor Skills (Beta)"
-						description={
-							<>
-								Install skills so Helmor can help with more workflows across
-								every workspace.
-								{skillsInstallError ? (
-									<span className="mt-1 block text-destructive">
-										{skillsInstallError}
-									</span>
-								) : null}
-								{skillsInstallError && skillsInstallCommand ? (
-									<code className="mt-2 block break-words rounded-md bg-muted px-2 py-1 font-mono text-[11px] leading-4 text-muted-foreground">
-										{skillsInstallCommand}
-									</code>
-								) : null}
-							</>
-						}
+						description="Install skills so Helmor can help with more workflows across every workspace."
 						actionLabel={isInstallingSkills ? "Installing" : "Set up"}
 						onAction={handleInstallSkills}
 						busy={isInstallingSkills}
 						ready={skillsInstalled}
+						error={skillsInstallFailed ? SETUP_FAILED_MESSAGE : null}
 					/>
 				</div>
 


### PR DESCRIPTION
## Summary

Polish the onboarding setup-failure UX and shave one unnecessary terminal popup off the GitLab flow.

- **`SetupItem` now takes an `error` prop** that renders a destructive-tone hint with a smooth grid-row reveal animation, so failures feel like a soft fall-back instead of a stack-trace dump.
- **`SkillsStep` swaps the raw error message + manual `npx --yes skills add ...` command** for a single, friendly fallback: _"Something went wrong — don't worry, Helmor will work fine without it."_ Both Helmor CLI and Helmor Skills (Beta) use the same hint so the step keeps onboarding moving instead of trapping the user on a copy-paste command.
- **`RepositoryCliStep` probes `glab auth status --hostname <host>`** before launching the terminal. If the entered domain is already authenticated we skip straight to the ready state and toast `${cliName} connected`, only falling through to the terminal when auth is genuinely needed.
- Adds the guided onboarding changeset (`minor`).

## Why

Setup failures shouldn't feel scary — onboarding already says these steps are optional, so the previous error blob (long error message + a command to copy-paste) over-promised that something is broken. The new hint mirrors the wording in the changeset ("setup failures don't block onboarding") and looks intentional next to the green "Ready" pill.

The GitLab probe avoids the awkward case where a user re-enters a host they're already signed into and we still spawn `glab auth login` in a terminal.

## Test notes

- Updated `skills-step.test.tsx` to assert the new unified hint and that raw error text is no longer rendered.
- Manual: trigger CLI / skills install failure -> error reveals with animation; succeed -> hint stays hidden, ready pill shows.
- Manual: enter an already-authed GitLab host -> goes straight to ready, no terminal spawned. Enter an unauthed host -> terminal opens as before.

## Follow-ups

- None planned. If the friendly fallback ever needs to surface details, route them through the new `error` prop on `SetupItem`.