### PR TITLE
feat: add Nix flake for reproducible development environment

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ test-results/
 !.claude/settings.json
 !.claude/hooks
 !.claude/hooks/*
+
+# Nix/direnv
+.direnv/

--- a/NIX_SETUP.md
+++ b/NIX_SETUP.md
@@ -175,7 +175,7 @@ nix flake update
 The flake uses **NixOS 24.11 (stable)** as the primary channel to ensure reliable Darwin SDK frameworks. A separate **nixpkgs-unstable** input is available for bleeding-edge packages when needed.
 
 This dual-input approach gives you:
-- Stable, tested packages from `pkgs.*` (24.11)
+- Stable, tested packages from `pkgs.*` (24.11 - last working Darwin SDK)
 - Latest packages from `pkgs-unstable.*` when you need them
 
 To use a package from unstable, modify `flake.nix`:
@@ -187,8 +187,8 @@ commonBuildInputs = with pkgs; [
 ];
 ```
 
-**Why 24.11 instead of unstable?**  
-As of April 2026, nixpkgs-unstable has breaking changes in Darwin SDK that cause build failures. The stable 24.11 release provides a reliable base while still giving access to unstable when needed.
+**Why 24.11 instead of 25.11 or unstable?**  
+As of April 2026, both 25.11 and nixpkgs-unstable have breaking changes in Darwin SDK (`apple_sdk_11_0` removal) that cause build failures on macOS. The 24.11 release is the last known version with working Darwin SDK frameworks. This approach gives you stability by default with the option to pull newer packages when needed.
 
 ### Included Frameworks (macOS)
 - Security, CoreServices, CoreFoundation

--- a/NIX_SETUP.md
+++ b/NIX_SETUP.md
@@ -1,0 +1,209 @@
+# Nix Development Environment Setup
+
+This project includes a `flake.nix` for reproducible development environments using Nix.
+
+## Prerequisites
+
+1. **Install Nix with flakes support:**
+   ```bash
+   # Official installer (recommended)
+   curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
+   
+   # Or use the official Nix installer and enable flakes:
+   sh <(curl -L https://nixos.org/nix/install)
+   # Then add to ~/.config/nix/nix.conf:
+   # experimental-features = nix-command flakes
+   ```
+
+2. **(Optional but recommended) Install direnv:**
+   ```bash
+   # macOS
+   brew install direnv
+   
+   # Or via Nix
+   nix profile install nixpkgs#direnv
+   ```
+
+   Then add to your shell config (`~/.bashrc` or `~/.zshrc`):
+   ```bash
+   eval "$(direnv hook bash)"  # for bash
+   eval "$(direnv hook zsh)"   # for zsh
+   ```
+
+## Quick Start
+
+### Option 1: Using direnv (Recommended)
+
+The repository includes a `.envrc` file that automatically loads the Nix environment:
+
+```bash
+cd /path/to/helmor/calypso
+
+# Allow direnv (first time only)
+direnv allow
+
+# Environment automatically loads when you cd into the directory!
+# You should see: "🚀 Helmor development environment loaded!"
+```
+
+Now you can run commands directly:
+```bash
+bun install
+bun run dev
+```
+
+### Option 2: Using nix develop
+
+Without direnv, manually enter the Nix shell:
+
+```bash
+cd /path/to/helmor/calypso
+
+# Enter the development shell
+nix develop
+
+# Now run your commands
+bun install
+bun run dev
+```
+
+### Option 3: One-off commands
+
+Run commands without entering the shell:
+
+```bash
+nix develop --command bun run dev
+nix develop --command bun run test
+```
+
+## What's Included
+
+The Nix flake provides:
+
+### Core Tools
+- **Bun** - JavaScript/TypeScript runtime and package manager
+- **Rust toolchain** - Stable Rust with `rust-analyzer`, `clippy`, `rust-src`
+- **Node.js 20** - For tools that require Node
+- **Git** - Version control
+- **cargo-watch** - Watch Rust files for changes
+
+### macOS-specific
+- Apple SDK frameworks (Security, CoreServices, AppKit, WebKit, Cocoa, etc.)
+- `libiconv`
+
+### Linux-specific
+- WebKitGTK 4.1
+- GTK3, Cairo, GDK-Pixbuf, GLib
+- DBus, OpenSSL 3, libsoup 3, librsvg
+- Additional build tools (ATK, Pango)
+
+### Environment Variables
+- `RUST_BACKTRACE=1` - Verbose Rust error traces
+- `RUST_LOG=info` - Rust logging level
+- Properly configured `PKG_CONFIG_PATH` and `LD_LIBRARY_PATH` (Linux)
+
+## Common Commands
+
+Once in the environment (via `nix develop` or direnv):
+
+```bash
+# Setup
+bun install                  # Install dependencies
+
+# Development
+bun run dev                  # Start Tauri + Vite dev server
+bun run dev:analyze          # Dev mode with performance HUD
+
+# Building
+bun run build                # Build frontend bundle
+bun run typecheck            # TypeScript type checking
+
+# Linting
+bun run lint                 # Run biome + clippy
+bun run lint:fix             # Auto-fix lint issues
+
+# Testing
+bun run test                 # Run all test suites
+bun run test:frontend        # Vitest (React components)
+bun run test:sidecar         # Sidecar TypeScript tests
+bun run test:rust            # Rust integration tests
+bun run test:rust:update-snapshots  # Update insta snapshots
+```
+
+## Troubleshooting
+
+### Flake not recognized
+Ensure flakes are enabled in your Nix config (`~/.config/nix/nix.conf`):
+```
+experimental-features = nix-command flakes
+```
+
+### direnv not loading
+1. Check that direnv is installed: `which direnv`
+2. Check that the hook is in your shell config: `echo $DIRENV_*`
+3. Allow the directory: `direnv allow`
+4. Reload your shell: `exec $SHELL`
+
+### "bun not found" in the Nix shell
+1. Exit and re-enter the shell: `exit` then `nix develop`
+2. Update flake inputs: `nix flake update`
+3. Rebuild: `nix develop --rebuild`
+
+### Rust compilation errors on macOS
+Ensure Xcode Command Line Tools are installed:
+```bash
+xcode-select --install
+```
+
+### Linux: WebKitGTK errors
+The flake includes WebKitGTK 4.1. If you still see errors:
+```bash
+# Update PKG_CONFIG_PATH manually
+export PKG_CONFIG_PATH="$(nix develop --print-build-environment | grep PKG_CONFIG_PATH | cut -d= -f2-)"
+```
+
+## Updating Dependencies
+
+Update Nix flake inputs to latest versions:
+```bash
+nix flake update
+```
+
+## Technical Details
+
+### Nixpkgs Version
+The flake uses **NixOS 24.11 (stable)** rather than `nixpkgs-unstable` to avoid breaking changes in Darwin SDK frameworks. If you need newer packages, you can override specific inputs, but the stable release provides a reliable base for Tauri development.
+
+### Included Frameworks (macOS)
+- Security, CoreServices, CoreFoundation
+- Foundation, AppKit, WebKit, Cocoa
+- libiconv
+
+### Rust Toolchain
+Stable Rust from rust-overlay with extensions:
+- `rust-src` (for IDE tooling)
+- `rust-analyzer` (LSP)
+- `clippy` (linter)
+
+## Advantages of Using Nix
+
+1. **Reproducible builds** - Same environment on every machine
+2. **No system pollution** - Dependencies isolated in Nix store
+3. **Version pinning** - Flake lock ensures consistent versions
+4. **Cross-platform** - Works on macOS, Linux, NixOS
+5. **Easy onboarding** - New developers just run `nix develop`
+6. **Automatic cleanup** - Old dependencies garbage collected
+
+## Alternative: Docker (not recommended)
+
+While a Dockerfile could provide similar isolation, Nix is preferred for Helmor because:
+- Lower overhead (no container runtime)
+- Native macOS support (important for Tauri)
+- Better IDE integration
+- Faster iteration (no rebuilds on `package.json` changes)
+
+## Learn More
+
+- [Nix Flakes Guide](https://nixos.wiki/wiki/Flakes)
+- [direnv Documentation](https://direnv.net/)
+- [Zero to Nix](https://zero-to-nix.com/) - Beginner-friendly tutorial

--- a/NIX_SETUP.md
+++ b/NIX_SETUP.md
@@ -172,7 +172,23 @@ nix flake update
 ## Technical Details
 
 ### Nixpkgs Version
-The flake uses **NixOS 24.11 (stable)** rather than `nixpkgs-unstable` to avoid breaking changes in Darwin SDK frameworks. If you need newer packages, you can override specific inputs, but the stable release provides a reliable base for Tauri development.
+The flake uses **NixOS 24.11 (stable)** as the primary channel to ensure reliable Darwin SDK frameworks. A separate **nixpkgs-unstable** input is available for bleeding-edge packages when needed.
+
+This dual-input approach gives you:
+- Stable, tested packages from `pkgs.*` (24.11)
+- Latest packages from `pkgs-unstable.*` when you need them
+
+To use a package from unstable, modify `flake.nix`:
+```nix
+commonBuildInputs = with pkgs; [
+  bun                           # from nixos-24.11 (stable)
+  pkgs-unstable.someNewPackage  # from nixpkgs-unstable (bleeding edge)
+  # ...
+];
+```
+
+**Why 24.11 instead of unstable?**  
+As of April 2026, nixpkgs-unstable has breaking changes in Darwin SDK that cause build failures. The stable 24.11 release provides a reliable base while still giving access to unstable when needed.
 
 ### Included Frameworks (macOS)
 - Security, CoreServices, CoreFoundation

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1751274312,
+        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777432579,
+        "narHash": "sha256-Ce11TStDsqCge2vAAfLKe2+4lDI5cSX5ZYZOuKJBKKQ=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "3ecb5e6ab380ced3272ef7fcfe398bffbcc0f152",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -34,10 +34,27 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1777270315,
+        "narHash": "sha256-yKB4G6cKsQsWN7M6rZGk6gkJPDNPIzT05y4qzRyCDlI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6368eda62c9775c38ef7f714b2555a741c20c72d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable",
         "rust-overlay": "rust-overlay"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,140 @@
+{
+  description = "Helmor - Local-first desktop app development environment";
+
+  inputs = {
+    # Use 24.11 (stable) instead of unstable to avoid SDK breaking changes
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, rust-overlay }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+        };
+
+        # Use stable Rust toolchain
+        rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+          extensions = [ "rust-src" "rust-analyzer" "clippy" ];
+        };
+
+        # Common build inputs for all platforms
+        commonBuildInputs = with pkgs; [
+          # Bun runtime (JavaScript/TypeScript)
+          bun
+
+          # Rust toolchain
+          rustToolchain
+          cargo-watch
+
+          # Build essentials
+          pkg-config
+          openssl
+
+          # Git (for version control operations)
+          git
+
+          # Node.js (some tools may need it)
+          nodejs_20
+        ];
+
+        # Platform-specific dependencies
+        darwinInputs = with pkgs; [
+          # macOS-specific frameworks and tools
+          libiconv
+        ] ++ (with pkgs.darwin.apple_sdk.frameworks; [
+          Security
+          CoreServices
+          CoreFoundation
+          Foundation
+          AppKit
+          WebKit
+          Cocoa
+        ]);
+
+        linuxInputs = with pkgs; [
+          # Linux-specific Tauri dependencies
+          webkitgtk_4_1
+          gtk3
+          cairo
+          gdk-pixbuf
+          glib
+          dbus
+          openssl_3
+          librsvg
+          libsoup_3
+
+          # Additional Linux build tools
+          atk
+          pango
+        ];
+
+        buildInputs = commonBuildInputs
+          ++ pkgs.lib.optionals pkgs.stdenv.isDarwin darwinInputs
+          ++ pkgs.lib.optionals pkgs.stdenv.isLinux linuxInputs;
+
+        # Environment variables
+        shellHook = ''
+          # Rust environment
+          export RUST_BACKTRACE=1
+          export RUST_LOG=info
+
+          # Tauri environment
+          ${if pkgs.stdenv.isLinux then ''
+            export PKG_CONFIG_PATH="${pkgs.openssl_3.dev}/lib/pkgconfig:${pkgs.webkitgtk_4_1}/lib/pkgconfig:${pkgs.gtk3}/lib/pkgconfig:$PKG_CONFIG_PATH"
+            export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath linuxInputs}:$LD_LIBRARY_PATH"
+          '' else ""}
+
+          # Helmor data directory (optional override)
+          # export HELMOR_DATA_DIR="$HOME/helmor-dev"
+
+          # Helmor logging (optional override)
+          # export HELMOR_LOG=debug
+
+          echo "🚀 Helmor development environment loaded!"
+          echo ""
+          echo "📦 Available tools:"
+          echo "  - bun $(bun --version)"
+          echo "  - rustc $(rustc --version)"
+          echo "  - cargo $(cargo --version)"
+          echo "  - node $(node --version)"
+          echo ""
+          echo "🔨 Common commands:"
+          echo "  bun install              # Install dependencies"
+          echo "  bun run dev              # Start dev server (Tauri + Vite)"
+          echo "  bun run dev:analyze      # Dev with perf HUD"
+          echo "  bun run build            # Build frontend"
+          echo "  bun run typecheck        # Type check"
+          echo "  bun run lint             # Lint (biome + clippy)"
+          echo "  bun run lint:fix         # Auto-fix lint issues"
+          echo "  bun run test             # Run all tests"
+          echo ""
+          echo "🧪 Test commands:"
+          echo "  bun run test:frontend    # Vitest tests"
+          echo "  bun run test:sidecar     # Sidecar tests"
+          echo "  bun run test:rust        # Rust tests"
+          echo ""
+        '';
+
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          inherit buildInputs shellHook;
+
+          # Additional native build inputs for linking
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+          ];
+        };
+
+        # Alias for convenience
+        devShell = self.devShells.${system}.default;
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,10 @@
   description = "Helmor - Local-first desktop app development environment";
 
   inputs = {
-    # Use 24.11 (stable) instead of unstable to avoid SDK breaking changes
+    # Use 24.11 stable for reliable Darwin SDK - unstable has breaking changes as of 2026-04
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    # Keep nixpkgs-unstable available for bleeding-edge packages if needed
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
@@ -11,12 +13,16 @@
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, rust-overlay }:
+  outputs = { self, nixpkgs, nixpkgs-unstable, flake-utils, rust-overlay }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         overlays = [ (import rust-overlay) ];
         pkgs = import nixpkgs {
           inherit system overlays;
+        };
+        # Make unstable packages available if needed
+        pkgs-unstable = import nixpkgs-unstable {
+          inherit system;
         };
 
         # Use stable Rust toolchain
@@ -25,6 +31,8 @@
         };
 
         # Common build inputs for all platforms
+        # Note: To use a package from unstable, use pkgs-unstable.packageName
+        # Example: pkgs-unstable.bun (if you need bleeding edge)
         commonBuildInputs = with pkgs; [
           # Bun runtime (JavaScript/TypeScript)
           bun

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,8 @@
   description = "Helmor - Local-first desktop app development environment";
 
   inputs = {
-    # Use 24.11 stable for reliable Darwin SDK - unstable has breaking changes as of 2026-04
+    # Use 24.11 stable - last known release with working Darwin SDK
+    # Note: 25.11 exists but has breaking Darwin SDK changes as of 2026-04
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
     # Keep nixpkgs-unstable available for bleeding-edge packages if needed
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";


### PR DESCRIPTION
## Summary

Adds a complete Nix flake configuration for reproducible Helmor development environments across macOS and Linux.

## What's Included

### Core Tools
- **Bun** - JavaScript/TypeScript runtime and package manager  
- **Rust stable** - Complete toolchain with rust-analyzer, clippy, and rust-src
- **Node.js 20** - For compatibility with tools that need Node
- **Build tools** - pkg-config, openssl, git, cargo-watch

### Platform-Specific Dependencies

**macOS:**
- Apple SDK frameworks (Security, CoreServices, CoreFoundation, Foundation, AppKit, WebKit, Cocoa)
- libiconv

**Linux:**
- WebKitGTK 4.1, GTK3, Cairo, GDK-Pixbuf, GLib
- DBus, OpenSSL 3, libsoup 3, librsvg
- Additional build tools (ATK, Pango)

## Usage

Three ways to use the Nix environment:

### Option 1: direnv (Recommended)
```bash
cd /path/to/helmor/calypso
direnv allow
# Environment auto-loads when you cd into the directory!
bun install
bun run dev
```

### Option 2: Manual nix develop
```bash
nix develop
bun run dev
```

### Option 3: One-off commands
```bash
nix develop --command bun run dev
```

## Documentation

See `NIX_SETUP.md` for comprehensive guide including:
- Nix installation instructions
- Troubleshooting guide  
- Technical details about packages
- Benefits and advantages

## Technical Notes

- Uses **NixOS 24.11 (stable)** instead of nixpkgs-unstable to avoid breaking Darwin SDK changes
- Fully cross-platform: macOS (Intel/Apple Silicon) and Linux
- Zero system pollution - all dependencies isolated in Nix store
- Reproducible builds via flake.lock version pinning
- Includes nice shell hook with welcome message and common commands

## Testing Locally

To test this PR:

```bash
# Fetch from the fork
git fetch https://github.com/jespada/helmor.git feat/nix-dev-environment
git checkout FETCH_HEAD

# Or if you've added jespada as a remote:
git fetch jespada
git checkout jespada/feat/nix-dev-environment

# Then try it:
nix develop
# You should see: "🚀 Helmor development environment loaded!"
bun install
bun run dev
```

Or with direnv:
```bash
git checkout jespada/feat/nix-dev-environment
direnv allow
# Environment loads automatically
```

## Benefits

1. **Reproducible** - Same environment on every machine
2. **No conflicts** - Isolated from system packages
3. **Easy onboarding** - New devs just run `nix develop`
4. **Version pinned** - flake.lock ensures consistency
5. **Automatic cleanup** - Old dependencies garbage collected
6. **Cross-platform** - Works on macOS, Linux, and NixOS

## Files Added

- `flake.nix` - Main Nix flake configuration
- `flake.lock` - Locked dependency versions
- `.envrc` - direnv configuration for auto-loading
- `NIX_SETUP.md` - Comprehensive documentation
- `.gitignore` - Added `.direnv/` to ignore cache