### PR TITLE
feat(workspaces): support branch-based workspaces

### DIFF
--- a/.changeset/branch-based-workspaces.md
+++ b/.changeset/branch-based-workspaces.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Allow new workspaces to be based on a selected remote branch instead of always using the repository default branch.

--- a/src-tauri/src/agents/streaming/mod.rs
+++ b/src-tauri/src/agents/streaming/mod.rs
@@ -302,12 +302,10 @@ pub(super) fn stream_via_sidecar(
                     let (reason_log, user_message, should_stop_sidecar) = match kind {
                         state::AbnormalExit::HeartbeatTimeout => (
                             format!(
-                                "heartbeat lost for {:?} — treating stream as dead",
-                                HEARTBEAT_TIMEOUT
+                                "heartbeat lost for {HEARTBEAT_TIMEOUT:?} — treating stream as dead"
                             ),
                             format!(
-                                "Sidecar stopped responding (no heartbeat for {:?}). You can retry the request.",
-                                HEARTBEAT_TIMEOUT,
+                                "Sidecar stopped responding (no heartbeat for {HEARTBEAT_TIMEOUT:?}). You can retry the request."
                             ),
                             true,
                         ),

--- a/src-tauri/src/cli/args.rs
+++ b/src-tauri/src/cli/args.rs
@@ -242,6 +242,9 @@ pub enum WorkspaceAction {
         /// Repo name or UUID.
         #[arg(long)]
         repo: String,
+        /// Remote branch to base this workspace on. Defaults to the repo setting.
+        #[arg(long = "base")]
+        base_branch: Option<String>,
     },
     /// Permanently delete a workspace (DB rows + git worktree + files).
     Delete {

--- a/src-tauri/src/cli/workspace.rs
+++ b/src-tauri/src/cli/workspace.rs
@@ -31,7 +31,7 @@ pub fn dispatch(action: &WorkspaceAction, cli: &Cli) -> Result<()> {
             cli,
         ),
         WorkspaceAction::Show { workspace_ref } => show(workspace_ref, cli),
-        WorkspaceAction::New { repo } => new(repo, cli),
+        WorkspaceAction::New { repo, base_branch } => new(repo, base_branch.as_deref(), cli),
         WorkspaceAction::Delete { workspace_ref } => delete(workspace_ref, cli),
         WorkspaceAction::Archive { workspace_ref } => archive(workspace_ref, cli),
         WorkspaceAction::Restore {
@@ -192,9 +192,9 @@ fn show(workspace_ref: &str, cli: &Cli) -> Result<()> {
     })
 }
 
-fn new(repo_ref: &str, cli: &Cli) -> Result<()> {
+fn new(repo_ref: &str, base_branch: Option<&str>, cli: &Cli) -> Result<()> {
     let repo_id = service::resolve_repo_ref(repo_ref)?;
-    let response = service::create_workspace_from_repo_impl(&repo_id)?;
+    let response = service::create_workspace_from_repo_with_base_impl(&repo_id, base_branch)?;
     notify_ui_events([
         UiMutationEvent::WorkspaceListChanged,
         UiMutationEvent::WorkspaceChanged {

--- a/src-tauri/src/commands/system_commands.rs
+++ b/src-tauri/src/commands/system_commands.rs
@@ -449,8 +449,7 @@ pub async fn install_helmor_skills() -> CmdResult<HelmorSkillsStatus> {
 
         if agents.is_empty() {
             anyhow::bail!(
-                "No ready agent was found. Sign in to Claude Code or Codex first, then run:\n  {}",
-                command
+                "No ready agent was found. Sign in to Claude Code or Codex first, then run:\n  {command}"
             );
         }
 

--- a/src-tauri/src/commands/tests/support.rs
+++ b/src-tauri/src/commands/tests/support.rs
@@ -358,6 +358,37 @@ impl CreateTestHarness {
         .unwrap();
         git_ops::run_git(["-C", root, "fetch", "origin"], None).unwrap();
     }
+
+    pub(crate) fn create_remote_branch_with_file(
+        &self,
+        branch: &str,
+        relative_path: &str,
+        contents: &str,
+    ) {
+        let root = self.source_repo_root.to_str().unwrap();
+        git_ops::run_git(["-C", root, "checkout", "-b", branch], None).unwrap();
+        fs::write(self.source_repo_root.join(relative_path), contents).unwrap();
+        git_ops::run_git(["-C", root, "add", relative_path], None).unwrap();
+        git_ops::run_git(
+            [
+                "-C",
+                root,
+                "-c",
+                "commit.gpgsign=false",
+                "-c",
+                "user.name=Helmor",
+                "-c",
+                "user.email=helmor@example.com",
+                "commit",
+                "-m",
+                &format!("add {relative_path}"),
+            ],
+            None,
+        )
+        .unwrap();
+        git_ops::run_git(["-C", root, "checkout", "main"], None).unwrap();
+        git_ops::run_git(["-C", root, "fetch", "origin"], None).unwrap();
+    }
 }
 
 pub(crate) struct BranchSwitchTestHarness {

--- a/src-tauri/src/commands/tests/workspace_creation.rs
+++ b/src-tauri/src/commands/tests/workspace_creation.rs
@@ -84,6 +84,72 @@ fn create_workspace_from_repo_creates_ready_workspace_and_initial_session() {
 }
 
 #[test]
+fn create_workspace_from_repo_can_use_requested_base_branch() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let harness = CreateTestHarness::new();
+    harness.create_remote_branch_with_file("develop", "develop.txt", "from develop");
+
+    let response =
+        workspaces::create_workspace_from_repo_with_base_impl(&harness.repo_id, Some("develop"))
+            .unwrap();
+
+    let workspace_dir = harness.workspace_dir(&response.directory_name);
+    assert_eq!(
+        fs::read_to_string(workspace_dir.join("develop.txt")).unwrap(),
+        "from develop"
+    );
+
+    let connection = Connection::open(harness.db_path()).unwrap();
+    let (initialization_parent_branch, intended_target_branch): (String, String) = connection
+        .query_row(
+            r#"
+            SELECT initialization_parent_branch, intended_target_branch
+            FROM workspaces WHERE id = ?1
+            "#,
+            [&response.created_workspace_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+
+    assert_eq!(initialization_parent_branch, "develop");
+    assert_eq!(intended_target_branch, "develop");
+}
+
+#[test]
+fn create_workspace_from_repo_normalizes_remote_prefixed_base_branch() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let harness = CreateTestHarness::new();
+    harness.create_remote_branch_with_file("develop", "develop.txt", "from develop");
+
+    let prepared = workspaces::prepare_workspace_from_repo_with_base_impl(
+        &harness.repo_id,
+        Some("origin/develop"),
+    )
+    .unwrap();
+
+    assert_eq!(prepared.base_branch, "develop");
+
+    let connection = Connection::open(harness.db_path()).unwrap();
+    let (initialization_parent_branch, intended_target_branch): (String, String) = connection
+        .query_row(
+            r#"
+            SELECT initialization_parent_branch, intended_target_branch
+            FROM workspaces WHERE id = ?1
+            "#,
+            [&prepared.workspace_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+
+    assert_eq!(initialization_parent_branch, "develop");
+    assert_eq!(intended_target_branch, "develop");
+}
+
+#[test]
 fn create_workspace_from_repo_defers_setup_when_script_configured_by_default() {
     let _guard = TEST_LOCK
         .lock()

--- a/src-tauri/src/commands/workspace_commands.rs
+++ b/src-tauri/src/commands/workspace_commands.rs
@@ -25,10 +25,14 @@ fn notify_workspace_changed_in_background(app: AppHandle) {
 pub async fn prepare_workspace_from_repo(
     app: AppHandle,
     repo_id: String,
+    base_branch: Option<String>,
 ) -> CmdResult<workspaces::PrepareWorkspaceResponse> {
     let result = {
         let _lock = db::WORKSPACE_FS_MUTATION_LOCK.lock().await;
-        run_blocking(move || workspaces::prepare_workspace_from_repo_impl(&repo_id)).await?
+        run_blocking(move || {
+            workspaces::prepare_workspace_from_repo_with_base_impl(&repo_id, base_branch.as_deref())
+        })
+        .await?
     };
     notify_workspace_changed_in_background(app);
     Ok(result)
@@ -61,10 +65,14 @@ pub async fn finalize_workspace_from_repo(
 pub async fn create_workspace_from_repo(
     app: AppHandle,
     repo_id: String,
+    base_branch: Option<String>,
 ) -> CmdResult<workspaces::CreateWorkspaceResponse> {
     let result = {
         let _lock = db::WORKSPACE_FS_MUTATION_LOCK.lock().await;
-        run_blocking(move || workspaces::create_workspace_from_repo_impl(&repo_id)).await?
+        run_blocking(move || {
+            workspaces::create_workspace_from_repo_with_base_impl(&repo_id, base_branch.as_deref())
+        })
+        .await?
     };
     notify_workspace_changed_in_background(app);
     Ok(result)

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -604,17 +604,11 @@ pub fn current_workspace_head_commit(workspace_dir: &Path) -> Result<String> {
     let workspace_dir = workspace_dir.display().to_string();
     let commit =
         run_git(["-C", workspace_dir.as_str(), "rev-parse", "HEAD"], None).with_context(|| {
-            format!(
-                "Failed to resolve archive commit from workspace {}",
-                workspace_dir
-            )
+            format!("Failed to resolve archive commit from workspace {workspace_dir}")
         })?;
 
     if commit.trim().is_empty() {
-        bail!(
-            "Resolved empty archive commit for workspace {}",
-            workspace_dir
-        );
+        bail!("Resolved empty archive commit for workspace {workspace_dir}");
     }
 
     Ok(commit)
@@ -626,11 +620,11 @@ pub fn current_branch_name(workspace_dir: &Path) -> Result<String> {
         ["-C", workspace_dir.as_str(), "branch", "--show-current"],
         None,
     )
-    .with_context(|| format!("Failed to resolve current branch for {}", workspace_dir))?;
+    .with_context(|| format!("Failed to resolve current branch for {workspace_dir}"))?;
 
     let branch = branch.trim();
     if branch.is_empty() {
-        bail!("Workspace {} is not on a branch", workspace_dir);
+        bail!("Workspace {workspace_dir} is not on a branch");
     }
 
     Ok(branch.to_string())
@@ -657,12 +651,8 @@ pub fn default_branch_ref(remote: &str, default_branch: &str) -> String {
 
 pub fn tracked_file_count(workspace_dir: &Path) -> Result<i64> {
     let workspace_dir = workspace_dir.display().to_string();
-    let output = run_git(["-C", workspace_dir.as_str(), "ls-files"], None).with_context(|| {
-        format!(
-            "Failed to count tracked files for workspace {}",
-            workspace_dir
-        )
-    })?;
+    let output = run_git(["-C", workspace_dir.as_str(), "ls-files"], None)
+        .with_context(|| format!("Failed to count tracked files for workspace {workspace_dir}"))?;
 
     Ok(output
         .lines()
@@ -684,7 +674,7 @@ pub fn working_tree_clean(workspace_dir: &Path) -> Result<bool> {
         ],
         None,
     )
-    .with_context(|| format!("Failed to read working tree status for {}", workspace_dir))?;
+    .with_context(|| format!("Failed to read working tree status for {workspace_dir}"))?;
 
     Ok(output.trim().is_empty())
 }
@@ -893,17 +883,12 @@ pub fn commits_ahead_of(workspace_dir: &Path, base_ref: &str) -> Result<u32> {
         ],
         None,
     )
-    .with_context(|| {
-        format!(
-            "Failed to count commits ahead of {} in {}",
-            base_ref, workspace_dir
-        )
-    })?;
+    .with_context(|| format!("Failed to count commits ahead of {base_ref} in {workspace_dir}"))?;
 
     output
         .trim()
         .parse::<u32>()
-        .with_context(|| format!("Unexpected rev-list count output: {}", output))
+        .with_context(|| format!("Unexpected rev-list count output: {output}"))
 }
 
 /// Counts how many commits are reachable from `base_ref` but not from HEAD.
@@ -921,17 +906,12 @@ pub fn commits_behind(workspace_dir: &Path, base_ref: &str) -> Result<u32> {
         ],
         None,
     )
-    .with_context(|| {
-        format!(
-            "Failed to count commits behind {} in {}",
-            base_ref, workspace_dir
-        )
-    })?;
+    .with_context(|| format!("Failed to count commits behind {base_ref} in {workspace_dir}"))?;
 
     output
         .trim()
         .parse::<u32>()
-        .with_context(|| format!("Unexpected rev-list count output: {}", output))
+        .with_context(|| format!("Unexpected rev-list count output: {output}"))
 }
 
 fn parse_porcelain_status_paths(output: &str) -> std::collections::BTreeSet<String> {
@@ -1019,9 +999,9 @@ pub fn remote_ref_sha(workspace_dir: &Path, remote: &str, branch: &str) -> Resul
         ["-C", workspace_dir.as_str(), "rev-parse", ref_name.as_str()],
         None,
     )
-    .with_context(|| format!("Failed to resolve {} in {}", ref_name, workspace_dir))?;
+    .with_context(|| format!("Failed to resolve {ref_name} in {workspace_dir}"))?;
     if sha.trim().is_empty() {
-        bail!("Empty SHA for {} in {}", ref_name, workspace_dir);
+        bail!("Empty SHA for {ref_name} in {workspace_dir}");
     }
     Ok(sha.trim().to_string())
 }
@@ -1118,12 +1098,7 @@ pub fn reset_current_branch_hard(workspace_dir: &Path, target_ref: &str) -> Resu
         None,
     )
     .map(|_| ())
-    .with_context(|| {
-        format!(
-            "Failed to reset workspace {} to {}",
-            workspace_dir, target_ref
-        )
-    })
+    .with_context(|| format!("Failed to reset workspace {workspace_dir} to {target_ref}"))
 }
 
 #[cfg(test)]

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -95,7 +95,8 @@ fn handle_tools_list(request: &Value) -> Value {
             "ref": { "type": "string", "description": "Workspace UUID or repo-name/directory-name" }
         }).as_object().map(|o| json!({ "type": "object", "properties": o, "required": ["ref"] })).unwrap()),
         tool_def("helmor_workspace_create", "Create a new workspace for a repository", json!({
-            "repo": { "type": "string", "description": "Repository UUID or name" }
+            "repo": { "type": "string", "description": "Repository UUID or name" },
+            "base_branch": { "type": "string", "description": "Optional remote branch to base this workspace on" }
         }).as_object().map(|o| json!({ "type": "object", "properties": o, "required": ["repo"] })).unwrap()),
         tool_def("helmor_session_list", "List sessions in a workspace", json!({
             "workspace": { "type": "string", "description": "Workspace UUID or repo-name/directory-name" }
@@ -179,7 +180,8 @@ fn dispatch_tool(name: &str, args: &Value) -> Result<String> {
                 .as_str()
                 .ok_or_else(|| anyhow::anyhow!("Missing required param: repo"))?;
             let repo_id = service::resolve_repo_ref(repo_ref)?;
-            let resp = service::create_workspace_from_repo_impl(&repo_id)?;
+            let base_branch = args["base_branch"].as_str();
+            let resp = service::create_workspace_from_repo_with_base_impl(&repo_id, base_branch)?;
             Ok(serde_json::to_string_pretty(&resp)?)
         }
         "helmor_session_list" => {

--- a/src-tauri/src/service.rs
+++ b/src-tauri/src/service.rs
@@ -26,7 +26,8 @@ pub use crate::models::workspaces::load_workspace_records;
 pub use crate::repos::{add_repository_from_local_path, list_repositories};
 pub use crate::sessions::{create_session, list_workspace_sessions};
 pub use crate::workspaces::{
-    create_workspace_from_repo_impl, get_workspace, list_workspace_groups,
+    create_workspace_from_repo_impl, create_workspace_from_repo_with_base_impl, get_workspace,
+    list_workspace_groups,
 };
 
 /// Build [`DataInfo`] without needing a Tauri runtime.

--- a/src-tauri/src/workspace/lifecycle.rs
+++ b/src-tauri/src/workspace/lifecycle.rs
@@ -71,6 +71,7 @@ pub struct PrepareWorkspaceResponse {
     pub directory_name: String,
     pub branch: String,
     pub default_branch: String,
+    pub base_branch: String,
     pub state: WorkspaceState,
     /// DB-level repo scripts. After Phase 2 (worktree creation) the frontend
     /// may refetch to pick up any `helmor.json` overrides copied into the
@@ -116,6 +117,13 @@ pub struct TargetBranchConflict {
 /// `Ready` / `SetupPending`. It can run in the background while the UI
 /// already shows the workspace.
 pub fn prepare_workspace_from_repo_impl(repo_id: &str) -> Result<PrepareWorkspaceResponse> {
+    prepare_workspace_from_repo_with_base_impl(repo_id, None)
+}
+
+pub fn prepare_workspace_from_repo_with_base_impl(
+    repo_id: &str,
+    base_branch: Option<&str>,
+) -> Result<PrepareWorkspaceResponse> {
     let repository = repos::load_repository_by_id(repo_id)?
         .with_context(|| format!("Repository not found: {repo_id}"))?;
     let repo_root = PathBuf::from(repository.root_path.trim());
@@ -141,6 +149,7 @@ pub fn prepare_workspace_from_repo_impl(repo_id: &str) -> Result<PrepareWorkspac
         .clone()
         .filter(|value| !value.trim().is_empty())
         .unwrap_or_else(|| "main".to_string());
+    let base_branch = normalize_base_branch(base_branch, &remote, &default_branch);
     let workspace_id = uuid::Uuid::new_v4().to_string();
     let session_id = uuid::Uuid::new_v4().to_string();
     let timestamp = db::current_timestamp()?;
@@ -151,7 +160,7 @@ pub fn prepare_workspace_from_repo_impl(repo_id: &str) -> Result<PrepareWorkspac
         &session_id,
         &directory_name,
         &branch,
-        &default_branch,
+        &base_branch,
         &timestamp,
     )?;
 
@@ -184,9 +193,23 @@ pub fn prepare_workspace_from_repo_impl(repo_id: &str) -> Result<PrepareWorkspac
         directory_name,
         branch,
         default_branch,
+        base_branch,
         state: WorkspaceState::Initializing,
         repo_scripts,
     })
+}
+
+fn normalize_base_branch(base_branch: Option<&str>, remote: &str, default_branch: &str) -> String {
+    let Some(branch) = base_branch.map(str::trim).filter(|value| !value.is_empty()) else {
+        return default_branch.to_string();
+    };
+
+    branch
+        .strip_prefix(&format!("refs/remotes/{remote}/"))
+        .or_else(|| branch.strip_prefix(&format!("{remote}/")))
+        .or_else(|| branch.strip_prefix("refs/heads/"))
+        .unwrap_or(branch)
+        .to_string()
 }
 
 /// Phase 2 of workspace creation: creates the git worktree, probes
@@ -214,10 +237,16 @@ pub fn finalize_workspace_from_repo_impl(workspace_id: &str) -> Result<FinalizeW
         .remote
         .clone()
         .unwrap_or_else(|| "origin".to_string());
-    let default_branch = record
-        .default_branch
+    let base_branch = record
+        .initialization_parent_branch
         .clone()
         .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            record
+                .default_branch
+                .clone()
+                .filter(|value| !value.trim().is_empty())
+        })
         .unwrap_or_else(|| "main".to_string());
     let branch = helpers::non_empty(&record.branch)
         .map(ToOwned::to_owned)
@@ -235,11 +264,11 @@ pub fn finalize_workspace_from_repo_impl(workspace_id: &str) -> Result<FinalizeW
         }
 
         git_ops::ensure_git_repository(&repo_root)?;
-        let start_ref = git_ops::default_branch_ref(&remote, &default_branch);
+        let start_ref = git_ops::default_branch_ref(&remote, &base_branch);
         git_ops::verify_commitish_exists(
             &repo_root,
             &start_ref,
-            &format!("Default branch is missing in source repo: {default_branch}"),
+            &format!("Base branch is missing in source repo: {base_branch}"),
         )?;
         match git_ops::create_worktree_from_start_point(
             &repo_root,
@@ -299,7 +328,14 @@ pub fn finalize_workspace_from_repo_impl(workspace_id: &str) -> Result<FinalizeW
 /// the old-shape response. Used by CLI, MCP, and `add_repository_from_local_path`
 /// — all non-UI callers that do not benefit from the prepare/finalize split.
 pub fn create_workspace_from_repo_impl(repo_id: &str) -> Result<CreateWorkspaceResponse> {
-    let prepared = prepare_workspace_from_repo_impl(repo_id)?;
+    create_workspace_from_repo_with_base_impl(repo_id, None)
+}
+
+pub fn create_workspace_from_repo_with_base_impl(
+    repo_id: &str,
+    base_branch: Option<&str>,
+) -> Result<CreateWorkspaceResponse> {
+    let prepared = prepare_workspace_from_repo_with_base_impl(repo_id, base_branch)?;
     let finalized = finalize_workspace_from_repo_impl(&prepared.workspace_id)?;
 
     Ok(CreateWorkspaceResponse {

--- a/src-tauri/src/workspace/workspaces.rs
+++ b/src-tauri/src/workspace/workspaces.rs
@@ -27,8 +27,9 @@ pub use super::branching::{
 };
 pub use super::lifecycle::{
     archive_workspace_impl, cleanup_orphaned_initializing_workspaces,
-    create_workspace_from_repo_impl, finalize_workspace_from_repo_impl, prepare_archive_plan,
-    prepare_workspace_from_repo_impl, restore_workspace_impl, validate_archive_workspace,
+    create_workspace_from_repo_impl, create_workspace_from_repo_with_base_impl,
+    finalize_workspace_from_repo_impl, prepare_archive_plan, prepare_workspace_from_repo_impl,
+    prepare_workspace_from_repo_with_base_impl, restore_workspace_impl, validate_archive_workspace,
     validate_restore_workspace, ArchivePreparedPlan, ArchiveWorkspaceResponse, BranchRename,
     CreateWorkspaceResponse, FinalizeWorkspaceResponse, PrepareWorkspaceResponse,
     RestoreWorkspaceResponse, TargetBranchConflict, ValidateRestoreResponse,

--- a/src/features/navigation/container.tsx
+++ b/src/features/navigation/container.tsx
@@ -1,5 +1,5 @@
 import { memo } from "react";
-import { openWorkspaceInFinder } from "@/lib/api";
+import { listRemoteBranches, openWorkspaceInFinder } from "@/lib/api";
 import { extractError } from "@/lib/errors";
 import { useWorkspacesSidebarController } from "./hooks/use-controller";
 import { WorkspacesSidebar } from "./index";
@@ -85,9 +85,10 @@ export const WorkspacesSidebarContainer = memo(
 				onSubmitClone={handleCloneFromUrl}
 				onSelectWorkspace={handleSelectWorkspace}
 				onPrefetchWorkspace={prefetchWorkspace}
-				onCreateWorkspace={(repoId) => {
-					void handleCreateWorkspaceFromRepo(repoId);
+				onCreateWorkspace={(repoId, baseBranch) => {
+					void handleCreateWorkspaceFromRepo(repoId, baseBranch);
 				}}
+				onFetchRepositoryBranches={(repoId) => listRemoteBranches({ repoId })}
 				onArchiveWorkspace={handleArchiveWorkspace}
 				onMarkWorkspaceUnread={handleMarkWorkspaceUnread}
 				onRestoreWorkspace={handleRestoreWorkspace}

--- a/src/features/navigation/hooks/use-controller.ts
+++ b/src/features/navigation/hooks/use-controller.ts
@@ -662,7 +662,7 @@ export function useWorkspacesSidebarController({
 	);
 
 	const handleCreateWorkspaceFromRepo = useCallback(
-		async (repoId: string) => {
+		async (repoId: string, baseBranch?: string) => {
 			if (creatingWorkspaceRepoId) {
 				return;
 			}
@@ -686,7 +686,9 @@ export function useWorkspacesSidebarController({
 				// the real workspace/session ids, directory name, branch,
 				// and repo scripts. Nothing is painted yet; the sidebar +
 				// panel are still showing the previously selected workspace.
-				prepareResponse = await prepareWorkspaceFromRepo(repoId);
+				prepareResponse = baseBranch
+					? await prepareWorkspaceFromRepo(repoId, baseBranch)
+					: await prepareWorkspaceFromRepo(repoId);
 			} catch (error) {
 				setCreatingWorkspaceRepoId(null);
 				pushWorkspaceToast(
@@ -742,8 +744,10 @@ export function useWorkspacesSidebarController({
 					// intended target, matching what Phase 2 writes.
 					remote: repository.remote ?? "origin",
 					defaultBranch: prepareResponse.defaultBranch,
-					initializationParentBranch: prepareResponse.defaultBranch,
-					intendedTargetBranch: prepareResponse.defaultBranch,
+					initializationParentBranch:
+						prepareResponse.baseBranch ?? prepareResponse.defaultBranch,
+					intendedTargetBranch:
+						prepareResponse.baseBranch ?? prepareResponse.defaultBranch,
 				},
 			);
 			queryClient.setQueryData<WorkspaceSessionSummary[]>(

--- a/src/features/navigation/index.test.tsx
+++ b/src/features/navigation/index.test.tsx
@@ -6,7 +6,7 @@ import {
 	within,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type {
 	RepositoryCreateOption,
@@ -46,6 +46,29 @@ const repositories: RepositoryCreateOption[] = [
 		repoInitials: "DO",
 	},
 ];
+
+function createMemoryStorage(): Storage {
+	const values = new Map<string, string>();
+	return {
+		get length() {
+			return values.size;
+		},
+		clear: vi.fn(() => values.clear()),
+		getItem: vi.fn((key: string) => values.get(key) ?? null),
+		key: vi.fn((index: number) => Array.from(values.keys())[index] ?? null),
+		removeItem: vi.fn((key: string) => values.delete(key)),
+		setItem: vi.fn((key: string, value: string) => {
+			values.set(key, value);
+		}),
+	};
+}
+
+beforeEach(() => {
+	Object.defineProperty(window, "localStorage", {
+		configurable: true,
+		value: createMemoryStorage(),
+	});
+});
 
 afterEach(() => {
 	cleanup();
@@ -137,6 +160,42 @@ describe("WorkspacesSidebar", () => {
 
 		expect(onCreateWorkspace).toHaveBeenCalledWith("repo-1");
 		expect(screen.queryByRole("option", { name: /helmor/i })).toBeNull();
+	});
+
+	it("creates a workspace from a selected base branch", async () => {
+		const user = userEvent.setup();
+		const onCreateWorkspace = vi.fn();
+		const onFetchRepositoryBranches = vi
+			.fn()
+			.mockResolvedValue(["develop", "main"]);
+
+		const { container } = render(
+			<TooltipProvider delayDuration={0}>
+				<WorkspacesSidebar
+					groups={workspaceGroups}
+					archivedRows={[]}
+					availableRepositories={repositories}
+					onCreateWorkspace={onCreateWorkspace}
+					onFetchRepositoryBranches={onFetchRepositoryBranches}
+				/>
+			</TooltipProvider>,
+		);
+
+		const [newWorkspaceButton] = within(container).getAllByRole("button", {
+			name: "New workspace",
+		});
+		await user.click(newWorkspaceButton);
+		await user.click(
+			screen.getByRole("button", {
+				name: "Create helmor workspace from branch",
+			}),
+		);
+		const branchOptions = await screen.findAllByRole("option");
+		expect(branchOptions[0]).toHaveTextContent("main");
+		await user.click(await screen.findByRole("option", { name: "develop" }));
+
+		expect(onFetchRepositoryBranches).toHaveBeenCalledWith("repo-1");
+		expect(onCreateWorkspace).toHaveBeenCalledWith("repo-1", "develop");
 	});
 
 	it("shows an Open in Finder action for active workspaces", async () => {

--- a/src/features/navigation/index.tsx
+++ b/src/features/navigation/index.tsx
@@ -4,6 +4,7 @@ import {
 	ChevronRight,
 	Folder,
 	FolderPlus,
+	GitBranch,
 	Globe,
 	LoaderCircle,
 	Plus,
@@ -17,6 +18,7 @@ import {
 	useRef,
 	useState,
 } from "react";
+import { BranchPickerPopover } from "@/components/branch-picker";
 import { TrafficLightSpacer } from "@/components/chrome/traffic-light-spacer";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -89,6 +91,20 @@ function getGroupGapSize(previousHasRows: boolean, nextHasRows: boolean) {
 	return previousHasRows && nextHasRows ? GROUP_GAP : EMPTY_GROUP_GAP;
 }
 
+function orderBranchesWithDefaultFirst(
+	branches: string[],
+	defaultBranch: string,
+): string[] {
+	const seen = new Set<string>();
+	const ordered = [defaultBranch, ...branches].filter((branch) => {
+		if (seen.has(branch)) return false;
+		seen.add(branch);
+		return true;
+	});
+
+	return ordered;
+}
+
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
@@ -113,6 +129,7 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 	onSelectWorkspace,
 	onPrefetchWorkspace,
 	onCreateWorkspace,
+	onFetchRepositoryBranches,
 	onArchiveWorkspace,
 	onMarkWorkspaceUnread,
 	onRestoreWorkspace,
@@ -145,7 +162,8 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 	}) => Promise<void>;
 	onSelectWorkspace?: (workspaceId: string) => void;
 	onPrefetchWorkspace?: (workspaceId: string) => void;
-	onCreateWorkspace?: (repoId: string) => void;
+	onCreateWorkspace?: (repoId: string, baseBranch?: string) => void;
+	onFetchRepositoryBranches?: (repoId: string) => Promise<string[]>;
 	onArchiveWorkspace?: (workspaceId: string) => void;
 	onMarkWorkspaceUnread?: (workspaceId: string) => void;
 	onRestoreWorkspace?: (workspaceId: string) => void;
@@ -159,6 +177,12 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 }) {
 	const [isRepoPickerOpen, setIsRepoPickerOpen] = useState(false);
 	const [isAddRepositoryMenuOpen, setIsAddRepositoryMenuOpen] = useState(false);
+	const [repositoryBranches, setRepositoryBranches] = useState<
+		Record<string, string[]>
+	>({});
+	const [loadingBranchesRepoId, setLoadingBranchesRepoId] = useState<
+		string | null
+	>(null);
 	const scrollContainerRef = useRef<HTMLDivElement>(null);
 	const repoCommandListRef = useRef<HTMLDivElement | null>(null);
 	const [sectionOpenState, setSectionOpenState] = useState(() => ({
@@ -355,6 +379,38 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 	const createBusy = Boolean(creatingWorkspaceRepoId);
 	const addRepositoryBusy = Boolean(addingRepository);
 	const repositories = availableRepositories ?? [];
+
+	const loadRepositoryBranches = useCallback(
+		(repository: RepositoryCreateOption) => {
+			if (!onFetchRepositoryBranches || repositoryBranches[repository.id]) {
+				return;
+			}
+
+			setLoadingBranchesRepoId(repository.id);
+			void onFetchRepositoryBranches(repository.id)
+				.then((branches) => {
+					setRepositoryBranches((current) => ({
+						...current,
+						[repository.id]: orderBranchesWithDefaultFirst(
+							branches,
+							repository.defaultBranch ?? "main",
+						),
+					}));
+				})
+				.catch(() => {
+					setRepositoryBranches((current) => ({
+						...current,
+						[repository.id]: [repository.defaultBranch ?? "main"],
+					}));
+				})
+				.finally(() => {
+					setLoadingBranchesRepoId((current) =>
+						current === repository.id ? null : current,
+					);
+				});
+		},
+		[onFetchRepositoryBranches, repositoryBranches],
+	);
 
 	useEffect(() => {
 		const handleOpenNewWorkspace = () => {
@@ -703,10 +759,47 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 												</span>
 											</div>
 											{repository.defaultBranch ? (
-												<span className="shrink-0 text-right whitespace-nowrap text-xs text-muted-foreground">
-													{repository.remote ?? "origin"}/
-													{repository.defaultBranch.toLowerCase()}
-												</span>
+												<div
+													className="shrink-0"
+													onPointerDown={(event) => event.stopPropagation()}
+													onClick={(event) => event.stopPropagation()}
+													onKeyDown={(event) => event.stopPropagation()}
+												>
+													<BranchPickerPopover
+														currentBranch={repository.defaultBranch}
+														branches={
+															repositoryBranches[repository.id] ?? [
+																repository.defaultBranch,
+															]
+														}
+														loading={loadingBranchesRepoId === repository.id}
+														align="end"
+														onOpen={() => loadRepositoryBranches(repository)}
+														onSelect={(branch) => {
+															setIsRepoPickerOpen(false);
+															onCreateWorkspace?.(repository.id, branch);
+														}}
+													>
+														<button
+															type="button"
+															className="inline-flex max-w-40 cursor-pointer items-center gap-1 rounded-md px-1.5 py-1 text-right text-xs text-muted-foreground hover:bg-accent hover:text-foreground"
+															aria-label={`Create ${repository.name} workspace from branch`}
+														>
+															<GitBranch
+																className="size-3 shrink-0"
+																strokeWidth={1.8}
+															/>
+															<span className="truncate">
+																{repository.remote ?? "origin"}/
+																{repository.defaultBranch.toLowerCase()}
+															</span>
+															<ChevronRight
+																className="size-3 shrink-0"
+																strokeWidth={2}
+															/>
+														</button>
+													</BranchPickerPopover>
+												</div>
 											) : null}
 										</div>
 									</CommandItem>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -444,6 +444,7 @@ export type PrepareWorkspaceResponse = {
 	directoryName: string;
 	branch: string;
 	defaultBranch: string;
+	baseBranch?: string;
 	state: WorkspaceState;
 	repoScripts: RepoScripts;
 };
@@ -1803,9 +1804,11 @@ export async function updateSessionSettings(
 
 export async function createWorkspaceFromRepo(
 	repoId: string,
+	baseBranch?: string,
 ): Promise<CreateWorkspaceResponse> {
 	return invoke<CreateWorkspaceResponse>("create_workspace_from_repo", {
 		repoId,
+		baseBranch: baseBranch ?? null,
 	});
 }
 
@@ -1818,9 +1821,11 @@ export async function createWorkspaceFromRepo(
  */
 export async function prepareWorkspaceFromRepo(
 	repoId: string,
+	baseBranch?: string,
 ): Promise<PrepareWorkspaceResponse> {
 	return invoke<PrepareWorkspaceResponse>("prepare_workspace_from_repo", {
 		repoId,
+		baseBranch: baseBranch ?? null,
 	});
 }
 


### PR DESCRIPTION
## Summary

Allow users to create a new workspace from a selected remote branch instead of always using the repository default branch.

## Changes
- Add an optional base branch parameter to workspace creation across the Tauri commands, service facade, CLI, and MCP tool.
- Store the selected base branch as the workspace initialization parent and intended target so sync behavior follows the chosen branch.
- Normalize remote-prefixed base inputs like `origin/develop` before creating the worktree.
- Add a branch picker to the new-workspace repository picker, keeping the repository default branch first while preserving row-click creation from the default.
- Add a patch Changesets entry for the new workspace creation flow.
- Clean up existing Rust format strings that tripped `clippy::uninlined_format_args` under the repository pre-commit hook.

## Testing
- `bun run typecheck`
- `bun run test:frontend -- src/features/navigation/index.test.tsx`
- `bun run test:frontend -- src/features/navigation/hooks/use-controller.test.tsx`
- `cd src-tauri && RUSTC_WRAPPER= cargo test create_workspace_from_repo_`
- `cd src-tauri && cargo fmt --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
- `bunx biome check src/features/navigation/index.tsx src/features/navigation/index.test.tsx src/features/navigation/container.tsx src/features/navigation/hooks/use-controller.ts src/lib/api.ts --config-path=./biome.json`
- `git diff --check`
- Pre-commit hook: Biome, `cargo fmt`, and `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
