### PR TITLE
fix(forge): pick an allowed merge method and surface the real failure reason

### DIFF
--- a/.changeset/pr-merge-method-fallback.md
+++ b/.changeset/pr-merge-method-fallback.md
@@ -1,0 +1,9 @@
+---
+"helmor": patch
+---
+
+Fix PR / MR merge failing because the merge call wasn't telling the server which method to use, and surface the actual server reason in the toast instead of a generic "merge failed."
+
+- GitHub: query the repo's allowed merge methods and pass `mergeMethod` (MERGE → SQUASH → REBASE) instead of relying on GitHub's default — fixes "Merge commits are not allowed on this repository."
+- GitLab: read the project's `squash_option` and pass `squash=true` when it's `always` or `default_on` — fixes "Squash commits is required for this project."
+- Toast errors from any Tauri command now include the full anyhow chain (e.g. `mergePullRequest failed: gh api graphql failed: <real reason>`), not just the outermost `.context(...)` label.

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -114,7 +114,10 @@ impl Serialize for CommandError {
 
 impl From<anyhow::Error> for CommandError {
     fn from(error: anyhow::Error) -> Self {
-        // Full chain goes to logs; user-facing message is just the outer context.
+        // Full chain goes to BOTH logs and the user-facing toast — the
+        // outermost `.context(...)` label is usually too generic to be
+        // actionable on its own (e.g. "mergePullRequest failed" hides
+        // the actual "Merge commits are not allowed" reason underneath).
         let code = extract_code(&error);
         if code == ErrorCode::ForgeOnboarding {
             tracing::warn!(
@@ -143,12 +146,22 @@ pub fn extract_code(err: &anyhow::Error) -> ErrorCode {
         .unwrap_or(ErrorCode::Unknown)
 }
 
-/// Outermost non-marker layer's `Display`. What the user sees in the toast.
+/// Full error chain rendered as `outer: middle: root`, with `CodedError`
+/// marker layers stripped out. This is what the user sees in the toast —
+/// the outer `.context(...)` label alone is usually too vague to act on
+/// (e.g. "mergePullRequest failed" hides "Merge commits are not allowed
+/// on this repository"), so we surface the whole chain.
 pub fn outermost_message(err: &anyhow::Error) -> String {
-    err.chain()
-        .find(|e| e.downcast_ref::<CodedError>().is_none())
+    let parts: Vec<String> = err
+        .chain()
+        .filter(|e| e.downcast_ref::<CodedError>().is_none())
         .map(|e| e.to_string())
-        .unwrap_or_else(|| "Unknown error".into())
+        .collect();
+    if parts.is_empty() {
+        "Unknown error".into()
+    } else {
+        parts.join(": ")
+    }
 }
 
 #[cfg(test)]
@@ -156,12 +169,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn coded_then_context_is_found_in_chain() {
+    fn coded_then_context_joins_full_chain_skipping_marker() {
         let err: anyhow::Error = coded(ErrorCode::WorkspaceBroken)
             .context("outer message")
             .context("outermost");
         assert_eq!(extract_code(&err), ErrorCode::WorkspaceBroken);
-        assert_eq!(outermost_message(&err), "outermost");
+        // Marker is stripped; both context layers are joined.
+        assert_eq!(outermost_message(&err), "outermost: outer message");
     }
 
     #[test]
@@ -169,7 +183,25 @@ mod tests {
         let base: anyhow::Error = anyhow::anyhow!("io failed").context("while reading file");
         let tagged = base.with_code(ErrorCode::WorkspaceBroken);
         assert_eq!(extract_code(&tagged), ErrorCode::WorkspaceBroken);
-        assert_eq!(outermost_message(&tagged), "while reading file");
+        // The marker now sits at the outermost layer. Strip it and join
+        // the rest — the user sees the full causal chain.
+        assert_eq!(outermost_message(&tagged), "while reading file: io failed");
+    }
+
+    /// Mirrors the real merge-PR failure: the outer `.context(...)` is a
+    /// generic label and the actionable detail lives in inner layers.
+    /// Toast users need to see the full chain, not just "mergePullRequest
+    /// failed".
+    #[test]
+    fn surfaces_inner_cause_through_generic_outer_context() {
+        let inner = anyhow::anyhow!(
+            "`gh api graphql` failed: gh: Merge commits are not allowed on this repository."
+        );
+        let err = inner.context("mergePullRequest failed");
+        assert_eq!(
+            outermost_message(&err),
+            "mergePullRequest failed: `gh api graphql` failed: gh: Merge commits are not allowed on this repository."
+        );
     }
 
     #[test]

--- a/src-tauri/src/forge/github/mod.rs
+++ b/src-tauri/src/forge/github/mod.rs
@@ -151,7 +151,7 @@ pub fn merge_workspace_pr(workspace_id: &str) -> Result<Option<ChangeRequestInfo
     let Some(pr_node_id) = fetch_open_pr_node_id(&context)? else {
         bail!("Could not resolve PR node ID for #{}", pr.number);
     };
-    merge_pull_request(&context.login, &pr_node_id).context("mergePullRequest failed")?;
+    merge_pull_request(&context, &pr_node_id).context("mergePullRequest failed")?;
     lookup_workspace_pr(workspace_id)
 }
 

--- a/src-tauri/src/forge/github/pull_request.rs
+++ b/src-tauri/src/forge/github/pull_request.rs
@@ -3,7 +3,7 @@
 //! lives in `super::api`; this module owns the queries + result
 //! transformations.
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, bail, Context, Result};
 
 use crate::forge::ChangeRequestInfo;
 
@@ -37,10 +37,16 @@ query($owner: String!, $name: String!, $head: String!) {
 }
 "#;
 
-const MERGE_PR_MUTATION: &str = r#"
-mutation($prId: ID!) {
-  mergePullRequest(input: { pullRequestId: $prId }) {
-    pullRequest { url, number, state, title, merged }
+// Repo-level merge settings query. We pick a `mergeMethod` from these
+// flags before issuing the merge mutation — sending it without a
+// method would default to MERGE and fail on repos that disallow merge
+// commits ("Merge commits are not allowed on this repository.").
+const REPO_MERGE_METHODS_QUERY: &str = r#"
+query($owner: String!, $name: String!) {
+  repository(owner: $owner, name: $name) {
+    mergeCommitAllowed
+    squashMergeAllowed
+    rebaseMergeAllowed
   }
 }
 "#;
@@ -52,6 +58,48 @@ mutation($prId: ID!) {
   }
 }
 "#;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MergeMethod {
+    Merge,
+    Squash,
+    Rebase,
+}
+
+impl MergeMethod {
+    fn as_graphql(self) -> &'static str {
+        match self {
+            Self::Merge => "MERGE",
+            Self::Squash => "SQUASH",
+            Self::Rebase => "REBASE",
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct AllowedMergeMethods {
+    merge: bool,
+    squash: bool,
+    rebase: bool,
+}
+
+impl AllowedMergeMethods {
+    /// Pick the first allowed method in MERGE → SQUASH → REBASE order.
+    /// MERGE first matches the historical default (and what users
+    /// usually mean by "Merge"); the others are fallbacks for repos
+    /// that disable merge commits.
+    fn pick(self) -> Option<MergeMethod> {
+        if self.merge {
+            Some(MergeMethod::Merge)
+        } else if self.squash {
+            Some(MergeMethod::Squash)
+        } else if self.rebase {
+            Some(MergeMethod::Rebase)
+        } else {
+            None
+        }
+    }
+}
 
 /// Fetch the most-recent PR matching this context's `(owner, name, head)`.
 /// Returns `Ok(None)` when there's no matching PR, when the token has
@@ -139,8 +187,71 @@ pub(super) fn fetch_open_pr_node_id(context: &GithubContext) -> Result<Option<St
 }
 
 /// Run the `mergePullRequest` mutation for `pr_node_id`.
-pub(super) fn merge_pull_request(login: &str, pr_node_id: &str) -> Result<()> {
-    run_pr_mutation(login, MERGE_PR_MUTATION, pr_node_id)
+///
+/// Queries the repo's allowed merge methods first and picks one
+/// (MERGE → SQUASH → REBASE). Sending the mutation without an explicit
+/// `mergeMethod` defaults to MERGE and fails on repos that disallow
+/// merge commits.
+pub(super) fn merge_pull_request(context: &GithubContext, pr_node_id: &str) -> Result<()> {
+    let methods = fetch_allowed_merge_methods(context)
+        .context("Failed to query repository merge settings")?;
+    let Some(method) = methods.pick() else {
+        bail!("Repository does not allow any merge method (merge / squash / rebase all disabled)");
+    };
+    run_pr_mutation(&context.login, &merge_mutation_for(method), pr_node_id)
+}
+
+fn merge_mutation_for(method: MergeMethod) -> String {
+    format!(
+        r#"
+mutation($prId: ID!) {{
+  mergePullRequest(input: {{ pullRequestId: $prId, mergeMethod: {} }}) {{
+    pullRequest {{ url, number, state, title, merged }}
+  }}
+}}
+"#,
+        method.as_graphql()
+    )
+}
+
+fn fetch_allowed_merge_methods(context: &GithubContext) -> Result<AllowedMergeMethods> {
+    let parsed: serde_json::Value = match run_graphql_raw(
+        &context.login,
+        REPO_MERGE_METHODS_QUERY,
+        &[
+            ("owner", context.owner.as_str()),
+            ("name", context.name.as_str()),
+        ],
+    )? {
+        GraphqlOutcome::Auth => bail!("GitHub token was rejected"),
+        GraphqlOutcome::Ok(value) => value,
+    };
+    if let Some(errors) = parsed.get("errors").and_then(|v| v.as_array()) {
+        if !errors.is_empty() {
+            let msgs: Vec<&str> = errors
+                .iter()
+                .filter_map(|e| e.get("message").and_then(|m| m.as_str()))
+                .collect();
+            bail!("GraphQL query failed: {}", msgs.join("; "));
+        }
+    }
+    let repo = parsed
+        .pointer("/data/repository")
+        .ok_or_else(|| anyhow!("Repository missing from merge-methods response"))?;
+    Ok(AllowedMergeMethods {
+        merge: repo
+            .get("mergeCommitAllowed")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        squash: repo
+            .get("squashMergeAllowed")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        rebase: repo
+            .get("rebaseMergeAllowed")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+    })
 }
 
 /// Run the `closePullRequest` mutation for `pr_node_id`.
@@ -209,5 +320,49 @@ mod tests {
         let info = pr_info(make_node("CLOSED", false));
         assert_eq!(info.state, "CLOSED");
         assert!(!info.is_merged);
+    }
+
+    #[test]
+    fn pick_prefers_merge_when_available() {
+        let methods = AllowedMergeMethods {
+            merge: true,
+            squash: true,
+            rebase: true,
+        };
+        assert_eq!(methods.pick(), Some(MergeMethod::Merge));
+    }
+
+    /// The original bug: repo disallows merge commits, only squash is
+    /// on. Picker must fall back to SQUASH instead of failing.
+    #[test]
+    fn pick_falls_back_to_squash_when_merge_disabled() {
+        let methods = AllowedMergeMethods {
+            merge: false,
+            squash: true,
+            rebase: true,
+        };
+        assert_eq!(methods.pick(), Some(MergeMethod::Squash));
+    }
+
+    #[test]
+    fn pick_falls_back_to_rebase_when_only_rebase_allowed() {
+        let methods = AllowedMergeMethods {
+            merge: false,
+            squash: false,
+            rebase: true,
+        };
+        assert_eq!(methods.pick(), Some(MergeMethod::Rebase));
+    }
+
+    #[test]
+    fn pick_returns_none_when_all_disabled() {
+        assert_eq!(AllowedMergeMethods::default().pick(), None);
+    }
+
+    #[test]
+    fn merge_mutation_inlines_method_literal() {
+        let body = merge_mutation_for(MergeMethod::Squash);
+        assert!(body.contains("mergeMethod: SQUASH"));
+        assert!(body.contains("pullRequestId: $prId"));
     }
 }

--- a/src-tauri/src/forge/gitlab/merge_request.rs
+++ b/src-tauri/src/forge/gitlab/merge_request.rs
@@ -91,6 +91,76 @@ pub(super) fn gitlab_mr_state(state: &str) -> &'static str {
     }
 }
 
+/// What value (if any) we should send as `squash` on the merge API,
+/// derived from the project's `squash_option`.
+///
+/// GitLab refuses the merge if we send a value incompatible with the
+/// project setting (e.g. `squash=true` when the project is `"never"`,
+/// or omitting it on `"always"`). We can't override the project-level
+/// `merge_method` (merge / rebase_merge / ff) — that's enforced
+/// server-side without an API knob — so this is the only knob we tune.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SquashChoice {
+    /// Pass `squash=true`. Required for `"always"`; honors project
+    /// preference for `"default_on"`.
+    Squash,
+    /// Omit `squash` (server default = false). Right for `"never"`,
+    /// `"default_off"`, missing fields, or older GitLab without the flag.
+    Default,
+}
+
+impl SquashChoice {
+    fn for_option(option: Option<&str>) -> Self {
+        match option {
+            Some("always") | Some("default_on") => Self::Squash,
+            _ => Self::Default,
+        }
+    }
+}
+
+/// Best-effort: ask GitLab for the project's `squash_option` and map it
+/// to a `SquashChoice`. Any failure (network, auth, parse) degrades to
+/// `Default` with a warning log — we'd rather attempt the merge with no
+/// squash flag and let GitLab surface the real error than block the
+/// user on a project-info lookup.
+pub(super) fn determine_squash_choice(context: &GitlabContext) -> SquashChoice {
+    let endpoint = format!("projects/{}", encode_path_component(&context.full_path));
+    let output = match glab_api(&context.remote.host, [endpoint.as_str()]) {
+        Ok(output) => output,
+        Err(error) => {
+            tracing::warn!(
+                host = %context.remote.host,
+                full_path = %context.full_path,
+                error = %format!("{error:#}"),
+                "Failed to fetch GitLab project for squash_option; using default"
+            );
+            return SquashChoice::Default;
+        }
+    };
+    if !output.success {
+        tracing::warn!(
+            host = %context.remote.host,
+            full_path = %context.full_path,
+            detail = %command_detail(&output),
+            "GitLab project lookup unsuccessful; using default squash choice"
+        );
+        return SquashChoice::Default;
+    }
+    let value: serde_json::Value = match serde_json::from_str(&output.stdout) {
+        Ok(value) => value,
+        Err(error) => {
+            tracing::warn!(
+                host = %context.remote.host,
+                full_path = %context.full_path,
+                error = %format!("{error:#}"),
+                "Failed to parse GitLab project response; using default squash choice"
+            );
+            return SquashChoice::Default;
+        }
+    };
+    SquashChoice::for_option(value.get("squash_option").and_then(|v| v.as_str()))
+}
+
 /// Map GitLab's merge status to the same three-way enum GitHub's
 /// `mergeable` field uses (`MERGEABLE` / `CONFLICTING` / `UNKNOWN`).
 pub(super) fn gitlab_mergeable(mr: &GitlabMergeRequest) -> Option<String> {
@@ -138,6 +208,34 @@ mod tests {
             detailed_merge_status: detailed_merge_status.map(str::to_string),
             has_conflicts,
             head_pipeline: None,
+        }
+    }
+
+    #[test]
+    fn squash_choice_required_when_project_demands_it() {
+        // The original bug shape: project requires squash, we used to send
+        // no params and GitLab rejected.
+        assert_eq!(
+            SquashChoice::for_option(Some("always")),
+            SquashChoice::Squash
+        );
+    }
+
+    #[test]
+    fn squash_choice_honors_default_on_preference() {
+        assert_eq!(
+            SquashChoice::for_option(Some("default_on")),
+            SquashChoice::Squash
+        );
+    }
+
+    #[test]
+    fn squash_choice_omits_flag_when_forbidden_or_optional() {
+        // never  → sending true would be rejected; default false matches.
+        // default_off → user-overridable but server default is false.
+        // None / unknown → older GitLab or missing field; safest is default.
+        for option in [Some("never"), Some("default_off"), None, Some("garbled")] {
+            assert_eq!(SquashChoice::for_option(option), SquashChoice::Default);
         }
     }
 

--- a/src-tauri/src/forge/gitlab/mod.rs
+++ b/src-tauri/src/forge/gitlab/mod.rs
@@ -36,7 +36,9 @@ mod types;
 
 use self::api::{command_detail, encode_path_component, glab_api, looks_like_auth_error};
 use self::context::load_gitlab_context;
-use self::merge_request::{find_workspace_mr, gitlab_mergeable, mr_info};
+use self::merge_request::{
+    determine_squash_choice, find_workspace_mr, gitlab_mergeable, mr_info, SquashChoice,
+};
 use self::pipeline::{
     build_gitlab_check_insert_text, load_job_trace, load_pipeline_jobs, pipeline_item,
 };
@@ -276,7 +278,12 @@ pub(super) fn merge_workspace_mr(workspace_id: &str) -> Result<Option<ChangeRequ
         encode_path_component(&context.full_path),
         mr.iid
     );
-    let output = glab_api(&context.remote.host, ["--method", "PUT", endpoint.as_str()])?;
+    let squash = determine_squash_choice(&context);
+    let mut args: Vec<&str> = vec!["--method", "PUT", endpoint.as_str()];
+    if matches!(squash, SquashChoice::Squash) {
+        args.extend(["--field", "squash=true"]);
+    }
+    let output = glab_api(&context.remote.host, args)?;
     if !output.success {
         let detail = command_detail(&output);
         tracing::warn!(
@@ -284,6 +291,7 @@ pub(super) fn merge_workspace_mr(workspace_id: &str) -> Result<Option<ChangeRequ
             host = %context.remote.host,
             iid = mr.iid,
             detail = %detail,
+            squash = ?squash,
             "GitLab MR merge API failed"
         );
         bail!("GitLab MR merge failed: {detail}");


### PR DESCRIPTION
## Summary

Two related bugs and a UX gap that all show up when a user clicks "Merge" on a PR or MR:

- **GitHub** — we sent `mergePullRequest` without a `mergeMethod`, so GitHub defaulted to MERGE and rejected on repos that disallow merge commits ("Merge commits are not allowed on this repository."). Now we query `mergeCommitAllowed` / `squashMergeAllowed` / `rebaseMergeAllowed` first and pick MERGE → SQUASH → REBASE.
- **GitLab** — projects with `squash_option = "always"` rejected the merge because we never sent `squash=true`. Now we read the project's `squash_option` and pass `squash=true` when it's `always` or `default_on`. Best-effort: if the project lookup fails we fall through with no flag and let GitLab surface the real error rather than blocking the user.
- **Toast errors** — `outermost_message` only returned the outer `.context(...)` label, so users saw a useless "mergePullRequest failed" while the actionable detail ("Merge commits are not allowed…") was hidden in inner layers. The full anyhow chain (minus marker layers) is now joined and shown.

## Why

Helmor was unusable on any repo/project that didn't allow plain merge commits, and when it did fail the toast didn't tell you why. Fix both in one go.

## Test plan

- [x] `cargo test` (unit tests cover the picker fallback order, GitLab squash mapping, and full-chain error rendering).
- [x] `cargo clippy --all-targets -- -D warnings` (via pre-commit hook).
- [ ] Manual: merge a PR on a GitHub repo with merge commits disabled (squash-only) — should now succeed.
- [ ] Manual: merge an MR on a GitLab project with `squash_option = always` — should now succeed.
- [ ] Manual: trigger any forge-side rejection and confirm the toast surfaces the underlying reason.