### PR TITLE
feat(commit): optimistic PR state + workspace lane updates

### DIFF
--- a/src/features/commit/hooks/use-commit-lifecycle.test.tsx
+++ b/src/features/commit/hooks/use-commit-lifecycle.test.tsx
@@ -5,7 +5,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
 	ChangeRequestInfo,
 	ForgeActionStatus,
+	WorkspaceDetail,
 	WorkspaceGitActionStatus,
+	WorkspaceGroup,
 } from "@/lib/api";
 import { helmorQueryKeys } from "@/lib/query-client";
 import { useWorkspaceCommitLifecycle } from "./use-commit-lifecycle";
@@ -107,10 +109,39 @@ describe("useWorkspaceCommitLifecycle", () => {
 			},
 		});
 		const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries");
-		queryClient.setQueryData(helmorQueryKeys.workspaceDetail("workspace-1"), {
-			id: "workspace-1",
-			activeSessionId: "session-after-close",
-		});
+		queryClient.setQueryData<WorkspaceDetail | null>(
+			helmorQueryKeys.workspaceDetail("workspace-1"),
+			{
+				id: "workspace-1",
+				activeSessionId: "session-after-close",
+				status: "in-progress",
+			} as unknown as WorkspaceDetail,
+		);
+		// Seed the sidebar so we can assert the optimistic move to "review".
+		queryClient.setQueryData<WorkspaceGroup[]>(
+			helmorQueryKeys.workspaceGroups,
+			[
+				{
+					id: "progress",
+					label: "In progress",
+					tone: "progress",
+					rows: [
+						{
+							id: "workspace-1",
+							title: "Workspace 1",
+							status: "in-progress",
+							createdAt: "2024-04-01T00:00:00Z",
+						},
+					],
+				},
+				{
+					id: "review",
+					label: "In review",
+					tone: "review",
+					rows: [],
+				},
+			] as WorkspaceGroup[],
+		);
 
 		const selectedWorkspaceIdRef = { current: "workspace-1" };
 		const onSelectSession = vi.fn();
@@ -183,12 +214,43 @@ describe("useWorkspaceCommitLifecycle", () => {
 			);
 		});
 		await waitFor(() => {
-			expect(invalidateQueriesSpy).toHaveBeenCalledWith({
-				queryKey: helmorQueryKeys.workspaceChangeRequest("workspace-1"),
-			});
+			// `workspaceChangeRequest` should be seeded directly via setQueryData
+			// from the awaited refresh result, not invalidated (which would
+			// trigger a duplicate `gh pr view`).
+			const cached = queryClient.getQueryData<ChangeRequestInfo | null>(
+				helmorQueryKeys.workspaceChangeRequest("workspace-1"),
+			);
+			expect(cached).toMatchObject({ state: "OPEN", number: 53 });
+		});
+		expect(invalidateQueriesSpy).not.toHaveBeenCalledWith({
+			queryKey: helmorQueryKeys.workspaceChangeRequest("workspace-1"),
+		});
+		await waitFor(() => {
 			expect(invalidateQueriesSpy).toHaveBeenCalledWith({
 				queryKey: helmorQueryKeys.workspaceForgeActionStatus("workspace-1"),
 			});
+		});
+		// Optimistic group + detail moves: workspace-1 should now sit in the
+		// "review" lane and its detail.status should be "review", before the
+		// event-driven invalidation has had a chance to refetch.
+		await waitFor(() => {
+			const groups = queryClient.getQueryData<WorkspaceGroup[]>(
+				helmorQueryKeys.workspaceGroups,
+			);
+			const reviewIds = groups
+				?.find((g) => g.id === "review")
+				?.rows.map((r) => r.id);
+			const progressIds = groups
+				?.find((g) => g.id === "progress")
+				?.rows.map((r) => r.id);
+			expect(reviewIds).toContain("workspace-1");
+			expect(progressIds).not.toContain("workspace-1");
+		});
+		await waitFor(() => {
+			const detail = queryClient.getQueryData<WorkspaceDetail | null>(
+				helmorQueryKeys.workspaceDetail("workspace-1"),
+			);
+			expect(detail?.status).toBe("review");
 		});
 		await waitFor(() => {
 			expect(apiMocks.hideSession).toHaveBeenCalledWith("session-action");
@@ -322,9 +384,6 @@ describe("useWorkspaceCommitLifecycle", () => {
 				queryKey: helmorQueryKeys.workspaceGitActionStatus("workspace-1"),
 			});
 			expect(invalidateQueriesSpy).toHaveBeenCalledWith({
-				queryKey: helmorQueryKeys.workspaceChangeRequest("workspace-1"),
-			});
-			expect(invalidateQueriesSpy).toHaveBeenCalledWith({
 				queryKey: helmorQueryKeys.workspaceForgeActionStatus("workspace-1"),
 			});
 			expect(invalidateQueriesSpy).toHaveBeenCalledWith({
@@ -336,6 +395,11 @@ describe("useWorkspaceCommitLifecycle", () => {
 			expect(invalidateQueriesSpy).toHaveBeenCalledWith({
 				queryKey: ["workspaceChanges"],
 			});
+		});
+		// Push doesn't change PR state — no workspaceChangeRequest invalidation
+		// (which would trigger a redundant `gh pr view`).
+		expect(invalidateQueriesSpy).not.toHaveBeenCalledWith({
+			queryKey: helmorQueryKeys.workspaceChangeRequest("workspace-1"),
 		});
 		expect(pushToast).not.toHaveBeenCalled();
 	});
@@ -433,6 +497,206 @@ describe("useWorkspaceCommitLifecycle", () => {
 			"Create PR failed",
 			"destructive",
 		);
+	});
+
+	it("optimistically moves the workspace to the done lane when merge is clicked", async () => {
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false } },
+		});
+		queryClient.setQueryData<ChangeRequestInfo | null>(
+			helmorQueryKeys.workspaceChangeRequest("workspace-1"),
+			{
+				number: 53,
+				title: "Fix overflow",
+				url: "https://github.com/example/repo/pull/53",
+				state: "OPEN",
+				isMerged: false,
+			},
+		);
+		queryClient.setQueryData<WorkspaceDetail | null>(
+			helmorQueryKeys.workspaceDetail("workspace-1"),
+			{
+				id: "workspace-1",
+				status: "review",
+			} as unknown as WorkspaceDetail,
+		);
+		queryClient.setQueryData<WorkspaceGroup[]>(
+			helmorQueryKeys.workspaceGroups,
+			[
+				{
+					id: "review",
+					label: "In review",
+					tone: "review",
+					rows: [
+						{
+							id: "workspace-1",
+							title: "W1",
+							status: "review",
+							createdAt: "2024-04-01T00:00:00Z",
+						},
+					],
+				},
+				{ id: "done", label: "Done", tone: "done", rows: [] },
+			] as WorkspaceGroup[],
+		);
+
+		// Slow-resolve so we can observe the optimistic state before the
+		// promise settles.
+		let resolveMerge: (value: ChangeRequestInfo) => void = () => {};
+		apiMocks.mergeWorkspaceChangeRequest.mockImplementationOnce(
+			() =>
+				new Promise<ChangeRequestInfo>((resolve) => {
+					resolveMerge = resolve;
+				}),
+		);
+
+		const { result } = renderHook(
+			() =>
+				useWorkspaceCommitLifecycle({
+					queryClient,
+					selectedWorkspaceId: "workspace-1",
+					selectedWorkspaceIdRef: { current: "workspace-1" },
+					selectedRepoId: "repo-1",
+					changeRequest: {
+						number: 53,
+						title: "Fix overflow",
+						url: "https://github.com/example/repo/pull/53",
+						state: "OPEN",
+						isMerged: false,
+					},
+					forgeActionStatus: {
+						...EMPTY_FORGE_ACTION_STATUS,
+						mergeable: "MERGEABLE",
+					},
+					workspaceGitActionStatus: EMPTY_GIT_ACTION_STATUS,
+					completedSessionIds: new Set<string>(),
+					interactionRequiredSessionIds: new Set<string>(),
+					sendingSessionIds: new Set<string>(),
+					onSelectSession: vi.fn(),
+				}),
+			{ wrapper: createWrapper(queryClient) },
+		);
+
+		await act(async () => {
+			await result.current.handleInspectorCommitAction("merge");
+		});
+
+		// Optimistic move happens synchronously in handleInspectorCommitAction.
+		const groups = queryClient.getQueryData<WorkspaceGroup[]>(
+			helmorQueryKeys.workspaceGroups,
+		);
+		expect(groups?.find((g) => g.id === "done")?.rows.map((r) => r.id)).toEqual(
+			["workspace-1"],
+		);
+		expect(
+			groups?.find((g) => g.id === "review")?.rows.map((r) => r.id),
+		).toEqual([]);
+		expect(
+			queryClient.getQueryData<WorkspaceDetail | null>(
+				helmorQueryKeys.workspaceDetail("workspace-1"),
+			)?.status,
+		).toBe("done");
+		expect(
+			queryClient.getQueryData<ChangeRequestInfo | null>(
+				helmorQueryKeys.workspaceChangeRequest("workspace-1"),
+			),
+		).toMatchObject({ state: "MERGED", isMerged: true });
+
+		// Resolve the in-flight merge so the test's hooks settle cleanly.
+		await act(async () => {
+			resolveMerge({
+				number: 53,
+				title: "Fix overflow",
+				url: "https://github.com/example/repo/pull/53",
+				state: "MERGED",
+				isMerged: true,
+			});
+			await Promise.resolve();
+		});
+	});
+
+	it("rolls back optimistic group + detail moves when merge fails", async () => {
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false } },
+		});
+		const initialDetail = {
+			id: "workspace-1",
+			status: "review",
+		} as unknown as WorkspaceDetail;
+		const initialGroups = [
+			{
+				id: "review",
+				label: "In review",
+				tone: "review",
+				rows: [
+					{
+						id: "workspace-1",
+						title: "W1",
+						status: "review",
+						createdAt: "2024-04-01T00:00:00Z",
+					},
+				],
+			},
+			{ id: "done", label: "Done", tone: "done", rows: [] },
+		] as WorkspaceGroup[];
+		queryClient.setQueryData(
+			helmorQueryKeys.workspaceDetail("workspace-1"),
+			initialDetail,
+		);
+		queryClient.setQueryData(helmorQueryKeys.workspaceGroups, initialGroups);
+
+		apiMocks.mergeWorkspaceChangeRequest.mockRejectedValueOnce(
+			new Error("GitHub merge failed"),
+		);
+
+		const { result } = renderHook(
+			() =>
+				useWorkspaceCommitLifecycle({
+					queryClient,
+					selectedWorkspaceId: "workspace-1",
+					selectedWorkspaceIdRef: { current: "workspace-1" },
+					selectedRepoId: "repo-1",
+					changeRequest: {
+						number: 53,
+						title: "Fix overflow",
+						url: "https://github.com/example/repo/pull/53",
+						state: "OPEN",
+						isMerged: false,
+					},
+					forgeActionStatus: {
+						...EMPTY_FORGE_ACTION_STATUS,
+						mergeable: "MERGEABLE",
+					},
+					workspaceGitActionStatus: EMPTY_GIT_ACTION_STATUS,
+					completedSessionIds: new Set<string>(),
+					interactionRequiredSessionIds: new Set<string>(),
+					sendingSessionIds: new Set<string>(),
+					onSelectSession: vi.fn(),
+					pushToast: vi.fn(),
+				}),
+			{ wrapper: createWrapper(queryClient) },
+		);
+
+		await act(async () => {
+			await result.current.handleInspectorCommitAction("merge");
+		});
+
+		await waitFor(() => {
+			const groups = queryClient.getQueryData<WorkspaceGroup[]>(
+				helmorQueryKeys.workspaceGroups,
+			);
+			expect(
+				groups?.find((g) => g.id === "review")?.rows.map((r) => r.id),
+			).toEqual(["workspace-1"]);
+			expect(
+				groups?.find((g) => g.id === "done")?.rows.map((r) => r.id),
+			).toEqual([]);
+		});
+		expect(
+			queryClient.getQueryData<WorkspaceDetail | null>(
+				helmorQueryKeys.workspaceDetail("workspace-1"),
+			)?.status,
+		).toBe("review");
 	});
 
 	it("shows a destructive workspace toast when merge fails", async () => {

--- a/src/features/commit/hooks/use-commit-lifecycle.ts
+++ b/src/features/commit/hooks/use-commit-lifecycle.ts
@@ -21,6 +21,8 @@ import {
 	refreshWorkspaceChangeRequest,
 	type WorkspaceDetail,
 	type WorkspaceGitActionStatus,
+	type WorkspaceGroup,
+	type WorkspaceStatus,
 } from "@/lib/api";
 import {
 	deriveCommitButtonMode,
@@ -34,8 +36,60 @@ import {
 	helmorQueryKeys,
 	workspaceForgeQueryOptions,
 } from "@/lib/query-client";
+import { moveWorkspaceToGroup } from "@/lib/workspace-helpers";
 import type { PushWorkspaceToast } from "@/lib/workspace-toast-context";
 import type { CommitButtonState, WorkspaceCommitButtonMode } from "../button";
+
+/**
+ * Derive the workspace lane this PR state implies. Mirrors the backend's
+ * `pr_sync_state_from_change_request` + `sync_workspace_pr_state` mapping
+ * in `src-tauri/src/workspace/workspaces.rs` so the optimistic placement
+ * lands in the same group the next refetch will choose.
+ */
+function deriveStatusFromChangeRequest(
+	changeRequest: ChangeRequestInfo | null,
+): WorkspaceStatus | null {
+	if (!changeRequest) return null;
+	if (changeRequest.isMerged || changeRequest.state === "MERGED") return "done";
+	if (changeRequest.state === "OPEN") return "review";
+	if (changeRequest.state === "CLOSED") return "canceled";
+	return null;
+}
+
+/**
+ * Snapshot the slice of caches we touch in an optimistic PR-state update so
+ * we can roll back atomically on error. Returned restore() is a no-op once
+ * we know the action succeeded.
+ */
+function applyOptimisticWorkspaceStatus(
+	queryClient: QueryClient,
+	workspaceId: string,
+	nextStatus: WorkspaceStatus,
+): () => void {
+	const previousGroups = queryClient.getQueryData<WorkspaceGroup[]>(
+		helmorQueryKeys.workspaceGroups,
+	);
+	const previousDetail = queryClient.getQueryData<WorkspaceDetail | null>(
+		helmorQueryKeys.workspaceDetail(workspaceId),
+	);
+
+	queryClient.setQueryData<WorkspaceGroup[] | undefined>(
+		helmorQueryKeys.workspaceGroups,
+		(current) => moveWorkspaceToGroup(current, workspaceId, nextStatus),
+	);
+	queryClient.setQueryData<WorkspaceDetail | null | undefined>(
+		helmorQueryKeys.workspaceDetail(workspaceId),
+		(detail) => (detail ? { ...detail, status: nextStatus } : detail),
+	);
+
+	return () => {
+		queryClient.setQueryData(helmorQueryKeys.workspaceGroups, previousGroups);
+		queryClient.setQueryData(
+			helmorQueryKeys.workspaceDetail(workspaceId),
+			previousDetail,
+		);
+	};
+}
 
 function getActionFailureTitle(
 	mode: WorkspaceCommitButtonMode,
@@ -133,13 +187,15 @@ export function useWorkspaceCommitLifecycle({
 	const forgeActionStatusRef = useRef(currentForgeActionStatus);
 	forgeActionStatusRef.current = currentForgeActionStatus;
 
+	// `workspaceChangeRequest` is intentionally NOT invalidated here. Callers
+	// that need fresh PR data already write it directly via setQueryData
+	// (either from `await refreshWorkspaceChangeRequest(...)` or from an
+	// optimistic snapshot), so an invalidation would just trigger a duplicate
+	// `gh pr view` round-trip.
 	const refreshWorkspaceRemoteStatus = useCallback(
 		(workspaceId: string) => {
 			void queryClient.invalidateQueries({
 				queryKey: helmorQueryKeys.workspaceGitActionStatus(workspaceId),
-			});
-			void queryClient.invalidateQueries({
-				queryKey: helmorQueryKeys.workspaceChangeRequest(workspaceId),
 			});
 			void queryClient.invalidateQueries({
 				queryKey: helmorQueryKeys.workspaceForgeActionStatus(workspaceId),
@@ -220,6 +276,15 @@ export function useWorkspaceCommitLifecycle({
 					helmorQueryKeys.workspaceChangeRequest(workspaceId),
 					optimisticChangeRequest,
 				);
+				// Move the workspace to its target sidebar group + flip the
+				// detail status in the same tick so the inspector header tone
+				// AND the sidebar lane reflect the new state immediately,
+				// instead of waiting for the GitHub round-trip + event invalidation.
+				const restoreWorkspaceStatus = applyOptimisticWorkspaceStatus(
+					queryClient,
+					workspaceId,
+					mode === "merge" ? "done" : "canceled",
+				);
 
 				void (async () => {
 					try {
@@ -242,6 +307,7 @@ export function useWorkspaceCommitLifecycle({
 							helmorQueryKeys.workspaceChangeRequest(workspaceId),
 							cachedChangeRequest,
 						);
+						restoreWorkspaceStatus();
 						setCommitLifecycle((prev) =>
 							prev
 								? {
@@ -448,6 +514,25 @@ export function useWorkspaceCommitLifecycle({
 					"[commitButton] refreshWorkspaceChangeRequest result",
 					currentChangeRequest,
 				);
+				// Seed caches directly from the result we just awaited so the
+				// downstream invalidation in `refreshWorkspaceRemoteStatus`
+				// doesn't trigger a duplicate `gh pr view`, and so the sidebar
+				// lane / inspector header reflect the PR state on the same
+				// frame as the lifecycle transition.
+				queryClient.setQueryData(
+					helmorQueryKeys.workspaceChangeRequest(workspaceId),
+					currentChangeRequest ?? null,
+				);
+				const optimisticStatus = deriveStatusFromChangeRequest(
+					currentChangeRequest ?? null,
+				);
+				if (optimisticStatus) {
+					applyOptimisticWorkspaceStatus(
+						queryClient,
+						workspaceId,
+						optimisticStatus,
+					);
+				}
 				setCommitLifecycle((prev) => {
 					if (!prev || prev.workspaceId !== workspaceId) return prev;
 					return {
@@ -477,6 +562,7 @@ export function useWorkspaceCommitLifecycle({
 		abortedSessionIds,
 		interactionRequiredSessionIds,
 		pushToast,
+		queryClient,
 		refreshWorkspaceRemoteStatus,
 		sendingSessionIds,
 	]);

--- a/src/features/inspector/sections/git-section-header.stories.tsx
+++ b/src/features/inspector/sections/git-section-header.stories.tsx
@@ -277,6 +277,20 @@ export const Merge: Story = {
 	},
 };
 
+// Captures the case the user complained about: a merge button that's
+// visibly disabled because GitHub is still computing mergeability. The
+// bottom shimmer signals to the user that this is a transient sync state,
+// not a permanent block.
+export const MergeComputing: Story = {
+	decorators: [singleDecorator],
+	args: {
+		commitButtonMode: "merge",
+		commitButtonState: "disabled",
+		changeRequest: CHANGE_REQUEST_OPEN,
+		hasChanges: false,
+	},
+};
+
 export const Merged: Story = {
 	decorators: [singleDecorator],
 	args: {

--- a/src/features/inspector/sections/git-section-header.test.tsx
+++ b/src/features/inspector/sections/git-section-header.test.tsx
@@ -291,6 +291,107 @@ describe("GitSectionHeader forge onboarding", () => {
 		});
 	});
 
+	it("shows shimmer when the commit button is disabled (mergeable computing)", () => {
+		renderWithProviders(
+			<GitSectionHeader
+				commitButtonMode="merge"
+				commitButtonState="disabled"
+				changeRequest={changeRequest}
+				changeRequestName="MR"
+				forgeDetection={gitlabDetection({
+					cli: {
+						status: "ready",
+						provider: "gitlab",
+						host: "gitlab.com",
+						cliName: "glab",
+						login: "liangeqiang",
+						version: "1.55.0",
+						message: "Connected.",
+					},
+				})}
+				workspaceId="workspace-1"
+			/>,
+		);
+
+		expect(screen.getByTestId("git-header-shimmer")).toBeInTheDocument();
+	});
+
+	it("shows shimmer on the first cold fetch", () => {
+		renderWithProviders(
+			<GitSectionHeader
+				commitButtonMode="merge"
+				commitButtonState="idle"
+				changeRequest={changeRequest}
+				changeRequestName="MR"
+				isRefreshing
+				forgeDetection={gitlabDetection({
+					cli: {
+						status: "ready",
+						provider: "gitlab",
+						host: "gitlab.com",
+						cliName: "glab",
+						login: "liangeqiang",
+						version: "1.55.0",
+						message: "Connected.",
+					},
+				})}
+				workspaceId="workspace-1"
+			/>,
+		);
+
+		expect(screen.getByTestId("git-header-shimmer")).toBeInTheDocument();
+	});
+
+	it("does not shimmer in idle / busy / done states", () => {
+		const { rerender } = renderWithProviders(
+			<GitSectionHeader
+				commitButtonMode="merge"
+				commitButtonState="idle"
+				changeRequest={changeRequest}
+				changeRequestName="MR"
+				forgeDetection={gitlabDetection({
+					cli: {
+						status: "ready",
+						provider: "gitlab",
+						host: "gitlab.com",
+						cliName: "glab",
+						login: "liangeqiang",
+						version: "1.55.0",
+						message: "Connected.",
+					},
+				})}
+				workspaceId="workspace-1"
+			/>,
+		);
+		expect(screen.queryByTestId("git-header-shimmer")).not.toBeInTheDocument();
+
+		for (const state of ["busy", "done", "error"] as const) {
+			rerender(
+				<GitSectionHeader
+					commitButtonMode="merge"
+					commitButtonState={state}
+					changeRequest={changeRequest}
+					changeRequestName="MR"
+					forgeDetection={gitlabDetection({
+						cli: {
+							status: "ready",
+							provider: "gitlab",
+							host: "gitlab.com",
+							cliName: "glab",
+							login: "liangeqiang",
+							version: "1.55.0",
+							message: "Connected.",
+						},
+					})}
+					workspaceId="workspace-1"
+				/>,
+			);
+			expect(
+				screen.queryByTestId("git-header-shimmer"),
+			).not.toBeInTheDocument();
+		}
+	});
+
 	it("uses the same connect CTA for GitHub onboarding", async () => {
 		apiMocks.getWorkspaceForge.mockResolvedValue(githubDetection());
 

--- a/src/features/inspector/sections/git-section-header.tsx
+++ b/src/features/inspector/sections/git-section-header.tsx
@@ -71,9 +71,12 @@ export type GitSectionHeaderProps = {
 	changeRequest: ChangeRequestInfo | null;
 	hasChanges?: boolean;
 	/**
-	 * Whether change request data is currently being (re)fetched. Drives the bottom
-	 * shimmer bar. Gated by a min display duration so fast responses don't
-	 * flicker.
+	 * Whether change request data is currently being (re)fetched. Drives the
+	 * bottom shimmer bar (combined with `commitButtonState === "disabled"`).
+	 * Gated by a min display duration so fast responses don't flicker.
+	 *
+	 * Scope: ONLY first cold fetch — owned by App. Background polling does
+	 * not flip this true (would be visually noisy).
 	 */
 	isRefreshing?: boolean;
 	changeRequestName?: string;
@@ -119,8 +122,20 @@ export function GitSectionHeader({
 		"action.openPullRequest",
 	);
 
+	// Shimmer fires while the header is in a transient "computing" state that
+	// directly affects what the user can do:
+	//   1. First cold fetch of PR / forge-action data (`isRefreshing`).
+	//   2. The commit button is `disabled` because GitHub is still computing
+	//      mergeability (`mergeable === "UNKNOWN"`). Without this cue, a
+	//      grayed-out merge button looks broken — the user can't tell whether
+	//      it's a transient sync or a permanent block.
+	// We deliberately do NOT shimmer for:
+	//   - Background polling on stable data (would be noisy).
+	//   - Active lifecycle phases (creating/streaming/verifying) — the button
+	//     itself shows a busy spinner, additional shimmer is redundant.
+	const isComputing = isRefreshing || commitButtonState === "disabled";
 	const showShimmer = useMinDisplayDuration(
-		isRefreshing,
+		isComputing,
 		SHIMMER_MIN_DISPLAY_MS,
 	);
 
@@ -234,6 +249,7 @@ export function GitSectionHeader({
 		>
 			{showShimmer && (
 				<div
+					data-testid="git-header-shimmer"
 					aria-hidden="true"
 					className="pointer-events-none absolute inset-x-0 bottom-0 h-px motion-safe:animate-[shine_2s_infinite_linear]"
 					style={{

--- a/src/lib/workspace-helpers.test.ts
+++ b/src/lib/workspace-helpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type {
 	AgentModelSection,
+	WorkspaceGroup,
 	WorkspaceRow,
 	WorkspaceSessionSummary,
 } from "./api";
@@ -12,6 +13,7 @@ import {
 	inferDefaultModelId,
 	insertRowByCreatedAtDesc,
 	isNewSession,
+	moveWorkspaceToGroup,
 	resolveSessionDisplayProvider,
 	resolveSessionSelectedModelId,
 	splitTextWithFiles,
@@ -211,6 +213,113 @@ describe("insertRowByCreatedAtDesc", () => {
 		];
 		const inserted = insertRowByCreatedAtDesc(rows, row("new"));
 		expect(inserted.map((r) => r.id)).toEqual(["new", "a", "b"]);
+	});
+});
+
+describe("moveWorkspaceToGroup", () => {
+	const row = (
+		id: string,
+		createdAt?: string,
+		extras: Partial<WorkspaceRow> = {},
+	): WorkspaceRow => ({
+		id,
+		title: id,
+		...(createdAt ? { createdAt } : {}),
+		...extras,
+	});
+
+	const buildGroups = (
+		init: Record<string, WorkspaceRow[]>,
+	): WorkspaceGroup[] =>
+		(
+			["pinned", "done", "review", "progress", "backlog", "canceled"] as const
+		).map((id) => ({
+			id,
+			label: id,
+			tone: "progress",
+			rows: init[id] ?? [],
+		}));
+
+	it("moves a workspace from progress to review preserving createdAt order", () => {
+		const groups = buildGroups({
+			progress: [
+				row("a", "2024-03-01T00:00:00Z"),
+				row("target", "2024-02-01T00:00:00Z"),
+			],
+			review: [
+				row("r1", "2024-03-15T00:00:00Z"),
+				row("r2", "2024-01-10T00:00:00Z"),
+			],
+		});
+
+		const next = moveWorkspaceToGroup(groups, "target", "review");
+
+		const progress = next?.find((g) => g.id === "progress");
+		const review = next?.find((g) => g.id === "review");
+		expect(progress?.rows.map((r) => r.id)).toEqual(["a"]);
+		// target has createdAt 2024-02-01, lands between r1 (2024-03-15) and r2 (2024-01-10)
+		expect(review?.rows.map((r) => r.id)).toEqual(["r1", "target", "r2"]);
+		expect(review?.rows.find((r) => r.id === "target")?.status).toBe("review");
+	});
+
+	it("moves merged workspace to done group", () => {
+		const groups = buildGroups({
+			review: [row("merged-target", "2024-02-01T00:00:00Z")],
+		});
+
+		const next = moveWorkspaceToGroup(groups, "merged-target", "done");
+
+		expect(next?.find((g) => g.id === "review")?.rows).toHaveLength(0);
+		expect(next?.find((g) => g.id === "done")?.rows.map((r) => r.id)).toEqual([
+			"merged-target",
+		]);
+	});
+
+	it("routes a pinned row to the pinned group regardless of nextStatus", () => {
+		const groups = buildGroups({
+			pinned: [
+				row("pin-target", "2024-02-01T00:00:00Z", {
+					pinnedAt: "2024-04-01T00:00:00Z",
+				}),
+			],
+		});
+
+		const next = moveWorkspaceToGroup(groups, "pin-target", "done");
+
+		// Stays pinned because workspaceGroupIdFromStatus respects pinnedAt.
+		expect(next?.find((g) => g.id === "pinned")?.rows.map((r) => r.id)).toEqual(
+			["pin-target"],
+		);
+		expect(next?.find((g) => g.id === "done")?.rows).toHaveLength(0);
+	});
+
+	it("returns groups unchanged when the workspace isn't in any group", () => {
+		const groups = buildGroups({
+			progress: [row("a", "2024-03-01T00:00:00Z")],
+		});
+
+		const next = moveWorkspaceToGroup(groups, "missing", "done");
+
+		expect(next).toBe(groups);
+	});
+
+	it("returns undefined when groups is undefined", () => {
+		expect(moveWorkspaceToGroup(undefined, "x", "done")).toBeUndefined();
+	});
+
+	it("updates the row's status to the new value", () => {
+		const groups = buildGroups({
+			progress: [
+				row("target", "2024-02-01T00:00:00Z", { status: "in-progress" }),
+			],
+		});
+
+		const next = moveWorkspaceToGroup(groups, "target", "canceled");
+
+		const moved = next
+			?.find((g) => g.id === "canceled")
+			?.rows.find((r) => r.id === "target");
+		expect(moved?.status).toBe("canceled");
 	});
 });
 

--- a/src/lib/workspace-helpers.ts
+++ b/src/lib/workspace-helpers.ts
@@ -9,6 +9,7 @@ import type {
 	WorkspaceGroup,
 	WorkspaceRow,
 	WorkspaceSessionSummary,
+	WorkspaceStatus,
 	WorkspaceSummary,
 } from "./api";
 import { extractError } from "./errors";
@@ -180,6 +181,46 @@ export function insertRowByCreatedAtDesc(
 	const index = rows.findIndex((existing) => key(existing) < incoming);
 	if (index === -1) return [...rows, row];
 	return [...rows.slice(0, index), row, ...rows.slice(index)];
+}
+
+/**
+ * Move a workspace row from its current sidebar group to the group implied by
+ * `nextStatus`. Preserves the row's existing fields (createdAt, pinnedAt, …)
+ * and uses `insertRowByCreatedAtDesc` so the optimistic position matches the
+ * spot the server will place the row on refetch — no reorder flicker.
+ *
+ * Returns `groups` unchanged when the workspace isn't in any live group
+ * (likely pinned-only / archived) — we don't fabricate a row out of thin air;
+ * the next event-driven invalidation will reconcile.
+ */
+export function moveWorkspaceToGroup(
+	groups: WorkspaceGroup[] | undefined,
+	workspaceId: string,
+	nextStatus: WorkspaceStatus,
+): WorkspaceGroup[] | undefined {
+	if (!groups) return groups;
+
+	let row: WorkspaceRow | null = null;
+	const stripped = groups.map((group) => {
+		const idx = group.rows.findIndex((r) => r.id === workspaceId);
+		if (idx === -1) return group;
+		row = group.rows[idx]!;
+		return { ...group, rows: group.rows.filter((_, i) => i !== idx) };
+	});
+	if (!row) return groups;
+
+	const sourceRow: WorkspaceRow = row;
+	const updatedRow: WorkspaceRow = { ...sourceRow, status: nextStatus };
+	const targetGroupId = workspaceGroupIdFromStatus(
+		nextStatus,
+		updatedRow.pinnedAt,
+	);
+
+	return stripped.map((group) =>
+		group.id === targetGroupId
+			? { ...group, rows: insertRowByCreatedAtDesc(group.rows, updatedRow) }
+			: group,
+	);
 }
 
 export type WorkspaceBranchTone =


### PR DESCRIPTION
## Summary

- **Optimistic sidebar/inspector updates on merge/close.** When the user clicks merge or close, the workspace now moves to its target sidebar lane (`done` / `canceled`) and the inspector header status flips in the same tick, instead of waiting for the GitHub round-trip + event-driven invalidation. On API failure, both the group placement and `WorkspaceDetail.status` roll back atomically alongside the existing `workspaceChangeRequest` rollback.
- **Optimistic update after `refreshWorkspaceChangeRequest`.** The hook now seeds `workspaceChangeRequest` directly from the awaited refresh result (and derives the implied lane via the same mapping the backend uses in `pr_sync_state_from_change_request`), so the lifecycle transition, sidebar lane, and inspector header land on the same frame.
- **Removed redundant `gh pr view` round-trip.** `refreshWorkspaceRemoteStatus` no longer invalidates `workspaceChangeRequest` — callers that need fresh PR data already write it via `setQueryData`, so the invalidation was just triggering a duplicate `gh pr view`.
- **Shimmer cue for "GitHub is computing mergeability".** `GitSectionHeader` now shimmers when the commit button is `disabled` (mergeable === `UNKNOWN`), in addition to the existing first-cold-fetch case. Without this, a grayed-out merge button looks broken — the shimmer signals "transient sync, not a permanent block."

## Why

The previous flow had two visible UX gaps: (1) clicking merge left the workspace in the `review` lane for several seconds until the GitHub event came back, making the action feel unresponsive; (2) when GitHub returned `mergeable: UNKNOWN`, the merge button silently disabled with no indication that it was a transient state — users would re-click thinking it was broken.

## Implementation notes

- New helper `moveWorkspaceToGroup` in `src/lib/workspace-helpers.ts`: extracts the row from its current group, applies `nextStatus`, routes via `workspaceGroupIdFromStatus` (so pinned rows stay pinned), and re-inserts via `insertRowByCreatedAtDesc` so the optimistic position matches where the server will place it on refetch — no reorder flicker.
- `applyOptimisticWorkspaceStatus` in `use-commit-lifecycle.ts` snapshots the slice of caches it touches and returns a `restore()` for atomic rollback.

## Test plan

- [x] `bun run test:frontend` — new tests in `use-commit-lifecycle.test.tsx` cover the optimistic merge + rollback, and `workspace-helpers.test.ts` covers `moveWorkspaceToGroup` (move across lanes, pinned routing, missing workspace, status update). New shimmer assertions in `git-section-header.test.tsx`.
- [ ] Smoke test in dev: merge an open PR → workspace should snap to `done` immediately, inspector header should flip without delay.
- [ ] Smoke test failure path: kill the network mid-merge → workspace should snap back to `review`, toast should show.
- [ ] Smoke test mergeable=UNKNOWN: open a brand-new PR → header should shimmer until GitHub finishes computing mergeability.