### PR TITLE
fix(forge): stop flickering "Connect" prompt on flaky networks

### DIFF
--- a/.changeset/steadier-github-connect.md
+++ b/.changeset/steadier-github-connect.md
@@ -1,0 +1,7 @@
+---
+"helmor": patch
+---
+
+A couple of small polish fixes:
+- Stop the GitHub "Connect" prompt from flickering on flaky networks: the gh / glab status check now tolerates transient blips for up to 10 minutes and no longer mistakes upstream "401 Service Unavailable" / "unauthenticated upstream" responses for a real logout.
+- Slightly darken the composer placeholder and the auto/plan-mode pill at rest so they stay legible instead of fading into the background.

--- a/src-tauri/src/forge/cli_status.rs
+++ b/src-tauri/src/forge/cli_status.rs
@@ -14,7 +14,7 @@ use super::types::{ForgeCliStatus, ForgeLabels, ForgeProvider};
 
 const OPEN_TERMINAL_TIMEOUT: Duration = Duration::from_secs(10);
 const GITLAB_CLI_STATUS_CACHE_TTL: Duration = Duration::from_secs(2);
-const GITLAB_CLI_READY_DOWNGRADE_GRACE: Duration = Duration::from_secs(30);
+const GITLAB_CLI_READY_DOWNGRADE_GRACE: Duration = Duration::from_secs(600);
 
 type GitlabStatusCache = Mutex<HashMap<String, CachedEntry<ForgeCliStatus>>>;
 static GITLAB_STATUS_CACHE: LazyLock<GitlabStatusCache> =

--- a/src-tauri/src/forge/github/auth.rs
+++ b/src-tauri/src/forge/github/auth.rs
@@ -196,10 +196,25 @@ pub fn get_github_identity_session() -> Result<GithubIdentitySnapshot> {
     let client = ReqwestGithubClient::new()?;
     let secret_store = active_secret_store();
     match get_github_identity_session_with(github_client_id(), &client, &secret_store) {
-        Ok(snapshot) => Ok(snapshot),
-        Err(error) => Ok(GithubIdentitySnapshot::Error {
-            message: format!("{error:#}"),
-        }),
+        Ok(snapshot) => {
+            tracing::debug!(snapshot = ?snapshot_kind(&snapshot), "GitHub identity session resolved");
+            Ok(snapshot)
+        }
+        Err(error) => {
+            tracing::error!(error = %format!("{error:#}"), "GitHub identity session lookup failed");
+            Ok(GithubIdentitySnapshot::Error {
+                message: format!("{error:#}"),
+            })
+        }
+    }
+}
+
+fn snapshot_kind(snapshot: &GithubIdentitySnapshot) -> &'static str {
+    match snapshot {
+        GithubIdentitySnapshot::Connected { .. } => "connected",
+        GithubIdentitySnapshot::Disconnected => "disconnected",
+        GithubIdentitySnapshot::Error { .. } => "error",
+        GithubIdentitySnapshot::Unconfigured { .. } => "unconfigured",
     }
 }
 
@@ -247,10 +262,12 @@ pub fn disconnect_github_identity_headless() -> Result<()> {
 /// snapshot API.
 pub(crate) fn load_valid_github_access_token() -> Result<Option<String>> {
     let Some(client_id) = github_client_id() else {
+        tracing::debug!("GitHub client_id not configured; skipping access token load");
         return Ok(None);
     };
     let secret_store = active_secret_store();
     let Some((_meta, mut secret)) = load_stored_identity(&secret_store)? else {
+        tracing::debug!("No stored GitHub identity; access token unavailable");
         return Ok(None);
     };
 
@@ -259,18 +276,30 @@ pub(crate) fn load_valid_github_access_token() -> Result<Option<String>> {
     }
 
     if is_expired(secret.refresh_token_expires_at.as_deref()) || secret.refresh_token.is_none() {
+        tracing::warn!(
+            refresh_token_expired = is_expired(secret.refresh_token_expires_at.as_deref()),
+            has_refresh_token = secret.refresh_token.is_some(),
+            "GitHub refresh token expired/missing; clearing stored identity"
+        );
         clear_stored_identity(&secret_store)?;
         return Ok(None);
     }
 
     let client = ReqwestGithubClient::new()?;
     let Some(refresh_token) = secret.refresh_token.as_deref() else {
+        tracing::warn!("GitHub refresh token unexpectedly absent after expiry check");
         return Ok(None);
     };
 
     let refreshed = match client.refresh_user_token(client_id, refresh_token) {
         Ok(response) => response,
-        Err(_) => {
+        Err(error) => {
+            // FIXME: this clears keychain on any error including transient
+            // network blips. We should classify error kind before wiping.
+            tracing::error!(
+                error = %format!("{error:#}"),
+                "GitHub OAuth refresh failed; clearing stored identity (load_valid_github_access_token)"
+            );
             clear_stored_identity(&secret_store)?;
             return Ok(None);
         }
@@ -307,21 +336,30 @@ fn get_github_identity_session_with(
 
     let stored = load_stored_identity(secret_store)?;
     let Some((mut meta, mut secret)) = stored else {
+        tracing::debug!("No stored GitHub identity");
         return Ok(GithubIdentitySnapshot::Disconnected);
     };
 
     if !is_expired(secret.access_token_expires_at.as_deref()) {
         sync_meta_expiry_fields(&mut meta, &secret);
+        tracing::debug!(login = %meta.login, "GitHub identity loaded from cache (token still fresh)");
         return Ok(GithubIdentitySnapshot::Connected {
             session: meta.into_session(),
         });
     }
 
     if is_expired(secret.refresh_token_expires_at.as_deref()) || secret.refresh_token.is_none() {
+        tracing::warn!(
+            login = %meta.login,
+            refresh_token_expired = is_expired(secret.refresh_token_expires_at.as_deref()),
+            has_refresh_token = secret.refresh_token.is_some(),
+            "GitHub refresh token expired/missing; clearing stored identity"
+        );
         clear_stored_identity(secret_store)?;
         return Ok(GithubIdentitySnapshot::Disconnected);
     }
 
+    tracing::info!(login = %meta.login, "Refreshing expired GitHub access token");
     let refreshed = match client.refresh_user_token(
         client_id,
         secret
@@ -330,7 +368,15 @@ fn get_github_identity_session_with(
             .context("Missing refresh token for GitHub identity refresh")?,
     ) {
         Ok(response) => response,
-        Err(_) => {
+        Err(error) => {
+            // FIXME: this clears keychain on any error including transient
+            // network blips. The right fix is to classify error kind (reqwest
+            // connect/timeout = transient = keep stored identity) before wipe.
+            tracing::error!(
+                login = %meta.login,
+                error = %format!("{error:#}"),
+                "GitHub OAuth refresh failed; clearing stored identity (network blip indistinguishable from invalid_grant)"
+            );
             clear_stored_identity(secret_store)?;
             return Ok(GithubIdentitySnapshot::Disconnected);
         }
@@ -344,6 +390,7 @@ fn get_github_identity_session_with(
     sync_meta_expiry_fields(&mut meta, &secret);
     save_stored_identity(&meta, &secret, secret_store)?;
 
+    tracing::info!(login = %meta.login, "GitHub access token refreshed successfully");
     Ok(GithubIdentitySnapshot::Connected {
         session: meta.into_session(),
     })
@@ -373,9 +420,19 @@ fn spawn_identity_poll_loop(
     flow: GithubIdentityDeviceFlowStart,
 ) {
     thread::spawn(move || {
+        tracing::info!(
+            generation,
+            interval_seconds = flow.interval_seconds,
+            "GitHub device flow poll loop started"
+        );
         let client = match ReqwestGithubClient::new() {
             Ok(client) => client,
             Err(error) => {
+                tracing::error!(
+                    generation,
+                    error = %format!("{error:#}"),
+                    "GitHub device flow: failed to construct HTTP client"
+                );
                 let _ = emit_github_identity_snapshot(
                     &app,
                     &GithubIdentitySnapshot::Error {
@@ -390,6 +447,10 @@ fn spawn_identity_poll_loop(
 
         loop {
             if !runtime.is_current_flow(generation) {
+                tracing::debug!(
+                    generation,
+                    "GitHub device flow superseded, exiting poll loop"
+                );
                 return;
             }
 
@@ -413,6 +474,11 @@ fn spawn_identity_poll_loop(
                 Ok(DeviceFlowPollOutcome::Pending {
                     interval_seconds: next_interval,
                 }) => {
+                    tracing::debug!(
+                        generation,
+                        next_interval_seconds = next_interval,
+                        "GitHub device flow still pending"
+                    );
                     interval_seconds = next_interval.max(1);
                 }
                 Ok(DeviceFlowPollOutcome::Connected { meta, secret }) => {
@@ -425,6 +491,12 @@ fn spawn_identity_poll_loop(
                             return;
                         }
 
+                        tracing::error!(
+                            generation,
+                            login = %meta.login,
+                            error = %format!("{error:#}"),
+                            "GitHub device flow: failed to persist stored identity"
+                        );
                         let _ = emit_github_identity_snapshot(
                             &app,
                             &GithubIdentitySnapshot::Error {
@@ -438,6 +510,11 @@ fn spawn_identity_poll_loop(
                         return;
                     }
 
+                    tracing::info!(
+                        generation,
+                        login = %meta.login,
+                        "GitHub device flow completed (Connected)"
+                    );
                     let _ = emit_github_identity_snapshot(
                         &app,
                         &GithubIdentitySnapshot::Connected {
@@ -446,11 +523,22 @@ fn spawn_identity_poll_loop(
                     );
                     return;
                 }
-                Ok(DeviceFlowPollOutcome::Error { message, .. }) => {
+                Ok(DeviceFlowPollOutcome::Error {
+                    code,
+                    message,
+                    retryable,
+                }) => {
                     if !runtime.is_current_flow(generation) {
                         return;
                     }
 
+                    tracing::warn!(
+                        generation,
+                        code = %code,
+                        retryable,
+                        message = %message,
+                        "GitHub device flow: server returned terminal error"
+                    );
                     let _ = emit_github_identity_snapshot(
                         &app,
                         &GithubIdentitySnapshot::Error { message },
@@ -462,6 +550,11 @@ fn spawn_identity_poll_loop(
                         return;
                     }
 
+                    tracing::error!(
+                        generation,
+                        error = %format!("{error:#}"),
+                        "GitHub device flow: poll request failed (network/transport)"
+                    );
                     let _ = emit_github_identity_snapshot(
                         &app,
                         &GithubIdentitySnapshot::Error {

--- a/src-tauri/src/forge/github/cli.rs
+++ b/src-tauri/src/forge/github/cli.rs
@@ -12,7 +12,7 @@ const GITHUB_HOST: &str = "github.com";
 const GITHUB_REPOS_ENDPOINT: &str =
     "/user/repos?per_page=100&sort=updated&affiliation=owner,collaborator,organization_member";
 const GITHUB_CLI_STATUS_CACHE_TTL: Duration = Duration::from_secs(2);
-const GITHUB_CLI_READY_DOWNGRADE_GRACE: Duration = Duration::from_secs(30);
+const GITHUB_CLI_READY_DOWNGRADE_GRACE: Duration = Duration::from_secs(600);
 
 type GithubStatusCache = Mutex<HashMap<&'static str, CachedEntry<GithubCliStatus>>>;
 static SYSTEM_GH_STATUS_CACHE: LazyLock<GithubStatusCache> =
@@ -129,10 +129,11 @@ pub fn list_github_accessible_repositories() -> Result<Vec<GithubRepositorySumma
 }
 
 fn get_github_cli_status_with(runner: &impl GhCommandRunner) -> Result<GithubCliStatus> {
-    tracing::debug!("Checking GitHub CLI status");
+    tracing::debug!(host = GITHUB_HOST, "Checking GitHub CLI status");
     let version = match runner.run(["--version"]) {
         Ok(output) => Some(parse_gh_version(&output.stdout)),
         Err(GhCommandError::NotFound) => {
+            tracing::warn!(host = GITHUB_HOST, "GitHub CLI binary not found");
             return Ok(GithubCliStatus::Unavailable {
                 host: GITHUB_HOST.to_string(),
                 message: "GitHub CLI is not installed on this machine.".to_string(),
@@ -143,16 +144,25 @@ fn get_github_cli_status_with(runner: &impl GhCommandRunner) -> Result<GithubCli
             stderr,
             code,
         }) => {
+            let detail = command_error_detail(&stdout, &stderr, code);
+            tracing::warn!(
+                host = GITHUB_HOST,
+                code = ?code,
+                detail = %detail,
+                "GitHub CLI version probe exited non-zero"
+            );
             return Ok(GithubCliStatus::Error {
                 host: GITHUB_HOST.to_string(),
                 version: None,
-                message: format!(
-                    "Unable to read GitHub CLI version: {}",
-                    command_error_detail(&stdout, &stderr, code)
-                ),
+                message: format!("Unable to read GitHub CLI version: {detail}"),
             });
         }
         Err(GhCommandError::Other(message)) => {
+            tracing::warn!(
+                host = GITHUB_HOST,
+                error = %message,
+                "GitHub CLI version probe failed (IO error)"
+            );
             return Ok(GithubCliStatus::Error {
                 host: GITHUB_HOST.to_string(),
                 version: None,
@@ -171,6 +181,10 @@ fn get_github_cli_status_with(runner: &impl GhCommandRunner) -> Result<GithubCli
     ]) {
         Ok(output) => output,
         Err(GhCommandError::NotFound) => {
+            tracing::warn!(
+                host = GITHUB_HOST,
+                "GitHub CLI binary disappeared between probes"
+            );
             return Ok(GithubCliStatus::Unavailable {
                 host: GITHUB_HOST.to_string(),
                 message: "GitHub CLI is not installed on this machine.".to_string(),
@@ -183,6 +197,12 @@ fn get_github_cli_status_with(runner: &impl GhCommandRunner) -> Result<GithubCli
         }) => {
             let detail = command_error_detail(&stdout, &stderr, code);
             if looks_like_unauthenticated(&detail) {
+                tracing::warn!(
+                    host = GITHUB_HOST,
+                    code = ?code,
+                    detail = %detail,
+                    "GitHub CLI unauthenticated"
+                );
                 return Ok(GithubCliStatus::Unauthenticated {
                     host: GITHUB_HOST.to_string(),
                     version,
@@ -190,6 +210,12 @@ fn get_github_cli_status_with(runner: &impl GhCommandRunner) -> Result<GithubCli
                 });
             }
 
+            tracing::warn!(
+                host = GITHUB_HOST,
+                code = ?code,
+                detail = %detail,
+                "GitHub CLI auth check failed (transient or unknown)"
+            );
             return Ok(GithubCliStatus::Error {
                 host: GITHUB_HOST.to_string(),
                 version,
@@ -197,6 +223,11 @@ fn get_github_cli_status_with(runner: &impl GhCommandRunner) -> Result<GithubCli
             });
         }
         Err(GhCommandError::Other(message)) => {
+            tracing::warn!(
+                host = GITHUB_HOST,
+                error = %message,
+                "GitHub CLI auth check failed (IO error)"
+            );
             return Ok(GithubCliStatus::Error {
                 host: GITHUB_HOST.to_string(),
                 version,
@@ -229,6 +260,12 @@ fn get_github_cli_status_with(runner: &impl GhCommandRunner) -> Result<GithubCli
     let login = host_entry.login.unwrap_or_default();
 
     if host_entry.state.as_deref() != Some("success") || login.trim().is_empty() {
+        tracing::warn!(
+            host = %host,
+            state = ?host_entry.state,
+            login_blank = login.trim().is_empty(),
+            "GitHub CLI auth status JSON missing success/login"
+        );
         return Ok(GithubCliStatus::Unauthenticated {
             host,
             version,
@@ -236,6 +273,7 @@ fn get_github_cli_status_with(runner: &impl GhCommandRunner) -> Result<GithubCli
         });
     }
 
+    tracing::debug!(host = %host, login = %login, "GitHub CLI authenticated");
     Ok(GithubCliStatus::Ready {
         host,
         login: login.clone(),
@@ -260,7 +298,10 @@ fn get_github_cli_user_with_status(
 
     let output = match runner.run(["api", "/user"]) {
         Ok(output) => output,
-        Err(GhCommandError::NotFound) => return Ok(None),
+        Err(GhCommandError::NotFound) => {
+            tracing::warn!("gh binary missing during /user lookup");
+            return Ok(None);
+        }
         Err(GhCommandError::Failed {
             stdout,
             stderr,
@@ -268,12 +309,15 @@ fn get_github_cli_user_with_status(
         }) => {
             let detail = command_error_detail(&stdout, &stderr, code);
             if looks_like_unauthenticated(&detail) {
+                tracing::warn!(code = ?code, detail = %detail, "gh /user unauthenticated");
                 return Ok(None);
             }
 
+            tracing::warn!(code = ?code, detail = %detail, "gh /user lookup failed");
             return Err(anyhow!("GitHub CLI user lookup failed: {detail}"));
         }
         Err(GhCommandError::Other(message)) => {
+            tracing::warn!(error = %message, "gh /user lookup failed (IO error)");
             return Err(anyhow!("GitHub CLI user lookup failed: {message}"));
         }
     };
@@ -308,7 +352,10 @@ fn list_github_accessible_repositories_with_status(
 
     let output = match runner.run(["api", GITHUB_REPOS_ENDPOINT]) {
         Ok(output) => output,
-        Err(GhCommandError::NotFound) => return Ok(Vec::new()),
+        Err(GhCommandError::NotFound) => {
+            tracing::warn!("gh binary missing during /user/repos lookup");
+            return Ok(Vec::new());
+        }
         Err(GhCommandError::Failed {
             stdout,
             stderr,
@@ -316,12 +363,15 @@ fn list_github_accessible_repositories_with_status(
         }) => {
             let detail = command_error_detail(&stdout, &stderr, code);
             if looks_like_unauthenticated(&detail) {
+                tracing::warn!(code = ?code, detail = %detail, "gh /user/repos unauthenticated");
                 return Ok(Vec::new());
             }
 
+            tracing::warn!(code = ?code, detail = %detail, "gh /user/repos lookup failed");
             return Err(anyhow!("GitHub CLI repository lookup failed: {detail}"));
         }
         Err(GhCommandError::Other(message)) => {
+            tracing::warn!(error = %message, "gh /user/repos lookup failed (IO error)");
             return Err(anyhow!("GitHub CLI repository lookup failed: {message}"));
         }
     };
@@ -371,14 +421,22 @@ fn command_error_detail(stdout: &str, stderr: &str, code: Option<i32>) -> String
     }
 }
 
+/// Match `gh` output that conclusively means "no valid auth on file".
+/// Avoid bare `401` / `unauthorized` / `unauthenticated` — those leak into
+/// transient network errors (e.g. `401 Service Unavailable`,
+/// `unauthenticated upstream timeout`) and would flap the UI on a network
+/// blip. Mirror the whitelist style used by `looks_like_glab_unauthenticated`.
 fn looks_like_unauthenticated(message: &str) -> bool {
     let normalized = message.to_ascii_lowercase();
-    normalized.contains("401")
-        || normalized.contains("unauthorized")
-        || normalized.contains("unauthenticated")
+    normalized.contains("401 unauthorized")
+        || normalized.contains("bad credentials")
         || normalized.contains("not logged into")
+        || normalized.contains("not logged in")
+        || normalized.contains("not authenticated")
         || normalized.contains("authentication failed")
         || normalized.contains("gh auth login")
+        || normalized.contains("no token found")
+        || normalized.contains("has not been authenticated")
 }
 
 fn github_cli_is_ready(status: &GithubCliStatus) -> bool {
@@ -695,5 +753,34 @@ mod tests {
                 message: "Unable to read GitHub CLI version: permission denied".to_string(),
             }
         );
+    }
+
+    #[test]
+    fn looks_like_unauthenticated_matches_canonical_phrases() {
+        assert!(looks_like_unauthenticated(
+            "You are not logged into any GitHub hosts. Run gh auth login"
+        ));
+        assert!(looks_like_unauthenticated("HTTP 401: Bad credentials"));
+        assert!(looks_like_unauthenticated("authentication failed"));
+        assert!(looks_like_unauthenticated("no token found"));
+    }
+
+    #[test]
+    fn looks_like_unauthenticated_ignores_transient_network_errors() {
+        // 401 codes returned for non-auth reasons (rate limit, service degraded).
+        assert!(!looks_like_unauthenticated("401 Service Unavailable"));
+        // Bare "unauthenticated" / "unauthorized" must not match — they leak
+        // into transient upstream errors.
+        assert!(!looks_like_unauthenticated(
+            "unauthenticated upstream timeout"
+        ));
+        assert!(!looks_like_unauthenticated("unauthorized origin: EOF"));
+        // DNS / connect failures.
+        assert!(!looks_like_unauthenticated(
+            "Get \"https://api.github.com\": dial tcp: lookup api.github.com: no such host"
+        ));
+        assert!(!looks_like_unauthenticated(
+            "connection reset by peer while reading response"
+        ));
     }
 }

--- a/src-tauri/src/forge/status_cache.rs
+++ b/src-tauri/src/forge/status_cache.rs
@@ -22,7 +22,7 @@ pub struct CachedEntry<S: Clone> {
     pub downgrade_observed_at: Option<Instant>,
 }
 
-pub trait CacheableStatus: Clone {
+pub trait CacheableStatus: Clone + std::fmt::Debug {
     fn is_ready(&self) -> bool;
     /// Whether a Ready → this transition should be suppressed during the
     /// grace window. Use it for genuinely transient failures, not
@@ -97,13 +97,23 @@ fn stabilize<S: CacheableStatus>(
         return loaded;
     }
     let observed_at = cached.downgrade_observed_at.unwrap_or(now);
-    if now.duration_since(observed_at) <= grace {
+    let elapsed = now.duration_since(observed_at);
+    if elapsed <= grace {
         tracing::warn!(
-            previous = ?std::any::type_name::<S>(),
-            "Ignoring transient forge CLI status downgrade"
+            type_name = std::any::type_name::<S>(),
+            transient_status = ?loaded,
+            grace_elapsed_ms = elapsed.as_millis() as u64,
+            grace_remaining_ms = (grace.saturating_sub(elapsed)).as_millis() as u64,
+            "Ignoring transient forge CLI status downgrade (grace window active)"
         );
         return cached.status.clone();
     }
+    tracing::warn!(
+        type_name = std::any::type_name::<S>(),
+        downgraded_status = ?loaded,
+        grace_elapsed_ms = elapsed.as_millis() as u64,
+        "Forge CLI status grace window expired; surfacing downgrade"
+    );
     loaded
 }
 

--- a/src/features/composer/index.tsx
+++ b/src/features/composer/index.tsx
@@ -536,7 +536,7 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 									/>
 								}
 								placeholder={
-									<div className="pointer-events-none absolute left-0 top-0 text-[14px] leading-5 tracking-[-0.01em] text-muted-foreground">
+									<div className="pointer-events-none absolute left-0 top-0 text-[14px] leading-5 tracking-[-0.01em] text-muted-foreground/70">
 										{hasPlanReview && permissionMode === "plan"
 											? "Describe what to change, then click Request Changes"
 											: "Ask to make changes, @mention files, run /commands"}
@@ -781,7 +781,7 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 											`gap-1 px-1.5 text-[11px] ${composerToolbarTriggerClassName}`,
 											permissionMode === "plan"
 												? "text-plan hover:text-plan"
-												: "text-muted-foreground/55 hover:text-muted-foreground/55",
+												: "text-muted-foreground/70 hover:text-muted-foreground/70",
 										)}
 										onClick={() =>
 											onChangePermissionMode(


### PR DESCRIPTION
## Summary

The GitHub "Connect" CTA was flickering on flaky networks because every transient
upstream blip looked like a real logout. This branch tightens the detection and
extends the smoothing window:

- **Grace window 30s → 10min** (`forge/cli_status.rs`, `forge/github/cli.rs`):
  a Ready→Unauthenticated downgrade is suppressed for up to 10 minutes while
  the most recent Ready snapshot is replayed. Long enough to ride out a Wi-Fi
  drop or VPN switch; still short enough that an actual logout surfaces
  promptly.
- **Whitelist canonical unauthenticated phrases** (`forge/github/cli.rs`):
  `looks_like_unauthenticated` no longer matches bare `401` / `unauthorized` /
  `unauthenticated`, which leaked into errors like `401 Service Unavailable`
  and `unauthenticated upstream timeout`. It now keys off concrete strings
  (`401 unauthorized`, `bad credentials`, `not logged into`, `gh auth login`,
  `no token found`, …). New unit tests pin both the matches and the
  not-matches.
- **Diagnostic tracing** across `forge/github/auth.rs`, `forge/github/cli.rs`,
  and `forge/status_cache.rs` so we can tell at a glance whether a
  disconnection is the grace window expiring, an OAuth refresh failure, or a
  CLI status downgrade. Two `FIXME`s flag where we still wipe the keychain on
  any refresh error — follow-up work to classify transient vs. invalid_grant.
- **Composer polish** (`features/composer/index.tsx`): bump the placeholder
  and at-rest auto/plan pill from `text-muted-foreground` /
  `text-muted-foreground/55` to `text-muted-foreground/70` so they stay
  legible without competing with real content.

## Why

Users on intermittently flaky networks (corporate VPN, train Wi-Fi) saw the
"Connect GitHub" prompt re-appear every few seconds even though their token
was fine — both because the 30s grace was too short and because we were
matching `401`/`unauthorized` substrings everywhere. The combination made the
UI feel broken on perfectly healthy auth state.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` (clean via pre-commit hook)
- [x] `cargo fmt` (clean via pre-commit hook)
- [x] New unit tests in `forge/github/cli.rs`:
  `looks_like_unauthenticated_matches_canonical_phrases` and
  `looks_like_unauthenticated_ignores_transient_network_errors`
- [ ] Manual: toggle Wi-Fi off briefly during normal use; confirm the
  GitHub Connect prompt does not flash.
- [ ] Manual: actually `gh auth logout`; confirm the Connect prompt appears
  within ~10 minutes (or immediately on next status poll once the cache
  expires).

## Follow-up

The two `FIXME` comments in `forge/github/auth.rs` mark the remaining
keychain-wipe-on-network-blip behavior. The right fix is to classify reqwest
errors (connect/timeout = transient = keep stored identity) before clearing.
Out of scope for this patch.