### PR TITLE
feat: add local-only mode without GitHub authentication

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ test-results/
 !.claude/settings.json
 !.claude/hooks
 !.claude/hooks/*
+
+# Nix/direnv
+.direnv/

--- a/NIX_SETUP.md
+++ b/NIX_SETUP.md
@@ -1,0 +1,209 @@
+# Nix Development Environment Setup
+
+This project includes a `flake.nix` for reproducible development environments using Nix.
+
+## Prerequisites
+
+1. **Install Nix with flakes support:**
+   ```bash
+   # Official installer (recommended)
+   curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
+   
+   # Or use the official Nix installer and enable flakes:
+   sh <(curl -L https://nixos.org/nix/install)
+   # Then add to ~/.config/nix/nix.conf:
+   # experimental-features = nix-command flakes
+   ```
+
+2. **(Optional but recommended) Install direnv:**
+   ```bash
+   # macOS
+   brew install direnv
+   
+   # Or via Nix
+   nix profile install nixpkgs#direnv
+   ```
+
+   Then add to your shell config (`~/.bashrc` or `~/.zshrc`):
+   ```bash
+   eval "$(direnv hook bash)"  # for bash
+   eval "$(direnv hook zsh)"   # for zsh
+   ```
+
+## Quick Start
+
+### Option 1: Using direnv (Recommended)
+
+The repository includes a `.envrc` file that automatically loads the Nix environment:
+
+```bash
+cd /path/to/helmor/calypso
+
+# Allow direnv (first time only)
+direnv allow
+
+# Environment automatically loads when you cd into the directory!
+# You should see: "🚀 Helmor development environment loaded!"
+```
+
+Now you can run commands directly:
+```bash
+bun install
+bun run dev
+```
+
+### Option 2: Using nix develop
+
+Without direnv, manually enter the Nix shell:
+
+```bash
+cd /path/to/helmor/calypso
+
+# Enter the development shell
+nix develop
+
+# Now run your commands
+bun install
+bun run dev
+```
+
+### Option 3: One-off commands
+
+Run commands without entering the shell:
+
+```bash
+nix develop --command bun run dev
+nix develop --command bun run test
+```
+
+## What's Included
+
+The Nix flake provides:
+
+### Core Tools
+- **Bun** - JavaScript/TypeScript runtime and package manager
+- **Rust toolchain** - Stable Rust with `rust-analyzer`, `clippy`, `rust-src`
+- **Node.js 20** - For tools that require Node
+- **Git** - Version control
+- **cargo-watch** - Watch Rust files for changes
+
+### macOS-specific
+- Apple SDK frameworks (Security, CoreServices, AppKit, WebKit, Cocoa, etc.)
+- `libiconv`
+
+### Linux-specific
+- WebKitGTK 4.1
+- GTK3, Cairo, GDK-Pixbuf, GLib
+- DBus, OpenSSL 3, libsoup 3, librsvg
+- Additional build tools (ATK, Pango)
+
+### Environment Variables
+- `RUST_BACKTRACE=1` - Verbose Rust error traces
+- `RUST_LOG=info` - Rust logging level
+- Properly configured `PKG_CONFIG_PATH` and `LD_LIBRARY_PATH` (Linux)
+
+## Common Commands
+
+Once in the environment (via `nix develop` or direnv):
+
+```bash
+# Setup
+bun install                  # Install dependencies
+
+# Development
+bun run dev                  # Start Tauri + Vite dev server
+bun run dev:analyze          # Dev mode with performance HUD
+
+# Building
+bun run build                # Build frontend bundle
+bun run typecheck            # TypeScript type checking
+
+# Linting
+bun run lint                 # Run biome + clippy
+bun run lint:fix             # Auto-fix lint issues
+
+# Testing
+bun run test                 # Run all test suites
+bun run test:frontend        # Vitest (React components)
+bun run test:sidecar         # Sidecar TypeScript tests
+bun run test:rust            # Rust integration tests
+bun run test:rust:update-snapshots  # Update insta snapshots
+```
+
+## Troubleshooting
+
+### Flake not recognized
+Ensure flakes are enabled in your Nix config (`~/.config/nix/nix.conf`):
+```
+experimental-features = nix-command flakes
+```
+
+### direnv not loading
+1. Check that direnv is installed: `which direnv`
+2. Check that the hook is in your shell config: `echo $DIRENV_*`
+3. Allow the directory: `direnv allow`
+4. Reload your shell: `exec $SHELL`
+
+### "bun not found" in the Nix shell
+1. Exit and re-enter the shell: `exit` then `nix develop`
+2. Update flake inputs: `nix flake update`
+3. Rebuild: `nix develop --rebuild`
+
+### Rust compilation errors on macOS
+Ensure Xcode Command Line Tools are installed:
+```bash
+xcode-select --install
+```
+
+### Linux: WebKitGTK errors
+The flake includes WebKitGTK 4.1. If you still see errors:
+```bash
+# Update PKG_CONFIG_PATH manually
+export PKG_CONFIG_PATH="$(nix develop --print-build-environment | grep PKG_CONFIG_PATH | cut -d= -f2-)"
+```
+
+## Updating Dependencies
+
+Update Nix flake inputs to latest versions:
+```bash
+nix flake update
+```
+
+## Technical Details
+
+### Nixpkgs Version
+The flake uses **NixOS 24.11 (stable)** rather than `nixpkgs-unstable` to avoid breaking changes in Darwin SDK frameworks. If you need newer packages, you can override specific inputs, but the stable release provides a reliable base for Tauri development.
+
+### Included Frameworks (macOS)
+- Security, CoreServices, CoreFoundation
+- Foundation, AppKit, WebKit, Cocoa
+- libiconv
+
+### Rust Toolchain
+Stable Rust from rust-overlay with extensions:
+- `rust-src` (for IDE tooling)
+- `rust-analyzer` (LSP)
+- `clippy` (linter)
+
+## Advantages of Using Nix
+
+1. **Reproducible builds** - Same environment on every machine
+2. **No system pollution** - Dependencies isolated in Nix store
+3. **Version pinning** - Flake lock ensures consistent versions
+4. **Cross-platform** - Works on macOS, Linux, NixOS
+5. **Easy onboarding** - New developers just run `nix develop`
+6. **Automatic cleanup** - Old dependencies garbage collected
+
+## Alternative: Docker (not recommended)
+
+While a Dockerfile could provide similar isolation, Nix is preferred for Helmor because:
+- Lower overhead (no container runtime)
+- Native macOS support (important for Tauri)
+- Better IDE integration
+- Faster iteration (no rebuilds on `package.json` changes)
+
+## Learn More
+
+- [Nix Flakes Guide](https://nixos.wiki/wiki/Flakes)
+- [direnv Documentation](https://direnv.net/)
+- [Zero to Nix](https://zero-to-nix.com/) - Beginner-friendly tutorial

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1751274312,
+        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777432579,
+        "narHash": "sha256-Ce11TStDsqCge2vAAfLKe2+4lDI5cSX5ZYZOuKJBKKQ=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "3ecb5e6ab380ced3272ef7fcfe398bffbcc0f152",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,140 @@
+{
+  description = "Helmor - Local-first desktop app development environment";
+
+  inputs = {
+    # Use 24.11 (stable) instead of unstable to avoid SDK breaking changes
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, rust-overlay }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+        };
+
+        # Use stable Rust toolchain
+        rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+          extensions = [ "rust-src" "rust-analyzer" "clippy" ];
+        };
+
+        # Common build inputs for all platforms
+        commonBuildInputs = with pkgs; [
+          # Bun runtime (JavaScript/TypeScript)
+          bun
+
+          # Rust toolchain
+          rustToolchain
+          cargo-watch
+
+          # Build essentials
+          pkg-config
+          openssl
+
+          # Git (for version control operations)
+          git
+
+          # Node.js (some tools may need it)
+          nodejs_20
+        ];
+
+        # Platform-specific dependencies
+        darwinInputs = with pkgs; [
+          # macOS-specific frameworks and tools
+          libiconv
+        ] ++ (with pkgs.darwin.apple_sdk.frameworks; [
+          Security
+          CoreServices
+          CoreFoundation
+          Foundation
+          AppKit
+          WebKit
+          Cocoa
+        ]);
+
+        linuxInputs = with pkgs; [
+          # Linux-specific Tauri dependencies
+          webkitgtk_4_1
+          gtk3
+          cairo
+          gdk-pixbuf
+          glib
+          dbus
+          openssl_3
+          librsvg
+          libsoup_3
+
+          # Additional Linux build tools
+          atk
+          pango
+        ];
+
+        buildInputs = commonBuildInputs
+          ++ pkgs.lib.optionals pkgs.stdenv.isDarwin darwinInputs
+          ++ pkgs.lib.optionals pkgs.stdenv.isLinux linuxInputs;
+
+        # Environment variables
+        shellHook = ''
+          # Rust environment
+          export RUST_BACKTRACE=1
+          export RUST_LOG=info
+
+          # Tauri environment
+          ${if pkgs.stdenv.isLinux then ''
+            export PKG_CONFIG_PATH="${pkgs.openssl_3.dev}/lib/pkgconfig:${pkgs.webkitgtk_4_1}/lib/pkgconfig:${pkgs.gtk3}/lib/pkgconfig:$PKG_CONFIG_PATH"
+            export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath linuxInputs}:$LD_LIBRARY_PATH"
+          '' else ""}
+
+          # Helmor data directory (optional override)
+          # export HELMOR_DATA_DIR="$HOME/helmor-dev"
+
+          # Helmor logging (optional override)
+          # export HELMOR_LOG=debug
+
+          echo "🚀 Helmor development environment loaded!"
+          echo ""
+          echo "📦 Available tools:"
+          echo "  - bun $(bun --version)"
+          echo "  - rustc $(rustc --version)"
+          echo "  - cargo $(cargo --version)"
+          echo "  - node $(node --version)"
+          echo ""
+          echo "🔨 Common commands:"
+          echo "  bun install              # Install dependencies"
+          echo "  bun run dev              # Start dev server (Tauri + Vite)"
+          echo "  bun run dev:analyze      # Dev with perf HUD"
+          echo "  bun run build            # Build frontend"
+          echo "  bun run typecheck        # Type check"
+          echo "  bun run lint             # Lint (biome + clippy)"
+          echo "  bun run lint:fix         # Auto-fix lint issues"
+          echo "  bun run test             # Run all tests"
+          echo ""
+          echo "🧪 Test commands:"
+          echo "  bun run test:frontend    # Vitest tests"
+          echo "  bun run test:sidecar     # Sidecar tests"
+          echo "  bun run test:rust        # Rust tests"
+          echo ""
+        '';
+
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          inherit buildInputs shellHook;
+
+          # Additional native build inputs for linking
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+          ];
+        };
+
+        # Alias for convenience
+        devShell = self.devShells.${system}.default;
+      }
+    );
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -345,6 +345,7 @@ function AppShell({
 }) {
 	useZoom();
 	const queryClient = useQueryClient();
+	const { settings: appSettings, updateSettings } = useSettings();
 	const workspaceSelectionRequestRef = useRef(0);
 	const sessionSelectionRequestRef = useRef(0);
 	const startupPrefetchedWorkspaceRef = useRef<string | null>(null);
@@ -2163,12 +2164,19 @@ function AppShell({
 		);
 	}, []);
 
+	const handleSkipGithubAuth = useCallback(() => {
+		void updateSettings({ requireGithubAuth: false });
+	}, [updateSettings]);
+
+	const shouldShowGithubGate =
+		appSettings.requireGithubAuth && !isIdentityConnected;
+
 	return (
 		<TooltipProvider delayDuration={0}>
 			<WorkspaceToastProvider value={pushWorkspaceToast}>
 				<SendingSessionsProvider value={sendingSessionIds}>
 					<ComposerInsertProvider value={handleInsertIntoComposer}>
-						{!isIdentityConnected ? (
+						{shouldShowGithubGate ? (
 							<GithubIdentityGate
 								identityState={githubIdentityState}
 								onConnectGithub={() => {
@@ -2178,6 +2186,7 @@ function AppShell({
 									handleCopyGithubDeviceCode(userCode)
 								}
 								onCancelGithubConnect={handleCancelGithubIdentityConnect}
+								onSkip={handleSkipGithubAuth}
 							/>
 						) : (
 							<main

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -38,6 +38,8 @@ export type AppSettings = {
 	alwaysShowContextUsage: boolean;
 	showUsageStats: boolean;
 	onboardingCompleted: boolean;
+	/** Require GitHub authentication. When false, user can work with local git repos without GitHub. */
+	requireGithubAuth: boolean;
 	shortcuts: ShortcutOverrides;
 	claudeCustomProviders: ClaudeCustomProviderSettings;
 };
@@ -65,6 +67,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
 	alwaysShowContextUsage: true,
 	showUsageStats: true,
 	onboardingCompleted: false,
+	requireGithubAuth: true,
 	shortcuts: {},
 	claudeCustomProviders: {
 		builtinProviderApiKeys: {},
@@ -92,6 +95,7 @@ const SETTINGS_KEY_MAP: Record<Exclude<keyof AppSettings, "theme">, string> = {
 	alwaysShowContextUsage: "app.always_show_context_usage",
 	showUsageStats: "app.show_usage_stats",
 	onboardingCompleted: "app.onboarding_completed",
+	requireGithubAuth: "app.require_github_auth",
 	shortcuts: "app.shortcuts",
 	claudeCustomProviders: "app.claude_custom_providers",
 };
@@ -199,6 +203,10 @@ export async function loadSettings(): Promise<AppSettings> {
 				raw[SETTINGS_KEY_MAP.onboardingCompleted] !== undefined
 					? raw[SETTINGS_KEY_MAP.onboardingCompleted] === "true"
 					: DEFAULT_SETTINGS.onboardingCompleted,
+			requireGithubAuth:
+				raw[SETTINGS_KEY_MAP.requireGithubAuth] !== undefined
+					? raw[SETTINGS_KEY_MAP.requireGithubAuth] === "true"
+					: DEFAULT_SETTINGS.requireGithubAuth,
 			shortcuts: parseShortcutOverrides(raw[SETTINGS_KEY_MAP.shortcuts]),
 			claudeCustomProviders: parseClaudeCustomProviderSettings(
 				raw[SETTINGS_KEY_MAP.claudeCustomProviders],

--- a/src/shell/github-identity-gate.tsx
+++ b/src/shell/github-identity-gate.tsx
@@ -14,11 +14,13 @@ export function GithubIdentityGate({
 	onConnectGithub,
 	onCopyGithubCode,
 	onCancelGithubConnect,
+	onSkip,
 }: {
 	identityState: GithubIdentityState;
 	onConnectGithub: () => void;
 	onCopyGithubCode: (userCode: string) => Promise<boolean>;
 	onCancelGithubConnect: () => void;
+	onSkip: () => void;
 }) {
 	const [codeCopied, setCodeCopied] = useState(false);
 
@@ -133,7 +135,7 @@ export function GithubIdentityGate({
 							Restoring your last session
 						</div>
 					) : (
-						<div className="mt-10 flex justify-center">
+						<div className="mt-10 flex flex-col items-center gap-3">
 							<Button
 								onClick={onConnectGithub}
 								size="lg"
@@ -143,6 +145,9 @@ export function GithubIdentityGate({
 								{identityState.status === "error"
 									? "Retry with GitHub"
 									: "Continue with GitHub"}
+							</Button>
+							<Button variant="ghost" size="sm" onClick={onSkip}>
+								Skip — Work locally
 							</Button>
 						</div>
 					)}


### PR DESCRIPTION
## Summary

Implements #318 - Adds ability to skip GitHub OAuth and work with local git repositories without GitHub integration.

## Motivation

Currently, Helmor requires GitHub authentication on first launch. This PR adds a "local-only mode" for users who want to:
- Work with local git repos without GitHub
- Use GitLab/Gitea/self-hosted forges
- Avoid cloud account connections for privacy
- Evaluate Helmor without OAuth commitment

## Changes

### 1. Settings (`src/lib/settings.ts`)
- Added `requireGithubAuth: boolean` setting
- Defaults to `true` (preserves existing behavior)
- Stored as `app.require_github_auth` in SQLite

### 2. GitHub Identity Gate (`src/shell/github-identity-gate.tsx`)
- Added `onSkip` prop and handler
- Added **"Skip — Work locally"** button below "Continue with GitHub"
- Allows bypassing OAuth flow

### 3. App Shell (`src/App.tsx`)
- Added `shouldShowGithubGate` computed value:
  - `requireGithubAuth === true` AND `!isIdentityConnected`
- Added `handleSkipGithubAuth` to set `requireGithubAuth: false`
- Gate only appears when both conditions are met

## User Flow

### Fresh Install
1. Complete onboarding
2. GitHub gate appears (default behavior)
3. User can choose:
   - **"Continue with GitHub"** → OAuth flow (current behavior)
   - **"Skip — Work locally"** → Bypass gate, work locally

### After Skipping
- Setting persists in `~/helmor/helmor.db`
- Gate won't appear on restart
- Can connect GitHub later via Settings → Account (UI not included in this PR)

### Existing Users
- **No change** - `requireGithubAuth` defaults to `true`
- Can disable via Settings if desired (Settings UI TODO)

## Feature Degradation

GitHub-dependent features gracefully degrade when not authenticated:

| Feature | Behavior |
|---------|----------|
| Local git ops (commit, branch, push) | ✅ Work normally |
| PR status sync | ❌ Hidden |
| Forge operations (issues, releases) | ❌ Disabled |
| GitHub API queries | ❌ Not enabled |
| Workspace management | ✅ Works |
| Agent streaming | ✅ Works |

All core Helmor functionality (agent chat, file editing, workspace management) works without GitHub.

## Testing

### Test Fresh Install Flow
```bash
# Wipe data directory
rm -rf ~/helmor-dev/

# Launch app in dev mode
bun run dev

# Complete onboarding
# Click "Skip — Work locally" on GitHub gate
# Verify app opens without gate

# Restart app
bun run dev
# Verify gate doesn't reappear
```

### Test Existing Behavior
```bash
# With existing data, gate should still appear
# (requireGithubAuth defaults to true)
```

## Screenshots

_TODO: Add screenshots of the "Skip — Work locally" button_

## Future Work

- [ ] Add Settings → Account UI for:
  - Toggle "Require GitHub authentication"
  - "Connect GitHub" button when skipped
- [ ] Add feature matrix docs showing what works without GitHub
- [ ] Consider GitLab/other forge support (separate PR)
- [ ] Add telemetry to track local-mode usage

## Breaking Changes

None - defaults to existing behavior.

## Related

Closes #318

---

**Note**: This is a draft PR to gather feedback. If maintainers approve the direction, I can add:
- Settings UI for toggling the requirement
- "Connect GitHub" button in Settings
- Documentation updates