### PR TITLE
fix(sidecar): ignore Codex reconnect notices

### DIFF
--- a/sidecar/src/codex-app-server-manager.ts
+++ b/sidecar/src/codex-app-server-manager.ts
@@ -62,6 +62,19 @@ function isRecoverableResumeError(err: unknown): boolean {
 	return RECOVERABLE_RESUME_SNIPPETS.some((s) => msg.includes(s));
 }
 
+function codexErrorMessage(params: unknown): string {
+	const errObj = deepGet(params, "error");
+	const nested =
+		typeof errObj === "object" && errObj !== null
+			? (errObj as Record<string, unknown>).message
+			: undefined;
+	return typeof nested === "string" ? nested : "Unknown Codex error";
+}
+
+function isTransientReconnectNotice(message: string): boolean {
+	return /^reconnecting\.\.\.\s+\d+\/\d+$/i.test(message.trim());
+}
+
 // ---------------------------------------------------------------------------
 // Per-session context
 // ---------------------------------------------------------------------------
@@ -299,16 +312,17 @@ export class CodexAppServerManager implements SessionManager {
 					await ctx.notificationGate;
 				}
 
-				// Codex sends errors as {method:"error", params:{error:{message:"..."}}}
-				// Extract the nested message and emit a proper error event.
+				// Codex sends errors as {method:"error", params:{error:{message:"..."}}}.
+				// Reconnect progress notices are not terminal: the app-server keeps
+				// the turn alive and may emit more deltas after reconnecting.
 				if (n.method === "error") {
-					const errObj = deepGet(n.params, "error");
-					const nested =
-						typeof errObj === "object" && errObj !== null
-							? (errObj as Record<string, unknown>).message
-							: undefined;
-					const msg =
-						typeof nested === "string" ? nested : "Unknown Codex error";
+					const msg = codexErrorMessage(n.params);
+					if (isTransientReconnectNotice(msg)) {
+						logger.debug(`[${requestId}] codex reconnect notice`, {
+							message: msg,
+						});
+						return;
+					}
 					emitter.error(requestId, msg);
 					ctx.activeTurnId = null;
 					ctx.turnResolve?.();

--- a/sidecar/test/codex-app-server-manager.test.ts
+++ b/sidecar/test/codex-app-server-manager.test.ts
@@ -398,6 +398,51 @@ describe("CodexAppServerManager", () => {
 		});
 	});
 
+	test("does not terminate stream for Codex reconnect progress notices", async () => {
+		const manager = new CodexAppServerManager();
+		const events: Array<Record<string, unknown>> = [];
+		const capturingEmitter = createSidecarEmitter((event) => {
+			events.push(event as Record<string, unknown>);
+		});
+
+		serverState.beforeTurnCompleted = () => {
+			serverState.onNotification?.({
+				method: "error",
+				params: { error: { message: "Reconnecting... 1/5" } },
+			});
+			serverState.onNotification?.({
+				method: "item/agentMessage/delta",
+				params: {
+					threadId: "thread-1",
+					turnId: "turn-1",
+					itemId: "msg-1",
+					delta: "still streaming",
+				},
+			});
+		};
+
+		await manager.sendMessage(
+			"REQ-reconnect",
+			{
+				sessionId: "session-reconnect",
+				prompt: "hi",
+				model: "gpt-5.4",
+				cwd: "/tmp",
+				resume: undefined,
+				permissionMode: undefined,
+				effortLevel: "medium",
+				fastMode: false,
+			},
+			capturingEmitter,
+		);
+
+		expect(events.map((event) => event.type)).toEqual(
+			expect.arrayContaining(["item/agentMessage/delta", "end"]),
+		);
+		expect(events.find((event) => event.type === "error")).toBeUndefined();
+		expect(events.at(-1)?.type).toBe("end");
+	});
+
 	test("skips contextUsageUpdated emit when tokenUsage payload is empty", async () => {
 		const manager = new CodexAppServerManager();
 		const events: Array<Record<string, unknown>> = [];


### PR DESCRIPTION
## Summary
- Treat Codex app-server reconnect progress messages as non-terminal notices
- Keep the active stream open so later deltas and the final end event still arrive
- Add sidecar coverage for the reconnect-notice path

## Tests
- cd sidecar && bun test test/codex-app-server-manager.test.ts