### PR TITLE
chore: add GitHub sponsors funding config

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+github:
+  - dohooo
+  - natllian


### PR DESCRIPTION
## What changed
- Added a GitHub Funding configuration for project sponsor links.
- Listed the GitHub Sponsors accounts for dohooo and natllian.

## Why
- Enables GitHub to surface sponsorship links from the repository UI.

## Follow-up / test notes
- No runtime tests were run; this is a repository metadata-only change.