### PR TITLE
chore: sync bun.lock configVersion field

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "helmor",


### PR DESCRIPTION
## Summary
- Adds the `configVersion: 0` field to `bun.lock` to align with the format Bun emits on newer versions.

## Why
- Without this field, `bun install` keeps rewriting the lockfile locally and producing noisy diffs across machines / CI. Pinning it explicitly stops the churn.

## Test plan
- [ ] `bun install` is a no-op against the lockfile (no spurious writes).
- [ ] `bun run typecheck` / `bun run lint` still pass.