### PR TITLE
fix: refresh forge auth connection state

### DIFF
--- a/.changeset/github-auth-cache-fix.md
+++ b/.changeset/github-auth-cache-fix.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix GitHub connection state so workspaces stop showing Connect GitHub after a successful authorization or restart.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -98,6 +98,7 @@ import {
 	detectedEditorsQueryOptions,
 	helmorQueryKeys,
 	helmorQueryPersister,
+	isVolatileForgeQueryKey,
 	sessionThreadMessagesQueryOptions,
 	workspaceChangeRequestQueryOptions,
 	workspaceDetailQueryOptions,
@@ -290,6 +291,9 @@ function MainApp() {
 							) {
 								return false;
 							}
+							if (isVolatileForgeQueryKey(key)) {
+								return false;
+							}
 							return query.state.status === "success";
 						},
 					},
@@ -302,6 +306,9 @@ function MainApp() {
 					});
 					queryClient.removeQueries({
 						queryKey: helmorQueryKeys.archivedWorkspaces,
+					});
+					queryClient.removeQueries({
+						predicate: (query) => isVolatileForgeQueryKey(query.queryKey),
 					});
 				}}
 			>

--- a/src/components/forge-connect-dialog.test.tsx
+++ b/src/components/forge-connect-dialog.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const apiMocks = vi.hoisted(() => ({
 	backfillForgeRepoBindings: vi.fn(),
 	listForgeLogins: vi.fn(),
+	loadWorkspaceDetail: vi.fn(),
 	resizeForgeCliAuthTerminal: vi.fn(),
 	retryRepoForgeBinding: vi.fn(),
 	spawnForgeCliAuthTerminal: vi.fn(),
@@ -21,6 +22,7 @@ vi.mock("@/lib/api", async (importOriginal) => {
 		...actual,
 		backfillForgeRepoBindings: apiMocks.backfillForgeRepoBindings,
 		listForgeLogins: apiMocks.listForgeLogins,
+		loadWorkspaceDetail: apiMocks.loadWorkspaceDetail,
 		resizeForgeCliAuthTerminal: apiMocks.resizeForgeCliAuthTerminal,
 		retryRepoForgeBinding: apiMocks.retryRepoForgeBinding,
 		spawnForgeCliAuthTerminal: apiMocks.spawnForgeCliAuthTerminal,
@@ -47,6 +49,7 @@ describe("ForgeConnectDialog", () => {
 			mock.mockReset();
 		}
 		apiMocks.backfillForgeRepoBindings.mockResolvedValue(0);
+		apiMocks.loadWorkspaceDetail.mockResolvedValue(null);
 		apiMocks.retryRepoForgeBinding.mockResolvedValue("octocat");
 		apiMocks.stopForgeCliAuthTerminal.mockResolvedValue(true);
 	});
@@ -117,6 +120,149 @@ describe("ForgeConnectDialog", () => {
 		});
 		expect(invalidateSpy).toHaveBeenCalledWith({
 			queryKey: helmorQueryKeys.forgeAccountsAll,
+		});
+	});
+
+	it("refreshes repo binding when auth reuses an existing login", async () => {
+		let onTerminalEvent: ((event: ScriptEvent) => void) | null = null;
+		apiMocks.listForgeLogins
+			.mockResolvedValueOnce(["octocat"])
+			.mockResolvedValueOnce(["octocat"]);
+		apiMocks.spawnForgeCliAuthTerminal.mockImplementation(
+			async (_provider, _host, _instanceId, callback) => {
+				onTerminalEvent = callback;
+			},
+		);
+		const onConnected = vi.fn();
+		const onCloseSettled = vi.fn();
+
+		renderWithProviders(
+			<ForgeConnectDialog
+				open
+				onOpenChange={vi.fn()}
+				provider="github"
+				host="github.com"
+				repoId="repo-1"
+				workspaceId="workspace-1"
+				onConnected={onConnected}
+				onCloseSettled={onCloseSettled}
+			/>,
+		);
+
+		await waitFor(() => {
+			expect(apiMocks.spawnForgeCliAuthTerminal).toHaveBeenCalled();
+		});
+
+		await act(async () => {
+			onTerminalEvent?.({ type: "exited", code: 0 });
+		});
+
+		await waitFor(() => {
+			expect(apiMocks.retryRepoForgeBinding).toHaveBeenCalledWith("repo-1");
+			expect(onConnected).toHaveBeenCalledWith({
+				provider: "github",
+				host: "github.com",
+				login: "octocat",
+			});
+			expect(onCloseSettled).toHaveBeenCalledWith({
+				provider: "github",
+				host: "github.com",
+				connected: true,
+				login: "octocat",
+			});
+		});
+	});
+
+	it("does not report connected when repo binding finds no accessible account", async () => {
+		let onTerminalEvent: ((event: ScriptEvent) => void) | null = null;
+		apiMocks.listForgeLogins
+			.mockResolvedValueOnce(["octocat"])
+			.mockResolvedValueOnce(["octocat"]);
+		apiMocks.retryRepoForgeBinding.mockResolvedValueOnce(null);
+		apiMocks.spawnForgeCliAuthTerminal.mockImplementation(
+			async (_provider, _host, _instanceId, callback) => {
+				onTerminalEvent = callback;
+			},
+		);
+		const onConnected = vi.fn();
+		const onCloseSettled = vi.fn();
+
+		renderWithProviders(
+			<ForgeConnectDialog
+				open
+				onOpenChange={vi.fn()}
+				provider="github"
+				host="github.com"
+				repoId="repo-1"
+				workspaceId="workspace-1"
+				onConnected={onConnected}
+				onCloseSettled={onCloseSettled}
+			/>,
+		);
+
+		await waitFor(() => {
+			expect(apiMocks.spawnForgeCliAuthTerminal).toHaveBeenCalled();
+		});
+
+		await act(async () => {
+			onTerminalEvent?.({ type: "exited", code: 0 });
+		});
+
+		await waitFor(() => {
+			expect(apiMocks.retryRepoForgeBinding).toHaveBeenCalledWith("repo-1");
+			expect(onConnected).not.toHaveBeenCalled();
+			expect(onCloseSettled).toHaveBeenCalledWith({
+				provider: "github",
+				host: "github.com",
+				connected: false,
+				login: null,
+			});
+		});
+	});
+
+	it("does not report connected when workspace context cannot resolve a repo", async () => {
+		let onTerminalEvent: ((event: ScriptEvent) => void) | null = null;
+		apiMocks.listForgeLogins
+			.mockResolvedValueOnce(["octocat"])
+			.mockResolvedValueOnce(["octocat"]);
+		apiMocks.spawnForgeCliAuthTerminal.mockImplementation(
+			async (_provider, _host, _instanceId, callback) => {
+				onTerminalEvent = callback;
+			},
+		);
+		const onConnected = vi.fn();
+		const onCloseSettled = vi.fn();
+
+		renderWithProviders(
+			<ForgeConnectDialog
+				open
+				onOpenChange={vi.fn()}
+				provider="github"
+				host="github.com"
+				workspaceId="workspace-1"
+				onConnected={onConnected}
+				onCloseSettled={onCloseSettled}
+			/>,
+		);
+
+		await waitFor(() => {
+			expect(apiMocks.spawnForgeCliAuthTerminal).toHaveBeenCalled();
+		});
+
+		await act(async () => {
+			onTerminalEvent?.({ type: "exited", code: 0 });
+		});
+
+		await waitFor(() => {
+			expect(apiMocks.loadWorkspaceDetail).toHaveBeenCalledWith("workspace-1");
+			expect(apiMocks.retryRepoForgeBinding).not.toHaveBeenCalled();
+			expect(onConnected).not.toHaveBeenCalled();
+			expect(onCloseSettled).toHaveBeenCalledWith({
+				provider: "github",
+				host: "github.com",
+				connected: false,
+				login: null,
+			});
 		});
 	});
 });

--- a/src/components/forge-connect-dialog.tsx
+++ b/src/components/forge-connect-dialog.tsx
@@ -31,6 +31,7 @@ import {
 	backfillForgeRepoBindings,
 	type ForgeProvider,
 	listForgeLogins,
+	loadWorkspaceDetail,
 	resizeForgeCliAuthTerminal,
 	retryRepoForgeBinding,
 	type ScriptEvent,
@@ -65,22 +66,27 @@ export type ForgeConnectDialogProps = {
 	}) => void;
 };
 
-/// The post-close handler that diffs the live login set against the
-/// snapshot taken at open time. One-shot delta check on dialog
-/// close — cheaper than polling every 2s while the terminal is up.
-async function detectNewLoginAfterClose(
+type LoginProbeResult = {
+	login: string | null;
+};
+
+/// The post-close handler probes the live login set once after the
+/// terminal exits. Prefer a login that was not present at open time,
+/// but fall back to any current login so re-authorizing the same
+/// account still drives repo rebind + cache refresh.
+async function detectLoginAfterClose(
 	provider: ForgeProvider,
 	host: string,
 	baseline: Set<string>,
-): Promise<string | null> {
+): Promise<LoginProbeResult> {
 	try {
 		const current = await listForgeLogins(provider, host, {
 			forceRefresh: true,
 		});
 		const newLogin = current.find((login) => !baseline.has(login));
-		return newLogin ?? null;
+		return { login: newLogin ?? current[0] ?? null };
 	} catch {
-		return null;
+		return { login: null };
 	}
 }
 
@@ -170,7 +176,7 @@ export function ForgeConnectDialog({
 			}
 		}
 
-		const newLogin = await detectNewLoginAfterClose(
+		const probe = await detectLoginAfterClose(
 			provider,
 			host,
 			baselineRef.current,
@@ -182,7 +188,8 @@ export function ForgeConnectDialog({
 			queryKey: helmorQueryKeys.forgeLogins(provider, host),
 		});
 
-		if (newLogin) {
+		let connectedLogin = probe.login;
+		if (probe.login) {
 			// Resolve the repo to rebind: explicit prop wins, otherwise
 			// pull from the workspace detail cache.
 			let resolvedRepoId = repoId ?? null;
@@ -192,12 +199,22 @@ export function ForgeConnectDialog({
 				);
 				resolvedRepoId = detail?.repoId ?? null;
 			}
+			if (!resolvedRepoId && workspaceId) {
+				try {
+					const detail = await loadWorkspaceDetail(workspaceId);
+					resolvedRepoId = detail?.repoId ?? null;
+				} catch {
+					resolvedRepoId = null;
+				}
+			}
 			if (resolvedRepoId) {
 				try {
-					await retryRepoForgeBinding(resolvedRepoId);
+					connectedLogin = await retryRepoForgeBinding(resolvedRepoId);
 				} catch {
-					// Best-effort: invalidations below pick up whatever stuck.
+					connectedLogin = null;
 				}
+			} else if (repoId || workspaceId) {
+				connectedLogin = null;
 			}
 
 			void queryClient.invalidateQueries({
@@ -234,14 +251,16 @@ export function ForgeConnectDialog({
 					}
 				})
 				.catch(() => {});
-			toast.success(connectedToastMessage(provider, newLogin));
-			onConnected?.({ provider, host, login: newLogin });
+			if (connectedLogin) {
+				toast.success(connectedToastMessage(provider, connectedLogin));
+				onConnected?.({ provider, host, login: connectedLogin });
+			}
 		}
 		onCloseSettled?.({
 			provider,
 			host,
-			connected: newLogin !== null,
-			login: newLogin,
+			connected: connectedLogin !== null,
+			login: connectedLogin,
 		});
 	}, [
 		host,

--- a/src/lib/query-client.test.ts
+++ b/src/lib/query-client.test.ts
@@ -8,6 +8,7 @@ import type {
 import {
 	changeRequestRefetchInterval,
 	forgeActionStatusRefetchInterval,
+	isVolatileForgeQueryKey,
 	workspaceForgeRefetchInterval,
 } from "./query-client";
 
@@ -235,5 +236,30 @@ describe("workspaceForgeRefetchInterval", () => {
 		expect(
 			workspaceForgeRefetchInterval(forgeDetection({ provider: "unknown" })),
 		).toBe(false);
+	});
+});
+
+describe("isVolatileForgeQueryKey", () => {
+	it("marks forge auth and identity queries as non-persistable", () => {
+		for (const key of [
+			["workspaceForge", "ws-1"],
+			["workspaceForgeActionStatus", "ws-1"],
+			["workspaceAccountProfile", "ws-1"],
+			["forgeLogins", "github", "github.com"],
+			["forgeAccounts", "gitlab.example.com"],
+		]) {
+			expect(isVolatileForgeQueryKey(key)).toBe(true);
+		}
+	});
+
+	it("leaves stable workspace and session queries persistable", () => {
+		for (const key of [
+			["workspaceDetail", "ws-1"],
+			["workspaceSessions", "ws-1"],
+			["sessionMessages", "session-1"],
+			["repositories"],
+		]) {
+			expect(isVolatileForgeQueryKey(key)).toBe(false);
+		}
 	});
 });

--- a/src/lib/query-client.ts
+++ b/src/lib/query-client.ts
@@ -118,6 +118,17 @@ export const helmorQueryKeys = {
 		["workspaceCandidateDirectories", excludeWorkspaceId ?? ""] as const,
 };
 
+export function isVolatileForgeQueryKey(queryKey: readonly unknown[]): boolean {
+	const root = queryKey[0];
+	return (
+		root === "workspaceForge" ||
+		root === "workspaceForgeActionStatus" ||
+		root === "workspaceAccountProfile" ||
+		root === "forgeLogins" ||
+		root === "forgeAccounts"
+	);
+}
+
 export function createHelmorQueryClient() {
 	// Replace React Query's default focus listener (browser visibilitychange)
 	// with Tauri's native window focus/blur events. This is the official


### PR DESCRIPTION
## What changed
- Re-probe forge logins after CLI auth exits and fall back to existing logins so re-authorizing the same GitHub account still refreshes repo binding state.
- Treat repo binding retry failures or missing workspace repo context as not connected, avoiding false connected UI state.
- Exclude volatile forge identity/auth queries from React Query persistence and clear them on app restore.
- Add focused frontend coverage plus a patch changeset.

## Why it changed
Workspaces could keep showing Connect GitHub after a successful authorization or after app restart because cached forge identity state could be reused and same-account re-auth did not trigger the repo rebind path.

## Follow-up / test notes
- Tested with: bun x vitest run src/components/forge-connect-dialog.test.tsx src/lib/query-client.test.ts