### PR TITLE
fix(navigation): handle "Open in Finder" on archived workspaces

### DIFF
--- a/.changeset/finder-archived-workspace-fix.md
+++ b/.changeset/finder-archived-workspace-fix.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Hide "Open in Finder" on archived workspaces and show the real error message instead of "[object Object]" when opening Finder fails.

--- a/src/features/navigation/container.tsx
+++ b/src/features/navigation/container.tsx
@@ -1,5 +1,6 @@
 import { memo } from "react";
 import { openWorkspaceInFinder } from "@/lib/api";
+import { extractError } from "@/lib/errors";
 import { useWorkspacesSidebarController } from "./hooks/use-controller";
 import { WorkspacesSidebar } from "./index";
 
@@ -93,7 +94,8 @@ export const WorkspacesSidebarContainer = memo(
 				onDeleteWorkspace={handleDeleteWorkspace}
 				onOpenInFinder={(workspaceId) => {
 					void openWorkspaceInFinder(workspaceId).catch((error) => {
-						pushWorkspaceToast(String(error), "Failed to open Finder");
+						const { message } = extractError(error, "Failed to open Finder");
+						pushWorkspaceToast(message, "Failed to open Finder", "destructive");
 					});
 				}}
 				onTogglePin={(workspaceId, pinned) => {

--- a/src/features/navigation/row-item.tsx
+++ b/src/features/navigation/row-item.tsx
@@ -374,7 +374,7 @@ export const WorkspaceRowItem = memo(
 						</ContextMenuItem>
 					) : null}
 
-					{onOpenInFinder ? (
+					{onOpenInFinder && !isRestoreAction ? (
 						<ContextMenuItem
 							disabled={isBusy || Boolean(workspaceActionsDisabled)}
 							onClick={() => onOpenInFinder(row.id)}


### PR DESCRIPTION
Fixes #322

After archiving a workspace the directory is removed from disk, but the row's context menu still showed "Open in Finder". Picking it always failed, and the toast surfaced `"[object Object]"` because `String(error)` was used on Tauri's structured `{ code, message }` payload.

## Changes
- `src/features/navigation/row-item.tsx` — hide the "Open in Finder" entry on archived rows (`row.state === "archived"`). Restore is already the only meaningful action.
- `src/features/navigation/container.tsx` — switch the catch handler to the existing `extractError()` helper (`src/lib/errors.ts`) so the toast shows the real Rust message. Marked the toast `destructive` to match the rest of the workspace error toasts in `use-controller.ts`.
- `.changeset/finder-archived-workspace-fix.md` — patch-level changelog entry.

## Testing
- `bun run lint`, `bun run typecheck`, `bun run test:frontend` (807 tests) all pass.
- Manual UI verification not performed in this PR — happy to walk through it on request, or for a maintainer to verify the three flows below:
  - Active workspace: "Open in Finder" still opens Finder at the workspace dir.
  - Archived workspace: menu entry no longer appears.
  - Forced-error path (rename workspace dir on disk while app is running, then "Open in Finder" on a non-archived row): toast shows the real "Workspace directory not found: …" message instead of "[object Object]".
- macOS only — `reveal_in_finder` is gated on `target_os = "macos"` and the bug only manifests on macOS.