### PR TITLE
feat(composer): add "send with opposite follow-up" shortcut

### DIFF
--- a/.changeset/swift-otters-pivot.md
+++ b/.changeset/swift-otters-pivot.md
@@ -1,0 +1,8 @@
+---
+"helmor": patch
+---
+
+Polish the composer follow-up flow:
+- Add a customizable "send with opposite follow-up behavior" shortcut (⌘Enter by default) so you can flip queue ↔ steer for one message without changing your persistent setting.
+- Drop the leading `$` from Codex credits in the composer context-usage ring.
+- Rename the Settings → Shortcuts "Pinned" section to "Global".

--- a/.changeset/swift-otters-pivot.md
+++ b/.changeset/swift-otters-pivot.md
@@ -2,7 +2,7 @@
 "helmor": patch
 ---
 
-Polish the composer follow-up flow:
-- Add a customizable "send with opposite follow-up behavior" shortcut (⌘Enter by default) so you can flip queue ↔ steer for one message without changing your persistent setting.
-- Drop the leading `$` from Codex credits in the composer context-usage ring.
-- Rename the Settings → Shortcuts "Pinned" section to "Global".
+Polish the composer in two places:
+- Add a customizable ⌘Enter shortcut that sends one message with the opposite follow-up behavior (queue ↔ steer).
+- Drop the leading `$` from Codex credits in the context-usage ring.
+- Thanks to [@robinebers](https://x.com/robinebers) for the feedback that prompted both.

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -122,6 +122,10 @@ type WorkspaceComposerContainerProps = {
 		fastMode: boolean;
 		/** Force queue (bypass `followUpBehavior`) if a turn is streaming. */
 		forceQueue?: boolean;
+		/** When set, override the user's `followUpBehavior` setting for this
+		 *  one submit (queue ↔ steer). Used by the "send with opposite
+		 *  follow-up" composer shortcut. Ignored when `forceQueue` is true. */
+		followUpBehaviorOverride?: "queue" | "steer";
 	}) => void;
 	/** Prompt queued by an external caller to auto-submit once the displayed
 	 * session matches `sessionId`. */
@@ -336,6 +340,11 @@ export const WorkspaceComposerContainer = memo(
 		]
 			? null
 			: getShortcut(settings.shortcuts, "composer.togglePlanMode");
+		const toggleFollowUpShortcut = shortcutConflicts.conflictById[
+			"composer.toggleFollowUpBehavior"
+		]
+			? null
+			: getShortcut(settings.shortcuts, "composer.toggleFollowUpBehavior");
 		const pendingOverrideActive =
 			pendingPromptForSession?.sessionId === displayedSessionId;
 		const pendingModel = useMemo(
@@ -567,11 +576,22 @@ export const WorkspaceComposerContainer = memo(
 				imagePaths: string[],
 				filePaths: string[],
 				customTags: ComposerCustomTag[],
-				options?: { permissionModeOverride?: string },
+				options?: {
+					permissionModeOverride?: string;
+					oppositeFollowUp?: boolean;
+				},
 			) => {
 				if (!effectiveModel) {
 					return;
 				}
+				// Translate the per-submit "opposite" toggle into a concrete
+				// override based on the user's persistent setting. The setting
+				// itself is left untouched.
+				const followUpBehaviorOverride = options?.oppositeFollowUp
+					? settings.followUpBehavior === "queue"
+						? "steer"
+						: "queue"
+					: undefined;
 				onSubmit({
 					prompt,
 					imagePaths,
@@ -583,6 +603,7 @@ export const WorkspaceComposerContainer = memo(
 					permissionMode:
 						options?.permissionModeOverride ?? effectivePermissionMode,
 					fastMode: supportsFastMode ? fastMode : false,
+					followUpBehaviorOverride,
 				});
 			},
 			[
@@ -593,6 +614,7 @@ export const WorkspaceComposerContainer = memo(
 				effectivePermissionMode,
 				fastMode,
 				supportsFastMode,
+				settings.followUpBehavior,
 			],
 		);
 
@@ -776,6 +798,7 @@ export const WorkspaceComposerContainer = memo(
 						}
 						focusShortcut={focusShortcut}
 						togglePlanShortcut={togglePlanShortcut}
+						toggleFollowUpShortcut={toggleFollowUpShortcut}
 						alwaysShowContextUsage={settings.alwaysShowContextUsage}
 						onSubmit={handleComposerSubmit}
 						disabled={composerUnavailable}

--- a/src/features/composer/context-usage-ring/parse.test.ts
+++ b/src/features/composer/context-usage-ring/parse.test.ts
@@ -244,7 +244,7 @@ describe("parseCodexRateLimits", () => {
 		expect(display?.secondary?.label).toBe("7d limit");
 		expect(display?.notes).toEqual([
 			{ label: "Plan", value: "Pro" },
-			{ label: "Credits", value: "$10.50" },
+			{ label: "Credits", value: "10.50" },
 		]);
 	});
 
@@ -261,7 +261,7 @@ describe("parseCodexRateLimits", () => {
 		expect(display?.secondary).toBeNull();
 		expect(display?.notes).toEqual([
 			{ label: "Plan", value: "Prolite" },
-			{ label: "Credits", value: "$0.00" },
+			{ label: "Credits", value: "0.00" },
 		]);
 	});
 

--- a/src/features/composer/context-usage-ring/parse.ts
+++ b/src/features/composer/context-usage-ring/parse.ts
@@ -240,7 +240,7 @@ function parseCodexNotes(
 			if (balance !== null) {
 				notes.push({ label: "Credits", value: formatCredits(balance) });
 			} else if (hasCredits === false) {
-				notes.push({ label: "Credits", value: "$0.00" });
+				notes.push({ label: "Credits", value: "0.00" });
 			}
 		}
 	}
@@ -261,7 +261,7 @@ function parseCreditsBalance(value: Json): number | null {
 
 function formatCredits(balance: number): string {
 	const safe = Math.max(0, balance);
-	return `$${safe.toFixed(2)}`;
+	return safe.toFixed(2);
 }
 
 function formatCodexPlan(value: Json): string | null {

--- a/src/features/composer/editor/plugins/submit-plugin.tsx
+++ b/src/features/composer/editor/plugins/submit-plugin.tsx
@@ -33,6 +33,7 @@
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { COMMAND_PRIORITY_HIGH, KEY_ENTER_COMMAND } from "lexical";
 import { useEffect } from "react";
+import { normalizeShortcutEvent } from "@/features/shortcuts/format";
 
 const TYPEAHEAD_SELECTABLE_SELECTOR = "[data-typeahead-popup] [cmdk-item]";
 
@@ -43,9 +44,19 @@ function isTypeaheadSelectable(): boolean {
 
 export function SubmitPlugin({
 	onSubmit,
+	onSubmitOpposite,
+	toggleHotkey,
 	disabled,
 }: {
 	onSubmit: () => void;
+	/** Called when the toggle hotkey fires — submits with the opposite
+	 *  follow-up behavior (queue ↔ steer) for this single message. */
+	onSubmitOpposite?: () => void;
+	/** The customized "send with opposite follow-up" hotkey, normalized
+	 *  via `normalizeShortcutEvent` (e.g. "Mod+Enter"). Only honored here
+	 *  when the hotkey involves Enter — non-Enter hotkeys are caught by
+	 *  the composer wrapper's keydown-capture handler. */
+	toggleHotkey?: string | null;
 	disabled: boolean;
 }) {
 	const [editor] = useLexicalComposerContext();
@@ -55,15 +66,29 @@ export function SubmitPlugin({
 			KEY_ENTER_COMMAND,
 			(event) => {
 				if (event?.isComposing || event?.keyCode === 229) return false; // IME confirm — let the browser process it
-				if (event?.shiftKey) return false; // let Lexical handle newline
 				if (isTypeaheadSelectable()) return false; // let typeahead select
+
+				// Customized toggle hotkey (e.g. ⌘Enter) — submit with the
+				// opposite follow-up behavior for this message only. Checked
+				// before the Shift+Enter newline guard so a user-configured
+				// toggle on Shift+Enter wins over newline.
+				if (event && toggleHotkey && onSubmitOpposite) {
+					const eventHotkey = normalizeShortcutEvent(event);
+					if (eventHotkey === toggleHotkey) {
+						event.preventDefault();
+						if (!disabled) onSubmitOpposite();
+						return true;
+					}
+				}
+
+				if (event?.shiftKey) return false; // let Lexical handle newline
 				event?.preventDefault();
 				if (!disabled) onSubmit();
 				return true;
 			},
 			COMMAND_PRIORITY_HIGH,
 		);
-	}, [editor, onSubmit, disabled]);
+	}, [editor, onSubmit, onSubmitOpposite, toggleHotkey, disabled]);
 
 	return null;
 }

--- a/src/features/composer/index.tsx
+++ b/src/features/composer/index.tsx
@@ -95,7 +95,12 @@ type WorkspaceComposerProps = {
 		imagePaths: string[],
 		filePaths: string[],
 		customTags: ComposerCustomTag[],
-		options?: { permissionModeOverride?: string },
+		options?: {
+			permissionModeOverride?: string;
+			/** Submit with the opposite follow-up behavior (queue ↔ steer)
+			 *  for this single message, leaving the persistent setting alone. */
+			oppositeFollowUp?: boolean;
+		},
 	) => void;
 	disabled?: boolean;
 	submitDisabled?: boolean;
@@ -152,6 +157,9 @@ type WorkspaceComposerProps = {
 	agentType?: "claude" | "codex" | null;
 	focusShortcut?: string | null;
 	togglePlanShortcut?: string | null;
+	/** Hotkey that submits the current draft with the opposite follow-up
+	 *  behavior (queue ↔ steer) for one message. */
+	toggleFollowUpShortcut?: string | null;
 };
 
 const EMPTY_SLASH_COMMANDS: readonly SlashCommandEntry[] = [];
@@ -226,6 +234,7 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 	agentType = null,
 	focusShortcut = null,
 	togglePlanShortcut = null,
+	toggleFollowUpShortcut = null,
 }: WorkspaceComposerProps) {
 	const instanceIdRef = useRef(
 		`composer-${Math.random().toString(36).slice(2, 10)}`,
@@ -424,45 +433,87 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 		}
 	}, [hasPlanReview, onSubmit, contextKey]);
 
+	const submitDraft = useCallback(
+		(options?: { oppositeFollowUp?: boolean }) => {
+			const editor = editorRef.current;
+			if (!editor) return;
+			let prompt = "";
+			let images: string[] = [];
+			let files: string[] = [];
+			let customTags: ComposerCustomTag[] = [];
+			editor.read(() => {
+				const result = $extractComposerContent();
+				prompt = result.text;
+				images = result.images;
+				files = result.files;
+				customTags = result.customTags;
+			});
+			if (
+				!prompt &&
+				images.length === 0 &&
+				files.length === 0 &&
+				customTags.length === 0
+			)
+				return;
+			if (options?.oppositeFollowUp) {
+				onSubmit(prompt, images, files, customTags, {
+					oppositeFollowUp: true,
+				});
+			} else {
+				onSubmit(prompt, images, files, customTags);
+			}
+			editor.update(() => {
+				$getRoot().clear();
+			});
+			clearPersistedDraft(contextKey);
+			setHasContent(false);
+		},
+		[onSubmit, contextKey],
+	);
+
 	const handleSubmit = useCallback(() => {
-		const editor = editorRef.current;
-		if (!editor) return;
-		let prompt = "";
-		let images: string[] = [];
-		let files: string[] = [];
-		let customTags: ComposerCustomTag[] = [];
-		editor.read(() => {
-			const result = $extractComposerContent();
-			prompt = result.text;
-			images = result.images;
-			files = result.files;
-			customTags = result.customTags;
-		});
-		if (
-			!prompt &&
-			images.length === 0 &&
-			files.length === 0 &&
-			customTags.length === 0
-		)
-			return;
-		onSubmit(prompt, images, files, customTags);
-		editor.update(() => {
-			$getRoot().clear();
-		});
-		clearPersistedDraft(contextKey);
-		setHasContent(false);
-	}, [onSubmit, contextKey]);
+		submitDraft();
+	}, [submitDraft]);
+
+	const handleSubmitOpposite = useCallback(() => {
+		submitDraft({ oppositeFollowUp: true });
+	}, [submitDraft]);
 
 	const handleComposerKeyDownCapture = useCallback(
 		(event: React.KeyboardEvent<HTMLDivElement>) => {
-			if (!togglePlanShortcut || inputDisabled) return;
+			if (inputDisabled) return;
 			const hotkey = normalizeShortcutEvent(event.nativeEvent);
-			if (hotkey !== togglePlanShortcut) return;
-			event.preventDefault();
-			event.stopPropagation();
-			onChangePermissionMode(permissionMode === "plan" ? "default" : "plan");
+			if (!hotkey) return;
+
+			// Toggle follow-up behavior for one message. Skip when the
+			// hotkey is Enter-based — SubmitPlugin handles those via
+			// Lexical's KEY_ENTER_COMMAND so we don't double-fire.
+			if (
+				toggleFollowUpShortcut &&
+				hotkey === toggleFollowUpShortcut &&
+				event.nativeEvent.key !== "Enter"
+			) {
+				event.preventDefault();
+				event.stopPropagation();
+				if (submitEnabled) handleSubmitOpposite();
+				return;
+			}
+
+			if (togglePlanShortcut && hotkey === togglePlanShortcut) {
+				event.preventDefault();
+				event.stopPropagation();
+				onChangePermissionMode(permissionMode === "plan" ? "default" : "plan");
+			}
 		},
-		[inputDisabled, onChangePermissionMode, permissionMode, togglePlanShortcut],
+		[
+			inputDisabled,
+			onChangePermissionMode,
+			permissionMode,
+			togglePlanShortcut,
+			toggleFollowUpShortcut,
+			handleSubmitOpposite,
+			submitEnabled,
+		],
 	);
 
 	return (
@@ -602,6 +653,8 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 						/>
 						<SubmitPlugin
 							onSubmit={handleSubmit}
+							onSubmitOpposite={handleSubmitOpposite}
+							toggleHotkey={toggleFollowUpShortcut}
 							disabled={submitDisabledForPlugin}
 						/>
 						<CompositionGuardPlugin />

--- a/src/features/conversation/hooks/use-streaming.test.tsx
+++ b/src/features/conversation/hooks/use-streaming.test.tsx
@@ -1928,6 +1928,185 @@ describe("useConversationStreaming", () => {
 			expect(enqueued?.[0]?.prompt).toBe("Resolve conflict");
 		});
 
+		it("followUpBehaviorOverride='queue' flips a 'steer' default into the queue for one submit", async () => {
+			apiMocks.startAgentMessageStream.mockImplementation(
+				async (_payload: unknown, _onEvent: (event: unknown) => void) => {
+					// Leave the turn streaming.
+				},
+			);
+			apiMocks.steerAgentStream.mockResolvedValue({ accepted: true });
+			const queue = createFakeQueue();
+
+			const { Wrapper } = createWrapper();
+			const { result } = renderHook(
+				() =>
+					useConversationStreaming({
+						composerContextKey: "session:session-1",
+						displayedSelectedModelId: MODEL.id,
+						displayedSessionId: "session-1",
+						displayedWorkspaceId: "workspace-1",
+						selectionPending: false,
+						// Default is steer — without the override the next
+						// submit would steer mid-turn.
+						followUpBehavior: "steer",
+						submitQueue: queue,
+					}),
+				{ wrapper: Wrapper },
+			);
+
+			await act(async () => {
+				await result.current.handleComposerSubmit({
+					prompt: "Primary",
+					imagePaths: [],
+					filePaths: [],
+					customTags: [],
+					model: MODEL,
+					workingDirectory: "/tmp/helmor",
+					effortLevel: "medium",
+					permissionMode: "default",
+					fastMode: false,
+				});
+			});
+			expect(result.current.isSending).toBe(true);
+
+			await act(async () => {
+				await result.current.handleComposerSubmit({
+					prompt: "One-shot queue",
+					imagePaths: [],
+					filePaths: [],
+					customTags: [],
+					model: MODEL,
+					workingDirectory: "/tmp/helmor",
+					effortLevel: "medium",
+					permissionMode: "default",
+					fastMode: false,
+					followUpBehaviorOverride: "queue",
+				});
+			});
+
+			expect(apiMocks.steerAgentStream).not.toHaveBeenCalled();
+			const enqueued = queue.snapshot().get("session-1");
+			expect(enqueued).toHaveLength(1);
+			expect(enqueued?.[0]?.prompt).toBe("One-shot queue");
+		});
+
+		it("followUpBehaviorOverride='steer' flips a 'queue' default into a mid-turn steer", async () => {
+			apiMocks.startAgentMessageStream.mockImplementation(
+				async (_payload: unknown, _onEvent: (event: unknown) => void) => {
+					// Leave the turn streaming.
+				},
+			);
+			apiMocks.steerAgentStream.mockResolvedValue({ accepted: true });
+			const queue = createFakeQueue();
+
+			const { Wrapper } = createWrapper();
+			const { result } = renderHook(
+				() =>
+					useConversationStreaming({
+						composerContextKey: "session:session-1",
+						displayedSelectedModelId: MODEL.id,
+						displayedSessionId: "session-1",
+						displayedWorkspaceId: "workspace-1",
+						selectionPending: false,
+						followUpBehavior: "queue",
+						submitQueue: queue,
+					}),
+				{ wrapper: Wrapper },
+			);
+
+			await act(async () => {
+				await result.current.handleComposerSubmit({
+					prompt: "Primary",
+					imagePaths: [],
+					filePaths: [],
+					customTags: [],
+					model: MODEL,
+					workingDirectory: "/tmp/helmor",
+					effortLevel: "medium",
+					permissionMode: "default",
+					fastMode: false,
+				});
+			});
+			expect(result.current.isSending).toBe(true);
+
+			await act(async () => {
+				await result.current.handleComposerSubmit({
+					prompt: "One-shot steer",
+					imagePaths: [],
+					filePaths: [],
+					customTags: [],
+					model: MODEL,
+					workingDirectory: "/tmp/helmor",
+					effortLevel: "medium",
+					permissionMode: "default",
+					fastMode: false,
+					followUpBehaviorOverride: "steer",
+				});
+			});
+
+			expect(apiMocks.steerAgentStream).toHaveBeenCalledTimes(1);
+			expect(queue.snapshot().get("session-1") ?? []).toHaveLength(0);
+		});
+
+		it("forceQueue takes precedence over followUpBehaviorOverride='steer'", async () => {
+			apiMocks.startAgentMessageStream.mockImplementation(
+				async (_payload: unknown, _onEvent: (event: unknown) => void) => {},
+			);
+			apiMocks.steerAgentStream.mockResolvedValue({ accepted: true });
+			const queue = createFakeQueue();
+
+			const { Wrapper } = createWrapper();
+			const { result } = renderHook(
+				() =>
+					useConversationStreaming({
+						composerContextKey: "session:session-1",
+						displayedSelectedModelId: MODEL.id,
+						displayedSessionId: "session-1",
+						displayedWorkspaceId: "workspace-1",
+						selectionPending: false,
+						followUpBehavior: "queue",
+						submitQueue: queue,
+					}),
+				{ wrapper: Wrapper },
+			);
+
+			await act(async () => {
+				await result.current.handleComposerSubmit({
+					prompt: "Primary",
+					imagePaths: [],
+					filePaths: [],
+					customTags: [],
+					model: MODEL,
+					workingDirectory: "/tmp/helmor",
+					effortLevel: "medium",
+					permissionMode: "default",
+					fastMode: false,
+				});
+			});
+			expect(result.current.isSending).toBe(true);
+
+			await act(async () => {
+				await result.current.handleComposerSubmit({
+					prompt: "Resolve conflict",
+					imagePaths: [],
+					filePaths: [],
+					customTags: [],
+					model: MODEL,
+					workingDirectory: "/tmp/helmor",
+					effortLevel: "medium",
+					permissionMode: "default",
+					fastMode: false,
+					forceQueue: true,
+					followUpBehaviorOverride: "steer",
+				});
+			});
+
+			expect(apiMocks.steerAgentStream).not.toHaveBeenCalled();
+			const enqueued = queue.snapshot().get("session-1");
+			expect(enqueued).toHaveLength(1);
+			expect(enqueued?.[0]?.prompt).toBe("Resolve conflict");
+		});
+
 		it("handleSteerQueued re-enqueues the item when provider rejects the steer", async () => {
 			apiMocks.startAgentMessageStream.mockImplementation(
 				async (_payload: unknown, _onEvent: (event: unknown) => void) => {

--- a/src/features/conversation/hooks/use-streaming.ts
+++ b/src/features/conversation/hooks/use-streaming.ts
@@ -110,6 +110,10 @@ type SubmitPayload = {
 	 *  `followUpBehavior` setting. Set by host-triggered submits (e.g.
 	 *  git-pull conflict resolution) that must never interrupt the turn. */
 	forceQueue?: boolean;
+	/** Per-submit override for `followUpBehavior` — used by the composer's
+	 *  "send with opposite follow-up" shortcut. Ignored when `forceQueue`
+	 *  is set. */
+	followUpBehaviorOverride?: FollowUpBehavior;
 };
 
 type UseConversationStreamingArgs = {
@@ -1004,6 +1008,7 @@ export function useConversationStreaming({
 				permissionMode,
 				fastMode,
 				forceQueue,
+				followUpBehaviorOverride,
 			}: SubmitPayload,
 			// Override for drain / queued-steer. When present, all
 			// session/workspace lookups use the override instead of the
@@ -1052,7 +1057,11 @@ export function useConversationStreaming({
 				// the routing to the queue regardless of the user's
 				// `followUpBehavior` setting — used for host-triggered
 				// prompts (e.g. git-pull) that must never steer.
-				const effectiveBehavior = forceQueue ? "queue" : followUpBehavior;
+				// `followUpBehaviorOverride` is the per-submit "opposite"
+				// flip from the composer shortcut; subordinate to forceQueue.
+				const effectiveBehavior = forceQueue
+					? "queue"
+					: (followUpBehaviorOverride ?? followUpBehavior);
 				if (effectiveBehavior === "queue" && !isOverride) {
 					// App-level queue: capture the current (session,
 					// workspace, contextKey) so drain can replay faithfully

--- a/src/features/settings/index.tsx
+++ b/src/features/settings/index.tsx
@@ -38,6 +38,7 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { getShortcut } from "@/features/shortcuts/registry";
 import { ShortcutsSettingsPanel } from "@/features/shortcuts/settings-panel";
 import { InlineShortcutDisplay } from "@/features/shortcuts/shortcut-display";
 import {
@@ -307,7 +308,30 @@ export const SettingsDialog = memo(function SettingsDialog({
 									</SettingsRow>
 									<SettingsRow
 										title="Follow-up behavior"
-										description="Queue follow-ups while the agent runs, or steer the current run."
+										description={
+											<>
+												Queue follow-ups while the agent runs or steer the
+												current run.
+												{(() => {
+													const toggleHotkey = getShortcut(
+														settings.shortcuts,
+														"composer.toggleFollowUpBehavior",
+													);
+													if (!toggleHotkey) return null;
+													return (
+														<>
+															{" "}
+															Press{" "}
+															<InlineShortcutDisplay
+																hotkey={toggleHotkey}
+																className="align-baseline text-muted-foreground"
+															/>{" "}
+															to do the opposite for one message.
+														</>
+													);
+												})()}
+											</>
+										}
 									>
 										<ToggleGroup
 											type="single"

--- a/src/features/shortcuts/registry.ts
+++ b/src/features/shortcuts/registry.ts
@@ -253,6 +253,14 @@ export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
 		editable: true,
 	},
 	{
+		id: "composer.toggleFollowUpBehavior",
+		title: "Send with opposite follow-up behavior",
+		group: "Composer",
+		defaultHotkey: "Mod+Enter",
+		scopes: ["composer"],
+		editable: true,
+	},
+	{
 		id: "terminal.new",
 		title: "New terminal",
 		group: "Terminal",

--- a/src/features/shortcuts/settings-panel.test.tsx
+++ b/src/features/shortcuts/settings-panel.test.tsx
@@ -12,7 +12,7 @@ describe("ShortcutsSettingsPanel", () => {
 		const user = userEvent.setup();
 		render(<ShortcutsSettingsPanel overrides={{}} onChange={vi.fn()} />);
 
-		expect(screen.getByText("Pinned")).toBeInTheDocument();
+		expect(screen.getByText("Global")).toBeInTheDocument();
 		expect(screen.getByText("Global hotkey")).toBeInTheDocument();
 
 		await user.type(

--- a/src/features/shortcuts/settings-panel.tsx
+++ b/src/features/shortcuts/settings-panel.tsx
@@ -146,7 +146,7 @@ export function ShortcutsSettingsPanel({
 
 			<section className="pb-1">
 				<div className="pb-1 text-[12px] font-medium tracking-normal text-muted-foreground">
-					Pinned
+					Global
 				</div>
 				{pinnedDefinitions.map((definition, index) =>
 					renderShortcutRow(definition, index === pinnedDefinitions.length - 1),

--- a/src/features/shortcuts/types.ts
+++ b/src/features/shortcuts/types.ts
@@ -29,6 +29,7 @@ export type ShortcutId =
 	| "composer.focus"
 	| "composer.togglePlanMode"
 	| "composer.openModelPicker"
+	| "composer.toggleFollowUpBehavior"
 	| "terminal.new"
 	| "terminal.close"
 	| "terminal.next"


### PR DESCRIPTION
## Summary

Polish the composer follow-up flow with one new shortcut and two small fixes:

- **New shortcut: "Send with opposite follow-up behavior"** (`composer.toggleFollowUpBehavior`, default `⌘Enter`). Lets you flip queue ↔ steer for a single message without changing your persistent `followUpBehavior` setting. Settings → Follow-up behavior now mentions this hotkey inline so it's discoverable.
  - Plumbing: `WorkspaceComposer` exposes `onSubmitOpposite` / `toggleHotkey`; `SubmitPlugin` watches `KEY_ENTER_COMMAND` for an Enter-based hotkey, and the composer wrapper's keydown-capture handles non-Enter hotkeys (so we don't double-fire).
  - `SubmitPayload` gains a per-submit `followUpBehaviorOverride` (`"queue" | "steer"`) — subordinate to `forceQueue` so host-triggered prompts (e.g. git-pull conflict resolution) still always queue.
- **Codex credits no longer prefix `$`** in the composer context-usage ring (`"10.50"` instead of `"$10.50"`). The label is already "Credits", and the unit isn't necessarily USD.
- **Settings → Shortcuts: rename "Pinned" → "Global"** to match the section's actual contents (it's the global hotkey row).

## Why

The follow-up-behavior toggle in Settings is a sticky preference, but in practice you often want to do the *other* thing for one message — e.g. you usually queue, but right now you want to steer mid-turn. Forcing users to dive into Settings, flip the toggle, send, then flip it back is friction. A per-submit override hotkey solves it without polluting the persistent setting.

The other two are small UX papercuts I noticed while in the area.

## Test plan

- [x] `bun run test:frontend` — new `useConversationStreaming` cases cover override='queue' over a 'steer' default, override='steer' over a 'queue' default, and `forceQueue` winning over the override.
- [x] `parseCodexRateLimits` tests updated for the new credits format.
- [x] `ShortcutsSettingsPanel` test updated for the "Pinned" → "Global" rename.
- [ ] Manual: in dev, with `followUpBehavior=queue`, press ⌘Enter mid-turn → message steers; press Enter → message queues. Confirm the persistent setting is unchanged afterwards.
- [ ] Manual: rebind `composer.toggleFollowUpBehavior` to a non-Enter chord (e.g. `Mod+Shift+S`) and confirm it still flips behavior on submit via the wrapper's keydown-capture path.
- [ ] Manual: confirm Settings description renders the inline hotkey badge.