### PR TITLE
feat(onboarding): detect Conductor and route to migration when available

### DIFF
--- a/.changeset/quiet-maps-join.md
+++ b/.changeset/quiet-maps-join.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Restore the Conductor migration path during onboarding and keep its import screen matched to the current app theme.

--- a/src/components/conductor-onboarding.tsx
+++ b/src/components/conductor-onboarding.tsx
@@ -423,29 +423,6 @@ const SKELETON_IDS = Array.from(
 	(_, i) => `skeleton-${i}`,
 );
 const LOGO_SIZE = 56;
-const CONDUCTOR_ONBOARDING_LIGHT_THEME = {
-	"--background": "oklch(1 0 0)",
-	"--foreground": "oklch(0.145 0 0)",
-	"--card": "oklch(1 0 0)",
-	"--card-foreground": "oklch(0.145 0 0)",
-	"--muted": "oklch(0.97 0 0)",
-	"--muted-foreground": "oklch(0.556 0 0)",
-	"--border": "oklch(0.922 0 0)",
-	"--primary": "oklch(0.205 0 0)",
-	"--primary-foreground": "oklch(0.985 0 0)",
-	"--destructive": "oklch(0.577 0.245 27.325)",
-	"--color-background": "var(--background)",
-	"--color-foreground": "var(--foreground)",
-	"--color-card": "var(--card)",
-	"--color-card-foreground": "var(--card-foreground)",
-	"--color-muted": "var(--muted)",
-	"--color-muted-foreground": "var(--muted-foreground)",
-	"--color-border": "var(--border)",
-	"--color-primary": "var(--primary)",
-	"--color-primary-foreground": "var(--primary-foreground)",
-	"--color-destructive": "var(--destructive)",
-} as React.CSSProperties;
-
 export function ConductorOnboarding({
 	onComplete,
 	workspaces = [],
@@ -552,7 +529,6 @@ export function ConductorOnboarding({
 		<div
 			ref={containerRef}
 			className="fixed inset-0 z-50 flex flex-col items-center justify-center overflow-hidden bg-background font-sans text-foreground antialiased"
-			style={CONDUCTOR_ONBOARDING_LIGHT_THEME}
 		>
 			{/* Drag region */}
 			<div

--- a/src/features/onboarding/index.test.tsx
+++ b/src/features/onboarding/index.test.tsx
@@ -1,0 +1,188 @@
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	isConductorAvailable,
+	listConductorRepos,
+	listConductorWorkspaces,
+} from "@/lib/api";
+import { AppOnboarding } from ".";
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+	open: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+	addRepositoryFromLocalPath: vi.fn(),
+	cloneRepositoryFromUrl: vi.fn(),
+	deleteRepository: vi.fn(),
+	enterOnboardingWindowMode: vi.fn(async () => undefined),
+	exitOnboardingWindowMode: vi.fn(async () => undefined),
+	getAgentLoginStatus: vi.fn(async () => undefined),
+	isConductorAvailable: vi.fn(async () => false),
+	listConductorRepos: vi.fn(async () => []),
+	listConductorWorkspaces: vi.fn(async () => []),
+	loadAddRepositoryDefaults: vi.fn(async () => ({
+		lastCloneDirectory: null,
+	})),
+}));
+
+vi.mock("@/components/chrome/traffic-light-spacer", () => ({
+	TrafficLightSpacer: () => null,
+}));
+
+vi.mock("@/components/conductor-onboarding", () => ({
+	ConductorOnboarding: ({ workspaces }: { workspaces: { id: string }[] }) => (
+		<div aria-label="Conductor onboarding">
+			Conductor workspaces: {workspaces.length}
+		</div>
+	),
+}));
+
+vi.mock("@/features/navigation/clone-from-url-dialog", () => ({
+	CloneFromUrlDialog: () => null,
+}));
+
+vi.mock("./components/intro-preview", () => ({
+	IntroPreview: ({ step, onNext }: { step: string; onNext: () => void }) =>
+		step === "intro" ? (
+			<button type="button" onClick={onNext}>
+				Continue intro
+			</button>
+		) : null,
+}));
+
+vi.mock("./steps/agent-login-step", () => ({
+	AgentLoginStep: ({ step, onNext }: { step: string; onNext: () => void }) =>
+		step === "agents" ? (
+			<button type="button" onClick={onNext}>
+				Continue agents
+			</button>
+		) : null,
+}));
+
+vi.mock("./steps/repository-cli-step", () => ({
+	RepositoryCliStep: ({
+		step,
+		onNext,
+	}: {
+		step: string;
+		onNext: () => void;
+	}) =>
+		step === "corner" ? (
+			<button type="button" onClick={onNext}>
+				Continue repository cli
+			</button>
+		) : null,
+}));
+
+vi.mock("./steps/skills-step", () => ({
+	SkillsStep: ({
+		step,
+		onNext,
+		isRoutingImport,
+	}: {
+		step: string;
+		onNext: () => void;
+		isRoutingImport: boolean;
+	}) =>
+		step === "skills" ? (
+			<button type="button" disabled={isRoutingImport} onClick={onNext}>
+				Continue skills
+			</button>
+		) : null,
+}));
+
+vi.mock("./steps/repo-import-step", () => ({
+	RepoImportStep: ({ step }: { step: string }) =>
+		step === "repoImport" ? (
+			<div aria-label="Repository import">Repository import</div>
+		) : null,
+}));
+
+afterEach(() => {
+	cleanup();
+	vi.clearAllMocks();
+});
+
+function renderAtSkillsStep() {
+	render(<AppOnboarding onComplete={vi.fn()} />);
+
+	fireEvent.click(screen.getByRole("button", { name: "Continue intro" }));
+	fireEvent.click(screen.getByRole("button", { name: "Continue agents" }));
+	fireEvent.click(
+		screen.getByRole("button", { name: "Continue repository cli" }),
+	);
+}
+
+const importableWorkspace = {
+	id: "workspace-1",
+	directoryName: "workspace-one",
+	state: "ready",
+	branch: "main",
+	status: null,
+	prTitle: null,
+	sessionCount: 2,
+	messageCount: 12,
+	alreadyImported: false,
+	iconSrc: null,
+};
+
+describe("AppOnboarding conductor routing", () => {
+	it("routes to repository import when Conductor is unavailable", async () => {
+		vi.mocked(isConductorAvailable).mockResolvedValue(false);
+
+		renderAtSkillsStep();
+		fireEvent.click(screen.getByRole("button", { name: "Continue skills" }));
+
+		await screen.findByLabelText("Repository import");
+		expect(listConductorRepos).not.toHaveBeenCalled();
+	});
+
+	it("routes to Conductor onboarding when importable workspaces exist", async () => {
+		vi.mocked(isConductorAvailable).mockResolvedValue(true);
+		vi.mocked(listConductorRepos).mockResolvedValue([
+			{
+				id: "repo-1",
+				name: "Repo 1",
+				remoteUrl: null,
+				workspaceCount: 1,
+				alreadyImportedCount: 0,
+			},
+		]);
+		vi.mocked(listConductorWorkspaces).mockResolvedValue([importableWorkspace]);
+
+		renderAtSkillsStep();
+		fireEvent.click(screen.getByRole("button", { name: "Continue skills" }));
+
+		await screen.findByLabelText("Conductor onboarding");
+		expect(screen.getByText("Conductor workspaces: 1")).toBeInTheDocument();
+		expect(listConductorWorkspaces).toHaveBeenCalledWith("repo-1");
+	});
+
+	it("falls back to repository import when Conductor has no new workspaces", async () => {
+		vi.mocked(isConductorAvailable).mockResolvedValue(true);
+		vi.mocked(listConductorRepos).mockResolvedValue([
+			{
+				id: "repo-1",
+				name: "Repo 1",
+				remoteUrl: null,
+				workspaceCount: 1,
+				alreadyImportedCount: 1,
+			},
+		]);
+
+		renderAtSkillsStep();
+		fireEvent.click(screen.getByRole("button", { name: "Continue skills" }));
+
+		await waitFor(() => {
+			expect(screen.getByLabelText("Repository import")).toBeInTheDocument();
+		});
+		expect(listConductorWorkspaces).not.toHaveBeenCalled();
+	});
+});

--- a/src/features/onboarding/index.tsx
+++ b/src/features/onboarding/index.tsx
@@ -5,11 +5,15 @@ import { ConductorOnboarding } from "@/components/conductor-onboarding";
 import { CloneFromUrlDialog } from "@/features/navigation/clone-from-url-dialog";
 import {
 	addRepositoryFromLocalPath,
+	type ConductorWorkspace,
 	cloneRepositoryFromUrl,
 	deleteRepository,
 	enterOnboardingWindowMode,
 	exitOnboardingWindowMode,
 	getAgentLoginStatus,
+	isConductorAvailable,
+	listConductorRepos,
+	listConductorWorkspaces,
 	loadAddRepositoryDefaults,
 } from "@/lib/api";
 import { describeUnknownError } from "@/lib/workspace-helpers";
@@ -45,6 +49,9 @@ export function AppOnboarding({ onComplete }: AppOnboardingProps) {
 		string | null
 	>(null);
 	const [repoImportError, setRepoImportError] = useState<string | null>(null);
+	const [conductorWorkspaces, setConductorWorkspaces] = useState<
+		ConductorWorkspace[]
+	>([]);
 
 	const refreshLoginItems = useCallback(() => {
 		void getAgentLoginStatus()
@@ -74,14 +81,43 @@ export function AppOnboarding({ onComplete }: AppOnboardingProps) {
 		};
 	}, []);
 
-	const handleSkillsNext = useCallback(() => {
+	const handleSkillsNext = useCallback(async () => {
 		if (isRoutingImport) {
 			return;
 		}
 		setIsRoutingImport(true);
-		// Temporary hardcoded route for tuning the default repository import screen.
-		setStep("repoImport");
-		setIsRoutingImport(false);
+		try {
+			const conductorAvailable = await isConductorAvailable();
+			if (!conductorAvailable) {
+				setConductorWorkspaces([]);
+				setStep("repoImport");
+				return;
+			}
+
+			const repos = await listConductorRepos();
+			const workspaceGroups = await Promise.all(
+				repos
+					.filter((repo) => repo.workspaceCount > repo.alreadyImportedCount)
+					.map((repo) => listConductorWorkspaces(repo.id)),
+			);
+			const importableWorkspaces = workspaceGroups
+				.flat()
+				.filter((workspace) => !workspace.alreadyImported);
+
+			if (importableWorkspaces.length > 0) {
+				setConductorWorkspaces(importableWorkspaces);
+				setStep("conductor");
+				return;
+			}
+
+			setConductorWorkspaces([]);
+			setStep("repoImport");
+		} catch {
+			setConductorWorkspaces([]);
+			setStep("repoImport");
+		} finally {
+			setIsRoutingImport(false);
+		}
 	}, [isRoutingImport]);
 
 	const rememberImportedRepository = useCallback(
@@ -210,7 +246,12 @@ export function AppOnboarding({ onComplete }: AppOnboardingProps) {
 	}, [onComplete]);
 
 	if (step === "conductor") {
-		return <ConductorOnboarding onComplete={onComplete} />;
+		return (
+			<ConductorOnboarding
+				onComplete={onComplete}
+				workspaces={conductorWorkspaces}
+			/>
+		);
 	}
 
 	return (


### PR DESCRIPTION
## Summary

- Restore the Conductor detection path in onboarding: when Conductor is installed and has workspaces that haven't been imported yet, advance to the Conductor migration screen instead of the default repo import flow.
- Drop the hardcoded light-theme variable override in `ConductorOnboarding` so the screen tracks the current app theme.
- Add `src/features/onboarding/index.test.tsx` covering the three routing branches (Conductor unavailable, importable workspaces present, only already-imported workspaces).

## Why

The skills step previously had a temporary hardcoded jump straight to `repoImport`, which skipped the Conductor migration entry point and left existing Conductor users without an obvious path to bring their workspaces over. The hardcoded light theme on the Conductor screen also clashed with users on dark mode.

## Test plan

- [ ] `bun run test:frontend` (new `index.test.tsx` covers the routing branches)
- [ ] Manual: with Conductor installed and unimported workspaces, walk through onboarding -> ends on Conductor screen
- [ ] Manual: without Conductor (or with everything already imported), walk through onboarding -> ends on repo import
- [ ] Manual: verify the Conductor onboarding screen renders correctly in both light and dark themes