### PR TITLE
fix(ci): build release on macos-26 so Tahoe scrollbars render correctly

### DIFF
--- a/.changeset/tahoe-scrollbar-runner.md
+++ b/.changeset/tahoe-scrollbar-runner.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix a regression on macOS 26 (Tahoe) where scrollbar backgrounds stayed permanently visible in the workspace sidebar, conversation thread, and inspector panels.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,9 @@ env:
 jobs:
   preflight:
     name: Release Preflight
-    runs-on: macos-latest
+    # macos-26 ensures the bundled binary links against macOS 26 SDK; pre-26
+    # SDK targets get Tahoe's legacy compat scrollbar rendering (always-on bg).
+    runs-on: macos-26
     outputs:
       version: ${{ steps.version.outputs.version }}
       release_body: ${{ steps.notes.outputs.release_body }}
@@ -104,7 +106,7 @@ jobs:
             tauri-args: "--target aarch64-apple-darwin"
           - target-triple: x86_64-apple-darwin
             tauri-args: "--target x86_64-apple-darwin"
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Pin the `preflight` and matrix release jobs in `.github/workflows/publish.yml` to `macos-26` instead of `macos-latest` so the bundled binary links against the macOS 26 SDK.
- Add a changeset (`patch`) describing the user-visible scrollbar fix.

## Why
On macOS 26 (Tahoe), apps built against pre-26 SDKs fall back to the legacy compatibility scrollbar — backgrounds stay permanently visible, which showed up as the "always-on" gutters in the workspace sidebar, conversation thread, and inspector panels of release builds. Building on the `macos-26` runner opts the binary into the new SDK so Tahoe renders the modern overlay scrollbars instead.

This only affects CI runner selection; no app code changes.

## Test plan
- [ ] CI green on `macos-26` runners (preflight + per-target build matrix).
- [ ] Verify a release build on macOS 26 (Tahoe) shows overlay scrollbars (not always-on backgrounds) in the sidebar / conversation / inspector.
- [ ] Verify the same release build still launches and renders correctly on the previous macOS major.

## Follow-ups
- Watch for `macos-26` runner availability/quotas; revisit if GitHub deprecates the label or shifts `macos-latest`.