### PR TITLE
chore: normalize funding configuration

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,1 @@
-github:
-  - dohooo
-  - natllian
+github: [dohooo, natllian]


### PR DESCRIPTION
## What changed
- Converted the GitHub Sponsors list in `.github/FUNDING.yml` to inline array syntax.

## Why
- Keeps the funding configuration compact while preserving the same sponsor entries.

## Follow-up / tests
- No runtime tests run; this is a GitHub metadata-only YAML formatting change.