### PR TITLE
fix: remove sidebar collapse button

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -233,7 +233,7 @@ describe("App", () => {
 		).toHaveAttribute("aria-valuenow", "388");
 	});
 
-	it("shows the update button beside the sidebar toggle when an update is ready", async () => {
+	it("shows the update button when an update is ready", async () => {
 		const invokeMock = vi.mocked(invoke);
 		const baseInvokeImpl = invokeMock.getMockImplementation();
 
@@ -260,17 +260,8 @@ describe("App", () => {
 		);
 
 		try {
-			const user = userEvent.setup();
 			render(<App />);
 			await screen.findByRole("main", { name: "Application shell" });
-
-			expect(
-				screen.getByRole("button", { name: "Update Helmor to 1.1.0" }),
-			).toBeInTheDocument();
-
-			await user.click(
-				screen.getByRole("button", { name: "Collapse left sidebar" }),
-			);
 
 			expect(
 				screen.getByRole("button", { name: "Update Helmor to 1.1.0" }),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,8 +8,6 @@ import {
 	ChevronDown,
 	CircleAlertIcon,
 	FolderOpen,
-	PanelLeftClose,
-	PanelLeftOpen,
 	PanelRightClose,
 	PanelRightOpen,
 } from "lucide-react";
@@ -618,10 +616,6 @@ function AppShell({
 	const addRepositoryShortcut = getShortcut(
 		appSettings.shortcuts,
 		"workspace.addRepository",
-	);
-	const leftSidebarToggleShortcut = getShortcut(
-		appSettings.shortcuts,
-		"sidebar.left.toggle",
 	);
 	const rightSidebarToggleShortcut = getShortcut(
 		appSettings.shortcuts,
@@ -2167,34 +2161,6 @@ function AppShell({
 												</div>
 												<div className="absolute right-[12px] top-[6px] z-20 flex items-center gap-[2px]">
 													<AppUpdateButton status={appUpdateStatus} />
-													<Tooltip>
-														<TooltipTrigger asChild>
-															<Button
-																aria-label="Collapse left sidebar"
-																onClick={() => setSidebarCollapsed(true)}
-																variant="ghost"
-																size="icon-xs"
-																className="text-muted-foreground hover:text-foreground"
-															>
-																<PanelLeftClose
-																	className="size-4"
-																	strokeWidth={1.8}
-																/>
-															</Button>
-														</TooltipTrigger>
-														<TooltipContent
-															side="bottom"
-															className="flex h-[24px] items-center gap-2 rounded-md px-2 text-[12px] leading-none"
-														>
-															<span>Collapse left sidebar</span>
-															{leftSidebarToggleShortcut ? (
-																<InlineShortcutDisplay
-																	hotkey={leftSidebarToggleShortcut}
-																	className="text-background/60"
-																/>
-															) : null}
-														</TooltipContent>
-													</Tooltip>
 												</div>
 												<div className="flex shrink-0 items-center justify-between px-3 pb-3 pt-1">
 													<SettingsButton
@@ -2327,34 +2293,6 @@ function AppShell({
 															<div className="w-[52px] shrink-0" />
 															<div className="flex items-center gap-[2px]">
 																<AppUpdateButton status={appUpdateStatus} />
-																<Tooltip>
-																	<TooltipTrigger asChild>
-																		<Button
-																			aria-label="Expand left sidebar"
-																			onClick={() => setSidebarCollapsed(false)}
-																			variant="ghost"
-																			size="icon-xs"
-																			className="text-muted-foreground hover:text-foreground"
-																		>
-																			<PanelLeftOpen
-																				className="size-4"
-																				strokeWidth={1.8}
-																			/>
-																		</Button>
-																	</TooltipTrigger>
-																	<TooltipContent
-																		side="bottom"
-																		className="flex h-[24px] items-center gap-2 rounded-md px-2 text-[12px] leading-none"
-																	>
-																		<span>Expand left sidebar</span>
-																		{leftSidebarToggleShortcut ? (
-																			<InlineShortcutDisplay
-																				hotkey={leftSidebarToggleShortcut}
-																				className="text-background/60"
-																			/>
-																		) : null}
-																	</TooltipContent>
-																</Tooltip>
 															</div>
 														</>
 													) : undefined


### PR DESCRIPTION
## What changed
- Removed the left sidebar collapse/expand button from the app chrome.
- Updated the app test to assert the update button remains visible without relying on the removed sidebar toggle.

## Why
The sidebar collapse control should no longer be exposed in this UI, while update status still needs to remain visible.

## Test notes
- Pre-commit ran Biome on the changed frontend files during commit.