### PR TITLE
fix(shortcuts): route chat shortcuts correctly when xterm holds focus

### DIFF
--- a/.changeset/swift-pandas-listen.md
+++ b/.changeset/swift-pandas-listen.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix chat shortcuts (new session, close session, prev/next session) being misrouted to the terminal after clicking from the terminal into the chat column.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2314,6 +2314,7 @@ function AppShell({
 												/>
 											)}
 											<div
+												data-focus-scope="chat"
 												className={
 													workspaceViewMode === "editor"
 														? "hidden"

--- a/src/features/panel/index.tsx
+++ b/src/features/panel/index.tsx
@@ -110,10 +110,7 @@ export const WorkspacePanel = memo(function WorkspacePanel({
 
 	return (
 		<HelmorProfiler id="WorkspacePanel">
-			<div
-				data-focus-scope="chat"
-				className="flex min-h-0 flex-1 flex-col bg-transparent"
-			>
+			<div className="flex min-h-0 flex-1 flex-col bg-transparent">
 				<WorkspacePanelHeader
 					workspace={workspace}
 					changeRequest={changeRequest}

--- a/src/features/shortcuts/focus-scope.test.ts
+++ b/src/features/shortcuts/focus-scope.test.ts
@@ -144,4 +144,45 @@ describe("getActiveScopes", () => {
 		(document.getElementById("sidebar") as HTMLInputElement).focus();
 		expect(getActiveScopes()).toEqual([DEFAULT_FOCUS_SCOPE]);
 	});
+
+	it("prefers a clicked scope over a stale focus owner (xterm-textarea case)", () => {
+		// xterm keeps its hidden textarea focused after a click on chat —
+		// pointer engagement must override stale focus.
+		document.body.innerHTML = `
+			<div data-focus-scope="terminal">
+				<input id="terminal-textarea" />
+			</div>
+			<div data-focus-scope="chat">
+				<div id="chat-messages">streamed text...</div>
+			</div>
+		`;
+		(document.getElementById("terminal-textarea") as HTMLInputElement).focus();
+		expect(getActiveScopes()).toEqual(["terminal"]);
+
+		const messages = document.getElementById("chat-messages") as HTMLDivElement;
+		messages.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+		// Focus is still on the terminal textarea, but the user clicked chat.
+		expect(document.activeElement?.id).toBe("terminal-textarea");
+		expect(getActiveScopes()).toEqual(["chat"]);
+	});
+
+	it("keeps composer + chat active when clicking inside chat without moving focus", () => {
+		// Focus in composer, click in chat: chat is reachable via
+		// SCOPE_PARENTS so the focus chain wins (composer shortcuts stay).
+		document.body.innerHTML = `
+			<div data-focus-scope="chat">
+				<div id="chat-messages">streamed text...</div>
+			</div>
+			<div data-focus-scope="composer">
+				<input id="composer-input" />
+			</div>
+		`;
+		(document.getElementById("composer-input") as HTMLInputElement).focus();
+		expect(getActiveScopes()).toEqual(["composer", "chat"]);
+
+		document
+			.getElementById("chat-messages")
+			?.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+		expect(getActiveScopes()).toEqual(["composer", "chat"]);
+	});
 });

--- a/src/features/shortcuts/focus-scope.ts
+++ b/src/features/shortcuts/focus-scope.ts
@@ -26,12 +26,10 @@ const SCOPE_PARENTS: Partial<Record<ShortcutScope, readonly ShortcutScope[]>> =
 
 export const DEFAULT_FOCUS_SCOPE: ShortcutScope = "chat";
 
-// Sticky memory of the last container the user explicitly engaged with.
-// Closing the focused terminal tab destroys its xterm textarea, which sends
-// `activeElement` back to `body` without firing a meaningful focusin — without
-// this memory, the very next keystroke would route to chat (the default) and
-// e.g. Mod+W would silently start closing chat sessions.
-let lastEngagedScope: ShortcutScope = DEFAULT_FOCUS_SCOPE;
+// Most recently engaged scope (focus or click). Pointer is needed because
+// xterm keeps DOM focus on its hidden textarea even after the user clicks
+// elsewhere. `null` = no engagement yet (distinct from chat-the-default).
+let lastEngagedScope: ShortcutScope | null = null;
 
 function readScopesFrom(element: Element | null): ShortcutScope[] {
 	if (!element) return [];
@@ -62,6 +60,12 @@ function withInheritedParents(
 	return out;
 }
 
+function rememberEngagement(target: Element | null): void {
+	if (!target) return;
+	const scopes = readScopesFrom(target);
+	lastEngagedScope = scopes[0] ?? null;
+}
+
 if (typeof document !== "undefined") {
 	document.addEventListener(
 		"focusin",
@@ -71,8 +75,17 @@ if (typeof document !== "undefined") {
 			// removed (e.g. xterm unmounted on tab close). Treat that as a
 			// transient focus loss and keep the sticky memory.
 			if (!target || target === document.body) return;
-			const scopes = readScopesFrom(target);
-			lastEngagedScope = scopes[0] ?? DEFAULT_FOCUS_SCOPE;
+			rememberEngagement(target);
+		},
+		true,
+	);
+
+	// Click engagement: covers non-focusable click targets (chat messages,
+	// padding) where focusin doesn't fire and xterm holds DOM focus.
+	document.addEventListener(
+		"pointerdown",
+		(event) => {
+			rememberEngagement(event.target as Element | null);
 		},
 		true,
 	);
@@ -87,20 +100,41 @@ export function getActiveScopes(): ShortcutScope[] {
 }
 
 function computeActiveLeafScopes(): readonly ShortcutScope[] {
-	if (typeof document === "undefined") return [lastEngagedScope];
+	if (typeof document === "undefined") {
+		return [lastEngagedScope ?? DEFAULT_FOCUS_SCOPE];
+	}
 	const active = document.activeElement;
 	if (active && active !== document.body) {
 		const scopes = readScopesFrom(active);
-		if (scopes.length > 0) return scopes;
+		if (scopes.length > 0) {
+			// Trust focus if engagement agrees (or is unset); otherwise the
+			// click wins — handles xterm keeping focus on its textarea.
+			const expanded = withInheritedParents(scopes);
+			if (lastEngagedScope === null || expanded.includes(lastEngagedScope)) {
+				return scopes;
+			}
+			const stillMounted = document.querySelector(
+				`[${FOCUS_SCOPE_ATTRIBUTE}="${lastEngagedScope}"]`,
+			);
+			if (stillMounted) return [lastEngagedScope];
+			return scopes;
+		}
 		// Real focus owner lives outside any tagged scope (sidebar, top
-		// chrome). Fall back to the default.
+		// chrome). Honor a sticky engagement that still exists, otherwise
+		// fall back to the default.
+		if (lastEngagedScope !== null) {
+			const stillMounted = document.querySelector(
+				`[${FOCUS_SCOPE_ATTRIBUTE}="${lastEngagedScope}"]`,
+			);
+			if (stillMounted) return [lastEngagedScope];
+		}
 		return [DEFAULT_FOCUS_SCOPE];
 	}
 	// activeElement === body — transient focus loss (e.g. focused element
 	// just unmounted). Honor sticky only if its scope container still
 	// exists in the DOM; otherwise the panel is gone and the sticky memory
 	// is stale.
-	if (lastEngagedScope === DEFAULT_FOCUS_SCOPE) return [lastEngagedScope];
+	if (lastEngagedScope === null) return [DEFAULT_FOCUS_SCOPE];
 	const stillMounted = document.querySelector(
 		`[${FOCUS_SCOPE_ATTRIBUTE}="${lastEngagedScope}"]`,
 	);
@@ -109,5 +143,5 @@ function computeActiveLeafScopes(): readonly ShortcutScope[] {
 
 /** Test-only: reset the sticky scope memory between tests. */
 export function _resetActiveScopeForTesting() {
-	lastEngagedScope = DEFAULT_FOCUS_SCOPE;
+	lastEngagedScope = null;
 }


### PR DESCRIPTION
## Summary

Chat shortcuts (new session, close session, prev/next session) were silently routed to the terminal scope after a user clicked from the terminal into the chat column. xterm keeps DOM focus on its hidden textarea even after the user clicks elsewhere, so `document.activeElement` still pointed inside the terminal scope and `getActiveScopes()` returned `["terminal"]` for keystrokes meant for chat.

This fixes the routing by:

- Adding a global `pointerdown` listener that records the most recently engaged scope, so a click can override stale focus.
- Tracking engagement as `ShortcutScope | null` (instead of forcing it to `chat` on init), so we can tell "no engagement yet" apart from "user is in chat".
- In `computeActiveLeafScopes`, trusting the focus owner only when engagement agrees with the focus chain (or is unset); otherwise the click wins as long as the engaged scope is still mounted.
- Moving `data-focus-scope="chat"` up one level from `WorkspacePanel`'s inner div to the outer chat-column wrapper in `App.tsx`, so clicks anywhere in the chat column (including padding around messages) are recognized as chat engagement.

## Why

The previous heuristic depended only on `focusin`, which never fires for clicks on non-focusable chat content (rendered messages, padding) — and xterm's textarea is the focus owner the whole time the terminal is mounted, even after the user has clearly moved on. Adding pointer engagement is the minimal change that makes the focus → scope mapping match user intent.

## Test plan

- [x] `bun x vitest run src/features/shortcuts/focus-scope.test.ts` — two new cases cover the xterm-textarea bug and the composer + chat overlap path
- [ ] Manual: focus terminal, click into chat column, hit Cmd+N / Cmd+W / Cmd+[ / Cmd+] — shortcuts hit chat, not terminal
- [ ] Manual: focus composer, click chat messages — composer shortcuts still active (chat is reachable via SCOPE_PARENTS)