### PR TITLE
feat(prompts): hide preference preamble from chat and inject workspace remote

### DIFF
--- a/.changeset/quiet-otters-confide.md
+++ b/.changeset/quiet-otters-confide.md
@@ -1,0 +1,7 @@
+---
+"helmor": patch
+---
+
+Polish how Helmor sends prompts to the agent on your behalf:
+- Stop showing your "general preferences" preamble inside your own chat bubbles. The preamble is still delivered to the agent on the wire, but it no longer appears in the visible message or gets persisted with the user prompt — so reloading a session shows only what you actually typed.
+- Substitute the workspace's real git remote name into the Create PR / Commit and push / Resolve conflicts prompts (e.g. `git push -u origin HEAD` instead of `git push -u <remote> HEAD`) so the agent gets a concrete command instead of a placeholder.

--- a/src-tauri/src/agents.rs
+++ b/src-tauri/src/agents.rs
@@ -162,6 +162,12 @@ pub struct AgentSendRequest {
     pub provider: String,
     pub model_id: String,
     pub prompt: String,
+    /// Hidden preamble prepended to `prompt` before sending to the agent
+    /// (e.g. the user's "general preferences"). Persisted user-prompt
+    /// content keeps `prompt` only — the prefix never enters the DB or
+    /// the chat bubble. Empty/absent ⇒ no prefix.
+    #[serde(default)]
+    pub prompt_prefix: Option<String>,
     #[serde(default)]
     pub resume_only: bool,
     pub session_id: Option<String>,
@@ -848,6 +854,7 @@ mod tests {
             provider: "claude".to_string(),
             model_id: "opus-1m".to_string(),
             prompt: String::new(),
+            prompt_prefix: None,
             resume_only: true,
             session_id: Some("provider-session-1".to_string()),
             helmor_session_id: Some("s1".to_string()),
@@ -883,6 +890,7 @@ mod tests {
             provider: "claude".to_string(),
             model_id: "opus-1m".to_string(),
             prompt: String::new(),
+            prompt_prefix: None,
             resume_only: true,
             session_id: Some("provider-session-1".to_string()),
             helmor_session_id: Some("s1".to_string()),

--- a/src-tauri/src/agents/streaming/mod.rs
+++ b/src-tauri/src/agents/streaming/mod.rs
@@ -103,9 +103,23 @@ pub(super) fn stream_via_sidecar(
         .clone()
         .unwrap_or_else(|| Uuid::new_v4().to_string());
 
+    // Combine the optional hidden preamble with the user's prompt. Only
+    // the wire payload sees the combined string — `prompt` (user text
+    // only) is what gets persisted in `persist_user_message` below, so
+    // the chat bubble + DB stay free of the preference prefix.
+    let prefix_trimmed = request
+        .prompt_prefix
+        .as_deref()
+        .map(str::trim)
+        .filter(|p| !p.is_empty());
+    let combined_prompt = match prefix_trimmed {
+        Some(prefix) => format!("{prefix}\n\nUser request:\n{prompt}"),
+        None => prompt.to_string(),
+    };
+
     let params = build_send_message_params(BuildSendMessageParamsInput {
         sidecar_session_id: &sidecar_session_id,
-        prompt,
+        prompt: &combined_prompt,
         cli_model: &model.cli_model,
         cwd: &working_directory.display().to_string(),
         resume_session_id: resume_session_id.as_deref(),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1426,6 +1426,7 @@ function AppShell({
 			selectedWorkspaceDetailQuery.data?.intendedTargetBranch ??
 			selectedWorkspaceDetailQuery.data?.defaultBranch ??
 			null,
+		selectedWorkspaceRemote: selectedWorkspaceDetailQuery.data?.remote ?? null,
 		changeRequest: workspaceChangeRequest,
 		forgeDetection: workspaceForge,
 		forgeActionStatus: workspaceForgeActionStatus,

--- a/src/features/commit/hooks/use-commit-lifecycle.ts
+++ b/src/features/commit/hooks/use-commit-lifecycle.ts
@@ -93,6 +93,7 @@ export function useWorkspaceCommitLifecycle({
 	selectedWorkspaceIdRef,
 	selectedRepoId,
 	selectedWorkspaceTargetBranch,
+	selectedWorkspaceRemote,
 	changeRequest,
 	forgeDetection,
 	forgeActionStatus,
@@ -109,6 +110,10 @@ export function useWorkspaceCommitLifecycle({
 	selectedWorkspaceIdRef: MutableRefObject<string | null>;
 	selectedRepoId: string | null;
 	selectedWorkspaceTargetBranch?: string | null;
+	/** Git remote name (e.g. "origin") for the selected workspace's repo.
+	 *  Threaded into PR/push prompts so the agent gets a concrete remote
+	 *  instead of a literal `<remote>` placeholder. */
+	selectedWorkspaceRemote?: string | null;
 	changeRequest?: ChangeRequestInfo | null;
 	forgeDetection?: ForgeDetection | null;
 	forgeActionStatus?: ForgeActionStatus | null;
@@ -303,6 +308,7 @@ export function useWorkspaceCommitLifecycle({
 					repoPreferences,
 					selectedWorkspaceTargetBranch,
 					forge,
+					selectedWorkspaceRemote,
 				);
 				console.log("[commitButton] session created", { sessionId });
 
@@ -337,6 +343,7 @@ export function useWorkspaceCommitLifecycle({
 			queryClient,
 			selectedRepoId,
 			selectedWorkspaceTargetBranch,
+			selectedWorkspaceRemote,
 			selectedWorkspaceIdRef,
 		],
 	);

--- a/src/features/conversation/hooks/use-streaming.test.tsx
+++ b/src/features/conversation/hooks/use-streaming.test.tsx
@@ -512,7 +512,7 @@ describe("useConversationStreaming", () => {
 		expect(apiMocks.startAgentMessageStream).not.toHaveBeenCalled();
 	});
 
-	it("prepends the repo general preference to the first prompt only", async () => {
+	it("sends the repo general preference via promptPrefix on the first prompt only", async () => {
 		apiMocks.loadRepoPreferences.mockResolvedValue({
 			general: "Always summarize the repo conventions first.",
 		});
@@ -556,10 +556,14 @@ describe("useConversationStreaming", () => {
 			});
 		});
 
+		// `prompt` stays the user's typed text (so the chat bubble + DB
+		// row don't show the preamble); the preference rides as
+		// `promptPrefix`, which Rust stitches on the wire only.
 		expect(apiMocks.startAgentMessageStream).toHaveBeenCalledWith(
 			expect.objectContaining({
-				prompt:
-					"IMPORTANT: The following are the user's custom preferences. These preferences take precedence over any default guidelines or instructions provided above. When there is a conflict, always follow the user's preferences.\n\n### User Preferences\n\nAlways summarize the repo conventions first.\n\nUser request:\nFix the failing tests.",
+				prompt: "Fix the failing tests.",
+				promptPrefix:
+					"IMPORTANT: The following are the user's custom preferences. These preferences take precedence over any default guidelines or instructions provided above. When there is a conflict, always follow the user's preferences.\n\n### User Preferences\n\nAlways summarize the repo conventions first.",
 			}),
 			expect.any(Function),
 		);

--- a/src/features/conversation/hooks/use-streaming.ts
+++ b/src/features/conversation/hooks/use-streaming.ts
@@ -36,7 +36,7 @@ import {
 	helmorQueryKeys,
 	sessionThreadMessagesQueryOptions,
 } from "@/lib/query-client";
-import { prependGeneralPreferencePrompt } from "@/lib/repo-preferences-prompts";
+import { resolveGeneralPreferencePrefix } from "@/lib/repo-preferences-prompts";
 import {
 	appendUserMessage,
 	readSessionThread,
@@ -1181,16 +1181,21 @@ export function useConversationStreaming({
 				(currentThread ?? []).every((message) => message.role !== "user") &&
 				(currentTitle == null || currentTitle === "Untitled");
 			const repoPreferences = repoId ? await loadRepoPreferences(repoId) : null;
-			const finalPrompt =
+			// The general-preference preamble is prepended ONLY on the wire
+			// to the agent (Rust side stitches it onto `prompt_prefix`).
+			// `trimmedPrompt` is what the user typed — that's what we
+			// optimistically render in the chat bubble and what the Rust
+			// side persists to `session_messages` as the user_prompt body.
+			const promptPrefix =
 				isFirstUserMessage && !isCompactCommand
-					? prependGeneralPreferencePrompt(trimmedPrompt, repoPreferences)
-					: trimmedPrompt;
+					? resolveGeneralPreferencePrefix(repoPreferences)
+					: null;
 			const now = new Date().toISOString();
 			const userMessageId = crypto.randomUUID();
 			const optimisticUserMessage = createLiveThreadMessage({
 				id: userMessageId,
 				role: "user",
-				text: finalPrompt,
+				text: trimmedPrompt,
 				createdAt: now,
 				files: filePaths,
 			});
@@ -1317,7 +1322,8 @@ export function useConversationStreaming({
 					{
 						provider: model.provider,
 						modelId: model.id,
-						prompt: finalPrompt,
+						prompt: trimmedPrompt,
+						promptPrefix,
 						sessionId: providerSessionId,
 						helmorSessionId: targetSessionId,
 						workingDirectory,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -125,6 +125,11 @@ export type AgentSendRequest = {
 	provider: AgentProvider;
 	modelId: string;
 	prompt: string;
+	/** Hidden preamble prepended to `prompt` only on the wire to the agent
+	 *  (e.g. the user's "general preferences"). Persisted user-prompt
+	 *  content keeps `prompt` only — the prefix never enters the DB or
+	 *  the chat bubble. */
+	promptPrefix?: string | null;
 	resumeOnly?: boolean | null;
 	sessionId?: string | null;
 	helmorSessionId?: string | null;

--- a/src/lib/commit-button-prompts.test.ts
+++ b/src/lib/commit-button-prompts.test.ts
@@ -169,4 +169,36 @@ describe("buildCommitButtonPrompt", () => {
 		expect(githubPrompt).toBe(gitlabPrompt);
 		expect(githubPrompt).toContain("Commit and push all uncommitted work");
 	});
+
+	it("substitutes the workspace remote into the commit-and-push prompt", () => {
+		const prompt = buildCommitButtonPrompt(
+			"commit-and-push",
+			null,
+			null,
+			null,
+			"upstream",
+		);
+		expect(prompt).toContain("Push the current branch to `upstream`.");
+		expect(prompt).toContain("`git push -u upstream HEAD`");
+		expect(prompt).not.toContain("<remote>");
+	});
+
+	it("falls back to `origin` when the workspace remote is missing", () => {
+		const prompt = buildCommitButtonPrompt("commit-and-push", null, null);
+		expect(prompt).toContain("`git push -u origin HEAD`");
+		expect(prompt).not.toContain("<remote>");
+	});
+
+	it("substitutes the workspace remote into the create-pr prompt", () => {
+		const prompt = buildCommitButtonPrompt(
+			"create-pr",
+			{},
+			"release/next",
+			GITHUB_FORGE,
+			"upstream",
+		);
+		expect(prompt).toContain("Push the current branch to `upstream`.");
+		expect(prompt).toContain("`git push -u upstream HEAD`");
+		expect(prompt).not.toContain("<remote>");
+	});
 });

--- a/src/lib/commit-button-prompts.ts
+++ b/src/lib/commit-button-prompts.ts
@@ -30,7 +30,10 @@ export function buildCommitButtonPrompt(
 	repoPreferences?: RepoPreferences | null,
 	targetBranch?: string | null,
 	forge?: ForgeDetection | null,
+	remote?: string | null,
 ): string {
+	const remoteName =
+		remote && remote.trim().length > 0 ? remote.trim() : "origin";
 	switch (mode) {
 		case "commit-and-push":
 			// Pure git — no forge involved.
@@ -40,7 +43,7 @@ Do the following, in order:
 1. Run \`git status\` and \`git diff\` to survey what's changed.
 2. Stage everything that should ship with \`git add\`.
 3. Commit with a concise, Conventional-Commits-style message (\`feat:\`, \`fix:\`, \`refactor:\`, etc.) summarizing the change.
-4. Push the current branch to its remote. If needed, create the remote tracking branch with \`git push -u <remote> HEAD\`.
+4. Push the current branch to \`${remoteName}\`. If needed, create the remote tracking branch with \`git push -u ${remoteName} HEAD\`.
 5. Report the resulting commit SHA and pushed ref.
 
 Don't stop to ask for confirmation — execute each step automatically. If a pre-commit / pre-push hook fails, report the failure and stop without force-pushing.`;
@@ -60,6 +63,7 @@ Use \`${dialect.reopenCommand}\` + \`${dialect.commentCommand}\`. Report the ${d
 				repoPreferences,
 				targetBranch,
 				forge,
+				remote,
 			});
 	}
 }

--- a/src/lib/repo-preferences-prompts.ts
+++ b/src/lib/repo-preferences-prompts.ts
@@ -21,7 +21,19 @@ type ResolveRepoPreferencePromptArgs = {
 	targetRef?: string | null;
 	dirtyWorktree?: boolean;
 	forge?: ForgeDetection | null;
+	/** Git remote name for this workspace (e.g. "origin"). Falls back to
+	 *  "origin" when unknown — matches the default git produces for a
+	 *  fresh clone, so the agent doesn't see a literal `<remote>`
+	 *  placeholder in the prompt. */
+	remote?: string | null;
 };
+
+const DEFAULT_REMOTE = "origin";
+
+function normalizeRemote(remote?: string | null): string {
+	const trimmed = remote?.trim();
+	return trimmed && trimmed.length > 0 ? trimmed : DEFAULT_REMOTE;
+}
 
 const DEFAULT_BRANCH_RENAME_PROMPT = `When you generate the branch name segment for a new chat:
 
@@ -66,15 +78,17 @@ If a conflict is too ambiguous to resolve automatically, stop and ask.`;
 function createPrPrompt(
 	dialect: ForgePromptDialect,
 	targetBranch?: string | null,
+	remote?: string | null,
 ): string {
 	const branch = requireTargetBranch("createPr", targetBranch);
+	const remoteName = normalizeRemote(remote);
 	return `Create a ${dialect.changeRequestFullName} for the uncommitted work in this workspace.
 
 Do the following, in order:
 1. Run \`git status\` and \`git diff\` to survey what's changed.
 2. Stage everything that should ship with \`git add\`.
 3. Commit with a concise, Conventional-Commits-style message (\`feat:\`, \`fix:\`, \`refactor:\`, \`chore:\`, etc.) that summarizes the change in one line.
-4. Push the current branch to its remote. If needed, create the remote tracking branch with \`git push -u <remote> HEAD\`.
+4. Push the current branch to \`${remoteName}\`. If needed, create the remote tracking branch with \`git push -u ${remoteName} HEAD\`.
 5. Open a ${dialect.changeRequestFullName} against \`${branch}\` using \`${dialect.createCommand(branch)}\`. Use a clear ${dialect.changeRequestName} title and a body that explains: what changed, why it changed, and any follow-up / test notes.
 6. Report the ${dialect.changeRequestName} URL in your final message so I can click it.
 
@@ -96,9 +110,10 @@ function resolveConflictsPrompt({
 	targetBranch,
 	targetRef,
 	dirtyWorktree,
+	remote,
 }: Pick<
 	ResolveRepoPreferencePromptArgs,
-	"targetBranch" | "targetRef" | "dirtyWorktree"
+	"targetBranch" | "targetRef" | "dirtyWorktree" | "remote"
 >): string {
 	if (targetRef) {
 		return dirtyWorktree
@@ -107,15 +122,16 @@ function resolveConflictsPrompt({
 	}
 
 	const branch = requireTargetBranch("resolveConflicts", targetBranch);
+	const remoteName = normalizeRemote(remote);
 
 	return `This branch has merge conflicts with \`${branch}\`, this workspace's target branch. Resolve them.
 
 Do the following, in order:
-1. Fetch the latest \`${branch}\` from its remote.
+1. Fetch the latest \`${branch}\` from \`${remoteName}\`.
 2. Rebase or merge \`${branch}\` into the current branch.
 3. Resolve each conflict, preserving intent from both sides where possible. Explain your resolution choices briefly in the session.
 4. Run the relevant tests locally to confirm nothing broke.
-5. Commit the resolution and push.
+5. Commit the resolution and push to \`${remoteName}\`.
 6. Report the conflicted files and how you resolved them.
 
 If a conflict is too ambiguous to resolve automatically, stop and ask.`;
@@ -205,6 +221,7 @@ export function resolveRepoPreferencePrompt({
 	targetRef,
 	dirtyWorktree = false,
 	forge,
+	remote,
 }: ResolveRepoPreferencePromptArgs): string {
 	const override = repoPreferenceOverride(key, repoPreferences);
 	const targetPlaceholderValue = targetRef ?? targetBranch ?? null;
@@ -221,12 +238,17 @@ export function resolveRepoPreferencePrompt({
 	switch (key) {
 		case "resolveConflicts":
 			return appendUserPreferences(
-				resolveConflictsPrompt({ targetBranch, targetRef, dirtyWorktree }),
+				resolveConflictsPrompt({
+					targetBranch,
+					targetRef,
+					dirtyWorktree,
+					remote,
+				}),
 				resolvedOverride,
 			);
 		case "createPr":
 			return appendUserPreferences(
-				createPrPrompt(forgePromptDialect(forge), targetBranch),
+				createPrPrompt(forgePromptDialect(forge), targetBranch, remote),
 				resolvedOverride,
 			);
 		case "fixErrors":
@@ -242,16 +264,25 @@ export function resolveRepoPreferencePrompt({
 	}
 }
 
-export function prependGeneralPreferencePrompt(
-	prompt: string,
+/** Bare "general preferences" prefix — the preamble we want the agent to
+ *  receive but the user's chat bubble (and the persisted user_prompt row)
+ *  should NOT contain. Returns `null` when there's nothing to prepend. The
+ *  Rust side stitches `${prefix}\n\nUser request:\n${prompt}` on the wire;
+ *  see `AgentSendRequest.prompt_prefix`. */
+export function resolveGeneralPreferencePrefix(
 	repoPreferences?: RepoPreferences | null,
-): string {
+): string | null {
 	const general = resolveRepoPreferencePrompt({
 		key: "general",
 		repoPreferences,
 	}).trim();
-	if (!general) {
-		return prompt;
-	}
-	return `${general}\n\nUser request:\n${prompt}`;
+	return general ? general : null;
+}
+
+export function prependGeneralPreferencePrompt(
+	prompt: string,
+	repoPreferences?: RepoPreferences | null,
+): string {
+	const prefix = resolveGeneralPreferencePrefix(repoPreferences);
+	return prefix ? `${prefix}\n\nUser request:\n${prompt}` : prompt;
 }


### PR DESCRIPTION
## Summary
- Route the general-preferences preamble through a new `AgentSendRequest.promptPrefix` field. The agent still receives it on the wire (Rust stitches `${prefix}\n\nUser request:\n${prompt}` in `agents/streaming/mod.rs`), but the user's chat bubble and the persisted `user_prompt` row now only contain what they actually typed — so reloading a session shows the real prompt, not the preamble.
- Substitute the workspace's actual git remote name into the **Create PR**, **Commit and push**, and **Resolve conflicts** prompts (falls back to `origin` when unknown). The agent now sees a concrete `git push -u origin HEAD` instead of a literal `<remote>` placeholder.
- Thread `selectedWorkspaceRemote` from `App.tsx` → `useWorkspaceCommitLifecycle` → `buildCommitButtonPrompt` / `resolveRepoPreferencePrompt` so the remote stays per-workspace.

## Why
- The hidden-preamble UX glitch: users were seeing a wall of "IMPORTANT: The following are the user's custom preferences…" text echoed back inside their own message bubble. That's noise — they wrote the prompt, they don't need to re-read the preference scaffolding.
- The `<remote>` placeholder leak: the prompt told the agent to run `git push -u <remote> HEAD` literally. Some agents would copy that verbatim; others would guess. Substituting the real remote upfront removes the ambiguity.

## Test plan
- [x] `bun run test:frontend` — updated `use-streaming.test.tsx` asserts `prompt` stays the user text and `promptPrefix` carries the preamble; new `commit-button-prompts.test.ts` cases cover remote substitution + `origin` fallback for both `commit-and-push` and `create-pr` modes.
- [x] `bun run test:rust` — updated `agents.rs` mod tests cover the new `prompt_prefix: None` field on `AgentSendRequest`.
- [ ] Manual: send a first prompt with a non-empty general preference set; confirm the chat bubble shows only the typed text, the agent still acts on the preference, and reloading the session preserves the typed-only view.
- [ ] Manual: trigger Commit + Push and Create PR on a workspace whose remote is something other than `origin` (e.g. `upstream`); confirm the prompt names that remote.