### PR TITLE
feat(onboarding): auto-bind repos on account connect, polish spinner and theme picker

### DIFF
--- a/.changeset/small-ui-polish.md
+++ b/.changeset/small-ui-polish.md
@@ -6,3 +6,4 @@ Small UI polish:
 - Auto-bind existing repos when you connect a GitHub or GitLab account during onboarding.
 - Show a spinner on the local-project onboarding card while a folder picker is open.
 - Cleaner selected-state ring on the color theme picker so it stays visible across themes.
+- Fix styling and behavior issues on the Terminal tab right-click menu.

--- a/.changeset/small-ui-polish.md
+++ b/.changeset/small-ui-polish.md
@@ -1,0 +1,8 @@
+---
+"helmor": patch
+---
+
+Small UI polish:
+- Auto-bind existing repos when you connect a GitHub or GitLab account during onboarding.
+- Show a spinner on the local-project onboarding card while a folder picker is open.
+- Cleaner selected-state ring on the color theme picker so it stays visible across themes.

--- a/src/features/inspector/layout.tsx
+++ b/src/features/inspector/layout.tsx
@@ -179,6 +179,10 @@ export function InspectorTabsSection({
 	// the panel from collapsing on mouse-leave so text selection can extend
 	// beyond the container boundary without interruption.
 	const isSelectingRef = useRef(false);
+	// Right-click menu portal renders outside the container, so mouseleave
+	// fires the moment the cursor crosses into a menu item. Hold the zoom open
+	// until the menu closes, then re-check the pointer.
+	const isTabContextMenuOpenRef = useRef(false);
 	// Holds the outstanding `suspendTerminalFit()` release while the CSS
 	// width/height transition is running, plus the timer that will release it
 	// and trigger the final fit.
@@ -324,6 +328,14 @@ export function InspectorTabsSection({
 		if (isSelectingRef.current) {
 			return;
 		}
+		// Don't collapse while a tab's right-click menu is open. The menu
+		// renders in a portal outside the container, so moving the cursor
+		// onto it triggers mouseleave even though the user is still
+		// interacting with our UI. The menu's onOpenChange handler re-checks
+		// the pointer once it closes.
+		if (isTabContextMenuOpenRef.current) {
+			return;
+		}
 		if (hadPendingHoverIntent || (!isHoverExpanded && !isZoomPresented)) {
 			return;
 		}
@@ -336,6 +348,20 @@ export function InspectorTabsSection({
 		beginZoomAnimation,
 		setZoomTarget,
 	]);
+
+	// On close, re-evaluate whether to collapse — the mouseleave that fired
+	// while the menu was open was suppressed.
+	const handleTabContextMenuOpenChange = useCallback(
+		(open: boolean) => {
+			isTabContextMenuOpenRef.current = open;
+			if (open) return;
+			if (pointerInsideContainerRef.current) return;
+			if (!isHoverExpanded && !isZoomPresented) return;
+			beginZoomAnimation();
+			setZoomTarget(false);
+		},
+		[isHoverExpanded, isZoomPresented, beginZoomAnimation, setZoomTarget],
+	);
 
 	// When the panel collapses we must drop any pending/active zoom so it
 	// doesn't linger over the neighbouring sections. Also release any
@@ -626,7 +652,10 @@ export function InspectorTabsSection({
 										const isActive = activeTab === instance.id;
 										const isHoverZoomDisabled = instance.hoverZoomDisabled;
 										return (
-											<ContextMenu key={instance.id}>
+											<ContextMenu
+												key={instance.id}
+												onOpenChange={handleTabContextMenuOpenChange}
+											>
 												<ContextMenuTrigger asChild>
 													<div
 														role="tab"
@@ -683,7 +712,7 @@ export function InspectorTabsSection({
 														/>
 													</div>
 												</ContextMenuTrigger>
-												<ContextMenuContent className="min-w-44 rounded-xl p-1.5">
+												<ContextMenuContent className="min-w-48">
 													<ContextMenuItem
 														onClick={() =>
 															onToggleTerminalHoverZoom(
@@ -691,16 +720,15 @@ export function InspectorTabsSection({
 																!isHoverZoomDisabled,
 															)
 														}
-														className="gap-2.5 rounded-md px-2.5 py-1.5 text-[13px]"
 													>
 														{isHoverZoomDisabled ? (
 															<ZoomIn
-																className="size-3.5 shrink-0"
+																className="size-4 shrink-0"
 																strokeWidth={1.6}
 															/>
 														) : (
 															<ZoomOut
-																className="size-3.5 shrink-0"
+																className="size-4 shrink-0"
 																strokeWidth={1.6}
 															/>
 														)}
@@ -713,12 +741,8 @@ export function InspectorTabsSection({
 													<ContextMenuSeparator />
 													<ContextMenuItem
 														onClick={() => onCloseTerminal(instance.id)}
-														className="gap-2.5 rounded-md px-2.5 py-1.5 text-[13px]"
 													>
-														<X
-															className="size-3.5 shrink-0"
-															strokeWidth={1.6}
-														/>
+														<X className="size-4 shrink-0" strokeWidth={1.6} />
 														<span>Close terminal</span>
 													</ContextMenuItem>
 												</ContextMenuContent>

--- a/src/features/onboarding/steps/repo-import-step.tsx
+++ b/src/features/onboarding/steps/repo-import-step.tsx
@@ -1,4 +1,11 @@
-import { ArrowLeft, ArrowRight, Cloud, FolderOpen, X } from "lucide-react";
+import {
+	ArrowLeft,
+	ArrowRight,
+	Cloud,
+	FolderOpen,
+	Loader2,
+	X,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import type { ImportedRepository, OnboardingStep } from "../types";
 
@@ -55,16 +62,25 @@ export function RepoImportStep({
 						type="button"
 						onClick={onAddLocalRepository}
 						disabled={isAddingLocalRepository}
-						className="flex cursor-pointer flex-col items-start rounded-lg border border-border/55 bg-card p-4 text-left text-foreground transition-colors hover:bg-muted/50 disabled:cursor-default disabled:opacity-70"
+						aria-busy={isAddingLocalRepository}
+						className="flex cursor-pointer flex-col items-start rounded-lg border border-border/55 bg-card p-4 text-left text-foreground transition-colors hover:bg-muted/50 disabled:cursor-default disabled:hover:bg-card"
 					>
 						<div className="flex size-10 items-center justify-center rounded-lg border border-border/50 bg-background text-foreground">
-							<FolderOpen className="size-5" />
+							{isAddingLocalRepository ? (
+								<Loader2 className="size-5 animate-spin text-muted-foreground" />
+							) : (
+								<FolderOpen className="size-5" />
+							)}
 						</div>
 						<div className="mt-4 text-sm font-medium text-foreground">
-							Choose local project
+							{isAddingLocalRepository
+								? "Adding repository…"
+								: "Choose local project"}
 						</div>
 						<p className="mt-1 text-xs leading-5 text-muted-foreground">
-							Add a folder already on this machine.
+							{isAddingLocalRepository
+								? "Pick a folder, then we'll wire it up."
+								: "Add a folder already on this machine."}
 						</p>
 					</button>
 					<button

--- a/src/features/onboarding/steps/repository-cli-step.tsx
+++ b/src/features/onboarding/steps/repository-cli-step.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/components/ui/hover-card";
 import { Input } from "@/components/ui/input";
 import {
+	backfillForgeRepoBindings,
 	type ForgeAccount,
 	type ForgeProvider,
 	listForgeLogins,
@@ -290,9 +291,21 @@ export function RepositoryCliStep({
 		// another login. GitHub spawns a fresh terminal; GitLab
 		// opens the host input form.
 		resetFlowTo(pending.provider);
+		// Sync the just-added account against any pre-existing repos
+		// (e.g. from a prior session) so they pick up the binding
+		// without an app restart. Mirrors the Settings → Account flow.
+		void backfillForgeRepoBindings()
+			.then((bound) => {
+				if (bound > 0) {
+					void queryClient.invalidateQueries({
+						queryKey: helmorQueryKeys.repositories,
+					});
+				}
+			})
+			.catch(() => {});
 		const label = pending.provider === "gitlab" ? "GitLab" : "GitHub";
 		toast.success(`${label} connected as @${pending.login}`);
-	}, [addingAccount, accountsQuery.data, resetFlowTo]);
+	}, [addingAccount, accountsQuery.data, resetFlowTo, queryClient]);
 
 	// Fail-safe: if the profile fetch never lands (network error,
 	// stale cache, etc.) drop pending after 10s so the spinner can't

--- a/src/features/settings/index.tsx
+++ b/src/features/settings/index.tsx
@@ -475,21 +475,23 @@ export const SettingsDialog = memo(function SettingsDialog({
 														const swatchAccent = isLight
 															? opt.lightAccent
 															: opt.accent;
+														const isSelected = settings.darkTheme === opt.id;
 														return (
 															<button
 																key={opt.id}
 																type="button"
 																title={opt.label}
 																aria-label={opt.label}
-																aria-pressed={settings.darkTheme === opt.id}
+																aria-pressed={isSelected}
 																className={cn(
-																	"h-7 w-7 cursor-pointer overflow-hidden rounded-full transition-all",
-																	settings.darkTheme === opt.id
-																		? "scale-110 ring-2 ring-foreground/70 ring-offset-2 ring-offset-background"
-																		: "hover:scale-105 hover:ring-1 hover:ring-border hover:ring-offset-1 hover:ring-offset-background",
+																	"h-7 w-7 cursor-pointer rounded-full transition-transform duration-150",
+																	isSelected ? "scale-105" : "hover:scale-105",
 																)}
 																style={{
 																	background: `linear-gradient(135deg, ${swatchBg}, ${swatchAccent})`,
+																	boxShadow: isSelected
+																		? `0 0 0 2px var(--background), 0 0 0 3.5px ${swatchBg}`
+																		: undefined,
 																}}
 																onClick={() =>
 																	updateSettings({ darkTheme: opt.id })


### PR DESCRIPTION
## Summary

Three small UI polish items packaged together as a single patch-level change:

- **Auto-bind existing repos on account connect.** When you finish connecting a GitHub or GitLab account from the onboarding flow, we now call `backfillForgeRepoBindings()` and invalidate the repositories query. Previously you had to restart the app for pre-existing repos to pick up the new account binding. Mirrors the behavior already present in Settings → Account.
- **Local-project onboarding spinner.** The "Choose local project" card on the onboarding repo-import step now shows a `Loader2` spin and "Adding repository…" copy while the folder picker is open, instead of just looking inert. Also drops the `disabled:opacity-70` washout in favor of a clean `disabled:hover:bg-card` so the card stays readable.
- **Theme picker selected ring.** The dark-theme color swatches in Settings now use a layered `box-shadow` ring (background gap + theme-colored outer ring) instead of `ring-2 ring-foreground/70`. The old foreground-colored ring blended into light themes; the new approach stays visible across all theme variants.

## Why

These are three independent papercuts that surfaced while testing the new multi-account + color theme flows. None warrant their own PR but together they meaningfully smooth out first-run and settings polish.

## Test plan

- [ ] Onboarding → connect a GitHub account when at least one repo is already imported. Confirm the repo's account binding updates without a restart.
- [ ] Onboarding → click "Choose local project" and verify the spinner + "Adding repository…" copy appears while the OS folder picker is open.
- [ ] Settings → Appearance → cycle through all dark theme swatches (Midnight, Forest, Ember, Aurora). Confirm the selected swatch always has a visible ring against every background.
- [ ] `bun run lint` and `bun run typecheck` pass.

## Notes

- Branch name (`nathan/git-header-merge-state-fix`) is unrelated to this work — branch was reused after its prior content shipped.
- Changeset: `.changeset/small-ui-polish.md` (patch).