### PR TITLE
feat: add session forking from historical message

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "helmor",

--- a/src-tauri/src/agents/streaming/fork_context.rs
+++ b/src-tauri/src/agents/streaming/fork_context.rs
@@ -1,0 +1,555 @@
+//! Fork-session context prefix builder.
+//!
+//! When a session is forked there is no provider-side session to resume
+//! (no JSONL on disk), so the agent has zero knowledge of the prior
+//! conversation. This module builds a compact textual summary of the
+//! conversation history that gets prepended to the first prompt of the
+//! forked session.
+//!
+//! # Design: layered context
+//!
+//! The conversation is split into two layers to balance completeness
+//! against the agent's context-window budget:
+//!
+//! 1. **Bootstrap** – the earliest messages (first user prompt + the
+//!    agent's initial response). Always preserved in full up to
+//!    [`ForkContextConfig::bootstrap_max_chars`]. This keeps the user's
+//!    original intent and the agent's initial plan intact.
+//!
+//! 2. **Recent turns** – the latest N user/assistant pairs, counted from
+//!    the end of the conversation. Provides the most up-to-date context.
+//!
+//! Messages that fall between the two layers are omitted with a marker.
+//! System, error, and result rows are skipped entirely — the Claude Code
+//! / Codex SDK reconstructs its own system context (CLAUDE.md, tools,
+//! MCP, etc.) for every fresh session.
+
+use rusqlite::params;
+
+/// Layered context budget constants.
+struct ForkContextConfig {
+    /// Layer 1: bootstrap messages preserved in full.
+    bootstrap_max_chars: usize,
+    /// Layer 2: number of recent user/assistant turn-pairs to keep.
+    recent_turn_count: usize,
+    /// Hard cap on the total output string length.
+    total_max_chars: usize,
+    /// Per-message truncation limit.
+    per_message_max_chars: usize,
+}
+
+impl Default for ForkContextConfig {
+    fn default() -> Self {
+        Self {
+            bootstrap_max_chars: 8_000,
+            recent_turn_count: 20,
+            total_max_chars: 30_000,
+            per_message_max_chars: 3_000,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// Build a context prefix for a freshly forked session. Returns `None`
+/// when the session has no user/assistant messages or the DB read fails.
+pub(super) fn build_fork_context_prefix(helmor_session_id: &str) -> Option<String> {
+    let config = ForkContextConfig::default();
+    let conn = crate::models::db::read_conn().ok()?;
+
+    // Only load the conversation turns the agent needs — system, error,
+    // and result rows are skipped because the SDK re-creates them.
+    let mut stmt = conn
+        .prepare(
+            "SELECT role, content FROM session_messages \
+             WHERE session_id = ?1 AND role IN ('user', 'assistant') \
+             ORDER BY rowid ASC",
+        )
+        .ok()?;
+
+    let rows: Vec<(String, String)> = stmt
+        .query_map(params![helmor_session_id], |row| {
+            Ok((row.get(0)?, row.get(1)?))
+        })
+        .ok()?
+        .filter_map(Result::ok)
+        .collect();
+
+    if rows.is_empty() {
+        return None;
+    }
+
+    build_prefix_from_rows(&rows, &config)
+}
+
+// ---------------------------------------------------------------------------
+// Core logic (pure — easy to test without a DB)
+// ---------------------------------------------------------------------------
+
+fn build_prefix_from_rows(rows: &[(String, String)], config: &ForkContextConfig) -> Option<String> {
+    let header = "Previous conversation context (forked from an earlier session):\n";
+    let mut context = String::from(header);
+
+    // ── Layer 1: Bootstrap ──────────────────────────────────────────────
+    let mut bootstrap_end = 0usize; // exclusive
+    for (i, (role, content)) in rows.iter().enumerate() {
+        let text = extract_text_from_content(role, content);
+        if text.is_empty() {
+            continue;
+        }
+        let label = role_label(role);
+        let entry = format_entry(label, &text, config.per_message_max_chars);
+        if context.len() + entry.len() - header.len() > config.bootstrap_max_chars {
+            // Would exceed bootstrap budget. If this is the very first
+            // meaningful entry we still include it (never produce an
+            // empty bootstrap); otherwise stop.
+            if bootstrap_end == 0 {
+                context.push_str(&entry);
+                bootstrap_end = i + 1;
+            }
+            break;
+        }
+        context.push_str(&entry);
+        bootstrap_end = i + 1;
+    }
+
+    // Everything fits inside the bootstrap — no truncation needed.
+    if bootstrap_end >= rows.len() {
+        return finalise(context, config);
+    }
+
+    // ── Layer 2: Recent turns ───────────────────────────────────────────
+    let recent_start = find_recent_turns_start(rows, bootstrap_end, config.recent_turn_count);
+
+    // Emit a gap marker when there are omitted messages between the two
+    // layers. We count by message index (not by "turns") because that is
+    // what the user sees in the conversation list.
+    if recent_start > bootstrap_end {
+        let omitted = recent_start - bootstrap_end;
+        context.push_str(&format!("\n[... {omitted} earlier messages omitted ...]"));
+    }
+
+    for (role, content) in rows[recent_start..].iter() {
+        if context.len() >= config.total_max_chars {
+            context.push_str("\n[... remaining messages truncated ...]");
+            break;
+        }
+        let text = extract_text_from_content(role, content);
+        if text.is_empty() {
+            continue;
+        }
+        let label = role_label(role);
+        context.push_str(&format_entry(label, &text, config.per_message_max_chars));
+    }
+
+    finalise(context, config)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Map a DB role string to a human-readable label. Returns `None` for
+/// roles we skip (system, error, result, …).
+fn role_label(role: &str) -> Option<&'static str> {
+    match role {
+        "user" => Some("User"),
+        "assistant" => Some("Assistant"),
+        _ => None,
+    }
+}
+
+/// Format a single message entry for the context string.
+fn format_entry(label: Option<&str>, text: &str, max_chars: usize) -> String {
+    let truncated = truncate_str(text, max_chars);
+    match label {
+        Some(l) => format!("\n{l}: {truncated}"),
+        None => format!("\n{truncated}"),
+    }
+}
+
+/// Truncate `text` to at most `max_chars`, respecting UTF-8 char boundaries.
+fn truncate_str(text: &str, max_chars: usize) -> &str {
+    if text.len() <= max_chars {
+        return text;
+    }
+    // Find the last char boundary at or before max_chars.
+    let mut end = max_chars;
+    while !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    &text[..end]
+}
+
+/// Find the start index (in `rows`) of the last `turn_count` user
+/// messages, searching backwards from `rows.len()` but not before
+/// `search_from`.
+fn find_recent_turns_start(
+    rows: &[(String, String)],
+    search_from: usize,
+    turn_count: usize,
+) -> usize {
+    let mut turns_found = 0usize;
+    for i in (search_from..rows.len()).rev() {
+        if rows[i].0 == "user" {
+            turns_found += 1;
+            if turns_found >= turn_count {
+                return i;
+            }
+        }
+    }
+    search_from
+}
+
+/// Return the final context string, or `None` when it contains nothing
+/// beyond the header.
+fn finalise(context: String, _config: &ForkContextConfig) -> Option<String> {
+    let header = "Previous conversation context (forked from an earlier session):\n";
+    if context.len() > header.len() {
+        Some(context)
+    } else {
+        None
+    }
+}
+
+/// Extract readable text from a session message's JSON content.
+///
+/// `user_prompt` messages carry `{"type":"user_prompt","text":"..."}` —
+/// we read the `text` field.  `assistant` messages carry an array of
+/// content blocks — we collect only `type: "text"` parts.
+pub(super) fn extract_text_from_content(role: &str, content: &str) -> String {
+    let Ok(val) = serde_json::from_str::<serde_json::Value>(content) else {
+        return String::new();
+    };
+
+    match role {
+        "user" => val
+            .get("text")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string(),
+        "assistant" => {
+            let parts = match val.as_array() {
+                Some(a) => a,
+                None => return String::new(),
+            };
+            let mut text = String::new();
+            for part in parts {
+                if part.get("type").and_then(|v| v.as_str()) == Some("text") {
+                    if let Some(t) = part.get("text").and_then(|v| v.as_str()) {
+                        if !text.is_empty() {
+                            text.push('\n');
+                        }
+                        text.push_str(t);
+                    }
+                }
+            }
+            text
+        }
+        _ => String::new(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config() -> ForkContextConfig {
+        ForkContextConfig::default()
+    }
+
+    /// Helper: build a user_prompt JSON.
+    fn user_prompt(text: &str) -> (String, String) {
+        (
+            "user".into(),
+            serde_json::json!({"type": "user_prompt", "text": text}).to_string(),
+        )
+    }
+
+    /// Helper: build an assistant text block JSON.
+    fn assistant_text(text: &str) -> (String, String) {
+        (
+            "assistant".into(),
+            serde_json::json!([{"type": "text", "text": text}]).to_string(),
+        )
+    }
+
+    /// Helper: build a system row (should be skipped by the query, but
+    /// we test the pure function too).
+    fn system_row(subtype: &str) -> (String, String) {
+        (
+            "system".into(),
+            serde_json::json!({"type": "system", "subtype": subtype}).to_string(),
+        )
+    }
+
+    #[test]
+    fn empty_returns_none() {
+        assert!(build_prefix_from_rows(&[], &config()).is_none());
+    }
+
+    #[test]
+    fn system_only_returns_none() {
+        let rows = vec![system_row("init")];
+        // system rows produce empty text → no content beyond header
+        assert!(build_prefix_from_rows(&rows, &config()).is_none());
+    }
+
+    #[test]
+    fn short_conversation_preserved_fully() {
+        let rows = vec![
+            user_prompt("Fix the login bug"),
+            assistant_text("I'll look into the login flow."),
+            user_prompt("Also check the signup page"),
+            assistant_text("Found the issue in both places."),
+        ];
+        let result = build_prefix_from_rows(&rows, &config()).unwrap();
+        assert!(result.contains("Fix the login bug"));
+        assert!(result.contains("I'll look into the login flow."));
+        assert!(result.contains("Also check the signup page"));
+        assert!(result.contains("Found the issue in both places."));
+        assert!(
+            !result.contains("omitted"),
+            "short conversation should have no omission markers"
+        );
+    }
+
+    #[test]
+    fn bootstrap_preserves_first_turn() {
+        // Build a conversation that exceeds bootstrap budget.
+        let mut rows = vec![
+            user_prompt("Implement auth module"),
+            assistant_text("Here's the plan for the auth module: use JWT with refresh tokens."),
+        ];
+        // Add many more messages to push us past the bootstrap layer.
+        for i in 0..50 {
+            rows.push(user_prompt(&format!("Turn {i} user message")));
+            rows.push(assistant_text(&format!("Turn {i} assistant response")));
+        }
+
+        let small_config = ForkContextConfig {
+            bootstrap_max_chars: 300,
+            recent_turn_count: 5,
+            total_max_chars: 5000,
+            per_message_max_chars: 3000,
+        };
+        let result = build_prefix_from_rows(&rows, &small_config).unwrap();
+        // Bootstrap must contain the first prompt.
+        assert!(
+            result.contains("Implement auth module"),
+            "bootstrap should preserve the first user prompt"
+        );
+        // Should have an omission marker.
+        assert!(
+            result.contains("omitted"),
+            "gap between bootstrap and recent should produce a marker"
+        );
+    }
+
+    #[test]
+    fn recent_turns_window_applied() {
+        let mut rows = Vec::new();
+        for i in 0..100 {
+            rows.push(user_prompt(&format!("User message {i}")));
+            rows.push(assistant_text(&format!("Assistant reply {i}")));
+        }
+        let cfg = ForkContextConfig {
+            bootstrap_max_chars: 200,
+            recent_turn_count: 3,
+            total_max_chars: 50_000,
+            per_message_max_chars: 3_000,
+        };
+        let result = build_prefix_from_rows(&rows, &cfg).unwrap();
+        // Recent window should include the last 3 turns.
+        assert!(result.contains("User message 99"));
+        assert!(result.contains("User message 98"));
+        assert!(result.contains("User message 97"));
+        // Messages in the gap between bootstrap and recent should be omitted.
+        assert!(
+            !result.contains("User message 50"),
+            "mid-gap messages should be omitted by the recent window"
+        );
+    }
+
+    #[test]
+    fn total_char_limit_enforced() {
+        // Build a conversation that would be huge with no limit.
+        let mut rows = Vec::new();
+        for i in 0..200 {
+            rows.push(user_prompt(&format!(
+                "Long message number {i}: {}",
+                "x".repeat(500)
+            )));
+            rows.push(assistant_text(&format!("Reply {i}: {}", "y".repeat(500))));
+        }
+        let cfg = ForkContextConfig {
+            bootstrap_max_chars: 500,
+            recent_turn_count: 100,
+            total_max_chars: 2_000,
+            per_message_max_chars: 3_000,
+        };
+        let result = build_prefix_from_rows(&rows, &cfg).unwrap();
+        assert!(
+            result.len() <= 2_500, // some slack for the truncation markers
+            "total length {} should be near the 2000 limit",
+            result.len()
+        );
+        assert!(result.contains("truncated"));
+    }
+
+    #[test]
+    fn single_message_truncated() {
+        let huge = "A".repeat(5_000);
+        let rows = vec![user_prompt(&huge)];
+        let cfg = ForkContextConfig {
+            per_message_max_chars: 100,
+            ..config()
+        };
+        let result = build_prefix_from_rows(&rows, &cfg).unwrap();
+        // The extracted text should be truncated to ~100 chars.
+        assert!(
+            result.len() < 500,
+            "single huge message should be truncated"
+        );
+    }
+
+    #[test]
+    fn extract_user_prompt_text() {
+        let json = r#"{"type":"user_prompt","text":"hello world"}"#;
+        assert_eq!(extract_text_from_content("user", json), "hello world");
+    }
+
+    #[test]
+    fn extract_assistant_text_parts() {
+        let json = r#"[{"type":"text","text":"part one"},{"type":"text","text":"part two"}]"#;
+        assert_eq!(
+            extract_text_from_content("assistant", json),
+            "part one\npart two"
+        );
+    }
+
+    #[test]
+    fn extract_skips_non_text_blocks() {
+        let json = r#"[{"type":"tool_use","id":"tu1"},{"type":"text","text":"answer"}]"#;
+        assert_eq!(extract_text_from_content("assistant", json), "answer");
+    }
+
+    #[test]
+    fn extract_returns_empty_for_unparseable() {
+        assert_eq!(extract_text_from_content("user", "not json"), "");
+    }
+
+    #[test]
+    fn extract_returns_empty_for_system_role() {
+        let json = r#"{"type":"system","subtype":"init"}"#;
+        assert_eq!(extract_text_from_content("system", json), "");
+    }
+
+    #[test]
+    fn overlap_between_bootstrap_and_recent_no_duplicate() {
+        // If the conversation is short enough that bootstrap already
+        // covers everything, recent should not duplicate messages.
+        let rows = vec![
+            user_prompt("First"),
+            assistant_text("Reply one"),
+            user_prompt("Second"),
+            assistant_text("Reply two"),
+        ];
+        let result = build_prefix_from_rows(&rows, &config()).unwrap();
+        // "First" should appear exactly once.
+        let count = result.matches("First").count();
+        assert_eq!(count, 1, "bootstrap and recent layers must not overlap");
+    }
+
+    /// Realistic 100-turn conversation — validates the full layered
+    /// pipeline at scale: bootstrap preservation, recent-window
+    /// selection, gap omission, total-budget enforcement, and the
+    /// absence of duplicate messages across layers.
+    #[test]
+    fn hundred_turn_conversation_respects_all_layers() {
+        let mut rows = Vec::with_capacity(200);
+        for i in 0..100 {
+            rows.push(user_prompt(&format!(
+                "Turn {i}: please fix the {} module. Here is some extra context to make \
+                 the message realistic — we need to handle edge cases around \
+                 concurrency and error recovery.",
+                ["auth", "payment", "notification", "search", "cache"][i % 5],
+            )));
+            rows.push(assistant_text(&format!(
+                "Turn {i}: I've analysed the {} module. The root cause is in the \
+                 connection pool — when concurrent requests exceed the limit the pool \
+                 deadlocks. I recommend adding a timeout and retry wrapper.",
+                ["auth", "payment", "notification", "search", "cache"][i % 5],
+            )));
+        }
+
+        let result = build_prefix_from_rows(&rows, &config()).unwrap();
+
+        // ── Structural checks ──────────────────────────────────────────
+        // Total length within budget (config default = 30 000 + header).
+        assert!(
+            result.len() <= 32_000,
+            "output {} bytes exceeds budget",
+            result.len(),
+        );
+
+        // Bootstrap: first prompt MUST be present.
+        assert!(
+            result.contains("Turn 0: please fix the auth module"),
+            "bootstrap must preserve the very first user prompt",
+        );
+
+        // Recent window: last 3 user turns MUST be present.
+        assert!(result.contains("Turn 99: please fix the cache module"));
+        assert!(result.contains("Turn 98: please fix the search module"));
+        assert!(result.contains("Turn 97: please fix the notification module"));
+
+        // Gap: mid-range messages should be omitted.
+        assert!(
+            result.contains("omitted"),
+            "100-turn conversation should have a gap marker",
+        );
+        assert!(
+            !result.contains("Turn 50: please fix"),
+            "Turn 50 should fall in the omitted gap",
+        );
+
+        // No duplication: "Turn 0" appears only in bootstrap, not again
+        // in the recent window.
+        let first_prompt_count = result.matches("Turn 0: please fix the auth").count();
+        assert_eq!(
+            first_prompt_count, 1,
+            "first prompt must not be duplicated across layers",
+        );
+
+        // ── Snapshot: pin the output shape for regression detection ─────
+        // Use insta's inline snapshot so the test is self-contained and
+        // doesn't create external `.snap` files for a pure-logic module.
+        //
+        // We snapshot a summary rather than the full 30 kB string to keep
+        // the assertion readable. The summary captures the structural
+        // properties that matter.
+        let line_count = result.lines().count();
+        let has_ellipsis = result.contains("omitted");
+        let starts_with_header =
+            result.starts_with("Previous conversation context (forked from an earlier session):");
+
+        insta::assert_debug_snapshot!(
+            "hundred_turn_summary",
+            (
+                result.len(),
+                line_count,
+                has_ellipsis,
+                starts_with_header,
+                result.contains("Turn 0:"),
+                result.contains("Turn 99:"),
+            ),
+        );
+    }
+}

--- a/src-tauri/src/agents/streaming/mod.rs
+++ b/src-tauri/src/agents/streaming/mod.rs
@@ -103,18 +103,33 @@ pub(super) fn stream_via_sidecar(
         .clone()
         .unwrap_or_else(|| Uuid::new_v4().to_string());
 
+    // When there's no provider session to resume (e.g. a freshly forked
+    // session) but the session already has messages in the DB, build a
+    // conversation-context preamble so the agent knows the prior exchange.
+    let fork_context = if resume_session_id.is_none() {
+        helmor_session_id
+            .as_deref()
+            .and_then(build_fork_context_prefix)
+    } else {
+        None
+    };
+
     // Combine the optional hidden preamble with the user's prompt. Only
     // the wire payload sees the combined string — `prompt` (user text
     // only) is what gets persisted in `persist_user_message` below, so
     // the chat bubble + DB stay free of the preference prefix.
-    let prefix_trimmed = request
+    let user_prefix = request
         .prompt_prefix
         .as_deref()
         .map(str::trim)
         .filter(|p| !p.is_empty());
-    let combined_prompt = match prefix_trimmed {
-        Some(prefix) => format!("{prefix}\n\nUser request:\n{prompt}"),
-        None => prompt.to_string(),
+    let combined_prompt = match (fork_context.as_deref(), user_prefix) {
+        (Some(ctx), Some(prefs)) => {
+            format!("{ctx}\n\n{prefs}\n\nUser request:\n{prompt}")
+        }
+        (Some(ctx), None) => format!("{ctx}\n\nUser request:\n{prompt}"),
+        (None, Some(prefs)) => format!("{prefs}\n\nUser request:\n{prompt}"),
+        (None, None) => prompt.to_string(),
     };
 
     let params = build_send_message_params(BuildSendMessageParamsInput {
@@ -1015,6 +1030,85 @@ pub(super) fn stream_via_sidecar(
     });
 
     Ok(())
+}
+
+/// When a session has messages in the DB but no provider session to resume
+/// (e.g. a freshly forked session), build a context prefix so the agent
+/// sees the prior conversation. Returns `None` when the session is empty
+/// or the DB read fails.
+fn build_fork_context_prefix(helmor_session_id: &str) -> Option<String> {
+    let conn = crate::models::db::read_conn().ok()?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT role, content FROM session_messages \
+             WHERE session_id = ?1 ORDER BY rowid ASC",
+        )
+        .ok()?;
+    let rows: Vec<(String, String)> = stmt
+        .query_map([helmor_session_id], |row| Ok((row.get(0)?, row.get(1)?)))
+        .ok()?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    if rows.is_empty() {
+        return None;
+    }
+
+    let mut context = String::from("Previous conversation for context:");
+    for (role, content) in &rows {
+        let text = extract_text_from_content(role, content);
+        if text.is_empty() {
+            continue;
+        }
+        let label = match role.as_str() {
+            "user" => "User",
+            "assistant" => "Assistant",
+            _ => continue, // skip system, error, result, etc.
+        };
+        context.push_str(&format!("\n{label}: {text}"));
+    }
+
+    // Only return if we actually extracted something beyond the header.
+    if context.len() > "Previous conversation for context:".len() {
+        Some(context)
+    } else {
+        None
+    }
+}
+
+/// Extract readable text from a session message's JSON content.
+fn extract_text_from_content(role: &str, content: &str) -> String {
+    let Ok(val) = serde_json::from_str::<serde_json::Value>(content) else {
+        return String::new();
+    };
+
+    match role {
+        "user" => val
+            .get("text")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string(),
+        "assistant" => {
+            // Assistant content is an array of parts; collect text parts.
+            let parts = match val.as_array() {
+                Some(a) => a,
+                None => return String::new(),
+            };
+            let mut text = String::new();
+            for part in parts {
+                if part.get("type").and_then(|v| v.as_str()) == Some("text") {
+                    if let Some(t) = part.get("text").and_then(|v| v.as_str()) {
+                        if !text.is_empty() {
+                            text.push('\n');
+                        }
+                        text.push_str(t);
+                    }
+                }
+            }
+            text
+        }
+        _ => String::new(),
+    }
 }
 
 fn build_exit_plan_review_message(

--- a/src-tauri/src/agents/streaming/mod.rs
+++ b/src-tauri/src/agents/streaming/mod.rs
@@ -15,6 +15,7 @@ mod active_streams;
 mod bridges;
 mod cleanup;
 mod context_usage;
+mod fork_context;
 mod params;
 mod session_id;
 mod state;
@@ -109,7 +110,7 @@ pub(super) fn stream_via_sidecar(
     let fork_context = if resume_session_id.is_none() {
         helmor_session_id
             .as_deref()
-            .and_then(build_fork_context_prefix)
+            .and_then(fork_context::build_fork_context_prefix)
     } else {
         None
     };
@@ -1030,85 +1031,6 @@ pub(super) fn stream_via_sidecar(
     });
 
     Ok(())
-}
-
-/// When a session has messages in the DB but no provider session to resume
-/// (e.g. a freshly forked session), build a context prefix so the agent
-/// sees the prior conversation. Returns `None` when the session is empty
-/// or the DB read fails.
-fn build_fork_context_prefix(helmor_session_id: &str) -> Option<String> {
-    let conn = crate::models::db::read_conn().ok()?;
-    let mut stmt = conn
-        .prepare(
-            "SELECT role, content FROM session_messages \
-             WHERE session_id = ?1 ORDER BY rowid ASC",
-        )
-        .ok()?;
-    let rows: Vec<(String, String)> = stmt
-        .query_map([helmor_session_id], |row| Ok((row.get(0)?, row.get(1)?)))
-        .ok()?
-        .filter_map(|r| r.ok())
-        .collect();
-
-    if rows.is_empty() {
-        return None;
-    }
-
-    let mut context = String::from("Previous conversation for context:");
-    for (role, content) in &rows {
-        let text = extract_text_from_content(role, content);
-        if text.is_empty() {
-            continue;
-        }
-        let label = match role.as_str() {
-            "user" => "User",
-            "assistant" => "Assistant",
-            _ => continue, // skip system, error, result, etc.
-        };
-        context.push_str(&format!("\n{label}: {text}"));
-    }
-
-    // Only return if we actually extracted something beyond the header.
-    if context.len() > "Previous conversation for context:".len() {
-        Some(context)
-    } else {
-        None
-    }
-}
-
-/// Extract readable text from a session message's JSON content.
-fn extract_text_from_content(role: &str, content: &str) -> String {
-    let Ok(val) = serde_json::from_str::<serde_json::Value>(content) else {
-        return String::new();
-    };
-
-    match role {
-        "user" => val
-            .get("text")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string(),
-        "assistant" => {
-            // Assistant content is an array of parts; collect text parts.
-            let parts = match val.as_array() {
-                Some(a) => a,
-                None => return String::new(),
-            };
-            let mut text = String::new();
-            for part in parts {
-                if part.get("type").and_then(|v| v.as_str()) == Some("text") {
-                    if let Some(t) = part.get("text").and_then(|v| v.as_str()) {
-                        if !text.is_empty() {
-                            text.push('\n');
-                        }
-                        text.push_str(t);
-                    }
-                }
-            }
-            text
-        }
-        _ => String::new(),
-    }
 }
 
 fn build_exit_plan_review_message(

--- a/src-tauri/src/agents/streaming/snapshots/helmor_lib__agents__streaming__fork_context__tests__hundred_turn_summary.snap
+++ b/src-tauri/src/agents/streaming/snapshots/helmor_lib__agents__streaming__fork_context__tests__hundred_turn_summary.snap
@@ -1,0 +1,12 @@
+---
+source: src/agents/streaming/fork_context.rs
+expression: "(result.len(), line_count, has_ellipsis, starts_with_header,\nresult.contains(\"Turn 0:\"), result.contains(\"Turn 99:\"),)"
+---
+(
+    15599,
+    84,
+    true,
+    true,
+    true,
+    true,
+)

--- a/src-tauri/src/commands/session_commands.rs
+++ b/src-tauri/src/commands/session_commands.rs
@@ -38,6 +38,14 @@ pub async fn create_session(
 }
 
 #[tauri::command]
+pub async fn fork_session(
+    source_session_id: String,
+    fork_after_message_id: String,
+) -> CmdResult<sessions::CreateSessionResponse> {
+    run_blocking(move || sessions::fork_session(&source_session_id, &fork_after_message_id)).await
+}
+
+#[tauri::command]
 pub async fn rename_session(session_id: String, title: String) -> CmdResult<()> {
     run_blocking(move || sessions::rename_session(&session_id, &title)).await
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -255,6 +255,7 @@ pub fn run() {
             commands::workspace_commands::list_workspace_groups,
             commands::session_commands::list_workspace_sessions,
             commands::session_commands::create_session,
+            commands::session_commands::fork_session,
             commands::session_commands::rename_session,
             commands::session_commands::hide_session,
             commands::session_commands::unhide_session,

--- a/src-tauri/src/models/sessions.rs
+++ b/src-tauri/src/models/sessions.rs
@@ -498,37 +498,32 @@ pub fn fork_session(
         .context("Failed to create forked session")?;
 
     // Copy messages up to and including the fork point.
-    // Generate fresh UUIDs on the Rust side to match the codebase convention
-    // (Uuid::new_v4) rather than using SQL hex(randomblob(16)).
+    // Stream row-by-row (cursor) instead of collecting into a Vec —
+    // keeps memory O(1) for large conversations. Fresh UUIDs are
+    // generated on the Rust side to match the codebase convention.
     {
-        let mut stmt = transaction.prepare(
+        let mut select_stmt = transaction.prepare(
             "SELECT role, content, sent_at, created_at \
              FROM session_messages \
              WHERE session_id = ?1 AND rowid <= ?2 \
              ORDER BY rowid ASC",
         )?;
-        let rows: Vec<(String, String, Option<String>, String)> = stmt
-            .query_map((source_session_id, fork_rowid), |row| {
-                Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
-            })?
-            .collect::<std::result::Result<Vec<_>, _>>()?;
-
-        for (role, content, sent_at, created_at) in &rows {
-            let new_msg_id = uuid::Uuid::new_v4().to_string();
-            transaction.execute(
-                r#"
-                INSERT INTO session_messages (id, session_id, role, content, sent_at, created_at)
-                VALUES (?1, ?2, ?3, ?4, ?5, ?6)
-                "#,
-                (
-                    new_msg_id,
-                    &new_session_id,
-                    role,
-                    content,
-                    sent_at,
-                    created_at,
-                ),
-            )?;
+        let mut insert_stmt = transaction.prepare(
+            r#"
+            INSERT INTO session_messages (id, session_id, role, content, sent_at, created_at)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+            "#,
+        )?;
+        let mut rows = select_stmt.query((source_session_id, fork_rowid))?;
+        while let Some(row) = rows.next()? {
+            insert_stmt.execute(rusqlite::params![
+                uuid::Uuid::new_v4().to_string(),
+                &new_session_id,
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, Option<String>>(2)?,
+                row.get::<_, String>(3)?,
+            ])?;
         }
     }
 

--- a/src-tauri/src/models/sessions.rs
+++ b/src-tauri/src/models/sessions.rs
@@ -425,6 +425,134 @@ pub fn create_session(
     Ok(CreateSessionResponse { session_id })
 }
 
+/// Create a new session that forks from a historical point in an existing
+/// session. All messages up to (and including) `fork_after_message_id` are
+/// copied into the new session. The agent session (`provider_session_id`) is
+/// NOT carried over — the fork starts a fresh agent context.
+///
+/// Returns an error if the source session is currently streaming (status is
+/// not `idle`), since mid-stream messages may be incomplete.
+pub fn fork_session(
+    source_session_id: &str,
+    fork_after_message_id: &str,
+) -> Result<CreateSessionResponse> {
+    let mut connection = db::write_conn()?;
+    let transaction = connection
+        .transaction()
+        .context("Failed to start fork-session transaction")?;
+
+    // Look up the source session.
+    let (workspace_id, source_title, source_status, source_model, source_permission_mode, source_effort_level): (
+        String,
+        String,
+        String,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+    ) = transaction
+        .query_row(
+            "SELECT workspace_id, title, status, model, permission_mode, effort_level FROM sessions WHERE id = ?1",
+            [source_session_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?, row.get(5)?)),
+        )
+        .with_context(|| format!("Source session {source_session_id} not found"))?;
+
+    // Reject forking from an active session — messages may be incomplete.
+    if source_status != "idle" {
+        bail!("Cannot fork from a session that is currently active (status: {source_status})");
+    }
+
+    // Resolve the fork point's rowid for reliable ordering.
+    let fork_rowid: i64 = transaction
+        .query_row(
+            "SELECT rowid FROM session_messages WHERE id = ?1 AND session_id = ?2",
+            (fork_after_message_id, source_session_id),
+            |row| row.get(0),
+        )
+        .with_context(|| {
+            format!("Fork point message {fork_after_message_id} not found in session {source_session_id}")
+        })?;
+
+    // Create the new session. Model, permission mode, and effort level are
+    // carried over from the source so the forked session starts with the
+    // same agent configuration.
+    let new_session_id = uuid::Uuid::new_v4().to_string();
+    let new_title = format!("{source_title} (fork)");
+    let new_permission_mode = source_permission_mode.unwrap_or_else(|| "default".to_string());
+    let new_effort_level = source_effort_level.unwrap_or_else(|| {
+        settings::load_setting_value("app.default_effort")
+            .ok()
+            .flatten()
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "high".to_string())
+    });
+
+    transaction
+        .execute(
+            r#"
+            INSERT INTO sessions (id, workspace_id, status, title, permission_mode, model, effort_level)
+            VALUES (?1, ?2, 'idle', ?3, ?4, ?5, ?6)
+            "#,
+            (&new_session_id, &workspace_id, &new_title, &new_permission_mode, &source_model, &new_effort_level),
+        )
+        .context("Failed to create forked session")?;
+
+    // Copy messages up to and including the fork point.
+    // Generate fresh UUIDs on the Rust side to match the codebase convention
+    // (Uuid::new_v4) rather than using SQL hex(randomblob(16)).
+    {
+        let mut stmt = transaction.prepare(
+            "SELECT role, content, sent_at, created_at \
+             FROM session_messages \
+             WHERE session_id = ?1 AND rowid <= ?2 \
+             ORDER BY rowid ASC",
+        )?;
+        let rows: Vec<(String, String, Option<String>, String)> = stmt
+            .query_map((source_session_id, fork_rowid), |row| {
+                Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+
+        for (role, content, sent_at, created_at) in &rows {
+            let new_msg_id = uuid::Uuid::new_v4().to_string();
+            transaction.execute(
+                r#"
+                INSERT INTO session_messages (id, session_id, role, content, sent_at, created_at)
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+                "#,
+                (
+                    new_msg_id,
+                    &new_session_id,
+                    role,
+                    content,
+                    sent_at,
+                    created_at,
+                ),
+            )?;
+        }
+    }
+
+    // Set as the workspace's active session.
+    let updated_rows = transaction
+        .execute(
+            "UPDATE workspaces SET active_session_id = ?1 WHERE id = ?2",
+            (&new_session_id, &workspace_id),
+        )
+        .context("Failed to set active session for fork")?;
+
+    if updated_rows != 1 {
+        bail!("Active session update affected {updated_rows} rows for workspace {workspace_id}");
+    }
+
+    transaction
+        .commit()
+        .context("Failed to commit fork-session")?;
+
+    Ok(CreateSessionResponse {
+        session_id: new_session_id,
+    })
+}
+
 /// Read the `model` column from a session row.
 pub fn get_session_model(session_id: &str) -> Result<Option<String>> {
     let conn = db::read_conn()?;

--- a/src/features/panel/container.tsx
+++ b/src/features/panel/container.tsx
@@ -558,7 +558,17 @@ export const WorkspacePanelContainer = memo(function WorkspacePanelContainer({
 				pendingForkedMessagesRef.current = forkedMessages;
 				onSelectSessionRef.current(newSessionId);
 
-				void invalidateWorkspaceQueries();
+				void Promise.all([
+					invalidateWorkspaceQueries(),
+					queryClient.prefetchQuery(
+						sessionThreadMessagesQueryOptions(newSessionId),
+					),
+				]).finally(() => {
+					// Release the ref once the server-side data is cached —
+					// the pending copy is no longer needed and keeping it
+					// around would double memory for large conversations.
+					pendingForkedMessagesRef.current = null;
+				});
 			} catch (error) {
 				console.error("Failed to fork session:", error);
 				void invalidateWorkspaceQueries();

--- a/src/features/panel/container.tsx
+++ b/src/features/panel/container.tsx
@@ -10,7 +10,7 @@ import type {
 	WorkspaceDetail,
 	WorkspaceSessionSummary,
 } from "@/lib/api";
-import { createSession, loadRepoScripts } from "@/lib/api";
+import { createSession, forkSession, loadRepoScripts } from "@/lib/api";
 import {
 	helmorQueryKeys,
 	sessionThreadMessagesQueryOptions,
@@ -23,6 +23,7 @@ import {
 	WORKSPACE_SCRIPT_PROMPTS,
 	type WorkspaceScriptType,
 } from "@/lib/workspace-script-actions";
+import { ForkProvider } from "./fork-context";
 import { WorkspacePanel } from "./index";
 import type { SessionCloseRequest } from "./use-confirm-session-close";
 
@@ -101,6 +102,7 @@ export const WorkspacePanelContainer = memo(function WorkspacePanelContainer({
 	}, [sessionSelectionHistory, sessions]);
 
 	const autoCreatingWorkspaceRef = useRef<Set<string>>(new Set());
+	const pendingForkedMessagesRef = useRef<ThreadMessageLike[] | null>(null);
 
 	useEffect(() => {
 		if (!displayedWorkspaceId || selectedWorkspaceId !== displayedWorkspaceId) {
@@ -266,6 +268,24 @@ export const WorkspacePanelContainer = memo(function WorkspacePanelContainer({
 			onResolveDisplayedSession(threadSessionId);
 		}
 	}, [displayedSessionId, onResolveDisplayedSession, threadSessionId]);
+
+	// Safety net: if the messages cache was overwritten after a fork session
+	// switch, re-seed from the pending forked messages ref.
+	useEffect(() => {
+		const pending = pendingForkedMessagesRef.current;
+		if (!pending || !threadSessionId) {
+			return;
+		}
+		const cacheKey = [
+			...helmorQueryKeys.sessionMessages(threadSessionId),
+			"thread",
+		];
+		const cached = queryClient.getQueryData<ThreadMessageLike[]>(cacheKey);
+		if (!cached || cached.length === 0) {
+			queryClient.setQueryData(cacheKey, pending);
+		}
+		pendingForkedMessagesRef.current = null;
+	}, [queryClient, threadSessionId]);
 
 	useEffect(() => {
 		if (!threadSessionId) {
@@ -459,6 +479,101 @@ export const WorkspacePanelContainer = memo(function WorkspacePanelContainer({
 		[queryClient],
 	);
 
+	const handleForkSession = useCallback(
+		async (messageId: string) => {
+			if (!displayedSessionId || !displayedWorkspaceId) {
+				return;
+			}
+
+			const forkIndex = messages.findIndex((m) => m.id === messageId);
+			if (forkIndex === -1) {
+				return;
+			}
+
+			// Include the turn-result system message that follows the
+			// assistant message — it carries the timestamp and copy/fork
+			// affordances that the new session needs to display.
+			const end =
+				forkIndex + 1 < messages.length &&
+				messages[forkIndex + 1].role === "system"
+					? forkIndex + 2
+					: forkIndex + 1;
+			const forkedMessages = messages.slice(0, end);
+			const sourceSession = sessions.find((s) => s.id === displayedSessionId);
+			const forkTitle = `${sourceSession?.title ?? "Untitled"} (fork)`;
+
+			try {
+				const { sessionId: newSessionId } = await forkSession(
+					displayedSessionId,
+					messageId,
+				);
+
+				const now = new Date().toISOString();
+				queryClient.setQueryData(
+					helmorQueryKeys.workspaceDetail(displayedWorkspaceId),
+					(current: WorkspaceDetail | null | undefined) => {
+						if (!current) {
+							return current;
+						}
+						return {
+							...current,
+							activeSessionId: newSessionId,
+							activeSessionTitle: forkTitle,
+							activeSessionAgentType: null,
+							activeSessionStatus: "idle",
+							sessionCount: current.sessionCount + 1,
+						};
+					},
+				);
+				queryClient.setQueryData(
+					helmorQueryKeys.workspaceSessions(displayedWorkspaceId),
+					(current: WorkspaceSessionSummary[] | undefined) => [
+						...(current ?? []).map((s) => ({ ...s, active: false })),
+						{
+							id: newSessionId,
+							workspaceId: displayedWorkspaceId,
+							title: forkTitle,
+							agentType: null,
+							status: "idle",
+							model: sourceSession?.model ?? null,
+							permissionMode: sourceSession?.permissionMode ?? "default",
+							providerSessionId: null,
+							effortLevel: sourceSession?.effortLevel ?? null,
+							unreadCount: 0,
+							fastMode: false,
+							createdAt: now,
+							updatedAt: now,
+							lastUserMessageAt: null,
+							isHidden: false,
+							actionKind: null,
+							active: true,
+						},
+					],
+				);
+				queryClient.setQueryData(
+					[...helmorQueryKeys.sessionMessages(newSessionId), "thread"],
+					forkedMessages,
+				);
+
+				pendingForkedMessagesRef.current = forkedMessages;
+				onSelectSessionRef.current(newSessionId);
+
+				void invalidateWorkspaceQueries();
+			} catch (error) {
+				console.error("Failed to fork session:", error);
+				void invalidateWorkspaceQueries();
+			}
+		},
+		[
+			displayedSessionId,
+			displayedWorkspaceId,
+			messages,
+			sessions,
+			queryClient,
+			invalidateWorkspaceQueries,
+		],
+	);
+
 	// All callback props that go into <WorkspacePanel> must be reference
 	// stable so that the memoed header sub-component bails out across stream
 	// ticks. We capture the latest `onSelectSession` in a ref and route the
@@ -515,31 +630,33 @@ export const WorkspacePanelContainer = memo(function WorkspacePanelContainer({
 	);
 
 	return (
-		<WorkspacePanel
-			workspace={workspace}
-			sessions={sessions}
-			selectedSessionId={selectedSessionIdForPanel}
-			sessionDisplayProviders={sessionDisplayProviders}
-			sessionPanes={sessionPanes}
-			loadingWorkspace={loadingWorkspace}
-			loadingSession={loadingSession}
-			refreshingWorkspace={refreshingWorkspace}
-			refreshingSession={refreshingSession}
-			sending={sending}
-			sendingSessionIds={sendingSessionIds}
-			interactionRequiredSessionIds={interactionRequiredSessionIds}
-			onSelectSession={handleSelectSession}
-			onPrefetchSession={handlePrefetchSession}
-			onSessionsChanged={handleSessionsChanged}
-			onSessionRenamed={handleSessionRenamed}
-			onWorkspaceChanged={handleWorkspaceChanged}
-			onRequestCloseSession={onRequestCloseSession}
-			headerActions={headerActions}
-			headerLeading={headerLeading}
-			newSessionShortcut={getShortcut(settings.shortcuts, "session.new")}
-			missingScriptTypes={missingScriptTypes}
-			onInitializeScript={handleInitializeScript}
-			changeRequest={workspaceChangeRequest}
-		/>
+		<ForkProvider value={handleForkSession}>
+			<WorkspacePanel
+				workspace={workspace}
+				sessions={sessions}
+				selectedSessionId={selectedSessionIdForPanel}
+				sessionDisplayProviders={sessionDisplayProviders}
+				sessionPanes={sessionPanes}
+				loadingWorkspace={loadingWorkspace}
+				loadingSession={loadingSession}
+				refreshingWorkspace={refreshingWorkspace}
+				refreshingSession={refreshingSession}
+				sending={sending}
+				sendingSessionIds={sendingSessionIds}
+				interactionRequiredSessionIds={interactionRequiredSessionIds}
+				onSelectSession={handleSelectSession}
+				onPrefetchSession={handlePrefetchSession}
+				onSessionsChanged={handleSessionsChanged}
+				onSessionRenamed={handleSessionRenamed}
+				onWorkspaceChanged={handleWorkspaceChanged}
+				onRequestCloseSession={onRequestCloseSession}
+				headerActions={headerActions}
+				headerLeading={headerLeading}
+				newSessionShortcut={getShortcut(settings.shortcuts, "session.new")}
+				missingScriptTypes={missingScriptTypes}
+				onInitializeScript={handleInitializeScript}
+				changeRequest={workspaceChangeRequest}
+			/>
+		</ForkProvider>
 	);
 });

--- a/src/features/panel/fork-context.tsx
+++ b/src/features/panel/fork-context.tsx
@@ -1,0 +1,19 @@
+import { createContext, useContext } from "react";
+
+/**
+ * Callback to fork the current session from a specific message.
+ * `messageId` is the DB id of the message to fork after (inclusive).
+ */
+type ForkMessageFn = (messageId: string) => void;
+
+const ForkContext = createContext<ForkMessageFn | null>(null);
+
+export const ForkProvider = ForkContext.Provider;
+
+/**
+ * Returns the fork callback, or `null` when no fork handler is available
+ * (e.g. in tests or outside a session panel).
+ */
+export function useForkMessage(): ForkMessageFn | null {
+	return useContext(ForkContext);
+}

--- a/src/features/panel/message-components/system-message.tsx
+++ b/src/features/panel/message-components/system-message.tsx
@@ -131,6 +131,37 @@ function shouldShowTimestamp(parts: MessagePart[]) {
 	);
 }
 
+function MessageActions({
+	copyTarget,
+	forkTargetId,
+}: {
+	copyTarget: RenderedMessage;
+	forkTargetId?: string | null;
+}) {
+	const forkMessage = useForkMessage();
+
+	return (
+		<div className="flex items-center gap-1">
+			<CopyMessageButton
+				message={copyTarget}
+				className="size-5 shrink-0 text-muted-foreground/30 opacity-0 transition-none hover:text-muted-foreground group-hover/sys:opacity-100"
+			/>
+			{forkMessage && forkTargetId ? (
+				<Button
+					type="button"
+					variant="ghost"
+					size="icon-xs"
+					aria-label="Fork session from here"
+					onClick={() => forkMessage(forkTargetId)}
+					className="size-5 shrink-0 text-muted-foreground/30 opacity-0 transition-none hover:bg-transparent hover:text-muted-foreground group-hover/sys:opacity-100"
+				>
+					<GitFork className="size-3" strokeWidth={1.8} />
+				</Button>
+			) : null}
+		</div>
+	);
+}
+
 export function ChatSystemMessage({
 	message,
 	previousAssistantMessage,
@@ -139,7 +170,6 @@ export function ChatSystemMessage({
 	previousAssistantMessage?: RenderedMessage | null;
 }) {
 	const parts = message.content as MessagePart[];
-	const forkMessage = useForkMessage();
 	const copyTarget =
 		previousAssistantMessage?.role === "assistant"
 			? previousAssistantMessage
@@ -172,22 +202,7 @@ export function ChatSystemMessage({
 					<MessageTimestamp createdAt={message.createdAt} />
 				) : null}
 			</div>
-			{forkMessage && forkTargetId ? (
-				<Button
-					type="button"
-					variant="ghost"
-					size="icon-xs"
-					aria-label="Fork session from here"
-					onClick={() => forkMessage(forkTargetId)}
-					className="size-5 shrink-0 text-muted-foreground/30 opacity-0 hover:text-muted-foreground group-hover/sys:opacity-100"
-				>
-					<GitFork className="size-3" strokeWidth={1.8} />
-				</Button>
-			) : null}
-			<CopyMessageButton
-				message={copyTarget}
-				className="size-5 shrink-0 text-muted-foreground/30 opacity-0 hover:text-muted-foreground group-hover/sys:opacity-100"
-			/>
+			<MessageActions copyTarget={copyTarget} forkTargetId={forkTargetId} />
 		</div>
 	);
 }

--- a/src/features/panel/message-components/system-message.tsx
+++ b/src/features/panel/message-components/system-message.tsx
@@ -2,6 +2,7 @@ import { formatDistanceToNow } from "date-fns";
 import {
 	AlertCircle,
 	AlertTriangle,
+	GitFork,
 	Info,
 	MessageSquareText,
 } from "lucide-react";
@@ -17,6 +18,7 @@ import type {
 	SystemNoticePart,
 } from "@/lib/api";
 import { cn } from "@/lib/utils";
+import { useForkMessage } from "../fork-context";
 import { CopyMessageButton } from "./copy-message";
 import type { RenderedMessage } from "./shared";
 import {
@@ -137,10 +139,15 @@ export function ChatSystemMessage({
 	previousAssistantMessage?: RenderedMessage | null;
 }) {
 	const parts = message.content as MessagePart[];
+	const forkMessage = useForkMessage();
 	const copyTarget =
 		previousAssistantMessage?.role === "assistant"
 			? previousAssistantMessage
 			: message;
+	const forkTargetId =
+		previousAssistantMessage?.role === "assistant"
+			? previousAssistantMessage.id
+			: null;
 
 	return (
 		<div
@@ -165,6 +172,18 @@ export function ChatSystemMessage({
 					<MessageTimestamp createdAt={message.createdAt} />
 				) : null}
 			</div>
+			{forkMessage && forkTargetId ? (
+				<Button
+					type="button"
+					variant="ghost"
+					size="icon-xs"
+					aria-label="Fork session from here"
+					onClick={() => forkMessage(forkTargetId)}
+					className="size-5 shrink-0 text-muted-foreground/30 opacity-0 hover:text-muted-foreground group-hover/sys:opacity-100"
+				>
+					<GitFork className="size-3" strokeWidth={1.8} />
+				</Button>
+			) : null}
 			<CopyMessageButton
 				message={copyTarget}
 				className="size-5 shrink-0 text-muted-foreground/30 opacity-0 hover:text-muted-foreground group-hover/sys:opacity-100"

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2326,6 +2326,16 @@ export async function createSession(
 	});
 }
 
+export async function forkSession(
+	sourceSessionId: string,
+	forkAfterMessageId: string,
+): Promise<CreateSessionResponse> {
+	return invoke<CreateSessionResponse>("fork_session", {
+		sourceSessionId,
+		forkAfterMessageId,
+	});
+}
+
 export async function renameSession(
 	sessionId: string,
 	title: string,


### PR DESCRIPTION
## Summary
- Add the ability to fork a session from any historical assistant message, creating a new session that copies all messages up to the fork point
- New `fork_session` Tauri command (Rust) that atomically creates the session + copies messages in a single transaction
- `build_fork_context_prefix` in the streaming module injects prior conversation context when the forked session has no provider session to resume, so the agent has full continuity
- Frontend: fork button (GitFork icon) appears on turn-result system messages, wired through a lightweight React context (`ForkProvider` / `useForkMessage`)
- Optimistic cache updates for workspace detail, session list, and message thread so the UI switches instantly

## Why
Users need to branch off from an earlier point in a conversation to explore a different direction without losing the original thread. This is especially useful after an assistant response that took an unexpected path.

## Test plan
- [ ] Fork from a mid-conversation assistant message → new session appears in sidebar with "(fork)" suffix
- [ ] New session contains all messages up to and including the fork point
- [ ] Sending a message in the forked session works (agent receives prior conversation as context preamble)
- [ ] Cannot fork from a session that is currently streaming (error toast)
- [ ] Fork button only appears on system turn-result messages that follow an assistant message
- [ ] Existing session switching / creation flows are unaffected