### PR TITLE
fix: limit marketing Vercel deploy triggers

### DIFF
--- a/apps/marketing/vercel.json
+++ b/apps/marketing/vercel.json
@@ -1,4 +1,5 @@
 {
 	"$schema": "https://openapi.vercel.sh/vercel.json",
-	"framework": "nextjs"
+	"framework": "nextjs",
+	"ignoreCommand": "git diff --quiet HEAD^ HEAD -- ':(top)apps/marketing'"
 }


### PR DESCRIPTION
## What changed
- Added a Vercel `ignoreCommand` for `apps/marketing` so deployments only proceed when the marketing app changes.

## Why
- Avoids unnecessary marketing-site Vercel builds for commits that do not touch `apps/marketing`.

## Test notes
- Pre-commit hook ran `biome check --write --error-on-warnings --no-errors-on-unmatched --files-ignore-unknown=true --config-path=./biome.json` on the staged JSON file and passed.
- No full test suite run; config-only change.