### PR TITLE
fix(account): stop CLI auth row jitter and dedupe connect flow

### DIFF
--- a/.changeset/quiet-account-rows.md
+++ b/.changeset/quiet-account-rows.md
@@ -1,0 +1,9 @@
+---
+"helmor": patch
+---
+
+Polish the Settings → Account CLI integration rows:
+- Pin every state (Connect / Ready / Error) to the same height so the row no longer jumps when the CLI status loads.
+- Refresh the row's cached status when the main UI detects the CLI auth has dropped, so Account no longer shows a stale "ready" after auth has failed elsewhere.
+- Surface CLI command errors (e.g. `gh` not on PATH) immediately during the auth flow instead of waiting out the full poll budget.
+- When the inspector's Connect button is shown because the remote disagrees with the local CLI snapshot, the terminal hand-off is no longer skipped — clicking Connect actually re-authenticates instead of toasting a misleading "connected".

--- a/.changeset/quiet-account-rows.md
+++ b/.changeset/quiet-account-rows.md
@@ -2,8 +2,11 @@
 "helmor": patch
 ---
 
-Polish the Settings → Account CLI integration rows:
-- Pin every state (Connect / Ready / Error) to the same height so the row no longer jumps when the CLI status loads.
-- Refresh the row's cached status when the main UI detects the CLI auth has dropped, so Account no longer shows a stale "ready" after auth has failed elsewhere.
-- Surface CLI command errors (e.g. `gh` not on PATH) immediately during the auth flow instead of waiting out the full poll budget.
-- When the inspector's Connect button is shown because the remote disagrees with the local CLI snapshot, the terminal hand-off is no longer skipped — clicking Connect actually re-authenticates instead of toasting a misleading "connected".
+A round of CLI auth and UI polish:
+- Pin Settings → Account CLI rows to a fixed height so they stop jumping between Connect / Ready / Error.
+- Edge-detect forge `Unauthenticated` in the backend so the 60s poll stops republishing on every tick, and fan it out to the Account CLI cache so it can't go stale.
+- Reflect external GitHub sign-in / sign-out in Settings → Account via the shared identity hook.
+- Surface CLI command errors (e.g. `gh` not on PATH) immediately during auth instead of waiting out the full poll budget.
+- Make the inspector Connect button actually re-authenticate when the remote disagrees with the local CLI snapshot, instead of toasting a misleading "connected".
+- Replace the editor close-button tooltip with an inline `Esc` shortcut next to the X.
+- Fall back to `logo.svg` / `public/logo.svg` when picking a workspace repo icon.

--- a/src-tauri/src/commands/forge_commands.rs
+++ b/src-tauri/src/commands/forge_commands.rs
@@ -4,9 +4,21 @@ use crate::forge::{
 };
 use crate::ui_sync::{self, UiMutationEvent};
 use crate::workspace::scripts::{ScriptContext, ScriptEvent, ScriptProcessManager};
+use std::collections::HashSet;
+use std::sync::Mutex;
 use tauri::{ipc::Channel, State};
 
 use super::common::{run_blocking, CmdResult};
+
+/// Per-workspace marker for "we already published Unauthenticated for this
+/// workspace". The action-status poll fires every ~60s while not OK; without
+/// edge-detection it would republish the same event on every tick and fan
+/// out a cache-wide invalidation storm. Registered as Tauri AppState so its
+/// lifecycle tracks the app and tests can construct their own.
+#[derive(Default)]
+pub struct ForgeAuthEdgeStore {
+    published_unauth: Mutex<HashSet<String>>,
+}
 
 #[tauri::command]
 pub async fn get_workspace_forge(workspace_id: String) -> CmdResult<ForgeDetection> {
@@ -180,12 +192,13 @@ pub async fn refresh_workspace_change_request(
 pub async fn get_workspace_forge_action_status(
     workspace_id: String,
     app: tauri::AppHandle,
+    edge_store: State<'_, ForgeAuthEdgeStore>,
 ) -> CmdResult<ForgeActionStatus> {
     let lookup_workspace_id = workspace_id.clone();
     let status =
         run_blocking(move || forge::lookup_workspace_forge_action_status(&lookup_workspace_id))
             .await?;
-    if should_publish_workspace_forge_changed(status.remote_state) {
+    if should_publish_workspace_forge_changed(&edge_store, &workspace_id, status.remote_state) {
         ui_sync::publish(
             &app,
             UiMutationEvent::WorkspaceForgeChanged { workspace_id },
@@ -241,8 +254,25 @@ async fn run_change_request_action(
     Ok(result)
 }
 
-fn should_publish_workspace_forge_changed(remote_state: RemoteState) -> bool {
-    remote_state == RemoteState::Unauthenticated
+fn should_publish_workspace_forge_changed(
+    store: &ForgeAuthEdgeStore,
+    workspace_id: &str,
+    remote_state: RemoteState,
+) -> bool {
+    let mut published = store
+        .published_unauth
+        .lock()
+        .expect("forge auth edge store mutex poisoned");
+    if remote_state == RemoteState::Unauthenticated {
+        // `insert` returns true only on first insertion → that's the edge
+        // we want to publish on. Subsequent ticks with the same state no-op.
+        published.insert(workspace_id.to_string())
+    } else {
+        // Any other state clears the marker so a future flip back into
+        // Unauthenticated republishes once.
+        published.remove(workspace_id);
+        false
+    }
 }
 
 #[cfg(test)]
@@ -250,15 +280,85 @@ mod tests {
     use super::*;
 
     #[test]
-    fn unauthenticated_action_status_refreshes_workspace_forge() {
+    fn first_unauthenticated_tick_publishes_then_subsequent_ticks_do_not() {
+        let store = ForgeAuthEdgeStore::default();
+        let ws = "ws";
         assert!(should_publish_workspace_forge_changed(
+            &store,
+            ws,
             RemoteState::Unauthenticated
         ));
-        assert!(!should_publish_workspace_forge_changed(RemoteState::Ok));
-        assert!(!should_publish_workspace_forge_changed(RemoteState::NoPr));
         assert!(!should_publish_workspace_forge_changed(
-            RemoteState::Unavailable
+            &store,
+            ws,
+            RemoteState::Unauthenticated
         ));
-        assert!(!should_publish_workspace_forge_changed(RemoteState::Error));
+        assert!(!should_publish_workspace_forge_changed(
+            &store,
+            ws,
+            RemoteState::Unauthenticated
+        ));
+    }
+
+    #[test]
+    fn non_unauth_states_never_publish_and_clear_the_marker() {
+        let store = ForgeAuthEdgeStore::default();
+        let ws = "ws";
+        for state in [
+            RemoteState::Ok,
+            RemoteState::NoPr,
+            RemoteState::Unavailable,
+            RemoteState::Error,
+        ] {
+            assert!(!should_publish_workspace_forge_changed(&store, ws, state));
+        }
+    }
+
+    #[test]
+    fn flipping_back_to_unauthenticated_republishes_once() {
+        let store = ForgeAuthEdgeStore::default();
+        let ws = "ws";
+        assert!(should_publish_workspace_forge_changed(
+            &store,
+            ws,
+            RemoteState::Unauthenticated
+        ));
+        // Recovered.
+        assert!(!should_publish_workspace_forge_changed(
+            &store,
+            ws,
+            RemoteState::Ok
+        ));
+        // Lost auth again — must publish.
+        assert!(should_publish_workspace_forge_changed(
+            &store,
+            ws,
+            RemoteState::Unauthenticated
+        ));
+        assert!(!should_publish_workspace_forge_changed(
+            &store,
+            ws,
+            RemoteState::Unauthenticated
+        ));
+    }
+
+    #[test]
+    fn workspaces_track_independent_edges() {
+        let store = ForgeAuthEdgeStore::default();
+        assert!(should_publish_workspace_forge_changed(
+            &store,
+            "ws-a",
+            RemoteState::Unauthenticated
+        ));
+        assert!(should_publish_workspace_forge_changed(
+            &store,
+            "ws-b",
+            RemoteState::Unauthenticated
+        ));
+        assert!(!should_publish_workspace_forge_changed(
+            &store,
+            "ws-a",
+            RemoteState::Unauthenticated
+        ));
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -69,6 +69,7 @@ pub fn run() {
         .manage(git_watcher::GitWatcherManager::new())
         .manage(workspace::scripts::ScriptProcessManager::new())
         .manage(ui_sync::UiSyncManager::new())
+        .manage(commands::forge_commands::ForgeAuthEdgeStore::default())
         .setup(|app| {
             // Ensure data directory structure exists
             data_dir::ensure_directory_structure()?;

--- a/src-tauri/src/workspace/helpers.rs
+++ b/src-tauri/src/workspace/helpers.rs
@@ -87,6 +87,8 @@ const REPO_ICON_CANDIDATES: &[&str] = &[
     "apple-touch-icon.png",
     "public/favicon.svg",
     "favicon.svg",
+    "public/logo.svg",
+    "logo.svg",
     "public/favicon.png",
     "public/icon.png",
     "public/logo.png",

--- a/src/features/composer/usage-stats-indicator/index.tsx
+++ b/src/features/composer/usage-stats-indicator/index.tsx
@@ -1,5 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo, useState } from "react";
+import { ClaudeIcon, OpenAIIcon } from "@/components/icons";
 import {
 	HoverCard,
 	HoverCardContent,
@@ -110,9 +111,16 @@ export function UsageStatsIndicator({ agentType, disabled, className }: Props) {
 						<div className="text-[14px] font-semibold text-foreground">
 							Usage Stats
 						</div>
-						<div className="text-[12px] text-muted-foreground">
-							{agentType === "claude" ? "Claude" : "Codex"}
-						</div>
+						<span
+							className="text-muted-foreground"
+							aria-label={agentType === "claude" ? "Claude" : "Codex"}
+						>
+							{agentType === "claude" ? (
+								<ClaudeIcon className="size-[13px]" />
+							) : (
+								<OpenAIIcon className="size-[13px]" />
+							)}
+						</span>
 					</div>
 					{stats.primary || stats.secondary || stats.extraWindows.length > 0 ? (
 						<div className="flex flex-col gap-2.5">

--- a/src/features/editor/index.tsx
+++ b/src/features/editor/index.tsx
@@ -8,12 +8,7 @@ import {
 } from "react";
 import { TrafficLightSpacer } from "@/components/chrome/traffic-light-spacer";
 import { Button } from "@/components/ui/button";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
-} from "@/components/ui/tooltip";
-import { InlineShortcutDisplay } from "@/features/shortcuts/shortcut-display";
+import { ShortcutDisplay } from "@/features/shortcuts/shortcut-display";
 import type { EditorSessionState } from "@/lib/editor-session";
 import { describeUnknownError } from "@/lib/workspace-helpers";
 
@@ -398,30 +393,17 @@ export function WorkspaceEditorSurface({
 				<div className="min-w-0 flex-1" data-tauri-drag-region />
 
 				<div className="flex shrink-0 items-center pr-2">
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								type="button"
-								variant="ghost"
-								size="icon-xs"
-								onClick={onExit}
-								aria-label={closeLabel}
-								className="aspect-square h-full text-muted-foreground hover:bg-transparent hover:text-foreground"
-							>
-								<X className="size-3.5" strokeWidth={1.8} />
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent
-							side="bottom"
-							className="flex h-[24px] items-center gap-2 rounded-md px-2 text-[12px] leading-none"
-						>
-							<span>{closeLabel}</span>
-							<InlineShortcutDisplay
-								hotkey="Escape"
-								className="text-background/60"
-							/>
-						</TooltipContent>
-					</Tooltip>
+					<Button
+						type="button"
+						variant="ghost"
+						size="sm"
+						onClick={onExit}
+						aria-label={closeLabel}
+						className="gap-1.5 px-2 text-muted-foreground hover:text-foreground"
+					>
+						<ShortcutDisplay hotkey="Escape" />
+						<X className="size-3.5" strokeWidth={1.8} />
+					</Button>
 				</div>
 			</div>
 

--- a/src/features/inspector/sections/actions.tsx
+++ b/src/features/inspector/sections/actions.tsx
@@ -6,7 +6,7 @@ import {
 	LoaderCircleIcon,
 	TriangleIcon,
 } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 import { toast } from "sonner";
 import {
 	AppendContextButton,
@@ -178,20 +178,7 @@ export function ActionsSection({
 	const forgeStatus = forgeStatusQuery.data ?? EMPTY_FORGE_ACTION_STATUS;
 	const changeRequestName = forgeQuery.data?.labels.changeRequestName ?? "PR";
 	const providerName = forgeQuery.data?.labels.providerName ?? "Forge";
-	const previousForgeRemoteStateRef = useRef(forgeStatus.remoteState);
-	useEffect(() => {
-		const previous = previousForgeRemoteStateRef.current;
-		previousForgeRemoteStateRef.current = forgeStatus.remoteState;
-		if (
-			workspaceId &&
-			forgeStatus.remoteState === "unauthenticated" &&
-			previous !== "unauthenticated"
-		) {
-			void queryClient.invalidateQueries({
-				queryKey: helmorQueryKeys.workspaceForge(workspaceId),
-			});
-		}
-	}, [forgeStatus.remoteState, queryClient, workspaceId]);
+	// Auth-flip invalidation lives in the sync bridge — no frontend edge-detect.
 	const gitRows = sortStatusRows(buildGitRows(gitStatus, workspaceRemote));
 	const reviewRows = sortStatusRows(
 		buildReviewRows(

--- a/src/features/inspector/sections/forge-cli-onboarding.tsx
+++ b/src/features/inspector/sections/forge-cli-onboarding.tsx
@@ -1,7 +1,6 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { Loader2 } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
-import { toast } from "sonner";
+import { useCallback } from "react";
 import { GithubBrandIcon, GitlabBrandIcon } from "@/components/brand-icon";
 import { Button } from "@/components/ui/button";
 import {
@@ -9,16 +8,10 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
-import {
-	type ForgeDetection,
-	getWorkspaceForge,
-	openForgeCliAuthTerminal,
-} from "@/lib/api";
+import type { ForgeDetection } from "@/lib/api";
 import { FORGE_AUTH_TOOLTIP_LINES } from "@/lib/forge-auth-copy";
 import { helmorQueryKeys } from "@/lib/query-client";
-
-const CLI_AUTH_POLL_INTERVAL_MS = 2000;
-const CLI_AUTH_POLL_TIMEOUT_MS = 120_000;
+import { useForgeCliConnect } from "@/lib/use-forge-cli-connect";
 
 export function ForgeCliTrigger({
 	detection,
@@ -30,132 +23,35 @@ export function ForgeCliTrigger({
 	authRequired?: boolean;
 }) {
 	const queryClient = useQueryClient();
-	const [connecting, setConnecting] = useState(false);
-	const authPollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-	const connectInFlightRef = useRef(false);
 
-	const clearAuthPoll = useCallback(() => {
-		if (authPollTimerRef.current !== null) {
-			clearTimeout(authPollTimerRef.current);
-			authPollTimerRef.current = null;
-		}
-	}, []);
-
-	useEffect(() => clearAuthPoll, [clearAuthPoll]);
-
-	const refreshForge = useCallback(async () => {
-		if (!workspaceId) {
-			return null;
-		}
-		const nextDetection = await getWorkspaceForge(workspaceId);
-		queryClient.setQueryData(
-			helmorQueryKeys.workspaceForge(workspaceId),
-			nextDetection,
-		);
-		return nextDetection;
+	// Inspector-specific tail of the connect flow: once CLI auth flips to
+	// ready, the PR + CI surfaces (which were gated on auth) need to refresh
+	// for the *current* workspace. The hook already invalidates the broader
+	// workspaceForge / forgeCliStatus caches.
+	const refreshWorkspaceSurfaces = useCallback(async () => {
+		if (!workspaceId) return;
+		await Promise.all([
+			queryClient.invalidateQueries({
+				queryKey: helmorQueryKeys.workspaceChangeRequest(workspaceId),
+			}),
+			queryClient.invalidateQueries({
+				queryKey: helmorQueryKeys.workspaceForgeActionStatus(workspaceId),
+			}),
+		]);
 	}, [queryClient, workspaceId]);
 
-	const refreshForgeSurfaces = useCallback(
-		async (nextDetection: ForgeDetection) => {
-			if (!workspaceId) {
-				return;
-			}
-			queryClient.setQueryData(
-				helmorQueryKeys.workspaceForge(workspaceId),
-				nextDetection,
-			);
-			await Promise.all([
-				queryClient.invalidateQueries({
-					queryKey: helmorQueryKeys.workspaceForge(workspaceId),
-				}),
-				queryClient.invalidateQueries({
-					queryKey: helmorQueryKeys.workspaceChangeRequest(workspaceId),
-				}),
-				queryClient.invalidateQueries({
-					queryKey: helmorQueryKeys.workspaceForgeActionStatus(workspaceId),
-				}),
-			]);
+	const { connect, connecting } = useForgeCliConnect(
+		detection.provider,
+		detection.host ?? "",
+		{
+			onReady: refreshWorkspaceSurfaces,
+			// Only trust the prop's `ready` when remote agrees. If the remote
+			// probe is what put us here (`authRequired`), the local CLI snapshot
+			// is stale — short-circuiting would just toast "connected" while
+			// nothing actually worked. Force the terminal hand-off instead.
+			hintedStatus: authRequired ? null : (detection.cli ?? null),
 		},
-		[queryClient, workspaceId],
 	);
-
-	const pollUntilCliReady = useCallback(
-		(startedAt = Date.now()) => {
-			if (!workspaceId) {
-				setConnecting(false);
-				connectInFlightRef.current = false;
-				return;
-			}
-			clearAuthPoll();
-			authPollTimerRef.current = setTimeout(async () => {
-				try {
-					const nextDetection = await refreshForge();
-					if (nextDetection?.cli?.status === "ready") {
-						clearAuthPoll();
-						await refreshForgeSurfaces(nextDetection);
-						toast.success(`${nextDetection.labels.cliName} connected`);
-						setConnecting(false);
-						connectInFlightRef.current = false;
-						return;
-					}
-				} catch {
-					// Keep polling; auth may still be in progress in Terminal.
-				}
-				if (Date.now() - startedAt >= CLI_AUTH_POLL_TIMEOUT_MS) {
-					clearAuthPoll();
-					toast(
-						`Finish ${detection.labels.cliName} auth, then click Connect again`,
-					);
-					setConnecting(false);
-					connectInFlightRef.current = false;
-					return;
-				}
-				pollUntilCliReady(startedAt);
-			}, CLI_AUTH_POLL_INTERVAL_MS);
-		},
-		[
-			clearAuthPoll,
-			detection.labels.cliName,
-			refreshForge,
-			refreshForgeSurfaces,
-			workspaceId,
-		],
-	);
-
-	const handleConnect = useCallback(async () => {
-		if (connecting || connectInFlightRef.current) {
-			return;
-		}
-		connectInFlightRef.current = true;
-		clearAuthPoll();
-		setConnecting(true);
-		try {
-			if (detection.cli?.status === "ready") {
-				await refreshForgeSurfaces(detection);
-				toast.success(`${detection.labels.cliName} connected`);
-				setConnecting(false);
-				connectInFlightRef.current = false;
-				return;
-			}
-			await openForgeCliAuthTerminal(detection.provider, detection.host);
-			toast(`Complete ${detection.labels.cliName} auth in Terminal`);
-			pollUntilCliReady();
-		} catch (error) {
-			const message =
-				error instanceof Error
-					? error.message
-					: `Unable to open ${detection.labels.cliName} auth.`;
-			toast.error(message);
-			setConnecting(false);
-			connectInFlightRef.current = false;
-		}
-	}, [
-		clearAuthPoll,
-		connecting,
-		detection,
-		pollUntilCliReady,
-		refreshForgeSurfaces,
-	]);
 
 	return (
 		<div className="ml-auto flex items-center self-center translate-y-px">
@@ -165,7 +61,7 @@ export function ForgeCliTrigger({
 						type="button"
 						size="xs"
 						variant="default"
-						onClick={() => void handleConnect()}
+						onClick={() => void connect()}
 						disabled={connecting}
 						className="gap-1 bg-primary text-primary-foreground hover:bg-primary/90"
 					>

--- a/src/features/inspector/sections/git-section-header.test.tsx
+++ b/src/features/inspector/sections/git-section-header.test.tsx
@@ -1,12 +1,17 @@
 import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { ChangeRequestInfo, ForgeDetection } from "@/lib/api";
+import type {
+	ChangeRequestInfo,
+	ForgeCliStatus,
+	ForgeDetection,
+} from "@/lib/api";
 import { helmorQueryKeys } from "@/lib/query-client";
 import { renderWithProviders } from "@/test/render-with-providers";
 import { GitSectionHeader } from "./git-section-header";
 
 const apiMocks = vi.hoisted(() => ({
 	getWorkspaceForge: vi.fn(),
+	getForgeCliStatus: vi.fn(),
 	openForgeCliAuthTerminal: vi.fn(),
 }));
 
@@ -16,6 +21,7 @@ vi.mock("@/lib/api", async (importOriginal) => {
 	return {
 		...actual,
 		getWorkspaceForge: apiMocks.getWorkspaceForge,
+		getForgeCliStatus: apiMocks.getForgeCliStatus,
 		openForgeCliAuthTerminal: apiMocks.openForgeCliAuthTerminal,
 	};
 });
@@ -93,6 +99,7 @@ function expectElementBefore(first: Element, second: Element) {
 describe("GitSectionHeader forge onboarding", () => {
 	beforeEach(() => {
 		apiMocks.getWorkspaceForge.mockReset();
+		apiMocks.getForgeCliStatus.mockReset();
 		apiMocks.openForgeCliAuthTerminal.mockReset();
 		apiMocks.openForgeCliAuthTerminal.mockResolvedValue(undefined);
 	});
@@ -180,18 +187,16 @@ describe("GitSectionHeader forge onboarding", () => {
 				loginCommand: "glab auth login --hostname gitlab.com",
 			},
 		});
-		const readyDetection = gitlabDetection({
-			cli: {
-				status: "ready",
-				provider: "gitlab",
-				host: "gitlab.com",
-				cliName: "glab",
-				login: "liangeqiang",
-				version: "1.55.0",
-				message: "Connected.",
-			},
-		});
-		apiMocks.getWorkspaceForge.mockResolvedValueOnce(readyDetection);
+		const readyStatus: ForgeCliStatus = {
+			status: "ready",
+			provider: "gitlab",
+			host: "gitlab.com",
+			cliName: "glab",
+			login: "liangeqiang",
+			version: "1.55.0",
+			message: "Connected.",
+		};
+		apiMocks.getForgeCliStatus.mockResolvedValueOnce(readyStatus);
 
 		const { queryClient } = renderWithProviders(
 			<GitSectionHeader
@@ -216,18 +221,62 @@ describe("GitSectionHeader forge onboarding", () => {
 		);
 		await vi.advanceTimersByTimeAsync(2000);
 
-		expect(apiMocks.getWorkspaceForge).toHaveBeenCalledTimes(1);
-		expect(
-			queryClient.getQueryData(helmorQueryKeys.workspaceForge("workspace-1")),
-		).toEqual(readyDetection);
+		expect(apiMocks.getForgeCliStatus).toHaveBeenCalledWith(
+			"gitlab",
+			"gitlab.com",
+		);
+		// Hook fans out: forgeCliStatusAll + every workspaceForge entry,
+		// onReady adds the workspace-scoped change request + action status.
 		expect(invalidateQueries).toHaveBeenCalledWith({
-			queryKey: helmorQueryKeys.workspaceForge("workspace-1"),
+			queryKey: helmorQueryKeys.forgeCliStatusAll,
 		});
+		expect(invalidateQueries).toHaveBeenCalledWith(
+			expect.objectContaining({ predicate: expect.any(Function) }),
+		);
 		expect(invalidateQueries).toHaveBeenCalledWith({
 			queryKey: helmorQueryKeys.workspaceChangeRequest("workspace-1"),
 		});
 		expect(invalidateQueries).toHaveBeenCalledWith({
 			queryKey: helmorQueryKeys.workspaceForgeActionStatus("workspace-1"),
+		});
+	});
+
+	// Edge case: local CLI snapshot says ready but the remote action probe
+	// returned unauthenticated. The trigger is mounted because remote disagrees;
+	// short-circuiting on the stale prop would toast "connected" while the user
+	// is still locked out. The hook must open the terminal anyway.
+	it("forces the terminal even when prop says ready, if remote disagrees", async () => {
+		const localReadyButRemoteUnauth = gitlabDetection({
+			cli: {
+				status: "ready",
+				provider: "gitlab",
+				host: "gitlab.com",
+				cliName: "glab",
+				login: "liangeqiang",
+				version: "1.55.0",
+				message: "Connected.",
+			},
+		});
+
+		renderWithProviders(
+			<GitSectionHeader
+				commitButtonMode="merge"
+				commitButtonState="idle"
+				changeRequest={changeRequest}
+				changeRequestName="MR"
+				forgeDetection={localReadyButRemoteUnauth}
+				forgeRemoteState="unauthenticated"
+				workspaceId="workspace-1"
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "Connect GitLab" }));
+
+		await waitFor(() => {
+			expect(apiMocks.openForgeCliAuthTerminal).toHaveBeenCalledWith(
+				"gitlab",
+				"gitlab.com",
+			);
 		});
 	});
 

--- a/src/features/navigation/index.tsx
+++ b/src/features/navigation/index.tsx
@@ -721,7 +721,7 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 			<div
 				ref={scrollContainerRef}
 				data-slot="workspace-groups-scroll"
-				className="relative mt-2 min-h-0 flex-1 overflow-y-auto px-2 pr-3"
+				className="scrollbar-stable relative mt-2 min-h-0 flex-1 overflow-y-auto pr-1 pl-2 [scrollbar-width:thin]"
 			>
 				<div
 					style={{

--- a/src/features/navigation/workspace-hover-card.tsx
+++ b/src/features/navigation/workspace-hover-card.tsx
@@ -7,7 +7,6 @@ import {
 	GitBranch,
 	GitPullRequest,
 	type LucideIcon,
-	MessageSquare,
 } from "lucide-react";
 import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { HelmorThinkingIndicator } from "@/components/helmor-thinking-indicator";
@@ -553,7 +552,6 @@ export function WorkspaceHoverCard({
 			: "Created";
 	const createdAt = relativeTime(row.createdAt);
 	const sessionCount = row.sessionCount ?? 0;
-	const messageCount = row.messageCount ?? 0;
 
 	return (
 		<HoverCardRoot
@@ -629,18 +627,12 @@ export function WorkspaceHoverCard({
 						</div>
 					) : null}
 
-					{/* Footer: counts on the left, last-activity timestamp on the right. */}
+					{/* Footer: session count on the left, last-activity timestamp on the right. */}
 					<div className="flex items-center justify-between gap-2 pt-1 text-[11px] text-muted-foreground/80">
 						<div className="flex items-center gap-2.5">
 							{sessionCount > 0 ? (
 								<span className="tabular-nums">
 									{sessionCount} {sessionCount === 1 ? "session" : "sessions"}
-								</span>
-							) : null}
-							{messageCount > 0 ? (
-								<span className="flex items-center gap-1 tabular-nums">
-									<MessageSquare className="size-3" strokeWidth={1.8} />
-									{messageCount}
 								</span>
 							) : null}
 						</div>

--- a/src/features/settings/panels/account.test.tsx
+++ b/src/features/settings/panels/account.test.tsx
@@ -1,4 +1,10 @@
-import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
+import {
+	act,
+	cleanup,
+	fireEvent,
+	screen,
+	waitFor,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GithubIdentitySnapshot, RepositoryCreateOption } from "@/lib/api";
 import { renderWithProviders } from "@/test/render-with-providers";
@@ -8,7 +14,12 @@ const apiMocks = vi.hoisted(() => ({
 	disconnectGithubIdentity: vi.fn(),
 	getForgeCliStatus: vi.fn(),
 	openForgeCliAuthTerminal: vi.fn(),
+	listenGithubIdentityChanged: vi.fn(),
 }));
+
+let capturedIdentityListener:
+	| ((snapshot: GithubIdentitySnapshot) => void)
+	| null = null;
 
 vi.mock("@/lib/api", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("@/lib/api")>();
@@ -18,6 +29,7 @@ vi.mock("@/lib/api", async (importOriginal) => {
 		disconnectGithubIdentity: apiMocks.disconnectGithubIdentity,
 		getForgeCliStatus: apiMocks.getForgeCliStatus,
 		openForgeCliAuthTerminal: apiMocks.openForgeCliAuthTerminal,
+		listenGithubIdentityChanged: apiMocks.listenGithubIdentityChanged,
 	};
 });
 
@@ -71,6 +83,16 @@ describe("AccountPanel", () => {
 		apiMocks.getForgeCliStatus.mockReset();
 		apiMocks.openForgeCliAuthTerminal.mockReset();
 		apiMocks.openForgeCliAuthTerminal.mockResolvedValue(undefined);
+		apiMocks.listenGithubIdentityChanged.mockReset();
+		capturedIdentityListener = null;
+		apiMocks.listenGithubIdentityChanged.mockImplementation(
+			async (callback: (snapshot: GithubIdentitySnapshot) => void) => {
+				capturedIdentityListener = callback;
+				return () => {
+					capturedIdentityListener = null;
+				};
+			},
+		);
 	});
 
 	afterEach(() => {
@@ -235,5 +257,34 @@ describe("AccountPanel", () => {
 			expect(apiMocks.disconnectGithubIdentity).toHaveBeenCalledTimes(1);
 		});
 		expect(onSignedOut).toHaveBeenCalledTimes(1);
+	});
+
+	// Regression coverage for the `useGithubIdentity` integration: when the
+	// backend pushes an identity change (e.g. user signed out from another
+	// surface), Account must reflect it without a manual reload — that's the
+	// whole point of replacing the local `useState` with the shared hook.
+	it("hides the identity row when the backend pushes a disconnect event", async () => {
+		apiMocks.loadGithubIdentitySession.mockResolvedValue(connectedSnapshot);
+		apiMocks.getForgeCliStatus.mockResolvedValue(githubReady);
+
+		renderWithProviders(<AccountPanel repositories={[]} />);
+
+		// First the identity row mounts with the connected snapshot.
+		expect(await screen.findByText("Nathan Lian")).toBeInTheDocument();
+		await waitFor(() => expect(capturedIdentityListener).not.toBeNull());
+
+		// Backend fan-out: another surface signs the user out.
+		act(() => {
+			capturedIdentityListener?.({
+				status: "disconnected",
+			} as GithubIdentitySnapshot);
+		});
+
+		await waitFor(() =>
+			expect(screen.queryByText("Nathan Lian")).not.toBeInTheDocument(),
+		);
+		expect(
+			screen.queryByRole("button", { name: "Sign out" }),
+		).not.toBeInTheDocument();
 	});
 });

--- a/src/features/settings/panels/account.tsx
+++ b/src/features/settings/panels/account.tsx
@@ -1,6 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { CheckCircle2, CircleAlert, Loader2, LogOut } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { type ReactNode, useCallback, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { GithubBrandIcon, GitlabBrandIcon } from "@/components/brand-icon";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -13,18 +13,16 @@ import {
 } from "@/components/ui/tooltip";
 import {
 	disconnectGithubIdentity,
+	type ForgeCliStatus,
 	type ForgeProvider,
 	type GithubIdentitySession,
-	loadGithubIdentitySession,
-	openForgeCliAuthTerminal,
 	type RepositoryCreateOption,
 } from "@/lib/api";
 import { forgeCliStatusQueryOptions } from "@/lib/query-client";
+import { useForgeCliConnect } from "@/lib/use-forge-cli-connect";
+import { useGithubIdentity } from "@/shell/hooks/use-github-identity";
 import { SettingsGroup, SettingsRow } from "../components/settings-row";
 import { gitlabHostsForRepositories } from "./cli-install-gitlab-hosts";
-
-const POLL_INTERVAL_MS = 2000;
-const POLL_TIMEOUT_MS = 120_000;
 
 export function AccountPanel({
 	repositories,
@@ -34,24 +32,24 @@ export function AccountPanel({
 	onSignedOut?: () => void;
 }) {
 	const queryClient = useQueryClient();
-	const [identity, setIdentity] = useState<GithubIdentitySession | null>(null);
+	// Reflects external sign-in / sign-out via backend events.
+	const { githubIdentityState } = useGithubIdentity();
 	const [signingOut, setSigningOut] = useState(false);
 	const gitlabHosts = useMemo(
 		() => gitlabHostsForRepositories(repositories),
 		[repositories],
 	);
 
-	useEffect(() => {
-		void loadGithubIdentitySession().then((snap) => {
-			if (snap.status === "connected") setIdentity(snap.session);
-		});
-	}, []);
+	const identity: GithubIdentitySession | null =
+		githubIdentityState.status === "connected"
+			? githubIdentityState.session
+			: null;
 
 	const handleSignOut = useCallback(async () => {
 		setSigningOut(true);
 		try {
 			await disconnectGithubIdentity();
-			setIdentity(null);
+			// Drop every auth-bound cache; backend pushes the identity update.
 			await queryClient.invalidateQueries();
 			onSignedOut?.();
 		} catch (error) {
@@ -161,70 +159,10 @@ function CliIntegrationRow({
 	title: string;
 	icon: React.ReactNode;
 }) {
-	const queryClient = useQueryClient();
 	const statusQuery = useQuery(forgeCliStatusQueryOptions(provider, host));
 	const status = statusQuery.data ?? null;
-	const [connecting, setConnecting] = useState(false);
-	const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-	const inFlightRef = useRef(false);
+	const { connect, connecting } = useForgeCliConnect(provider, host);
 
-	useEffect(() => {
-		return () => {
-			if (pollTimerRef.current) clearTimeout(pollTimerRef.current);
-		};
-	}, []);
-
-	const pollUntilReady = useCallback(
-		(startedAt = Date.now()) => {
-			if (pollTimerRef.current) clearTimeout(pollTimerRef.current);
-			pollTimerRef.current = setTimeout(async () => {
-				try {
-					const next = await queryClient.fetchQuery(
-						forgeCliStatusQueryOptions(provider, host),
-					);
-					if (next.status === "ready") {
-						toast.success(`${next.cliName} connected`);
-						setConnecting(false);
-						inFlightRef.current = false;
-						return;
-					}
-				} catch (error) {
-					toast.error(
-						error instanceof Error
-							? error.message
-							: "Failed to read CLI status.",
-					);
-				}
-				if (Date.now() - startedAt >= POLL_TIMEOUT_MS) {
-					toast("Finish CLI auth in Terminal, then click Connect again.");
-					setConnecting(false);
-					inFlightRef.current = false;
-					return;
-				}
-				pollUntilReady(startedAt);
-			}, POLL_INTERVAL_MS);
-		},
-		[host, provider, queryClient],
-	);
-
-	const handleConnect = useCallback(async () => {
-		if (connecting || inFlightRef.current) return;
-		inFlightRef.current = true;
-		setConnecting(true);
-		try {
-			await openForgeCliAuthTerminal(provider, host);
-			toast("Complete the login in Terminal.");
-			pollUntilReady();
-		} catch (error) {
-			toast.error(
-				error instanceof Error ? error.message : "Failed to open Terminal.",
-			);
-			setConnecting(false);
-			inFlightRef.current = false;
-		}
-	}, [connecting, host, pollUntilReady, provider]);
-
-	const isReady = status?.status === "ready";
 	const errorMessage =
 		status?.status === "error"
 			? status.message
@@ -232,6 +170,40 @@ function CliIntegrationRow({
 				? statusQuery.error.message
 				: null;
 
+	return (
+		<CliIntegrationRowView
+			title={title}
+			icon={icon}
+			status={status}
+			connecting={connecting}
+			isPending={statusQuery.isPending}
+			errorMessage={errorMessage}
+			onConnect={() => void connect()}
+		/>
+	);
+}
+
+// Pure presentation split out from `CliIntegrationRow`. All right-side variants
+// pin to `h-7` so the row height stays constant across Connect / Ready / Error
+// states (otherwise the row visibly jumps when the query resolves).
+function CliIntegrationRowView({
+	title,
+	icon,
+	status,
+	connecting,
+	isPending,
+	errorMessage,
+	onConnect,
+}: {
+	title: ReactNode;
+	icon: ReactNode;
+	status: ForgeCliStatus | null;
+	connecting: boolean;
+	isPending: boolean;
+	errorMessage: string | null;
+	onConnect: () => void;
+}) {
+	const isReady = status?.status === "ready";
 	return (
 		<SettingsRow
 			title={
@@ -242,7 +214,7 @@ function CliIntegrationRow({
 			}
 		>
 			{isReady && status ? (
-				<div className="flex items-center gap-1.5 text-[12px] text-muted-foreground">
+				<div className="inline-flex h-7 items-center gap-1.5 text-[12px] text-muted-foreground">
 					<CheckCircle2 className="size-3.5 text-green-500" strokeWidth={2} />
 					<span className="truncate">{status.login}</span>
 				</div>
@@ -252,7 +224,7 @@ function CliIntegrationRow({
 						<button
 							type="button"
 							aria-label="CLI status error"
-							className="cursor-default text-destructive"
+							className="inline-flex h-7 cursor-default items-center justify-center text-destructive"
 						>
 							<CircleAlert className="size-4" strokeWidth={2.2} />
 						</button>
@@ -268,8 +240,8 @@ function CliIntegrationRow({
 				<Button
 					variant="outline"
 					size="sm"
-					onClick={() => void handleConnect()}
-					disabled={connecting || statusQuery.isPending}
+					onClick={onConnect}
+					disabled={connecting || isPending}
 				>
 					{connecting ? <Loader2 className="size-3.5 animate-spin" /> : null}
 					Connect

--- a/src/lib/query-client.ts
+++ b/src/lib/query-client.ts
@@ -82,6 +82,9 @@ export const helmorQueryKeys = {
 		["workspaceForge", workspaceId] as const,
 	forgeCliStatus: (provider: ForgeProvider, host: string) =>
 		["forgeCliStatus", provider, host] as const,
+	// Prefix for matching every `forgeCliStatus` cache entry — pass to
+	// `invalidateQueries` when an auth signal arrives from elsewhere.
+	forgeCliStatusAll: ["forgeCliStatus"] as const,
 	workspaceGitActionStatus: (workspaceId: string) =>
 		["workspaceGitActionStatus", workspaceId] as const,
 	workspaceForgeActionStatus: (workspaceId: string) =>

--- a/src/lib/use-forge-cli-connect.test.tsx
+++ b/src/lib/use-forge-cli-connect.test.tsx
@@ -1,0 +1,322 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ForgeCliStatus } from "@/lib/api";
+import { helmorQueryKeys } from "@/lib/query-client";
+import { useForgeCliConnect } from "./use-forge-cli-connect";
+
+const apiMocks = vi.hoisted(() => ({
+	getForgeCliStatus: vi.fn(),
+	openForgeCliAuthTerminal: vi.fn(),
+}));
+
+vi.mock("@/lib/api", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/lib/api")>();
+	return {
+		...actual,
+		getForgeCliStatus: apiMocks.getForgeCliStatus,
+		openForgeCliAuthTerminal: apiMocks.openForgeCliAuthTerminal,
+	};
+});
+
+const toastMocks = vi.hoisted(() => {
+	const toast = vi.fn();
+	const success = vi.fn();
+	const error = vi.fn();
+	const dismiss = vi.fn();
+	Object.assign(toast, { success, error, dismiss });
+	return { toast, success, error, dismiss };
+});
+
+vi.mock("sonner", () => ({
+	toast: toastMocks.toast,
+}));
+
+const readyStatus: ForgeCliStatus = {
+	status: "ready",
+	provider: "github",
+	host: "github.com",
+	cliName: "gh",
+	login: "natllian",
+	version: "2.65.0",
+	message: "GitHub CLI ready as natllian.",
+};
+
+const unauthStatus: ForgeCliStatus = {
+	status: "unauthenticated",
+	provider: "github",
+	host: "github.com",
+	cliName: "gh",
+	version: "2.65.0",
+	message: "Run `gh auth login`.",
+	loginCommand: "gh auth login",
+};
+
+const errorStatus: ForgeCliStatus = {
+	status: "error",
+	provider: "github",
+	host: "github.com",
+	cliName: "gh",
+	version: null,
+	message: "gh CLI not found in PATH.",
+};
+
+function makeWrapper() {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	});
+	const wrapper = ({ children }: { children: ReactNode }) => (
+		<QueryClientProvider client={client}>{children}</QueryClientProvider>
+	);
+	return { client, wrapper };
+}
+
+describe("useForgeCliConnect", () => {
+	beforeEach(() => {
+		apiMocks.getForgeCliStatus.mockReset();
+		apiMocks.openForgeCliAuthTerminal.mockReset();
+		apiMocks.openForgeCliAuthTerminal.mockResolvedValue(undefined);
+		toastMocks.toast.mockClear();
+		toastMocks.success.mockClear();
+		toastMocks.error.mockClear();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("opens the terminal, polls until ready, then fans out invalidations and fires onReady", async () => {
+		vi.useFakeTimers();
+		apiMocks.getForgeCliStatus.mockResolvedValue(readyStatus);
+		const { client, wrapper } = makeWrapper();
+		const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+		const onReady = vi.fn();
+
+		const { result } = renderHook(
+			() => useForgeCliConnect("github", "github.com", { onReady }),
+			{ wrapper },
+		);
+
+		// `await connect()` resolves once the terminal hand-off finishes and
+		// the first poll setTimeout is scheduled.
+		await act(async () => {
+			await result.current.connect();
+		});
+
+		expect(apiMocks.openForgeCliAuthTerminal).toHaveBeenCalledWith(
+			"github",
+			"github.com",
+		);
+		expect(result.current.connecting).toBe(true);
+
+		// First poll tick lands on ready. `runOnlyPendingTimersAsync` fires
+		// the queued 2s timer and drains the inner microtask chain so the
+		// React state update lands inside `act`.
+		await act(async () => {
+			await vi.runOnlyPendingTimersAsync();
+		});
+
+		expect(apiMocks.getForgeCliStatus).toHaveBeenCalledWith(
+			"github",
+			"github.com",
+		);
+		// Hook fans out to BOTH cache layers.
+		expect(invalidateSpy).toHaveBeenCalledWith({
+			queryKey: helmorQueryKeys.forgeCliStatusAll,
+		});
+		expect(invalidateSpy).toHaveBeenCalledWith(
+			expect.objectContaining({ predicate: expect.any(Function) }),
+		);
+		expect(onReady).toHaveBeenCalledWith(readyStatus);
+		expect(toastMocks.success).toHaveBeenCalledWith("gh connected");
+		expect(result.current.connecting).toBe(false);
+	});
+
+	it("short-circuits the terminal hand-off when the standalone cache already says ready", async () => {
+		const { client, wrapper } = makeWrapper();
+		client.setQueryData(
+			helmorQueryKeys.forgeCliStatus("github", "github.com"),
+			readyStatus,
+		);
+		const onReady = vi.fn();
+
+		const { result } = renderHook(
+			() => useForgeCliConnect("github", "github.com", { onReady }),
+			{ wrapper },
+		);
+
+		await act(async () => {
+			await result.current.connect();
+		});
+
+		expect(apiMocks.openForgeCliAuthTerminal).not.toHaveBeenCalled();
+		expect(onReady).toHaveBeenCalledWith(readyStatus);
+		expect(toastMocks.success).toHaveBeenCalledWith("gh connected");
+	});
+
+	it("short-circuits when the caller passes a `hintedStatus` that is already ready", async () => {
+		const { wrapper } = makeWrapper();
+		const onReady = vi.fn();
+
+		const { result } = renderHook(
+			() =>
+				useForgeCliConnect("github", "github.com", {
+					onReady,
+					hintedStatus: readyStatus,
+				}),
+			{ wrapper },
+		);
+
+		await act(async () => {
+			await result.current.connect();
+		});
+
+		expect(apiMocks.openForgeCliAuthTerminal).not.toHaveBeenCalled();
+		expect(onReady).toHaveBeenCalledWith(readyStatus);
+	});
+
+	it("does not short-circuit when the hint is unauthenticated — proceeds with the terminal flow", async () => {
+		vi.useFakeTimers();
+		apiMocks.getForgeCliStatus.mockResolvedValue(unauthStatus);
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook(
+			() =>
+				useForgeCliConnect("github", "github.com", {
+					hintedStatus: unauthStatus,
+				}),
+			{ wrapper },
+		);
+
+		await act(async () => {
+			await result.current.connect();
+		});
+
+		expect(apiMocks.openForgeCliAuthTerminal).toHaveBeenCalledOnce();
+	});
+
+	it("times out after the poll budget, leaving connecting=false and no onReady", async () => {
+		vi.useFakeTimers();
+		apiMocks.getForgeCliStatus.mockResolvedValue(unauthStatus);
+		const { wrapper } = makeWrapper();
+		const onReady = vi.fn();
+
+		const { result } = renderHook(
+			() => useForgeCliConnect("github", "github.com", { onReady }),
+			{ wrapper },
+		);
+
+		await act(async () => {
+			await result.current.connect();
+		});
+
+		// Burn the full 120s budget worth of 2s polls. Each pending timer
+		// fires once and reschedules the next, so we step through them.
+		for (let i = 0; i < 65; i++) {
+			await act(async () => {
+				await vi.runOnlyPendingTimersAsync();
+			});
+			if (!result.current.connecting) break;
+		}
+
+		expect(onReady).not.toHaveBeenCalled();
+		expect(toastMocks.toast).toHaveBeenCalledWith(
+			expect.stringContaining("Finish CLI auth"),
+		);
+		expect(result.current.connecting).toBe(false);
+	});
+
+	it("ignores re-entrant connect() calls while a flow is already in flight", async () => {
+		vi.useFakeTimers();
+		apiMocks.getForgeCliStatus.mockResolvedValue(unauthStatus);
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook(
+			() => useForgeCliConnect("github", "github.com"),
+			{ wrapper },
+		);
+
+		await act(async () => {
+			void result.current.connect();
+			void result.current.connect();
+			void result.current.connect();
+		});
+
+		expect(apiMocks.openForgeCliAuthTerminal).toHaveBeenCalledOnce();
+	});
+
+	it("respects `silent: true` and skips the default ready toast", async () => {
+		vi.useFakeTimers();
+		apiMocks.getForgeCliStatus.mockResolvedValue(readyStatus);
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook(
+			() => useForgeCliConnect("github", "github.com", { silent: true }),
+			{ wrapper },
+		);
+
+		await act(async () => {
+			await result.current.connect();
+		});
+		await act(async () => {
+			await vi.runOnlyPendingTimersAsync();
+		});
+
+		expect(toastMocks.success).not.toHaveBeenCalled();
+	});
+
+	it("surfaces a CLI error status during polling instead of silently waiting out the timeout", async () => {
+		vi.useFakeTimers();
+		apiMocks.getForgeCliStatus.mockResolvedValue(errorStatus);
+		const { wrapper } = makeWrapper();
+		const onReady = vi.fn();
+
+		const { result } = renderHook(
+			() => useForgeCliConnect("github", "github.com", { onReady }),
+			{ wrapper },
+		);
+
+		await act(async () => {
+			await result.current.connect();
+		});
+		await act(async () => {
+			await vi.runOnlyPendingTimersAsync();
+		});
+
+		expect(toastMocks.error).toHaveBeenCalledWith(errorStatus.message);
+		expect(onReady).not.toHaveBeenCalled();
+		expect(result.current.connecting).toBe(false);
+		// One poll call, then we stopped — no second tick.
+		expect(apiMocks.getForgeCliStatus).toHaveBeenCalledTimes(1);
+	});
+
+	it("clears its poll timer on unmount so callbacks don't fire after teardown", async () => {
+		vi.useFakeTimers();
+		apiMocks.getForgeCliStatus.mockResolvedValue(unauthStatus);
+		const { wrapper } = makeWrapper();
+		const onReady = vi.fn();
+
+		const { result, unmount } = renderHook(
+			() => useForgeCliConnect("github", "github.com", { onReady }),
+			{ wrapper },
+		);
+
+		await act(async () => {
+			await result.current.connect();
+		});
+
+		const callsBeforeUnmount = apiMocks.getForgeCliStatus.mock.calls.length;
+		unmount();
+
+		// The poll callback is queued; advance well past one tick. Without
+		// the cleanup the next `getForgeCliStatus` would fire and onReady /
+		// toasts would still trip after the consumer is gone.
+		await vi.advanceTimersByTimeAsync(10_000);
+
+		expect(apiMocks.getForgeCliStatus.mock.calls.length).toBe(
+			callsBeforeUnmount,
+		);
+		expect(onReady).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/use-forge-cli-connect.ts
+++ b/src/lib/use-forge-cli-connect.ts
@@ -1,0 +1,142 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+import {
+	type ForgeCliStatus,
+	type ForgeProvider,
+	openForgeCliAuthTerminal,
+} from "@/lib/api";
+import {
+	forgeCliStatusQueryOptions,
+	helmorQueryKeys,
+} from "@/lib/query-client";
+
+const POLL_INTERVAL_MS = 2000;
+const POLL_TIMEOUT_MS = 120_000;
+
+type ForgeCliReadyStatus = Extract<ForgeCliStatus, { status: "ready" }>;
+
+export type UseForgeCliConnectOptions = {
+	// Fired the first time polling observes `status === "ready"`. Caller can
+	// chain extra invalidation here.
+	onReady?: (status: ForgeCliReadyStatus) => void | Promise<void>;
+	// Skip the default `"<cliName> connected"` toast.
+	silent?: boolean;
+	// If already `ready`, skip the terminal hand-off and fan out directly.
+	hintedStatus?: ForgeCliStatus | null;
+};
+
+// Shared open-terminal + poll-until-ready flow. On ready we invalidate both
+// the `forgeCliStatus` cache and the `workspaceForge` cache that embeds it,
+// so the two layers can't disagree.
+export function useForgeCliConnect(
+	provider: ForgeProvider,
+	host: string,
+	options: UseForgeCliConnectOptions = {},
+) {
+	const queryClient = useQueryClient();
+	const [connecting, setConnecting] = useState(false);
+	const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const inFlightRef = useRef(false);
+	const onReadyRef = useRef(options.onReady);
+	const silentRef = useRef(options.silent ?? false);
+	const hintedStatusRef = useRef(options.hintedStatus ?? null);
+
+	useEffect(() => {
+		onReadyRef.current = options.onReady;
+		silentRef.current = options.silent ?? false;
+		hintedStatusRef.current = options.hintedStatus ?? null;
+	}, [options.hintedStatus, options.onReady, options.silent]);
+
+	useEffect(() => {
+		return () => {
+			if (pollTimerRef.current) clearTimeout(pollTimerRef.current);
+		};
+	}, []);
+
+	const finishReady = useCallback(
+		async (status: ForgeCliReadyStatus) => {
+			void queryClient.invalidateQueries({
+				queryKey: helmorQueryKeys.forgeCliStatusAll,
+			});
+			void queryClient.invalidateQueries({
+				predicate: (q) => q.queryKey[0] === "workspaceForge",
+			});
+			if (!silentRef.current) {
+				toast.success(`${status.cliName} connected`);
+			}
+			await onReadyRef.current?.(status);
+			setConnecting(false);
+			inFlightRef.current = false;
+		},
+		[queryClient],
+	);
+
+	const pollUntilReady = useCallback(
+		(startedAt = Date.now()) => {
+			if (pollTimerRef.current) clearTimeout(pollTimerRef.current);
+			pollTimerRef.current = setTimeout(async () => {
+				try {
+					const next = await queryClient.fetchQuery(
+						forgeCliStatusQueryOptions(provider, host),
+					);
+					if (next.status === "ready") {
+						await finishReady(next);
+						return;
+					}
+					if (next.status === "error") {
+						// Persistent error (CLI not installed, exec failure, etc.).
+						// Sitting silent until the 120s budget burns is the wrong UX —
+						// surface it now so the user knows the terminal won't help.
+						toast.error(next.message);
+						setConnecting(false);
+						inFlightRef.current = false;
+						return;
+					}
+				} catch {
+					// Transient IPC error — keep polling, auth may still be in progress.
+				}
+				if (Date.now() - startedAt >= POLL_TIMEOUT_MS) {
+					toast("Finish CLI auth in Terminal, then click Connect again.");
+					setConnecting(false);
+					inFlightRef.current = false;
+					return;
+				}
+				pollUntilReady(startedAt);
+			}, POLL_INTERVAL_MS);
+		},
+		[finishReady, host, provider, queryClient],
+	);
+
+	const connect = useCallback(async () => {
+		if (connecting || inFlightRef.current) return;
+		inFlightRef.current = true;
+		setConnecting(true);
+		try {
+			// Caller-provided hint or cached `ready` short-circuits the terminal
+			// hand-off — e.g. user already authed via another surface and we just
+			// need to fan out invalidations.
+			const hint = hintedStatusRef.current;
+			const cached =
+				hint ??
+				queryClient.getQueryData<ForgeCliStatus>(
+					helmorQueryKeys.forgeCliStatus(provider, host),
+				);
+			if (cached?.status === "ready") {
+				await finishReady(cached);
+				return;
+			}
+			await openForgeCliAuthTerminal(provider, host);
+			toast("Complete the login in Terminal.");
+			pollUntilReady();
+		} catch (error) {
+			toast.error(
+				error instanceof Error ? error.message : "Failed to open Terminal.",
+			);
+			setConnecting(false);
+			inFlightRef.current = false;
+		}
+	}, [connecting, finishReady, host, pollUntilReady, provider, queryClient]);
+
+	return { connect, connecting };
+}

--- a/src/shell/hooks/use-github-identity.test.tsx
+++ b/src/shell/hooks/use-github-identity.test.tsx
@@ -1,0 +1,94 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GithubIdentitySnapshot } from "@/lib/api";
+import { useGithubIdentity } from "./use-github-identity";
+
+const apiMocks = vi.hoisted(() => ({
+	loadGithubIdentitySession: vi.fn(),
+	listenGithubIdentityChanged: vi.fn(),
+	disconnectGithubIdentity: vi.fn(),
+	startGithubIdentityConnect: vi.fn(),
+	cancelGithubIdentityConnect: vi.fn(),
+}));
+
+vi.mock("@/lib/api", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/lib/api")>();
+	return {
+		...actual,
+		loadGithubIdentitySession: apiMocks.loadGithubIdentitySession,
+		listenGithubIdentityChanged: apiMocks.listenGithubIdentityChanged,
+		disconnectGithubIdentity: apiMocks.disconnectGithubIdentity,
+		startGithubIdentityConnect: apiMocks.startGithubIdentityConnect,
+		cancelGithubIdentityConnect: apiMocks.cancelGithubIdentityConnect,
+	};
+});
+
+const toastMocks = vi.hoisted(() => {
+	const toast = vi.fn();
+	const error = vi.fn();
+	const success = vi.fn();
+	const dismiss = vi.fn();
+	Object.assign(toast, { error, success, dismiss });
+	return { toast, error, success, dismiss };
+});
+
+vi.mock("sonner", () => ({
+	toast: toastMocks.toast,
+}));
+
+describe("useGithubIdentity — pushWorkspaceToast fallback", () => {
+	beforeEach(() => {
+		toastMocks.toast.mockClear();
+		toastMocks.error.mockClear();
+		toastMocks.success.mockClear();
+		apiMocks.loadGithubIdentitySession.mockResolvedValue({
+			status: "disconnected",
+		} as GithubIdentitySnapshot);
+		apiMocks.listenGithubIdentityChanged.mockResolvedValue(() => {});
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("falls back to sonner toast when no pushWorkspaceToast is provided", async () => {
+		// Force the clipboard branch: report no clipboard so the hook hits
+		// the failure path that emits a toast. With no pushWorkspaceToast
+		// passed, the sonner fallback should fire.
+		vi.stubGlobal("navigator", {});
+
+		const { result } = renderHook(() => useGithubIdentity());
+
+		await waitFor(() => {
+			expect(apiMocks.loadGithubIdentitySession).toHaveBeenCalled();
+		});
+
+		await act(async () => {
+			const ok = await result.current.handleCopyGithubDeviceCode("ABCD-1234");
+			expect(ok).toBe(false);
+		});
+
+		// Sonner's `toast()` is the default channel for the fallback.
+		expect(toastMocks.toast).toHaveBeenCalled();
+		const [first] = toastMocks.toast.mock.calls[0] ?? [];
+		expect(typeof first).toBe("string");
+	});
+
+	it("routes through the explicit pushWorkspaceToast when provided (no sonner fallback)", async () => {
+		vi.stubGlobal("navigator", {});
+		const pushWorkspaceToast = vi.fn();
+
+		const { result } = renderHook(() => useGithubIdentity(pushWorkspaceToast));
+
+		await waitFor(() => {
+			expect(apiMocks.loadGithubIdentitySession).toHaveBeenCalled();
+		});
+
+		await act(async () => {
+			await result.current.handleCopyGithubDeviceCode("ABCD-1234");
+		});
+
+		expect(pushWorkspaceToast).toHaveBeenCalled();
+		expect(toastMocks.toast).not.toHaveBeenCalled();
+	});
+});

--- a/src/shell/hooks/use-github-identity.ts
+++ b/src/shell/hooks/use-github-identity.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
 import {
 	cancelGithubIdentityConnect,
 	disconnectGithubIdentity,
@@ -16,7 +17,15 @@ type WorkspaceToastFn = (
 	variant?: "default" | "destructive",
 ) => void;
 
-export function useGithubIdentity(pushWorkspaceToast: WorkspaceToastFn) {
+// Sonner fallback for callers without a workspace-specific toast surface
+// (e.g. Settings → Account, which doesn't sit inside the WorkspaceToastProvider).
+const sonnerFallbackToast: WorkspaceToastFn = (description, title, variant) => {
+	const fn = variant === "destructive" ? toast.error : toast;
+	fn(title ?? description, title ? { description } : undefined);
+};
+
+export function useGithubIdentity(pushWorkspaceToast?: WorkspaceToastFn) {
+	const pushToast = pushWorkspaceToast ?? sonnerFallbackToast;
 	const [githubIdentityState, setGithubIdentityState] =
 		useState<GithubIdentityState>(getInitialGithubIdentityState);
 
@@ -69,7 +78,7 @@ export function useGithubIdentity(pushWorkspaceToast: WorkspaceToastFn) {
 	const handleCopyGithubDeviceCode = useCallback(
 		async (userCode: string) => {
 			if (typeof navigator === "undefined" || !navigator.clipboard?.writeText) {
-				pushWorkspaceToast(
+				pushToast(
 					"Unable to copy the one-time code on this device.",
 					"Copy failed",
 				);
@@ -80,11 +89,11 @@ export function useGithubIdentity(pushWorkspaceToast: WorkspaceToastFn) {
 				await navigator.clipboard.writeText(userCode);
 				return true;
 			} catch {
-				pushWorkspaceToast("Unable to copy the one-time code.", "Copy failed");
+				pushToast("Unable to copy the one-time code.", "Copy failed");
 				return false;
 			}
 		},
-		[pushWorkspaceToast],
+		[pushToast],
 	);
 
 	const handleCancelGithubIdentityConnect = useCallback(() => {

--- a/src/shell/hooks/use-ui-sync-bridge.test.tsx
+++ b/src/shell/hooks/use-ui-sync-bridge.test.tsx
@@ -131,6 +131,12 @@ describe("useUiSyncBridge", () => {
 				queryKey: helmorQueryKeys.workspaceForge("workspace-1"),
 			});
 		});
+		// Settings → Account stores CLI auth under a separate cache key; the
+		// bridge fans the same backend signal out to it so a stale "ready"
+		// in Account can't survive an auth flip detected elsewhere.
+		expect(invalidateQueries).toHaveBeenCalledWith({
+			queryKey: helmorQueryKeys.forgeCliStatusAll,
+		});
 	});
 
 	it("invalidates baseline + rich on contextUsageChanged", async () => {

--- a/src/shell/hooks/use-ui-sync-bridge.ts
+++ b/src/shell/hooks/use-ui-sync-bridge.ts
@@ -94,6 +94,13 @@ function handleUiMutation(
 			void queryClient.invalidateQueries({
 				queryKey: helmorQueryKeys.workspaceForge(event.workspaceId),
 			});
+			// CLI auth status lives in a separate cache (Settings → Account).
+			// Backend already debounces/edge-detects this event, so the bridge
+			// is the right place to fan out instead of redoing the check in
+			// individual feature components.
+			void queryClient.invalidateQueries({
+				queryKey: helmorQueryKeys.forgeCliStatusAll,
+			});
 			return;
 		case "workspaceChangeRequestChanged":
 			void queryClient.invalidateQueries({


### PR DESCRIPTION
## What

- **Edge-detect the workspace forge auth event** in the Rust backend (`forge_commands::ForgeAuthEdgeStore`) so the ~60s `get_workspace_forge_action_status` poll only publishes `WorkspaceForgeChanged` on the *transition* into `Unauthenticated`, not on every tick. Flipping back to any other state clears the marker, so a future re-auth-loss republishes once.
- **Fan that signal out via the UI sync bridge** to `forgeCliStatusAll` so Settings → Account's CLI cache (a different query key from `workspaceForge`) can no longer hold a stale `ready` after the remote disagrees.
- **Extract the shared connect flow** into a new `useForgeCliConnect` hook (open terminal → poll until ready → invalidate both cache layers → optional `onReady`). Both the inspector's `ForgeCliTrigger` and the Account panel's `CliIntegrationRow` now call it instead of each maintaining their own polling state.
- **Account panel** now sources GitHub identity from the shared `useGithubIdentity` hook so external sign-out events update the row immediately. The hook gained a sonner fallback for callers (like Account) that aren't inside a workspace toast provider.
- Drive-by: simplify the editor close button (drop the redundant tooltip wrapper around `InlineShortcutDisplay`); add `logo.svg` / `public/logo.svg` to the repo-icon candidate list.

## Why

- The action-status poll was republishing `Unauthenticated` every tick, which the bridge was turning into a cache-wide invalidation storm. Combined with frontend edge-detect logic in `actions.tsx` doing essentially the same job (badly — it ran inside the React render cycle), the Account row would visibly jitter and the inspector would re-fetch the same probe over and over.
- Two near-identical 80-line copies of the open-terminal-and-poll flow had drifted apart (different timeouts, different invalidation sets, the inspector silently ignored CLI `error` status). Consolidating them fixes the inspector edge case where the prop said `ready` but the remote disagreed (used to toast a misleading \"connected\"), and surfaces persistent CLI errors immediately instead of waiting out the 120s budget.

## Test notes

- `cargo test` covers the new `ForgeAuthEdgeStore` edge-detection (first tick publishes, repeats no-op, flip clears marker, workspaces are independent).
- `bun run test:frontend`:
  - `src/lib/use-forge-cli-connect.test.tsx` — full hook coverage (poll → ready, hint short-circuit, hint=unauth still opens terminal, timeout, re-entrancy guard, silent mode, error surfacing, unmount cleanup).
  - `src/shell/hooks/use-github-identity.test.tsx` — sonner-fallback path when no workspace toast is wired.
  - `src/features/settings/panels/account.test.tsx` — backend identity push event hides the row.
  - `src/features/inspector/sections/git-section-header.test.tsx` — updated to assert the new bridge-driven invalidation set + the \"local ready, remote disagrees → still open terminal\" path.
  - `src/shell/hooks/use-ui-sync-bridge.test.tsx` — bridge fans `workspaceForgeChanged` out to `forgeCliStatusAll`.

## Manual verification

- [ ] Sign out from Settings → Account on one window, confirm the row collapses without a manual reload.
- [ ] Run `gh auth logout`, watch the inspector flip to Connect within ~60s without the action-status poll spamming logs.
- [ ] Click Connect from the inspector when local CLI status is stale; the terminal opens instead of toasting \"connected\".