### PR TITLE
feat(shortcuts): broaden global shortcut scopes and inspector tab UX

### DIFF
--- a/.changeset/agile-shortcuts-roam.md
+++ b/.changeset/agile-shortcuts-roam.md
@@ -1,0 +1,8 @@
+---
+"helmor": patch
+---
+
+Loosen up keyboard shortcuts and the inspector tabs panel:
+- Make global shortcuts (Cmd+R run script, sidebar/zen toggles, workspace navigation, commit/PR actions) fire from anywhere in the window instead of silently doing nothing when focus is in the file editor.
+- Cmd+T while looking at script output now opens a new terminal instead of a new chat session.
+- Any inspector tab — Setup, Run, a terminal tab, or the "+" button — now opens the tabs panel when clicked, and collapses it when you click the already-active tab.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1769,30 +1769,29 @@ function AppShell({
 				callback: handleOpenPreferredEditor,
 				enabled:
 					isIdentityConnected &&
-					workspaceViewMode === "conversation" &&
 					Boolean(selectedWorkspaceId && preferredEditor),
 			},
 			{
 				id: "workspace.new" as const,
 				callback: () =>
 					window.dispatchEvent(new Event("helmor:open-new-workspace")),
-				enabled: isIdentityConnected && workspaceViewMode === "conversation",
+				enabled: isIdentityConnected,
 			},
 			{
 				id: "workspace.addRepository" as const,
 				callback: () =>
 					window.dispatchEvent(new Event("helmor:open-add-repository")),
-				enabled: isIdentityConnected && workspaceViewMode === "conversation",
+				enabled: isIdentityConnected,
 			},
 			{
 				id: "workspace.previous" as const,
 				callback: () => handleNavigateWorkspaces(-1),
-				enabled: isIdentityConnected && workspaceViewMode === "conversation",
+				enabled: isIdentityConnected,
 			},
 			{
 				id: "workspace.next" as const,
 				callback: () => handleNavigateWorkspaces(1),
-				enabled: isIdentityConnected && workspaceViewMode === "conversation",
+				enabled: isIdentityConnected,
 			},
 			{
 				id: "session.previous" as const,
@@ -1820,7 +1819,7 @@ function AppShell({
 			{
 				id: "session.reopenClosed" as const,
 				callback: () => void handleReopenClosedSession(),
-				enabled: isIdentityConnected && workspaceViewMode === "conversation",
+				enabled: isIdentityConnected,
 			},
 			{
 				id: "script.run" as const,
@@ -1835,53 +1834,47 @@ function AppShell({
 			{
 				id: "sidebar.left.toggle" as const,
 				callback: () => setSidebarCollapsed((collapsed) => !collapsed),
-				enabled: isIdentityConnected && workspaceViewMode === "conversation",
+				enabled: isIdentityConnected,
 			},
 			{
 				id: "sidebar.right.toggle" as const,
 				callback: () => setInspectorCollapsed((collapsed) => !collapsed),
-				enabled: isIdentityConnected && workspaceViewMode === "conversation",
+				enabled: isIdentityConnected,
 			},
 			{
 				id: "zen.toggle" as const,
 				callback: handleToggleZenMode,
-				enabled: isIdentityConnected && workspaceViewMode === "conversation",
+				enabled: isIdentityConnected,
 			},
 			{
 				id: "action.createPr" as const,
 				callback: () => void handleInspectorCommitAction("create-pr"),
-				enabled: isIdentityConnected && workspaceViewMode === "conversation",
+				enabled: isIdentityConnected,
 			},
 			{
 				id: "action.commitAndPush" as const,
 				callback: () => void handleInspectorCommitAction("commit-and-push"),
-				enabled: isIdentityConnected && workspaceViewMode === "conversation",
+				enabled: isIdentityConnected,
 			},
 			{
 				id: "action.pullLatest" as const,
 				callback: () => void handlePullLatest(),
-				enabled:
-					isIdentityConnected &&
-					workspaceViewMode === "conversation" &&
-					Boolean(selectedWorkspaceId),
+				enabled: isIdentityConnected && Boolean(selectedWorkspaceId),
 			},
 			{
 				id: "action.mergePr" as const,
 				callback: () => void handleInspectorCommitAction("merge"),
-				enabled: isIdentityConnected && workspaceViewMode === "conversation",
+				enabled: isIdentityConnected,
 			},
 			{
 				id: "action.fixErrors" as const,
 				callback: () => void handleInspectorCommitAction("fix"),
-				enabled: isIdentityConnected && workspaceViewMode === "conversation",
+				enabled: isIdentityConnected,
 			},
 			{
 				id: "action.openPullRequest" as const,
 				callback: handleOpenPullRequest,
-				enabled:
-					isIdentityConnected &&
-					workspaceViewMode === "conversation" &&
-					Boolean(pullRequestUrl),
+				enabled: isIdentityConnected && Boolean(pullRequestUrl),
 			},
 			{
 				id: "composer.focus" as const,

--- a/src/features/composer/index.tsx
+++ b/src/features/composer/index.tsx
@@ -448,6 +448,7 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 		<div
 			ref={composerRootRef}
 			aria-label="Workspace composer"
+			data-focus-scope="composer"
 			onKeyDownCapture={handleComposerKeyDownCapture}
 			className={cn(
 				"relative flex flex-col rounded-2xl border border-border/40 bg-sidebar shadow-[0_-1px_8px_rgba(0,0,0,0.05),0_0_0_1px_rgba(255,255,255,0.02)]",

--- a/src/features/editor/index.tsx
+++ b/src/features/editor/index.tsx
@@ -386,6 +386,7 @@ export function WorkspaceEditorSurface({
 	return (
 		<section
 			aria-label="Workspace editor surface"
+			data-focus-scope="editor"
 			className="flex h-full min-h-0 flex-col overflow-hidden bg-background text-foreground"
 		>
 			<div

--- a/src/features/inspector/index.tsx
+++ b/src/features/inspector/index.tsx
@@ -184,9 +184,10 @@ export function WorkspaceInspectorSidebar({
 
 	const isTerminalTabActive = terminalInstances.some((t) => t.id === activeTab);
 
-	// Terminal-scope shortcuts. Fire only while xterm has DOM focus — the
-	// `data-focus-scope="terminal"` tag on the panel resolves to "terminal" via
-	// getActiveScope — so they don't compete with chat's Mod+T / Mod+W.
+	// Terminal-scope shortcuts. Fire while focus is anywhere in the inspector
+	// tabs section (Setup / Run / Terminal) — the `data-focus-scope="terminal"`
+	// tag on the section root resolves to "terminal" via getActiveScopes — so
+	// they don't compete with chat's Mod+T / Mod+W.
 	const navigateTerminal = useCallback(
 		(offset: -1 | 1) => {
 			if (terminalInstances.length === 0) return;

--- a/src/features/inspector/layout.tsx
+++ b/src/features/inspector/layout.tsx
@@ -367,6 +367,32 @@ export function InspectorTabsSection({
 
 	const zoomedSize = `${TABS_HOVER_ZOOM_MULTIPLIER * 100}%`;
 
+	// Smart tab click: closed → open + activate; open + clicking the active
+	// tab → collapse; open + different tab → just switch. Lets the user use
+	// any tab as a toggle handle, not just the chevron.
+	const handleTabClick = useCallback(
+		(tabId: string) => {
+			if (!open) {
+				onTabChange(tabId);
+				onToggle();
+				return;
+			}
+			if (activeTab === tabId) {
+				onToggle();
+				return;
+			}
+			onTabChange(tabId);
+		},
+		[open, activeTab, onTabChange, onToggle],
+	);
+
+	// "+" / placeholder Terminal: spawning a terminal while the panel is
+	// collapsed would create one the user can't see — pop the panel open too.
+	const handleNewTerminalClick = useCallback(() => {
+		if (!open) onToggle();
+		onAddTerminal();
+	}, [open, onAddTerminal, onToggle]);
+
 	return (
 		<div
 			ref={wrapperRef}
@@ -438,6 +464,9 @@ export function InspectorTabsSection({
 			>
 				<section
 					aria-label="Inspector section Tabs"
+					// Whole scripts-area belongs to terminal scope so Mod+T from
+					// Run output spawns a terminal instead of a chat session.
+					data-focus-scope="terminal"
 					className={cn(
 						"relative flex min-h-0 flex-1 flex-col overflow-hidden border-b border-border/60 bg-sidebar",
 						// Draw the top edge line on the section itself so it paints
@@ -485,7 +514,7 @@ export function InspectorTabsSection({
 										"shrink-0",
 										activeTab === "setup" && "text-foreground",
 									)}
-									onClick={() => onTabChange("setup")}
+									onClick={() => handleTabClick("setup")}
 								>
 									<ScriptStatusIcon state={setupScriptState} />
 									Setup
@@ -509,7 +538,7 @@ export function InspectorTabsSection({
 										"shrink-0",
 										activeTab === "run" && "text-foreground",
 									)}
-									onClick={() => onTabChange("run")}
+									onClick={() => handleTabClick("run")}
 								>
 									<ScriptStatusIcon state={runScriptState} />
 									Run
@@ -533,7 +562,7 @@ export function InspectorTabsSection({
 										aria-selected={false}
 										tabIndex={-1}
 										disabled={!canSpawnTerminal}
-										onClick={onAddTerminal}
+										onClick={handleNewTerminalClick}
 										className={cn(
 											INSPECTOR_TAB_BUTTON_CLASS,
 											"shrink-0 disabled:cursor-not-allowed disabled:opacity-50",
@@ -563,11 +592,11 @@ export function InspectorTabsSection({
 													"group/tab relative flex h-full min-w-[5rem] shrink-0 transform-gpu cursor-pointer items-center overflow-hidden px-3 text-[12px] font-medium text-muted-foreground focus-visible:outline-none focus-visible:ring-0",
 													isActive && "text-foreground",
 												)}
-												onClick={() => onTabChange(instance.id)}
+												onClick={() => handleTabClick(instance.id)}
 												onKeyDown={(e) => {
 													if (e.key === "Enter" || e.key === " ") {
 														e.preventDefault();
-														onTabChange(instance.id);
+														handleTabClick(instance.id);
 													}
 												}}
 											>
@@ -603,7 +632,7 @@ export function InspectorTabsSection({
 										<button
 											type="button"
 											aria-label="New terminal"
-											onClick={onAddTerminal}
+											onClick={handleNewTerminalClick}
 											disabled={!canSpawnTerminal}
 											className="ml-1 flex h-full w-6 shrink-0 cursor-pointer items-center justify-center self-center text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-0 disabled:cursor-not-allowed disabled:opacity-50"
 										>

--- a/src/features/inspector/sections/terminal.tsx
+++ b/src/features/inspector/sections/terminal.tsx
@@ -146,7 +146,6 @@ export function TerminalInstancePanel({
 
 	return (
 		<div
-			data-focus-scope="terminal"
 			id={`inspector-panel-terminal-${instance.id}`}
 			role="tabpanel"
 			aria-labelledby={`inspector-tab-terminal-${instance.id}`}

--- a/src/features/shortcuts/focus-scope.test.ts
+++ b/src/features/shortcuts/focus-scope.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
 	_resetActiveScopeForTesting,
 	DEFAULT_FOCUS_SCOPE,
-	getActiveScope,
+	getActiveScopes,
 } from "./focus-scope";
 
 beforeEach(() => {
@@ -14,12 +14,12 @@ afterEach(() => {
 	document.body.innerHTML = "";
 });
 
-describe("getActiveScope", () => {
+describe("getActiveScopes", () => {
 	it("returns the default when nothing is focused", () => {
-		expect(getActiveScope()).toBe(DEFAULT_FOCUS_SCOPE);
+		expect(getActiveScopes()).toEqual([DEFAULT_FOCUS_SCOPE]);
 	});
 
-	it("walks up to the closest [data-focus-scope] ancestor", () => {
+	it("walks up to the [data-focus-scope] ancestor", () => {
 		document.body.innerHTML = `
 			<div data-focus-scope="terminal">
 				<div>
@@ -29,7 +29,9 @@ describe("getActiveScope", () => {
 		`;
 		const probe = document.getElementById("probe") as HTMLInputElement;
 		probe.focus();
-		expect(getActiveScope()).toBe("terminal");
+		// Pure terminal scope — chat-bound shortcuts (Cmd+T) must NOT fire,
+		// so chat is deliberately absent.
+		expect(getActiveScopes()).toEqual(["terminal"]);
 	});
 
 	it("falls back to default for unknown scope values", () => {
@@ -39,19 +41,38 @@ describe("getActiveScope", () => {
 			</div>
 		`;
 		(document.getElementById("probe") as HTMLInputElement).focus();
-		expect(getActiveScope()).toBe(DEFAULT_FOCUS_SCOPE);
+		expect(getActiveScopes()).toEqual([DEFAULT_FOCUS_SCOPE]);
 	});
 
-	it("nested scopes use the innermost tag", () => {
+	it("collects nested scopes leaf-first", () => {
 		document.body.innerHTML = `
 			<div data-focus-scope="chat">
-				<div data-focus-scope="terminal">
+				<div data-focus-scope="composer">
 					<input id="probe" />
 				</div>
 			</div>
 		`;
 		(document.getElementById("probe") as HTMLInputElement).focus();
-		expect(getActiveScope()).toBe("terminal");
+		// Composer is nested inside chat — both scopes are active so
+		// chat-bound shortcuts (Cmd+T) AND composer-bound shortcuts
+		// (Shift+Tab) fire while typing in the composer.
+		expect(getActiveScopes()).toEqual(["composer", "chat"]);
+	});
+
+	it("inherits chat from composer even when DOM-sibling (not nested)", () => {
+		// Real layout: composer is rendered as a sibling of the chat panel,
+		// not a descendant. SCOPE_PARENTS still pulls in chat so session-
+		// navigation (chat-only) shortcuts work while typing.
+		document.body.innerHTML = `
+			<div data-focus-scope="chat">
+				<input id="msg" />
+			</div>
+			<div data-focus-scope="composer">
+				<input id="probe" />
+			</div>
+		`;
+		(document.getElementById("probe") as HTMLInputElement).focus();
+		expect(getActiveScopes()).toEqual(["composer", "chat"]);
 	});
 
 	it("keeps sticky scope when focused element is removed but container still exists", () => {
@@ -67,14 +88,14 @@ describe("getActiveScope", () => {
 		`;
 		const probe = document.getElementById("probe") as HTMLInputElement;
 		probe.focus();
-		expect(getActiveScope()).toBe("terminal");
+		expect(getActiveScopes()).toEqual(["terminal"]);
 
 		document.getElementById("t1")?.remove();
 		expect(document.activeElement).toBe(document.body);
 
 		// One terminal container still exists — sticky should hold so the
 		// next shortcut routes to the panel the user just engaged with.
-		expect(getActiveScope()).toBe("terminal");
+		expect(getActiveScopes()).toEqual(["terminal"]);
 	});
 
 	it("drops sticky when the engaged scope is no longer in the DOM", () => {
@@ -88,10 +109,10 @@ describe("getActiveScope", () => {
 		`;
 		const probe = document.getElementById("probe") as HTMLInputElement;
 		probe.focus();
-		expect(getActiveScope()).toBe("terminal");
+		expect(getActiveScopes()).toEqual(["terminal"]);
 
 		document.getElementById("t1")?.remove();
-		expect(getActiveScope()).toBe(DEFAULT_FOCUS_SCOPE);
+		expect(getActiveScopes()).toEqual([DEFAULT_FOCUS_SCOPE]);
 	});
 
 	it("updates sticky when user explicitly focuses a different scope", () => {
@@ -104,10 +125,10 @@ describe("getActiveScope", () => {
 			</div>
 		`;
 		(document.getElementById("t") as HTMLInputElement).focus();
-		expect(getActiveScope()).toBe("terminal");
+		expect(getActiveScopes()).toEqual(["terminal"]);
 
 		(document.getElementById("c") as HTMLInputElement).focus();
-		expect(getActiveScope()).toBe("chat");
+		expect(getActiveScopes()).toEqual(["chat"]);
 	});
 
 	it("treats explicit focus on an unscoped surface as a return to default", () => {
@@ -118,9 +139,9 @@ describe("getActiveScope", () => {
 			<input id="sidebar" />
 		`;
 		(document.getElementById("t") as HTMLInputElement).focus();
-		expect(getActiveScope()).toBe("terminal");
+		expect(getActiveScopes()).toEqual(["terminal"]);
 
 		(document.getElementById("sidebar") as HTMLInputElement).focus();
-		expect(getActiveScope()).toBe(DEFAULT_FOCUS_SCOPE);
+		expect(getActiveScopes()).toEqual([DEFAULT_FOCUS_SCOPE]);
 	});
 });

--- a/src/features/shortcuts/focus-scope.ts
+++ b/src/features/shortcuts/focus-scope.ts
@@ -1,17 +1,28 @@
 import type { ShortcutScope } from "./types";
 
 // DOM contract: any container can opt in to a focus scope by setting
-// `data-focus-scope="chat" | "terminal" | "editor"`. The active scope is
-// resolved at dispatch time from the closest tagged ancestor of
-// `document.activeElement`, with a sticky fallback for transient focus loss.
+// `data-focus-scope="chat" | "composer" | "terminal" | "editor"`. The active
+// scope set is resolved at dispatch time by walking from
+// `document.activeElement` up to the document root, collecting every tagged
+// ancestor (so nested scopes like composer-inside-chat both apply).
 export const FOCUS_SCOPE_ATTRIBUTE = "data-focus-scope";
 
 const KNOWN_SCOPES: ReadonlySet<ShortcutScope> = new Set([
 	"app",
 	"chat",
+	"composer",
 	"terminal",
 	"editor",
 ]);
+
+// Scope inheritance: when a leaf scope is active, every parent scope is also
+// considered active. The composer is a sibling of the chat panel in the DOM
+// (not a descendant), but semantically it IS chat — so chat-bound shortcuts
+// (Cmd+T, Cmd+W, session navigation) must keep firing while typing.
+const SCOPE_PARENTS: Partial<Record<ShortcutScope, readonly ShortcutScope[]>> =
+	{
+		composer: ["chat"],
+	};
 
 export const DEFAULT_FOCUS_SCOPE: ShortcutScope = "chat";
 
@@ -22,14 +33,33 @@ export const DEFAULT_FOCUS_SCOPE: ShortcutScope = "chat";
 // e.g. Mod+W would silently start closing chat sessions.
 let lastEngagedScope: ShortcutScope = DEFAULT_FOCUS_SCOPE;
 
-function readScopeFrom(element: Element | null): ShortcutScope | null {
-	if (!element) return null;
-	const container = element.closest(`[${FOCUS_SCOPE_ATTRIBUTE}]`);
-	const value = container?.getAttribute(FOCUS_SCOPE_ATTRIBUTE);
-	if (value && KNOWN_SCOPES.has(value as ShortcutScope)) {
-		return value as ShortcutScope;
+function readScopesFrom(element: Element | null): ShortcutScope[] {
+	if (!element) return [];
+	const collected: ShortcutScope[] = [];
+	let cursor: Element | null = element.closest(`[${FOCUS_SCOPE_ATTRIBUTE}]`);
+	while (cursor) {
+		const value = cursor.getAttribute(FOCUS_SCOPE_ATTRIBUTE);
+		if (value && KNOWN_SCOPES.has(value as ShortcutScope)) {
+			const scope = value as ShortcutScope;
+			if (!collected.includes(scope)) collected.push(scope);
+		}
+		const parent: Element | null = cursor.parentElement;
+		cursor = parent?.closest(`[${FOCUS_SCOPE_ATTRIBUTE}]`) ?? null;
 	}
-	return null;
+	return collected;
+}
+
+function withInheritedParents(
+	scopes: readonly ShortcutScope[],
+): ShortcutScope[] {
+	const out: ShortcutScope[] = [];
+	const append = (scope: ShortcutScope) => {
+		if (out.includes(scope)) return;
+		out.push(scope);
+		for (const parent of SCOPE_PARENTS[scope] ?? []) append(parent);
+	};
+	for (const scope of scopes) append(scope);
+	return out;
 }
 
 if (typeof document !== "undefined") {
@@ -41,31 +71,40 @@ if (typeof document !== "undefined") {
 			// removed (e.g. xterm unmounted on tab close). Treat that as a
 			// transient focus loss and keep the sticky memory.
 			if (!target || target === document.body) return;
-			lastEngagedScope = readScopeFrom(target) ?? DEFAULT_FOCUS_SCOPE;
+			const scopes = readScopesFrom(target);
+			lastEngagedScope = scopes[0] ?? DEFAULT_FOCUS_SCOPE;
 		},
 		true,
 	);
 }
 
-export function getActiveScope(): ShortcutScope {
-	if (typeof document === "undefined") return lastEngagedScope;
+// Returns every scope active for the current focus, leaf-first, with
+// SCOPE_PARENTS expanded so semantic parents (e.g. composer ⊂ chat) come
+// along automatically. When focus is outside any tagged container —
+// sidebar, top chrome — falls back to the default scope.
+export function getActiveScopes(): ShortcutScope[] {
+	return withInheritedParents(computeActiveLeafScopes());
+}
+
+function computeActiveLeafScopes(): readonly ShortcutScope[] {
+	if (typeof document === "undefined") return [lastEngagedScope];
 	const active = document.activeElement;
 	if (active && active !== document.body) {
-		const scope = readScopeFrom(active);
-		if (scope) return scope;
+		const scopes = readScopesFrom(active);
+		if (scopes.length > 0) return scopes;
 		// Real focus owner lives outside any tagged scope (sidebar, top
 		// chrome). Fall back to the default.
-		return DEFAULT_FOCUS_SCOPE;
+		return [DEFAULT_FOCUS_SCOPE];
 	}
 	// activeElement === body — transient focus loss (e.g. focused element
 	// just unmounted). Honor sticky only if its scope container still
 	// exists in the DOM; otherwise the panel is gone and the sticky memory
 	// is stale.
-	if (lastEngagedScope === DEFAULT_FOCUS_SCOPE) return lastEngagedScope;
+	if (lastEngagedScope === DEFAULT_FOCUS_SCOPE) return [lastEngagedScope];
 	const stillMounted = document.querySelector(
 		`[${FOCUS_SCOPE_ATTRIBUTE}="${lastEngagedScope}"]`,
 	);
-	return stillMounted ? lastEngagedScope : DEFAULT_FOCUS_SCOPE;
+	return stillMounted ? [lastEngagedScope] : [DEFAULT_FOCUS_SCOPE];
 }
 
 /** Test-only: reset the sticky scope memory between tests. */

--- a/src/features/shortcuts/registry.ts
+++ b/src/features/shortcuts/registry.ts
@@ -11,7 +11,7 @@ export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
 		title: "Previous workspace",
 		group: "Navigation",
 		defaultHotkey: "Mod+Alt+ArrowUp",
-		scopes: ["chat"],
+		scopes: ["app"],
 		editable: true,
 	},
 	{
@@ -19,7 +19,7 @@ export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
 		title: "Next workspace",
 		group: "Navigation",
 		defaultHotkey: "Mod+Alt+ArrowDown",
-		scopes: ["chat"],
+		scopes: ["app"],
 		editable: true,
 	},
 	{
@@ -59,7 +59,7 @@ export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
 		title: "Reopen closed session",
 		group: "Session",
 		defaultHotkey: "Mod+Shift+T",
-		scopes: ["chat"],
+		scopes: ["app"],
 		editable: true,
 	},
 	{
@@ -75,7 +75,7 @@ export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
 		title: "Open repository in default app",
 		group: "Workspace",
 		defaultHotkey: "Mod+O",
-		scopes: ["chat"],
+		scopes: ["app"],
 		editable: true,
 	},
 	{
@@ -83,7 +83,7 @@ export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
 		title: "Create new workspace",
 		group: "Workspace",
 		defaultHotkey: "Mod+N",
-		scopes: ["chat"],
+		scopes: ["app"],
 		editable: true,
 	},
 	{
@@ -91,16 +91,17 @@ export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
 		title: "Add repository",
 		group: "Workspace",
 		defaultHotkey: "Mod+Shift+N",
-		scopes: ["chat"],
+		scopes: ["app"],
 		editable: true,
 	},
 	{
 		id: "script.run",
 		title: "Run / stop script",
 		group: "Actions",
-		// chat-only so the terminal owns Mod+R for shell readline.
+		// Excludes "terminal" so Mod+R stays free for shell readline
+		// (reverse-search). Anywhere else — chat, editor, sidebars — fires.
 		defaultHotkey: "Mod+R",
-		scopes: ["chat"],
+		scopes: ["chat", "editor"],
 		editable: true,
 	},
 	{
@@ -108,7 +109,7 @@ export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
 		title: "Create PR",
 		group: "Actions",
 		defaultHotkey: "Mod+Shift+P",
-		scopes: ["chat"],
+		scopes: ["app"],
 		editable: true,
 	},
 	{
@@ -116,7 +117,7 @@ export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
 		title: "Commit and push",
 		group: "Actions",
 		defaultHotkey: "Mod+Shift+Y",
-		scopes: ["chat"],
+		scopes: ["app"],
 		editable: true,
 	},
 	{
@@ -124,7 +125,7 @@ export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
 		title: "Pull latest from main",
 		group: "Actions",
 		defaultHotkey: "Mod+Shift+L",
-		scopes: ["chat"],
+		scopes: ["app"],
 		editable: true,
 	},
 	{
@@ -132,7 +133,7 @@ export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
 		title: "Merge PR",
 		group: "Actions",
 		defaultHotkey: "Mod+Shift+M",
-		scopes: ["chat"],
+		scopes: ["app"],
 		editable: true,
 	},
 	{
@@ -140,7 +141,7 @@ export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
 		title: "Fix errors",
 		group: "Actions",
 		defaultHotkey: "Mod+Shift+X",
-		scopes: ["chat"],
+		scopes: ["app"],
 		editable: true,
 	},
 	{
@@ -148,7 +149,7 @@ export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
 		title: "Open PR in browser",
 		group: "Actions",
 		defaultHotkey: "Mod+Shift+G",
-		scopes: ["chat"],
+		scopes: ["app"],
 		editable: true,
 	},
 	{
@@ -172,7 +173,7 @@ export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
 		title: "Toggle left sidebar",
 		group: "System",
 		defaultHotkey: "Mod+B",
-		scopes: ["chat"],
+		scopes: ["app"],
 		editable: true,
 	},
 	{
@@ -180,7 +181,7 @@ export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
 		title: "Toggle right sidebar",
 		group: "System",
 		defaultHotkey: "Mod+Alt+B",
-		scopes: ["chat"],
+		scopes: ["app"],
 		editable: true,
 	},
 	{
@@ -188,7 +189,7 @@ export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
 		title: "Toggle zen mode",
 		group: "System",
 		defaultHotkey: "Mod+.",
-		scopes: ["chat"],
+		scopes: ["app"],
 		editable: true,
 	},
 	{
@@ -231,7 +232,9 @@ export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
 		title: "Toggle plan mode",
 		group: "Composer",
 		defaultHotkey: "Shift+Tab",
-		scopes: ["chat"],
+		// composer-only: don't let Shift+Tab steal default a11y focus traversal
+		// from the inspector / message list.
+		scopes: ["composer"],
 		editable: true,
 	},
 	{
@@ -239,7 +242,7 @@ export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
 		title: "Open model picker",
 		group: "Composer",
 		defaultHotkey: "Alt+P",
-		scopes: ["chat"],
+		scopes: ["composer"],
 		editable: true,
 	},
 	{

--- a/src/features/shortcuts/types.ts
+++ b/src/features/shortcuts/types.ts
@@ -45,10 +45,12 @@ export type ShortcutGroup =
 	| "Terminal";
 
 // Scopes a shortcut can live in. "app" = always active regardless of focus.
-// All others gate on the nearest [data-focus-scope] DOM ancestor of the
-// active element. New scopes (e.g. "editor") get appended here as panels
-// learn to own their own keymap.
-export type ShortcutScope = "app" | "chat" | "terminal" | "editor";
+// All others gate on [data-focus-scope] DOM ancestors of the active element;
+// nested scopes accumulate (e.g. focusing inside the composer surfaces both
+// "composer" and "chat"), so a shortcut bound to "chat" still fires while
+// typing — and a "composer"-only shortcut stays off when chat focus lives
+// elsewhere (inspector, message list).
+export type ShortcutScope = "app" | "chat" | "composer" | "terminal" | "editor";
 
 export type ShortcutDefinition = {
 	id: ShortcutId;

--- a/src/features/shortcuts/use-app-shortcuts.test.tsx
+++ b/src/features/shortcuts/use-app-shortcuts.test.tsx
@@ -119,6 +119,68 @@ describe("useAppShortcuts", () => {
 		expect(sessionNew).not.toHaveBeenCalled();
 	});
 
+	it("routes both chat- and composer-bound shortcuts when typing in nested composer scope", () => {
+		const sessionNew = vi.fn();
+		const togglePlanMode = vi.fn();
+
+		function Harness() {
+			useAppShortcuts({
+				overrides: {},
+				handlers: [
+					{ id: "session.new", callback: sessionNew },
+					{ id: "composer.togglePlanMode", callback: togglePlanMode },
+				],
+			});
+			return (
+				<div data-focus-scope="chat">
+					<div data-focus-scope="composer">
+						<input data-testid="composer-input" />
+					</div>
+				</div>
+			);
+		}
+
+		const { getByTestId } = render(<Harness />);
+		(getByTestId("composer-input") as HTMLInputElement).focus();
+
+		// Cmd+T (chat) still works while typing in composer.
+		fireModT();
+		expect(sessionNew).toHaveBeenCalledTimes(1);
+
+		// Shift+Tab (composer) fires.
+		window.dispatchEvent(
+			new KeyboardEvent("keydown", { key: "Tab", code: "Tab", shiftKey: true }),
+		);
+		expect(togglePlanMode).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not fire composer-only shortcuts when chat focus is outside composer", () => {
+		const togglePlanMode = vi.fn();
+
+		function Harness() {
+			useAppShortcuts({
+				overrides: {},
+				handlers: [{ id: "composer.togglePlanMode", callback: togglePlanMode }],
+			});
+			return (
+				<div data-focus-scope="chat">
+					<input data-testid="inspector-input" />
+					<div data-focus-scope="composer">
+						<input data-testid="composer-input" />
+					</div>
+				</div>
+			);
+		}
+
+		const { getByTestId } = render(<Harness />);
+		(getByTestId("inspector-input") as HTMLInputElement).focus();
+
+		window.dispatchEvent(
+			new KeyboardEvent("keydown", { key: "Tab", code: "Tab", shiftKey: true }),
+		);
+		expect(togglePlanMode).not.toHaveBeenCalled();
+	});
+
 	it("fires app-scope shortcuts regardless of focus scope", () => {
 		const themeToggle = vi.fn();
 

--- a/src/features/shortcuts/use-app-shortcuts.ts
+++ b/src/features/shortcuts/use-app-shortcuts.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef } from "react";
-import { getActiveScope } from "./focus-scope";
+import { getActiveScopes } from "./focus-scope";
 import { normalizeShortcutEvent } from "./format";
 import { isShortcutRecordingActive } from "./recording-state";
 import {
@@ -56,14 +56,14 @@ export function useAppShortcuts({ overrides, handlers }: UseAppShortcutsArgs) {
 
 			const hotkey = normalizeShortcutEvent(event);
 			if (!hotkey) return;
-			const activeScope = getActiveScope();
+			const activeScopes = getActiveScopes();
 
 			const match = registrationsRef.current.find(
 				(registration) =>
 					registration.enabled &&
 					registration.hotkey === hotkey &&
 					(registration.scopes.includes("app") ||
-						registration.scopes.includes(activeScope)),
+						registration.scopes.some((scope) => activeScopes.includes(scope))),
 			);
 			if (!match) return;
 			event.preventDefault();


### PR DESCRIPTION
## Summary

Two pieces of polish that came out of analyzing why several shortcuts felt inconsistent or silently broken:

### Focus-scope refactor
- `getActiveScope()` -> `getActiveScopes()`: returns a leaf-first list of every `data-focus-scope` ancestor instead of just the innermost one.
- New `composer` scope, with `SCOPE_PARENTS` declaring `composer ⊂ chat`. The composer is rendered as a DOM sibling of the chat panel (not a descendant), so semantic inheritance has to be explicit — otherwise chat-bound shortcuts (Cmd+T, Cmd+W, session navigation) silently die while typing.
- Shortcut matcher now accepts a registration if **any** of its scopes is in the active set.

### Shortcut scope reshuffle (`registry.ts`)
- Promoted these from `chat` to `app` so they fire from the editor, sidebars, settings dialogs, etc.: workspace prev/next, reopen-closed, open-repo, new workspace, add repository, sidebar toggles, zen toggle, create PR, commit-and-push, pull-latest, merge PR, fix errors, open PR.
- `script.run` (Cmd+R) goes to `["chat", "editor"]` — explicitly excludes `terminal` so the shell still owns Cmd+R for reverse-search.
- `composer.togglePlanMode` and `composer.openModelPicker` move to the new `composer` scope so they don't interfere with default a11y traversal in the inspector / message list.
- Companion change in `App.tsx`: drop the `workspaceViewMode === "conversation"` gate from the now-app-scoped registrations (their enablement is already implied by being registered).

### Inspector tabs UX
- Tag the inspector tabs section root with `data-focus-scope="terminal"` (moved up from individual terminal panels). Now Cmd+T from the Run-output pane spawns a terminal instead of a new chat session.
- Smart tab click handler: closed -> open + activate; clicking the active tab -> collapse; clicking another tab -> just switch. Any tab now works as a toggle handle, not just the chevron.
- New-terminal "+" button auto-opens the panel before spawning, so the user actually sees the terminal they just created.

## Why

Quality-of-life: while the editor was a first-class panel, anything bound to "chat" silently dropped on the floor when focus lived in Monaco. Promoting the global-feeling actions (sidebar toggles, commit, PRs, workspace navigation) to the `app` scope makes them behave the way users already expect. The composer scope inheritance story prevents a regression where moving `togglePlanMode` to a tighter scope would have killed Cmd+T for typing-in-composer.

## Test plan

- [x] `bun run test:frontend` — focus-scope + use-app-shortcuts suites cover nested composer scope, terminal scope, app-scope routing.
- [ ] Manual: Cmd+B / Cmd+Alt+B / Cmd+. while focus is in the file editor — should toggle sidebars / zen.
- [ ] Manual: Cmd+T while clicked into Run output — should spawn a new terminal, not a new chat session.
- [ ] Manual: Click an inactive tab while panel is collapsed — should open + activate. Click the active tab — should collapse.
- [ ] Manual: Shift+Tab in the composer toggles plan mode; Shift+Tab elsewhere does not.
- [ ] Manual: Cmd+R in the terminal still does reverse-search; Cmd+R elsewhere runs the script.