### PR TITLE
fix(pull): stash + merge + pop instead of prompting agent to commit/push

### DIFF
--- a/.changeset/pull-stash-and-merge.md
+++ b/.changeset/pull-stash-and-merge.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Pull now mechanically stashes uncommitted work, fast-forwards from the target branch, and re-applies the stash — instead of asking the agent to commit and push for you. Only an actual merge conflict (or a stash-pop conflict) hands off to the agent, with a narrower prompt that no longer prescribes commit/push.

--- a/src-tauri/src/commands/tests/branch_switch.rs
+++ b/src-tauri/src/commands/tests/branch_switch.rs
@@ -356,30 +356,94 @@ fn sync_workspace_target_branch_reports_conflict() {
 }
 
 #[test]
-fn sync_workspace_target_branch_reports_dirty_worktree_without_error() {
+fn sync_workspace_target_branch_dirty_unrelated_change_pulls_and_preserves_dirty() {
     let _guard = TEST_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     let harness = BranchSwitchTestHarness::new();
-    harness.dirty_tracked_file();
+    harness.dirty_tracked_file(); // README.md = "user edits"
     harness.upstream_advance("main", "main2.txt", "fresh", "advance main");
 
     let result = workspaces::sync_workspace_with_target_branch(&harness.workspace_id).unwrap();
 
     assert_eq!(
         result.outcome,
-        workspaces::SyncWorkspaceTargetOutcome::DirtyWorktree
+        workspaces::SyncWorkspaceTargetOutcome::Updated
     );
     assert!(result.conflicted_files.is_empty());
+    let merged = fs::read_to_string(harness.workspace_dir().join("main2.txt")).unwrap();
+    assert_eq!(merged, "fresh", "target's commit must land in workspace");
+    let dirty_readme = fs::read_to_string(harness.workspace_dir().join("README.md")).unwrap();
     assert_eq!(
-        harness.workspace_head(),
-        harness.workspace_remote_ref_sha("main")
+        dirty_readme, "user edits",
+        "uncommitted edits must survive the stash + merge + pop dance"
     );
     let status =
         git_ops::workspace_action_status(&harness.workspace_dir(), Some("origin"), Some("main"))
             .unwrap();
     assert_eq!(status.conflict_count, 0);
-    assert_eq!(status.uncommitted_count, 1);
+    assert_eq!(
+        status.uncommitted_count, 1,
+        "dirty README.md should remain uncommitted after pull"
+    );
+}
+
+#[test]
+fn sync_workspace_target_branch_dirty_with_overlapping_change_returns_conflict() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let harness = BranchSwitchTestHarness::new();
+    // Workspace HEAD diverges (committed change) AND has uncommitted edits.
+    harness.commit_in_workspace("README.md", "workspace change", "workspace change");
+    harness.add_untracked_file();
+    harness.upstream_advance("main", "README.md", "upstream change", "advance readme");
+
+    let result = workspaces::sync_workspace_with_target_branch(&harness.workspace_id).unwrap();
+
+    assert_eq!(
+        result.outcome,
+        workspaces::SyncWorkspaceTargetOutcome::Conflict
+    );
+    assert_eq!(result.conflicted_files, vec!["README.md".to_string()]);
+    // Preflight catches the conflict before we touch the worktree, so the
+    // user's untracked scratchpad must still be there.
+    assert!(harness.workspace_dir().join("scratch.txt").exists());
+    let status =
+        git_ops::workspace_action_status(&harness.workspace_dir(), Some("origin"), Some("main"))
+            .unwrap();
+    assert_eq!(
+        status.conflict_count, 0,
+        "preflight conflicts must not dirty the real workspace"
+    );
+}
+
+#[test]
+fn sync_workspace_target_branch_stash_pop_conflict_reports_outcome() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let harness = BranchSwitchTestHarness::new();
+    // HEAD is clean (preflight will be clean), but the worktree has
+    // uncommitted edits to README.md and the upstream commits a competing
+    // change to the same file. Pop will conflict after merge succeeds.
+    harness.dirty_tracked_file(); // README.md = "user edits" (uncommitted)
+    harness.upstream_advance("main", "README.md", "upstream rewrite", "rewrite readme");
+
+    let result = workspaces::sync_workspace_with_target_branch(&harness.workspace_id).unwrap();
+
+    assert_eq!(
+        result.outcome,
+        workspaces::SyncWorkspaceTargetOutcome::StashPopConflict
+    );
+    assert!(result.conflicted_files.is_empty());
+    let status =
+        git_ops::workspace_action_status(&harness.workspace_dir(), Some("origin"), Some("main"))
+            .unwrap();
+    assert!(
+        status.conflict_count > 0,
+        "stash pop conflict should leave unmerged paths in the worktree"
+    );
 }
 
 #[test]

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -1049,6 +1049,57 @@ pub fn abort_merge(workspace_dir: &Path) -> Result<()> {
         .with_context(|| format!("Failed to abort merge in {workspace_dir}"))
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StashPopOutcome {
+    Clean,
+    Conflict,
+}
+
+/// Push a stash entry that captures both tracked changes and untracked files.
+/// Returns `true` when a new stash entry was created, `false` if there was
+/// nothing to save.
+pub fn stash_push_include_untracked(workspace_dir: &Path, message: &str) -> Result<bool> {
+    let workspace_dir_arg = workspace_dir.display().to_string();
+    let output = run_git(
+        [
+            "-C",
+            workspace_dir_arg.as_str(),
+            "stash",
+            "push",
+            "--include-untracked",
+            "-m",
+            message,
+        ],
+        None,
+    )
+    .with_context(|| format!("Failed to git stash push in {}", workspace_dir.display()))?;
+    Ok(!output.contains("No local changes to save"))
+}
+
+/// Pop the most recent stash entry. Conflicts during pop leave the stash
+/// entry intact (git's default), so the caller / agent can retry.
+pub fn stash_pop(workspace_dir: &Path) -> Result<StashPopOutcome> {
+    let workspace_dir_arg = workspace_dir.display().to_string();
+    let output = Command::new("git")
+        .args(["-C", workspace_dir_arg.as_str(), "stash", "pop"])
+        .output()
+        .with_context(|| format!("Failed to git stash pop in {}", workspace_dir.display()))?;
+    if output.status.success() {
+        return Ok(StashPopOutcome::Clean);
+    }
+    let unmerged =
+        run_git(["-C", workspace_dir_arg.as_str(), "ls-files", "-u"], None).unwrap_or_default();
+    if unmerged.trim().is_empty() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!(
+            "git stash pop failed in {}: {}",
+            workspace_dir.display(),
+            stderr.trim()
+        );
+    }
+    Ok(StashPopOutcome::Conflict)
+}
+
 pub fn preflight_merge_ref(workspace_dir: &Path, target_ref: &str) -> Result<MergePreflightResult> {
     let head_sha = current_workspace_head_commit(workspace_dir)?;
     let preflight_dir =

--- a/src-tauri/src/workspace/branching.rs
+++ b/src-tauri/src/workspace/branching.rs
@@ -326,7 +326,8 @@ pub enum SyncWorkspaceTargetOutcome {
     Updated,
     AlreadyUpToDate,
     Conflict,
-    DirtyWorktree,
+    /// Merge succeeded but restoring the user's stashed work hit conflicts.
+    StashPopConflict,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -427,6 +428,7 @@ pub fn sync_workspace_with_target_branch(
 
     let current_status =
         git_ops::workspace_action_status(&workspace_dir, Some(&remote), Some(&target_branch))?;
+    // Pre-existing in-progress merge — let the user/agent resolve before we touch it.
     if current_status.conflict_count > 0 {
         return Ok(SyncWorkspaceTargetResponse {
             outcome: SyncWorkspaceTargetOutcome::Conflict,
@@ -434,19 +436,11 @@ pub fn sync_workspace_with_target_branch(
             conflicted_files: Vec::new(),
         });
     }
-    if current_status.uncommitted_count > 0 {
-        return Ok(SyncWorkspaceTargetResponse {
-            outcome: SyncWorkspaceTargetOutcome::DirtyWorktree,
-            target_branch,
-            conflicted_files: Vec::new(),
-        });
-    }
+    let dirty = current_status.uncommitted_count > 0;
 
     git_ops::fetch_remote_branch(&workspace_dir, &remote, &target_branch)?;
-    let behind_count = git_ops::commits_behind(
-        &workspace_dir,
-        &format!("refs/remotes/{remote}/{target_branch}"),
-    )?;
+    let target_remote_ref = format!("refs/remotes/{remote}/{target_branch}");
+    let behind_count = git_ops::commits_behind(&workspace_dir, &target_remote_ref)?;
     if behind_count == 0 {
         return Ok(SyncWorkspaceTargetResponse {
             outcome: SyncWorkspaceTargetOutcome::AlreadyUpToDate,
@@ -455,10 +449,11 @@ pub fn sync_workspace_with_target_branch(
         });
     }
 
-    let preflight = git_ops::preflight_merge_ref(
-        &workspace_dir,
-        &format!("refs/remotes/{remote}/{target_branch}"),
-    )?;
+    // Preflight in a temp worktree against HEAD only — dirty work isn't
+    // visible there, so a clean preflight doesn't guarantee a clean stash
+    // pop. We still gate on it to catch HEAD-vs-target conflicts cheaply
+    // before touching the user's worktree.
+    let preflight = git_ops::preflight_merge_ref(&workspace_dir, &target_remote_ref)?;
     if !preflight.conflicted_files.is_empty() {
         return Ok(SyncWorkspaceTargetResponse {
             outcome: SyncWorkspaceTargetOutcome::Conflict,
@@ -467,33 +462,67 @@ pub fn sync_workspace_with_target_branch(
         });
     }
 
-    match git_ops::merge_ref_no_edit(
-        &workspace_dir,
-        &format!("refs/remotes/{remote}/{target_branch}"),
-    ) {
-        Ok(()) => Ok(SyncWorkspaceTargetResponse {
-            outcome: SyncWorkspaceTargetOutcome::Updated,
-            target_branch,
-            conflicted_files: Vec::new(),
-        }),
-        Err(error) => {
-            let merge_status = git_ops::workspace_action_status(
-                &workspace_dir,
-                Some(&remote),
-                Some(&target_branch),
-            )?;
-            if merge_status.conflict_count > 0 {
-                let _ = git_ops::abort_merge(&workspace_dir);
-                Ok(SyncWorkspaceTargetResponse {
-                    outcome: SyncWorkspaceTargetOutcome::Conflict,
+    let stash_message = format!("helmor-sync-{workspace_id}");
+    let stashed = if dirty {
+        git_ops::stash_push_include_untracked(&workspace_dir, &stash_message)?
+    } else {
+        false
+    };
+
+    if let Err(error) = git_ops::merge_ref_no_edit(&workspace_dir, &target_remote_ref) {
+        let merge_status =
+            git_ops::workspace_action_status(&workspace_dir, Some(&remote), Some(&target_branch))?;
+        let merge_conflict = merge_status.conflict_count > 0;
+        if merge_conflict {
+            let _ = git_ops::abort_merge(&workspace_dir);
+        }
+        if stashed {
+            // Best-effort restore of the user's work. If this somehow fails
+            // the stash entry is preserved on the stack for manual recovery.
+            match git_ops::stash_pop(&workspace_dir) {
+                Ok(git_ops::StashPopOutcome::Clean) => {}
+                Ok(git_ops::StashPopOutcome::Conflict) => {
+                    tracing::warn!(
+                        workspace_id,
+                        "stash pop hit conflicts on merge-error path; worktree has unmerged paths"
+                    );
+                }
+                Err(pop_error) => {
+                    tracing::warn!(
+                        workspace_id,
+                        "stash pop failed on merge-error path; stash preserved for manual recovery: {pop_error:#}"
+                    );
+                }
+            }
+        }
+        if merge_conflict {
+            return Ok(SyncWorkspaceTargetResponse {
+                outcome: SyncWorkspaceTargetOutcome::Conflict,
+                target_branch,
+                conflicted_files: Vec::new(),
+            });
+        }
+        return Err(error);
+    }
+
+    if stashed {
+        match git_ops::stash_pop(&workspace_dir)? {
+            git_ops::StashPopOutcome::Clean => {}
+            git_ops::StashPopOutcome::Conflict => {
+                return Ok(SyncWorkspaceTargetResponse {
+                    outcome: SyncWorkspaceTargetOutcome::StashPopConflict,
                     target_branch,
                     conflicted_files: Vec::new(),
-                })
-            } else {
-                Err(error)
+                });
             }
         }
     }
+
+    Ok(SyncWorkspaceTargetResponse {
+        outcome: SyncWorkspaceTargetOutcome::Updated,
+        target_branch,
+        conflicted_files: Vec::new(),
+    })
 }
 
 pub fn push_workspace_to_remote(workspace_id: &str) -> Result<PushWorkspaceToRemoteResponse> {

--- a/src/features/inspector/index.test.tsx
+++ b/src/features/inspector/index.test.tsx
@@ -214,11 +214,11 @@ describe("WorkspaceInspectorSidebar Actions section", () => {
 		});
 	});
 
-	it("queues the pull task into the current chat when the worktree is dirty", async () => {
+	it("queues a narrow stash-pop-conflict prompt when restoring stashed work fails", async () => {
 		const user = userEvent.setup();
 		const onQueuePendingPromptForSession = vi.fn();
 		apiMocks.syncWorkspaceWithTargetBranch.mockResolvedValue({
-			outcome: "dirtyWorktree",
+			outcome: "stashPopConflict",
 			targetBranch: "main",
 			conflictedFiles: [],
 		});
@@ -239,7 +239,7 @@ describe("WorkspaceInspectorSidebar Actions section", () => {
 			expect(onQueuePendingPromptForSession).toHaveBeenCalledWith({
 				sessionId: "session-1",
 				prompt:
-					"Commit uncommitted changes, then merge testuser/main into this branch. Then push.",
+					"Resolve the conflicts from restoring the stashed uncommitted work in this branch. Don't commit. Don't push.",
 				forceQueue: true,
 			});
 		});
@@ -269,7 +269,8 @@ describe("WorkspaceInspectorSidebar Actions section", () => {
 		await waitFor(() => {
 			expect(onQueuePendingPromptForSession).toHaveBeenCalledWith({
 				sessionId: "session-1",
-				prompt: "Merge testuser/main into this branch. Then push.",
+				prompt:
+					"Bring this branch up to date with testuser/main. Resolve any conflicts. Preserve any uncommitted work. Don't push.",
 				forceQueue: true,
 			});
 		});
@@ -302,7 +303,8 @@ describe("WorkspaceInspectorSidebar Actions section", () => {
 		await waitFor(() => {
 			expect(onQueuePendingPromptForSession).toHaveBeenCalledWith({
 				sessionId: "session-1",
-				prompt: "Merge Origin/testuser/testing into this branch. Then push.",
+				prompt:
+					"Bring this branch up to date with Origin/testuser/testing. Resolve any conflicts. Preserve any uncommitted work. Don't push.",
 				forceQueue: true,
 			});
 		});

--- a/src/features/inspector/sections/actions.tsx
+++ b/src/features/inspector/sections/actions.tsx
@@ -138,7 +138,10 @@ function buildSyncResolutionPrompt(
 		key: "resolveConflicts",
 		repoPreferences,
 		targetRef,
-		dirtyWorktree: result.outcome === "dirtyWorktree",
+		resolveConflictsKind:
+			result.outcome === "stashPopConflict"
+				? "stashPopConflict"
+				: "mergeConflict",
 	});
 }
 
@@ -230,9 +233,9 @@ export function ActionsSection({
 				toast.success(`Pulled latest from ${target}`);
 			} else if (result.outcome === "alreadyUpToDate") {
 				toast(`Already up to date with ${target}`);
-			} else if (result.outcome === "conflict") {
-				await queueSyncResolutionPrompt(result);
 			} else {
+				// conflict or stashPopConflict — both hand off to the agent
+				// with a kind-specific narrow prompt.
 				await queueSyncResolutionPrompt(result);
 			}
 		} catch (error) {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1529,7 +1529,7 @@ export type SyncWorkspaceTargetOutcome =
 	| "updated"
 	| "alreadyUpToDate"
 	| "conflict"
-	| "dirtyWorktree";
+	| "stashPopConflict";
 
 export type SyncWorkspaceTargetResponse = {
 	outcome: SyncWorkspaceTargetOutcome;

--- a/src/lib/repo-preferences-prompts.test.ts
+++ b/src/lib/repo-preferences-prompts.test.ts
@@ -25,7 +25,6 @@ const GITLAB_FORGE: ForgeDetection = {
 
 describe("repo preference prompts", () => {
 	const targetRefPlaceholder = "$" + "{TARGET_REF}";
-	const dirtyWorktreePlaceholder = "$" + "{DIRTY_WORKTREE}";
 
 	it("leaves the general preview empty when no override exists", () => {
 		expect(resolveRepoPreferencePreview("general", {})).toBe("");
@@ -93,16 +92,28 @@ describe("repo preference prompts", () => {
 		expect(prompt).toContain("`glab ci list` / `glab ci view`");
 	});
 
-	it("renders the dynamic resolve-conflicts fallback", () => {
+	it("renders the intent-only resolve-conflicts prompt for merge conflicts", () => {
 		expect(
 			resolveRepoPreferencePrompt({
 				key: "resolveConflicts",
 				repoPreferences: {},
 				targetRef: "origin/main",
-				dirtyWorktree: true,
 			}),
 		).toBe(
-			"Commit uncommitted changes, then merge origin/main into this branch. Then push.",
+			"Bring this branch up to date with origin/main. Resolve any conflicts. Preserve any uncommitted work. Don't push.",
+		);
+	});
+
+	it("renders a narrow prompt for stash-pop conflicts", () => {
+		expect(
+			resolveRepoPreferencePrompt({
+				key: "resolveConflicts",
+				repoPreferences: {},
+				targetRef: "origin/main",
+				resolveConflictsKind: "stashPopConflict",
+			}),
+		).toBe(
+			"Resolve the conflicts from restoring the stashed uncommitted work in this branch. Don't commit. Don't push.",
 		);
 	});
 
@@ -137,18 +148,17 @@ describe("repo preference prompts", () => {
 		);
 	});
 
-	it("appends resolve-conflicts overrides after the dynamic fallback", () => {
+	it("appends resolve-conflicts overrides after the intent-only prompt", () => {
 		expect(
 			resolveRepoPreferencePrompt({
 				key: "resolveConflicts",
 				repoPreferences: {
-					resolveConflicts: `Prefer rebase when possible. Target: ${targetRefPlaceholder}. Dirty: ${dirtyWorktreePlaceholder}.`,
+					resolveConflicts: `Prefer rebase when possible. Target: ${targetRefPlaceholder}.`,
 				},
 				targetRef: "origin/main",
-				dirtyWorktree: true,
 			}),
 		).toBe(
-			"Commit uncommitted changes, then merge origin/main into this branch. Then push.\n\nIMPORTANT: The following are the user's custom preferences. These preferences take precedence over any default guidelines or instructions provided above. When there is a conflict, always follow the user's preferences.\n\n### User Preferences\n\nPrefer rebase when possible. Target: origin/main. Dirty: true.",
+			"Bring this branch up to date with origin/main. Resolve any conflicts. Preserve any uncommitted work. Don't push.\n\nIMPORTANT: The following are the user's custom preferences. These preferences take precedence over any default guidelines or instructions provided above. When there is a conflict, always follow the user's preferences.\n\n### User Preferences\n\nPrefer rebase when possible. Target: origin/main.",
 		);
 	});
 

--- a/src/lib/repo-preferences-prompts.ts
+++ b/src/lib/repo-preferences-prompts.ts
@@ -5,7 +5,6 @@ import {
 } from "@/lib/forge-dialect";
 
 const TARGET_REF_PLACEHOLDER = "$" + "{TARGET_REF}";
-const DIRTY_WORKTREE_PLACEHOLDER = "$" + "{DIRTY_WORKTREE}";
 
 export type RepoPreferenceKey =
 	| "createPr"
@@ -14,12 +13,17 @@ export type RepoPreferenceKey =
 	| "branchRename"
 	| "general";
 
+/** Which conflict path is being prompted. `mergeConflict` is the default
+ *  (target ↔ HEAD conflict). `stashPopConflict` fires only when Helmor
+ *  successfully merged but couldn't restore the user's stashed work cleanly. */
+export type ResolveConflictsKind = "mergeConflict" | "stashPopConflict";
+
 type ResolveRepoPreferencePromptArgs = {
 	key: RepoPreferenceKey;
 	repoPreferences?: RepoPreferences | null;
 	targetBranch?: string | null;
 	targetRef?: string | null;
-	dirtyWorktree?: boolean;
+	resolveConflictsKind?: ResolveConflictsKind;
 	forge?: ForgeDetection | null;
 	/** Git remote name for this workspace (e.g. "origin"). Falls back to
 	 *  "origin" when unknown — matches the default git produces for a
@@ -109,16 +113,16 @@ Do the following, in order:
 function resolveConflictsPrompt({
 	targetBranch,
 	targetRef,
-	dirtyWorktree,
+	resolveConflictsKind,
 	remote,
 }: Pick<
 	ResolveRepoPreferencePromptArgs,
-	"targetBranch" | "targetRef" | "dirtyWorktree" | "remote"
+	"targetBranch" | "targetRef" | "resolveConflictsKind" | "remote"
 >): string {
 	if (targetRef) {
-		return dirtyWorktree
-			? `Commit uncommitted changes, then merge ${targetRef} into this branch. Then push.`
-			: `Merge ${targetRef} into this branch. Then push.`;
+		return resolveConflictsKind === "stashPopConflict"
+			? `Resolve the conflicts from restoring the stashed uncommitted work in this branch. Don't commit. Don't push.`
+			: `Bring this branch up to date with ${targetRef}. Resolve any conflicts. Preserve any uncommitted work. Don't push.`;
 	}
 
 	const branch = requireTargetBranch("resolveConflicts", targetBranch);
@@ -219,7 +223,7 @@ export function resolveRepoPreferencePrompt({
 	repoPreferences,
 	targetBranch,
 	targetRef,
-	dirtyWorktree = false,
+	resolveConflictsKind = "mergeConflict",
 	forge,
 	remote,
 }: ResolveRepoPreferencePromptArgs): string {
@@ -227,12 +231,7 @@ export function resolveRepoPreferencePrompt({
 	const targetPlaceholderValue = targetRef ?? targetBranch ?? null;
 	const resolvedOverride =
 		key === "resolveConflicts" && targetPlaceholderValue && override
-			? override
-					.replaceAll(TARGET_REF_PLACEHOLDER, targetPlaceholderValue)
-					.replaceAll(
-						DIRTY_WORKTREE_PLACEHOLDER,
-						dirtyWorktree ? "true" : "false",
-					)
+			? override.replaceAll(TARGET_REF_PLACEHOLDER, targetPlaceholderValue)
 			: override;
 
 	switch (key) {
@@ -241,7 +240,7 @@ export function resolveRepoPreferencePrompt({
 				resolveConflictsPrompt({
 					targetBranch,
 					targetRef,
-					dirtyWorktree,
+					resolveConflictsKind,
 					remote,
 				}),
 				resolvedOverride,


### PR DESCRIPTION
## Summary

Closes #304.

The Pull button used to bail with `DirtyWorktree` whenever the worktree had uncommitted changes, queueing a prompt that asked the agent to "commit uncommitted changes, then merge ... then push." That overstepped Pull's scope (commit message + push are user decisions) and prescribed a workflow.

Now Pull mechanically:

1. Stashes (`git stash push --include-untracked`) if dirty.
2. Fast-forwards from the target branch.
3. Pops the stash.

Only real conflicts hand off to the agent, with a narrower prompt that preserves uncommitted work and never pushes:

- **merge conflict** → `Bring this branch up to date with $TARGET. Resolve any conflicts. Preserve any uncommitted work. Don't push.`
- **stash-pop conflict** → `Resolve the conflicts from restoring the stashed uncommitted work in this branch. Don't commit. Don't push.`

Backend outcome `DirtyWorktree` is gone; new `StashPopConflict` covers the case where merge succeeded but restoring the user's stashed work conflicted. The `${DIRTY_WORKTREE}` template placeholder in user prompt overrides is also removed (it has no meaning in the new flow).

UI is unchanged — the Pull button itself looks identical, only the post-click behavior shifts.

## Test plan

- [x] `cargo test --lib sync_workspace_target_branch` — 6/6 pass, including 3 new cases:
  - `dirty_unrelated_change_pulls_and_preserves_dirty` (happy path: dirty + clean pull → Updated, dirty preserved)
  - `dirty_with_overlapping_change_returns_conflict` (preflight catches HEAD-vs-target conflict, worktree untouched)
  - `stash_pop_conflict_reports_outcome` (clean HEAD merges, but stash pop hits worktree conflict)
- [x] `bun x vitest run src/features/inspector/index.test.tsx src/lib/repo-preferences-prompts.test.ts` — 41/41 pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `bun run lint` clean
- [ ] Manual smoke: Pull on a dirty workspace that's behind main with no overlap → toast "Pulled latest from main", uncommitted work intact
- [ ] Manual smoke: Pull on a workspace with an overlapping HEAD-vs-target conflict → agent gets the merge-conflict prompt
- [ ] Manual smoke: Pull on a workspace where dirty edits overlap target's edits → agent gets the stash-pop-conflict prompt