### PR TITLE
Fix UI sync subscription cleanup

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -345,6 +345,7 @@ pub fn run() {
             commands::settings_commands::save_auto_close_opt_in_asked,
             global_hotkey::sync_global_hotkey,
             ui_sync::subscribe_ui_mutations,
+            ui_sync::unsubscribe_ui_mutations,
             commands::updater_commands::get_app_update_status,
             commands::updater_commands::check_for_app_update,
             commands::updater_commands::install_downloaded_app_update,

--- a/src-tauri/src/ui_sync/manager.rs
+++ b/src-tauri/src/ui_sync/manager.rs
@@ -6,7 +6,12 @@ use super::events::UiMutationEvent;
 
 #[derive(Default)]
 pub struct UiSyncManager {
-    subscribers: Mutex<Vec<Channel<UiMutationEvent>>>,
+    subscribers: Mutex<Vec<UiSyncSubscriber>>,
+}
+
+struct UiSyncSubscriber {
+    id: String,
+    channel: Channel<UiMutationEvent>,
 }
 
 impl UiSyncManager {
@@ -14,9 +19,16 @@ impl UiSyncManager {
         Self::default()
     }
 
-    pub fn subscribe(&self, channel: Channel<UiMutationEvent>) {
+    pub fn subscribe(&self, id: String, channel: Channel<UiMutationEvent>) {
         if let Ok(mut subscribers) = self.subscribers.lock() {
-            subscribers.push(channel);
+            subscribers.retain(|subscriber| subscriber.id != id);
+            subscribers.push(UiSyncSubscriber { id, channel });
+        }
+    }
+
+    pub fn unsubscribe(&self, id: &str) {
+        if let Ok(mut subscribers) = self.subscribers.lock() {
+            subscribers.retain(|subscriber| subscriber.id != id);
         }
     }
 
@@ -25,7 +37,7 @@ impl UiSyncManager {
             return;
         };
 
-        subscribers.retain(|channel| channel.send(event.clone()).is_ok());
+        subscribers.retain(|subscriber| subscriber.channel.send(event.clone()).is_ok());
     }
 
     #[cfg(test)]
@@ -48,6 +60,13 @@ mod tests {
     fn publish_with_no_subscribers_is_a_noop() {
         let manager = UiSyncManager::new();
         manager.publish(UiMutationEvent::WorkspaceListChanged);
+        assert_eq!(manager.subscriber_count(), 0);
+    }
+
+    #[test]
+    fn unsubscribe_missing_subscriber_is_a_noop() {
+        let manager = UiSyncManager::new();
+        manager.unsubscribe("missing");
         assert_eq!(manager.subscriber_count(), 0);
     }
 

--- a/src-tauri/src/ui_sync/mod.rs
+++ b/src-tauri/src/ui_sync/mod.rs
@@ -16,7 +16,13 @@ pub fn publish<R: Runtime>(app: &AppHandle<R>, event: UiMutationEvent) {
 #[tauri::command]
 pub fn subscribe_ui_mutations(
     manager: tauri::State<'_, UiSyncManager>,
+    subscription_id: String,
     on_event: Channel<UiMutationEvent>,
 ) {
-    manager.subscribe(on_event);
+    manager.subscribe(subscription_id, on_event);
+}
+
+#[tauri::command]
+pub fn unsubscribe_ui_mutations(manager: tauri::State<'_, UiSyncManager>, subscription_id: String) {
+    manager.unsubscribe(&subscription_id);
 }

--- a/src/features/composer/context-usage-ring/index.test.tsx
+++ b/src/features/composer/context-usage-ring/index.test.tsx
@@ -12,6 +12,7 @@ const apiMockState = vi.hoisted(() => ({
 	getSessionContextUsage: vi.fn(),
 	getLiveContextUsage: vi.fn(),
 	subscribeUiMutations: vi.fn(),
+	unlistenUiMutations: vi.fn(),
 	capturedCallback: null as null | ((event: unknown) => void),
 }));
 
@@ -69,11 +70,13 @@ describe("ContextUsageRing end-to-end with UI sync bridge", () => {
 		apiMockState.getSessionContextUsage.mockReset();
 		apiMockState.getLiveContextUsage.mockReset();
 		apiMockState.subscribeUiMutations.mockReset();
+		apiMockState.unlistenUiMutations.mockReset();
 		apiMockState.capturedCallback = null;
 
 		apiMockState.subscribeUiMutations.mockImplementation(
 			async (callback: (event: unknown) => void) => {
 				apiMockState.capturedCallback = callback;
+				return apiMockState.unlistenUiMutations;
 			},
 		);
 	});

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1130,11 +1130,16 @@ export async function listenGitRefsChanged(
 
 export async function subscribeUiMutations(
 	callback: (event: UiMutationEvent) => void,
-): Promise<void> {
+): Promise<UnlistenFn> {
 	const { Channel } = await import("@tauri-apps/api/core");
+	const subscriptionId = crypto.randomUUID();
 	const onEvent = new Channel<UiMutationEvent>();
 	onEvent.onmessage = callback;
-	await invoke("subscribe_ui_mutations", { onEvent });
+	await invoke("subscribe_ui_mutations", { subscriptionId, onEvent });
+	return () => {
+		onEvent.onmessage = () => {};
+		void invoke("unsubscribe_ui_mutations", { subscriptionId });
+	};
 }
 
 export type PrefetchRemoteRefsResponse = {

--- a/src/shell/hooks/use-ui-sync-bridge.test.tsx
+++ b/src/shell/hooks/use-ui-sync-bridge.test.tsx
@@ -7,6 +7,7 @@ import { useUiSyncBridge } from "./use-ui-sync-bridge";
 
 const apiMocks = vi.hoisted(() => ({
 	subscribeUiMutations: vi.fn(),
+	unlistenUiMutations: vi.fn(),
 }));
 
 let capturedSubscription: ((event: UiMutationEvent) => void) | null = null;
@@ -18,6 +19,7 @@ vi.mock("@/lib/api", async () => {
 		subscribeUiMutations: apiMocks.subscribeUiMutations.mockImplementation(
 			async (callback: (event: UiMutationEvent) => void) => {
 				capturedSubscription = callback;
+				return apiMocks.unlistenUiMutations;
 			},
 		),
 	};
@@ -33,6 +35,7 @@ describe("useUiSyncBridge", () => {
 	beforeEach(() => {
 		capturedSubscription = null;
 		apiMocks.subscribeUiMutations.mockClear();
+		apiMocks.unlistenUiMutations.mockClear();
 	});
 
 	it("invalidates the expected query families for workspace git state changes", async () => {
@@ -208,5 +211,25 @@ describe("useUiSyncBridge", () => {
 		await waitFor(() => {
 			expect(reloadSettings).toHaveBeenCalledOnce();
 		});
+	});
+
+	it("unsubscribes from backend mutations on unmount", async () => {
+		const queryClient = makeClient();
+
+		const { unmount } = renderHook(() =>
+			useUiSyncBridge({
+				queryClient,
+				processPendingCliSends: vi.fn(),
+				reloadSettings: vi.fn(),
+			}),
+		);
+
+		await waitFor(() => {
+			expect(apiMocks.subscribeUiMutations).toHaveBeenCalledOnce();
+		});
+
+		unmount();
+
+		expect(apiMocks.unlistenUiMutations).toHaveBeenCalledOnce();
 	});
 });

--- a/src/shell/hooks/use-ui-sync-bridge.ts
+++ b/src/shell/hooks/use-ui-sync-bridge.ts
@@ -196,6 +196,7 @@ export function useUiSyncBridge({
 
 	useEffect(() => {
 		let disposed = false;
+		let unlisten: (() => void) | null = null;
 
 		void subscribeUiMutations((event) => {
 			if (disposed) {
@@ -206,10 +207,18 @@ export function useUiSyncBridge({
 				processPendingCliSends: () => processPendingCliSendsRef.current(),
 				reloadSettings: () => reloadSettingsRef.current(),
 			});
+		}).then((cleanup) => {
+			if (disposed) {
+				cleanup();
+				return;
+			}
+
+			unlisten = cleanup;
 		});
 
 		return () => {
 			disposed = true;
+			unlisten?.();
 		};
 	}, [queryClient]);
 }


### PR DESCRIPTION
## Summary

Fixes a UI sync subscription leak where `useUiSyncBridge` created backend Tauri Channel subscribers without unregistering them on unmount.

## Details

Previously, frontend cleanup only set a local `disposed` flag. The Rust `UiSyncManager` kept the Channel in its subscribers list until a future publish failed, so StrictMode, HMR, or remounts could accumulate stale subscribers during idle periods.

This change:
- Adds subscription IDs to UI sync subscribers
- Adds `unsubscribe_ui_mutations` IPC
- Returns an `UnlistenFn` from `subscribeUiMutations`
- Calls that cleanup from `useUiSyncBridge`, including async unmount races
- Adds focused frontend cleanup coverage

## Validation

- `bun x vitest run src/shell/hooks/use-ui-sync-bridge.test.tsx src/features/composer/context-usage-ring/index.test.tsx`
- `cd src-tauri && cargo test ui_sync`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `bun x biome check src/lib/api.ts src/shell/hooks/use-ui-sync-bridge.ts src/shell/hooks/use-ui-sync-bridge.test.tsx src/features/composer/context-usage-ring/index.test.tsx`
- `bun run typecheck`
