### PR TITLE
feat(agents): support custom Claude model providers

### DIFF
--- a/.changeset/calm-models-dance.md
+++ b/.changeset/calm-models-dance.md
@@ -1,0 +1,8 @@
+---
+"helmor": minor
+---
+
+Add Claude Code custom provider support:
+- Configure built-in third-party providers or a custom Claude-compatible endpoint from Settings with API key shortcuts.
+- Use configured third-party models alongside official Claude Code models in the composer and default model picker.
+- Prefer configured Claude-compatible models for automatic session title generation before falling back to official Claude and Codex.

--- a/sidecar/src/claude-session-manager.ts
+++ b/sidecar/src/claude-session-manager.ts
@@ -394,6 +394,7 @@ export class ClaudeSessionManager implements SessionManager {
 			permissionMode,
 			effortLevel,
 			fastMode,
+			claudeEnvironment,
 		} = params;
 		const abortController = new AbortController();
 		const additionalDirectories = [...(params.additionalDirectories ?? [])];
@@ -435,9 +436,17 @@ export class ClaudeSessionManager implements SessionManager {
 
 		const effectiveFastMode =
 			fastMode === true && modelSupportsFastMode("claude", model);
+		const claudeEnv =
+			claudeEnvironment && Object.keys(claudeEnvironment).length > 0
+				? claudeEnvironment
+				: undefined;
 		const additionalDirectoryEnv =
 			additionalDirectories.length > 0
 				? { CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: "1" }
+				: undefined;
+		const queryEnv =
+			claudeEnv || additionalDirectoryEnv
+				? { ...claudeEnv, ...additionalDirectoryEnv }
 				: undefined;
 
 		const q = query({
@@ -448,7 +457,7 @@ export class ClaudeSessionManager implements SessionManager {
 				...executableOptions(),
 				cwd: cwd || undefined,
 				...(additionalDirectories.length > 0 ? { additionalDirectories } : {}),
-				...(additionalDirectoryEnv ? { env: additionalDirectoryEnv } : {}),
+				...(queryEnv ? { env: queryEnv } : {}),
 				model: model || undefined,
 				...(resume ? { resume } : {}),
 				permissionMode: parsePermissionMode(permissionMode),

--- a/sidecar/src/claude-session-manager.ts
+++ b/sidecar/src/claude-session-manager.ts
@@ -26,6 +26,7 @@ import { errorDetails, logger } from "./logger.js";
 import { listProviderModels, modelSupportsFastMode } from "./model-catalog.js";
 import { createPushable, type Pushable } from "./pushable-iterable.js";
 import type {
+	GenerateTitleOptions,
 	GetContextUsageParams,
 	ListSlashCommandsParams,
 	ProviderModelInfo,
@@ -729,9 +730,16 @@ export class ClaudeSessionManager implements SessionManager {
 		branchRenamePrompt: string | null,
 		emitter: SidecarEmitter,
 		timeoutMs = TITLE_GENERATION_TIMEOUT_MS,
+		options?: GenerateTitleOptions,
 	): Promise<void> {
 		const abortController = new AbortController();
 		const timeout = setTimeout(() => abortController.abort(), timeoutMs);
+		const model = options?.model?.trim() || "haiku";
+		const claudeEnv =
+			options?.claudeEnvironment &&
+			Object.keys(options.claudeEnvironment).length > 0
+				? options.claudeEnvironment
+				: undefined;
 
 		const q = query({
 			prompt: buildTitlePrompt(userMessage, branchRenamePrompt),
@@ -739,7 +747,8 @@ export class ClaudeSessionManager implements SessionManager {
 				abortController,
 				pathToClaudeCodeExecutable: CLAUDE_CLI_PATH,
 				...executableOptions(),
-				model: "haiku",
+				...(claudeEnv ? { env: claudeEnv } : {}),
+				model,
 				permissionMode: "plan",
 				allowDangerouslySkipPermissions: true,
 			},

--- a/sidecar/src/codex-app-server-manager.ts
+++ b/sidecar/src/codex-app-server-manager.ts
@@ -21,6 +21,7 @@ import { prependLinkedDirectoriesContext } from "./linked-directories-context.js
 import { errorDetails, logger } from "./logger.js";
 import { listProviderModels, modelSupportsFastMode } from "./model-catalog.js";
 import type {
+	GenerateTitleOptions,
 	ListSlashCommandsParams,
 	ProviderModelInfo,
 	SendMessageParams,
@@ -482,6 +483,7 @@ export class CodexAppServerManager implements SessionManager {
 		branchRenamePrompt: string | null,
 		emitter: SidecarEmitter,
 		timeoutMs = TITLE_GENERATION_TIMEOUT_MS,
+		_options?: GenerateTitleOptions,
 	): Promise<void> {
 		const cwd = process.cwd();
 		const server = new CodexAppServer({

--- a/sidecar/src/index.ts
+++ b/sidecar/src/index.ts
@@ -21,6 +21,7 @@ import {
 	parseElicitationResultContent,
 	parseGetContextUsageParams,
 	parseListSlashCommandsParams,
+	parseOptionalStringRecord,
 	parseProvider,
 	parseRequest,
 	parseSendMessageParams,
@@ -150,13 +151,19 @@ async function handleGenerateTitle(
 			typeof params.branchRenamePrompt === "string"
 				? params.branchRenamePrompt
 				: null;
+		const claudeModel = optionalString(params, "claudeModel");
+		const claudeEnvironment = parseOptionalStringRecord(
+			params,
+			"claudeEnvironment",
+		);
 		logger.debug(`[${id}] generateTitle`, {
 			userMessage: userMessage.slice(0, 100),
+			claudeModel: claudeModel ?? "haiku",
+			customClaudeEnvironment: Boolean(claudeEnvironment),
 		});
 
-		// Try Claude (cheap haiku) first; fall back to Codex if Claude is
-		// unavailable. Both implementations emit `titleGenerated` in the
-		// same shape, so the caller can't tell which one ran.
+		// Try the configured Claude-compatible model first when available;
+		// otherwise use official Claude, then fall back to Codex.
 		try {
 			await managers.claude.generateTitle(
 				id,
@@ -164,12 +171,34 @@ async function handleGenerateTitle(
 				branchRenamePrompt,
 				emitter,
 				TITLE_GENERATION_TIMEOUT_MS,
+				{ model: claudeModel, claudeEnvironment },
 			);
 			logger.debug(`[${id}] generateTitle completed (claude)`);
 		} catch (claudeErr) {
-			logger.debug(
-				`[${id}] generateTitle claude failed, trying codex: ${errorMessage(claudeErr)}`,
-			);
+			if (claudeModel || claudeEnvironment) {
+				logger.debug(
+					`[${id}] generateTitle custom claude failed, trying official claude: ${errorMessage(claudeErr)}`,
+				);
+				try {
+					await managers.claude.generateTitle(
+						id,
+						userMessage,
+						branchRenamePrompt,
+						emitter,
+						TITLE_GENERATION_TIMEOUT_MS,
+					);
+					logger.debug(`[${id}] generateTitle completed (official claude)`);
+					return;
+				} catch (officialClaudeErr) {
+					logger.debug(
+						`[${id}] generateTitle official claude failed, trying codex: ${errorMessage(officialClaudeErr)}`,
+					);
+				}
+			} else {
+				logger.debug(
+					`[${id}] generateTitle claude failed, trying codex: ${errorMessage(claudeErr)}`,
+				);
+			}
 			await managers.codex.generateTitle(
 				id,
 				userMessage,

--- a/sidecar/src/request-parser.ts
+++ b/sidecar/src/request-parser.ts
@@ -134,7 +134,7 @@ export function parseSendMessageParams(
 	};
 }
 
-function parseOptionalStringRecord(
+export function parseOptionalStringRecord(
 	params: Record<string, unknown>,
 	key: string,
 ): Readonly<Record<string, string>> | undefined {

--- a/sidecar/src/request-parser.ts
+++ b/sidecar/src/request-parser.ts
@@ -126,11 +126,31 @@ export function parseSendMessageParams(
 		permissionMode: optionalString(params, "permissionMode"),
 		effortLevel: optionalString(params, "effortLevel"),
 		fastMode: optionalBoolean(params, "fastMode"),
+		claudeEnvironment: parseOptionalStringRecord(params, "claudeEnvironment"),
 		additionalDirectories: parseOptionalStringArray(
 			params,
 			"additionalDirectories",
 		),
 	};
+}
+
+function parseOptionalStringRecord(
+	params: Record<string, unknown>,
+	key: string,
+): Readonly<Record<string, string>> | undefined {
+	const value = params[key];
+	if (value === undefined || value === null) return undefined;
+	if (typeof value !== "object" || Array.isArray(value)) {
+		throw new Error(`params.${key} must be an object`);
+	}
+	const out: Record<string, string> = {};
+	for (const [recordKey, recordValue] of Object.entries(value)) {
+		if (typeof recordValue !== "string") {
+			throw new Error(`params.${key}.${recordKey} must be a string`);
+		}
+		out[recordKey] = recordValue;
+	}
+	return out;
 }
 
 function parseOptionalStringArray(

--- a/sidecar/src/session-manager.ts
+++ b/sidecar/src/session-manager.ts
@@ -47,6 +47,11 @@ export interface GetContextUsageParams {
 	readonly cwd: string | undefined;
 }
 
+export interface GenerateTitleOptions {
+	readonly model?: string;
+	readonly claudeEnvironment?: Readonly<Record<string, string>>;
+}
+
 /**
  * One slash-command entry exposed to the composer popup. Mirrors the Claude
  * Agent SDK's `SlashCommand` shape so the Claude path is a 1:1 forward, and
@@ -91,6 +96,7 @@ export interface SessionManager {
 		branchRenamePrompt: string | null,
 		emitter: SidecarEmitter,
 		timeoutMs?: number,
+		options?: GenerateTitleOptions,
 	): Promise<void>;
 
 	/**

--- a/sidecar/src/session-manager.ts
+++ b/sidecar/src/session-manager.ts
@@ -18,6 +18,7 @@ export interface SendMessageParams {
 	readonly permissionMode: string | undefined;
 	readonly effortLevel: string | undefined;
 	readonly fastMode: boolean | undefined;
+	readonly claudeEnvironment?: Readonly<Record<string, string>>;
 	/**
 	 * Extra directories the user linked via `/add-dir`. Passed to Claude as
 	 * `additionalDirectories`; merged into Codex's per-turn `sandboxPolicy`

--- a/src-tauri/src/agents.rs
+++ b/src-tauri/src/agents.rs
@@ -8,7 +8,9 @@ use uuid::Uuid;
 use crate::error::CommandError;
 
 pub mod action_kind;
+mod builtin_claude_providers;
 mod catalog;
+mod custom_providers;
 mod persistence;
 mod queries;
 mod slash_commands;

--- a/src-tauri/src/agents/builtin_claude_providers.rs
+++ b/src-tauri/src/agents/builtin_claude_providers.rs
@@ -1,94 +1,32 @@
+use std::sync::OnceLock;
+
+use serde::Deserialize;
+
+const CATALOG_JSON: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../src/shared/builtin-claude-providers.json"
+));
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct BuiltinClaudeProvider {
-    pub key: &'static str,
-    pub name: &'static str,
-    pub base_url: &'static str,
-    pub models: &'static [BuiltinClaudeModel],
+    pub key: String,
+    pub base_url: String,
+    pub models: Vec<BuiltinClaudeModel>,
 }
 
+#[derive(Debug, Clone, Deserialize)]
 pub struct BuiltinClaudeModel {
-    pub id: &'static str,
-    pub label: &'static str,
+    pub id: String,
+    pub label: String,
 }
 
-pub const MINIMAX_MODELS: &[BuiltinClaudeModel] = &[BuiltinClaudeModel {
-    id: "MiniMax-M2.7",
-    label: "MiniMax M2.7",
-}];
-
-pub const BUILTIN_CLAUDE_PROVIDERS: &[BuiltinClaudeProvider] = &[
-    BuiltinClaudeProvider {
-        key: "minimax",
-        name: "MiniMax",
-        base_url: "https://api.minimax.io/anthropic",
-        models: MINIMAX_MODELS,
-    },
-    BuiltinClaudeProvider {
-        key: "minimax-cn",
-        name: "MiniMax CN",
-        base_url: "https://api.minimaxi.com/anthropic",
-        models: MINIMAX_MODELS,
-    },
-    BuiltinClaudeProvider {
-        key: "moonshot",
-        name: "Moonshot / Kimi",
-        base_url: "https://api.moonshot.ai/anthropic",
-        models: &[BuiltinClaudeModel {
-            id: "kimi-k2.5",
-            label: "Kimi K2.5",
-        }],
-    },
-    BuiltinClaudeProvider {
-        key: "moonshot-cn",
-        name: "Moonshot / Kimi CN",
-        base_url: "https://api.moonshot.cn/anthropic",
-        models: &[BuiltinClaudeModel {
-            id: "kimi-k2.5",
-            label: "Kimi K2.5",
-        }],
-    },
-    BuiltinClaudeProvider {
-        key: "zai",
-        name: "Z.AI / GLM",
-        base_url: "https://api.z.ai/api/anthropic",
-        models: &[BuiltinClaudeModel {
-            id: "glm-4.7",
-            label: "GLM 4.7",
-        }],
-    },
-    BuiltinClaudeProvider {
-        key: "zai-cn",
-        name: "Z.AI / GLM CN",
-        base_url: "https://open.bigmodel.cn/api/anthropic",
-        models: &[BuiltinClaudeModel {
-            id: "glm-5.1",
-            label: "GLM 5.1",
-        }],
-    },
-    BuiltinClaudeProvider {
-        key: "qwen",
-        name: "Qwen / DashScope",
-        base_url: "https://dashscope.aliyuncs.com/apps/anthropic",
-        models: &[BuiltinClaudeModel {
-            id: "qwen3.6-plus",
-            label: "Qwen 3.6 Plus",
-        }],
-    },
-    BuiltinClaudeProvider {
-        key: "qwen-intl",
-        name: "Qwen / DashScope Intl",
-        base_url: "https://dashscope-intl.aliyuncs.com/apps/anthropic",
-        models: &[BuiltinClaudeModel {
-            id: "qwen3.5-plus",
-            label: "Qwen 3.5 Plus",
-        }],
-    },
-    BuiltinClaudeProvider {
-        key: "xiaomi",
-        name: "Xiaomi MiMo",
-        base_url: "https://api.xiaomimimo.com/anthropic",
-        models: &[BuiltinClaudeModel {
-            id: "mimo-v2-flash",
-            label: "MiMo V2 Flash",
-        }],
-    },
-];
+pub fn builtin_claude_providers() -> &'static [BuiltinClaudeProvider] {
+    static PROVIDERS: OnceLock<Vec<BuiltinClaudeProvider>> = OnceLock::new();
+    PROVIDERS
+        .get_or_init(|| {
+            serde_json::from_str(CATALOG_JSON)
+                .expect("src/shared/builtin-claude-providers.json must be valid")
+        })
+        .as_slice()
+}

--- a/src-tauri/src/agents/builtin_claude_providers.rs
+++ b/src-tauri/src/agents/builtin_claude_providers.rs
@@ -1,0 +1,94 @@
+pub struct BuiltinClaudeProvider {
+    pub key: &'static str,
+    pub name: &'static str,
+    pub base_url: &'static str,
+    pub models: &'static [BuiltinClaudeModel],
+}
+
+pub struct BuiltinClaudeModel {
+    pub id: &'static str,
+    pub label: &'static str,
+}
+
+pub const MINIMAX_MODELS: &[BuiltinClaudeModel] = &[BuiltinClaudeModel {
+    id: "MiniMax-M2.7",
+    label: "MiniMax M2.7",
+}];
+
+pub const BUILTIN_CLAUDE_PROVIDERS: &[BuiltinClaudeProvider] = &[
+    BuiltinClaudeProvider {
+        key: "minimax",
+        name: "MiniMax",
+        base_url: "https://api.minimax.io/anthropic",
+        models: MINIMAX_MODELS,
+    },
+    BuiltinClaudeProvider {
+        key: "minimax-cn",
+        name: "MiniMax CN",
+        base_url: "https://api.minimaxi.com/anthropic",
+        models: MINIMAX_MODELS,
+    },
+    BuiltinClaudeProvider {
+        key: "moonshot",
+        name: "Moonshot / Kimi",
+        base_url: "https://api.moonshot.ai/anthropic",
+        models: &[BuiltinClaudeModel {
+            id: "kimi-k2.5",
+            label: "Kimi K2.5",
+        }],
+    },
+    BuiltinClaudeProvider {
+        key: "moonshot-cn",
+        name: "Moonshot / Kimi CN",
+        base_url: "https://api.moonshot.cn/anthropic",
+        models: &[BuiltinClaudeModel {
+            id: "kimi-k2.5",
+            label: "Kimi K2.5",
+        }],
+    },
+    BuiltinClaudeProvider {
+        key: "zai",
+        name: "Z.AI / GLM",
+        base_url: "https://api.z.ai/api/anthropic",
+        models: &[BuiltinClaudeModel {
+            id: "glm-4.7",
+            label: "GLM 4.7",
+        }],
+    },
+    BuiltinClaudeProvider {
+        key: "zai-cn",
+        name: "Z.AI / GLM CN",
+        base_url: "https://open.bigmodel.cn/api/anthropic",
+        models: &[BuiltinClaudeModel {
+            id: "glm-5.1",
+            label: "GLM 5.1",
+        }],
+    },
+    BuiltinClaudeProvider {
+        key: "qwen",
+        name: "Qwen / DashScope",
+        base_url: "https://dashscope.aliyuncs.com/apps/anthropic",
+        models: &[BuiltinClaudeModel {
+            id: "qwen3.6-plus",
+            label: "Qwen 3.6 Plus",
+        }],
+    },
+    BuiltinClaudeProvider {
+        key: "qwen-intl",
+        name: "Qwen / DashScope Intl",
+        base_url: "https://dashscope-intl.aliyuncs.com/apps/anthropic",
+        models: &[BuiltinClaudeModel {
+            id: "qwen3.5-plus",
+            label: "Qwen 3.5 Plus",
+        }],
+    },
+    BuiltinClaudeProvider {
+        key: "xiaomi",
+        name: "Xiaomi MiMo",
+        base_url: "https://api.xiaomimimo.com/anthropic",
+        models: &[BuiltinClaudeModel {
+            id: "mimo-v2-flash",
+            label: "MiMo V2 Flash",
+        }],
+    },
+];

--- a/src-tauri/src/agents/catalog.rs
+++ b/src-tauri/src/agents/catalog.rs
@@ -40,12 +40,11 @@ pub fn static_model_sections() -> Vec<AgentModelSection> {
 fn model_sections_for_custom(
     custom: Vec<super::custom_providers::ClaudeProviderModel>,
 ) -> Vec<AgentModelSection> {
-    let mut sections = if custom.is_empty() {
-        vec![official_claude_section()]
-    } else {
-        custom_provider_sections(custom)
-    };
-
+    let mut claude_section = official_claude_section();
+    claude_section
+        .options
+        .extend(custom_provider_options(custom));
+    let mut sections = vec![claude_section];
     sections.push(codex_section());
 
     sections
@@ -91,33 +90,20 @@ fn codex_section() -> AgentModelSection {
     }
 }
 
-fn custom_provider_sections(
+fn custom_provider_options(
     custom: Vec<super::custom_providers::ClaudeProviderModel>,
-) -> Vec<AgentModelSection> {
-    let mut grouped = std::collections::BTreeMap::<(String, String), Vec<AgentModelOption>>::new();
-    for model in custom {
-        grouped
-            .entry((model.provider_key.clone(), model.provider_name.clone()))
-            .or_default()
-            .push(AgentModelOption {
-                id: model.id,
-                provider: "claude".to_string(),
-                label: model.label,
-                cli_model: model.cli_model,
-                provider_key: Some(model.provider_key),
-                effort_levels: claude_effort_levels(),
-                supports_fast_mode: false,
-                supports_context_usage: false,
-            });
-    }
-
-    grouped
+) -> Vec<AgentModelOption> {
+    custom
         .into_iter()
-        .map(|((provider_key, label), options)| AgentModelSection {
-            id: format!("claude-provider-{provider_key}"),
-            label,
-            status: AgentModelSectionStatus::Ready,
-            options,
+        .map(|model| AgentModelOption {
+            id: model.id,
+            provider: "claude".to_string(),
+            label: model.label,
+            cli_model: model.cli_model,
+            provider_key: Some(model.provider_key),
+            effort_levels: claude_effort_levels(),
+            supports_fast_mode: false,
+            supports_context_usage: false,
         })
         .collect()
 }
@@ -213,7 +199,7 @@ mod tests {
 
     #[test]
     fn static_model_sections_returns_hardcoded_catalog() {
-        let sections = static_model_sections();
+        let sections = model_sections_for_custom(Vec::new());
 
         assert_eq!(sections.len(), 2);
         assert_eq!(sections[0].id, "claude");
@@ -255,12 +241,11 @@ mod tests {
     }
 
     #[test]
-    fn custom_provider_sections_replace_official_claude_section() {
+    fn custom_provider_models_append_to_official_claude_section() {
         let sections =
             model_sections_for_custom(vec![super::super::custom_providers::ClaudeProviderModel {
                 id: "claude-custom|minimax|MiniMax-M2.7".to_string(),
                 provider_key: "minimax".to_string(),
-                provider_name: "MiniMax".to_string(),
                 label: "MiniMax M2.7".to_string(),
                 cli_model: "MiniMax-M2.7".to_string(),
                 base_url: "https://api.minimax.io/anthropic".to_string(),
@@ -268,19 +253,32 @@ mod tests {
             }]);
 
         assert_eq!(sections.len(), 2);
-        assert_eq!(sections[0].id, "claude-provider-minimax");
-        assert_eq!(sections[0].label, "MiniMax");
+        assert_eq!(sections[0].id, "claude");
+        assert_eq!(sections[0].label, "Claude Code");
         assert_eq!(
-            sections[0].options[0].provider_key.as_deref(),
+            sections[0]
+                .options
+                .iter()
+                .map(|model| model.id.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "default",
+                "claude-opus-4-6[1m]",
+                "sonnet",
+                "haiku",
+                "claude-custom|minimax|MiniMax-M2.7",
+            ]
+        );
+        assert_eq!(
+            sections[0].options[4].provider_key.as_deref(),
             Some("minimax")
         );
         assert_eq!(
-            sections[0].options[0].effort_levels,
+            sections[0].options[4].effort_levels,
             vec!["low", "medium", "high", "xhigh", "max"]
         );
-        assert!(!sections[0].options[0].supports_context_usage);
+        assert!(!sections[0].options[4].supports_context_usage);
         assert_eq!(sections[1].id, "codex");
-        assert!(!sections.iter().any(|section| section.id == "claude"));
     }
 
     #[test]

--- a/src-tauri/src/agents/catalog.rs
+++ b/src-tauri/src/agents/catalog.rs
@@ -7,10 +7,13 @@ pub struct AgentModelOption {
     pub provider: String,
     pub label: String,
     pub cli_model: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_key: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub effort_levels: Vec<String>,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub supports_fast_mode: bool,
+    pub supports_context_usage: bool,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
@@ -31,42 +34,92 @@ pub struct AgentModelSection {
 }
 
 pub fn static_model_sections() -> Vec<AgentModelSection> {
-    vec![
-        AgentModelSection {
-            id: "claude".to_string(),
-            label: "Claude Code".to_string(),
+    model_sections_for_custom(super::custom_providers::configured_models())
+}
+
+fn model_sections_for_custom(
+    custom: Vec<super::custom_providers::ClaudeProviderModel>,
+) -> Vec<AgentModelSection> {
+    let mut sections = if custom.is_empty() {
+        vec![official_claude_section()]
+    } else {
+        custom_provider_sections(custom)
+    };
+
+    sections.push(codex_section());
+
+    sections
+}
+
+fn official_claude_section() -> AgentModelSection {
+    AgentModelSection {
+        id: "claude".to_string(),
+        label: "Claude Code".to_string(),
+        status: AgentModelSectionStatus::Ready,
+        options: vec![
+            claude_model(
+                "default",
+                "Opus 4.7 1M",
+                &["low", "medium", "high", "xhigh", "max"],
+                false,
+            ),
+            claude_model(
+                "claude-opus-4-6[1m]",
+                "Opus 4.6 1M",
+                &["low", "medium", "high", "max"],
+                true,
+            ),
+            claude_model("sonnet", "Sonnet", &["low", "medium", "high", "max"], false),
+            claude_model("haiku", "Haiku", &[], false),
+        ],
+    }
+}
+
+fn codex_section() -> AgentModelSection {
+    AgentModelSection {
+        id: "codex".to_string(),
+        label: "Codex".to_string(),
+        status: AgentModelSectionStatus::Ready,
+        options: vec![
+            codex_model("gpt-5.5", "GPT-5.5"),
+            codex_model("gpt-5.4", "GPT-5.4"),
+            codex_model("gpt-5.4-mini", "GPT-5.4-Mini"),
+            codex_model("gpt-5.3-codex", "GPT-5.3-Codex"),
+            codex_model("gpt-5.3-codex-spark", "GPT-5.3-Codex-Spark"),
+            codex_model("gpt-5.2", "GPT-5.2"),
+        ],
+    }
+}
+
+fn custom_provider_sections(
+    custom: Vec<super::custom_providers::ClaudeProviderModel>,
+) -> Vec<AgentModelSection> {
+    let mut grouped = std::collections::BTreeMap::<(String, String), Vec<AgentModelOption>>::new();
+    for model in custom {
+        grouped
+            .entry((model.provider_key.clone(), model.provider_name.clone()))
+            .or_default()
+            .push(AgentModelOption {
+                id: model.id,
+                provider: "claude".to_string(),
+                label: model.label,
+                cli_model: model.cli_model,
+                provider_key: Some(model.provider_key),
+                effort_levels: claude_effort_levels(),
+                supports_fast_mode: false,
+                supports_context_usage: false,
+            });
+    }
+
+    grouped
+        .into_iter()
+        .map(|((provider_key, label), options)| AgentModelSection {
+            id: format!("claude-provider-{provider_key}"),
+            label,
             status: AgentModelSectionStatus::Ready,
-            options: vec![
-                claude_model(
-                    "default",
-                    "Opus 4.7 1M",
-                    &["low", "medium", "high", "xhigh", "max"],
-                    false,
-                ),
-                claude_model(
-                    "claude-opus-4-6[1m]",
-                    "Opus 4.6 1M",
-                    &["low", "medium", "high", "max"],
-                    true,
-                ),
-                claude_model("sonnet", "Sonnet", &["low", "medium", "high", "max"], false),
-                claude_model("haiku", "Haiku", &[], false),
-            ],
-        },
-        AgentModelSection {
-            id: "codex".to_string(),
-            label: "Codex".to_string(),
-            status: AgentModelSectionStatus::Ready,
-            options: vec![
-                codex_model("gpt-5.5", "GPT-5.5"),
-                codex_model("gpt-5.4", "GPT-5.4"),
-                codex_model("gpt-5.4-mini", "GPT-5.4-Mini"),
-                codex_model("gpt-5.3-codex", "GPT-5.3-Codex"),
-                codex_model("gpt-5.3-codex-spark", "GPT-5.3-Codex-Spark"),
-                codex_model("gpt-5.2", "GPT-5.2"),
-            ],
-        },
-    ]
+            options,
+        })
+        .collect()
 }
 
 fn claude_model(
@@ -80,11 +133,13 @@ fn claude_model(
         provider: "claude".to_string(),
         label: label.to_string(),
         cli_model: id.to_string(),
+        provider_key: None,
         effort_levels: effort_levels
             .iter()
             .map(|level| level.to_string())
             .collect(),
         supports_fast_mode,
+        supports_context_usage: true,
     }
 }
 
@@ -94,12 +149,21 @@ fn codex_model(id: &str, label: &str) -> AgentModelOption {
         provider: "codex".to_string(),
         label: label.to_string(),
         cli_model: id.to_string(),
+        provider_key: None,
         effort_levels: ["low", "medium", "high", "xhigh"]
             .into_iter()
             .map(str::to_string)
             .collect(),
         supports_fast_mode: true,
+        supports_context_usage: true,
     }
+}
+
+fn claude_effort_levels() -> Vec<String> {
+    ["low", "medium", "high", "xhigh", "max"]
+        .into_iter()
+        .map(str::to_string)
+        .collect()
 }
 
 /// Resolved model info needed by the streaming path.
@@ -108,12 +172,26 @@ pub struct ResolvedModel {
     pub id: String,
     pub provider: String,
     pub cli_model: String,
+    pub supports_effort: bool,
+    pub claude_base_url: Option<String>,
+    pub claude_auth_token: Option<String>,
 }
 
 /// Resolve a model ID to provider + cli_model. Provider is inferred from the
 /// ID: `gpt-*` → codex, everything else → claude. The ID is passed through
 /// as cli_model directly — the sidecar/SDK handles the actual mapping.
 pub fn resolve_model(model_id: &str) -> ResolvedModel {
+    if let Some(model) = super::custom_providers::resolve(model_id) {
+        return ResolvedModel {
+            id: model.id,
+            provider: "claude".to_string(),
+            cli_model: model.cli_model,
+            supports_effort: true,
+            claude_base_url: Some(model.base_url),
+            claude_auth_token: Some(model.api_key),
+        };
+    }
+
     let provider = if model_id.starts_with("gpt-") {
         "codex"
     } else {
@@ -123,6 +201,9 @@ pub fn resolve_model(model_id: &str) -> ResolvedModel {
         id: model_id.to_string(),
         provider: provider.to_string(),
         cli_model: model_id.to_string(),
+        supports_effort: true,
+        claude_base_url: None,
+        claude_auth_token: None,
     }
 }
 
@@ -174,11 +255,41 @@ mod tests {
     }
 
     #[test]
+    fn custom_provider_sections_replace_official_claude_section() {
+        let sections =
+            model_sections_for_custom(vec![super::super::custom_providers::ClaudeProviderModel {
+                id: "claude-custom|minimax|MiniMax-M2.7".to_string(),
+                provider_key: "minimax".to_string(),
+                provider_name: "MiniMax".to_string(),
+                label: "MiniMax M2.7".to_string(),
+                cli_model: "MiniMax-M2.7".to_string(),
+                base_url: "https://api.minimax.io/anthropic".to_string(),
+                api_key: "sk-test".to_string(),
+            }]);
+
+        assert_eq!(sections.len(), 2);
+        assert_eq!(sections[0].id, "claude-provider-minimax");
+        assert_eq!(sections[0].label, "MiniMax");
+        assert_eq!(
+            sections[0].options[0].provider_key.as_deref(),
+            Some("minimax")
+        );
+        assert_eq!(
+            sections[0].options[0].effort_levels,
+            vec!["low", "medium", "high", "xhigh", "max"]
+        );
+        assert!(!sections[0].options[0].supports_context_usage);
+        assert_eq!(sections[1].id, "codex");
+        assert!(!sections.iter().any(|section| section.id == "claude"));
+    }
+
+    #[test]
     fn resolve_claude_model() {
         let m = resolve_model("default");
         assert_eq!(m.provider, "claude");
         assert_eq!(m.cli_model, "default");
         assert_eq!(m.id, "default");
+        assert!(m.supports_effort);
     }
 
     #[test]

--- a/src-tauri/src/agents/custom_providers.rs
+++ b/src-tauri/src/agents/custom_providers.rs
@@ -1,0 +1,168 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+const SETTINGS_KEY: &str = "app.claude_custom_providers";
+const MODEL_ID_PREFIX: &str = "claude-custom|";
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaudeCustomProviderSettings {
+    #[serde(default)]
+    pub minimax_api_key: String,
+    #[serde(default)]
+    pub minimax_cn_api_key: String,
+    #[serde(default)]
+    pub builtin_provider_api_keys: HashMap<String, String>,
+    #[serde(default)]
+    pub custom_provider_name: String,
+    #[serde(default)]
+    pub custom_base_url: String,
+    #[serde(default)]
+    pub custom_api_key: String,
+    #[serde(default)]
+    pub custom_models: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ClaudeProviderModel {
+    pub id: String,
+    pub provider_key: String,
+    pub provider_name: String,
+    pub label: String,
+    pub cli_model: String,
+    pub base_url: String,
+    pub api_key: String,
+}
+
+pub fn load_settings() -> ClaudeCustomProviderSettings {
+    crate::settings::load_setting_json::<ClaudeCustomProviderSettings>(SETTINGS_KEY)
+        .ok()
+        .flatten()
+        .unwrap_or_default()
+}
+
+pub fn configured_models() -> Vec<ClaudeProviderModel> {
+    let settings = load_settings();
+    let mut models = Vec::new();
+
+    for provider in super::builtin_claude_providers::BUILTIN_CLAUDE_PROVIDERS {
+        append_builtin_models(
+            &mut models,
+            provider.key,
+            builtin_api_key(&settings, provider.key).trim(),
+        );
+    }
+
+    let provider_name = settings.custom_provider_name.trim();
+    let base_url = settings.custom_base_url.trim();
+    let api_key = settings.custom_api_key.trim();
+    if !provider_name.is_empty() && !base_url.is_empty() && !api_key.is_empty() {
+        for model in parse_models(&settings.custom_models) {
+            models.push(ClaudeProviderModel {
+                id: model_id("custom", &model),
+                provider_key: "custom".to_string(),
+                provider_name: provider_name.to_string(),
+                label: model.clone(),
+                cli_model: model,
+                base_url: base_url.to_string(),
+                api_key: api_key.to_string(),
+            });
+        }
+    }
+
+    models
+}
+
+fn builtin_api_key(settings: &ClaudeCustomProviderSettings, provider_key: &str) -> String {
+    settings
+        .builtin_provider_api_keys
+        .get(provider_key)
+        .cloned()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| match provider_key {
+            "minimax" => settings.minimax_api_key.clone(),
+            "minimax-cn" => settings.minimax_cn_api_key.clone(),
+            _ => String::new(),
+        })
+}
+
+fn append_builtin_models(models: &mut Vec<ClaudeProviderModel>, provider_key: &str, api_key: &str) {
+    if api_key.is_empty() {
+        return;
+    }
+
+    let Some(provider) = super::builtin_claude_providers::BUILTIN_CLAUDE_PROVIDERS
+        .iter()
+        .find(|provider| provider.key == provider_key)
+    else {
+        return;
+    };
+
+    for model in provider.models {
+        models.push(ClaudeProviderModel {
+            id: model_id(provider.key, model.id),
+            provider_key: provider.key.to_string(),
+            provider_name: provider.name.to_string(),
+            label: model.label.to_string(),
+            cli_model: model.id.to_string(),
+            base_url: provider.base_url.to_string(),
+            api_key: api_key.to_string(),
+        });
+    }
+}
+
+pub fn resolve(model_id: &str) -> Option<ClaudeProviderModel> {
+    configured_models()
+        .into_iter()
+        .find(|model| model.id == model_id)
+}
+
+fn model_id(provider_key: &str, model: &str) -> String {
+    format!("{MODEL_ID_PREFIX}{provider_key}|{model}")
+}
+
+fn parse_models(raw: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for item in raw.split([',', '\n', ';']) {
+        let model = item.trim();
+        if model.is_empty() || model.contains('|') || out.iter().any(|m| m == model) {
+            continue;
+        }
+        out.push(model.to_string());
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_model_list() {
+        assert_eq!(
+            parse_models("a, b\nc; a | bad"),
+            vec!["a".to_string(), "b".to_string(), "c".to_string()]
+        );
+    }
+
+    #[test]
+    fn deserializes_minimax_region_keys() {
+        let settings: ClaudeCustomProviderSettings =
+            serde_json::from_str(r#"{"minimaxApiKey":"global-key","minimaxCnApiKey":"cn-key"}"#)
+                .unwrap();
+
+        assert_eq!(settings.minimax_api_key, "global-key");
+        assert_eq!(settings.minimax_cn_api_key, "cn-key");
+    }
+
+    #[test]
+    fn builtin_api_key_prefers_generic_map() {
+        let settings: ClaudeCustomProviderSettings = serde_json::from_str(
+            r#"{"minimaxApiKey":"legacy","builtinProviderApiKeys":{"minimax":"mapped"}}"#,
+        )
+        .unwrap();
+
+        assert_eq!(builtin_api_key(&settings, "minimax"), "mapped");
+    }
+}

--- a/src-tauri/src/agents/custom_providers.rs
+++ b/src-tauri/src/agents/custom_providers.rs
@@ -9,13 +9,7 @@ const MODEL_ID_PREFIX: &str = "claude-custom|";
 #[serde(rename_all = "camelCase")]
 pub struct ClaudeCustomProviderSettings {
     #[serde(default)]
-    pub minimax_api_key: String,
-    #[serde(default)]
-    pub minimax_cn_api_key: String,
-    #[serde(default)]
     pub builtin_provider_api_keys: HashMap<String, String>,
-    #[serde(default)]
-    pub custom_provider_name: String,
     #[serde(default)]
     pub custom_base_url: String,
     #[serde(default)]
@@ -28,7 +22,6 @@ pub struct ClaudeCustomProviderSettings {
 pub struct ClaudeProviderModel {
     pub id: String,
     pub provider_key: String,
-    pub provider_name: String,
     pub label: String,
     pub cli_model: String,
     pub base_url: String,
@@ -46,23 +39,21 @@ pub fn configured_models() -> Vec<ClaudeProviderModel> {
     let settings = load_settings();
     let mut models = Vec::new();
 
-    for provider in super::builtin_claude_providers::BUILTIN_CLAUDE_PROVIDERS {
+    for provider in super::builtin_claude_providers::builtin_claude_providers() {
         append_builtin_models(
             &mut models,
-            provider.key,
-            builtin_api_key(&settings, provider.key).trim(),
+            provider.key.as_str(),
+            builtin_api_key(&settings, provider.key.as_str()).trim(),
         );
     }
 
-    let provider_name = settings.custom_provider_name.trim();
     let base_url = settings.custom_base_url.trim();
     let api_key = settings.custom_api_key.trim();
-    if !provider_name.is_empty() && !base_url.is_empty() && !api_key.is_empty() {
+    if !base_url.is_empty() && !api_key.is_empty() {
         for model in parse_models(&settings.custom_models) {
             models.push(ClaudeProviderModel {
                 id: model_id("custom", &model),
                 provider_key: "custom".to_string(),
-                provider_name: provider_name.to_string(),
                 label: model.clone(),
                 cli_model: model,
                 base_url: base_url.to_string(),
@@ -80,11 +71,7 @@ fn builtin_api_key(settings: &ClaudeCustomProviderSettings, provider_key: &str) 
         .get(provider_key)
         .cloned()
         .filter(|value| !value.trim().is_empty())
-        .unwrap_or_else(|| match provider_key {
-            "minimax" => settings.minimax_api_key.clone(),
-            "minimax-cn" => settings.minimax_cn_api_key.clone(),
-            _ => String::new(),
-        })
+        .unwrap_or_default()
 }
 
 fn append_builtin_models(models: &mut Vec<ClaudeProviderModel>, provider_key: &str, api_key: &str) {
@@ -92,21 +79,20 @@ fn append_builtin_models(models: &mut Vec<ClaudeProviderModel>, provider_key: &s
         return;
     }
 
-    let Some(provider) = super::builtin_claude_providers::BUILTIN_CLAUDE_PROVIDERS
+    let Some(provider) = super::builtin_claude_providers::builtin_claude_providers()
         .iter()
         .find(|provider| provider.key == provider_key)
     else {
         return;
     };
 
-    for model in provider.models {
+    for model in &provider.models {
         models.push(ClaudeProviderModel {
-            id: model_id(provider.key, model.id),
-            provider_key: provider.key.to_string(),
-            provider_name: provider.name.to_string(),
-            label: model.label.to_string(),
-            cli_model: model.id.to_string(),
-            base_url: provider.base_url.to_string(),
+            id: model_id(provider.key.as_str(), model.id.as_str()),
+            provider_key: provider.key.clone(),
+            label: model.label.clone(),
+            cli_model: model.id.clone(),
+            base_url: provider.base_url.clone(),
             api_key: api_key.to_string(),
         });
     }
@@ -124,7 +110,7 @@ fn model_id(provider_key: &str, model: &str) -> String {
 
 fn parse_models(raw: &str) -> Vec<String> {
     let mut out = Vec::new();
-    for item in raw.split([',', '\n', ';']) {
+    for item in raw.lines() {
         let model = item.trim();
         if model.is_empty() || model.contains('|') || out.iter().any(|m| m == model) {
             continue;
@@ -141,28 +127,24 @@ mod tests {
     #[test]
     fn parses_model_list() {
         assert_eq!(
-            parse_models("a, b\nc; a | bad"),
+            parse_models("a\nb\nc\na | bad"),
             vec!["a".to_string(), "b".to_string(), "c".to_string()]
         );
     }
 
     #[test]
-    fn deserializes_minimax_region_keys() {
+    fn builtin_api_key_reads_canonical_map() {
         let settings: ClaudeCustomProviderSettings =
-            serde_json::from_str(r#"{"minimaxApiKey":"global-key","minimaxCnApiKey":"cn-key"}"#)
-                .unwrap();
+            serde_json::from_str(r#"{"builtinProviderApiKeys":{"minimax":"mapped"}}"#).unwrap();
 
-        assert_eq!(settings.minimax_api_key, "global-key");
-        assert_eq!(settings.minimax_cn_api_key, "cn-key");
+        assert_eq!(builtin_api_key(&settings, "minimax"), "mapped");
     }
 
     #[test]
-    fn builtin_api_key_prefers_generic_map() {
-        let settings: ClaudeCustomProviderSettings = serde_json::from_str(
-            r#"{"minimaxApiKey":"legacy","builtinProviderApiKeys":{"minimax":"mapped"}}"#,
-        )
-        .unwrap();
+    fn builtin_api_key_ignores_blank_values() {
+        let settings: ClaudeCustomProviderSettings =
+            serde_json::from_str(r#"{"builtinProviderApiKeys":{"minimax":"   "}}"#).unwrap();
 
-        assert_eq!(builtin_api_key(&settings, "minimax"), "mapped");
+        assert_eq!(builtin_api_key(&settings, "minimax"), "");
     }
 }

--- a/src-tauri/src/agents/queries.rs
+++ b/src-tauri/src/agents/queries.rs
@@ -23,9 +23,9 @@ pub struct GenerateSessionTitleResponse {
     pub skipped: bool,
 }
 
-/// Sidecar response timeout. The sidecar gives Claude 30 s and Codex fallback
-/// another 30 s, so keep a small buffer here for request handoff and delivery.
-const TITLE_GEN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(65);
+/// Sidecar response timeout. The sidecar may try a configured Claude-compatible
+/// model, official Claude, then Codex, so keep a small buffer for handoff.
+const TITLE_GEN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(95);
 
 type WorkspaceInfo = (String, String, Option<String>, String, Option<String>);
 
@@ -133,13 +133,32 @@ pub async fn generate_session_title(
     }
 
     let request_id = Uuid::new_v4().to_string();
+    let mut params = serde_json::json!({
+        "userMessage": request.user_message,
+        "branchRenamePrompt": branch_rename_prompt,
+    });
+    if let Some(model) = super::custom_providers::configured_models()
+        .into_iter()
+        .next()
+    {
+        if let Some(obj) = params.as_object_mut() {
+            obj.insert(
+                "claudeModel".to_string(),
+                Value::String(model.cli_model.clone()),
+            );
+            obj.insert(
+                "claudeEnvironment".to_string(),
+                serde_json::json!({
+                    "ANTHROPIC_BASE_URL": model.base_url,
+                    "ANTHROPIC_AUTH_TOKEN": model.api_key,
+                }),
+            );
+        }
+    }
     let sidecar_req = crate::sidecar::SidecarRequest {
         id: request_id.clone(),
         method: "generateTitle".to_string(),
-        params: serde_json::json!({
-            "userMessage": request.user_message,
-            "branchRenamePrompt": branch_rename_prompt,
-        }),
+        params,
     };
 
     let rx = sidecar.subscribe(&request_id);

--- a/src-tauri/src/agents/streaming/mod.rs
+++ b/src-tauri/src/agents/streaming/mod.rs
@@ -128,6 +128,8 @@ pub(super) fn stream_via_sidecar(
         permission_mode: request.permission_mode.as_deref(),
         fast_mode: request.fast_mode.unwrap_or(false),
         helmor_session_id: request.helmor_session_id.as_deref(),
+        claude_base_url: model.claude_base_url.as_deref(),
+        claude_auth_token: model.claude_auth_token.as_deref(),
     });
 
     // Surface the `/add-dir` decision in logs — we often debug linked-

--- a/src-tauri/src/agents/streaming/params.rs
+++ b/src-tauri/src/agents/streaming/params.rs
@@ -19,6 +19,8 @@ pub struct BuildSendMessageParamsInput<'a> {
     pub permission_mode: Option<&'a str>,
     pub fast_mode: bool,
     pub helmor_session_id: Option<&'a str>,
+    pub claude_base_url: Option<&'a str>,
+    pub claude_auth_token: Option<&'a str>,
 }
 
 /// Build the `sendMessage` request params that the sidecar receives.
@@ -45,6 +47,17 @@ pub fn build_send_message_params(input: BuildSendMessageParamsInput<'_>) -> Valu
             obj.insert(
                 "additionalDirectories".to_string(),
                 Value::from(additional_directories),
+            );
+        }
+    }
+    if let (Some(base_url), Some(auth_token)) = (input.claude_base_url, input.claude_auth_token) {
+        if let Some(obj) = params.as_object_mut() {
+            obj.insert(
+                "claudeEnvironment".to_string(),
+                serde_json::json!({
+                    "ANTHROPIC_BASE_URL": base_url,
+                    "ANTHROPIC_AUTH_TOKEN": auth_token,
+                }),
             );
         }
     }

--- a/src-tauri/tests/snapshots/streaming_send_params__params_with_claude_environment.snap
+++ b/src-tauri/tests/snapshots/streaming_send_params__params_with_claude_environment.snap
@@ -1,0 +1,17 @@
+---
+source: tests/streaming_send_params.rs
+assertion_line: 139
+expression: "&params"
+---
+claudeEnvironment:
+  ANTHROPIC_AUTH_TOKEN: sk-test
+  ANTHROPIC_BASE_URL: "https://api.example.com/anthropic"
+cwd: /abs/workspace
+effortLevel: high
+fastMode: false
+model: claude-opus-4
+permissionMode: bypassPermissions
+prompt: hello
+provider: claude
+resume: ~
+sessionId: sidecar-sess-1

--- a/src-tauri/tests/streaming_send_params.rs
+++ b/src-tauri/tests/streaming_send_params.rs
@@ -98,6 +98,8 @@ fn base_input<'a>(session_id: Option<&'a str>) -> BuildSendMessageParamsInput<'a
         permission_mode: Some("bypassPermissions"),
         fast_mode: false,
         helmor_session_id: session_id,
+        claude_base_url: None,
+        claude_auth_token: None,
     }
 }
 
@@ -122,6 +124,19 @@ fn includes_additional_directories_from_workspace() {
 
     let params = build(base_input(Some("s-2")));
     assert_yaml_snapshot!("params_with_linked_dirs", &params);
+}
+
+#[test]
+fn includes_claude_environment_for_custom_provider() {
+    let env = TestEnv::new();
+    seed_workspace_session(&env.connection(), "w-3", "s-3", None);
+
+    let mut input = base_input(Some("s-3"));
+    input.claude_base_url = Some("https://api.example.com/anthropic");
+    input.claude_auth_token = Some("sk-test");
+
+    let params = build(input);
+    assert_yaml_snapshot!("params_with_claude_environment", &params);
 }
 
 #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,7 +40,11 @@ import { WorkspacesSidebarContainer } from "@/features/navigation/container";
 import { AppOnboarding } from "@/features/onboarding";
 import { seedNewSessionInCache } from "@/features/panel/session-cache";
 import { useConfirmSessionClose } from "@/features/panel/use-confirm-session-close";
-import { SettingsButton, SettingsDialog } from "@/features/settings";
+import {
+	SettingsButton,
+	SettingsDialog,
+	type SettingsSection,
+} from "@/features/settings";
 import { getShortcut } from "@/features/shortcuts/registry";
 import { InlineShortcutDisplay } from "@/features/shortcuts/shortcut-display";
 import {
@@ -132,6 +136,7 @@ import {
 import { StreamingFooterOverlapScenario } from "./test/e2e-scenarios/streaming-footer-overlap";
 
 const SETTINGS_RELOAD_EVENT = "helmor:reload-settings";
+const OPEN_SETTINGS_EVENT = "helmor:open-settings";
 
 function App() {
 	const e2eScenario =
@@ -155,6 +160,8 @@ function MainApp() {
 	const [settingsWorkspaceRepoId, setSettingsWorkspaceRepoId] = useState<
 		string | null
 	>(null);
+	const [settingsInitialSection, setSettingsInitialSection] =
+		useState<SettingsSection>();
 	const [queryClient] = useState(() => createHelmorQueryClient());
 	const preloadSettings = useMemo<AppSettings>(() => {
 		const t = localStorage.getItem(THEME_STORAGE_KEY) as ThemeMode | null;
@@ -175,6 +182,27 @@ function MainApp() {
 		}),
 		[appSettings, preloadSettings],
 	);
+	useEffect(() => {
+		const handleOpenSettings = (event: Event) => {
+			const detail =
+				event instanceof CustomEvent &&
+				event.detail &&
+				typeof event.detail === "object"
+					? (event.detail as { section?: unknown })
+					: {};
+			const section =
+				typeof detail.section === "string"
+					? (detail.section as SettingsSection)
+					: undefined;
+			setSettingsInitialSection(section);
+			setSettingsWorkspaceId(null);
+			setSettingsWorkspaceRepoId(null);
+			setSettingsOpen(true);
+		};
+		window.addEventListener(OPEN_SETTINGS_EVENT, handleOpenSettings);
+		return () =>
+			window.removeEventListener(OPEN_SETTINGS_EVENT, handleOpenSettings);
+	}, []);
 	const [splashVisible, setSplashVisible] = useState(true);
 	const [splashMounted, setSplashMounted] = useState(true);
 
@@ -282,6 +310,7 @@ function MainApp() {
 				) : (
 					<AppShell
 						onOpenSettings={(workspaceId, workspaceRepoId) => {
+							setSettingsInitialSection(undefined);
 							setSettingsWorkspaceId(workspaceId);
 							setSettingsWorkspaceRepoId(workspaceRepoId);
 							setSettingsOpen(true);
@@ -293,6 +322,7 @@ function MainApp() {
 					open={settingsOpen}
 					workspaceId={settingsWorkspaceId}
 					workspaceRepoId={settingsWorkspaceRepoId}
+					initialSection={settingsInitialSection}
 					onClose={() => {
 						setSettingsOpen(false);
 						void queryClient.invalidateQueries({

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -168,9 +168,9 @@ function MainApp() {
 			updateSettings: (patch: Partial<AppSettings>) => {
 				setAppSettings((previous) => {
 					const next = { ...(previous ?? DEFAULT_SETTINGS), ...patch };
-					void saveSettings(patch);
 					return next;
 				});
+				return saveSettings(patch);
 			},
 		}),
 		[appSettings, preloadSettings],

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -1,10 +1,10 @@
-import Claude from "@lobehub/icons/es/Claude";
-import Kimi from "@lobehub/icons/es/Kimi";
-import Minimax from "@lobehub/icons/es/Minimax";
-import OpenAI from "@lobehub/icons/es/OpenAI";
-import Qwen from "@lobehub/icons/es/Qwen";
-import XiaomiMiMo from "@lobehub/icons/es/XiaomiMiMo";
-import Zhipu from "@lobehub/icons/es/Zhipu";
+import ClaudeColor from "@lobehub/icons/es/Claude/components/Color";
+import KimiMono from "@lobehub/icons/es/Kimi/components/Mono";
+import MinimaxColor from "@lobehub/icons/es/Minimax/components/Color";
+import OpenAIMono from "@lobehub/icons/es/OpenAI/components/Mono";
+import QwenColor from "@lobehub/icons/es/Qwen/components/Color";
+import XiaomiMiMoMono from "@lobehub/icons/es/XiaomiMiMo/components/Mono";
+import ZhipuColor from "@lobehub/icons/es/Zhipu/components/Color";
 import type { SVGProps } from "react";
 
 export function ClaudeIcon(props: SVGProps<SVGSVGElement>) {
@@ -36,29 +36,29 @@ export function OpenAIIcon(props: SVGProps<SVGSVGElement>) {
 }
 
 export function ClaudeColorIcon(props: SVGProps<SVGSVGElement>) {
-	return <Claude.Color {...props} />;
+	return <ClaudeColor {...props} />;
 }
 
 export function OpenAIColorIcon(props: SVGProps<SVGSVGElement>) {
-	return <OpenAI {...props} />;
+	return <OpenAIMono {...props} />;
 }
 
 export function MinimaxIcon(props: SVGProps<SVGSVGElement>) {
-	return <Minimax.Color {...props} />;
+	return <MinimaxColor {...props} />;
 }
 
 export function KimiIcon(props: SVGProps<SVGSVGElement>) {
-	return <Kimi {...props} />;
+	return <KimiMono {...props} />;
 }
 
 export function QwenIcon(props: SVGProps<SVGSVGElement>) {
-	return <Qwen.Color {...props} />;
+	return <QwenColor {...props} />;
 }
 
 export function XiaomiMiMoIcon(props: SVGProps<SVGSVGElement>) {
-	return <XiaomiMiMo {...props} />;
+	return <XiaomiMiMoMono {...props} />;
 }
 
 export function ZhipuIcon(props: SVGProps<SVGSVGElement>) {
-	return <Zhipu.Color {...props} />;
+	return <ZhipuColor {...props} />;
 }

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -1,3 +1,8 @@
+import Kimi from "@lobehub/icons/es/Kimi";
+import Minimax from "@lobehub/icons/es/Minimax";
+import Qwen from "@lobehub/icons/es/Qwen";
+import XiaomiMiMo from "@lobehub/icons/es/XiaomiMiMo";
+import Zhipu from "@lobehub/icons/es/Zhipu";
 import type { SVGProps } from "react";
 
 export function ClaudeIcon(props: SVGProps<SVGSVGElement>) {
@@ -26,4 +31,24 @@ export function OpenAIIcon(props: SVGProps<SVGSVGElement>) {
 			<path d="M9.205 8.658v-2.26c0-.19.072-.333.238-.428l4.543-2.616c.619-.357 1.356-.523 2.117-.523 2.854 0 4.662 2.212 4.662 4.566 0 .167 0 .357-.024.547l-4.71-2.759a.797.797 0 00-.856 0l-5.97 3.473zm10.609 8.8V12.06c0-.333-.143-.57-.429-.737l-5.97-3.473 1.95-1.118a.433.433 0 01.476 0l4.543 2.617c1.309.76 2.189 2.378 2.189 3.948 0 1.808-1.07 3.473-2.76 4.163zM7.802 12.703l-1.95-1.142c-.167-.095-.239-.238-.239-.428V5.899c0-2.545 1.95-4.472 4.591-4.472 1 0 1.927.333 2.712.928L8.23 5.067c-.285.166-.428.404-.428.737v6.898zM12 15.128l-2.795-1.57v-3.33L12 8.658l2.795 1.57v3.33L12 15.128zm1.796 7.23c-1 0-1.927-.332-2.712-.927l4.686-2.712c.285-.166.428-.404.428-.737v-6.898l1.974 1.142c.167.095.238.238.238.428v5.233c0 2.545-1.974 4.472-4.614 4.472zm-5.637-5.303l-4.544-2.617c-1.308-.761-2.188-2.378-2.188-3.948A4.482 4.482 0 014.21 6.327v5.423c0 .333.143.571.428.738l5.947 3.449-1.95 1.118a.432.432 0 01-.476 0zm-.262 3.9c-2.688 0-4.662-2.021-4.662-4.519 0-.19.024-.38.047-.57l4.686 2.71c.286.167.571.167.856 0l5.97-3.448v2.26c0 .19-.07.333-.237.428l-4.543 2.616c-.619.357-1.356.523-2.117.523zm5.899 2.83a5.947 5.947 0 005.827-4.756C22.287 18.339 24 15.84 24 13.296c0-1.665-.713-3.282-1.998-4.448.119-.5.19-.999.19-1.498 0-3.401-2.759-5.947-5.946-5.947-.642 0-1.26.095-1.88.31A5.962 5.962 0 0010.205 0a5.947 5.947 0 00-5.827 4.757C1.713 5.447 0 7.945 0 10.49c0 1.666.713 3.283 1.998 4.448-.119.5-.19 1-.19 1.499 0 3.401 2.759 5.946 5.946 5.946.642 0 1.26-.095 1.88-.309a5.96 5.96 0 004.162 1.713z" />
 		</svg>
 	);
+}
+
+export function MinimaxIcon(props: SVGProps<SVGSVGElement>) {
+	return <Minimax.Color {...props} />;
+}
+
+export function KimiIcon(props: SVGProps<SVGSVGElement>) {
+	return <Kimi.Color {...props} />;
+}
+
+export function QwenIcon(props: SVGProps<SVGSVGElement>) {
+	return <Qwen.Color {...props} />;
+}
+
+export function XiaomiMiMoIcon(props: SVGProps<SVGSVGElement>) {
+	return <XiaomiMiMo {...props} />;
+}
+
+export function ZhipuIcon(props: SVGProps<SVGSVGElement>) {
+	return <Zhipu.Color {...props} />;
 }

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -1,5 +1,7 @@
+import Claude from "@lobehub/icons/es/Claude";
 import Kimi from "@lobehub/icons/es/Kimi";
 import Minimax from "@lobehub/icons/es/Minimax";
+import OpenAI from "@lobehub/icons/es/OpenAI";
 import Qwen from "@lobehub/icons/es/Qwen";
 import XiaomiMiMo from "@lobehub/icons/es/XiaomiMiMo";
 import Zhipu from "@lobehub/icons/es/Zhipu";
@@ -33,12 +35,20 @@ export function OpenAIIcon(props: SVGProps<SVGSVGElement>) {
 	);
 }
 
+export function ClaudeColorIcon(props: SVGProps<SVGSVGElement>) {
+	return <Claude.Color {...props} />;
+}
+
+export function OpenAIColorIcon(props: SVGProps<SVGSVGElement>) {
+	return <OpenAI {...props} />;
+}
+
 export function MinimaxIcon(props: SVGProps<SVGSVGElement>) {
 	return <Minimax.Color {...props} />;
 }
 
 export function KimiIcon(props: SVGProps<SVGSVGElement>) {
-	return <Kimi.Color {...props} />;
+	return <Kimi {...props} />;
 }
 
 export function QwenIcon(props: SVGProps<SVGSVGElement>) {

--- a/src/components/model-icon.tsx
+++ b/src/components/model-icon.tsx
@@ -1,0 +1,35 @@
+import { Box } from "lucide-react";
+import {
+	ClaudeColorIcon,
+	KimiIcon,
+	MinimaxIcon,
+	OpenAIColorIcon,
+	QwenIcon,
+	XiaomiMiMoIcon,
+	ZhipuIcon,
+} from "@/components/icons";
+import type { AgentModelOption } from "@/lib/api";
+
+export function ModelIcon({
+	model,
+	className,
+}: {
+	model?: AgentModelOption | null;
+	className?: string;
+}) {
+	if (model?.provider === "codex")
+		return <OpenAIColorIcon className={className} />;
+	if (model?.providerKey === "custom")
+		return <Box className={className} strokeWidth={1.8} />;
+	if (model?.providerKey === "minimax" || model?.providerKey === "minimax-cn")
+		return <MinimaxIcon className={className} />;
+	if (model?.providerKey === "moonshot" || model?.providerKey === "moonshot-cn")
+		return <KimiIcon className={className} />;
+	if (model?.providerKey === "zai" || model?.providerKey === "zai-cn")
+		return <ZhipuIcon className={className} />;
+	if (model?.providerKey === "qwen" || model?.providerKey === "qwen-intl")
+		return <QwenIcon className={className} />;
+	if (model?.providerKey === "xiaomi")
+		return <XiaomiMiMoIcon className={className} />;
+	return <ClaudeColorIcon className={className} />;
+}

--- a/src/features/composer/index.tsx
+++ b/src/features/composer/index.tsx
@@ -11,19 +11,12 @@ import {
 	ChevronDown,
 	ClipboardList,
 	MessageSquareMore,
+	Plus,
 	Square,
 	Zap,
 } from "lucide-react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import {
-	ClaudeIcon,
-	KimiIcon,
-	MinimaxIcon,
-	OpenAIIcon,
-	QwenIcon,
-	XiaomiMiMoIcon,
-	ZhipuIcon,
-} from "@/components/icons";
+import { ModelIcon } from "@/components/model-icon";
 import { Button } from "@/components/ui/button";
 import {
 	DropdownMenu,
@@ -46,7 +39,6 @@ import { humanizeBranch } from "@/features/navigation/shared";
 import { normalizeShortcutEvent } from "@/features/shortcuts/format";
 import { InlineShortcutDisplay } from "@/features/shortcuts/shortcut-display";
 import type {
-	AgentModelOption,
 	AgentModelSection,
 	CandidateDirectory,
 	SlashCommandEntry,
@@ -93,6 +85,8 @@ import type { ElicitationResponseHandler } from "./elicitation";
 import { ElicitationPanel } from "./elicitation-panel";
 import { FastModeLottieIcon } from "./fast-mode-lottie-icon";
 import { UsageStatsIndicator } from "./usage-stats-indicator";
+
+const OPEN_SETTINGS_EVENT = "helmor:open-settings";
 
 type WorkspaceComposerProps = {
 	contextKey: string;
@@ -159,27 +153,6 @@ type WorkspaceComposerProps = {
 	focusShortcut?: string | null;
 	togglePlanShortcut?: string | null;
 };
-
-function ModelIcon({
-	model,
-	className,
-}: {
-	model?: AgentModelOption | null;
-	className?: string;
-}) {
-	if (model?.provider === "codex") return <OpenAIIcon className={className} />;
-	if (model?.providerKey === "minimax" || model?.providerKey === "minimax-cn")
-		return <MinimaxIcon className={className} />;
-	if (model?.providerKey === "moonshot" || model?.providerKey === "moonshot-cn")
-		return <KimiIcon className={className} />;
-	if (model?.providerKey === "zai" || model?.providerKey === "zai-cn")
-		return <ZhipuIcon className={className} />;
-	if (model?.providerKey === "qwen" || model?.providerKey === "qwen-intl")
-		return <QwenIcon className={className} />;
-	if (model?.providerKey === "xiaomi")
-		return <XiaomiMiMoIcon className={className} />;
-	return <ClaudeIcon className={className} />;
-}
 
 const EMPTY_SLASH_COMMANDS: readonly SlashCommandEntry[] = [];
 const EMPTY_LINKED_DIRECTORIES: readonly string[] = [];
@@ -292,6 +265,15 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 		}
 		return null;
 	}, [modelSections, selectedModelId]);
+	const hasConfiguredClaudeProviderModels = useMemo(
+		() =>
+			modelSections.some(
+				(section) =>
+					section.id === "claude" &&
+					section.options.some((option) => Boolean(option.providerKey)),
+			),
+		[modelSections],
+	);
 	const availableEffortLevels = useMemo(
 		() => selectedModel?.effortLevels ?? [],
 		[selectedModel],
@@ -336,6 +318,14 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 				handleOpenModelPicker,
 			);
 	}, [toolbarDisabled]);
+	const handleOpenModelSettings = useCallback(() => {
+		setModelPickerOpen(false);
+		window.dispatchEvent(
+			new CustomEvent(OPEN_SETTINGS_EVENT, {
+				detail: { section: "model" },
+			}),
+		);
+	}, []);
 	const composerToolbarTriggerClassName =
 		"cursor-pointer rounded-[9px] px-1 py-0.5 text-[13px] font-medium transition-colors hover:bg-accent/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50";
 	// Shared gate for Send and Steer — the only difference is whether a
@@ -691,16 +681,33 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 															}}
 															className="flex items-center justify-between gap-3"
 														>
-															<div className="flex items-center gap-3">
-																<span className="text-muted-foreground">
-																	<ModelIcon model={option} />
+															<div className="grid min-w-0 grid-cols-[1rem_minmax(0,1fr)] items-center gap-3">
+																<span className="flex size-4 items-center justify-center text-muted-foreground">
+																	<ModelIcon
+																		model={option}
+																		className="size-4"
+																	/>
 																</span>
-																<span className="font-mono tabular-nums">
+																<span className="truncate font-mono tabular-nums">
 																	{option.label}
 																</span>
 															</div>
 														</DropdownMenuItem>
 													))}
+													{section.id === "claude" &&
+													!hasConfiguredClaudeProviderModels ? (
+														<DropdownMenuItem
+															onClick={handleOpenModelSettings}
+															className="flex items-center gap-3"
+														>
+															<span className="flex size-4 items-center justify-center text-muted-foreground">
+																<Plus className="size-4" strokeWidth={1.8} />
+															</span>
+															<span className="font-mono tabular-nums">
+																Add custom model...
+															</span>
+														</DropdownMenuItem>
+													) : null}
 												</DropdownMenuGroup>
 											))}
 										</DropdownMenuContent>

--- a/src/features/composer/index.tsx
+++ b/src/features/composer/index.tsx
@@ -15,7 +15,15 @@ import {
 	Zap,
 } from "lucide-react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ClaudeIcon, OpenAIIcon } from "@/components/icons";
+import {
+	ClaudeIcon,
+	KimiIcon,
+	MinimaxIcon,
+	OpenAIIcon,
+	QwenIcon,
+	XiaomiMiMoIcon,
+	ZhipuIcon,
+} from "@/components/icons";
 import { Button } from "@/components/ui/button";
 import {
 	DropdownMenu,
@@ -38,6 +46,7 @@ import { humanizeBranch } from "@/features/navigation/shared";
 import { normalizeShortcutEvent } from "@/features/shortcuts/format";
 import { InlineShortcutDisplay } from "@/features/shortcuts/shortcut-display";
 import type {
+	AgentModelOption,
 	AgentModelSection,
 	CandidateDirectory,
 	SlashCommandEntry,
@@ -150,6 +159,27 @@ type WorkspaceComposerProps = {
 	focusShortcut?: string | null;
 	togglePlanShortcut?: string | null;
 };
+
+function ModelIcon({
+	model,
+	className,
+}: {
+	model?: AgentModelOption | null;
+	className?: string;
+}) {
+	if (model?.provider === "codex") return <OpenAIIcon className={className} />;
+	if (model?.providerKey === "minimax" || model?.providerKey === "minimax-cn")
+		return <MinimaxIcon className={className} />;
+	if (model?.providerKey === "moonshot" || model?.providerKey === "moonshot-cn")
+		return <KimiIcon className={className} />;
+	if (model?.providerKey === "zai" || model?.providerKey === "zai-cn")
+		return <ZhipuIcon className={className} />;
+	if (model?.providerKey === "qwen" || model?.providerKey === "qwen-intl")
+		return <QwenIcon className={className} />;
+	if (model?.providerKey === "xiaomi")
+		return <XiaomiMiMoIcon className={className} />;
+	return <ClaudeIcon className={className} />;
+}
 
 const EMPTY_SLASH_COMMANDS: readonly SlashCommandEntry[] = [];
 const EMPTY_LINKED_DIRECTORIES: readonly string[] = [];
@@ -268,6 +298,7 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 	);
 	const supportsEffort = availableEffortLevels.length > 0;
 	const supportsFastMode = selectedModel?.supportsFastMode === true;
+	const supportsContextUsage = selectedModel?.supportsContextUsage !== false;
 	const effectiveEffort = useMemo(
 		() => clampEffort(effortLevel, availableEffortLevels),
 		[effortLevel, availableEffortLevels],
@@ -626,11 +657,10 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 													"cursor-not-allowed opacity-45 hover:bg-transparent hover:text-muted-foreground",
 											)}
 										>
-											{selectedModel?.provider === "codex" ? (
-												<OpenAIIcon className="size-[13px]" />
-											) : (
-												<ClaudeIcon className="size-[13px]" />
-											)}
+											<ModelIcon
+												model={selectedModel}
+												className="size-[13px]"
+											/>
 											<span>
 												{selectedModel?.label ??
 													selectedModelId ??
@@ -663,11 +693,7 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 														>
 															<div className="flex items-center gap-3">
 																<span className="text-muted-foreground">
-																	{option.provider === "codex" ? (
-																		<OpenAIIcon />
-																	) : (
-																		<ClaudeIcon />
-																	)}
+																	<ModelIcon model={option} />
 																</span>
 																<span className="font-mono tabular-nums">
 																	{option.label}
@@ -801,7 +827,7 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 
 						<div className="flex items-center gap-1">
 							<UsageStatsIndicator agentType={agentType} disabled={disabled} />
-							{sessionId ? (
+							{sessionId && supportsContextUsage ? (
 								<ContextUsageRing
 									sessionId={sessionId}
 									providerSessionId={providerSessionId}

--- a/src/features/settings/index.tsx
+++ b/src/features/settings/index.tsx
@@ -9,6 +9,7 @@ import {
 	Sun,
 } from "lucide-react";
 import { memo, useEffect, useState } from "react";
+import { ModelIcon } from "@/components/model-icon";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import {
@@ -51,6 +52,7 @@ import {
 } from "@/lib/query-client";
 import type { ThemeMode } from "@/lib/settings";
 import { useSettings } from "@/lib/settings";
+import { cn } from "@/lib/utils";
 import { clampEffort, findModelOption } from "@/lib/workspace-helpers";
 import { SettingsGroup, SettingsRow } from "./components/settings-row";
 import { AccountPanel } from "./panels/account";
@@ -65,7 +67,7 @@ const MIN_FONT_SIZE = 12;
 const MAX_FONT_SIZE = 20;
 const FALLBACK_EFFORT_LEVELS = ["low", "medium", "high"];
 
-type SettingsSection =
+export type SettingsSection =
 	| "general"
 	| "shortcuts"
 	| "appearance"
@@ -99,11 +101,13 @@ export const SettingsDialog = memo(function SettingsDialog({
 	open,
 	workspaceId,
 	workspaceRepoId,
+	initialSection,
 	onClose,
 }: {
 	open: boolean;
 	workspaceId: string | null;
 	workspaceRepoId: string | null;
+	initialSection?: SettingsSection;
 	onClose: () => void;
 }) {
 	const { settings, updateSettings } = useSettings();
@@ -112,6 +116,12 @@ export const SettingsDialog = memo(function SettingsDialog({
 		useState<SettingsSection>("general");
 	const [githubLogin, setGithubLogin] = useState<string | null>(null);
 	const [conductorEnabled, setConductorEnabled] = useState(false);
+
+	useEffect(() => {
+		if (open && initialSection) {
+			setActiveSection(initialSection);
+		}
+	}, [open, initialSection]);
 
 	const reposQuery = useQuery({
 		...repositoriesQueryOptions(),
@@ -419,11 +429,24 @@ export const SettingsDialog = memo(function SettingsDialog({
 										title="Default model"
 										description="Model for new chats"
 									>
-										<div className="flex items-center gap-2">
+										<div className="flex w-[360px] items-center gap-2">
 											<DropdownMenu>
-												<DropdownMenuTrigger className="flex cursor-pointer items-center gap-1.5 rounded-lg border border-border/50 bg-muted/30 px-3 py-1.5 text-[13px] text-foreground hover:bg-muted/50">
-													<span>{defaultModelLabel}</span>
-													<ChevronDown className="size-3 opacity-40" />
+												<DropdownMenuTrigger
+													className={cn(
+														"flex h-8 cursor-pointer items-center justify-between rounded-lg border border-border/50 bg-muted/30 px-3 text-[13px] text-foreground hover:bg-muted/50",
+														"min-w-0 flex-1 gap-1.5",
+													)}
+												>
+													<span className="flex min-w-0 items-center gap-1.5">
+														<ModelIcon
+															model={selectedDefaultModel}
+															className="size-[13px] shrink-0"
+														/>
+														<span className="min-w-0 truncate whitespace-nowrap">
+															{defaultModelLabel}
+														</span>
+													</span>
+													<ChevronDown className="size-3 shrink-0 opacity-40" />
 												</DropdownMenuTrigger>
 												<DropdownMenuContent
 													align="end"
@@ -436,14 +459,21 @@ export const SettingsDialog = memo(function SettingsDialog({
 															onClick={() =>
 																updateSettings({ defaultModelId: m.id })
 															}
+															className="gap-2"
 														>
+															<ModelIcon model={m} className="size-4" />
 															{m.label}
 														</DropdownMenuItem>
 													))}
 												</DropdownMenuContent>
 											</DropdownMenu>
 											<DropdownMenu>
-												<DropdownMenuTrigger className="flex cursor-pointer items-center gap-1.5 rounded-lg border border-border/50 bg-muted/30 px-3 py-1.5 text-[13px] text-foreground hover:bg-muted/50">
+												<DropdownMenuTrigger
+													className={cn(
+														"flex h-8 cursor-pointer items-center rounded-lg border border-border/50 bg-muted/30 px-3 text-[13px] text-foreground hover:bg-muted/50",
+														"shrink-0 gap-1.5",
+													)}
+												>
 													<span>
 														{effortLabel(settings.defaultEffort ?? "high")}
 													</span>
@@ -466,7 +496,12 @@ export const SettingsDialog = memo(function SettingsDialog({
 													))}
 												</DropdownMenuContent>
 											</DropdownMenu>
-											<div className="flex items-center gap-2 rounded-lg border border-border/50 bg-muted/30 px-3 py-1.5">
+											<div
+												className={cn(
+													"flex h-8 cursor-pointer items-center rounded-lg border border-border/50 bg-muted/30 px-3 text-[13px] text-foreground hover:bg-muted/50",
+													"shrink-0 gap-2",
+												)}
+											>
 												<span
 													className={
 														defaultModelSupportsFastMode

--- a/src/features/settings/index.tsx
+++ b/src/features/settings/index.tsx
@@ -58,6 +58,7 @@ import { AppUpdatesPanel } from "./panels/app-updates";
 import { CliInstallPanel } from "./panels/cli-install";
 import { ConductorImportPanel } from "./panels/conductor-import";
 import { DevToolsPanel } from "./panels/dev-tools";
+import { ClaudeCustomProvidersPanel } from "./panels/model-providers";
 import { RepositorySettingsPanel } from "./panels/repository-settings";
 
 const MIN_FONT_SIZE = 12;
@@ -489,6 +490,7 @@ export const SettingsDialog = memo(function SettingsDialog({
 											</div>
 										</div>
 									</SettingsRow>
+									<ClaudeCustomProvidersPanel />
 								</SettingsGroup>
 							)}
 

--- a/src/features/settings/panels/builtin-claude-providers.ts
+++ b/src/features/settings/panels/builtin-claude-providers.ts
@@ -1,0 +1,100 @@
+export type BuiltinClaudeProviderKey =
+	| "minimax"
+	| "minimax-cn"
+	| "moonshot"
+	| "moonshot-cn"
+	| "zai"
+	| "zai-cn"
+	| "qwen"
+	| "qwen-intl"
+	| "xiaomi";
+
+export type BuiltinClaudeProvider = {
+	key: BuiltinClaudeProviderKey;
+	label: string;
+	baseUrl: string;
+	apiKeyUrl: string;
+	models: readonly string[];
+	icon: "minimax" | "moonshot" | "zhipu" | "qwen" | "xiaomi";
+};
+
+export const BUILTIN_CLAUDE_PROVIDERS: readonly BuiltinClaudeProvider[] = [
+	{
+		key: "minimax",
+		label: "MiniMax",
+		baseUrl: "https://api.minimax.io/anthropic",
+		apiKeyUrl:
+			"https://platform.minimax.io/user-center/basic-information/interface-key",
+		models: ["MiniMax-M2.7"],
+		icon: "minimax",
+	},
+	{
+		key: "minimax-cn",
+		label: "MiniMax CN",
+		baseUrl: "https://api.minimaxi.com/anthropic",
+		apiKeyUrl:
+			"https://platform.minimaxi.com/user-center/basic-information/interface-key",
+		models: ["MiniMax-M2.7"],
+		icon: "minimax",
+	},
+	{
+		key: "moonshot",
+		label: "Moonshot / Kimi",
+		baseUrl: "https://api.moonshot.ai/anthropic",
+		apiKeyUrl: "https://platform.kimi.ai/console/api-keys",
+		models: ["kimi-k2.5"],
+		icon: "moonshot",
+	},
+	{
+		key: "moonshot-cn",
+		label: "Moonshot / Kimi CN",
+		baseUrl: "https://api.moonshot.cn/anthropic",
+		apiKeyUrl: "https://platform.moonshot.cn/console/api-keys",
+		models: ["kimi-k2.5"],
+		icon: "moonshot",
+	},
+	{
+		key: "zai",
+		label: "Z.AI / GLM",
+		baseUrl: "https://api.z.ai/api/anthropic",
+		apiKeyUrl: "https://z.ai/manage-apikey/apikey-list",
+		models: ["glm-4.7"],
+		icon: "zhipu",
+	},
+	{
+		key: "zai-cn",
+		label: "Z.AI / GLM CN",
+		baseUrl: "https://open.bigmodel.cn/api/anthropic",
+		apiKeyUrl: "https://open.bigmodel.cn/usercenter/apikeys",
+		models: ["glm-5.1"],
+		icon: "zhipu",
+	},
+	{
+		key: "qwen",
+		label: "Qwen / DashScope",
+		baseUrl: "https://dashscope.aliyuncs.com/apps/anthropic",
+		apiKeyUrl: "https://bailian.console.aliyun.com/?tab=model#/api-key",
+		models: ["qwen3.6-plus"],
+		icon: "qwen",
+	},
+	{
+		key: "qwen-intl",
+		label: "Qwen / DashScope Intl",
+		baseUrl: "https://dashscope-intl.aliyuncs.com/apps/anthropic",
+		apiKeyUrl: "https://bailian.console.alibabacloud.com/?tab=model#/api-key",
+		models: ["qwen3.5-plus"],
+		icon: "qwen",
+	},
+	{
+		key: "xiaomi",
+		label: "Xiaomi MiMo",
+		baseUrl: "https://api.xiaomimimo.com/anthropic",
+		apiKeyUrl: "https://platform.xiaomimimo.com/#/console/api-keys",
+		models: ["mimo-v2-flash"],
+		icon: "xiaomi",
+	},
+];
+
+export function findBuiltinClaudeProvider(key: BuiltinClaudeProviderKey) {
+	return BUILTIN_CLAUDE_PROVIDERS.find((provider) => provider.key === key);
+}

--- a/src/features/settings/panels/builtin-claude-providers.ts
+++ b/src/features/settings/panels/builtin-claude-providers.ts
@@ -1,99 +1,23 @@
-export type BuiltinClaudeProviderKey =
-	| "minimax"
-	| "minimax-cn"
-	| "moonshot"
-	| "moonshot-cn"
-	| "zai"
-	| "zai-cn"
-	| "qwen"
-	| "qwen-intl"
-	| "xiaomi";
+import providers from "@/shared/builtin-claude-providers.json";
+
+export type BuiltinClaudeProviderKey = string;
+
+export type BuiltinClaudeProviderModel = {
+	id: string;
+	label: string;
+};
 
 export type BuiltinClaudeProvider = {
 	key: BuiltinClaudeProviderKey;
 	label: string;
 	baseUrl: string;
 	apiKeyUrl: string;
-	models: readonly string[];
+	models: readonly BuiltinClaudeProviderModel[];
 	icon: "minimax" | "moonshot" | "zhipu" | "qwen" | "xiaomi";
 };
 
-export const BUILTIN_CLAUDE_PROVIDERS: readonly BuiltinClaudeProvider[] = [
-	{
-		key: "minimax",
-		label: "MiniMax",
-		baseUrl: "https://api.minimax.io/anthropic",
-		apiKeyUrl:
-			"https://platform.minimax.io/user-center/basic-information/interface-key",
-		models: ["MiniMax-M2.7"],
-		icon: "minimax",
-	},
-	{
-		key: "minimax-cn",
-		label: "MiniMax CN",
-		baseUrl: "https://api.minimaxi.com/anthropic",
-		apiKeyUrl:
-			"https://platform.minimaxi.com/user-center/basic-information/interface-key",
-		models: ["MiniMax-M2.7"],
-		icon: "minimax",
-	},
-	{
-		key: "moonshot",
-		label: "Moonshot / Kimi",
-		baseUrl: "https://api.moonshot.ai/anthropic",
-		apiKeyUrl: "https://platform.kimi.ai/console/api-keys",
-		models: ["kimi-k2.5"],
-		icon: "moonshot",
-	},
-	{
-		key: "moonshot-cn",
-		label: "Moonshot / Kimi CN",
-		baseUrl: "https://api.moonshot.cn/anthropic",
-		apiKeyUrl: "https://platform.moonshot.cn/console/api-keys",
-		models: ["kimi-k2.5"],
-		icon: "moonshot",
-	},
-	{
-		key: "zai",
-		label: "Z.AI / GLM",
-		baseUrl: "https://api.z.ai/api/anthropic",
-		apiKeyUrl: "https://z.ai/manage-apikey/apikey-list",
-		models: ["glm-4.7"],
-		icon: "zhipu",
-	},
-	{
-		key: "zai-cn",
-		label: "Z.AI / GLM CN",
-		baseUrl: "https://open.bigmodel.cn/api/anthropic",
-		apiKeyUrl: "https://open.bigmodel.cn/usercenter/apikeys",
-		models: ["glm-5.1"],
-		icon: "zhipu",
-	},
-	{
-		key: "qwen",
-		label: "Qwen / DashScope",
-		baseUrl: "https://dashscope.aliyuncs.com/apps/anthropic",
-		apiKeyUrl: "https://bailian.console.aliyun.com/?tab=model#/api-key",
-		models: ["qwen3.6-plus"],
-		icon: "qwen",
-	},
-	{
-		key: "qwen-intl",
-		label: "Qwen / DashScope Intl",
-		baseUrl: "https://dashscope-intl.aliyuncs.com/apps/anthropic",
-		apiKeyUrl: "https://bailian.console.alibabacloud.com/?tab=model#/api-key",
-		models: ["qwen3.5-plus"],
-		icon: "qwen",
-	},
-	{
-		key: "xiaomi",
-		label: "Xiaomi MiMo",
-		baseUrl: "https://api.xiaomimimo.com/anthropic",
-		apiKeyUrl: "https://platform.xiaomimimo.com/#/console/api-keys",
-		models: ["mimo-v2-flash"],
-		icon: "xiaomi",
-	},
-];
+export const BUILTIN_CLAUDE_PROVIDERS =
+	providers as readonly BuiltinClaudeProvider[];
 
 export function findBuiltinClaudeProvider(key: BuiltinClaudeProviderKey) {
 	return BUILTIN_CLAUDE_PROVIDERS.find((provider) => provider.key === key);

--- a/src/features/settings/panels/model-providers.tsx
+++ b/src/features/settings/panels/model-providers.tsx
@@ -45,7 +45,6 @@ import {
 type ProviderKind = BuiltinClaudeProviderKey | "custom";
 
 type Draft = {
-	providerName: string;
 	baseUrl: string;
 	apiKey: string;
 	models: string;
@@ -87,7 +86,6 @@ export function ClaudeCustomProvidersPanel() {
 		const apiKey = draft.apiKey.trim();
 		if (kind === "custom") {
 			updateProvider({
-				customProviderName: draft.providerName.trim(),
 				customBaseUrl: draft.baseUrl.trim(),
 				customApiKey: apiKey,
 				customModels: draft.models.trim(),
@@ -103,15 +101,12 @@ export function ClaudeCustomProvidersPanel() {
 		}
 		updateProvider({
 			builtinProviderApiKeys: nextKeys,
-			...(kind === "minimax" ? { minimaxApiKey: apiKey } : {}),
-			...(kind === "minimax-cn" ? { minimaxCnApiKey: apiKey } : {}),
 		});
 	}
 
 	function removeProvider(itemKind: ProviderKind) {
 		if (itemKind === "custom") {
 			updateProvider({
-				customProviderName: "",
 				customBaseUrl: "",
 				customApiKey: "",
 				customModels: "",
@@ -124,8 +119,6 @@ export function ClaudeCustomProvidersPanel() {
 		delete nextKeys[itemKind];
 		updateProvider({
 			builtinProviderApiKeys: nextKeys,
-			...(itemKind === "minimax" ? { minimaxApiKey: "" } : {}),
-			...(itemKind === "minimax-cn" ? { minimaxCnApiKey: "" } : {}),
 		});
 	}
 
@@ -135,11 +128,11 @@ export function ClaudeCustomProvidersPanel() {
 	return (
 		<SettingsRow
 			title="Claude Code custom providers"
-			description="Enter API keys here to use third-party models instead of Claude Code's official models."
+			description="Enter API keys here to use third-party models. They can be used alongside Claude Code's official models."
 			align="start"
 			className="gap-8"
 		>
-			<div className="flex w-[340px] flex-col gap-3">
+			<div className="flex w-[360px] flex-col gap-3">
 				<div className="grid gap-2">
 					<ProviderPicker
 						kind={kind}
@@ -182,18 +175,6 @@ export function ClaudeCustomProvidersPanel() {
 					) : (
 						<div className="grid gap-2">
 							<Input
-								value={draft.providerName}
-								onBlur={saveDraftIfComplete}
-								onChange={(event) =>
-									setDraft((current) => ({
-										...current,
-										providerName: event.target.value,
-									}))
-								}
-								placeholder="Provider name"
-								className="h-8 border-border/50 bg-muted/20 text-[13px]"
-							/>
-							<Input
 								value={draft.baseUrl}
 								onBlur={saveDraftIfComplete}
 								onChange={(event) =>
@@ -227,8 +208,10 @@ export function ClaudeCustomProvidersPanel() {
 										models: event.target.value,
 									}))
 								}
-								placeholder="model-a, model-b"
-								className="min-h-20 border-border/50 bg-muted/20 text-[13px]"
+								placeholder={`model-a
+model-b
+model-c`}
+								className="h-20 resize-none overflow-y-auto border-border/50 bg-muted/20 text-[13px]"
 							/>
 						</div>
 					)}
@@ -256,7 +239,11 @@ function ProviderPicker({
 
 	return (
 		<DropdownMenu>
-			<DropdownMenuTrigger className="flex h-8 min-w-0 flex-1 cursor-pointer items-center justify-between rounded-lg border border-border/50 bg-background/70 px-3 text-[13px] text-foreground hover:bg-muted/50">
+			<DropdownMenuTrigger
+				className={cn(
+					"flex h-8 min-w-0 flex-1 cursor-pointer items-center justify-between rounded-lg border border-border/50 bg-muted/30 px-3 text-[13px] text-foreground hover:bg-muted/50",
+				)}
+			>
 				<span className="flex min-w-0 items-center gap-2">
 					{builtinProvider ? (
 						<BuiltinProviderIcon
@@ -270,7 +257,7 @@ function ProviderPicker({
 				</span>
 				<ChevronDown className="size-3 shrink-0 opacity-40" />
 			</DropdownMenuTrigger>
-			<DropdownMenuContent align="end" className="w-[340px]">
+			<DropdownMenuContent align="end" className="w-[360px]">
 				{BUILTIN_CLAUDE_PROVIDERS.map((provider) => (
 					<DropdownMenuItem
 						key={provider.key}
@@ -319,7 +306,7 @@ function ConfiguredProvidersList({
 	}
 
 	return (
-		<div className="pt-1">
+		<div className="px-3 pt-1">
 			{items.map((item, index) => (
 				<div
 					key={item.kind}
@@ -328,17 +315,14 @@ function ConfiguredProvidersList({
 						index > 0 ? "border-t border-border/30" : null,
 					)}
 				>
-					<div className="flex size-5 shrink-0 items-center justify-center">
+					<div className="flex size-4 shrink-0 items-center justify-center">
 						<ProviderIcon item={item} className="size-4" />
 					</div>
-					<div className="min-w-0 flex-1 truncate">
-						<span className="text-[13px] font-medium text-foreground">
-							{item.label}
-						</span>
-						<span className="mx-2 text-muted-foreground/40">·</span>
-						<span className="font-mono text-[11px] text-muted-foreground">
-							{item.keyPreview}
-						</span>
+					<div className="min-w-0 flex-1 truncate text-[13px] font-medium text-foreground">
+						{item.label}
+					</div>
+					<div className="w-[88px] shrink-0 text-right font-mono text-[11px] text-muted-foreground">
+						{item.keyPreview}
 					</div>
 					<Button
 						type="button"
@@ -381,7 +365,7 @@ function getConfiguredItems(
 	if (isCustomConfigured(value)) {
 		items.push({
 			kind: "custom",
-			label: value.customProviderName.trim(),
+			label: "Custom",
 			keyPreview: maskSecret(value.customApiKey),
 		});
 	}
@@ -394,14 +378,12 @@ function draftFromSettings(
 ): Draft {
 	if (kind === "custom") {
 		return {
-			providerName: value.customProviderName,
 			baseUrl: value.customBaseUrl,
 			apiKey: value.customApiKey,
 			models: value.customModels,
 		};
 	}
 	return {
-		providerName: "",
 		baseUrl: "",
 		apiKey: value.builtinProviderApiKeys?.[kind] ?? "",
 		models: "",
@@ -411,8 +393,7 @@ function draftFromSettings(
 function canSave(kind: ProviderKind, draft: Draft): boolean {
 	if (kind === "custom") {
 		return Boolean(
-			draft.providerName.trim() &&
-				draft.baseUrl.trim() &&
+			draft.baseUrl.trim() &&
 				draft.apiKey.trim() &&
 				parseModelList(draft.models).length > 0,
 		);
@@ -422,8 +403,7 @@ function canSave(kind: ProviderKind, draft: Draft): boolean {
 
 function isCustomConfigured(value: ClaudeCustomProviderSettings): boolean {
 	return Boolean(
-		value.customProviderName.trim() &&
-			value.customBaseUrl.trim() &&
+		value.customBaseUrl.trim() &&
 			value.customApiKey.trim() &&
 			parseModelList(value.customModels).length > 0,
 	);
@@ -431,7 +411,7 @@ function isCustomConfigured(value: ClaudeCustomProviderSettings): boolean {
 
 function parseModelList(raw: string): string[] {
 	return raw
-		.split(/[,;\n]/)
+		.split("\n")
 		.map((item) => item.trim())
 		.filter(Boolean);
 }

--- a/src/features/settings/panels/model-providers.tsx
+++ b/src/features/settings/panels/model-providers.tsx
@@ -1,0 +1,477 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import {
+	Box,
+	CheckCircle2,
+	ChevronDown,
+	ExternalLink,
+	Trash2,
+} from "lucide-react";
+import type { SVGProps } from "react";
+import { useEffect, useMemo, useState } from "react";
+import {
+	KimiIcon,
+	MinimaxIcon,
+	QwenIcon,
+	XiaomiMiMoIcon,
+	ZhipuIcon,
+} from "@/components/icons";
+import { Button } from "@/components/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { helmorQueryKeys } from "@/lib/query-client";
+import type { ClaudeCustomProviderSettings } from "@/lib/settings";
+import { useSettings } from "@/lib/settings";
+import { cn } from "@/lib/utils";
+import { SettingsRow } from "../components/settings-row";
+import {
+	BUILTIN_CLAUDE_PROVIDERS,
+	type BuiltinClaudeProviderKey,
+	findBuiltinClaudeProvider,
+} from "./builtin-claude-providers";
+
+type ProviderKind = BuiltinClaudeProviderKey | "custom";
+
+type Draft = {
+	providerName: string;
+	baseUrl: string;
+	apiKey: string;
+	models: string;
+};
+
+export function ClaudeCustomProvidersPanel() {
+	const queryClient = useQueryClient();
+	const { settings, updateSettings } = useSettings();
+	const value = settings.claudeCustomProviders;
+	const builtinProviderApiKeys = value.builtinProviderApiKeys ?? {};
+	const configuredItems = useMemo(() => getConfiguredItems(value), [value]);
+	const initialKind = configuredItems[0]?.kind ?? "minimax";
+	const [kind, setKind] = useState<ProviderKind>(initialKind);
+	const [draft, setDraft] = useState<Draft>(() =>
+		draftFromSettings(value, initialKind),
+	);
+
+	useEffect(() => {
+		setDraft(draftFromSettings(value, kind));
+	}, [kind, value]);
+
+	function updateProvider(patch: Partial<ClaudeCustomProviderSettings>) {
+		void Promise.resolve(
+			updateSettings({
+				claudeCustomProviders: {
+					...value,
+					...patch,
+				},
+			}),
+		).then(() =>
+			queryClient.invalidateQueries({
+				queryKey: helmorQueryKeys.agentModelSections,
+			}),
+		);
+	}
+
+	function saveDraftIfComplete() {
+		if (!canSave(kind, draft)) return;
+		const apiKey = draft.apiKey.trim();
+		if (kind === "custom") {
+			updateProvider({
+				customProviderName: draft.providerName.trim(),
+				customBaseUrl: draft.baseUrl.trim(),
+				customApiKey: apiKey,
+				customModels: draft.models.trim(),
+			});
+			return;
+		}
+
+		const nextKeys = { ...builtinProviderApiKeys };
+		if (apiKey) {
+			nextKeys[kind] = apiKey;
+		} else {
+			delete nextKeys[kind];
+		}
+		updateProvider({
+			builtinProviderApiKeys: nextKeys,
+			...(kind === "minimax" ? { minimaxApiKey: apiKey } : {}),
+			...(kind === "minimax-cn" ? { minimaxCnApiKey: apiKey } : {}),
+		});
+	}
+
+	function removeProvider(itemKind: ProviderKind) {
+		if (itemKind === "custom") {
+			updateProvider({
+				customProviderName: "",
+				customBaseUrl: "",
+				customApiKey: "",
+				customModels: "",
+			});
+			if (kind === "custom") setKind("minimax");
+			return;
+		}
+
+		const nextKeys = { ...builtinProviderApiKeys };
+		delete nextKeys[itemKind];
+		updateProvider({
+			builtinProviderApiKeys: nextKeys,
+			...(itemKind === "minimax" ? { minimaxApiKey: "" } : {}),
+			...(itemKind === "minimax-cn" ? { minimaxCnApiKey: "" } : {}),
+		});
+	}
+
+	const builtinProvider =
+		kind === "custom" ? null : findBuiltinClaudeProvider(kind);
+
+	return (
+		<SettingsRow
+			title="Claude Code custom providers"
+			description="Enter API keys here to use third-party models instead of Claude Code's official models."
+			align="start"
+			className="gap-8"
+		>
+			<div className="flex w-[340px] flex-col gap-3">
+				<div className="grid gap-2">
+					<ProviderPicker
+						kind={kind}
+						configuredKinds={new Set(configuredItems.map((item) => item.kind))}
+						onChange={setKind}
+					/>
+
+					{builtinProvider ? (
+						<div className="flex items-center gap-2">
+							<Input
+								type="password"
+								value={draft.apiKey}
+								onBlur={saveDraftIfComplete}
+								onChange={(event) =>
+									setDraft((current) => ({
+										...current,
+										apiKey: event.target.value,
+									}))
+								}
+								placeholder={`${builtinProvider.label} API key`}
+								className="h-8 min-w-0 flex-1 border-border/50 bg-muted/20 text-[13px]"
+							/>
+							<TooltipProvider>
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<Button
+											type="button"
+											variant="outline"
+											size="icon-sm"
+											aria-label={`Get ${builtinProvider.label} API key`}
+											onClick={() => void openUrl(builtinProvider.apiKeyUrl)}
+										>
+											<ExternalLink className="size-3.5" />
+										</Button>
+									</TooltipTrigger>
+									<TooltipContent>Get API key</TooltipContent>
+								</Tooltip>
+							</TooltipProvider>
+						</div>
+					) : (
+						<div className="grid gap-2">
+							<Input
+								value={draft.providerName}
+								onBlur={saveDraftIfComplete}
+								onChange={(event) =>
+									setDraft((current) => ({
+										...current,
+										providerName: event.target.value,
+									}))
+								}
+								placeholder="Provider name"
+								className="h-8 border-border/50 bg-muted/20 text-[13px]"
+							/>
+							<Input
+								value={draft.baseUrl}
+								onBlur={saveDraftIfComplete}
+								onChange={(event) =>
+									setDraft((current) => ({
+										...current,
+										baseUrl: event.target.value,
+									}))
+								}
+								placeholder="Base URL"
+								className="h-8 border-border/50 bg-muted/20 text-[13px]"
+							/>
+							<Input
+								type="password"
+								value={draft.apiKey}
+								onBlur={saveDraftIfComplete}
+								onChange={(event) =>
+									setDraft((current) => ({
+										...current,
+										apiKey: event.target.value,
+									}))
+								}
+								placeholder="API key"
+								className="h-8 border-border/50 bg-muted/20 text-[13px]"
+							/>
+							<Textarea
+								value={draft.models}
+								onBlur={saveDraftIfComplete}
+								onChange={(event) =>
+									setDraft((current) => ({
+										...current,
+										models: event.target.value,
+									}))
+								}
+								placeholder="model-a, model-b"
+								className="min-h-20 border-border/50 bg-muted/20 text-[13px]"
+							/>
+						</div>
+					)}
+				</div>
+
+				<ConfiguredProvidersList
+					items={configuredItems}
+					onRemove={removeProvider}
+				/>
+			</div>
+		</SettingsRow>
+	);
+}
+function ProviderPicker({
+	kind,
+	configuredKinds,
+	onChange,
+}: {
+	kind: ProviderKind;
+	configuredKinds: Set<ProviderKind>;
+	onChange: (kind: ProviderKind) => void;
+}) {
+	const builtinProvider =
+		kind === "custom" ? null : findBuiltinClaudeProvider(kind);
+
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger className="flex h-8 min-w-0 flex-1 cursor-pointer items-center justify-between rounded-lg border border-border/50 bg-background/70 px-3 text-[13px] text-foreground hover:bg-muted/50">
+				<span className="flex min-w-0 items-center gap-2">
+					{builtinProvider ? (
+						<BuiltinProviderIcon
+							icon={builtinProvider.icon}
+							className="size-4"
+						/>
+					) : (
+						<Box className="size-4 text-muted-foreground" />
+					)}
+					<span className="truncate">{builtinProvider?.label ?? "Custom"}</span>
+				</span>
+				<ChevronDown className="size-3 shrink-0 opacity-40" />
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end" className="w-[340px]">
+				{BUILTIN_CLAUDE_PROVIDERS.map((provider) => (
+					<DropdownMenuItem
+						key={provider.key}
+						onClick={() => onChange(provider.key)}
+						className="flex items-center justify-between gap-3"
+					>
+						<span className="flex items-center gap-2">
+							<BuiltinProviderIcon icon={provider.icon} className="size-4" />
+							{provider.label}
+						</span>
+						{configuredKinds.has(provider.key) ? (
+							<CheckCircle2 className="size-3.5 text-emerald-500" />
+						) : null}
+					</DropdownMenuItem>
+				))}
+				<DropdownMenuItem
+					onClick={() => onChange("custom")}
+					className="flex items-center justify-between gap-3"
+				>
+					<span className="flex items-center gap-2">
+						<Box className="size-4 text-muted-foreground" />
+						Custom
+					</span>
+					{configuredKinds.has("custom") ? (
+						<CheckCircle2 className="size-3.5 text-emerald-500" />
+					) : null}
+				</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}
+
+function ConfiguredProvidersList({
+	items,
+	onRemove,
+}: {
+	items: ConfiguredItem[];
+	onRemove: (kind: ProviderKind) => void;
+}) {
+	if (items.length === 0) {
+		return (
+			<div className="pt-1 text-[12px] text-muted-foreground">
+				No third-party providers configured.
+			</div>
+		);
+	}
+
+	return (
+		<div className="pt-1">
+			{items.map((item, index) => (
+				<div
+					key={item.kind}
+					className={cn(
+						"flex min-h-8 items-center gap-2 py-1.5",
+						index > 0 ? "border-t border-border/30" : null,
+					)}
+				>
+					<div className="flex size-5 shrink-0 items-center justify-center">
+						<ProviderIcon item={item} className="size-4" />
+					</div>
+					<div className="min-w-0 flex-1 truncate">
+						<span className="text-[13px] font-medium text-foreground">
+							{item.label}
+						</span>
+						<span className="mx-2 text-muted-foreground/40">·</span>
+						<span className="font-mono text-[11px] text-muted-foreground">
+							{item.keyPreview}
+						</span>
+					</div>
+					<Button
+						type="button"
+						variant="ghost"
+						size="icon-xs"
+						aria-label={`Remove ${item.label}`}
+						onClick={() => onRemove(item.kind)}
+						className="text-muted-foreground hover:text-destructive"
+					>
+						<Trash2 className="size-3.5" strokeWidth={1.8} />
+					</Button>
+				</div>
+			))}
+		</div>
+	);
+}
+
+type ConfiguredItem = {
+	kind: ProviderKind;
+	label: string;
+	icon?: "minimax" | "moonshot" | "zhipu" | "qwen" | "xiaomi";
+	keyPreview: string;
+};
+
+function getConfiguredItems(
+	value: ClaudeCustomProviderSettings,
+): ConfiguredItem[] {
+	const items: ConfiguredItem[] = [];
+	const keys = value.builtinProviderApiKeys ?? {};
+	for (const provider of BUILTIN_CLAUDE_PROVIDERS) {
+		const apiKey = keys[provider.key]?.trim();
+		if (!apiKey) continue;
+		items.push({
+			kind: provider.key,
+			label: provider.label,
+			icon: provider.icon,
+			keyPreview: maskSecret(apiKey),
+		});
+	}
+	if (isCustomConfigured(value)) {
+		items.push({
+			kind: "custom",
+			label: value.customProviderName.trim(),
+			keyPreview: maskSecret(value.customApiKey),
+		});
+	}
+	return items;
+}
+
+function draftFromSettings(
+	value: ClaudeCustomProviderSettings,
+	kind: ProviderKind,
+): Draft {
+	if (kind === "custom") {
+		return {
+			providerName: value.customProviderName,
+			baseUrl: value.customBaseUrl,
+			apiKey: value.customApiKey,
+			models: value.customModels,
+		};
+	}
+	return {
+		providerName: "",
+		baseUrl: "",
+		apiKey: value.builtinProviderApiKeys?.[kind] ?? "",
+		models: "",
+	};
+}
+
+function canSave(kind: ProviderKind, draft: Draft): boolean {
+	if (kind === "custom") {
+		return Boolean(
+			draft.providerName.trim() &&
+				draft.baseUrl.trim() &&
+				draft.apiKey.trim() &&
+				parseModelList(draft.models).length > 0,
+		);
+	}
+	return Boolean(draft.apiKey.trim());
+}
+
+function isCustomConfigured(value: ClaudeCustomProviderSettings): boolean {
+	return Boolean(
+		value.customProviderName.trim() &&
+			value.customBaseUrl.trim() &&
+			value.customApiKey.trim() &&
+			parseModelList(value.customModels).length > 0,
+	);
+}
+
+function parseModelList(raw: string): string[] {
+	return raw
+		.split(/[,;\n]/)
+		.map((item) => item.trim())
+		.filter(Boolean);
+}
+
+function maskSecret(value: string): string {
+	const trimmed = value.trim();
+	if (trimmed.length <= 8) return "••••";
+	return `${trimmed.slice(0, 4)}••••${trimmed.slice(-4)}`;
+}
+
+function ProviderIcon({
+	item,
+	className,
+}: {
+	item: ConfiguredItem;
+	className?: string;
+}) {
+	if (item.icon)
+		return <BuiltinProviderIcon icon={item.icon} className={className} />;
+	return <Box className={cn("text-muted-foreground", className)} />;
+}
+
+function BuiltinProviderIcon({
+	icon,
+	className,
+}: {
+	icon: "minimax" | "moonshot" | "zhipu" | "qwen" | "xiaomi";
+	className?: string;
+}) {
+	const props: SVGProps<SVGSVGElement> = { className };
+	switch (icon) {
+		case "moonshot":
+			return <KimiIcon {...props} />;
+		case "zhipu":
+			return <ZhipuIcon {...props} />;
+		case "qwen":
+			return <QwenIcon {...props} />;
+		case "xiaomi":
+			return <XiaomiMiMoIcon {...props} />;
+		default:
+			return <MinimaxIcon {...props} />;
+	}
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -120,14 +120,16 @@ export type AgentModelOption = {
 	provider: AgentProvider;
 	label: string;
 	cliModel: string;
+	providerKey?: string | null;
 	effortLevels?: string[];
 	supportsFastMode?: boolean;
+	supportsContextUsage?: boolean;
 };
 
 export type AgentModelSectionStatus = "ready" | "unavailable" | "error";
 
 export type AgentModelSection = {
-	id: AgentProvider;
+	id: string;
 	label: string;
 	status?: AgentModelSectionStatus;
 	options: AgentModelOption[];

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -12,10 +12,7 @@ export type FollowUpBehavior = "steer" | "queue";
 export type ShortcutOverrides = Record<string, string | null>;
 
 export type ClaudeCustomProviderSettings = {
-	minimaxApiKey: string;
-	minimaxCnApiKey: string;
 	builtinProviderApiKeys: Record<string, string>;
-	customProviderName: string;
 	customBaseUrl: string;
 	customApiKey: string;
 	customModels: string;
@@ -70,10 +67,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
 	onboardingCompleted: false,
 	shortcuts: {},
 	claudeCustomProviders: {
-		minimaxApiKey: "",
-		minimaxCnApiKey: "",
 		builtinProviderApiKeys: {},
-		customProviderName: "",
 		customBaseUrl: "",
 		customApiKey: "",
 		customModels: "",
@@ -124,7 +118,7 @@ function parseClaudeCustomProviderSettings(
 ): ClaudeCustomProviderSettings {
 	if (!raw) return DEFAULT_SETTINGS.claudeCustomProviders;
 	try {
-		const parsed = JSON.parse(raw) as Partial<ClaudeCustomProviderSettings>;
+		const parsed = JSON.parse(raw) as Record<string, unknown>;
 		const builtinProviderApiKeys =
 			parsed.builtinProviderApiKeys &&
 			typeof parsed.builtinProviderApiKeys === "object" &&
@@ -135,30 +129,8 @@ function parseClaudeCustomProviderSettings(
 						),
 					)
 				: {};
-		if (
-			typeof parsed.minimaxApiKey === "string" &&
-			!builtinProviderApiKeys.minimax
-		) {
-			builtinProviderApiKeys.minimax = parsed.minimaxApiKey;
-		}
-		if (
-			typeof parsed.minimaxCnApiKey === "string" &&
-			!builtinProviderApiKeys["minimax-cn"]
-		) {
-			builtinProviderApiKeys["minimax-cn"] = parsed.minimaxCnApiKey;
-		}
 		return {
-			minimaxApiKey:
-				typeof parsed.minimaxApiKey === "string" ? parsed.minimaxApiKey : "",
-			minimaxCnApiKey:
-				typeof parsed.minimaxCnApiKey === "string"
-					? parsed.minimaxCnApiKey
-					: "",
 			builtinProviderApiKeys,
-			customProviderName:
-				typeof parsed.customProviderName === "string"
-					? parsed.customProviderName
-					: "",
 			customBaseUrl:
 				typeof parsed.customBaseUrl === "string" ? parsed.customBaseUrl : "",
 			customApiKey:

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -11,6 +11,16 @@ export type FollowUpBehavior = "steer" | "queue";
 
 export type ShortcutOverrides = Record<string, string | null>;
 
+export type ClaudeCustomProviderSettings = {
+	minimaxApiKey: string;
+	minimaxCnApiKey: string;
+	builtinProviderApiKeys: Record<string, string>;
+	customProviderName: string;
+	customBaseUrl: string;
+	customApiKey: string;
+	customModels: string;
+};
+
 export type AppSettings = {
 	fontSize: number;
 	branchPrefixType: "github" | "custom" | "none";
@@ -32,6 +42,7 @@ export type AppSettings = {
 	showUsageStats: boolean;
 	onboardingCompleted: boolean;
 	shortcuts: ShortcutOverrides;
+	claudeCustomProviders: ClaudeCustomProviderSettings;
 };
 
 /**
@@ -58,6 +69,15 @@ export const DEFAULT_SETTINGS: AppSettings = {
 	showUsageStats: true,
 	onboardingCompleted: false,
 	shortcuts: {},
+	claudeCustomProviders: {
+		minimaxApiKey: "",
+		minimaxCnApiKey: "",
+		builtinProviderApiKeys: {},
+		customProviderName: "",
+		customBaseUrl: "",
+		customApiKey: "",
+		customModels: "",
+	},
 };
 
 export const THEME_STORAGE_KEY = "helmor-theme";
@@ -79,6 +99,7 @@ const SETTINGS_KEY_MAP: Record<Exclude<keyof AppSettings, "theme">, string> = {
 	showUsageStats: "app.show_usage_stats",
 	onboardingCompleted: "app.onboarding_completed",
 	shortcuts: "app.shortcuts",
+	claudeCustomProviders: "app.claude_custom_providers",
 };
 
 function parseShortcutOverrides(raw: string | undefined): ShortcutOverrides {
@@ -95,6 +116,58 @@ function parseShortcutOverrides(raw: string | undefined): ShortcutOverrides {
 		) as ShortcutOverrides;
 	} catch {
 		return DEFAULT_SETTINGS.shortcuts;
+	}
+}
+
+function parseClaudeCustomProviderSettings(
+	raw: string | undefined,
+): ClaudeCustomProviderSettings {
+	if (!raw) return DEFAULT_SETTINGS.claudeCustomProviders;
+	try {
+		const parsed = JSON.parse(raw) as Partial<ClaudeCustomProviderSettings>;
+		const builtinProviderApiKeys =
+			parsed.builtinProviderApiKeys &&
+			typeof parsed.builtinProviderApiKeys === "object" &&
+			!Array.isArray(parsed.builtinProviderApiKeys)
+				? Object.fromEntries(
+						Object.entries(parsed.builtinProviderApiKeys).filter(
+							([, value]) => typeof value === "string",
+						),
+					)
+				: {};
+		if (
+			typeof parsed.minimaxApiKey === "string" &&
+			!builtinProviderApiKeys.minimax
+		) {
+			builtinProviderApiKeys.minimax = parsed.minimaxApiKey;
+		}
+		if (
+			typeof parsed.minimaxCnApiKey === "string" &&
+			!builtinProviderApiKeys["minimax-cn"]
+		) {
+			builtinProviderApiKeys["minimax-cn"] = parsed.minimaxCnApiKey;
+		}
+		return {
+			minimaxApiKey:
+				typeof parsed.minimaxApiKey === "string" ? parsed.minimaxApiKey : "",
+			minimaxCnApiKey:
+				typeof parsed.minimaxCnApiKey === "string"
+					? parsed.minimaxCnApiKey
+					: "",
+			builtinProviderApiKeys,
+			customProviderName:
+				typeof parsed.customProviderName === "string"
+					? parsed.customProviderName
+					: "",
+			customBaseUrl:
+				typeof parsed.customBaseUrl === "string" ? parsed.customBaseUrl : "",
+			customApiKey:
+				typeof parsed.customApiKey === "string" ? parsed.customApiKey : "",
+			customModels:
+				typeof parsed.customModels === "string" ? parsed.customModels : "",
+		};
+	} catch {
+		return DEFAULT_SETTINGS.claudeCustomProviders;
 	}
 }
 
@@ -155,6 +228,9 @@ export async function loadSettings(): Promise<AppSettings> {
 					? raw[SETTINGS_KEY_MAP.onboardingCompleted] === "true"
 					: DEFAULT_SETTINGS.onboardingCompleted,
 			shortcuts: parseShortcutOverrides(raw[SETTINGS_KEY_MAP.shortcuts]),
+			claudeCustomProviders: parseClaudeCustomProviderSettings(
+				raw[SETTINGS_KEY_MAP.claudeCustomProviders],
+			),
 		};
 	} catch {
 		return { ...DEFAULT_SETTINGS };
@@ -178,7 +254,7 @@ export async function saveSettings(patch: Partial<AppSettings>): Promise<void> {
 		const value = patch[key as keyof Omit<AppSettings, "theme">];
 		if (value !== undefined) {
 			settings[dbKey] =
-				key === "shortcuts"
+				key === "shortcuts" || key === "claudeCustomProviders"
 					? JSON.stringify(value)
 					: value === null
 						? ""
@@ -197,13 +273,13 @@ export type SettingsContextValue = {
 	settings: AppSettings;
 	/** False while the initial load from SQLite is still in flight. */
 	isLoaded: boolean;
-	updateSettings: (patch: Partial<AppSettings>) => void;
+	updateSettings: (patch: Partial<AppSettings>) => void | Promise<void>;
 };
 
 export const SettingsContext = createContext<SettingsContextValue>({
 	settings: DEFAULT_SETTINGS,
 	isLoaded: false,
-	updateSettings: () => {},
+	updateSettings: async () => {},
 });
 
 export function useSettings(): SettingsContextValue {

--- a/src/shared/builtin-claude-providers.json
+++ b/src/shared/builtin-claude-providers.json
@@ -1,0 +1,74 @@
+[
+	{
+		"key": "minimax",
+		"label": "MiniMax",
+		"baseUrl": "https://api.minimax.io/anthropic",
+		"apiKeyUrl": "https://platform.minimax.io/user-center/basic-information/interface-key",
+		"models": [{ "id": "MiniMax-M2.7", "label": "MiniMax M2.7" }],
+		"icon": "minimax"
+	},
+	{
+		"key": "minimax-cn",
+		"label": "MiniMax CN",
+		"baseUrl": "https://api.minimaxi.com/anthropic",
+		"apiKeyUrl": "https://platform.minimaxi.com/user-center/basic-information/interface-key",
+		"models": [{ "id": "MiniMax-M2.7", "label": "MiniMax M2.7" }],
+		"icon": "minimax"
+	},
+	{
+		"key": "moonshot",
+		"label": "Moonshot / Kimi",
+		"baseUrl": "https://api.moonshot.ai/anthropic",
+		"apiKeyUrl": "https://platform.kimi.ai/console/api-keys",
+		"models": [{ "id": "kimi-k2.5", "label": "Kimi K2.5" }],
+		"icon": "moonshot"
+	},
+	{
+		"key": "moonshot-cn",
+		"label": "Moonshot / Kimi CN",
+		"baseUrl": "https://api.moonshot.cn/anthropic",
+		"apiKeyUrl": "https://platform.moonshot.cn/console/api-keys",
+		"models": [{ "id": "kimi-k2.5", "label": "Kimi K2.5" }],
+		"icon": "moonshot"
+	},
+	{
+		"key": "zai",
+		"label": "Z.AI / GLM",
+		"baseUrl": "https://api.z.ai/api/anthropic",
+		"apiKeyUrl": "https://z.ai/manage-apikey/apikey-list",
+		"models": [{ "id": "glm-4.7", "label": "GLM 4.7" }],
+		"icon": "zhipu"
+	},
+	{
+		"key": "zai-cn",
+		"label": "Z.AI / GLM CN",
+		"baseUrl": "https://open.bigmodel.cn/api/anthropic",
+		"apiKeyUrl": "https://open.bigmodel.cn/usercenter/apikeys",
+		"models": [{ "id": "glm-5.1", "label": "GLM 5.1" }],
+		"icon": "zhipu"
+	},
+	{
+		"key": "qwen",
+		"label": "Qwen / DashScope",
+		"baseUrl": "https://dashscope.aliyuncs.com/apps/anthropic",
+		"apiKeyUrl": "https://bailian.console.aliyun.com/?tab=model#/api-key",
+		"models": [{ "id": "qwen3.6-plus", "label": "Qwen 3.6 Plus" }],
+		"icon": "qwen"
+	},
+	{
+		"key": "qwen-intl",
+		"label": "Qwen / DashScope Intl",
+		"baseUrl": "https://dashscope-intl.aliyuncs.com/apps/anthropic",
+		"apiKeyUrl": "https://bailian.console.alibabacloud.com/?tab=model#/api-key",
+		"models": [{ "id": "qwen3.5-plus", "label": "Qwen 3.5 Plus" }],
+		"icon": "qwen"
+	},
+	{
+		"key": "xiaomi",
+		"label": "Xiaomi MiMo",
+		"baseUrl": "https://api.xiaomimimo.com/anthropic",
+		"apiKeyUrl": "https://platform.xiaomimimo.com/#/console/api-keys",
+		"models": [{ "id": "mimo-v2.5-pro", "label": "MiMo V2.5 Pro" }],
+		"icon": "xiaomi"
+	}
+]


### PR DESCRIPTION
## Summary

Lets users plug third-party Claude-compatible API providers (MiniMax, Moonshot/Kimi, Z.AI/GLM, Qwen, Xiaomi MiMo) or a fully custom endpoint into Helmor and use those models alongside official Claude Code.

- **Built-in + custom providers in Settings.** New "Claude Code custom providers" panel: pick a built-in provider for an API-key shortcut, or define a custom Claude-compatible endpoint by base URL + key + newline-separated model list. Provider catalog is now a single shared JSON file (`src/shared/builtin-claude-providers.json`) consumed by both the Rust backend and the React UI, so adding a provider is a one-line edit.
- **One unified Claude section.** Custom provider models are appended to the official Claude section in the composer and the default-model picker (instead of replacing it as in the prior commit), each labeled with a provider-specific icon. Empty composer dropdown for Claude shows an "Add custom model…" entry that deep-links into the right Settings section via a new `helmor:open-settings` event.
- **Title generation honors the configured model.** When a Claude-compatible provider is configured, sidecar `generateTitle` uses it first (with `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN` env), then falls back to official Claude haiku, then Codex. `TITLE_GEN_TIMEOUT` bumped from 65s to 95s to cover the extra fallback hop.
- **Cleanup.** Dropped legacy `minimaxApiKey` / `minimaxCnApiKey` / `customProviderName` settings fields now that the canonical `builtinProviderApiKeys` map and a fixed "Custom" label cover everything.

## Why

Users in regions where official Claude isn't available (or who already pay for Claude-compatible endpoints) couldn't use Helmor end-to-end. The first commit (#prior) added provider configuration; this PR refines the UX so custom and official models live side-by-side, makes title generation respect the user's configured provider, and consolidates the catalog so we don't drift between Rust and TS lists.

## Test plan

- [ ] `bun run test` (frontend + sidecar + rust) green.
- [ ] `bun run lint` clean (clippy + biome).
- [ ] Configure a built-in provider (e.g. MiniMax) in Settings → composer model picker shows official Claude *and* MiniMax M2.7; custom models render with the right icon.
- [ ] Configure a custom provider (base URL + key + 2 newline-separated models) → both models appear under Claude with the generic Box icon.
- [ ] With no configured providers, composer dropdown shows "Add custom model…" entry that opens Settings on the model providers panel.
- [ ] New session with a configured custom Claude model: title is generated via the custom endpoint (check sidecar logs for `claudeModel` / `customClaudeEnvironment: true`).
- [ ] Stop the custom endpoint mid-flight and confirm fallback to official Claude → Codex still works.
- [ ] Existing user settings with legacy `minimaxApiKey` keys still parse (migration path in `parseClaudeCustomProviderSettings`).