### PR TITLE
feat(shortcuts): add optional global hotkey to summon Helmor

### DIFF
--- a/.changeset/global-hotkey-summon.md
+++ b/.changeset/global-hotkey-summon.md
@@ -1,0 +1,7 @@
+---
+"helmor": patch
+---
+
+Improve shortcut behavior:
+- Add an optional global hotkey that can show Helmor from anywhere and hide it when focused.
+- Let the Run / Stop script shortcut work app-wide.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1527,6 +1527,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1662,6 +1672,24 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "global-hotkey"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9247516746aa8e53411a0db9b62b0e24efbcf6a76e0ba73e5a91b512ddabed7"
+dependencies = [
+ "crossbeam-channel",
+ "keyboard-types",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.18",
+ "windows-sys 0.59.0",
+ "x11rb",
+ "xkeysym",
+]
 
 [[package]]
 name = "globset"
@@ -1818,6 +1846,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
+ "tauri-plugin-global-shortcut",
  "tauri-plugin-mcp-bridge",
  "tauri-plugin-notification",
  "tauri-plugin-opener",
@@ -5112,6 +5141,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-global-shortcut"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "424af23c7e88d05e4a1a6fc2c7be077912f8c76bd7900fd50aa2b7cbf5a2c405"
+dependencies = [
+ "global-hotkey",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-mcp-bridge"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6918,6 +6962,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6926,6 +6987,12 @@ dependencies = [
  "libc",
  "rustix",
 ]
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yoke"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,6 +35,7 @@ serde_json = "1"
 tauri = { version = "2", features = ["protocol-asset", "test", "devtools"] }
 tauri-plugin-deep-link = "2"
 tauri-plugin-dialog = "2"
+tauri-plugin-global-shortcut = "2"
 tauri-plugin-mcp-bridge = "0.11.0"
 tauri-plugin-notification = "2"
 tauri-plugin-opener = "2"

--- a/src-tauri/src/global_hotkey.rs
+++ b/src-tauri/src/global_hotkey.rs
@@ -1,0 +1,190 @@
+use std::{str::FromStr, sync::Mutex};
+
+use anyhow::{anyhow, Context, Result};
+use serde_json::Value;
+use tauri::{AppHandle, Manager};
+use tauri_plugin_global_shortcut::{GlobalShortcutExt, Shortcut, ShortcutEvent, ShortcutState};
+
+use crate::error::CommandError;
+
+const SHORTCUTS_SETTING_KEY: &str = "app.shortcuts";
+const GLOBAL_HOTKEY_ID: &str = "global.hotkey";
+const MAIN_WINDOW_LABEL: &str = "main";
+
+// Rust owns plugin registration, so no frontend plugin capability is needed.
+// Startup reads only stored overrides; keep the TS default null unless this
+// module learns the registry default too.
+#[derive(Default)]
+pub struct GlobalHotkeyState {
+    current: Mutex<Option<String>>,
+}
+
+pub fn sync_from_settings(app: &AppHandle) -> Result<()> {
+    let raw = crate::settings::load_setting_value(SHORTCUTS_SETTING_KEY)?;
+    let hotkey = raw.as_deref().and_then(global_hotkey_from_shortcuts_json);
+    sync_global_hotkey_inner(app, hotkey)
+}
+
+#[tauri::command]
+pub fn sync_global_hotkey(app: AppHandle, hotkey: Option<String>) -> Result<(), CommandError> {
+    Ok(sync_global_hotkey_inner(&app, hotkey)?)
+}
+
+fn sync_global_hotkey_inner(app: &AppHandle, hotkey: Option<String>) -> Result<()> {
+    let normalized = hotkey
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(to_tauri_accelerator)
+        .transpose()?;
+
+    let state = app.state::<GlobalHotkeyState>();
+    let mut current = state.current.lock().expect("global hotkey state poisoned");
+    if *current == normalized {
+        return Ok(());
+    }
+
+    let previous = current.clone();
+    if let Some(previous) = previous.as_deref() {
+        app.global_shortcut()
+            .unregister(previous)
+            .with_context(|| format!("Failed to unregister global hotkey {previous}"))?;
+    }
+
+    if let Some(next) = normalized.as_deref() {
+        if let Err(error) = app
+            .global_shortcut()
+            .on_shortcut(next, handle_global_hotkey)
+        {
+            if let Some(previous) = previous.as_deref() {
+                if let Err(restore_error) = app
+                    .global_shortcut()
+                    .on_shortcut(previous, handle_global_hotkey)
+                {
+                    tracing::warn!(
+                        error = %restore_error,
+                        hotkey = %previous,
+                        "Failed to restore previous global hotkey",
+                    );
+                    *current = None;
+                }
+            }
+            return Err(error).with_context(|| format!("Failed to register global hotkey {next}"));
+        }
+    }
+
+    *current = normalized;
+    Ok(())
+}
+
+fn handle_global_hotkey(
+    app: &AppHandle,
+    _shortcut: &tauri_plugin_global_shortcut::Shortcut,
+    event: ShortcutEvent,
+) {
+    if event.state != ShortcutState::Pressed {
+        return;
+    }
+    if let Err(error) = toggle_main_window(app) {
+        tracing::warn!(error = %format!("{error:#}"), "Failed to toggle main window from global hotkey");
+    }
+}
+
+fn toggle_main_window(app: &AppHandle) -> Result<()> {
+    let window = app
+        .get_webview_window(MAIN_WINDOW_LABEL)
+        .ok_or_else(|| anyhow!("Main window is not available"))?;
+
+    if window.is_visible()? && window.is_focused()? {
+        window.hide()?;
+        return Ok(());
+    }
+
+    window.show()?;
+    window.unminimize()?;
+    window.set_focus()?;
+    Ok(())
+}
+
+fn global_hotkey_from_shortcuts_json(raw: &str) -> Option<String> {
+    let value = serde_json::from_str::<Value>(raw).ok()?;
+    value
+        .get(GLOBAL_HOTKEY_ID)
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+}
+
+fn to_tauri_accelerator(hotkey: &str) -> Result<String> {
+    let parts: Vec<&str> = hotkey
+        .split('+')
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .collect();
+    if parts.is_empty() {
+        return Err(anyhow!("Global hotkey is empty"));
+    }
+
+    let mut converted = Vec::with_capacity(parts.len());
+    for part in parts {
+        converted.push(match part {
+            "Mod" => "CommandOrControl".to_owned(),
+            "Control" => "Ctrl".to_owned(),
+            "ArrowUp" => "Up".to_owned(),
+            "ArrowDown" => "Down".to_owned(),
+            "ArrowLeft" => "Left".to_owned(),
+            "ArrowRight" => "Right".to_owned(),
+            "Escape" => "Esc".to_owned(),
+            " " | "Space" => "Space".to_owned(),
+            key => key.to_owned(),
+        });
+    }
+
+    let accelerator = converted.join("+");
+    Shortcut::from_str(&accelerator).with_context(|| format!("Invalid global hotkey {hotkey}"))?;
+    Ok(accelerator)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_global_hotkey_from_shortcuts_json() {
+        assert_eq!(
+            global_hotkey_from_shortcuts_json(r#"{"global.hotkey":"Mod+Shift+Space"}"#),
+            Some("Mod+Shift+Space".to_owned()),
+        );
+        assert_eq!(
+            global_hotkey_from_shortcuts_json(r#"{"global.hotkey":null}"#),
+            None,
+        );
+    }
+
+    #[test]
+    fn converts_frontend_hotkey_to_tauri_accelerator() {
+        assert_eq!(
+            to_tauri_accelerator("Mod+Shift+Space").unwrap(),
+            "CommandOrControl+Shift+Space",
+        );
+        assert_eq!(
+            to_tauri_accelerator("Control+Alt+ArrowUp").unwrap(),
+            "Ctrl+Alt+Up",
+        );
+    }
+
+    #[test]
+    fn validates_special_key_accelerators() {
+        assert_eq!(to_tauri_accelerator("Mod+=").unwrap(), "CommandOrControl+=");
+        assert_eq!(to_tauri_accelerator("Mod+-").unwrap(), "CommandOrControl+-");
+        assert_eq!(to_tauri_accelerator("Mod+,").unwrap(), "CommandOrControl+,");
+        assert_eq!(to_tauri_accelerator("Mod+/").unwrap(), "CommandOrControl+/");
+    }
+
+    #[test]
+    fn rejects_empty_or_modifier_only_hotkeys() {
+        assert!(to_tauri_accelerator("").is_err());
+        assert!(to_tauri_accelerator("   ").is_err());
+        assert!(to_tauri_accelerator("Mod+").is_err());
+        assert!(to_tauri_accelerator("Mod+Shift").is_err());
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ pub mod data_dir;
 pub mod error;
 pub mod forge;
 pub mod git;
+pub mod global_hotkey;
 pub mod image_store;
 mod import;
 pub mod logging;
@@ -53,6 +54,7 @@ pub fn run() {
     let builder = tauri::Builder::default()
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_global_shortcut::Builder::new().build())
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_updater::Builder::new().build());
@@ -69,6 +71,7 @@ pub fn run() {
         .manage(git_watcher::GitWatcherManager::new())
         .manage(workspace::scripts::ScriptProcessManager::new())
         .manage(ui_sync::UiSyncManager::new())
+        .manage(global_hotkey::GlobalHotkeyState::default())
         .manage(commands::forge_commands::ForgeAuthEdgeStore::default())
         .setup(|app| {
             // Ensure data directory structure exists
@@ -137,6 +140,12 @@ pub fn run() {
             updater::spawn_interval_worker(app.handle().clone());
 
             agents::prewarm_slash_command_cache(app.handle());
+            if let Err(error) = global_hotkey::sync_from_settings(app.handle()) {
+                tracing::warn!(
+                    error = %format!("{error:#}"),
+                    "Failed to register startup global hotkey",
+                );
+            }
 
             // Start git filesystem watchers for all ready workspaces.
             let watcher_handle = app.handle().clone();
@@ -303,6 +312,7 @@ pub fn run() {
             commands::settings_commands::save_auto_close_action_kinds,
             commands::settings_commands::load_auto_close_opt_in_asked,
             commands::settings_commands::save_auto_close_opt_in_asked,
+            global_hotkey::sync_global_hotkey,
             ui_sync::subscribe_ui_mutations,
             commands::updater_commands::get_app_update_status,
             commands::updater_commands::check_for_app_update,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,6 +47,7 @@ import {
 	type ShortcutHandler,
 	useAppShortcuts,
 } from "@/features/shortcuts/use-app-shortcuts";
+import { useGlobalHotkeySync } from "@/features/shortcuts/use-global-hotkey-sync";
 import { AppUpdateButton } from "@/features/updater/app-update-button";
 import { useAppUpdater } from "@/features/updater/use-app-updater";
 import { EditorIcon } from "@/shell/editor-icon";
@@ -111,6 +112,7 @@ import {
 	loadSettings,
 	resolveTheme,
 	SettingsContext,
+	type ShortcutOverrides,
 	saveSettings,
 	THEME_STORAGE_KEY,
 	type ThemeMode,
@@ -594,7 +596,11 @@ function AppShell({
 		workspaceReselectTick,
 	]);
 
-	const { settings: appSettings, updateSettings } = useSettings();
+	const {
+		settings: appSettings,
+		isLoaded: areSettingsLoaded,
+		updateSettings,
+	} = useSettings();
 	const appUpdateStatus = useAppUpdater();
 	useDockUnreadBadge();
 	useEnsureDefaultModel();
@@ -628,6 +634,15 @@ function AppShell({
 		appSettings.shortcuts,
 		"sidebar.right.toggle",
 	);
+	const handleUpdateGlobalHotkeyShortcuts = useCallback(
+		(shortcuts: ShortcutOverrides) => updateSettings({ shortcuts }),
+		[updateSettings],
+	);
+	useGlobalHotkeySync({
+		isLoaded: areSettingsLoaded,
+		shortcuts: appSettings.shortcuts,
+		updateShortcuts: handleUpdateGlobalHotkeyShortcuts,
+	});
 	const handleOpenPreferredEditor = useCallback(() => {
 		if (!selectedWorkspaceId || !preferredEditor) return;
 		void openWorkspaceInEditor(selectedWorkspaceId, preferredEditor.id).catch(

--- a/src/features/shortcuts/registry.test.ts
+++ b/src/features/shortcuts/registry.test.ts
@@ -16,6 +16,7 @@ describe("shortcut registry", () => {
 
 	it("resolves defaults, overrides, and disabled shortcuts", () => {
 		expect(getShortcut({}, "workspace.previous")).toBe("Mod+Alt+ArrowUp");
+		expect(getShortcut({}, "global.hotkey")).toBeNull();
 		expect(
 			getShortcut({ "workspace.previous": "Mod+A" }, "workspace.previous"),
 		).toBe("Mod+A");

--- a/src/features/shortcuts/registry.ts
+++ b/src/features/shortcuts/registry.ts
@@ -98,10 +98,8 @@ export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
 		id: "script.run",
 		title: "Run / stop script",
 		group: "Actions",
-		// Excludes "terminal" so Mod+R stays free for shell readline
-		// (reverse-search). Anywhere else — chat, editor, sidebars — fires.
 		defaultHotkey: "Mod+R",
-		scopes: ["chat", "editor"],
+		scopes: ["app"],
 		editable: true,
 	},
 	{
@@ -157,6 +155,15 @@ export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
 		title: "Open settings",
 		group: "System",
 		defaultHotkey: "Mod+,",
+		scopes: ["app"],
+		editable: true,
+	},
+	{
+		id: "global.hotkey",
+		title: "Global hotkey",
+		description: "Show/hide Helmor from anywhere.",
+		group: "System",
+		defaultHotkey: null,
 		scopes: ["app"],
 		editable: true,
 	},

--- a/src/features/shortcuts/settings-panel.test.tsx
+++ b/src/features/shortcuts/settings-panel.test.tsx
@@ -1,0 +1,26 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ShortcutsSettingsPanel } from "./settings-panel";
+
+describe("ShortcutsSettingsPanel", () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	it("keeps the global hotkey pinned when search does not match it", async () => {
+		const user = userEvent.setup();
+		render(<ShortcutsSettingsPanel overrides={{}} onChange={vi.fn()} />);
+
+		expect(screen.getByText("Pinned")).toBeInTheDocument();
+		expect(screen.getByText("Global hotkey")).toBeInTheDocument();
+
+		await user.type(
+			screen.getByPlaceholderText("Search shortcuts"),
+			"no match",
+		);
+
+		expect(screen.getByText("Global hotkey")).toBeInTheDocument();
+		expect(screen.queryByText("Create PR")).not.toBeInTheDocument();
+	});
+});

--- a/src/features/shortcuts/settings-panel.tsx
+++ b/src/features/shortcuts/settings-panel.tsx
@@ -38,6 +38,8 @@ const GROUPS: ShortcutGroup[] = [
 	"Composer",
 	"Terminal",
 ];
+const PINNED_SHORTCUT_IDS: ShortcutId[] = ["global.hotkey"];
+const PINNED_SHORTCUT_ID_SET = new Set<ShortcutId>(PINNED_SHORTCUT_IDS);
 
 const MODIFIER_KEYS = new Set(["Alt", "Control", "Meta", "Shift"]);
 const FUNCTION_KEYS = new Set([
@@ -84,12 +86,46 @@ export function ShortcutsSettingsPanel({
 			}),
 		[normalizedQuery, overrides],
 	);
+	const pinnedDefinitions = useMemo(
+		() =>
+			SHORTCUT_DEFINITIONS.filter((definition) =>
+				PINNED_SHORTCUT_ID_SET.has(definition.id),
+			),
+		[],
+	);
+	const regularDefinitions = useMemo(
+		() =>
+			filteredDefinitions.filter(
+				(definition) => !PINNED_SHORTCUT_ID_SET.has(definition.id),
+			),
+		[filteredDefinitions],
+	);
 	const triggerConflictShake = (id: ShortcutId) => {
 		setShakeId(id);
 		window.setTimeout(() => {
 			setShakeId((current) => (current === id ? null : current));
 		}, 260);
 	};
+	const renderShortcutRow = (
+		definition: ShortcutDefinition,
+		isLastInGroup: boolean,
+	) => (
+		<ShortcutRow
+			key={definition.id}
+			definition={definition}
+			hotkey={getShortcut(overrides, definition.id)}
+			conflicts={conflicts.conflictById[definition.id] ?? []}
+			isRecording={recordingId === definition.id}
+			shake={shakeId === definition.id}
+			overrides={overrides}
+			onChange={onChange}
+			onConflictRecorded={() => triggerConflictShake(definition.id)}
+			onRecordingChange={(recording) =>
+				setRecordingId(recording ? definition.id : null)
+			}
+			isLastInGroup={isLastInGroup}
+		/>
+	);
 
 	return (
 		<TooltipProvider delayDuration={150}>
@@ -108,8 +144,17 @@ export function ShortcutsSettingsPanel({
 				</div>
 			</div>
 
+			<section className="pb-1">
+				<div className="pb-1 text-[12px] font-medium tracking-normal text-muted-foreground">
+					Pinned
+				</div>
+				{pinnedDefinitions.map((definition, index) =>
+					renderShortcutRow(definition, index === pinnedDefinitions.length - 1),
+				)}
+			</section>
+
 			{GROUPS.map((group) => {
-				const definitions = filteredDefinitions.filter(
+				const definitions = regularDefinitions.filter(
 					(definition) => definition.group === group,
 				);
 				if (definitions.length === 0) return null;
@@ -119,23 +164,9 @@ export function ShortcutsSettingsPanel({
 						<div className="pb-1 text-[12px] font-medium tracking-normal text-muted-foreground">
 							{group}
 						</div>
-						{definitions.map((definition, index) => (
-							<ShortcutRow
-								key={definition.id}
-								definition={definition}
-								hotkey={getShortcut(overrides, definition.id)}
-								conflicts={conflicts.conflictById[definition.id] ?? []}
-								isRecording={recordingId === definition.id}
-								shake={shakeId === definition.id}
-								overrides={overrides}
-								onChange={onChange}
-								onConflictRecorded={() => triggerConflictShake(definition.id)}
-								onRecordingChange={(recording) =>
-									setRecordingId(recording ? definition.id : null)
-								}
-								isLastInGroup={index === definitions.length - 1}
-							/>
-						))}
+						{definitions.map((definition, index) =>
+							renderShortcutRow(definition, index === definitions.length - 1),
+						)}
 					</section>
 				);
 			})}

--- a/src/features/shortcuts/types.ts
+++ b/src/features/shortcuts/types.ts
@@ -19,6 +19,7 @@ export type ShortcutId =
 	| "zoom.in"
 	| "zoom.out"
 	| "zoom.reset"
+	| "global.hotkey"
 	| "action.createPr"
 	| "action.commitAndPush"
 	| "action.pullLatest"

--- a/src/features/shortcuts/use-global-hotkey-sync.test.tsx
+++ b/src/features/shortcuts/use-global-hotkey-sync.test.tsx
@@ -1,0 +1,70 @@
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ShortcutOverrides } from "@/lib/settings";
+
+const apiMocks = vi.hoisted(() => ({
+	syncGlobalHotkey: vi.fn(),
+}));
+
+const toastMocks = vi.hoisted(() => ({
+	error: vi.fn(),
+}));
+
+vi.mock("@/lib/api", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/lib/api")>();
+	return {
+		...actual,
+		syncGlobalHotkey: apiMocks.syncGlobalHotkey,
+	};
+});
+
+vi.mock("sonner", () => ({
+	toast: toastMocks,
+}));
+
+import { useGlobalHotkeySync } from "./use-global-hotkey-sync";
+
+function Harness({
+	shortcuts,
+	updateShortcuts,
+}: {
+	shortcuts: ShortcutOverrides;
+	updateShortcuts: (shortcuts: ShortcutOverrides) => void;
+}) {
+	useGlobalHotkeySync({
+		isLoaded: true,
+		shortcuts,
+		updateShortcuts,
+	});
+	return null;
+}
+
+describe("useGlobalHotkeySync", () => {
+	beforeEach(() => {
+		apiMocks.syncGlobalHotkey.mockReset();
+		toastMocks.error.mockReset();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it("clears a persisted global hotkey when registration fails", async () => {
+		apiMocks.syncGlobalHotkey.mockRejectedValue(
+			new Error("Hotkey unavailable"),
+		);
+		const updateShortcuts = vi.fn();
+
+		render(
+			<Harness
+				shortcuts={{ "global.hotkey": "Mod+Shift+Space" }}
+				updateShortcuts={updateShortcuts}
+			/>,
+		);
+
+		await waitFor(() => {
+			expect(updateShortcuts).toHaveBeenCalledWith({});
+		});
+		expect(toastMocks.error).toHaveBeenCalledWith("Hotkey unavailable");
+	});
+});

--- a/src/features/shortcuts/use-global-hotkey-sync.ts
+++ b/src/features/shortcuts/use-global-hotkey-sync.ts
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from "react";
+import { toast } from "sonner";
+import { syncGlobalHotkey } from "@/lib/api";
+import type { ShortcutOverrides } from "@/lib/settings";
+import { getShortcut, updateShortcutOverride } from "./registry";
+
+type GlobalHotkeySyncOptions = {
+	isLoaded: boolean;
+	shortcuts: ShortcutOverrides;
+	updateShortcuts: (shortcuts: ShortcutOverrides) => void;
+};
+
+export function useGlobalHotkeySync({
+	isLoaded,
+	shortcuts,
+	updateShortcuts,
+}: GlobalHotkeySyncOptions) {
+	const globalHotkey = getShortcut(shortcuts, "global.hotkey");
+	const lastFailureRef = useRef<string | null>(null);
+
+	useEffect(() => {
+		if (!isLoaded) return;
+
+		void syncGlobalHotkey(globalHotkey)
+			.then(() => {
+				lastFailureRef.current = null;
+			})
+			.catch((error) => {
+				const key = globalHotkey ?? "<disabled>";
+				if (lastFailureRef.current !== key) {
+					lastFailureRef.current = key;
+					toast.error(
+						error instanceof Error
+							? error.message
+							: "Failed to register global hotkey",
+					);
+				}
+
+				if (globalHotkey) {
+					const nextShortcuts = updateShortcutOverride(
+						shortcuts,
+						"global.hotkey",
+						null,
+					);
+					updateShortcuts(nextShortcuts as ShortcutOverrides);
+				}
+			});
+	}, [globalHotkey, isLoaded, shortcuts, updateShortcuts]);
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -753,6 +753,14 @@ export async function installDownloadedAppUpdate(): Promise<AppUpdateStatus> {
 	return invoke<AppUpdateStatus>("install_downloaded_app_update");
 }
 
+export async function syncGlobalHotkey(hotkey: string | null): Promise<void> {
+	try {
+		await invoke<void>("sync_global_hotkey", { hotkey });
+	} catch (error) {
+		throw new Error(describeInvokeError(error, "Unable to set global hotkey."));
+	}
+}
+
 export async function listenAppUpdateStatus(
 	callback: (payload: AppUpdateStatus) => void,
 ): Promise<UnlistenFn> {


### PR DESCRIPTION
## Summary
- Add a configurable global hotkey (`global.hotkey`) that shows/hides Helmor from anywhere — registered via `tauri-plugin-global-shortcut` and pinned at the top of the Shortcuts settings panel.
- Sync the hotkey on startup from stored settings, and live-sync as the user edits it via a new `sync_global_hotkey` Tauri command + `useGlobalHotkeySync` hook (auto-clears the binding and toasts on registration failures).
- Broaden `script.run` (Mod+R) to the `app` scope so it works from anywhere, not just chat/editor.

## Why
Users want to bring Helmor to the foreground without alt-tabbing or clicking the dock icon. A user-configurable global shortcut is the standard pattern for desktop assistants, and pinning it in the settings UI signals it as a top-level feature rather than burying it under a group.

## Notes
- The frontend hotkey string (e.g. `Mod+Shift+Space`) is converted to Tauri's accelerator format (`CommandOrControl+Shift+Space`) before registration; common keys (`Mod`, `Control`, arrows, `Escape`, `Space`) are normalized.
- If registration fails (e.g. conflict with another app), the binding is cleared and a toast surfaces the error so settings stay in sync with reality.
- New tests cover registry defaults, settings panel pinning, the sync hook, and Rust accelerator conversion / JSON extraction.

## Test plan
- [ ] `bun run test` (frontend + sidecar + rust)
- [ ] `bun run lint`
- [ ] Manual: set a global hotkey in settings, verify it summons Helmor when minimized and hides it when focused
- [ ] Manual: try registering a conflicting hotkey and confirm the toast + auto-clear behavior
- [ ] Manual: relaunch the app and confirm the previously-set hotkey re-registers on startup