### PR TITLE
feat(providers): add DeepSeek as a built-in Claude provider

### DIFF
--- a/.changeset/quiet-deepseek-models.md
+++ b/.changeset/quiet-deepseek-models.md
@@ -1,5 +1,5 @@
 ---
-"helmor": minor
+"helmor": patch
 ---
 
 Add DeepSeek as a built-in Claude Code custom provider with DeepSeek V4 Pro 1M and DeepSeek V4 Flash model options.

--- a/.changeset/quiet-deepseek-models.md
+++ b/.changeset/quiet-deepseek-models.md
@@ -1,0 +1,5 @@
+---
+"helmor": minor
+---
+
+Add DeepSeek as a built-in Claude Code custom provider with DeepSeek V4 Pro 1M and DeepSeek V4 Flash model options.

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -1,4 +1,5 @@
 import ClaudeColor from "@lobehub/icons/es/Claude/components/Color";
+import DeepSeekColor from "@lobehub/icons/es/DeepSeek/components/Color";
 import KimiMono from "@lobehub/icons/es/Kimi/components/Mono";
 import MinimaxColor from "@lobehub/icons/es/Minimax/components/Color";
 import OpenAIMono from "@lobehub/icons/es/OpenAI/components/Mono";
@@ -49,6 +50,10 @@ export function MinimaxIcon(props: SVGProps<SVGSVGElement>) {
 
 export function KimiIcon(props: SVGProps<SVGSVGElement>) {
 	return <KimiMono {...props} />;
+}
+
+export function DeepSeekIcon(props: SVGProps<SVGSVGElement>) {
+	return <DeepSeekColor {...props} />;
 }
 
 export function QwenIcon(props: SVGProps<SVGSVGElement>) {

--- a/src/components/model-icon.tsx
+++ b/src/components/model-icon.tsx
@@ -1,6 +1,7 @@
 import { Box } from "lucide-react";
 import {
 	ClaudeColorIcon,
+	DeepSeekIcon,
 	KimiIcon,
 	MinimaxIcon,
 	OpenAIColorIcon,
@@ -25,6 +26,8 @@ export function ModelIcon({
 		return <MinimaxIcon className={className} />;
 	if (model?.providerKey === "moonshot" || model?.providerKey === "moonshot-cn")
 		return <KimiIcon className={className} />;
+	if (model?.providerKey === "deepseek")
+		return <DeepSeekIcon className={className} />;
 	if (model?.providerKey === "zai" || model?.providerKey === "zai-cn")
 		return <ZhipuIcon className={className} />;
 	if (model?.providerKey === "qwen" || model?.providerKey === "qwen-intl")

--- a/src/features/settings/panels/builtin-claude-providers.ts
+++ b/src/features/settings/panels/builtin-claude-providers.ts
@@ -13,7 +13,7 @@ export type BuiltinClaudeProvider = {
 	baseUrl: string;
 	apiKeyUrl: string;
 	models: readonly BuiltinClaudeProviderModel[];
-	icon: "minimax" | "moonshot" | "zhipu" | "qwen" | "xiaomi";
+	icon: "minimax" | "moonshot" | "deepseek" | "zhipu" | "qwen" | "xiaomi";
 };
 
 export const BUILTIN_CLAUDE_PROVIDERS =

--- a/src/features/settings/panels/model-providers.tsx
+++ b/src/features/settings/panels/model-providers.tsx
@@ -10,6 +10,7 @@ import {
 import type { SVGProps } from "react";
 import { useEffect, useMemo, useState } from "react";
 import {
+	DeepSeekIcon,
 	KimiIcon,
 	MinimaxIcon,
 	QwenIcon,
@@ -343,7 +344,7 @@ function ConfiguredProvidersList({
 type ConfiguredItem = {
 	kind: ProviderKind;
 	label: string;
-	icon?: "minimax" | "moonshot" | "zhipu" | "qwen" | "xiaomi";
+	icon?: "minimax" | "moonshot" | "deepseek" | "zhipu" | "qwen" | "xiaomi";
 	keyPreview: string;
 };
 
@@ -438,13 +439,15 @@ function BuiltinProviderIcon({
 	icon,
 	className,
 }: {
-	icon: "minimax" | "moonshot" | "zhipu" | "qwen" | "xiaomi";
+	icon: "minimax" | "moonshot" | "deepseek" | "zhipu" | "qwen" | "xiaomi";
 	className?: string;
 }) {
 	const props: SVGProps<SVGSVGElement> = { className };
 	switch (icon) {
 		case "moonshot":
 			return <KimiIcon {...props} />;
+		case "deepseek":
+			return <DeepSeekIcon {...props} />;
 		case "zhipu":
 			return <ZhipuIcon {...props} />;
 		case "qwen":

--- a/src/shared/builtin-claude-providers.json
+++ b/src/shared/builtin-claude-providers.json
@@ -70,5 +70,16 @@
 		"apiKeyUrl": "https://platform.xiaomimimo.com/#/console/api-keys",
 		"models": [{ "id": "mimo-v2.5-pro", "label": "MiMo V2.5 Pro" }],
 		"icon": "xiaomi"
+	},
+	{
+		"key": "deepseek",
+		"label": "DeepSeek",
+		"baseUrl": "https://api.deepseek.com/anthropic",
+		"apiKeyUrl": "https://platform.deepseek.com/api_keys",
+		"models": [
+			{ "id": "deepseek-v4-pro[1m]", "label": "DeepSeek V4 Pro 1M" },
+			{ "id": "deepseek-v4-flash", "label": "DeepSeek V4 Flash" }
+		],
+		"icon": "deepseek"
 	}
 ]


### PR DESCRIPTION
## Summary

- Add **DeepSeek** to the list of built-in Claude Code custom providers (`src/shared/builtin-claude-providers.json`), wired to `https://api.deepseek.com/anthropic` with two preset models: `deepseek-v4-pro[1m]` (V4 Pro 1M) and `deepseek-v4-flash` (V4 Flash).
- Surface a colored DeepSeek brand icon (`@lobehub/icons` `DeepSeek/Color`) via a new `DeepSeekIcon` export, and route it through `ModelIcon` (provider key `deepseek`) and the settings panel's `BuiltinProviderIcon` switch.
- Extend the `icon` union type on `BuiltinClaudeProvider` / `ConfiguredItem` so `"deepseek"` is a valid icon discriminator.

## Why

Users running Claude Code via Helmor were asking for one-click DeepSeek setup. Adding it as a built-in custom provider means they can pick it from the providers list (with the right base URL + API key link) instead of hand-configuring a generic Anthropic-compatible endpoint.

## Test notes

- `bun run typecheck` should pass — the new provider/icon discriminator is exhaustively handled in the `BuiltinProviderIcon` switch and `ModelIcon` mapping.
- Manual: open Settings → Model providers → add provider, confirm DeepSeek appears with the colored icon, models populate, and the "Get API key" link points at `platform.deepseek.com/api_keys`.
- Changeset: `.changeset/quiet-deepseek-models.md` (minor bump).