### PR TITLE
fix(tool-call): collapse tool calls by default in chat thread

### DIFF
--- a/.changeset/quiet-tools-fold.md
+++ b/.changeset/quiet-tools-fold.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Collapse all tool calls in the chat thread by default.

--- a/src/features/panel/message-components.test.tsx
+++ b/src/features/panel/message-components.test.tsx
@@ -60,8 +60,8 @@ describe("MemoConversationMessage plan review", () => {
 		).not.toBeInTheDocument();
 	});
 
-	it("renders multi-file edits as compact rows", () => {
-		render(
+	it("renders multi-file edits as compact rows when expanded", () => {
+		const { container } = render(
 			<AssistantToolCall
 				toolName="apply_patch"
 				args={{
@@ -80,6 +80,14 @@ describe("MemoConversationMessage plan review", () => {
 				}}
 			/>,
 		);
+
+		// Tool calls default to collapsed; expand before asserting on the body.
+		const details = container.querySelector(
+			"details",
+		) as HTMLDetailsElement | null;
+		expect(details).not.toBeNull();
+		details!.open = true;
+		fireEvent(details!, new Event("toggle"));
 
 		expect(
 			screen.getByText("index.test.tsx").closest("[data-variant='row']"),

--- a/src/features/panel/message-components/tool-call.test.tsx
+++ b/src/features/panel/message-components/tool-call.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { AssistantToolCall } from "./tool-call";
 
 describe("AssistantToolCall apply_patch", () => {
-	it("collapses multi-file edits instead of showing generic patch text", () => {
+	it("defaults multi-file edits to collapsed and suppresses generic patch text when expanded", () => {
 		const { container } = render(
 			<AssistantToolCall
 				toolName="apply_patch"
@@ -18,20 +18,63 @@ describe("AssistantToolCall apply_patch", () => {
 			/>,
 		);
 
-		expect(screen.queryByText("Patch applied")).not.toBeInTheDocument();
-		expect(screen.getByText("request-parser.ts")).toBeInTheDocument();
-		expect(screen.getByText("data_dir.rs")).toBeInTheDocument();
-		expect(screen.getByText("App.tsx")).toBeInTheDocument();
+		// Default: collapsed.
+		expect(screen.queryByText("request-parser.ts")).not.toBeInTheDocument();
+		expect(screen.queryByText("data_dir.rs")).not.toBeInTheDocument();
+		expect(screen.queryByText("App.tsx")).not.toBeInTheDocument();
 
 		const details = container.querySelector(
 			"details",
 		) as HTMLDetailsElement | null;
 		expect(details).not.toBeNull();
+
+		// Expand: file list appears, generic "Patch applied" stays suppressed.
+		details!.open = true;
+		fireEvent(details!, new Event("toggle"));
+
+		expect(screen.queryByText("Patch applied")).not.toBeInTheDocument();
+		expect(screen.getByText("request-parser.ts")).toBeInTheDocument();
+		expect(screen.getByText("data_dir.rs")).toBeInTheDocument();
+		expect(screen.getByText("App.tsx")).toBeInTheDocument();
+
+		// Collapse again: file list disappears.
 		details!.open = false;
 		fireEvent(details!, new Event("toggle"));
 
 		expect(screen.queryByText("request-parser.ts")).not.toBeInTheDocument();
 		expect(screen.queryByText("data_dir.rs")).not.toBeInTheDocument();
 		expect(screen.queryByText("App.tsx")).not.toBeInTheDocument();
+	});
+});
+
+describe("AssistantToolCall default-collapsed", () => {
+	it("keeps a streaming Read collapsed until the user opens it", () => {
+		const { container } = render(
+			<AssistantToolCall
+				toolName="Read"
+				args={{ file_path: "/src/App.tsx" }}
+				streamingStatus="in_progress"
+			/>,
+		);
+
+		const details = container.querySelector("details");
+		expect(details).not.toBeNull();
+		expect(details!.open).toBe(false);
+	});
+
+	it("keeps a finished Bash with output collapsed by default", () => {
+		const { container } = render(
+			<AssistantToolCall
+				toolName="Bash"
+				args={{ command: "ls -la" }}
+				result={"total 8\ndrwxr-xr-x  3 user staff   96 Jan  1 00:00 .\n"}
+			/>,
+		);
+
+		const details = container.querySelector("details");
+		expect(details).not.toBeNull();
+		expect(details!.open).toBe(false);
+		// Output content should not be rendered until the user opens the details.
+		expect(screen.queryByText(/drwxr-xr-x/)).not.toBeInTheDocument();
 	});
 });

--- a/src/features/panel/message-components/tool-call.tsx
+++ b/src/features/panel/message-components/tool-call.tsx
@@ -8,7 +8,7 @@ import {
 	Search,
 	Terminal,
 } from "lucide-react";
-import { memo, useEffect, useMemo, useState } from "react";
+import { memo, useMemo, useState } from "react";
 import {
 	Reasoning,
 	ReasoningContent,
@@ -120,16 +120,8 @@ export const AssistantToolCall = memo(function AssistantToolCall({
 	const hasOutput = resultText != null && resultText.length > 5;
 	const canExpand = hasOutput || hasFiles;
 	const isLiveTool = isLiveStreamingStatus(streamingStatus);
-	const [isOpen, setIsOpen] = useState(isLiveTool || hasFiles);
-	useEffect(() => {
-		if (isLiveTool) {
-			setIsOpen(true);
-			return;
-		}
-		if (!canExpand) {
-			setIsOpen(false);
-		}
-	}, [canExpand, isLiveTool]);
+	// All tool calls default to collapsed; user must click to expand.
+	const [isOpen, setIsOpen] = useState(false);
 
 	const statusIndicator = isLiveTool ? (
 		<LoaderCircle
@@ -231,7 +223,7 @@ export const AssistantToolCall = memo(function AssistantToolCall({
 				onToggle={(event) => {
 					setIsOpen(event.currentTarget.open);
 				}}
-				open={isLiveTool || isOpen}
+				open={isOpen}
 			>
 				<summary
 					className={cn(
@@ -258,7 +250,7 @@ export const AssistantToolCall = memo(function AssistantToolCall({
 						</span>
 					) : null}
 				</summary>
-				{canExpand && (isLiveTool || isOpen) ? (
+				{canExpand && isOpen ? (
 					<div className="flex flex-col gap-1">
 						{hasOutput ? (
 							<div className="max-h-[16rem] overflow-auto rounded-md bg-accent/35 text-[11px] leading-5">


### PR DESCRIPTION
## Summary
- Tool calls in the chat thread now default to collapsed; users explicitly click to expand each one.
- Removes the prior auto-expand behavior for live-streaming tools and multi-file edits — both start closed and the body is only rendered after the user opens the `<details>`.
- Updates `tool-call.tsx` to drop the `useEffect` that forced `isOpen` based on streaming state and to gate body rendering on `isOpen` only.

## Why
Auto-expanding tool calls (especially streaming ones and multi-file `apply_patch` edits) made the thread noisy and pushed conversation context off-screen. Keeping them folded gives a quieter default while still letting users dig in on demand.

## Test plan
- [x] `bun run test:frontend` — updated `tool-call.test.tsx` and `message-components.test.tsx` to expand `<details>` before asserting on the body, plus new cases verifying default-collapsed for streaming `Read` and finished `Bash`.
- [ ] Manual: streaming tool call stays collapsed during execution; clicking opens it and shows live output.
- [ ] Manual: multi-file `apply_patch` shows summary collapsed, file rows after expand.

## Notes
- Includes a `.changeset/quiet-tools-fold.md` patch entry.