### PR TITLE
Fix Codex stream hang on app-server exit

### DIFF
--- a/.changeset/quiet-codex-turns.md
+++ b/.changeset/quiet-codex-turns.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix Codex sessions so the stream ends cleanly instead of hanging when the app-server exits during an active turn.

--- a/sidecar/src/codex-app-server-manager.ts
+++ b/sidecar/src/codex-app-server-manager.ts
@@ -541,6 +541,11 @@ export class CodexAppServerManager implements SessionManager {
 			} else {
 				emitter.end(requestId);
 			}
+			if (ctx.activeRequestId === requestId) {
+				ctx.activeRequestId = null;
+				ctx.activeEmitter = null;
+				ctx.lastRetryNotice = null;
+			}
 		});
 	}
 
@@ -828,6 +833,45 @@ export class CodexAppServerManager implements SessionManager {
 
 	// ── Private ──────────────────────────────────────────────────────────
 
+	private settleUnexpectedExit(
+		sessionId: string,
+		ctx: AppServerContext,
+		code: number | null,
+		signal: string | null,
+	): void {
+		const hasActiveTurn =
+			ctx.turnResolve !== null ||
+			ctx.turnReject !== null ||
+			ctx.activeTurnId !== null;
+		if (!hasActiveTurn) return;
+
+		for (const [id, p] of this.pendingApprovals) {
+			if (p.sessionId === sessionId) this.pendingApprovals.delete(id);
+		}
+		for (const [id, p] of this.pendingUserInputs) {
+			if (p.sessionId === sessionId) this.pendingUserInputs.delete(id);
+		}
+
+		const requestId = ctx.activeRequestId;
+		const emitter = ctx.activeEmitter;
+		logger.error("codex app-server exited during active turn", {
+			sessionId,
+			requestId: requestId ?? "(none)",
+			turnId: ctx.activeTurnId ?? "(none)",
+			code,
+			signal,
+		});
+		ctx.activeTurnId = null;
+		const resolve = ctx.turnResolve;
+		ctx.turnResolve = null;
+		ctx.turnReject = null;
+
+		if (requestId && emitter) {
+			emitter.error(requestId, "Codex app-server exited unexpectedly");
+		}
+		resolve?.();
+	}
+
 	/**
 	 * Get an existing session context or create a new one. When `resume`
 	 * is set (provider thread ID from a previous session), attempts
@@ -856,7 +900,11 @@ export class CodexAppServerManager implements SessionManager {
 			cwd,
 			onNotification: () => {},
 			onRequest: () => {},
-			onExit: () => {
+			onExit: (code, signal) => {
+				const ctx = ctxRef.current;
+				if (ctx) {
+					this.settleUnexpectedExit(sessionId, ctx, code, signal);
+				}
 				this.sessions.delete(sessionId);
 			},
 			onError: (err) => {

--- a/sidecar/test/codex-app-server-manager.test.ts
+++ b/sidecar/test/codex-app-server-manager.test.ts
@@ -15,9 +15,11 @@ const serverState = {
 	onNotification: null as
 		| null
 		| ((notification: { method: string; params?: unknown }) => void),
+	onExit: null as null | ((code: number | null, signal: string | null) => void),
 	/** Optional hook tests use to inject extra notifications between
 	 *  `turn/started` and `turn/completed` (e.g. `thread/tokenUsage/updated`). */
 	beforeTurnCompleted: null as null | (() => void),
+	exitAfterTurnStarted: false,
 };
 const gitAccessState = {
 	directories: [] as string[],
@@ -25,6 +27,12 @@ const gitAccessState = {
 
 class MockCodexAppServer {
 	killed = false;
+
+	constructor(opts: {
+		onExit: (code: number | null, signal: string | null) => void;
+	}) {
+		serverState.onExit = opts.onExit;
+	}
 
 	async sendRequest(method: string, params: unknown): Promise<unknown> {
 		serverState.requests.push({ method, params });
@@ -39,6 +47,10 @@ class MockCodexAppServer {
 					method: "turn/started",
 					params: { turn: { id: "turn-1" } },
 				});
+				if (serverState.exitAfterTurnStarted) {
+					serverState.onExit?.(1, null);
+					return;
+				}
 				serverState.beforeTurnCompleted?.();
 				serverState.onNotification?.({
 					method: "turn/completed",
@@ -87,7 +99,9 @@ describe("CodexAppServerManager", () => {
 	beforeEach(() => {
 		serverState.requests = [];
 		serverState.onNotification = null;
+		serverState.onExit = null;
 		serverState.beforeTurnCompleted = null;
+		serverState.exitAfterTurnStarted = false;
 		gitAccessState.directories = [];
 		emitter = createSidecarEmitter(() => {});
 	});
@@ -537,5 +551,53 @@ describe("CodexAppServerManager", () => {
 				}),
 			]),
 		);
+	});
+
+	test("settles an active turn when the app-server exits unexpectedly", async () => {
+		const manager = new CodexAppServerManager();
+		const events: Array<Record<string, unknown>> = [];
+		const capturingEmitter = createSidecarEmitter((event) => {
+			events.push(event as Record<string, unknown>);
+		});
+		serverState.exitAfterTurnStarted = true;
+
+		const sendPromise = manager.sendMessage(
+			"REQ-app-server-exit",
+			{
+				sessionId: "session-app-server-exit",
+				prompt: "hi",
+				model: "gpt-5.4",
+				cwd: "/tmp",
+				resume: undefined,
+				permissionMode: undefined,
+				effortLevel: "medium",
+				fastMode: false,
+				images: [],
+			},
+			capturingEmitter,
+		);
+
+		const result = await Promise.race([
+			sendPromise.then(() => "settled" as const),
+			new Promise<"timed-out">((resolve) => {
+				setTimeout(() => resolve("timed-out"), 50);
+			}),
+		]);
+
+		expect(result).toBe("settled");
+		expect(events).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					id: "REQ-app-server-exit",
+					type: "error",
+					message: "Codex app-server exited unexpectedly",
+				}),
+				expect.objectContaining({
+					id: "REQ-app-server-exit",
+					type: "end",
+				}),
+			]),
+		);
+		expect(events.find((e) => e.type === "aborted")).toBeUndefined();
 	});
 });


### PR DESCRIPTION
## Summary

Fixes a Codex stream hang when the app-server exits mid-turn by clearing active request state and emitting `error` + `end`.

## Before

```mermaid
sequenceDiagram
  participant UI
  participant Sidecar
  participant AppServer as Codex app-server

  UI->>Sidecar: Send prompt
  Sidecar->>AppServer: Start turn
  AppServer-->>Sidecar: turn/started
  AppServer--xSidecar: exits unexpectedly
  Sidecar->>Sidecar: deletes session
  Note over UI,Sidecar: Request never settles, so the stream hangs
```

## After

```mermaid
sequenceDiagram
  participant UI
  participant Sidecar
  participant AppServer as Codex app-server

  UI->>Sidecar: Send prompt
  Sidecar->>AppServer: Start turn
  AppServer-->>Sidecar: turn/started
  AppServer--xSidecar: exits unexpectedly
  Sidecar->>Sidecar: clears active turn/request state
  Sidecar-->>UI: error
  Sidecar-->>UI: end
  Note over UI,Sidecar: Request settles cleanly instead of hanging
```

## Demo

Before: https://cap.so/s/2vwzatnvhhmac8y  
After: 

<img width="1445" height="884" alt="SCR-20260502-mqfa" src="https://github.com/user-attachments/assets/16f21070-07ea-433f-8335-d4cce4e15def" />


## Test Plan

- `cd sidecar && bun test test/codex-app-server-manager.test.ts`
