### PR TITLE
feat(agents): native-binary CLIs (claude 2.1.126, codex 0.128.0) + Codex /goal

### DIFF
--- a/.changeset/claude-code-native-binary.md
+++ b/.changeset/claude-code-native-binary.md
@@ -2,4 +2,8 @@
 "helmor": patch
 ---
 
-Bump bundled Claude Code from 2.1.111 to 2.1.126 and switch to its new platform-native binary distribution.
+Bump bundled agent CLIs and add Codex `/goal` support:
+
+- Bump Claude Code from 2.1.111 to 2.1.126 and switch to its new platform-native binary distribution.
+- Bump Codex from 0.124.0 to 0.128.0.
+- Add a Codex `/goal` slash command (set, pause, resume, clear, optional `--tokens` budget) that drives the new `thread/goal/*` JSON-RPC API, plus a thread-header banner showing the active goal's status and token usage.

--- a/.changeset/claude-code-native-binary.md
+++ b/.changeset/claude-code-native-binary.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Bump bundled Claude Code from 2.1.111 to 2.1.126 and switch to its new platform-native binary distribution.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,11 @@ When a snapshot drifts: look at the diff first. Only accept after confirming the
   2. Pull the new SHA256 from `…/checksums.txt` (URLs in the file's header comment) and update `GH_SHA256` / `GLAB_SHA256`.
   3. Wipe `sidecar/.bundle-cache/` and re-run `bun run build` in `sidecar/` to force re-download + verify.
   Bump cadence: every release cycle if upstream has shipped a notable fix; immediately on security advisories. Pin so the auth-status JSON shape Helmor parses doesn't drift unexpectedly.
+- **Bundled agent CLIs (`claude-code`, `codex`)**: Pulled in via `sidecar/package.json` and staged into `sidecar/dist/vendor/{claude-code,codex}/` as platform-native binaries. Both upstreams ship per-platform npm sub-packages (`@anthropic-ai/claude-code-darwin-{arm64,x64}`, `@openai/codex-darwin-{arm64,x64}`). Cross-arch CI staging downloads the tarball straight from the npm registry and verifies against `CLAUDE_CODE_SHA256` / `CODEX_SHA256` in `stage-vendor.ts`. To upgrade:
+  1. Bump the version in `sidecar/package.json`, `cd sidecar && bun install`.
+  2. Compute the SHA256 of both arch tarballs (`shasum -a 256` on the cached `.tgz`) and update the table in `stage-vendor.ts` (key it under the new version string).
+  3. Wipe `sidecar/.bundle-cache/` and run `bun run build` in `sidecar/` to verify.
+  Both binaries are `bun build --compile` output (~200 MB each on macOS), so `maybeSignMacBinary(_, true)` is required — JSC needs `allow-jit` / `allow-unsigned-executable-memory` under hardened runtime. Run pipeline snapshot tests after every claude-code bump (`cd src-tauri && cargo test --tests`); the SDK event shape is the contract Helmor's accumulator depends on.
 
 ## 🚨 Code organization rules
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "helmor",

--- a/sidecar/bun.lock
+++ b/sidecar/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "@helmor/sidecar",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.2.111",
-        "@anthropic-ai/claude-code": "2.1.111",
+        "@anthropic-ai/claude-agent-sdk": "0.2.126",
+        "@anthropic-ai/claude-code": "2.1.126",
         "@openai/codex": "0.124.0",
       },
       "devDependencies": {
@@ -15,48 +15,51 @@
       },
     },
   },
+  "trustedDependencies": [
+    "@anthropic-ai/claude-code",
+  ],
   "packages": {
-    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.111", "", { "dependencies": { "@anthropic-ai/sdk": "^0.81.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-DwXyJpVL8JXB8L2toSw1by7uIt1p8hPGi0P+hqr5tL+Ae7DcK9O3tUd6XcGown3LZ49zNCUAIpqX3wDmOhqp0Q=="],
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.126", "", { "dependencies": { "@anthropic-ai/sdk": "^0.81.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.126", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.126", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.126", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.126", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.126", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.126", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.126", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.126" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-4ZrVu0XUEwNG6wxvsLgppRAmSfAf3oeEMEUPhgazb0AXUUe/7W8MxwZKJWOffqSLWaNYzOt3ZCIL7NJY6toqWw=="],
 
-    "@anthropic-ai/claude-code": ["@anthropic-ai/claude-code@2.1.111", "", { "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "bin": { "claude": "cli.js" } }, "sha512-zNZcINqvtMpDM4lZqnOZcrou57k9rUBfCZziH47nMG9FNks7I6azN7+SMU3zhwqBwYrvx6o4i7Ecu7mDCi0AmA=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.126", "", { "os": "darwin", "cpu": "arm64" }, "sha512-JFlJBbeAlx7Ic5s4lGUN9SppobryXk/lIqPCvhp6KrJTQIerh3MIBzxsVIJ0MaDut7jVni/oYgsvDni7NIyqHA=="],
+
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.126", "", { "os": "darwin", "cpu": "x64" }, "sha512-J8BpMj16NK9FUaG3HnHSivyp4Xww9DKWHiC8QSHT9oiT8pH5IG7nl0jxyjIq/lY79evlTY+ubgDVWlMUhUAN/g=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.126", "", { "os": "linux", "cpu": "arm64" }, "sha512-LM+mnfQsgI+1i5mYZwIPDDf14NGBu5wbhzm5U8P11dCa2p8sXmKoWpkbO16BFM2NxeW44I/RXCxE5qFsbz4zcg=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.126", "", { "os": "linux", "cpu": "arm64" }, "sha512-GO0BnIUw3LQ3XAy+nipAabkN0GwQGPhHB6ITI4XLoR99fLHB3TA6WfyvTf0fnpxd25A+c/+UsAoxz4zBQaHlhA=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.2.126", "", { "os": "linux", "cpu": "x64" }, "sha512-yaOTDcYCdscxC0LKg9w8IwSa5g+993WggFZJBTZpqvflA2+WMQeTarDnKlsFTCw9XUZkL8XZeBALYJGx0HutuA=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.126", "", { "os": "linux", "cpu": "x64" }, "sha512-ByJGO0+mu7EplxSFSCIHd7QWsXdrF3qgtzQ177o/j+oSppLoqR1ot5ktf8aw5oR3CC5lFHg4tqd6TnneQpEoIg=="],
+
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.126", "", { "os": "win32", "cpu": "arm64" }, "sha512-gv3MOsOBkCx3LajOOIjD7AKsOtz/qNHsS2oshGt2GVoy7JA3XbCDeCetDjM6SorV4SE+7F/IH0UJdXe5ejI/Zg=="],
+
+    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.2.126", "", { "os": "win32", "cpu": "x64" }, "sha512-oRV75HwyoOd1/t5+kipAM2g62CaElpKGvSBx3Ys4lCwCiFUyOnmet/O+hRXENsY6ShDeQZEcJL2UWljr2d5NQw=="],
+
+    "@anthropic-ai/claude-code": ["@anthropic-ai/claude-code@2.1.126", "", { "optionalDependencies": { "@anthropic-ai/claude-code-darwin-arm64": "2.1.126", "@anthropic-ai/claude-code-darwin-x64": "2.1.126", "@anthropic-ai/claude-code-linux-arm64": "2.1.126", "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.126", "@anthropic-ai/claude-code-linux-x64": "2.1.126", "@anthropic-ai/claude-code-linux-x64-musl": "2.1.126", "@anthropic-ai/claude-code-win32-arm64": "2.1.126", "@anthropic-ai/claude-code-win32-x64": "2.1.126" }, "bin": { "claude": "bin/claude.exe" } }, "sha512-eLuqO0iiXjQUipXQQEHBoCXG1CdxG+VBazV5sc8eA6HeRU18ur1UoL6xDrS1GA5A3IgIkgIFa9OMrJSVosdi6w=="],
+
+    "@anthropic-ai/claude-code-darwin-arm64": ["@anthropic-ai/claude-code-darwin-arm64@2.1.126", "", { "os": "darwin", "cpu": "arm64" }, "sha512-e1p/d4ugb3a28+i1AfRcjFMDnFS9isxsJOy9sYlINmX98pDyCIY76MyJw1HDH0z0x/8jEK30nx/lrrNAvIMNwA=="],
+
+    "@anthropic-ai/claude-code-darwin-x64": ["@anthropic-ai/claude-code-darwin-x64@2.1.126", "", { "os": "darwin", "cpu": "x64" }, "sha512-3fR0npNig7/ncwetfDAdtkFYo+hPN8vB6zRQpILVR/Atk0BjLuBFy0rA4/ALBOIftkVCenXMD5UIURPMnhh/sA=="],
+
+    "@anthropic-ai/claude-code-linux-arm64": ["@anthropic-ai/claude-code-linux-arm64@2.1.126", "", { "os": "linux", "cpu": "arm64" }, "sha512-iqdERAVEhU2BwEPlHy/S0O3ioKnlFUvlk5xS/G8DXnWok4Niin1HJ+7q4u6ayXWw7JFou3GW3pg34V31ddGhGg=="],
+
+    "@anthropic-ai/claude-code-linux-arm64-musl": ["@anthropic-ai/claude-code-linux-arm64-musl@2.1.126", "", { "os": "linux", "cpu": "arm64" }, "sha512-soOkg7QjoQ1nMa78YmyhLeKDkFtRXgucsE9P84+J3HB3CDIcZI+MWQvwZT9lr5IuU8KbkNOijSzIRaUCLZAPuQ=="],
+
+    "@anthropic-ai/claude-code-linux-x64": ["@anthropic-ai/claude-code-linux-x64@2.1.126", "", { "os": "linux", "cpu": "x64" }, "sha512-D2A9TI62aoQcxxbZzsiOWlfqs+7X/K49qSthkPdCg4B24aQWv2rL0PWTvnvMTbQUTlg6bBL0PjauANdgHs+WjQ=="],
+
+    "@anthropic-ai/claude-code-linux-x64-musl": ["@anthropic-ai/claude-code-linux-x64-musl@2.1.126", "", { "os": "linux", "cpu": "x64" }, "sha512-y9NhIWnITVmKssq0XNoUFqLdfWiD9BmZI8SAVqcxUbFUpDmbsCKpNB2SrvMQmjYLZneDnmxdHLfciU0DS9S7HQ=="],
+
+    "@anthropic-ai/claude-code-win32-arm64": ["@anthropic-ai/claude-code-win32-arm64@2.1.126", "", { "os": "win32", "cpu": "arm64" }, "sha512-uKVVUKaAMq83IJSla9YMh/QUQJYhQP0Q95aYryXF/qNMUSqf0QUfi8dygkTkCzJqEbyLHTG0w+8q1gRCVydBVA=="],
+
+    "@anthropic-ai/claude-code-win32-x64": ["@anthropic-ai/claude-code-win32-x64@2.1.126", "", { "os": "win32", "cpu": "x64" }, "sha512-heB2dj1f2rV2OshT2bKenPWCWoFJZV/gp2QSZmSVsYgDLS5mbv8kUBar69S+4ldLH9oeDERePnnoDHpch4BWew=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.81.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw=="],
 
     "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.12", "", { "peerDependencies": { "hono": "^4" } }, "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw=="],
-
-    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
-
-    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
-
-    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
-
-    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
-
-    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
-
-    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
-
-    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
-
-    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
-
-    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
-
-    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
-
-    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
-
-    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
-
-    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
-
-    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
-
-    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
-
-    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 

--- a/sidecar/bun.lock
+++ b/sidecar/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.126",
         "@anthropic-ai/claude-code": "2.1.126",
-        "@openai/codex": "0.124.0",
+        "@openai/codex": "0.128.0",
       },
       "devDependencies": {
         "@types/bun": "^1.3.11",
@@ -63,19 +63,19 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@openai/codex": ["@openai/codex@0.124.0", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.124.0-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.124.0-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.124.0-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.124.0-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.124.0-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.124.0-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-1EVAuPyAQZ8zIVMw3bPJ6a4R8ifLAZ7LGsOyknj5c2he9AFXVRCmWx12WrdZJ25wcBvOEKt1n1Zx+QAj0EVGbQ=="],
+    "@openai/codex": ["@openai/codex@0.128.0", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.128.0-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.128.0-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.128.0-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.128.0-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.128.0-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.128.0-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-+xp6ODmFfBNnexIWRHApEaPXot2j6gyM8A5we/5IS/uY4eYHj4arETct4hQ5M4eO+MK7JY3ZU4xhuobhlysr0A=="],
 
-    "@openai/codex-darwin-arm64": ["@openai/codex@0.124.0-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-lnuqeAdl+RjPWsqVZ8rrPskRIOZmzlyr8e5q/wFVEnMPsm9dWgjRW1PKa84UmDSQVOuz9GObF28DEHFyC4A8NA=="],
+    "@openai/codex-darwin-arm64": ["@openai/codex@0.128.0-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-w+6zohfHx/kHBdles/CyFKaY57u9I3nK8QI9+NrdwMliKA0b7xn13yblRNkMpe09j6vL1oAWoxYsMOQ/vjBGug=="],
 
-    "@openai/codex-darwin-x64": ["@openai/codex@0.124.0-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-Br+VlL83IOu96Urw+mkZ1PQXLsQXGAYEH6kXNt4ULuVt7qAdQY2FKYwIgLLVLl0vpMk8qWxdfdVMqhiu2uCHlg=="],
+    "@openai/codex-darwin-x64": ["@openai/codex@0.128.0-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-SDbn6fO22Puy8xmMIbZi4f2znMrUEPwABApke4mo+4ihaauwuVjeqzXvW5SPJz5ty/bG11/mSupQgReT7T8BBw=="],
 
-    "@openai/codex-linux-arm64": ["@openai/codex@0.124.0-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-QXafFVQJxPfU1LSCI5afuHsF5evKAcbQpFuKou0Kl241/HG/zYHdwoWj546zH844gJgegIPAxPf36+RSkUsbbA=="],
+    "@openai/codex-linux-arm64": ["@openai/codex@0.128.0-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-+SvH73H60qvCXFuQGP/EsmR//s1hHMBR22PvJkXvM/hdnTIGucx+JqRUjAWdmmQ1IU6j3kgwVvdLW/6ICB+M6w=="],
 
-    "@openai/codex-linux-x64": ["@openai/codex@0.124.0-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-cJ4QfQIrz2gkXVWephiGo9JDyD3qLKhvkTTLk7gI8rKd7MZpVXn9/1e7pZCQnJVA7Dk6ocA5G+sxnR78SoIejw=="],
+    "@openai/codex-linux-x64": ["@openai/codex@0.128.0-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-2lnSPA05CRRuKAzFW8BCmmNCSieDcToLwfC2ALLbBYilGLgzhRibjlDglK9F1BkEzfohSSWJu4PBbRu/aG60lQ=="],
 
-    "@openai/codex-win32-arm64": ["@openai/codex@0.124.0-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-oDSI/CQh0kagBwWVPG9EiUBfHiY27ju3LPrjTVZg4VMpVJVNA31JTK8rHMZ6G/2gfNmOl6DMBA6+0ICxSkkshg=="],
+    "@openai/codex-win32-arm64": ["@openai/codex@0.128.0-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-ECJvsqmYFdA9pn42xxK3Odp/G16AjmBW0BglX8L0PwPjqbstbmlew9bfHf7xvL+SNfNl4NmyotW0+RNo1phgaA=="],
 
-    "@openai/codex-win32-x64": ["@openai/codex@0.124.0-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-t+lAwmCWwIWQKk6dKaYetRhQsmA+uDmQy1NLka1xAAv3PlNOH8iNz9Lsisr3qYkBR8Tf7tbQlt+pl9tw/A5mfA=="],
+    "@openai/codex-win32-x64": ["@openai/codex@0.128.0-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-k3jmUAFrzkUtvjGTXvSKjQqJLLlzjxp/VoHJDYedgmXUn6j70HxK38IwapzmnYfiBiTuzETvGwjXHzZgzKjhoQ=="],
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 

--- a/sidecar/package.json
+++ b/sidecar/package.json
@@ -15,7 +15,7 @@
 	"dependencies": {
 		"@anthropic-ai/claude-agent-sdk": "0.2.126",
 		"@anthropic-ai/claude-code": "2.1.126",
-		"@openai/codex": "0.124.0"
+		"@openai/codex": "0.128.0"
 	},
 	"devDependencies": {
 		"@types/bun": "^1.3.11",

--- a/sidecar/package.json
+++ b/sidecar/package.json
@@ -13,12 +13,15 @@
 		"typecheck": "bunx tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.2.111",
-		"@anthropic-ai/claude-code": "2.1.111",
+		"@anthropic-ai/claude-agent-sdk": "0.2.126",
+		"@anthropic-ai/claude-code": "2.1.126",
 		"@openai/codex": "0.124.0"
 	},
 	"devDependencies": {
 		"@types/bun": "^1.3.11",
 		"@types/node": "^25.5.2"
-	}
+	},
+	"trustedDependencies": [
+		"@anthropic-ai/claude-code"
+	]
 }

--- a/sidecar/scripts/stage-vendor.ts
+++ b/sidecar/scripts/stage-vendor.ts
@@ -1,4 +1,4 @@
-// Stage claude-code + codex + bun + gh + glab into `sidecar/dist/vendor/`
+// Stage claude-code + codex + gh + glab into `sidecar/dist/vendor/`
 // for Tauri to ship as bundle resources. macOS host only.
 //
 // Cross-arch staging: in CI the host is always Apple Silicon (macos-26
@@ -6,6 +6,11 @@
 // bundles. We honor TAURI_TARGET_TRIPLE so the staged vendor binaries match
 // the bundle target — otherwise Intel users get arm64 binaries and
 // `gh auth login` fails with "bad CPU type in executable" (#293).
+//
+// Claude Code and Codex are each shipped as a single self-contained native
+// binary, pulled from the platform-specific npm sub-package
+// (@anthropic-ai/claude-code-darwin-{arm64,x64}/claude,
+//  @openai/codex-darwin-{arm64,x64}/.../codex).
 
 import { execFileSync } from "node:child_process";
 import {
@@ -27,11 +32,12 @@ const DIST_VENDOR = join(SIDECAR_ROOT, "dist", "vendor");
 const BUNDLE_CACHE = join(SIDECAR_ROOT, ".bundle-cache");
 
 // Bumping any version: update SHA256 below + wipe sidecar/.bundle-cache.
-//   gh:    github.com/cli/cli/releases/download/v$VER/gh_${VER}_checksums.txt
-//   glab:  gitlab.com/gitlab-org/cli/-/releases/v$VER/downloads/checksums.txt
-//   bun:   github.com/oven-sh/bun/releases/download/bun-v$VER/SHASUMS256.txt
-//   codex: shasum -a 256 of the npm tarball at
-//          registry.npmjs.org/@openai/codex/-/codex-$VER-darwin-{arm64,x64}.tgz
+//   gh:          github.com/cli/cli/releases/download/v$VER/gh_${VER}_checksums.txt
+//   glab:        gitlab.com/gitlab-org/cli/-/releases/v$VER/downloads/checksums.txt
+//   codex:       shasum -a 256 of the npm tarball at
+//                registry.npmjs.org/@openai/codex/-/codex-$VER-darwin-{arm64,x64}.tgz
+//   claude-code: shasum -a 256 of the npm tarballs at
+//                registry.npmjs.org/@anthropic-ai/claude-code-darwin-{arm64,x64}/-/claude-code-darwin-{arm64,x64}-$VER.tgz
 
 const GH_VERSION = "2.91.0";
 const GH_SHA256 = {
@@ -45,12 +51,6 @@ const GLAB_SHA256 = {
 	amd64: "79d1a4f933919689c5fb7774feb1dd08f30b9c896dff4283b4a7387689ee0531",
 } as const;
 
-const BUN_VERSION = "1.3.2";
-const BUN_SHA256 = {
-	arm64: "d85847982db574518130a45582bcf14d8e2be9610b66cb5046c20348578b0fe2",
-	x64: "78d4f0c8637427ac0be55639a697ff6a025e8eb940a6920ca508603c41a5a7b0",
-} as const;
-
 // Codex version is whatever sidecar/package.json pulled in. The SHAs below
 // must match THAT version — bump them together (or staging cross-arch will
 // abort with a clear error).
@@ -58,6 +58,18 @@ const CODEX_SHA256: Readonly<Record<string, { arm64: string; x64: string }>> = {
 	"0.124.0": {
 		arm64: "8221653b5f1592007ff19a756cfd00afaa4005b3e944412a3ca2372d0abb3b5a",
 		x64: "eb9c0cf46fc9aa58592cd103f0cbc9535667087eb3369d0b99ae62b49f9133da",
+	},
+};
+
+// Same versioning rule as Codex: must match whatever sidecar/package.json
+// pulled in (`@anthropic-ai/claude-code`). Cross-arch staging downloads
+// straight from the npm registry and verifies against this table.
+const CLAUDE_CODE_SHA256: Readonly<
+	Record<string, { arm64: string; x64: string }>
+> = {
+	"2.1.126": {
+		arm64: "8ef17e23ed2987a3fdd39beae7750acef7b45026c9b7a9384d98a8808c4ba5f8",
+		x64: "0aa89a9bfc0b3667bc652c21df2e8cb09a26b32f8c4faf11b94d2128b96acffc",
 	},
 };
 
@@ -71,8 +83,10 @@ type DarwinArch = "arm64" | "x64";
 
 interface TargetInfo {
 	arch: DarwinArch;
-	/** `@anthropic-ai/claude-code` uses `<arch>-darwin` naming. */
-	ccVendorArch: string;
+	/** `@anthropic-ai/claude-code-darwin-<arch>` is the platform sub-package. */
+	claudeCodePkg: string;
+	/** claude-code npm tarball suffix: `darwin-arm64` / `darwin-x64`. */
+	claudeCodeNpmSuffix: string;
 	/** `@openai/codex-darwin-<arch>` is the npm optional-dep package. */
 	codexPkg: string;
 	/** Target triple inside the codex platform package. */
@@ -83,32 +97,30 @@ interface TargetInfo {
 	ghArch: "arm64" | "amd64";
 	/** `glab` release naming: `arm64` / `amd64`. */
 	glabArch: "arm64" | "amd64";
-	/** `bun` release naming: `aarch64` / `x64`. */
-	bunArch: "aarch64" | "x64";
 }
 
 function infoForArch(arch: DarwinArch): TargetInfo {
 	if (arch === "arm64") {
 		return {
 			arch,
-			ccVendorArch: "arm64-darwin",
+			claudeCodePkg: "@anthropic-ai/claude-code-darwin-arm64",
+			claudeCodeNpmSuffix: "darwin-arm64",
 			codexPkg: "@openai/codex-darwin-arm64",
 			codexTriple: "aarch64-apple-darwin",
 			codexNpmSuffix: "darwin-arm64",
 			ghArch: "arm64",
 			glabArch: "arm64",
-			bunArch: "aarch64",
 		};
 	}
 	return {
 		arch,
-		ccVendorArch: "x64-darwin",
+		claudeCodePkg: "@anthropic-ai/claude-code-darwin-x64",
+		claudeCodeNpmSuffix: "darwin-x64",
 		codexPkg: "@openai/codex-darwin-x64",
 		codexTriple: "x86_64-apple-darwin",
 		codexNpmSuffix: "darwin-x64",
 		ghArch: "amd64",
 		glabArch: "amd64",
-		bunArch: "x64",
 	};
 }
 
@@ -154,11 +166,6 @@ function ensureExists(path: string, label: string): void {
 function copyFile(src: string, dest: string): void {
 	mkdirSync(dirname(dest), { recursive: true });
 	cpSync(src, dest);
-}
-
-function copyDir(src: string, dest: string): void {
-	mkdirSync(dirname(dest), { recursive: true });
-	cpSync(src, dest, { recursive: true });
 }
 
 function humanSize(path: string): string {
@@ -329,36 +336,77 @@ function stageGlabBinary(arch: "arm64" | "amd64"): string {
 }
 
 // ---------------------------------------------------------------------------
-// bun — pinned download from oven-sh/bun releases for the target arch.
-// Was previously copied from `which bun`, which silently produced an arm64
-// binary for x86_64 builds whenever the runner host was Apple Silicon.
+// claude-code — prefer the platform sub-package already on disk; fall back to
+// downloading the npm tarball when staging for a non-host architecture.
+//
+// Source layout: `node_modules/@anthropic-ai/claude-code-darwin-<arch>/claude`
+// (single self-contained native binary, ~210 MB; ripgrep + audio-capture +
+// JSC runtime are statically embedded).
+//
+// codesign uses entitlements (allow-jit / allow-unsigned-executable-memory)
+// because it's `bun build --compile` output and JSC needs JIT under
+// hardened runtime.
 // ---------------------------------------------------------------------------
 
-function stageBunBinary(target: TargetInfo): string {
-	ensureCacheDir();
-	const slug = `bun-darwin-${target.bunArch}`;
-	const archive = join(BUNDLE_CACHE, `${slug}-${BUN_VERSION}.zip`);
-	const url = `https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/${slug}.zip`;
-	downloadAndVerify(url, archive, BUN_SHA256[target.arch]);
+function readClaudeCodeVersion(): string {
+	const pkgJsonPath = join(
+		NODE_MODULES,
+		"@anthropic-ai",
+		"claude-code",
+		"package.json",
+	);
+	ensureExists(pkgJsonPath, "@anthropic-ai/claude-code package.json");
+	const pkg = JSON.parse(readFileSync(pkgJsonPath, "utf8")) as {
+		version?: string;
+	};
+	if (!pkg.version) {
+		throw new Error(`[stage-vendor] @anthropic-ai/claude-code has no version`);
+	}
+	return pkg.version;
+}
 
-	const extractDir = join(BUNDLE_CACHE, `bun-${BUN_VERSION}-${target.bunArch}`);
+function copyClaudeCodeBin(src: string): string {
+	const dest = join(DIST_VENDOR, "claude-code", "claude");
+	copyFile(src, dest);
+	chmodSync(dest, 0o755);
+	maybeSignMacBinary(dest, true);
+	return dest;
+}
+
+function stageClaudeCodeBinary(target: TargetInfo): string {
+	const installed = join(NODE_MODULES, target.claudeCodePkg, "claude");
+	if (existsSync(installed)) {
+		return copyClaudeCodeBin(installed);
+	}
+
+	// Cross-arch: download the platform tarball from npm.
+	const version = readClaudeCodeVersion();
+	const shaTable = CLAUDE_CODE_SHA256[version];
+	if (!shaTable) {
+		throw new Error(
+			`[stage-vendor] no pinned SHA256 for claude-code ${version} — add it to CLAUDE_CODE_SHA256 in stage-vendor.ts`,
+		);
+	}
+	ensureCacheDir();
+	const slug = `claude-code-${target.claudeCodeNpmSuffix}-${version}`;
+	const archive = join(BUNDLE_CACHE, `${slug}.tgz`);
+	const url = `https://registry.npmjs.org/${target.claudeCodePkg}/-/claude-code-${target.claudeCodeNpmSuffix}-${version}.tgz`;
+	downloadAndVerify(url, archive, shaTable[target.arch]);
+
+	const extractDir = join(BUNDLE_CACHE, slug);
 	freshExtractDir(extractDir);
-	execFileSync("unzip", ["-q", "-o", archive, "-d", extractDir], {
+	execFileSync("tar", ["-xzf", archive, "-C", extractDir], {
 		stdio: "inherit",
 	});
 
-	// Archive layout: `bun-darwin-<arch>/bun`.
-	const binSrc = join(extractDir, slug, "bun");
+	// npm tarballs nest everything under `package/`.
+	const binSrc = join(extractDir, "package", "claude");
 	if (!existsSync(binSrc)) {
 		throw new Error(
-			`[stage-vendor] bun binary missing after extract: ${binSrc}`,
+			`[stage-vendor] claude-code binary missing after extract: ${binSrc}`,
 		);
 	}
-	const binDest = join(DIST_VENDOR, "bun", "bun");
-	copyFile(binSrc, binDest);
-	chmodSync(binDest, 0o755);
-	maybeSignMacBinary(binDest, true);
-	return binDest;
+	return copyClaudeCodeBin(binSrc);
 }
 
 // ---------------------------------------------------------------------------
@@ -451,43 +499,10 @@ rmSync(DIST_VENDOR, { recursive: true, force: true });
 mkdirSync(DIST_VENDOR, { recursive: true });
 
 // ----- Claude Code -----
-const ccSrc = join(NODE_MODULES, "@anthropic-ai/claude-code");
-const ccDest = join(DIST_VENDOR, "claude-code");
-ensureExists(join(ccSrc, "cli.js"), "@anthropic-ai/claude-code/cli.js");
-
-copyFile(join(ccSrc, "cli.js"), join(ccDest, "cli.js"));
-
-// Target-arch subset of claude-code's vendor dirs. cli.js resolves these
-// relative to itself at runtime; any missing subdir just disables that
-// particular feature (ripgrep -> /search, audio-capture -> voice I/O).
-const ccVendorSubdirs = ["ripgrep", "audio-capture"] as const;
-for (const sub of ccVendorSubdirs) {
-	const from = join(ccSrc, "vendor", sub, target.ccVendorArch);
-	if (existsSync(from)) {
-		copyDir(from, join(ccDest, "vendor", sub, target.ccVendorArch));
-	}
-}
+stageClaudeCodeBinary(target);
 
 // ----- Codex -----
 stageCodexBinary(target);
-
-// ----- Bun -----
-stageBunBinary(target);
-
-for (const rel of [
-	join(ccDest, "vendor", "ripgrep", target.ccVendorArch, "rg"),
-	join(
-		ccDest,
-		"vendor",
-		"audio-capture",
-		target.ccVendorArch,
-		"audio-capture.node",
-	),
-]) {
-	if (existsSync(rel)) {
-		maybeSignMacBinary(rel, false);
-	}
-}
 
 // ----- gh + glab (forge CLIs) -----
 stageGhBinary(target.ghArch);
@@ -495,8 +510,7 @@ stageGlabBinary(target.glabArch);
 
 // ----- Summary -----
 console.log(`[stage-vendor] ✓ staged → ${DIST_VENDOR}`);
-console.log(`  claude-code ${humanSize(ccDest)}`);
+console.log(`  claude-code ${humanSize(join(DIST_VENDOR, "claude-code"))}`);
 console.log(`  codex       ${humanSize(join(DIST_VENDOR, "codex"))}`);
-console.log(`  bun         ${humanSize(join(DIST_VENDOR, "bun"))}`);
 console.log(`  gh          ${humanSize(join(DIST_VENDOR, "gh"))}`);
 console.log(`  glab        ${humanSize(join(DIST_VENDOR, "glab"))}`);

--- a/sidecar/scripts/stage-vendor.ts
+++ b/sidecar/scripts/stage-vendor.ts
@@ -55,9 +55,9 @@ const GLAB_SHA256 = {
 // must match THAT version — bump them together (or staging cross-arch will
 // abort with a clear error).
 const CODEX_SHA256: Readonly<Record<string, { arm64: string; x64: string }>> = {
-	"0.124.0": {
-		arm64: "8221653b5f1592007ff19a756cfd00afaa4005b3e944412a3ca2372d0abb3b5a",
-		x64: "eb9c0cf46fc9aa58592cd103f0cbc9535667087eb3369d0b99ae62b49f9133da",
+	"0.128.0": {
+		arm64: "25499d957ae18d317cd13012750e681a60a1d7ce45f577c6f07e53d374199d9b",
+		x64: "1f4ffa3c70c243c2993dedb67635f6a98c13d3f2b86a5caa445ef762532fc21f",
 	},
 };
 
@@ -426,25 +426,55 @@ function readCodexVersion(): string {
 	return pkg.version;
 }
 
-function copyCodexBin(src: string): string {
-	const dest = join(DIST_VENDOR, "codex", "codex");
-	copyFile(src, dest);
-	chmodSync(dest, 0o755);
-	maybeSignMacBinary(dest, false);
-	return dest;
+/**
+ * Stage codex out of `<vendorRoot>/<triple>/`.
+ *
+ * Source layout (npm tarball or installed package):
+ *   <triple>/codex/codex      — the binary
+ *   <triple>/path/rg          — ripgrep, expected on PATH at runtime
+ *                                (codex spawns it for /search)
+ *
+ * Output:
+ *   dist/vendor/codex/codex
+ *   dist/vendor/codex/path/rg
+ *
+ * The sidecar prepends `dist/vendor/codex/path/` to the codex child's PATH
+ * env when spawning, so codex finds `rg` without it being globally installed.
+ */
+function stageCodexFromVendorRoot(archRoot: string): void {
+	const binSrc = join(archRoot, "codex", "codex");
+	if (!existsSync(binSrc)) {
+		throw new Error(`[stage-vendor] codex binary missing at ${binSrc}`);
+	}
+	const binDest = join(DIST_VENDOR, "codex", "codex");
+	copyFile(binSrc, binDest);
+	chmodSync(binDest, 0o755);
+	maybeSignMacBinary(binDest, false);
+
+	const pathSrc = join(archRoot, "path");
+	if (existsSync(pathSrc)) {
+		const pathDest = join(DIST_VENDOR, "codex", "path");
+		cpSync(pathSrc, pathDest, { recursive: true });
+		for (const entry of readdirSync(pathDest)) {
+			const file = join(pathDest, entry);
+			if (statSync(file).isFile()) {
+				chmodSync(file, 0o755);
+				maybeSignMacBinary(file, false);
+			}
+		}
+	}
 }
 
-function stageCodexBinary(target: TargetInfo): string {
-	const installed = join(
+function stageCodexBinary(target: TargetInfo): void {
+	const installedRoot = join(
 		NODE_MODULES,
 		target.codexPkg,
 		"vendor",
 		target.codexTriple,
-		"codex",
-		"codex",
 	);
-	if (existsSync(installed)) {
-		return copyCodexBin(installed);
+	if (existsSync(join(installedRoot, "codex", "codex"))) {
+		stageCodexFromVendorRoot(installedRoot);
+		return;
 	}
 
 	// Cross-arch: download the platform tarball from npm.
@@ -468,20 +498,13 @@ function stageCodexBinary(target: TargetInfo): string {
 	});
 
 	// npm tarballs nest everything under `package/`.
-	const binSrc = join(
+	const extractedRoot = join(
 		extractDir,
 		"package",
 		"vendor",
 		target.codexTriple,
-		"codex",
-		"codex",
 	);
-	if (!existsSync(binSrc)) {
-		throw new Error(
-			`[stage-vendor] codex binary missing after extract: ${binSrc}`,
-		);
-	}
-	return copyCodexBin(binSrc);
+	stageCodexFromVendorRoot(extractedRoot);
 }
 
 // ---------------------------------------------------------------------------

--- a/sidecar/src/claude-session-manager.ts
+++ b/sidecar/src/claude-session-manager.ts
@@ -5,7 +5,7 @@
 import { randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
-import { basename, extname } from "node:path";
+import { basename, dirname, extname, join } from "node:path";
 import {
 	type ElicitationResult,
 	type HookInput,
@@ -59,65 +59,31 @@ const SLASH_COMMANDS_TIMEOUT_MS = 20_000;
 const CONTEXT_USAGE_TIMEOUT_MS = 30_000;
 
 /**
- * Resolve the path to `@anthropic-ai/claude-code`'s `cli.js`, used as the
- * explicit `pathToClaudeCodeExecutable` for every SDK `query()` call.
+ * Resolve the path to the Claude Code native binary, passed as
+ * `pathToClaudeCodeExecutable` on every SDK `query()` call.
  *
  * Resolution order:
- *   1. `HELMOR_CLAUDE_CODE_CLI_PATH` — set by the Tauri host process in
- *      release builds, pointing at the bundled resource copy inside
- *      `Helmor.app/Contents/Resources/vendor/claude-code/cli.js`.
- *   2. `createRequire` lookup against `node_modules` — used in dev
- *      (`bun run src/index.ts`) and in `bun test`, where `@anthropic-ai/
- *      claude-code` is a direct sidecar dep.
- *
- * We never fall back to the SDK's bundled cli.js: that version is pinned
- * to whatever `@anthropic-ai/claude-agent-sdk` shipped and can drift from
- * what we ship via `sidecar/dist/vendor/`. Failing loudly here surfaces
- * install-state problems at sidecar startup instead of mid-conversation.
+ *   1. `HELMOR_CLAUDE_CODE_BIN_PATH` — set by the Tauri host in release
+ *      builds, pointing at the bundled copy inside
+ *      `Helmor.app/Contents/Resources/vendor/claude-code/claude`.
+ *   2. `createRequire` lookup of the wrapper package's `bin/claude.exe`,
+ *      which `@anthropic-ai/claude-code/install.cjs` populates from the
+ *      platform sub-package on `bun install`. Used in dev
+ *      (`bun run src/index.ts`) and `bun test`. The `.exe` suffix is
+ *      Anthropic's chosen filename across all platforms — it's not a
+ *      Windows-only thing.
  */
-function resolveClaudeCliPath(): string {
-	const override = process.env.HELMOR_CLAUDE_CODE_CLI_PATH;
+function resolveClaudeBinPath(): string {
+	const override = process.env.HELMOR_CLAUDE_CODE_BIN_PATH;
 	if (override) {
 		return override;
 	}
 	const require = createRequire(import.meta.url);
-	return require.resolve("@anthropic-ai/claude-code/cli.js");
+	const pkgJson = require.resolve("@anthropic-ai/claude-code/package.json");
+	return join(dirname(pkgJson), "bin", "claude.exe");
 }
 
-const CLAUDE_CLI_PATH = resolveClaudeCliPath();
-
-/**
- * Optional absolute path to a bundled `bun` binary, used as the SDK's
- * `executable` option when set.
- *
- * Background: the Claude Agent SDK spawns `cli.js` through a JS interpreter
- * (`bun` or `node`) resolved off `PATH`. Inside a Finder-launched `.app`
- * bundle, `PATH = /usr/bin:/bin:/usr/sbin:/sbin` — neither `bun` nor `node`
- * are there, so the spawn fails with ENOENT and the SDK misreports it as
- * "Claude Code executable not found at …/cli.js". To fix this for release
- * builds, Tauri stages the host's bun binary under `vendor/bun/bun` and
- * `lib.rs` exports `HELMOR_BUN_PATH` before spawning us.
- *
- * Dev mode leaves the env unset — `bun run src/index.ts` is already running
- * under a bun instance that's on the developer's PATH, so the SDK's default
- * `"bun"` lookup succeeds.
- */
-const CLAUDE_EXECUTABLE_OVERRIDE = process.env.HELMOR_BUN_PATH || undefined;
-
-/**
- * Build the `executable` / `executableArgs` half of a query() options bag.
- * Returned as a plain object so callers can spread it inline and the SDK's
- * type narrowing still applies. The `as "bun"` cast is deliberate: at
- * runtime the SDK passes `executable` straight to `child_process.spawn`,
- * which accepts absolute paths — but the TS declaration narrows it to the
- * literal `"bun" | "deno" | "node"`. See `sdk.d.ts` line 987.
- */
-function executableOptions(): {
-	executable?: "bun" | "deno" | "node";
-} {
-	if (!CLAUDE_EXECUTABLE_OVERRIDE) return {};
-	return { executable: CLAUDE_EXECUTABLE_OVERRIDE as "bun" };
-}
+const CLAUDE_BIN_PATH = resolveClaudeBinPath();
 
 interface LiveSession {
 	readonly query: Query;
@@ -455,8 +421,7 @@ export class ClaudeSessionManager implements SessionManager {
 			prompt: isResumeOnly ? "" : promptSource,
 			options: {
 				abortController,
-				pathToClaudeCodeExecutable: CLAUDE_CLI_PATH,
-				...executableOptions(),
+				pathToClaudeCodeExecutable: CLAUDE_BIN_PATH,
 				cwd: cwd || undefined,
 				...(additionalDirectories.length > 0 ? { additionalDirectories } : {}),
 				...(queryEnv ? { env: queryEnv } : {}),
@@ -754,8 +719,7 @@ export class ClaudeSessionManager implements SessionManager {
 			prompt: buildTitlePrompt(userMessage, branchRenamePrompt),
 			options: {
 				abortController,
-				pathToClaudeCodeExecutable: CLAUDE_CLI_PATH,
-				...executableOptions(),
+				pathToClaudeCodeExecutable: CLAUDE_BIN_PATH,
 				...(claudeEnv ? { env: claudeEnv } : {}),
 				model,
 				permissionMode: "plan",
@@ -853,8 +817,7 @@ export class ClaudeSessionManager implements SessionManager {
 			prompt: promptIter,
 			options: {
 				abortController,
-				pathToClaudeCodeExecutable: CLAUDE_CLI_PATH,
-				...executableOptions(),
+				pathToClaudeCodeExecutable: CLAUDE_BIN_PATH,
 				cwd: cwd || undefined,
 				...(additionalDirectories.length > 0 ? { additionalDirectories } : {}),
 				...(additionalDirectoryEnv ? { env: additionalDirectoryEnv } : {}),
@@ -1009,8 +972,7 @@ export class ClaudeSessionManager implements SessionManager {
 			prompt: promptIter,
 			options: {
 				abortController,
-				pathToClaudeCodeExecutable: CLAUDE_CLI_PATH,
-				...executableOptions(),
+				pathToClaudeCodeExecutable: CLAUDE_BIN_PATH,
 				cwd: cwd || undefined,
 				model: model || undefined,
 				...(providerSessionId ? { resume: providerSessionId } : {}),

--- a/sidecar/src/codex-app-server-manager.ts
+++ b/sidecar/src/codex-app-server-manager.ts
@@ -818,8 +818,17 @@ export class CodexAppServerManager implements SessionManager {
 		action: "pause" | "resume" | "clear",
 	): Promise<void> {
 		const ctx = this.sessions.get(sessionId);
+		logger.info("mutateGoal request", {
+			sessionId,
+			action,
+			hasContext: !!ctx,
+			threadId: ctx?.providerThreadId ?? "(none)",
+			knownSessions: [...this.sessions.keys()],
+		});
 		if (!ctx) {
-			throw new Error(`No active Codex session for ${sessionId}`);
+			throw new Error(
+				"This Codex session has no active process — send a message first to wake it up, then try again.",
+			);
 		}
 		const threadId = ctx.providerThreadId;
 		if (!threadId) {

--- a/sidecar/src/codex-app-server-manager.ts
+++ b/sidecar/src/codex-app-server-manager.ts
@@ -835,7 +835,7 @@ export class CodexAppServerManager implements SessionManager {
 	 */
 	async mutateGoal(
 		sessionId: string,
-		action: "pause" | "resume" | "clear",
+		action: "pause" | "clear",
 	): Promise<void> {
 		const ctx = this.sessions.get(sessionId);
 		logger.info("mutateGoal request", {
@@ -892,10 +892,10 @@ export class CodexAppServerManager implements SessionManager {
 				await ctx.server.sendRequest("thread/goal/clear", { threadId }, 20_000);
 				return;
 			}
-			const status = action === "pause" ? "paused" : "active";
+			// action === "pause"
 			await ctx.server.sendRequest(
 				"thread/goal/set",
-				{ threadId, status },
+				{ threadId, status: "paused" },
 				20_000,
 			);
 		} catch (err) {

--- a/sidecar/src/codex-app-server-manager.ts
+++ b/sidecar/src/codex-app-server-manager.ts
@@ -871,6 +871,17 @@ export class CodexAppServerManager implements SessionManager {
 		// Clear deliberately does NOT interrupt — codex keeps streaming
 		// the current turn naturally; clearing just removes the goal so
 		// no further continuations spawn after the turn finishes.
+		//
+		// Contract on `ctx.activeTurnId`: it's only updated by
+		// `setHandlers` from inside an active sendMessage stream, so a
+		// goal-continuation turn that codex auto-spawns when no fresh
+		// sendMessage is in flight will NOT be tracked here. In practice
+		// `mutateGoal("pause")` is currently only fired by the Composer
+		// Stop button, which runs `stopAgentStream` immediately after —
+		// `stopSession` kills the codex child unconditionally, so any
+		// untracked turn dies with the process. If a future caller fires
+		// pause without that backup, this branch may silently no-op on
+		// the untracked turn.
 		if (action === "pause" && ctx.activeTurnId) {
 			try {
 				await ctx.server.sendRequest(

--- a/sidecar/src/codex-app-server-manager.ts
+++ b/sidecar/src/codex-app-server-manager.ts
@@ -823,6 +823,7 @@ export class CodexAppServerManager implements SessionManager {
 			action,
 			hasContext: !!ctx,
 			threadId: ctx?.providerThreadId ?? "(none)",
+			activeTurnId: ctx?.activeTurnId ?? "(none)",
 			knownSessions: [...this.sessions.keys()],
 		});
 		if (!ctx) {
@@ -834,6 +835,29 @@ export class CodexAppServerManager implements SessionManager {
 		if (!threadId) {
 			throw new Error("Codex thread has not started yet");
 		}
+
+		// Codex's pause/clear semantics only stop the continuation loop —
+		// any in-flight turn keeps streaming until natural end. To match
+		// user intent ("pause = stop now"), we abort the active turn
+		// ourselves before flipping the goal state. The interrupt produces
+		// a normal turn/completed downstream, which lets the streaming
+		// pipeline transition out of the loading state.
+		if ((action === "pause" || action === "clear") && ctx.activeTurnId) {
+			try {
+				await ctx.server.sendRequest(
+					"turn/interrupt",
+					{ threadId, turnId: ctx.activeTurnId },
+					5_000,
+				);
+			} catch (err) {
+				// Best-effort — don't let an interrupt failure block the
+				// goal state change. Codex may have just finished naturally.
+				logger.debug("mutateGoal interrupt failed (best-effort)", {
+					...errorDetails(err),
+				});
+			}
+		}
+
 		if (action === "clear") {
 			await ctx.server.sendRequest("thread/goal/clear", { threadId }, 20_000);
 			return;

--- a/sidecar/src/codex-app-server-manager.ts
+++ b/sidecar/src/codex-app-server-manager.ts
@@ -106,18 +106,28 @@ function codexTargetTriple(): string | null {
 const CODEX_BIN_PATH = resolveCodexBinPath();
 
 /**
- * `/goal <objective>` parses to a goal-set request. Other flows
- * (pause / resume / clear / budget edits) go through `mutateCodexGoal`
- * out-of-band so they don't show up in the chat as user messages.
+ * Recognised `/goal` slash-command shapes. `set` carries the objective;
+ * `resume` exists so the user can recover an active goal after a pause
+ * by typing `/goal resume`. We deliberately route `resume` through the
+ * sendMessage path (rather than `mutateCodexGoal`) — the resulting
+ * stream subscription is what catches the goal-continuation turn that
+ * codex auto-spawns, otherwise those events fire into a dead handler.
+ *
+ * Pause / Clear are NOT here on purpose: they live on banner / Composer
+ * Stop and go through `mutateCodexGoal` so they don't show up as user
+ * messages in the chat.
  */
-export type GoalCommand = { kind: "set"; objective: string };
+export type GoalCommand =
+	| { kind: "set"; objective: string }
+	| { kind: "resume" };
 
 export function parseGoalCommand(prompt: string): GoalCommand | null {
 	const m = prompt.trim().match(/^\/goal(?:\s+([\s\S]+))?$/);
 	if (!m) return null;
-	const objective = (m[1] ?? "").trim();
-	if (objective === "") return null;
-	return { kind: "set", objective };
+	const arg = (m[1] ?? "").trim();
+	if (arg === "") return null;
+	if (arg === "resume") return { kind: "resume" };
+	return { kind: "set", objective: arg };
 }
 
 function dispatchGoalCommand(
@@ -125,6 +135,16 @@ function dispatchGoalCommand(
 	threadId: string,
 	cmd: GoalCommand,
 ): { method: string; promise: Promise<unknown> } {
+	if (cmd.kind === "resume") {
+		return {
+			method: "thread/goal/set",
+			promise: server.sendRequest(
+				"thread/goal/set",
+				{ threadId, status: "active" },
+				20_000,
+			),
+		};
+	}
 	return {
 		method: "thread/goal/set",
 		promise: server.sendRequest(
@@ -826,15 +846,20 @@ export class CodexAppServerManager implements SessionManager {
 			activeTurnId: ctx?.activeTurnId ?? "(none)",
 			knownSessions: [...this.sessions.keys()],
 		});
-		if (!ctx) {
-			throw new Error(
-				"This Codex session has no active process — send a message first to wake it up, then try again.",
-			);
+		if (!ctx?.providerThreadId) {
+			// No live codex process or no thread yet — silent skip rather
+			// than throw. The Composer Stop path fires this concurrently
+			// with `stopAgentStream`, and a race where Stop kills the
+			// process first must NOT surface as a user-facing error. The
+			// Rust caller still applies the mutation to the local DB so
+			// the banner reflects the new state.
+			logger.debug("mutateGoal: no active codex context, skipping RPC", {
+				sessionId,
+				action,
+			});
+			return;
 		}
 		const threadId = ctx.providerThreadId;
-		if (!threadId) {
-			throw new Error("Codex thread has not started yet");
-		}
 
 		// Codex's pause/clear semantics only stop the continuation loop —
 		// any in-flight turn keeps streaming until natural end. To match
@@ -858,16 +883,24 @@ export class CodexAppServerManager implements SessionManager {
 			}
 		}
 
-		if (action === "clear") {
-			await ctx.server.sendRequest("thread/goal/clear", { threadId }, 20_000);
-			return;
+		try {
+			if (action === "clear") {
+				await ctx.server.sendRequest("thread/goal/clear", { threadId }, 20_000);
+				return;
+			}
+			const status = action === "pause" ? "paused" : "active";
+			await ctx.server.sendRequest(
+				"thread/goal/set",
+				{ threadId, status },
+				20_000,
+			);
+		} catch (err) {
+			// The codex child may have been killed (Composer Stop's parallel
+			// stopSession path) — same idempotency rule as the no-ctx case.
+			logger.debug("mutateGoal RPC failed (best-effort)", {
+				...errorDetails(err),
+			});
 		}
-		const status = action === "pause" ? "paused" : "active";
-		await ctx.server.sendRequest(
-			"thread/goal/set",
-			{ threadId, status },
-			20_000,
-		);
 	}
 
 	// ── stopSession / shutdown ───────────────────────────────────────────

--- a/sidecar/src/codex-app-server-manager.ts
+++ b/sidecar/src/codex-app-server-manager.ts
@@ -105,71 +105,33 @@ function codexTargetTriple(): string | null {
 
 const CODEX_BIN_PATH = resolveCodexBinPath();
 
-/** /goal slash-command parser. Maps to `thread/goal/*` JSON-RPC calls. */
-export type GoalCommand =
-	| { kind: "set"; objective: string; tokenBudget?: number }
-	| { kind: "pause" }
-	| { kind: "resume" }
-	| { kind: "clear" };
+/**
+ * `/goal <objective>` parses to a goal-set request. Other flows
+ * (pause / resume / clear / budget edits) go through `mutateCodexGoal`
+ * out-of-band so they don't show up in the chat as user messages.
+ */
+export type GoalCommand = { kind: "set"; objective: string };
 
 export function parseGoalCommand(prompt: string): GoalCommand | null {
 	const m = prompt.trim().match(/^\/goal(?:\s+([\s\S]+))?$/);
 	if (!m) return null;
-	const arg = (m[1] ?? "").trim();
-	if (arg === "") return null; // bare `/goal` — fall through to the agent
-	if (arg === "pause") return { kind: "pause" };
-	if (arg === "resume") return { kind: "resume" };
-	if (arg === "clear") return { kind: "clear" };
-	const budgetMatch = arg.match(/^--tokens\s+(\S+)\s+([\s\S]+)$/);
-	if (budgetMatch) {
-		const budget = parseTokenSpec(budgetMatch[1] ?? "");
-		const objective = (budgetMatch[2] ?? "").trim();
-		if (budget !== null && objective) {
-			return { kind: "set", objective, tokenBudget: budget };
-		}
-	}
-	return { kind: "set", objective: arg };
+	const objective = (m[1] ?? "").trim();
+	if (objective === "") return null;
+	return { kind: "set", objective };
 }
 
-/** Parse "98.5K" / "1M" / "10000" → integer token count. */
-function parseTokenSpec(spec: string): number | null {
-	const m = spec.match(/^(\d+(?:\.\d+)?)([KkMm]?)$/);
-	if (!m) return null;
-	const n = Number.parseFloat(m[1] ?? "0");
-	const suffix = (m[2] ?? "").toLowerCase();
-	if (suffix === "k") return Math.round(n * 1_000);
-	if (suffix === "m") return Math.round(n * 1_000_000);
-	return Math.round(n);
-}
-
-/**
- * Translate a parsed `/goal` command into the right `thread/goal/*` RPC.
- * `pause` and `resume` are aliases for `thread/goal/set` with a `status`
- * field — this matches the upstream TUI's own implementation.
- */
 function dispatchGoalCommand(
 	server: CodexAppServer,
 	threadId: string,
 	cmd: GoalCommand,
 ): { method: string; promise: Promise<unknown> } {
-	if (cmd.kind === "clear") {
-		return {
-			method: "thread/goal/clear",
-			promise: server.sendRequest("thread/goal/clear", { threadId }, 20_000),
-		};
-	}
-	const params: Record<string, unknown> = { threadId };
-	if (cmd.kind === "set") {
-		params.objective = cmd.objective;
-		if (cmd.tokenBudget !== undefined) params.tokenBudget = cmd.tokenBudget;
-	} else if (cmd.kind === "pause") {
-		params.status = "paused";
-	} else if (cmd.kind === "resume") {
-		params.status = "active";
-	}
 	return {
 		method: "thread/goal/set",
-		promise: server.sendRequest("thread/goal/set", params, 20_000),
+		promise: server.sendRequest(
+			"thread/goal/set",
+			{ threadId, objective: cmd.objective },
+			20_000,
+		),
 	};
 }
 
@@ -841,6 +803,38 @@ export class CodexAppServerManager implements SessionManager {
 
 	async listModels(): Promise<readonly ProviderModelInfo[]> {
 		return listProviderModels("codex");
+	}
+
+	// ── mutateGoal ───────────────────────────────────────────────────────
+
+	/**
+	 * Out-of-band Codex `/goal` lifecycle control. Called when the user
+	 * clicks Pause / Resume / Clear on the goal banner — these operations
+	 * shouldn't appear in chat history, so they bypass the prompt-parsing
+	 * path entirely and go straight to the right `thread/goal/*` RPC.
+	 */
+	async mutateGoal(
+		sessionId: string,
+		action: "pause" | "resume" | "clear",
+	): Promise<void> {
+		const ctx = this.sessions.get(sessionId);
+		if (!ctx) {
+			throw new Error(`No active Codex session for ${sessionId}`);
+		}
+		const threadId = ctx.providerThreadId;
+		if (!threadId) {
+			throw new Error("Codex thread has not started yet");
+		}
+		if (action === "clear") {
+			await ctx.server.sendRequest("thread/goal/clear", { threadId }, 20_000);
+			return;
+		}
+		const status = action === "pause" ? "paused" : "active";
+		await ctx.server.sendRequest(
+			"thread/goal/set",
+			{ threadId, status },
+			20_000,
+		);
 	}
 
 	// ── stopSession / shutdown ───────────────────────────────────────────

--- a/sidecar/src/codex-app-server-manager.ts
+++ b/sidecar/src/codex-app-server-manager.ts
@@ -861,13 +861,17 @@ export class CodexAppServerManager implements SessionManager {
 		}
 		const threadId = ctx.providerThreadId;
 
-		// Codex's pause/clear semantics only stop the continuation loop —
-		// any in-flight turn keeps streaming until natural end. To match
-		// user intent ("pause = stop now"), we abort the active turn
-		// ourselves before flipping the goal state. The interrupt produces
-		// a normal turn/completed downstream, which lets the streaming
-		// pipeline transition out of the loading state.
-		if ((action === "pause" || action === "clear") && ctx.activeTurnId) {
+		// Pause-only: codex's `thread/goal/set { paused }` stops the
+		// continuation loop but doesn't abort the in-flight turn, leaving
+		// helmor's loading spinner stuck. Issue `turn/interrupt` ourselves
+		// to match the user intent ("pause = stop now"). The interrupt
+		// produces a normal turn/completed downstream, which lets the
+		// streaming pipeline transition out of the loading state.
+		//
+		// Clear deliberately does NOT interrupt — codex keeps streaming
+		// the current turn naturally; clearing just removes the goal so
+		// no further continuations spawn after the turn finishes.
+		if (action === "pause" && ctx.activeTurnId) {
 			try {
 				await ctx.server.sendRequest(
 					"turn/interrupt",

--- a/sidecar/src/codex-app-server-manager.ts
+++ b/sidecar/src/codex-app-server-manager.ts
@@ -8,6 +8,9 @@
  */
 
 import crypto from "node:crypto";
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
 import {
 	CodexAppServer,
 	type JsonRpcNotification,
@@ -34,7 +37,141 @@ import {
 	TITLE_GENERATION_TIMEOUT_MS,
 } from "./title.js";
 
-const CODEX_BIN_PATH = process.env.HELMOR_CODEX_BIN_PATH || "codex";
+/**
+ * Resolve the path to the Codex native binary, used as the spawn target for
+ * every `codex app-server` child process.
+ *
+ * Resolution order:
+ *   1. `HELMOR_CODEX_BIN_PATH` — set by the Tauri host in release builds,
+ *      pointing at `Helmor.app/Contents/Resources/vendor/codex/codex`.
+ *   2. `createRequire` lookup of the platform sub-package's binary inside
+ *      `node_modules`. Used in dev (`bun run src/index.ts`) and `bun test`.
+ *   3. Fall back to `"codex"` so the OS resolves it from PATH — last-resort
+ *      for unusual setups; surfaces as ENOENT if not installed.
+ */
+function resolveCodexBinPath(): string {
+	const override = process.env.HELMOR_CODEX_BIN_PATH;
+	if (override) {
+		return override;
+	}
+	const triple = codexTargetTriple();
+	if (triple) {
+		const platformPkg = `@openai/codex-${platformShort()}`;
+		try {
+			const require = createRequire(import.meta.url);
+			const pkgJson = require.resolve(`${platformPkg}/package.json`);
+			const candidate = join(
+				dirname(pkgJson),
+				"vendor",
+				triple,
+				"codex",
+				process.platform === "win32" ? "codex.exe" : "codex",
+			);
+			if (existsSync(candidate)) {
+				return candidate;
+			}
+		} catch {
+			// Platform sub-package missing (e.g. --omit=optional) — fall through.
+		}
+	}
+	return "codex";
+}
+
+function platformShort(): string {
+	const arch = process.arch === "x64" ? "x64" : "arm64";
+	if (process.platform === "darwin") return `darwin-${arch}`;
+	if (process.platform === "linux") return `linux-${arch}`;
+	if (process.platform === "win32") return `win32-${arch}`;
+	return "";
+}
+
+function codexTargetTriple(): string | null {
+	const arch = process.arch;
+	if (process.platform === "darwin") {
+		return arch === "arm64" ? "aarch64-apple-darwin" : "x86_64-apple-darwin";
+	}
+	if (process.platform === "linux") {
+		return arch === "arm64"
+			? "aarch64-unknown-linux-musl"
+			: "x86_64-unknown-linux-musl";
+	}
+	if (process.platform === "win32") {
+		return arch === "arm64"
+			? "aarch64-pc-windows-msvc"
+			: "x86_64-pc-windows-msvc";
+	}
+	return null;
+}
+
+const CODEX_BIN_PATH = resolveCodexBinPath();
+
+/** /goal slash-command parser. Maps to `thread/goal/*` JSON-RPC calls. */
+export type GoalCommand =
+	| { kind: "set"; objective: string; tokenBudget?: number }
+	| { kind: "pause" }
+	| { kind: "resume" }
+	| { kind: "clear" };
+
+export function parseGoalCommand(prompt: string): GoalCommand | null {
+	const m = prompt.trim().match(/^\/goal(?:\s+([\s\S]+))?$/);
+	if (!m) return null;
+	const arg = (m[1] ?? "").trim();
+	if (arg === "") return null; // bare `/goal` — fall through to the agent
+	if (arg === "pause") return { kind: "pause" };
+	if (arg === "resume") return { kind: "resume" };
+	if (arg === "clear") return { kind: "clear" };
+	const budgetMatch = arg.match(/^--tokens\s+(\S+)\s+([\s\S]+)$/);
+	if (budgetMatch) {
+		const budget = parseTokenSpec(budgetMatch[1] ?? "");
+		const objective = (budgetMatch[2] ?? "").trim();
+		if (budget !== null && objective) {
+			return { kind: "set", objective, tokenBudget: budget };
+		}
+	}
+	return { kind: "set", objective: arg };
+}
+
+/** Parse "98.5K" / "1M" / "10000" → integer token count. */
+function parseTokenSpec(spec: string): number | null {
+	const m = spec.match(/^(\d+(?:\.\d+)?)([KkMm]?)$/);
+	if (!m) return null;
+	const n = Number.parseFloat(m[1] ?? "0");
+	const suffix = (m[2] ?? "").toLowerCase();
+	if (suffix === "k") return Math.round(n * 1_000);
+	if (suffix === "m") return Math.round(n * 1_000_000);
+	return Math.round(n);
+}
+
+/**
+ * Translate a parsed `/goal` command into the right `thread/goal/*` RPC.
+ * `pause` and `resume` are aliases for `thread/goal/set` with a `status`
+ * field — this matches the upstream TUI's own implementation.
+ */
+function dispatchGoalCommand(
+	server: CodexAppServer,
+	threadId: string,
+	cmd: GoalCommand,
+): { method: string; promise: Promise<unknown> } {
+	if (cmd.kind === "clear") {
+		return {
+			method: "thread/goal/clear",
+			promise: server.sendRequest("thread/goal/clear", { threadId }, 20_000),
+		};
+	}
+	const params: Record<string, unknown> = { threadId };
+	if (cmd.kind === "set") {
+		params.objective = cmd.objective;
+		if (cmd.tokenBudget !== undefined) params.tokenBudget = cmd.tokenBudget;
+	} else if (cmd.kind === "pause") {
+		params.status = "paused";
+	} else if (cmd.kind === "resume") {
+		params.status = "active";
+	}
+	return {
+		method: "thread/goal/set",
+		promise: server.sendRequest("thread/goal/set", params, 20_000),
+	};
+}
 
 /** How long after a "Reconnecting…" stderr line we keep emitting
  *  synthetic heartbeats while Codex owns its retry loop. */
@@ -288,7 +425,8 @@ export class CodexAppServerManager implements SessionManager {
 			prompt,
 			resolvedAdditionalDirectories,
 		);
-		const isCompactCommand = prompt.trim() === "/compact";
+		const goalCommand = parseGoalCommand(prompt);
+		const isCompactCommand = !goalCommand && prompt.trim() === "/compact";
 		const input = buildTurnInput(promptWithContext, images);
 		const turnStartParams: Record<string, unknown> = {
 			threadId: ctx.providerThreadId,
@@ -403,6 +541,24 @@ export class CodexAppServerManager implements SessionManager {
 					}
 				}
 
+				// Forward Codex goal state changes so the panel header banner
+				// can render the active goal. `thread/goal/updated` carries
+				// the full ThreadGoal payload; `thread/goal/cleared` flips it
+				// off (we send a null goal in the same event type).
+				if (n.method === "thread/goal/updated") {
+					const goal = deepGet(n.params, "goal");
+					if (goal && typeof goal === "object") {
+						emitter.codexGoalUpdated(
+							requestId,
+							sessionId,
+							JSON.stringify(goal),
+						);
+					}
+				}
+				if (n.method === "thread/goal/cleared") {
+					emitter.codexGoalUpdated(requestId, sessionId, null);
+				}
+
 				// Forward Codex token usage to the context-usage ring.
 				if (n.method === "thread/tokenUsage/updated") {
 					const tokenUsage = deepGet(n.params, "tokenUsage");
@@ -508,18 +664,43 @@ export class CodexAppServerManager implements SessionManager {
 			ctx.server.setHandlers(handleNotification, handleRequest);
 			ctx.server.setActiveRequestId(requestId);
 
-			if (isCompactCommand && !ctx.providerThreadId) {
-				reject(new Error("Cannot compact before a Codex thread has started"));
+			if ((isCompactCommand || goalCommand) && !ctx.providerThreadId) {
+				reject(
+					new Error(
+						`Cannot run /${isCompactCommand ? "compact" : "goal"} before a Codex thread has started`,
+					),
+				);
 				return;
 			}
 
-			const requestPromise = isCompactCommand
-				? ctx.server.sendRequest(
-						"thread/compact/start",
-						{ threadId: ctx.providerThreadId },
-						20_000,
-					)
-				: ctx.server.sendRequest("turn/start", turnStartParams);
+			const dispatchPrompt = (): {
+				method: string;
+				promise: Promise<unknown>;
+			} => {
+				if (isCompactCommand) {
+					return {
+						method: "thread/compact/start",
+						promise: ctx.server.sendRequest(
+							"thread/compact/start",
+							{ threadId: ctx.providerThreadId },
+							20_000,
+						),
+					};
+				}
+				if (goalCommand) {
+					return dispatchGoalCommand(
+						ctx.server,
+						ctx.providerThreadId as string,
+						goalCommand,
+					);
+				}
+				return {
+					method: "turn/start",
+					promise: ctx.server.sendRequest("turn/start", turnStartParams),
+				};
+			};
+
+			const { method, promise: requestPromise } = dispatchPrompt();
 
 			requestPromise
 				.then((response) => {
@@ -529,10 +710,7 @@ export class CodexAppServerManager implements SessionManager {
 					}
 				})
 				.catch((err) => {
-					logger.error(
-						`${isCompactCommand ? "thread/compact/start" : "turn/start"} failed`,
-						errorDetails(err),
-					);
+					logger.error(`${method} failed`, errorDetails(err));
 					reject(err);
 				});
 		}).finally(() => {

--- a/sidecar/src/codex-app-server.ts
+++ b/sidecar/src/codex-app-server.ts
@@ -7,6 +7,8 @@
  */
 
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
 import readline from "node:readline";
 import { logger } from "./logger.js";
 
@@ -79,6 +81,28 @@ export function buildCodexAppServerArgs(): string[] {
 	return [...CODEX_APP_SERVER_ARGS];
 }
 
+/**
+ * Codex ships ripgrep next to its binary and spawns it by name on PATH for
+ * in-thread search. Two layouts to support:
+ *   - dev (node_modules):  <pkg>/vendor/<triple>/codex/codex
+ *                          <pkg>/vendor/<triple>/path/rg          ← parent's sibling
+ *   - staged (release):    dist/vendor/codex/codex
+ *                          dist/vendor/codex/path/rg              ← own sibling
+ */
+function buildCodexEnv(binaryPath: string): NodeJS.ProcessEnv {
+	const env = { ...process.env };
+	const candidates = [
+		join(dirname(binaryPath), "..", "path"),
+		join(dirname(binaryPath), "path"),
+	];
+	const pathDir = candidates.find((p) => existsSync(p));
+	if (pathDir) {
+		const sep = process.platform === "win32" ? ";" : ":";
+		env.PATH = `${pathDir}${sep}${env.PATH ?? ""}`;
+	}
+	return env;
+}
+
 export class CodexAppServer {
 	private child: ChildProcessWithoutNullStreams;
 	private output: readline.Interface;
@@ -98,6 +122,7 @@ export class CodexAppServer {
 		this.child = spawn(opts.binaryPath, buildCodexAppServerArgs(), {
 			cwd: opts.cwd,
 			stdio: ["pipe", "pipe", "pipe"],
+			env: buildCodexEnv(opts.binaryPath),
 		});
 
 		this.output = readline.createInterface({ input: this.child.stdout });

--- a/sidecar/src/emitter.ts
+++ b/sidecar/src/emitter.ts
@@ -161,6 +161,17 @@ export type ContextUsageResultEvent = {
 	readonly meta: string;
 };
 
+// Codex `/goal` state change. `goal` is the stringified `ThreadGoal`
+// payload from `thread/goal/updated`; `null` means the goal was cleared.
+// Rust persists this to an in-memory map so the banner can render the
+// active goal in the panel header.
+export type CodexGoalUpdatedEvent = {
+	readonly id: string;
+	readonly type: "codexGoalUpdated";
+	readonly sessionId: string;
+	readonly goal: string | null;
+};
+
 export type SidecarControlEvent =
 	| ReadyEvent
 	| EndEvent
@@ -180,7 +191,8 @@ export type SidecarControlEvent =
 	| ModelsListedEvent
 	| UserInputRequestEvent
 	| ContextUsageUpdatedEvent
-	| ContextUsageResultEvent;
+	| ContextUsageResultEvent
+	| CodexGoalUpdatedEvent;
 
 /**
  * Typed emitter for the sidecar's stdout protocol.
@@ -258,6 +270,11 @@ export interface SidecarEmitter {
 		meta: string | null,
 	): void;
 	contextUsageResult(requestId: string, meta: string): void;
+	codexGoalUpdated(
+		requestId: string,
+		sessionId: string,
+		goal: string | null,
+	): void;
 	/**
 	 * Forward a raw provider SDK message. `id` is appended LAST so an SDK
 	 * field named `id` can never override our request id.
@@ -371,6 +388,13 @@ export function createSidecarEmitter(
 			}),
 		contextUsageResult: (requestId, meta) =>
 			write({ id: requestId, type: "contextUsageResult", meta }),
+		codexGoalUpdated: (requestId, sessionId, goal) =>
+			write({
+				id: requestId,
+				type: "codexGoalUpdated",
+				sessionId,
+				goal,
+			}),
 		passthrough: (requestId, message) =>
 			write({ ...(message as Record<string, unknown>), id: requestId }),
 	};

--- a/sidecar/src/index.ts
+++ b/sidecar/src/index.ts
@@ -291,6 +291,30 @@ async function handleGetContextUsage(
 	}
 }
 
+async function handleMutateCodexGoal(
+	id: string,
+	params: Record<string, unknown>,
+): Promise<void> {
+	try {
+		const sessionId = requireString(params, "sessionId");
+		const actionRaw = requireString(params, "action");
+		if (
+			actionRaw !== "pause" &&
+			actionRaw !== "resume" &&
+			actionRaw !== "clear"
+		) {
+			throw new Error(`Invalid mutateCodexGoal action: ${actionRaw}`);
+		}
+		logger.debug(`[${id}] mutateCodexGoal`, { sessionId, action: actionRaw });
+		await codexManager.mutateGoal(sessionId, actionRaw);
+		emitter.pong(id);
+	} catch (err) {
+		const msg = errorMessage(err);
+		logger.error(`[${id}] mutateCodexGoal FAILED: ${msg}`, errorDetails(err));
+		emitter.error(id, msg);
+	}
+}
+
 async function handleSteerSession(
 	id: string,
 	params: Record<string, unknown>,
@@ -433,6 +457,9 @@ for await (const line of rl) {
 				break;
 			case "steerSession":
 				await handleSteerSession(id, params);
+				break;
+			case "mutateCodexGoal":
+				await handleMutateCodexGoal(id, params);
 				break;
 			case "shutdown":
 				await handleShutdown(id);

--- a/sidecar/src/index.ts
+++ b/sidecar/src/index.ts
@@ -298,11 +298,7 @@ async function handleMutateCodexGoal(
 	try {
 		const sessionId = requireString(params, "sessionId");
 		const actionRaw = requireString(params, "action");
-		if (
-			actionRaw !== "pause" &&
-			actionRaw !== "resume" &&
-			actionRaw !== "clear"
-		) {
+		if (actionRaw !== "pause" && actionRaw !== "clear") {
 			throw new Error(`Invalid mutateCodexGoal action: ${actionRaw}`);
 		}
 		logger.debug(`[${id}] mutateCodexGoal`, { sessionId, action: actionRaw });

--- a/sidecar/test/codex-app-server-manager.test.ts
+++ b/sidecar/test/codex-app-server-manager.test.ts
@@ -629,4 +629,33 @@ describe("parseGoalCommand", () => {
 			objective: "improve benchmark coverage",
 		});
 	});
+
+	test("recognises /goal resume as the resume kind", async () => {
+		const { parseGoalCommand } = await import(
+			"../src/codex-app-server-manager.js"
+		);
+		expect(parseGoalCommand("/goal resume")).toEqual({ kind: "resume" });
+	});
+
+	// Contract: pause/clear are NOT recognised by the sidecar parser. The
+	// container-level intercept catches them BEFORE the prompt ever reaches
+	// the sidecar — they're routed through `mutateCodexGoal` so they don't
+	// pollute chat history. If this changes (e.g. parser starts returning
+	// pause/clear variants), the container intercept must lose its short-
+	// circuit too, or `/goal pause` will be both lifecycle-mutated AND
+	// echoed as a chat user prompt.
+	test("does NOT recognise /goal pause or /goal clear (handled by container intercept)", async () => {
+		const { parseGoalCommand } = await import(
+			"../src/codex-app-server-manager.js"
+		);
+		// Sidecar treats them as plain objectives if they ever arrive here.
+		expect(parseGoalCommand("/goal pause")).toEqual({
+			kind: "set",
+			objective: "pause",
+		});
+		expect(parseGoalCommand("/goal clear")).toEqual({
+			kind: "set",
+			objective: "clear",
+		});
+	});
 });

--- a/sidecar/test/codex-app-server-manager.test.ts
+++ b/sidecar/test/codex-app-server-manager.test.ts
@@ -620,15 +620,6 @@ describe("parseGoalCommand", () => {
 		expect(parseGoalCommand("  /goal  ")).toBeNull();
 	});
 
-	test("recognises pause / resume / clear", async () => {
-		const { parseGoalCommand } = await import(
-			"../src/codex-app-server-manager.js"
-		);
-		expect(parseGoalCommand("/goal pause")).toEqual({ kind: "pause" });
-		expect(parseGoalCommand("/goal resume")).toEqual({ kind: "resume" });
-		expect(parseGoalCommand("/goal clear")).toEqual({ kind: "clear" });
-	});
-
 	test("treats free-form text as the objective", async () => {
 		const { parseGoalCommand } = await import(
 			"../src/codex-app-server-manager.js"
@@ -636,37 +627,6 @@ describe("parseGoalCommand", () => {
 		expect(parseGoalCommand("/goal improve benchmark coverage")).toEqual({
 			kind: "set",
 			objective: "improve benchmark coverage",
-		});
-	});
-
-	test("parses --tokens budget with K / M suffixes", async () => {
-		const { parseGoalCommand } = await import(
-			"../src/codex-app-server-manager.js"
-		);
-		expect(parseGoalCommand("/goal --tokens 98.5K refactor module")).toEqual({
-			kind: "set",
-			objective: "refactor module",
-			tokenBudget: 98_500,
-		});
-		expect(parseGoalCommand("/goal --tokens 1M big task")).toEqual({
-			kind: "set",
-			objective: "big task",
-			tokenBudget: 1_000_000,
-		});
-		expect(parseGoalCommand("/goal --tokens 50000 plain")).toEqual({
-			kind: "set",
-			objective: "plain",
-			tokenBudget: 50_000,
-		});
-	});
-
-	test("falls through to plain set when --tokens spec is malformed", async () => {
-		const { parseGoalCommand } = await import(
-			"../src/codex-app-server-manager.js"
-		);
-		expect(parseGoalCommand("/goal --tokens xyz objective text")).toEqual({
-			kind: "set",
-			objective: "--tokens xyz objective text",
 		});
 	});
 });

--- a/sidecar/test/codex-app-server-manager.test.ts
+++ b/sidecar/test/codex-app-server-manager.test.ts
@@ -539,3 +539,72 @@ describe("CodexAppServerManager", () => {
 		);
 	});
 });
+
+describe("parseGoalCommand", () => {
+	test("returns null for non-/goal prompts", async () => {
+		const { parseGoalCommand } = await import(
+			"../src/codex-app-server-manager.js"
+		);
+		expect(parseGoalCommand("hello world")).toBeNull();
+		expect(parseGoalCommand("/compact")).toBeNull();
+		expect(parseGoalCommand("/goalish trick")).toBeNull();
+	});
+
+	test("returns null for bare /goal so the agent handles it", async () => {
+		const { parseGoalCommand } = await import(
+			"../src/codex-app-server-manager.js"
+		);
+		expect(parseGoalCommand("/goal")).toBeNull();
+		expect(parseGoalCommand("  /goal  ")).toBeNull();
+	});
+
+	test("recognises pause / resume / clear", async () => {
+		const { parseGoalCommand } = await import(
+			"../src/codex-app-server-manager.js"
+		);
+		expect(parseGoalCommand("/goal pause")).toEqual({ kind: "pause" });
+		expect(parseGoalCommand("/goal resume")).toEqual({ kind: "resume" });
+		expect(parseGoalCommand("/goal clear")).toEqual({ kind: "clear" });
+	});
+
+	test("treats free-form text as the objective", async () => {
+		const { parseGoalCommand } = await import(
+			"../src/codex-app-server-manager.js"
+		);
+		expect(parseGoalCommand("/goal improve benchmark coverage")).toEqual({
+			kind: "set",
+			objective: "improve benchmark coverage",
+		});
+	});
+
+	test("parses --tokens budget with K / M suffixes", async () => {
+		const { parseGoalCommand } = await import(
+			"../src/codex-app-server-manager.js"
+		);
+		expect(parseGoalCommand("/goal --tokens 98.5K refactor module")).toEqual({
+			kind: "set",
+			objective: "refactor module",
+			tokenBudget: 98_500,
+		});
+		expect(parseGoalCommand("/goal --tokens 1M big task")).toEqual({
+			kind: "set",
+			objective: "big task",
+			tokenBudget: 1_000_000,
+		});
+		expect(parseGoalCommand("/goal --tokens 50000 plain")).toEqual({
+			kind: "set",
+			objective: "plain",
+			tokenBudget: 50_000,
+		});
+	});
+
+	test("falls through to plain set when --tokens spec is malformed", async () => {
+		const { parseGoalCommand } = await import(
+			"../src/codex-app-server-manager.js"
+		);
+		expect(parseGoalCommand("/goal --tokens xyz objective text")).toEqual({
+			kind: "set",
+			objective: "--tokens xyz objective text",
+		});
+	});
+});

--- a/src-tauri/src/agents.rs
+++ b/src-tauri/src/agents.rs
@@ -14,7 +14,7 @@ mod custom_providers;
 mod persistence;
 mod queries;
 mod slash_commands;
-mod streaming;
+pub(crate) mod streaming;
 mod support;
 
 pub use self::action_kind::ActionKind;
@@ -193,11 +193,11 @@ pub struct AgentSendRequest {
 use crate::pipeline::types::{AgentUsage, CollectedTurn, MessageRole};
 
 /// Context shared across incremental persistence calls within a single exchange.
-struct ExchangeContext {
-    helmor_session_id: String,
-    model_id: String,
-    model_provider: String,
-    user_message_id: String,
+pub(crate) struct ExchangeContext {
+    pub(crate) helmor_session_id: String,
+    pub(crate) model_id: String,
+    pub(crate) model_provider: String,
+    pub(crate) user_message_id: String,
 }
 
 #[tauri::command]

--- a/src-tauri/src/agents/streaming/actions.rs
+++ b/src-tauri/src/agents/streaming/actions.rs
@@ -93,6 +93,10 @@ pub(super) enum Action {
     /// `ContextUsageChanged` UI mutation.
     PersistContextUsage { raw: Value },
 
+    /// Persist the parsed `codexGoalUpdated` payload + broadcast a
+    /// `CodexGoalChanged` UI mutation.
+    PersistCodexGoal { raw: Value },
+
     /// Finalize the session row to the given status (`idle` for normal
     /// exits, `aborted` for user-requested stops). Emitted on terminal
     /// transitions that don't go through `PersistResult` (e.g., aborts
@@ -129,6 +133,9 @@ pub(super) fn apply_action(action: Action, ctx: &ApplyContext) {
         }
         Action::PersistContextUsage { raw } => {
             super::context_usage::persist_context_usage_event(ctx.app, &raw);
+        }
+        Action::PersistCodexGoal { raw } => {
+            super::codex_goal::persist_codex_goal_event(ctx.app, &raw);
         }
         other => {
             tracing::error!(

--- a/src-tauri/src/agents/streaming/codex_goal.rs
+++ b/src-tauri/src/agents/streaming/codex_goal.rs
@@ -10,9 +10,16 @@ use tauri::AppHandle;
 pub(super) enum CodexGoalWriteOutcome {
     /// Malformed event (missing/empty sessionId).
     Skipped,
-    /// Event valid, DB row updated. `Some(json)` = active goal,
-    /// `None` = goal cleared.
-    Wrote(String),
+    /// Event valid, DB row updated. `inserted_message` flips on only
+    /// when the transition actually produced a new chat-history system
+    /// message — used by the broadcaster to skip a wasteful
+    /// `SessionMessagesAppended` invalidation on idempotent writes
+    /// (e.g. the codex push that arrives right after a local mutation
+    /// already wrote the same payload).
+    Wrote {
+        session_id: String,
+        inserted_message: bool,
+    },
     /// Session row not found — likely a stale/post-delete event.
     UnknownSession(String),
 }
@@ -57,13 +64,18 @@ pub(super) fn write_codex_goal_meta(
             session_id.to_string(),
         ));
     }
-    if let Some(label) = transition_label {
+    let inserted_message = if let Some(label) = transition_label {
         // Best-effort: a failed system-message insert shouldn't fail the
         // whole write — banner still reflects the new state via the
         // codex_goal_meta column itself.
-        let _ = insert_goal_system_message(conn, session_id, &label);
-    }
-    Ok(CodexGoalWriteOutcome::Wrote(session_id.to_string()))
+        insert_goal_system_message(conn, session_id, &label).is_ok()
+    } else {
+        false
+    };
+    Ok(CodexGoalWriteOutcome::Wrote {
+        session_id: session_id.to_string(),
+        inserted_message,
+    })
 }
 
 /// Compare the old and new `codex_goal_meta` values and return a
@@ -190,17 +202,15 @@ fn compute_local_mutation(
         return Ok(None);
     }
 
+    if action != "pause" {
+        return Err(format!("invalid action {action}"));
+    }
     let prev = prev_meta
         .as_deref()
         .ok_or_else(|| "no goal to mutate".to_string())?;
     let mut value: Value = serde_json::from_str(prev).map_err(|e| e.to_string())?;
-    let new_status = match action {
-        "pause" => "paused",
-        "resume" => "active",
-        other => return Err(format!("invalid action {other}")),
-    };
     if let Some(obj) = value.as_object_mut() {
-        obj.insert("status".to_string(), Value::String(new_status.to_string()));
+        obj.insert("status".to_string(), Value::String("paused".to_string()));
     } else {
         return Err("codex_goal_meta is not an object".to_string());
     }
@@ -221,7 +231,7 @@ pub(super) fn persist_codex_goal_event(app: &AppHandle, raw: &Value) {
             return;
         }
     };
-    let session_id = match outcome {
+    let (session_id, inserted_message) = match outcome {
         CodexGoalWriteOutcome::Skipped => {
             tracing::warn!("codexGoalUpdated event malformed (missing sessionId)");
             return;
@@ -233,7 +243,10 @@ pub(super) fn persist_codex_goal_event(app: &AppHandle, raw: &Value) {
             );
             return;
         }
-        CodexGoalWriteOutcome::Wrote(id) => id,
+        CodexGoalWriteOutcome::Wrote {
+            session_id,
+            inserted_message,
+        } => (session_id, inserted_message),
     };
     crate::ui_sync::publish(
         app,
@@ -241,12 +254,18 @@ pub(super) fn persist_codex_goal_event(app: &AppHandle, raw: &Value) {
             session_id: session_id.clone(),
         },
     );
-    // Force the chat to refetch so any synthesised goal_status system
-    // message we just inserted shows up immediately.
-    crate::ui_sync::publish(
-        app,
-        crate::ui_sync::UiMutationEvent::SessionMessagesAppended { session_id },
-    );
+    // Only broadcast SessionMessagesAppended when we actually inserted a
+    // chat-history message. A re-write that flips no fields (e.g. the
+    // codex notification arriving after a local mutation already wrote
+    // the same payload) must not invalidate the chat — that triggers a
+    // refetch which fights with in-flight streaming and shows up as a
+    // visible flicker / "interrupted output".
+    if inserted_message {
+        crate::ui_sync::publish(
+            app,
+            crate::ui_sync::UiMutationEvent::SessionMessagesAppended { session_id },
+        );
+    }
 }
 
 #[cfg(test)]
@@ -281,7 +300,14 @@ mod tests {
             "goal": r#"{"objective":"refactor","status":"active","tokensUsed":100}"#,
         });
         let outcome = write_codex_goal_meta(&conn, &raw).unwrap();
-        assert_eq!(outcome, CodexGoalWriteOutcome::Wrote("s1".to_string()));
+        // First write of an active goal counts as a transition → message inserted.
+        assert_eq!(
+            outcome,
+            CodexGoalWriteOutcome::Wrote {
+                session_id: "s1".to_string(),
+                inserted_message: true,
+            }
+        );
         assert!(read_meta(&conn, "s1").unwrap().contains("\"objective\""));
     }
 
@@ -295,8 +321,38 @@ mod tests {
         .unwrap();
         let raw = serde_json::json!({ "sessionId": "s1", "goal": null });
         let outcome = write_codex_goal_meta(&conn, &raw).unwrap();
-        assert_eq!(outcome, CodexGoalWriteOutcome::Wrote("s1".to_string()));
+        // {} -> null isn't a goal-status transition we narrate.
+        assert_eq!(
+            outcome,
+            CodexGoalWriteOutcome::Wrote {
+                session_id: "s1".to_string(),
+                inserted_message: false,
+            }
+        );
         assert_eq!(read_meta(&conn, "s1"), None);
+    }
+
+    #[test]
+    fn idempotent_rewrite_does_not_insert_message() {
+        // Simulates the codex notification arriving after a local mutation
+        // already wrote the same payload — must NOT fire a second
+        // SessionMessagesAppended invalidation.
+        let conn = open_test_db_with_session("s1");
+        let active_meta = r#"{"objective":"x","status":"active","tokensUsed":0,"timeUsedSeconds":0,"createdAt":0,"updatedAt":0,"threadId":"t","tokenBudget":null}"#;
+        conn.execute(
+            "UPDATE sessions SET codex_goal_meta = ?1 WHERE id = 's1'",
+            [active_meta],
+        )
+        .unwrap();
+        let raw = serde_json::json!({ "sessionId": "s1", "goal": active_meta });
+        let outcome = write_codex_goal_meta(&conn, &raw).unwrap();
+        assert_eq!(
+            outcome,
+            CodexGoalWriteOutcome::Wrote {
+                session_id: "s1".to_string(),
+                inserted_message: false,
+            }
+        );
     }
 
     #[test]
@@ -436,14 +492,6 @@ mod tests {
             let new_meta = compute_local_mutation(sid, "pause").unwrap().unwrap();
             assert!(new_meta.contains("\"status\":\"paused\""));
             assert!(new_meta.contains("\"objective\":\"obj\""));
-        });
-    }
-
-    #[test]
-    fn compute_local_mutation_resume_flips_to_active() {
-        with_db_session(Some(&meta("paused", "obj")), |sid| {
-            let new_meta = compute_local_mutation(sid, "resume").unwrap().unwrap();
-            assert!(new_meta.contains("\"status\":\"active\""));
         });
     }
 

--- a/src-tauri/src/agents/streaming/codex_goal.rs
+++ b/src-tauri/src/agents/streaming/codex_goal.rs
@@ -153,11 +153,36 @@ fn insert_goal_system_message(
 /// without waiting for codex's `thread/goal/updated` notification to
 /// round-trip back through the stale per-stream notification handler.
 ///
+/// Holds the writer connection for the whole read-modify-write window,
+/// so a concurrent codex push can't interleave between us reading the
+/// previous payload and writing the mutated one — which used to drop
+/// fields like `tokensUsed` that codex had updated in between.
+///
 /// Idempotent with whatever codex eventually pushes — both writes go
 /// through `write_codex_goal_meta`, so the second one (whichever it is)
 /// just observes "no transition" and skips the system message.
 pub fn apply_local_mutation(app: &AppHandle, session_id: &str, action: &str) {
-    let new_meta = match compute_local_mutation(session_id, action) {
+    let conn = match crate::models::db::write_conn() {
+        Ok(conn) => conn,
+        Err(err) => {
+            tracing::warn!(session_id = %session_id, action = %action, error = %err, "apply_local_mutation: write_conn failed");
+            return;
+        }
+    };
+    let prev_meta: Option<String> = match conn.query_row(
+        "SELECT codex_goal_meta FROM sessions WHERE id = ?1",
+        [session_id],
+        |row| row.get(0),
+    ) {
+        Ok(value) => value,
+        Err(rusqlite::Error::QueryReturnedNoRows) => None,
+        Err(err) => {
+            tracing::warn!(session_id = %session_id, action = %action, error = %err, "apply_local_mutation: read prev failed");
+            return;
+        }
+    };
+
+    let new_meta = match project_action_on_prev(prev_meta.as_deref(), action) {
         Ok(meta) => meta,
         Err(err) => {
             tracing::warn!(session_id = %session_id, action = %action, error = %err, "apply_local_mutation: skipped");
@@ -168,37 +193,34 @@ pub fn apply_local_mutation(app: &AppHandle, session_id: &str, action: &str) {
         "sessionId": session_id,
         "goal": new_meta,
     });
-    persist_codex_goal_event(app, &raw);
+    let outcome = match write_codex_goal_meta(&conn, &raw) {
+        Ok(outcome) => outcome,
+        Err(err) => {
+            tracing::warn!("Failed to persist codex_goal_meta: {err}");
+            return;
+        }
+    };
+    // Release the writer before fanning out invalidations — broadcasting
+    // doesn't need the lock and any followers waiting on it shouldn't be
+    // blocked behind a UI mutation publish.
+    drop(conn);
+    broadcast_codex_goal_outcome(app, outcome);
 }
 
-/// Read current `codex_goal_meta`, project the button action onto it,
-/// return the new meta as a stringified ThreadGoal (or `None` for
-/// `clear`). Returns `Err` when there's no current goal to mutate
-/// (clicking Pause when nothing is set is a no-op the caller swallows).
-fn compute_local_mutation(
-    session_id: &str,
+/// Project a banner-button action onto the previously-stored meta and
+/// return the new payload (or `None` for `clear`). Returns `Err` when
+/// the action can't be applied (e.g. pause without an existing goal).
+fn project_action_on_prev(
+    prev_meta: Option<&str>,
     action: &str,
 ) -> std::result::Result<Option<String>, String> {
-    let conn = crate::models::db::read_conn().map_err(|e| e.to_string())?;
-    let prev_meta: Option<String> = conn
-        .query_row(
-            "SELECT codex_goal_meta FROM sessions WHERE id = ?1",
-            [session_id],
-            |row| row.get(0),
-        )
-        .map_err(|e| e.to_string())?;
-    drop(conn);
-
     if action == "clear" {
         return Ok(None);
     }
-
     if action != "pause" {
         return Err(format!("invalid action {action}"));
     }
-    let prev = prev_meta
-        .as_deref()
-        .ok_or_else(|| "no goal to mutate".to_string())?;
+    let prev = prev_meta.ok_or_else(|| "no goal to mutate".to_string())?;
     let mut value: Value = serde_json::from_str(prev).map_err(|e| e.to_string())?;
     if let Some(obj) = value.as_object_mut() {
         obj.insert("status".to_string(), Value::String("paused".to_string()));
@@ -222,6 +244,10 @@ pub(super) fn persist_codex_goal_event(app: &AppHandle, raw: &Value) {
             return;
         }
     };
+    broadcast_codex_goal_outcome(app, outcome);
+}
+
+fn broadcast_codex_goal_outcome(app: &AppHandle, outcome: CodexGoalWriteOutcome) {
     let (session_id, inserted_message) = match outcome {
         CodexGoalWriteOutcome::Skipped => {
             tracing::warn!("codexGoalUpdated event malformed (missing sessionId)");
@@ -454,61 +480,40 @@ mod tests {
         assert_eq!(label, Some("Goal complete"));
     }
 
-    // The compute_local_mutation tests need to drive the real DB pool
-    // because they read codex_goal_meta via the shared connection. We
-    // do that through the same TEST_ENV_LOCK setup other DB-touching
-    // tests use.
-    fn with_db_session<F: FnOnce(&str)>(prev_meta: Option<&str>, f: F) {
-        let dir = tempfile::tempdir().unwrap();
-        let _guard = crate::data_dir::TEST_ENV_LOCK
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
-        std::env::set_var("HELMOR_DATA_DIR", dir.path());
-        crate::data_dir::ensure_directory_structure().unwrap();
-
-        let session_id = "s-mutate";
-        {
-            let conn = crate::models::db::write_conn().unwrap();
-            crate::schema::ensure_schema(&conn).unwrap();
-            conn.execute(
-                "INSERT OR REPLACE INTO sessions (id, workspace_id, status, codex_goal_meta) VALUES (?1, 'w', 'idle', ?2)",
-                rusqlite::params![session_id, prev_meta],
-            )
+    // `project_action_on_prev` is a pure function — no DB. Tests drive
+    // it directly without a session row.
+    #[test]
+    fn project_action_pause_flips_status_to_paused() {
+        let prev = meta("active", "obj");
+        let new_meta = project_action_on_prev(Some(prev.as_str()), "pause")
+            .unwrap()
             .unwrap();
-        }
-        f(session_id);
-        std::env::remove_var("HELMOR_DATA_DIR");
+        assert!(new_meta.contains("\"status\":\"paused\""));
+        assert!(new_meta.contains("\"objective\":\"obj\""));
     }
 
     #[test]
-    fn compute_local_mutation_pause_flips_status_to_paused() {
-        with_db_session(Some(&meta("active", "obj")), |sid| {
-            let new_meta = compute_local_mutation(sid, "pause").unwrap().unwrap();
-            assert!(new_meta.contains("\"status\":\"paused\""));
-            assert!(new_meta.contains("\"objective\":\"obj\""));
-        });
+    fn project_action_clear_returns_none() {
+        let prev = meta("active", "obj");
+        let new_meta = project_action_on_prev(Some(prev.as_str()), "clear").unwrap();
+        assert_eq!(new_meta, None);
     }
 
     #[test]
-    fn compute_local_mutation_clear_returns_none() {
-        with_db_session(Some(&meta("active", "obj")), |sid| {
-            let new_meta = compute_local_mutation(sid, "clear").unwrap();
-            assert_eq!(new_meta, None);
-        });
+    fn project_action_pause_without_existing_goal_errors() {
+        assert!(project_action_on_prev(None, "pause").is_err());
     }
 
     #[test]
-    fn compute_local_mutation_pause_without_existing_goal_errors() {
-        with_db_session(None, |sid| {
-            assert!(compute_local_mutation(sid, "pause").is_err());
-        });
+    fn project_action_clear_without_existing_goal_is_idempotent() {
+        // Clear is tolerant — clearing nothing is a no-op (returns None).
+        assert_eq!(project_action_on_prev(None, "clear").unwrap(), None);
     }
 
     #[test]
-    fn compute_local_mutation_clear_without_existing_goal_is_idempotent() {
-        with_db_session(None, |sid| {
-            // Clear should be tolerant — clearing nothing is a no-op.
-            assert_eq!(compute_local_mutation(sid, "clear").unwrap(), None);
-        });
+    fn project_action_invalid_returns_err() {
+        let prev = meta("active", "obj");
+        assert!(project_action_on_prev(Some(prev.as_str()), "resume").is_err());
+        assert!(project_action_on_prev(Some(prev.as_str()), "garbage").is_err());
     }
 }

--- a/src-tauri/src/agents/streaming/codex_goal.rs
+++ b/src-tauri/src/agents/streaming/codex_goal.rs
@@ -146,6 +146,67 @@ fn insert_goal_system_message(
     Ok(())
 }
 
+/// Apply a banner-button-driven goal mutation directly to the local DB
+/// without waiting for codex's `thread/goal/updated` notification to
+/// round-trip back through the stale per-stream notification handler.
+///
+/// Idempotent with whatever codex eventually pushes — both writes go
+/// through `write_codex_goal_meta`, so the second one (whichever it is)
+/// just observes "no transition" and skips the system message.
+pub fn apply_local_mutation(app: &AppHandle, session_id: &str, action: &str) {
+    let new_meta = match compute_local_mutation(session_id, action) {
+        Ok(meta) => meta,
+        Err(err) => {
+            tracing::warn!(session_id = %session_id, action = %action, error = %err, "apply_local_mutation: skipped");
+            return;
+        }
+    };
+    let raw = serde_json::json!({
+        "sessionId": session_id,
+        "goal": new_meta,
+    });
+    persist_codex_goal_event(app, &raw);
+}
+
+/// Read current `codex_goal_meta`, project the button action onto it,
+/// return the new meta as a stringified ThreadGoal (or `None` for
+/// `clear`). Returns `Err` when there's no current goal to mutate
+/// (clicking Pause when nothing is set is a no-op the caller swallows).
+fn compute_local_mutation(
+    session_id: &str,
+    action: &str,
+) -> std::result::Result<Option<String>, String> {
+    let conn = crate::models::db::read_conn().map_err(|e| e.to_string())?;
+    let prev_meta: Option<String> = conn
+        .query_row(
+            "SELECT codex_goal_meta FROM sessions WHERE id = ?1",
+            [session_id],
+            |row| row.get(0),
+        )
+        .map_err(|e| e.to_string())?;
+    drop(conn);
+
+    if action == "clear" {
+        return Ok(None);
+    }
+
+    let prev = prev_meta
+        .as_deref()
+        .ok_or_else(|| "no goal to mutate".to_string())?;
+    let mut value: Value = serde_json::from_str(prev).map_err(|e| e.to_string())?;
+    let new_status = match action {
+        "pause" => "paused",
+        "resume" => "active",
+        other => return Err(format!("invalid action {other}")),
+    };
+    if let Some(obj) = value.as_object_mut() {
+        obj.insert("status".to_string(), Value::String(new_status.to_string()));
+    } else {
+        return Err("codex_goal_meta is not an object".to_string());
+    }
+    Ok(Some(value.to_string()))
+}
+
 pub(super) fn persist_codex_goal_event(app: &AppHandle, raw: &Value) {
     let outcome = match crate::models::db::write_conn() {
         Ok(conn) => match write_codex_goal_meta(&conn, raw) {
@@ -341,5 +402,71 @@ mod tests {
             Some(meta("complete", "x").as_str()),
         );
         assert_eq!(label.as_deref(), Some("Goal complete"));
+    }
+
+    // The compute_local_mutation tests need to drive the real DB pool
+    // because they read codex_goal_meta via the shared connection. We
+    // do that through the same TEST_ENV_LOCK setup other DB-touching
+    // tests use.
+    fn with_db_session<F: FnOnce(&str)>(prev_meta: Option<&str>, f: F) {
+        let dir = tempfile::tempdir().unwrap();
+        let _guard = crate::data_dir::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        std::env::set_var("HELMOR_DATA_DIR", dir.path());
+        crate::data_dir::ensure_directory_structure().unwrap();
+
+        let session_id = "s-mutate";
+        {
+            let conn = crate::models::db::write_conn().unwrap();
+            crate::schema::ensure_schema(&conn).unwrap();
+            conn.execute(
+                "INSERT OR REPLACE INTO sessions (id, workspace_id, status, codex_goal_meta) VALUES (?1, 'w', 'idle', ?2)",
+                rusqlite::params![session_id, prev_meta],
+            )
+            .unwrap();
+        }
+        f(session_id);
+        std::env::remove_var("HELMOR_DATA_DIR");
+    }
+
+    #[test]
+    fn compute_local_mutation_pause_flips_status_to_paused() {
+        with_db_session(Some(&meta("active", "obj")), |sid| {
+            let new_meta = compute_local_mutation(sid, "pause").unwrap().unwrap();
+            assert!(new_meta.contains("\"status\":\"paused\""));
+            assert!(new_meta.contains("\"objective\":\"obj\""));
+        });
+    }
+
+    #[test]
+    fn compute_local_mutation_resume_flips_to_active() {
+        with_db_session(Some(&meta("paused", "obj")), |sid| {
+            let new_meta = compute_local_mutation(sid, "resume").unwrap().unwrap();
+            assert!(new_meta.contains("\"status\":\"active\""));
+        });
+    }
+
+    #[test]
+    fn compute_local_mutation_clear_returns_none() {
+        with_db_session(Some(&meta("active", "obj")), |sid| {
+            let new_meta = compute_local_mutation(sid, "clear").unwrap();
+            assert_eq!(new_meta, None);
+        });
+    }
+
+    #[test]
+    fn compute_local_mutation_pause_without_existing_goal_errors() {
+        with_db_session(None, |sid| {
+            assert!(compute_local_mutation(sid, "pause").is_err());
+        });
+    }
+
+    #[test]
+    fn compute_local_mutation_clear_without_existing_goal_is_idempotent() {
+        with_db_session(None, |sid| {
+            // Clear should be tolerant — clearing nothing is a no-op.
+            assert_eq!(compute_local_mutation(sid, "clear").unwrap(), None);
+        });
     }
 }

--- a/src-tauri/src/agents/streaming/codex_goal.rs
+++ b/src-tauri/src/agents/streaming/codex_goal.rs
@@ -68,7 +68,7 @@ pub(super) fn write_codex_goal_meta(
         // Best-effort: a failed system-message insert shouldn't fail the
         // whole write — banner still reflects the new state via the
         // codex_goal_meta column itself.
-        insert_goal_system_message(conn, session_id, &label).is_ok()
+        insert_goal_system_message(conn, session_id, label).is_ok()
     } else {
         false
     };
@@ -82,33 +82,31 @@ pub(super) fn write_codex_goal_meta(
 /// human-readable label when the transition is worth narrating in chat.
 /// `None` when no message should be inserted (e.g. unchanged status,
 /// background token-usage updates that don't move status).
+///
+/// Labels intentionally don't include the objective — the user's
+/// `/goal X` prompt already produced a chat bubble carrying that text,
+/// and repeating it on the system row would just be visual noise.
 pub(super) fn goal_transition_label(
     previous_meta: Option<&str>,
     new_meta: Option<&str>,
-) -> Option<String> {
+) -> Option<&'static str> {
     let prev = previous_meta.and_then(parse_goal_status);
     let curr = new_meta.and_then(parse_goal_status);
-    let new_objective = new_meta.and_then(parse_goal_objective);
 
     if prev == curr {
         return None;
     }
     match (prev, curr) {
         (None, None) => None,
-        // First time setting a goal: include the objective.
-        (None, Some(GoalStatus::Active)) => match new_objective {
-            Some(obj) if !obj.is_empty() => Some(format!("Goal set: {obj}")),
-            _ => Some("Goal started".to_string()),
-        },
-        // Brand-new goal in any other status — fallback.
-        (None, Some(_)) => Some("Goal updated".to_string()),
+        // Brand-new goal — `Goal set` regardless of starting status.
+        (None, Some(_)) => Some("Goal set"),
         // Cleared.
-        (Some(_), None) => Some("Goal cleared".to_string()),
+        (Some(_), None) => Some("Goal cleared"),
         // Status flips while goal exists.
-        (Some(_), Some(GoalStatus::Paused)) => Some("Goal paused".to_string()),
-        (Some(_), Some(GoalStatus::Active)) => Some("Goal resumed".to_string()),
-        (Some(_), Some(GoalStatus::BudgetLimited)) => Some("Goal reached token budget".to_string()),
-        (Some(_), Some(GoalStatus::Complete)) => Some("Goal complete".to_string()),
+        (Some(_), Some(GoalStatus::Paused)) => Some("Goal paused"),
+        (Some(_), Some(GoalStatus::Active)) => Some("Goal resumed"),
+        (Some(_), Some(GoalStatus::BudgetLimited)) => Some("Goal reached token budget"),
+        (Some(_), Some(GoalStatus::Complete)) => Some("Goal complete"),
     }
 }
 
@@ -130,13 +128,6 @@ fn parse_goal_status(meta: &str) -> Option<GoalStatus> {
         "complete" => Some(GoalStatus::Complete),
         _ => None,
     }
-}
-
-fn parse_goal_objective(meta: &str) -> Option<String> {
-    let v: Value = serde_json::from_str(meta).ok()?;
-    v.get("objective")
-        .and_then(Value::as_str)
-        .map(str::to_string)
 }
 
 fn insert_goal_system_message(
@@ -395,9 +386,12 @@ mod tests {
     }
 
     #[test]
-    fn transition_label_first_set_includes_objective() {
+    fn transition_label_first_set_does_not_include_objective() {
+        // The user's `/goal X` prompt already produces a chat bubble with
+        // the objective text — repeating it on the system row would just
+        // be noise. So the label is the same regardless of objective.
         let label = goal_transition_label(None, Some(meta("active", "fix the bug").as_str()));
-        assert_eq!(label.as_deref(), Some("Goal set: fix the bug"));
+        assert_eq!(label, Some("Goal set"));
     }
 
     #[test]
@@ -406,7 +400,7 @@ mod tests {
             Some(meta("active", "x").as_str()),
             Some(meta("paused", "x").as_str()),
         );
-        assert_eq!(label.as_deref(), Some("Goal paused"));
+        assert_eq!(label, Some("Goal paused"));
     }
 
     #[test]
@@ -415,13 +409,13 @@ mod tests {
             Some(meta("paused", "x").as_str()),
             Some(meta("active", "x").as_str()),
         );
-        assert_eq!(label.as_deref(), Some("Goal resumed"));
+        assert_eq!(label, Some("Goal resumed"));
     }
 
     #[test]
     fn transition_label_cleared() {
         let label = goal_transition_label(Some(meta("active", "x").as_str()), None);
-        assert_eq!(label.as_deref(), Some("Goal cleared"));
+        assert_eq!(label, Some("Goal cleared"));
     }
 
     #[test]
@@ -448,7 +442,7 @@ mod tests {
             Some(meta("active", "x").as_str()),
             Some(meta("budgetLimited", "x").as_str()),
         );
-        assert_eq!(label.as_deref(), Some("Goal reached token budget"));
+        assert_eq!(label, Some("Goal reached token budget"));
     }
 
     #[test]
@@ -457,7 +451,7 @@ mod tests {
             Some(meta("active", "x").as_str()),
             Some(meta("complete", "x").as_str()),
         );
-        assert_eq!(label.as_deref(), Some("Goal complete"));
+        assert_eq!(label, Some("Goal complete"));
     }
 
     // The compute_local_mutation tests need to drive the real DB pool

--- a/src-tauri/src/agents/streaming/codex_goal.rs
+++ b/src-tauri/src/agents/streaming/codex_goal.rs
@@ -3,7 +3,7 @@
 //! through React Query — the channel only carries the invalidation cue.
 
 use rusqlite::params;
-use serde_json::Value;
+use serde_json::{json, Value};
 use tauri::AppHandle;
 
 #[derive(Debug, PartialEq, Eq)]
@@ -35,6 +35,19 @@ pub(super) fn write_codex_goal_meta(
         Some(Value::Null) | None => None,
         _ => return Ok(CodexGoalWriteOutcome::Skipped),
     };
+
+    // Read previous meta to detect transitions worth narrating in the
+    // chat as a system message ("Goal paused", "Goal resumed", etc.).
+    let previous_meta: Option<String> = conn
+        .query_row(
+            "SELECT codex_goal_meta FROM sessions WHERE id = ?1",
+            [session_id],
+            |row| row.get(0),
+        )
+        .ok()
+        .flatten();
+    let transition_label = goal_transition_label(previous_meta.as_deref(), value);
+
     let affected = conn.execute(
         "UPDATE sessions SET codex_goal_meta = ?1 WHERE id = ?2",
         params![value, session_id],
@@ -44,7 +57,93 @@ pub(super) fn write_codex_goal_meta(
             session_id.to_string(),
         ));
     }
+    if let Some(label) = transition_label {
+        // Best-effort: a failed system-message insert shouldn't fail the
+        // whole write — banner still reflects the new state via the
+        // codex_goal_meta column itself.
+        let _ = insert_goal_system_message(conn, session_id, &label);
+    }
     Ok(CodexGoalWriteOutcome::Wrote(session_id.to_string()))
+}
+
+/// Compare the old and new `codex_goal_meta` values and return a
+/// human-readable label when the transition is worth narrating in chat.
+/// `None` when no message should be inserted (e.g. unchanged status,
+/// background token-usage updates that don't move status).
+pub(super) fn goal_transition_label(
+    previous_meta: Option<&str>,
+    new_meta: Option<&str>,
+) -> Option<String> {
+    let prev = previous_meta.and_then(parse_goal_status);
+    let curr = new_meta.and_then(parse_goal_status);
+    let new_objective = new_meta.and_then(parse_goal_objective);
+
+    if prev == curr {
+        return None;
+    }
+    match (prev, curr) {
+        (None, None) => None,
+        // First time setting a goal: include the objective.
+        (None, Some(GoalStatus::Active)) => match new_objective {
+            Some(obj) if !obj.is_empty() => Some(format!("Goal set: {obj}")),
+            _ => Some("Goal started".to_string()),
+        },
+        // Brand-new goal in any other status — fallback.
+        (None, Some(_)) => Some("Goal updated".to_string()),
+        // Cleared.
+        (Some(_), None) => Some("Goal cleared".to_string()),
+        // Status flips while goal exists.
+        (Some(_), Some(GoalStatus::Paused)) => Some("Goal paused".to_string()),
+        (Some(_), Some(GoalStatus::Active)) => Some("Goal resumed".to_string()),
+        (Some(_), Some(GoalStatus::BudgetLimited)) => Some("Goal reached token budget".to_string()),
+        (Some(_), Some(GoalStatus::Complete)) => Some("Goal complete".to_string()),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GoalStatus {
+    Active,
+    Paused,
+    BudgetLimited,
+    Complete,
+}
+
+fn parse_goal_status(meta: &str) -> Option<GoalStatus> {
+    let v: Value = serde_json::from_str(meta).ok()?;
+    let s = v.get("status").and_then(Value::as_str)?;
+    match s {
+        "active" => Some(GoalStatus::Active),
+        "paused" => Some(GoalStatus::Paused),
+        "budgetLimited" => Some(GoalStatus::BudgetLimited),
+        "complete" => Some(GoalStatus::Complete),
+        _ => None,
+    }
+}
+
+fn parse_goal_objective(meta: &str) -> Option<String> {
+    let v: Value = serde_json::from_str(meta).ok()?;
+    v.get("objective")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+fn insert_goal_system_message(
+    conn: &rusqlite::Connection,
+    session_id: &str,
+    label: &str,
+) -> std::result::Result<(), rusqlite::Error> {
+    let msg_id = uuid::Uuid::new_v4().to_string();
+    let content = json!({ "type": "goal_status", "text": label }).to_string();
+    let now = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
+    conn.execute(
+        r#"
+            INSERT INTO session_messages (
+              id, session_id, role, content, created_at, sent_at
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?5)
+        "#,
+        params![msg_id, session_id, "system", content, now],
+    )?;
+    Ok(())
 }
 
 pub(super) fn persist_codex_goal_event(app: &AppHandle, raw: &Value) {
@@ -77,7 +176,15 @@ pub(super) fn persist_codex_goal_event(app: &AppHandle, raw: &Value) {
     };
     crate::ui_sync::publish(
         app,
-        crate::ui_sync::UiMutationEvent::CodexGoalChanged { session_id },
+        crate::ui_sync::UiMutationEvent::CodexGoalChanged {
+            session_id: session_id.clone(),
+        },
+    );
+    // Force the chat to refetch so any synthesised goal_status system
+    // message we just inserted shows up immediately.
+    crate::ui_sync::publish(
+        app,
+        crate::ui_sync::UiMutationEvent::SessionMessagesAppended { session_id },
     );
 }
 
@@ -162,5 +269,77 @@ mod tests {
         let raw = serde_json::json!({ "sessionId": "s1", "goal": 42 });
         let outcome = write_codex_goal_meta(&conn, &raw).unwrap();
         assert_eq!(outcome, CodexGoalWriteOutcome::Skipped);
+    }
+
+    fn meta(status: &str, objective: &str) -> String {
+        format!(
+            r#"{{"status":"{status}","objective":"{objective}","tokensUsed":0,"timeUsedSeconds":0,"createdAt":0,"updatedAt":0,"threadId":"t","tokenBudget":null}}"#
+        )
+    }
+
+    #[test]
+    fn transition_label_first_set_includes_objective() {
+        let label = goal_transition_label(None, Some(meta("active", "fix the bug").as_str()));
+        assert_eq!(label.as_deref(), Some("Goal set: fix the bug"));
+    }
+
+    #[test]
+    fn transition_label_pause() {
+        let label = goal_transition_label(
+            Some(meta("active", "x").as_str()),
+            Some(meta("paused", "x").as_str()),
+        );
+        assert_eq!(label.as_deref(), Some("Goal paused"));
+    }
+
+    #[test]
+    fn transition_label_resume() {
+        let label = goal_transition_label(
+            Some(meta("paused", "x").as_str()),
+            Some(meta("active", "x").as_str()),
+        );
+        assert_eq!(label.as_deref(), Some("Goal resumed"));
+    }
+
+    #[test]
+    fn transition_label_cleared() {
+        let label = goal_transition_label(Some(meta("active", "x").as_str()), None);
+        assert_eq!(label.as_deref(), Some("Goal cleared"));
+    }
+
+    #[test]
+    fn transition_label_no_change() {
+        let label = goal_transition_label(
+            Some(meta("active", "x").as_str()),
+            Some(meta("active", "x").as_str()),
+        );
+        assert_eq!(label, None);
+    }
+
+    #[test]
+    fn transition_label_token_only_update_no_message() {
+        // tokensUsed bumps every turn — must not spam system messages.
+        let prev = r#"{"status":"active","objective":"x","tokensUsed":100,"timeUsedSeconds":0,"createdAt":0,"updatedAt":0,"threadId":"t","tokenBudget":null}"#;
+        let next = r#"{"status":"active","objective":"x","tokensUsed":250,"timeUsedSeconds":0,"createdAt":0,"updatedAt":0,"threadId":"t","tokenBudget":null}"#;
+        let label = goal_transition_label(Some(prev), Some(next));
+        assert_eq!(label, None);
+    }
+
+    #[test]
+    fn transition_label_budget_limited() {
+        let label = goal_transition_label(
+            Some(meta("active", "x").as_str()),
+            Some(meta("budgetLimited", "x").as_str()),
+        );
+        assert_eq!(label.as_deref(), Some("Goal reached token budget"));
+    }
+
+    #[test]
+    fn transition_label_complete() {
+        let label = goal_transition_label(
+            Some(meta("active", "x").as_str()),
+            Some(meta("complete", "x").as_str()),
+        );
+        assert_eq!(label.as_deref(), Some("Goal complete"));
     }
 }

--- a/src-tauri/src/agents/streaming/codex_goal.rs
+++ b/src-tauri/src/agents/streaming/codex_goal.rs
@@ -1,0 +1,166 @@
+//! Persist `codexGoalUpdated` sidecar events into the session row and
+//! broadcast a `CodexGoalChanged` UI mutation. Frontend reads the meta
+//! through React Query — the channel only carries the invalidation cue.
+
+use rusqlite::params;
+use serde_json::Value;
+use tauri::AppHandle;
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum CodexGoalWriteOutcome {
+    /// Malformed event (missing/empty sessionId).
+    Skipped,
+    /// Event valid, DB row updated. `Some(json)` = active goal,
+    /// `None` = goal cleared.
+    Wrote(String),
+    /// Session row not found — likely a stale/post-delete event.
+    UnknownSession(String),
+}
+
+pub(super) fn write_codex_goal_meta(
+    conn: &rusqlite::Connection,
+    raw: &Value,
+) -> std::result::Result<CodexGoalWriteOutcome, rusqlite::Error> {
+    let Some(session_id) = raw.get("sessionId").and_then(Value::as_str) else {
+        return Ok(CodexGoalWriteOutcome::Skipped);
+    };
+    if session_id.is_empty() {
+        return Ok(CodexGoalWriteOutcome::Skipped);
+    }
+    // `goal` is either a stringified ThreadGoal JSON or null/absent
+    // (cleared). Anything else is malformed.
+    let goal = raw.get("goal");
+    let value: Option<&str> = match goal {
+        Some(Value::String(s)) => Some(s.as_str()),
+        Some(Value::Null) | None => None,
+        _ => return Ok(CodexGoalWriteOutcome::Skipped),
+    };
+    let affected = conn.execute(
+        "UPDATE sessions SET codex_goal_meta = ?1 WHERE id = ?2",
+        params![value, session_id],
+    )?;
+    if affected == 0 {
+        return Ok(CodexGoalWriteOutcome::UnknownSession(
+            session_id.to_string(),
+        ));
+    }
+    Ok(CodexGoalWriteOutcome::Wrote(session_id.to_string()))
+}
+
+pub(super) fn persist_codex_goal_event(app: &AppHandle, raw: &Value) {
+    let outcome = match crate::models::db::write_conn() {
+        Ok(conn) => match write_codex_goal_meta(&conn, raw) {
+            Ok(outcome) => outcome,
+            Err(err) => {
+                tracing::warn!("Failed to persist codex_goal_meta: {err}");
+                return;
+            }
+        },
+        Err(err) => {
+            tracing::warn!("codex_goal write_conn borrow failed: {err}");
+            return;
+        }
+    };
+    let session_id = match outcome {
+        CodexGoalWriteOutcome::Skipped => {
+            tracing::warn!("codexGoalUpdated event malformed (missing sessionId)");
+            return;
+        }
+        CodexGoalWriteOutcome::UnknownSession(id) => {
+            tracing::warn!(
+                session_id = %id,
+                "codexGoalUpdated for unknown session — likely a stale/post-delete event"
+            );
+            return;
+        }
+        CodexGoalWriteOutcome::Wrote(id) => id,
+    };
+    crate::ui_sync::publish(
+        app,
+        crate::ui_sync::UiMutationEvent::CodexGoalChanged { session_id },
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn open_test_db_with_session(session_id: &str) -> rusqlite::Connection {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        crate::schema::ensure_schema(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO sessions (id, workspace_id, status) VALUES (?1, 'w1', 'idle')",
+            [session_id],
+        )
+        .unwrap();
+        conn
+    }
+
+    fn read_meta(conn: &rusqlite::Connection, session_id: &str) -> Option<String> {
+        conn.query_row(
+            "SELECT codex_goal_meta FROM sessions WHERE id = ?1",
+            [session_id],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn writes_active_goal_json() {
+        let conn = open_test_db_with_session("s1");
+        let raw = serde_json::json!({
+            "sessionId": "s1",
+            "goal": r#"{"objective":"refactor","status":"active","tokensUsed":100}"#,
+        });
+        let outcome = write_codex_goal_meta(&conn, &raw).unwrap();
+        assert_eq!(outcome, CodexGoalWriteOutcome::Wrote("s1".to_string()));
+        assert!(read_meta(&conn, "s1").unwrap().contains("\"objective\""));
+    }
+
+    #[test]
+    fn null_goal_clears_the_column() {
+        let conn = open_test_db_with_session("s1");
+        conn.execute(
+            "UPDATE sessions SET codex_goal_meta = '{}' WHERE id = 's1'",
+            [],
+        )
+        .unwrap();
+        let raw = serde_json::json!({ "sessionId": "s1", "goal": null });
+        let outcome = write_codex_goal_meta(&conn, &raw).unwrap();
+        assert_eq!(outcome, CodexGoalWriteOutcome::Wrote("s1".to_string()));
+        assert_eq!(read_meta(&conn, "s1"), None);
+    }
+
+    #[test]
+    fn missing_session_id_skips() {
+        let conn = open_test_db_with_session("s1");
+        for raw in [
+            serde_json::json!({}),
+            serde_json::json!({ "sessionId": "" }),
+            serde_json::json!({ "sessionId": null, "goal": "{}" }),
+        ] {
+            let outcome = write_codex_goal_meta(&conn, &raw).unwrap();
+            assert_eq!(outcome, CodexGoalWriteOutcome::Skipped);
+        }
+    }
+
+    #[test]
+    fn unknown_session_does_not_write() {
+        let conn = open_test_db_with_session("s1");
+        let raw = serde_json::json!({ "sessionId": "ghost", "goal": "{}" });
+        let outcome = write_codex_goal_meta(&conn, &raw).unwrap();
+        assert_eq!(
+            outcome,
+            CodexGoalWriteOutcome::UnknownSession("ghost".to_string())
+        );
+        assert!(read_meta(&conn, "s1").is_none());
+    }
+
+    #[test]
+    fn malformed_goal_field_skips() {
+        let conn = open_test_db_with_session("s1");
+        let raw = serde_json::json!({ "sessionId": "s1", "goal": 42 });
+        let outcome = write_codex_goal_meta(&conn, &raw).unwrap();
+        assert_eq!(outcome, CodexGoalWriteOutcome::Skipped);
+    }
+}

--- a/src-tauri/src/agents/streaming/mod.rs
+++ b/src-tauri/src/agents/streaming/mod.rs
@@ -14,7 +14,7 @@ mod actions;
 mod active_streams;
 mod bridges;
 mod cleanup;
-mod codex_goal;
+pub(crate) mod codex_goal;
 mod context_usage;
 mod params;
 mod session_id;

--- a/src-tauri/src/agents/streaming/mod.rs
+++ b/src-tauri/src/agents/streaming/mod.rs
@@ -14,6 +14,7 @@ mod actions;
 mod active_streams;
 mod bridges;
 mod cleanup;
+mod codex_goal;
 mod context_usage;
 mod params;
 mod session_id;
@@ -885,6 +886,20 @@ pub(super) fn stream_via_sidecar(
                         }
                     }
                 }
+                "codexGoalUpdated" => match turn_session.handle_codex_goal_updated(&event.raw) {
+                    Ok(actions) => {
+                        for action in actions {
+                            actions::apply_action(action, &apply_ctx);
+                        }
+                    }
+                    Err(err) => {
+                        tracing::error!(
+                            rid = %rid,
+                            error = ?err,
+                            "codexGoalUpdated transition rejected",
+                        );
+                    }
+                },
                 "elicitationRequest" => {
                     let resolved_model = pipeline
                         .as_ref()

--- a/src-tauri/src/agents/streaming/state.rs
+++ b/src-tauri/src/agents/streaming/state.rs
@@ -590,6 +590,21 @@ impl TurnSession {
         Ok(vec![Action::PersistContextUsage { raw: raw.clone() }])
     }
 
+    /// Handle a `codexGoalUpdated` sidecar event (Codex `/goal` lifecycle).
+    /// Persists the goal payload to the session row and broadcasts a
+    /// `CodexGoalChanged` invalidation so the panel-header banner refetches.
+    pub(super) fn handle_codex_goal_updated(
+        &mut self,
+        raw: &Value,
+    ) -> Result<Vec<Action>, TransitionError> {
+        if self.state.is_terminated() {
+            return Err(TransitionError::AlreadyTerminated {
+                event_kind: "codexGoalUpdated".into(),
+            });
+        }
+        Ok(vec![Action::PersistCodexGoal { raw: raw.clone() }])
+    }
+
     /// Handle a `permissionModeChanged` sidecar event.
     ///
     /// State-mutating with no frontend emit: stores the new mode in

--- a/src-tauri/src/agents/streaming/state.rs
+++ b/src-tauri/src/agents/streaming/state.rs
@@ -1262,6 +1262,44 @@ mod tests {
     }
 
     #[test]
+    fn handle_codex_goal_updated_returns_persist_action_when_active() {
+        let mut session = TurnSession::new(test_ctx());
+        let raw = json!({
+            "sessionId": "session-1",
+            "goal": "{\"status\":\"active\"}"
+        });
+
+        let actions = session.handle_codex_goal_updated(&raw).unwrap();
+
+        assert_eq!(actions.len(), 1);
+        assert!(matches!(actions[0], Action::PersistCodexGoal { .. }));
+    }
+
+    // Regression: codex pushes `thread/goal/updated` exactly at the turn
+    // boundary carrying the final tokens / `complete` status. The handler
+    // must NOT bail with `AlreadyTerminated` — that would drop the final
+    // payload and leave the banner stale forever. The action is just a DB
+    // write + UI invalidation; it has no state-machine invariants to
+    // protect post-termination.
+    #[test]
+    fn handle_codex_goal_updated_still_persists_after_termination() {
+        let mut session = TurnSession::new(test_ctx());
+        session.state = TurnState::Terminated(TerminalReason::Done);
+
+        let raw = json!({
+            "sessionId": "session-1",
+            "goal": "{\"status\":\"complete\",\"tokensUsed\":12345}"
+        });
+
+        let actions = session.handle_codex_goal_updated(&raw).expect(
+            "goal-updated must remain accepted post-termination so the banner sees \
+             the final tokens / complete status codex emits at the turn boundary",
+        );
+        assert_eq!(actions.len(), 1);
+        assert!(matches!(actions[0], Action::PersistCodexGoal { .. }));
+    }
+
+    #[test]
     fn handle_permission_mode_changed_clears_when_field_missing() {
         let mut session = TurnSession::new(test_ctx());
         session.ctx.permission_mode = Some("acceptEdits".into());

--- a/src-tauri/src/agents/streaming/state.rs
+++ b/src-tauri/src/agents/streaming/state.rs
@@ -593,15 +593,16 @@ impl TurnSession {
     /// Handle a `codexGoalUpdated` sidecar event (Codex `/goal` lifecycle).
     /// Persists the goal payload to the session row and broadcasts a
     /// `CodexGoalChanged` invalidation so the panel-header banner refetches.
+    ///
+    /// Intentionally does NOT bail when the turn is already terminated:
+    /// codex pushes `thread/goal/updated` exactly at the turn boundary
+    /// with the final tokens / `complete` status, and we want the banner
+    /// to reflect that. The action is a pure DB write + UI invalidation
+    /// — no state-machine invariants to protect.
     pub(super) fn handle_codex_goal_updated(
         &mut self,
         raw: &Value,
     ) -> Result<Vec<Action>, TransitionError> {
-        if self.state.is_terminated() {
-            return Err(TransitionError::AlreadyTerminated {
-                event_kind: "codexGoalUpdated".into(),
-            });
-        }
         Ok(vec![Action::PersistCodexGoal { raw: raw.clone() }])
     }
 

--- a/src-tauri/src/commands/session_commands.rs
+++ b/src-tauri/src/commands/session_commands.rs
@@ -74,6 +74,76 @@ pub async fn get_session_codex_goal(session_id: String) -> CmdResult<Option<Stri
     run_blocking(move || sessions::get_session_codex_goal(&session_id)).await
 }
 
+/// Out-of-band Codex `/goal` lifecycle control. The banner buttons
+/// (Pause / Resume / Clear) call this directly so the operations don't
+/// appear in chat history. Routes to the sidecar's `mutateCodexGoal`
+/// method, which then dispatches to the right `thread/goal/*` RPC.
+#[tauri::command]
+pub async fn mutate_codex_goal(
+    sidecar: tauri::State<'_, crate::sidecar::ManagedSidecar>,
+    session_id: String,
+    action: String,
+) -> CmdResult<()> {
+    if !matches!(action.as_str(), "pause" | "resume" | "clear") {
+        return Err(anyhow::anyhow!("Invalid mutateCodexGoal action: {action}").into());
+    }
+
+    let request_id = uuid::Uuid::new_v4().to_string();
+    let req = crate::sidecar::SidecarRequest {
+        id: request_id.clone(),
+        method: "mutateCodexGoal".to_string(),
+        params: serde_json::json!({
+            "sessionId": session_id,
+            "action": action,
+        }),
+    };
+
+    let rx = sidecar.subscribe(&request_id);
+    if let Err(error) = sidecar.send(&req) {
+        sidecar.unsubscribe(&request_id);
+        return Err(anyhow::anyhow!("Sidecar send failed: {error}").into());
+    }
+
+    let rid = request_id.clone();
+    let outcome = tauri::async_runtime::spawn_blocking(move || {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+        loop {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            if remaining.is_zero() {
+                return Err(anyhow::anyhow!("mutateCodexGoal timed out"));
+            }
+            match rx.recv_timeout(remaining) {
+                Ok(event) => {
+                    if event.event_type() == "pong" {
+                        return Ok(());
+                    }
+                    if event.event_type() == "error" {
+                        let msg = event
+                            .raw
+                            .get("message")
+                            .and_then(serde_json::Value::as_str)
+                            .unwrap_or("sidecar error")
+                            .to_string();
+                        return Err(anyhow::anyhow!(msg));
+                    }
+                }
+                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                    return Err(anyhow::anyhow!("mutateCodexGoal timed out"));
+                }
+                Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                    return Err(anyhow::anyhow!("Sidecar disconnected before responding"));
+                }
+            }
+        }
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("mutate_codex_goal worker join failed: {e}"))?;
+
+    sidecar.unsubscribe(&rid);
+    outcome?;
+    Ok(())
+}
+
 /// Ad-hoc Claude-only context-usage fetch for the hover popover. Pure
 /// passthrough to the sidecar — no DB write, no mutex, no TTL. The
 /// frontend caches the result for 30 s via React Query.

--- a/src-tauri/src/commands/session_commands.rs
+++ b/src-tauri/src/commands/session_commands.rs
@@ -107,7 +107,7 @@ pub async fn mutate_codex_goal(
     }
 
     let rid = request_id.clone();
-    let outcome = tauri::async_runtime::spawn_blocking(move || {
+    let join_result = tauri::async_runtime::spawn_blocking(move || {
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
         loop {
             let remaining = deadline.saturating_duration_since(std::time::Instant::now());
@@ -138,10 +138,15 @@ pub async fn mutate_codex_goal(
             }
         }
     })
-    .await
-    .map_err(|e| anyhow::anyhow!("mutate_codex_goal worker join failed: {e}"))?;
+    .await;
 
+    // Always unsubscribe — even when the worker panicked / produced a
+    // join error — to avoid leaking the listener slot in the sidecar's
+    // map. Both the join error and the worker's own outcome propagate
+    // after the cleanup.
     sidecar.unsubscribe(&rid);
+    let outcome =
+        join_result.map_err(|e| anyhow::anyhow!("mutate_codex_goal worker join failed: {e}"))?;
     outcome?;
 
     // Mirror the goal mutation locally so the banner reflects the new

--- a/src-tauri/src/commands/session_commands.rs
+++ b/src-tauri/src/commands/session_commands.rs
@@ -80,6 +80,7 @@ pub async fn get_session_codex_goal(session_id: String) -> CmdResult<Option<Stri
 /// method, which then dispatches to the right `thread/goal/*` RPC.
 #[tauri::command]
 pub async fn mutate_codex_goal(
+    app: tauri::AppHandle,
     sidecar: tauri::State<'_, crate::sidecar::ManagedSidecar>,
     session_id: String,
     action: String,
@@ -142,6 +143,23 @@ pub async fn mutate_codex_goal(
 
     sidecar.unsubscribe(&rid);
     outcome?;
+
+    // Mirror the goal mutation locally so the banner reflects the new
+    // state on the next React Query refetch. Codex eventually pushes
+    // `thread/goal/updated` too, but the notification flows through a
+    // stale per-stream handler when no fresh sendMessage is in flight,
+    // so we can't rely on it. `apply_local_mutation` is idempotent.
+    let session_for_local = session_id.clone();
+    let action_for_local = action.clone();
+    let _ = tauri::async_runtime::spawn_blocking(move || {
+        crate::agents::streaming::codex_goal::apply_local_mutation(
+            &app,
+            &session_for_local,
+            &action_for_local,
+        );
+    })
+    .await;
+
     Ok(())
 }
 

--- a/src-tauri/src/commands/session_commands.rs
+++ b/src-tauri/src/commands/session_commands.rs
@@ -69,6 +69,11 @@ pub async fn get_session_context_usage(session_id: String) -> CmdResult<Option<S
     run_blocking(move || sessions::get_session_context_usage(&session_id)).await
 }
 
+#[tauri::command]
+pub async fn get_session_codex_goal(session_id: String) -> CmdResult<Option<String>> {
+    run_blocking(move || sessions::get_session_codex_goal(&session_id)).await
+}
+
 /// Ad-hoc Claude-only context-usage fetch for the hover popover. Pure
 /// passthrough to the sidecar — no DB write, no mutex, no TTL. The
 /// frontend caches the result for 30 s via React Query.

--- a/src-tauri/src/commands/session_commands.rs
+++ b/src-tauri/src/commands/session_commands.rs
@@ -85,7 +85,7 @@ pub async fn mutate_codex_goal(
     session_id: String,
     action: String,
 ) -> CmdResult<()> {
-    if !matches!(action.as_str(), "pause" | "resume" | "clear") {
+    if !matches!(action.as_str(), "pause" | "clear") {
         return Err(anyhow::anyhow!("Invalid mutateCodexGoal action: {action}").into());
     }
     tracing::info!(session_id = %session_id, action = %action, "mutate_codex_goal");

--- a/src-tauri/src/commands/session_commands.rs
+++ b/src-tauri/src/commands/session_commands.rs
@@ -87,6 +87,7 @@ pub async fn mutate_codex_goal(
     if !matches!(action.as_str(), "pause" | "resume" | "clear") {
         return Err(anyhow::anyhow!("Invalid mutateCodexGoal action: {action}").into());
     }
+    tracing::info!(session_id = %session_id, action = %action, "mutate_codex_goal");
 
     let request_id = uuid::Uuid::new_v4().to_string();
     let req = crate::sidecar::SidecarRequest {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -294,6 +294,7 @@ pub fn run() {
             commands::session_commands::list_hidden_sessions,
             commands::session_commands::get_session_context_usage,
             commands::session_commands::get_session_codex_goal,
+            commands::session_commands::mutate_codex_goal,
             commands::session_commands::get_live_context_usage,
             commands::session_commands::mark_session_read,
             commands::session_commands::mark_session_unread,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -292,6 +292,7 @@ pub fn run() {
             commands::session_commands::delete_session,
             commands::session_commands::list_hidden_sessions,
             commands::session_commands::get_session_context_usage,
+            commands::session_commands::get_session_codex_goal,
             commands::session_commands::get_live_context_usage,
             commands::session_commands::mark_session_read,
             commands::session_commands::mark_session_unread,

--- a/src-tauri/src/models/sessions.rs
+++ b/src-tauri/src/models/sessions.rs
@@ -465,6 +465,26 @@ fn read_session_context_usage(conn: &Connection, session_id: &str) -> Result<Opt
     Ok(meta.filter(|s| !s.is_empty()))
 }
 
+/// Read the opaque `codex_goal_meta` JSON for the panel-header goal banner.
+/// `None` means no active goal (cleared, never set, or unknown session).
+pub fn get_session_codex_goal(session_id: &str) -> Result<Option<String>> {
+    let conn = db::read_conn()?;
+    let meta: Option<String> = match conn.query_row(
+        "SELECT codex_goal_meta FROM sessions WHERE id = ?1",
+        [session_id],
+        |row| row.get(0),
+    ) {
+        Ok(value) => value,
+        Err(rusqlite::Error::QueryReturnedNoRows) => return Ok(None),
+        Err(err) => {
+            return Err(err).with_context(|| {
+                format!("Failed to read codex_goal_meta for session {session_id}")
+            });
+        }
+    };
+    Ok(meta.filter(|s| !s.is_empty()))
+}
+
 pub fn rename_session(session_id: &str, title: &str) -> Result<()> {
     let connection = db::write_conn()?;
 

--- a/src-tauri/src/pipeline/accumulator/mod.rs
+++ b/src-tauri/src/pipeline/accumulator/mod.rs
@@ -481,6 +481,8 @@ impl StreamAccumulator {
             Some("thread/status/changed")
             | Some("thread/tokenUsage/updated")
             | Some("thread/name/updated")
+            | Some("thread/goal/updated")
+            | Some("thread/goal/cleared")
             | Some("account/rateLimits/updated")
             | Some("account/updated")
             | Some("mcpServer/startupStatus/updated")

--- a/src-tauri/src/pipeline/adapter/mod.rs
+++ b/src-tauri/src/pipeline/adapter/mod.rs
@@ -162,6 +162,21 @@ fn convert_flat(messages: &[IntermediateMessage]) -> Vec<ThreadMessageLike> {
             continue;
         }
 
+        // codex /goal lifecycle markers (Goal paused / resumed / cleared
+        // / set: <objective>). Inserted by `codex_goal::write_codex_goal_meta`
+        // out-of-band whenever the goal state transitions in a way the
+        // user should see in chat history.
+        if msg_type == Some("goal_status") {
+            let text = parsed
+                .and_then(|p| p.get("text"))
+                .and_then(Value::as_str)
+                .unwrap_or("Goal updated")
+                .to_string();
+            result.push(make_system(msg, &text));
+            i += 1;
+            continue;
+        }
+
         // assistant (by JSON type or by role for plain-text live messages)
         if msg_type == Some("assistant") || (parsed.is_none() && msg.role == MessageRole::Assistant)
         {

--- a/src-tauri/src/schema.rs
+++ b/src-tauri/src/schema.rs
@@ -357,6 +357,14 @@ fn run_migrations(connection: &Connection) -> Result<()> {
             .context("Failed to add context_usage_meta column")?;
     }
 
+    // Migration: opaque JSON snapshot of the active Codex `/goal` state, used
+    // by the panel-header banner. NULL means no active goal.
+    if !has_column(connection, "sessions", "codex_goal_meta") {
+        connection
+            .execute_batch("ALTER TABLE sessions ADD COLUMN codex_goal_meta TEXT")
+            .context("Failed to add codex_goal_meta column")?;
+    }
+
     // Migration: toggle for auto-running the setup script on workspace
     // creation. Default 1 (on) — preserves the pre-feature behavior for
     // existing repos and is the most common case. Users opt out per-repo
@@ -564,6 +572,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     fast_mode INTEGER DEFAULT 0,
     action_kind TEXT,
     context_usage_meta TEXT,
+    codex_goal_meta TEXT,
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );

--- a/src-tauri/src/sidecar.rs
+++ b/src-tauri/src/sidecar.rs
@@ -78,9 +78,8 @@ struct SidecarProcess {
 
 #[derive(Debug, Default)]
 struct BundledAgentPaths {
-    claude_cli: Option<PathBuf>,
+    claude_bin: Option<PathBuf>,
     codex_bin: Option<PathBuf>,
-    bun_bin: Option<PathBuf>,
 }
 
 fn resolve_bundled_agent_paths() -> BundledAgentPaths {
@@ -94,17 +93,19 @@ fn resolve_bundled_agent_paths_for_exe(exe: &std::path::Path) -> Option<BundledA
     let exe_dir = exe.parent()?;
     let contents_dir = exe_dir.parent()?;
     let resources_dir = contents_dir.join("Resources");
+    let claude_bin_name = if cfg!(windows) {
+        "claude.exe"
+    } else {
+        "claude"
+    };
     let codex_bin_name = if cfg!(windows) { "codex.exe" } else { "codex" };
-    let bun_bin_name = if cfg!(windows) { "bun.exe" } else { "bun" };
 
-    let claude_cli = resources_dir.join("vendor/claude-code/cli.js");
+    let claude_bin = resources_dir.join(format!("vendor/claude-code/{claude_bin_name}"));
     let codex_bin = resources_dir.join(format!("vendor/codex/{codex_bin_name}"));
-    let bun_bin = resources_dir.join(format!("vendor/bun/{bun_bin_name}"));
 
     Some(BundledAgentPaths {
-        claude_cli: claude_cli.is_file().then_some(claude_cli),
+        claude_bin: claude_bin.is_file().then_some(claude_bin),
         codex_bin: codex_bin.is_file().then_some(codex_bin),
-        bun_bin: bun_bin.is_file().then_some(bun_bin),
     })
 }
 
@@ -152,19 +153,15 @@ impl SidecarProcess {
             let exe = std::env::current_exe().ok();
             tracing::info!(
                 exe = ?exe,
-                claude_cli = ?bundled_paths.claude_cli,
+                claude_bin = ?bundled_paths.claude_bin,
                 codex_bin = ?bundled_paths.codex_bin,
-                bun_bin = ?bundled_paths.bun_bin,
                 "Resolved bundled agent paths"
             );
-            if let Some(path) = bundled_paths.claude_cli {
-                cmd.env("HELMOR_CLAUDE_CODE_CLI_PATH", &path);
+            if let Some(path) = bundled_paths.claude_bin {
+                cmd.env("HELMOR_CLAUDE_CODE_BIN_PATH", &path);
             }
             if let Some(path) = bundled_paths.codex_bin {
                 cmd.env("HELMOR_CODEX_BIN_PATH", &path);
-            }
-            if let Some(path) = bundled_paths.bun_bin {
-                cmd.env("HELMOR_BUN_PATH", &path);
             }
         }
 
@@ -798,27 +795,20 @@ mod tests {
         let resources = root.path().join("Helmor.app/Contents/Resources/vendor");
         std::fs::create_dir_all(resources.join("claude-code")).unwrap();
         std::fs::create_dir_all(resources.join("codex")).unwrap();
-        std::fs::create_dir_all(resources.join("bun")).unwrap();
-        std::fs::write(resources.join("claude-code/cli.js"), "").unwrap();
+        std::fs::write(resources.join("claude-code/claude"), "").unwrap();
         std::fs::write(resources.join("codex/codex"), "").unwrap();
-        std::fs::write(resources.join("bun/bun"), "").unwrap();
 
         let paths = resolve_bundled_agent_paths_for_exe(&exe).unwrap();
 
         assert_eq!(
-            paths.claude_cli.unwrap(),
+            paths.claude_bin.unwrap(),
             root.path()
-                .join("Helmor.app/Contents/Resources/vendor/claude-code/cli.js")
+                .join("Helmor.app/Contents/Resources/vendor/claude-code/claude")
         );
         assert_eq!(
             paths.codex_bin.unwrap(),
             root.path()
                 .join("Helmor.app/Contents/Resources/vendor/codex/codex")
-        );
-        assert_eq!(
-            paths.bun_bin.unwrap(),
-            root.path()
-                .join("Helmor.app/Contents/Resources/vendor/bun/bun")
         );
     }
 }

--- a/src-tauri/src/ui_sync/events.rs
+++ b/src-tauri/src/ui_sync/events.rs
@@ -17,6 +17,9 @@ pub enum UiMutationEvent {
     ContextUsageChanged {
         session_id: String,
     },
+    CodexGoalChanged {
+        session_id: String,
+    },
     WorkspaceFilesChanged {
         workspace_id: String,
     },
@@ -85,6 +88,9 @@ mod tests {
                 workspace_id: "w".into(),
             },
             UiMutationEvent::ContextUsageChanged {
+                session_id: "s".into(),
+            },
+            UiMutationEvent::CodexGoalChanged {
                 session_id: "s".into(),
             },
             UiMutationEvent::WorkspaceFilesChanged {

--- a/src-tauri/src/ui_sync/events.rs
+++ b/src-tauri/src/ui_sync/events.rs
@@ -20,6 +20,13 @@ pub enum UiMutationEvent {
     CodexGoalChanged {
         session_id: String,
     },
+    /// Fires when a `goal_status` system message has been synthesised into
+    /// the conversation history out-of-band — the streaming pipeline owns
+    /// real assistant messages, this exists for the lifecycle markers
+    /// (Goal paused / resumed / cleared) we insert ourselves.
+    SessionMessagesAppended {
+        session_id: String,
+    },
     WorkspaceFilesChanged {
         workspace_id: String,
     },
@@ -91,6 +98,9 @@ mod tests {
                 session_id: "s".into(),
             },
             UiMutationEvent::CodexGoalChanged {
+                session_id: "s".into(),
+            },
+            UiMutationEvent::SessionMessagesAppended {
                 session_id: "s".into(),
             },
             UiMutationEvent::WorkspaceFilesChanged {

--- a/src/features/composer/container.test.tsx
+++ b/src/features/composer/container.test.tsx
@@ -9,6 +9,7 @@ const apiMockState = vi.hoisted(() => ({
 	listSlashCommands: vi.fn(),
 	listWorkspaceLinkedDirectories: vi.fn(),
 	setWorkspaceLinkedDirectories: vi.fn(),
+	mutateCodexGoal: vi.fn(),
 }));
 
 vi.mock("@/lib/api", async () => {
@@ -18,11 +19,20 @@ vi.mock("@/lib/api", async () => {
 		listSlashCommands: apiMockState.listSlashCommands,
 		listWorkspaceLinkedDirectories: apiMockState.listWorkspaceLinkedDirectories,
 		setWorkspaceLinkedDirectories: apiMockState.setWorkspaceLinkedDirectories,
+		mutateCodexGoal: apiMockState.mutateCodexGoal,
 	};
 });
 
 type PickHandler = (entry: unknown) => void;
 type RemoveHandler = (path: string) => void;
+
+type ComposerSubmitHandler = (
+	prompt: string,
+	imagePaths: string[],
+	filePaths: string[],
+	customTags: unknown[],
+	options?: { permissionModeOverride?: string; oppositeFollowUp?: boolean },
+) => void;
 
 const composerMockState = vi.hoisted(() => ({
 	renders: [] as string[],
@@ -38,6 +48,7 @@ const composerMockState = vi.hoisted(() => ({
 	lastOnRemoveLinkedDirectory: null as RemoveHandler | null,
 	lastAddDirCandidates: [] as readonly unknown[],
 	lastOnPickAddDir: null as PickHandler | null,
+	lastOnSubmit: null as ComposerSubmitHandler | null,
 }));
 
 vi.mock("./index", async () => {
@@ -60,6 +71,7 @@ vi.mock("./index", async () => {
 			onRemoveLinkedDirectory?: RemoveHandler;
 			addDirCandidates?: readonly unknown[];
 			onPickAddDir?: PickHandler;
+			onSubmit?: ComposerSubmitHandler;
 		}) => {
 			composerMockState.renders.push(props.contextKey);
 			composerMockState.lastSlashCommands = [...(props.slashCommands ?? [])];
@@ -70,6 +82,7 @@ vi.mock("./index", async () => {
 				...(props.addDirCandidates ?? []),
 			];
 			composerMockState.lastOnPickAddDir = props.onPickAddDir ?? null;
+			composerMockState.lastOnSubmit = props.onSubmit ?? null;
 			React.useEffect(() => {
 				composerMockState.mounts += 1;
 				return () => {
@@ -193,10 +206,13 @@ describe("WorkspaceComposerContainer", () => {
 		composerMockState.renders = [];
 		composerMockState.mounts = 0;
 		composerMockState.unmounts = 0;
+		composerMockState.lastOnSubmit = null;
 		apiMockState.listSlashCommands.mockReset();
 		apiMockState.listWorkspaceLinkedDirectories.mockReset();
 		apiMockState.listWorkspaceLinkedDirectories.mockResolvedValue([]);
 		apiMockState.setWorkspaceLinkedDirectories.mockReset();
+		apiMockState.mutateCodexGoal.mockReset();
+		apiMockState.mutateCodexGoal.mockResolvedValue(undefined);
 		apiMockState.listSlashCommands.mockResolvedValue({
 			commands: [],
 		});
@@ -736,6 +752,145 @@ describe("WorkspaceComposerContainer", () => {
 			// AddDirTypeaheadPlugin dispatches through it when the user
 			// picks a candidate from the inline popup.
 			expect(composerMockState.lastOnPickAddDir).not.toBeNull();
+		});
+	});
+
+	// Regression coverage for the review-flagged bug where typing
+	// `/goal pause` (or `/goal clear`) was interpreted by the sidecar
+	// parser as `{kind: "set", objective: "pause"}` and would silently
+	// overwrite the existing goal. The container intercept must short-
+	// circuit these out-of-band so they go through `mutateCodexGoal`
+	// instead of leaking to the agent stream.
+	describe("/goal pause/clear interception", () => {
+		const ACTIVE_GOAL = {
+			threadId: "t1",
+			objective: "improve test coverage",
+			status: "active" as const,
+			tokenBudget: null,
+			tokensUsed: 100,
+			timeUsedSeconds: 30,
+			createdAt: 0,
+			updatedAt: 0,
+		};
+
+		function setupCodexSessionWithGoal(): {
+			queryClient: ReturnType<typeof createHelmorQueryClient>;
+		} {
+			const queryClient = createHelmorQueryClient();
+			queryClient.setQueryData(
+				helmorQueryKeys.agentModelSections,
+				MODEL_SECTIONS,
+			);
+			queryClient.setQueryData(
+				helmorQueryKeys.workspaceDetail("workspace-1"),
+				WORKSPACE_DETAIL,
+			);
+			queryClient.setQueryData(
+				helmorQueryKeys.workspaceSessions("workspace-1"),
+				WORKSPACE_SESSIONS,
+			);
+			queryClient.setQueryData(
+				helmorQueryKeys.sessionCodexGoal("session-2"),
+				ACTIVE_GOAL,
+			);
+			return { queryClient };
+		}
+
+		function renderCodexComposer(
+			queryClient: ReturnType<typeof createHelmorQueryClient>,
+			onSubmit: ReturnType<typeof vi.fn>,
+		) {
+			render(
+				<QueryClientProvider client={queryClient}>
+					<TooltipProvider>
+						<SettingsContext.Provider
+							value={{
+								settings: DEFAULT_SETTINGS,
+								updateSettings: vi.fn(),
+								loaded: true,
+								reload: vi.fn(),
+							}}
+						>
+							<WorkspaceComposerContainer
+								displayedWorkspaceId="workspace-1"
+								displayedSessionId="session-2"
+								disabled={false}
+								sending={false}
+								sendError={null}
+								restoreDraft={null}
+								restoreImages={[]}
+								restoreFiles={[]}
+								restoreNonce={0}
+								modelSelections={{ "session:session-2": "gpt-5.4" }}
+								effortLevels={{}}
+								permissionModes={{}}
+								fastModes={{}}
+								onSelectModel={vi.fn()}
+								onSelectEffort={vi.fn()}
+								onChangePermissionMode={vi.fn()}
+								onChangeFastMode={vi.fn()}
+								onSubmit={onSubmit}
+							/>
+						</SettingsContext.Provider>
+					</TooltipProvider>
+				</QueryClientProvider>,
+			);
+		}
+
+		it("routes /goal pause to mutateCodexGoal and does NOT call onSubmit", async () => {
+			const { queryClient } = setupCodexSessionWithGoal();
+			const onSubmit = vi.fn();
+			renderCodexComposer(queryClient, onSubmit);
+
+			await waitFor(() =>
+				expect(composerMockState.lastOnSubmit).not.toBeNull(),
+			);
+
+			composerMockState.lastOnSubmit?.("/goal pause", [], [], []);
+
+			expect(apiMockState.mutateCodexGoal).toHaveBeenCalledTimes(1);
+			expect(apiMockState.mutateCodexGoal).toHaveBeenCalledWith(
+				"session-2",
+				"pause",
+			);
+			expect(onSubmit).not.toHaveBeenCalled();
+		});
+
+		it("routes /goal clear to mutateCodexGoal and does NOT call onSubmit", async () => {
+			const { queryClient } = setupCodexSessionWithGoal();
+			const onSubmit = vi.fn();
+			renderCodexComposer(queryClient, onSubmit);
+
+			await waitFor(() =>
+				expect(composerMockState.lastOnSubmit).not.toBeNull(),
+			);
+
+			composerMockState.lastOnSubmit?.("/goal clear", [], [], []);
+
+			expect(apiMockState.mutateCodexGoal).toHaveBeenCalledTimes(1);
+			expect(apiMockState.mutateCodexGoal).toHaveBeenCalledWith(
+				"session-2",
+				"clear",
+			);
+			expect(onSubmit).not.toHaveBeenCalled();
+		});
+
+		it("lets /goal resume fall through to onSubmit (sendMessage path)", async () => {
+			const { queryClient } = setupCodexSessionWithGoal();
+			const onSubmit = vi.fn();
+			renderCodexComposer(queryClient, onSubmit);
+
+			await waitFor(() =>
+				expect(composerMockState.lastOnSubmit).not.toBeNull(),
+			);
+
+			composerMockState.lastOnSubmit?.("/goal resume", [], [], []);
+
+			expect(apiMockState.mutateCodexGoal).not.toHaveBeenCalled();
+			expect(onSubmit).toHaveBeenCalledTimes(1);
+			expect(onSubmit).toHaveBeenCalledWith(
+				expect.objectContaining({ prompt: "/goal resume" }),
+			);
 		});
 	});
 });

--- a/src/features/composer/container.test.tsx
+++ b/src/features/composer/container.test.tsx
@@ -714,7 +714,7 @@ describe("WorkspaceComposerContainer", () => {
 				name: "goal",
 				description:
 					"Set a persistent goal Codex pursues turn-after-turn until done or paused",
-				argumentHint: "<objective> | pause | resume | clear",
+				argumentHint: "<objective>",
 				source: "builtin",
 				providers: ["codex"],
 			});

--- a/src/features/composer/container.test.tsx
+++ b/src/features/composer/container.test.tsx
@@ -1,5 +1,6 @@
 import { QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import type { ComponentProps } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { createHelmorQueryClient, helmorQueryKeys } from "@/lib/query-client";
@@ -796,9 +797,13 @@ describe("WorkspaceComposerContainer", () => {
 			return { queryClient };
 		}
 
+		type ContainerOnSubmit = ComponentProps<
+			typeof WorkspaceComposerContainer
+		>["onSubmit"];
+
 		function renderCodexComposer(
 			queryClient: ReturnType<typeof createHelmorQueryClient>,
-			onSubmit: ReturnType<typeof vi.fn>,
+			onSubmit: ContainerOnSubmit,
 		) {
 			render(
 				<QueryClientProvider client={queryClient}>
@@ -807,8 +812,7 @@ describe("WorkspaceComposerContainer", () => {
 							value={{
 								settings: DEFAULT_SETTINGS,
 								updateSettings: vi.fn(),
-								loaded: true,
-								reload: vi.fn(),
+								isLoaded: true,
 							}}
 						>
 							<WorkspaceComposerContainer
@@ -839,7 +843,7 @@ describe("WorkspaceComposerContainer", () => {
 
 		it("routes /goal pause to mutateCodexGoal and does NOT call onSubmit", async () => {
 			const { queryClient } = setupCodexSessionWithGoal();
-			const onSubmit = vi.fn();
+			const onSubmit = vi.fn<ContainerOnSubmit>();
 			renderCodexComposer(queryClient, onSubmit);
 
 			await waitFor(() =>
@@ -858,7 +862,7 @@ describe("WorkspaceComposerContainer", () => {
 
 		it("routes /goal clear to mutateCodexGoal and does NOT call onSubmit", async () => {
 			const { queryClient } = setupCodexSessionWithGoal();
-			const onSubmit = vi.fn();
+			const onSubmit = vi.fn<ContainerOnSubmit>();
 			renderCodexComposer(queryClient, onSubmit);
 
 			await waitFor(() =>
@@ -877,7 +881,7 @@ describe("WorkspaceComposerContainer", () => {
 
 		it("lets /goal resume fall through to onSubmit (sendMessage path)", async () => {
 			const { queryClient } = setupCodexSessionWithGoal();
-			const onSubmit = vi.fn();
+			const onSubmit = vi.fn<ContainerOnSubmit>();
 			renderCodexComposer(queryClient, onSubmit);
 
 			await waitFor(() =>

--- a/src/features/composer/container.test.tsx
+++ b/src/features/composer/container.test.tsx
@@ -261,10 +261,14 @@ describe("WorkspaceComposerContainer", () => {
 		);
 		expect(composerMockState.mounts).toBe(1);
 		expect(composerMockState.unmounts).toBe(0);
-		expect(composerMockState.renders).toEqual([
-			"session:session-1",
-			"session:session-2",
-		]);
+		// Allow extra synchronous renders from react-query observers
+		// (CodexGoal banner subscribes to a per-session query). The
+		// invariant we care about: no remount, and the session id seen
+		// in the rendered child stream eventually flips to session-2.
+		expect(composerMockState.renders[0]).toBe("session:session-1");
+		expect(
+			composerMockState.renders[composerMockState.renders.length - 1],
+		).toBe("session:session-2");
 	});
 
 	it("auto-submits queued CLI prompts with queued model and permission mode", async () => {

--- a/src/features/composer/container.test.tsx
+++ b/src/features/composer/container.test.tsx
@@ -689,7 +689,7 @@ describe("WorkspaceComposerContainer", () => {
 			});
 		});
 
-		it("adds a built-in /compact command for Codex sessions", async () => {
+		it("adds built-in /compact and /goal commands for Codex sessions", async () => {
 			apiMockState.listSlashCommands.mockResolvedValue({
 				commands: [],
 				isComplete: true,
@@ -701,11 +701,20 @@ describe("WorkspaceComposerContainer", () => {
 				expect(composerMockState.lastSlashCommands.map((c) => c.name)).toEqual([
 					"add-dir",
 					"compact",
+					"goal",
 				]);
 			});
 			expect(composerMockState.lastSlashCommands[1]).toEqual({
 				name: "compact",
 				description: "Compact this Codex thread's context",
+				source: "builtin",
+				providers: ["codex"],
+			});
+			expect(composerMockState.lastSlashCommands[2]).toEqual({
+				name: "goal",
+				description:
+					"Set a persistent goal Codex pursues turn-after-turn until done or paused",
+				argumentHint: "<objective> | pause | resume | clear",
 				source: "builtin",
 				providers: ["codex"],
 			});

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { open as openDirectoryDialog } from "@tauri-apps/plugin-dialog";
 import { CircleAlert, TimerReset } from "lucide-react";
-import { memo, useCallback, useEffect, useMemo, useRef } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ActionRow, ActionRowButton } from "@/components/action-row";
 import { ShimmerText } from "@/components/ui/shimmer-text";
@@ -32,6 +32,7 @@ import {
 	agentModelSectionsQueryOptions,
 	autoCloseActionKindsQueryOptions,
 	helmorQueryKeys,
+	sessionCodexGoalQueryOptions,
 	slashCommandsQueryOptions,
 	workspaceCandidateDirectoriesQueryOptions,
 	workspaceDetailQueryOptions,
@@ -52,6 +53,7 @@ import { CodexGoalBanner } from "../panel/codex-goal-banner";
 import type { DeferredToolResponseHandler } from "./deferred-tool";
 import type { AddDirPickerEntry } from "./editor/add-dir/typeahead-plugin";
 import type { ElicitationResponseHandler } from "./elicitation";
+import { GoalReplaceConfirm } from "./goal-replace-confirm";
 import { WorkspaceComposer } from "./index";
 import { SubmitQueueList } from "./submit-queue-list";
 
@@ -581,7 +583,23 @@ export const WorkspaceComposerContainer = memo(
 			void slashCommandsQuery.refetch();
 		}, [slashCommandsQuery]);
 
-		const handleComposerSubmit = useCallback(
+		// Pull the active codex goal so we can intercept `/goal X` submissions
+		// when one is already in flight and ask the user for confirmation
+		// before replacing it.
+		const codexGoalQuery = useQuery({
+			...sessionCodexGoalQueryOptions(displayedSessionId ?? "__none__"),
+			enabled: Boolean(displayedSessionId) && provider === "codex",
+		});
+		const activeGoal = codexGoalQuery.data ?? null;
+
+		type PendingGoalReplace = {
+			newObjective: string;
+			args: Parameters<typeof handleComposerSubmitInner>;
+		};
+		const [goalReplaceConfirm, setGoalReplaceConfirm] =
+			useState<PendingGoalReplace | null>(null);
+
+		const handleComposerSubmitInner = useCallback(
 			(
 				prompt: string,
 				imagePaths: string[],
@@ -628,6 +646,53 @@ export const WorkspaceComposerContainer = memo(
 				settings.followUpBehavior,
 			],
 		);
+
+		const handleComposerSubmit = useCallback(
+			(
+				prompt: string,
+				imagePaths: string[],
+				filePaths: string[],
+				customTags: ComposerCustomTag[],
+				options?: {
+					permissionModeOverride?: string;
+					oppositeFollowUp?: boolean;
+				},
+			) => {
+				// Intercept `/goal <objective>` for codex sessions that already
+				// have an active or paused goal — surface a confirm panel
+				// instead of silently replacing.
+				if (provider === "codex" && activeGoal) {
+					const match = prompt.trim().match(/^\/goal\s+([\s\S]+)$/);
+					const newObjective = match ? match[1]?.trim() : "";
+					if (newObjective && newObjective !== activeGoal.objective) {
+						setGoalReplaceConfirm({
+							newObjective,
+							args: [prompt, imagePaths, filePaths, customTags, options],
+						});
+						return;
+					}
+				}
+				handleComposerSubmitInner(
+					prompt,
+					imagePaths,
+					filePaths,
+					customTags,
+					options,
+				);
+			},
+			[provider, activeGoal, handleComposerSubmitInner],
+		);
+
+		const handleGoalReplaceConfirm = useCallback(() => {
+			if (!goalReplaceConfirm) return;
+			const args = goalReplaceConfirm.args;
+			setGoalReplaceConfirm(null);
+			handleComposerSubmitInner(...args);
+		}, [goalReplaceConfirm, handleComposerSubmitInner]);
+
+		const handleGoalReplaceCancel = useCallback(() => {
+			setGoalReplaceConfirm(null);
+		}, []);
 
 		// Track which queued prompt we've already dispatched so a re-render
 		// (e.g. due to query invalidation refreshing the session list) can't
@@ -793,6 +858,15 @@ export const WorkspaceComposerContainer = memo(
 
 				<div className="relative z-10">
 					<div className="pointer-events-none absolute inset-x-0 bottom-[calc(100%-1px)] z-20 flex flex-col items-center gap-1.5">
+						{goalReplaceConfirm && activeGoal ? (
+							<GoalReplaceConfirm
+								currentObjective={activeGoal.objective}
+								newObjective={goalReplaceConfirm.newObjective}
+								disabled={composerUnavailable}
+								onReplace={handleGoalReplaceConfirm}
+								onCancel={handleGoalReplaceCancel}
+							/>
+						) : null}
 						{displayedSessionId ? (
 							<CodexGoalBanner
 								sessionId={displayedSessionId}

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -21,6 +21,7 @@ import type {
 } from "@/lib/api";
 import {
 	createSession,
+	mutateCodexGoal,
 	saveAutoCloseActionKinds,
 	setWorkspaceLinkedDirectories,
 } from "@/lib/api";
@@ -687,17 +688,33 @@ export const WorkspaceComposerContainer = memo(
 					oppositeFollowUp?: boolean;
 				},
 			) => {
-				// Intercept `/goal <objective>` for codex sessions that already
-				// have an active or paused goal — surface a confirm panel
-				// instead of silently replacing. Reserved subcommands
-				// (resume / pause / clear) are NOT new objectives; they're
-				// lifecycle ops on the existing goal and should pass through.
-				if (provider === "codex" && activeGoal) {
+				// `/goal …` interception for codex sessions. Three flavors:
+				//   - `/goal pause` / `/goal clear`  → out-of-band mutate IPC,
+				//     no chat bubble (matches the banner-button behaviour).
+				//   - `/goal resume`                 → falls through to send-
+				//     Message so the resulting stream subscription catches
+				//     the goal-continuation turn codex auto-spawns.
+				//   - `/goal <new objective>` while a goal already exists
+				//                                    → confirm-replace panel.
+				if (provider === "codex" && displayedSessionId) {
 					const match = prompt.trim().match(/^\/goal\s+([\s\S]+)$/);
 					const arg = match ? (match[1]?.trim() ?? "") : "";
-					const isReservedSubcommand =
-						arg === "resume" || arg === "pause" || arg === "clear";
-					if (arg && !isReservedSubcommand && arg !== activeGoal.objective) {
+					if (arg === "pause" || arg === "clear") {
+						if (activeGoal) {
+							void mutateCodexGoal(displayedSessionId, arg).catch((err) => {
+								toast.error(
+									err instanceof Error ? err.message : `Failed to ${arg} goal`,
+								);
+							});
+						}
+						return;
+					}
+					if (
+						arg &&
+						arg !== "resume" &&
+						activeGoal &&
+						arg !== activeGoal.objective
+					) {
 						setGoalReplaceConfirm({
 							newObjective: arg,
 							args: [prompt, imagePaths, filePaths, customTags, options],
@@ -713,7 +730,7 @@ export const WorkspaceComposerContainer = memo(
 					options,
 				);
 			},
-			[provider, activeGoal, handleComposerSubmitInner],
+			[provider, displayedSessionId, activeGoal, handleComposerSubmitInner],
 		);
 
 		const handleGoalReplaceConfirm = useCallback(() => {

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -796,6 +796,7 @@ export const WorkspaceComposerContainer = memo(
 						{displayedSessionId ? (
 							<CodexGoalBanner
 								sessionId={displayedSessionId}
+								hasQueueBelow={queueItems.length > 0}
 								disabled={composerUnavailable}
 							/>
 						) : null}

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -81,7 +81,7 @@ const CODEX_GOAL_COMMAND: SlashCommandEntry = {
 	name: "goal",
 	description:
 		"Set a persistent goal Codex pursues turn-after-turn until done or paused",
-	argumentHint: "<objective> | pause | resume | clear",
+	argumentHint: "<objective>",
 	source: "builtin",
 	providers: ["codex"],
 };

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -697,6 +697,16 @@ export const WorkspaceComposerContainer = memo(
 			setGoalReplaceConfirm(null);
 		}, []);
 
+		// Resume button on the goal banner — synthesises a `/goal resume`
+		// submit so it travels through the normal sendMessage path. The
+		// resulting stream subscription is what catches the
+		// goal-continuation turn codex auto-spawns server-side; routing
+		// resume through `mutateCodexGoal` would skip that subscription
+		// and the chat would go silent even though the agent is working.
+		const handleResumeGoal = useCallback(() => {
+			handleComposerSubmitInner("/goal resume", [], [], []);
+		}, [handleComposerSubmitInner]);
+
 		// Track which queued prompt we've already dispatched so a re-render
 		// (e.g. due to query invalidation refreshing the session list) can't
 		// resubmit the same prompt twice before the parent clears the queue.
@@ -866,6 +876,7 @@ export const WorkspaceComposerContainer = memo(
 								sessionId={displayedSessionId}
 								hasQueueBelow={queueItems.length > 0}
 								disabled={composerUnavailable}
+								onResume={handleResumeGoal}
 							/>
 						) : null}
 						<SubmitQueueList

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -53,7 +53,6 @@ import { CodexGoalBanner } from "../panel/codex-goal-banner";
 import type { DeferredToolResponseHandler } from "./deferred-tool";
 import type { AddDirPickerEntry } from "./editor/add-dir/typeahead-plugin";
 import type { ElicitationResponseHandler } from "./elicitation";
-import { GoalReplaceConfirm } from "./goal-replace-confirm";
 import { WorkspaceComposer } from "./index";
 import { SubmitQueueList } from "./submit-queue-list";
 
@@ -862,15 +861,6 @@ export const WorkspaceComposerContainer = memo(
 
 				<div className="relative z-10">
 					<div className="pointer-events-none absolute inset-x-0 bottom-[calc(100%-1px)] z-20 flex flex-col items-center gap-1.5">
-						{goalReplaceConfirm && activeGoal ? (
-							<GoalReplaceConfirm
-								currentObjective={activeGoal.objective}
-								newObjective={goalReplaceConfirm.newObjective}
-								disabled={composerUnavailable}
-								onReplace={handleGoalReplaceConfirm}
-								onCancel={handleGoalReplaceCancel}
-							/>
-						) : null}
 						{displayedSessionId ? (
 							<CodexGoalBanner
 								sessionId={displayedSessionId}
@@ -928,6 +918,16 @@ export const WorkspaceComposerContainer = memo(
 						elicitationResponsePending={elicitationResponsePending}
 						pendingDeferredTool={pendingDeferredTool}
 						onDeferredToolResponse={onDeferredToolResponse}
+						goalReplace={
+							goalReplaceConfirm && activeGoal
+								? {
+										currentObjective: activeGoal.objective,
+										newObjective: goalReplaceConfirm.newObjective,
+										onReplace: handleGoalReplaceConfirm,
+										onCancel: handleGoalReplaceCancel,
+									}
+								: null
+						}
 						hasPlanReview={hasPlanReview}
 						pendingInsertRequests={pendingInsertRequests}
 						onPendingInsertRequestsConsumed={onPendingInsertRequestsConsumed}

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -660,13 +660,17 @@ export const WorkspaceComposerContainer = memo(
 			) => {
 				// Intercept `/goal <objective>` for codex sessions that already
 				// have an active or paused goal — surface a confirm panel
-				// instead of silently replacing.
+				// instead of silently replacing. Reserved subcommands
+				// (resume / pause / clear) are NOT new objectives; they're
+				// lifecycle ops on the existing goal and should pass through.
 				if (provider === "codex" && activeGoal) {
 					const match = prompt.trim().match(/^\/goal\s+([\s\S]+)$/);
-					const newObjective = match ? match[1]?.trim() : "";
-					if (newObjective && newObjective !== activeGoal.objective) {
+					const arg = match ? (match[1]?.trim() ?? "") : "";
+					const isReservedSubcommand =
+						arg === "resume" || arg === "pause" || arg === "clear";
+					if (arg && !isReservedSubcommand && arg !== activeGoal.objective) {
 						setGoalReplaceConfirm({
-							newObjective,
+							newObjective: arg,
 							args: [prompt, imagePaths, filePaths, customTags, options],
 						});
 						return;

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -48,6 +48,7 @@ import {
 	isNewSession,
 	resolveSessionSelectedModelId,
 } from "@/lib/workspace-helpers";
+import { CodexGoalBanner } from "../panel/codex-goal-banner";
 import type { DeferredToolResponseHandler } from "./deferred-tool";
 import type { AddDirPickerEntry } from "./editor/add-dir/typeahead-plugin";
 import type { ElicitationResponseHandler } from "./elicitation";
@@ -791,7 +792,14 @@ export const WorkspaceComposerContainer = memo(
 				) : null}
 
 				<div className="relative z-10">
-					<div className="pointer-events-none absolute inset-x-0 bottom-[calc(100%-1px)] z-20 flex justify-center">
+					<div className="pointer-events-none absolute inset-x-0 bottom-[calc(100%-1px)] z-20 flex flex-col items-center">
+						{displayedSessionId ? (
+							<CodexGoalBanner
+								sessionId={displayedSessionId}
+								hasQueueBelow={queueItems.length > 0}
+								disabled={composerUnavailable}
+							/>
+						) : null}
 						<SubmitQueueList
 							items={queueItems}
 							onSteer={(id) => onSteerQueued?.(id)}

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -77,9 +77,19 @@ const CODEX_COMPACT_COMMAND: SlashCommandEntry = {
 	providers: ["codex"],
 };
 
+const CODEX_GOAL_COMMAND: SlashCommandEntry = {
+	name: "goal",
+	description:
+		"Set a persistent goal Codex pursues turn-after-turn until done or paused",
+	argumentHint: "<objective> | pause | resume | clear",
+	source: "builtin",
+	providers: ["codex"],
+};
+
 const BUILTIN_CLIENT_COMMANDS: readonly SlashCommandEntry[] = [
 	ADD_DIR_COMMAND,
 	CODEX_COMPACT_COMMAND,
+	CODEX_GOAL_COMMAND,
 ];
 
 type WorkspaceComposerContainerProps = {

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -792,11 +792,10 @@ export const WorkspaceComposerContainer = memo(
 				) : null}
 
 				<div className="relative z-10">
-					<div className="pointer-events-none absolute inset-x-0 bottom-[calc(100%-1px)] z-20 flex flex-col items-center">
+					<div className="pointer-events-none absolute inset-x-0 bottom-[calc(100%-1px)] z-20 flex flex-col items-center gap-1.5">
 						{displayedSessionId ? (
 							<CodexGoalBanner
 								sessionId={displayedSessionId}
-								hasQueueBelow={queueItems.length > 0}
 								disabled={composerUnavailable}
 							/>
 						) : null}

--- a/src/features/composer/goal-replace-confirm.tsx
+++ b/src/features/composer/goal-replace-confirm.tsx
@@ -2,16 +2,21 @@
  * Inline confirm panel that pops above the composer when the user types
  * a fresh `/goal <objective>` while an active goal already exists.
  *
- * UI primitives are borrowed from the AskUserQuestion panel (purely
- * visual reuse — `InteractionOptionRow` + `InteractionHeader`). The
- * actual flow is local: no JSON-RPC, no deferred-tool plumbing. We
- * just intercept the submit, show the user a choice, and either drop
- * the prompt or let it through.
+ * Visually mirrors `AskUserQuestionPanel`: same header / option row /
+ * footer primitives + the `DeferredToolCard` inner padding wrapper. The
+ * only addition is an outer floating shell because we sit above the
+ * composer instead of replacing it.
  */
 
-import { Target } from "lucide-react";
+import { Check, Target, X } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { DeferredToolCard } from "./deferred-tool-panel/shared";
+import { InteractionFooter } from "./interaction/footer";
 import { InteractionHeader } from "./interaction/header";
 import { InteractionOptionRow } from "./interaction/option-row";
+
+type Choice = "replace" | "cancel";
 
 export type GoalReplaceConfirmProps = {
 	currentObjective: string;
@@ -28,37 +33,68 @@ export function GoalReplaceConfirm({
 	onCancel,
 	disabled,
 }: GoalReplaceConfirmProps) {
+	const [choice, setChoice] = useState<Choice | null>(null);
+
+	const handleConfirm = () => {
+		if (!choice || disabled) return;
+		if (choice === "replace") onReplace();
+		else onCancel();
+	};
+
 	return (
-		<div className="pointer-events-auto mx-auto w-[90%] overflow-hidden rounded-md border border-secondary/80 bg-background px-3 py-3 shadow-sm">
-			<InteractionHeader
-				icon={Target}
-				title="Replace goal?"
-				description={
-					<>
-						Current: <span className="text-foreground">{currentObjective}</span>
-						<br />
-						New: <span className="text-foreground">{newObjective}</span>
-					</>
-				}
-			/>
-			<div className="mt-1 grid gap-1 px-1">
-				<InteractionOptionRow
-					selected={false}
-					indicator="radio"
-					label="Replace current goal"
-					description="Set the new objective and start it now"
-					disabled={disabled}
-					onClick={onReplace}
+		<div className="pointer-events-auto mx-auto w-[90%] overflow-hidden rounded-2xl border border-secondary/80 bg-background shadow-lg">
+			<DeferredToolCard>
+				<InteractionHeader
+					icon={Target}
+					title="Replace goal?"
+					description={
+						<>
+							Current:{" "}
+							<span className="text-foreground">{currentObjective}</span>
+							<br />
+							New: <span className="text-foreground">{newObjective}</span>
+						</>
+					}
 				/>
-				<InteractionOptionRow
-					selected={false}
-					indicator="radio"
-					label="Cancel"
-					description="Keep the current goal"
-					disabled={disabled}
-					onClick={onCancel}
-				/>
-			</div>
+				<div className="grid gap-1 px-1">
+					<InteractionOptionRow
+						selected={choice === "replace"}
+						indicator="radio"
+						label="Replace current goal"
+						description="Set the new objective and start it now"
+						disabled={disabled}
+						onClick={() => setChoice("replace")}
+					/>
+					<InteractionOptionRow
+						selected={choice === "cancel"}
+						indicator="radio"
+						label="Cancel"
+						description="Keep the current goal"
+						disabled={disabled}
+						onClick={() => setChoice("cancel")}
+					/>
+				</div>
+				<InteractionFooter>
+					<Button
+						variant="outline"
+						size="sm"
+						disabled={disabled}
+						onClick={onCancel}
+					>
+						<X className="size-3.5" strokeWidth={2} />
+						<span>Cancel</span>
+					</Button>
+					<Button
+						variant="default"
+						size="sm"
+						disabled={disabled || !choice}
+						onClick={handleConfirm}
+					>
+						<Check className="size-3.5" strokeWidth={2} />
+						<span>Confirm</span>
+					</Button>
+				</InteractionFooter>
+			</DeferredToolCard>
 		</div>
 	);
 }

--- a/src/features/composer/goal-replace-confirm.tsx
+++ b/src/features/composer/goal-replace-confirm.tsx
@@ -1,0 +1,64 @@
+/**
+ * Inline confirm panel that pops above the composer when the user types
+ * a fresh `/goal <objective>` while an active goal already exists.
+ *
+ * UI primitives are borrowed from the AskUserQuestion panel (purely
+ * visual reuse — `InteractionOptionRow` + `InteractionHeader`). The
+ * actual flow is local: no JSON-RPC, no deferred-tool plumbing. We
+ * just intercept the submit, show the user a choice, and either drop
+ * the prompt or let it through.
+ */
+
+import { Target } from "lucide-react";
+import { InteractionHeader } from "./interaction/header";
+import { InteractionOptionRow } from "./interaction/option-row";
+
+export type GoalReplaceConfirmProps = {
+	currentObjective: string;
+	newObjective: string;
+	onReplace: () => void;
+	onCancel: () => void;
+	disabled?: boolean;
+};
+
+export function GoalReplaceConfirm({
+	currentObjective,
+	newObjective,
+	onReplace,
+	onCancel,
+	disabled,
+}: GoalReplaceConfirmProps) {
+	return (
+		<div className="pointer-events-auto mx-auto w-[90%] overflow-hidden rounded-md border border-secondary/80 bg-background px-3 py-3 shadow-sm">
+			<InteractionHeader
+				icon={Target}
+				title="Replace goal?"
+				description={
+					<>
+						Current: <span className="text-foreground">{currentObjective}</span>
+						<br />
+						New: <span className="text-foreground">{newObjective}</span>
+					</>
+				}
+			/>
+			<div className="mt-1 grid gap-1 px-1">
+				<InteractionOptionRow
+					selected={false}
+					indicator="radio"
+					label="Replace current goal"
+					description="Set the new objective and start it now"
+					disabled={disabled}
+					onClick={onReplace}
+				/>
+				<InteractionOptionRow
+					selected={false}
+					indicator="radio"
+					label="Cancel"
+					description="Keep the current goal"
+					disabled={disabled}
+					onClick={onCancel}
+				/>
+			</div>
+		</div>
+	);
+}

--- a/src/features/composer/goal-replace-confirm.tsx
+++ b/src/features/composer/goal-replace-confirm.tsx
@@ -1,11 +1,9 @@
 /**
- * Inline confirm panel that pops above the composer when the user types
- * a fresh `/goal <objective>` while an active goal already exists.
- *
- * Visually mirrors `AskUserQuestionPanel`: same header / option row /
- * footer primitives + the `DeferredToolCard` inner padding wrapper. The
- * only addition is an outer floating shell because we sit above the
- * composer instead of replacing it.
+ * In-place confirm panel rendered when the user types a fresh
+ * `/goal <objective>` while an active goal already exists. The composer
+ * outer shell takes over the body just like `DeferredToolPanel` /
+ * `ElicitationPanel` do — same `DeferredToolCard` wrapper, same header /
+ * option row / footer primitives as `AskUserQuestionPanel`.
  */
 
 import { Check, Target, X } from "lucide-react";
@@ -42,59 +40,56 @@ export function GoalReplaceConfirm({
 	};
 
 	return (
-		<div className="pointer-events-auto mx-auto w-[90%] overflow-hidden rounded-2xl border border-secondary/80 bg-background shadow-lg">
-			<DeferredToolCard>
-				<InteractionHeader
-					icon={Target}
-					title="Replace goal?"
-					description={
-						<>
-							Current:{" "}
-							<span className="text-foreground">{currentObjective}</span>
-							<br />
-							New: <span className="text-foreground">{newObjective}</span>
-						</>
-					}
+		<DeferredToolCard>
+			<InteractionHeader
+				icon={Target}
+				title="Replace goal?"
+				description={
+					<>
+						Current: <span className="text-foreground">{currentObjective}</span>
+						<br />
+						New: <span className="text-foreground">{newObjective}</span>
+					</>
+				}
+			/>
+			<div className="grid gap-1 px-1">
+				<InteractionOptionRow
+					selected={choice === "replace"}
+					indicator="radio"
+					label="Replace current goal"
+					description="Set the new objective and start it now"
+					disabled={disabled}
+					onClick={() => setChoice("replace")}
 				/>
-				<div className="grid gap-1 px-1">
-					<InteractionOptionRow
-						selected={choice === "replace"}
-						indicator="radio"
-						label="Replace current goal"
-						description="Set the new objective and start it now"
-						disabled={disabled}
-						onClick={() => setChoice("replace")}
-					/>
-					<InteractionOptionRow
-						selected={choice === "cancel"}
-						indicator="radio"
-						label="Cancel"
-						description="Keep the current goal"
-						disabled={disabled}
-						onClick={() => setChoice("cancel")}
-					/>
-				</div>
-				<InteractionFooter>
-					<Button
-						variant="outline"
-						size="sm"
-						disabled={disabled}
-						onClick={onCancel}
-					>
-						<X className="size-3.5" strokeWidth={2} />
-						<span>Cancel</span>
-					</Button>
-					<Button
-						variant="default"
-						size="sm"
-						disabled={disabled || !choice}
-						onClick={handleConfirm}
-					>
-						<Check className="size-3.5" strokeWidth={2} />
-						<span>Confirm</span>
-					</Button>
-				</InteractionFooter>
-			</DeferredToolCard>
-		</div>
+				<InteractionOptionRow
+					selected={choice === "cancel"}
+					indicator="radio"
+					label="Cancel"
+					description="Keep the current goal"
+					disabled={disabled}
+					onClick={() => setChoice("cancel")}
+				/>
+			</div>
+			<InteractionFooter>
+				<Button
+					variant="outline"
+					size="sm"
+					disabled={disabled}
+					onClick={onCancel}
+				>
+					<X className="size-3.5" strokeWidth={2} />
+					<span>Cancel</span>
+				</Button>
+				<Button
+					variant="default"
+					size="sm"
+					disabled={disabled || !choice}
+					onClick={handleConfirm}
+				>
+					<Check className="size-3.5" strokeWidth={2} />
+					<span>Confirm</span>
+				</Button>
+			</InteractionFooter>
+		</DeferredToolCard>
 	);
 }

--- a/src/features/composer/goal-replace-confirm.tsx
+++ b/src/features/composer/goal-replace-confirm.tsx
@@ -6,7 +6,7 @@
  * option row / footer primitives as `AskUserQuestionPanel`.
  */
 
-import { Check, Target, X } from "lucide-react";
+import { Check, Goal, X } from "lucide-react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { DeferredToolCard } from "./deferred-tool-panel/shared";
@@ -42,7 +42,7 @@ export function GoalReplaceConfirm({
 	return (
 		<DeferredToolCard>
 			<InteractionHeader
-				icon={Target}
+				icon={Goal}
 				title="Replace goal?"
 				description={
 					<>

--- a/src/features/composer/index.tsx
+++ b/src/features/composer/index.tsx
@@ -84,6 +84,7 @@ import { $appendComposerInsertItems } from "./editor-ops";
 import type { ElicitationResponseHandler } from "./elicitation";
 import { ElicitationPanel } from "./elicitation-panel";
 import { FastModeLottieIcon } from "./fast-mode-lottie-icon";
+import { GoalReplaceConfirm } from "./goal-replace-confirm";
 import { UsageStatsIndicator } from "./usage-stats-indicator";
 
 const OPEN_SETTINGS_EVENT = "helmor:open-settings";
@@ -143,6 +144,15 @@ type WorkspaceComposerProps = {
 	elicitationResponsePending?: boolean;
 	pendingDeferredTool?: PendingDeferredTool | null;
 	onDeferredToolResponse?: DeferredToolResponseHandler;
+	/** When set, the composer body is replaced with a GoalReplaceConfirm
+	 *  panel asking the user whether to overwrite the active codex goal.
+	 *  Same in-place takeover pattern as `pendingDeferredTool`. */
+	goalReplace?: {
+		currentObjective: string;
+		newObjective: string;
+		onReplace: () => void;
+		onCancel: () => void;
+	} | null;
 	hasPlanReview?: boolean;
 	/** When true, the ring is always rendered next to the send button.
 	 *  When false (the default), the ring auto-reveals only after usage
@@ -227,6 +237,7 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 	elicitationResponsePending = false,
 	pendingDeferredTool = null,
 	onDeferredToolResponse = noopDeferredToolResponse,
+	goalReplace = null,
 	hasPlanReview = false,
 	alwaysShowContextUsage = false,
 	sessionId = null,
@@ -312,7 +323,9 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 	]);
 	const hasPendingElicitation = pendingElicitation !== null;
 	const hasPendingDeferredTool = pendingDeferredTool !== null;
-	const hasPendingInteraction = hasPendingElicitation || hasPendingDeferredTool;
+	const hasGoalReplace = goalReplace !== null;
+	const hasPendingInteraction =
+		hasPendingElicitation || hasPendingDeferredTool || hasGoalReplace;
 	const inputDisabled = disabled || hasPendingInteraction;
 	const toolbarDisabled = disabled || hasPendingInteraction;
 	useEffect(() => {
@@ -548,6 +561,14 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 					deferred={pendingDeferredTool!}
 					disabled={disabled}
 					onResponse={onDeferredToolResponse}
+				/>
+			) : hasGoalReplace ? (
+				<GoalReplaceConfirm
+					currentObjective={goalReplace.currentObjective}
+					newObjective={goalReplace.newObjective}
+					onReplace={goalReplace.onReplace}
+					onCancel={goalReplace.onCancel}
+					disabled={disabled}
 				/>
 			) : (
 				<>

--- a/src/features/conversation/hooks/use-streaming.ts
+++ b/src/features/conversation/hooks/use-streaming.ts
@@ -17,10 +17,15 @@ import {
 	type PendingElicitation,
 } from "@/features/conversation/pending-elicitation";
 import { stabilizeStreamingMessages } from "@/features/conversation/streaming-tail-collapse";
-import type { AgentModelOption, ThreadMessageLike } from "@/lib/api";
+import type {
+	AgentModelOption,
+	CodexGoalState,
+	ThreadMessageLike,
+} from "@/lib/api";
 import {
 	generateSessionTitle,
 	loadRepoPreferences,
+	mutateCodexGoal,
 	renameSession,
 	respondToDeferredTool,
 	respondToElicitationRequest,
@@ -469,8 +474,30 @@ export function useConversationStreaming({
 			return;
 		}
 
-		void stopAgentStream(activeSession.stopSessionId, activeSession.provider);
-	}, [activeSessionByContext, composerContextKey]);
+		// For codex sessions with an active (non-paused) goal, flip the goal
+		// to paused first so codex doesn't auto-spawn a fresh continuation
+		// turn the moment we abort the current one. The user can resume from
+		// the banner whenever they're ready.
+		const sessionId = activeSession.stopSessionId;
+		const goal =
+			activeSession.provider === "codex"
+				? queryClient.getQueryData<CodexGoalState | null>(
+						helmorQueryKeys.sessionCodexGoal(sessionId),
+					)
+				: null;
+
+		const stopPromise = stopAgentStream(sessionId, activeSession.provider);
+		if (goal && goal.status === "active") {
+			// Fire pause concurrently — both routes end up calling
+			// `turn/interrupt` server-side, which is idempotent under codex's
+			// thread state machine. mutateCodexGoal also flips the goal
+			// status, which is the bit we actually need.
+			void mutateCodexGoal(sessionId, "pause").catch(() => {
+				// Best-effort — surface stop errors via the existing pipeline.
+			});
+		}
+		void stopPromise;
+	}, [activeSessionByContext, composerContextKey, queryClient]);
 
 	const handlePermissionResponse = useCallback(
 		(

--- a/src/features/conversation/hooks/use-streaming.ts
+++ b/src/features/conversation/hooks/use-streaming.ts
@@ -468,16 +468,11 @@ export function useConversationStreaming({
 		[],
 	);
 
-	const handleStopStream = useCallback(() => {
+	const handleStopStream = useCallback(async () => {
 		const activeSession = activeSessionByContext[composerContextKey];
 		if (!activeSession) {
 			return;
 		}
-
-		// For codex sessions with an active (non-paused) goal, flip the goal
-		// to paused first so codex doesn't auto-spawn a fresh continuation
-		// turn the moment we abort the current one. The user can resume from
-		// the banner whenever they're ready.
 		const sessionId = activeSession.stopSessionId;
 		const goal =
 			activeSession.provider === "codex"
@@ -486,17 +481,22 @@ export function useConversationStreaming({
 					)
 				: null;
 
-		const stopPromise = stopAgentStream(sessionId, activeSession.provider);
+		// For codex sessions with an active goal, flip the goal to paused
+		// FIRST so codex doesn't auto-spawn a fresh continuation turn the
+		// moment we abort the current one. Sequential: mutate -> stop, so
+		// the codex child is still alive when mutateCodexGoal needs it.
+		// (mutateCodexGoal is best-effort on the sidecar side too — if a
+		// race somehow kills the child first it just no-ops.) The user
+		// resumes by typing `/goal resume`.
 		if (goal && goal.status === "active") {
-			// Fire pause concurrently — both routes end up calling
-			// `turn/interrupt` server-side, which is idempotent under codex's
-			// thread state machine. mutateCodexGoal also flips the goal
-			// status, which is the bit we actually need.
-			void mutateCodexGoal(sessionId, "pause").catch(() => {
-				// Best-effort — surface stop errors via the existing pipeline.
-			});
+			try {
+				await mutateCodexGoal(sessionId, "pause");
+			} catch {
+				// Surfaced via toast inside mutateCodexGoal already; don't
+				// block the abort.
+			}
 		}
-		void stopPromise;
+		await stopAgentStream(sessionId, activeSession.provider);
 	}, [activeSessionByContext, composerContextKey, queryClient]);
 
 	const handlePermissionResponse = useCallback(

--- a/src/features/panel/codex-goal-banner.test.tsx
+++ b/src/features/panel/codex-goal-banner.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * Component tests for the Codex goal banner. Pairs with the Rust
+ * `codex_goal::tests` (which prove the DB layer narrates transitions
+ * correctly) and the sidecar `parseGoalCommand` tests (which prove the
+ * `/goal` flavors parse). What these specifically guard:
+ *
+ *   - The banner hides when there's no goal (mount overhead is
+ *     cheap, but rendering the chrome shouldn't happen for sessions
+ *     without a goal — most sessions).
+ *   - Clear button fires `mutateCodexGoal(sessionId, "clear")`.
+ *   - Paused state shows the Resume button + clicking it fires the
+ *     host-supplied `onResume` callback.
+ *   - Active state hides the Resume button.
+ *
+ * The mutate call is mocked via `vi.mock("@/lib/api", ...)` so the
+ * tests don't need a Tauri runtime.
+ */
+
+import { QueryClientProvider } from "@tanstack/react-query";
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CodexGoalState } from "@/lib/api";
+import { createHelmorQueryClient, helmorQueryKeys } from "@/lib/query-client";
+
+const apiMockState = vi.hoisted(() => ({
+	mutateCodexGoal: vi.fn(),
+}));
+
+vi.mock("@/lib/api", async () => {
+	const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+	return {
+		...actual,
+		mutateCodexGoal: apiMockState.mutateCodexGoal,
+	};
+});
+
+import { CodexGoalBanner } from "./codex-goal-banner";
+
+function activeGoal(): CodexGoalState {
+	return {
+		threadId: "t1",
+		objective: "improve test coverage",
+		status: "active",
+		tokenBudget: null,
+		tokensUsed: 1234,
+		timeUsedSeconds: 60,
+		createdAt: 0,
+		updatedAt: 0,
+	};
+}
+
+function pausedGoal(): CodexGoalState {
+	return { ...activeGoal(), status: "paused" };
+}
+
+function renderWithGoal(goal: CodexGoalState | null, onResume?: () => void) {
+	const queryClient = createHelmorQueryClient();
+	queryClient.setQueryData(helmorQueryKeys.sessionCodexGoal("session-1"), goal);
+	return render(
+		<QueryClientProvider client={queryClient}>
+			<CodexGoalBanner sessionId="session-1" onResume={onResume} />
+		</QueryClientProvider>,
+	);
+}
+
+describe("CodexGoalBanner", () => {
+	beforeEach(() => {
+		apiMockState.mutateCodexGoal.mockReset();
+		apiMockState.mutateCodexGoal.mockResolvedValue(undefined);
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it("renders nothing when no goal is set", () => {
+		const { container } = renderWithGoal(null);
+		// Goal-less sessions (Claude, fresh codex sessions, cleared goals)
+		// must not paint the floating header.
+		expect(
+			container.querySelector("[data-testid='codex-goal-banner']"),
+		).toBeNull();
+	});
+
+	it("renders objective + status + tokens when an active goal exists", async () => {
+		renderWithGoal(activeGoal());
+
+		await waitFor(() => {
+			expect(screen.getByTestId("codex-goal-banner")).toBeInTheDocument();
+		});
+		expect(screen.getByText("improve test coverage")).toBeInTheDocument();
+		expect(screen.getByText("active")).toBeInTheDocument();
+		// tokens render as "Used: 1.2K" via formatTokens.
+		expect(screen.getByText(/Used:/)).toBeInTheDocument();
+	});
+
+	it("Clear button fires mutateCodexGoal with action=clear", async () => {
+		renderWithGoal(activeGoal());
+
+		await waitFor(() => {
+			expect(screen.getByTestId("codex-goal-banner")).toBeInTheDocument();
+		});
+
+		fireEvent.click(screen.getByRole("button", { name: /clear goal/i }));
+
+		// useMutation dispatches async — wait one tick for the mutation
+		// queue to flush before asserting.
+		await waitFor(() =>
+			expect(apiMockState.mutateCodexGoal).toHaveBeenCalledTimes(1),
+		);
+		expect(apiMockState.mutateCodexGoal).toHaveBeenCalledWith(
+			"session-1",
+			"clear",
+		);
+	});
+
+	it("hides the Resume button when goal is active", async () => {
+		renderWithGoal(activeGoal(), vi.fn());
+
+		await waitFor(() => {
+			expect(screen.getByTestId("codex-goal-banner")).toBeInTheDocument();
+		});
+		expect(screen.queryByRole("button", { name: /resume goal/i })).toBeNull();
+	});
+
+	it("shows Resume button when goal is paused and onResume is provided", async () => {
+		const onResume = vi.fn();
+		renderWithGoal(pausedGoal(), onResume);
+
+		await waitFor(() => {
+			expect(
+				screen.getByRole("button", { name: /resume goal/i }),
+			).toBeInTheDocument();
+		});
+
+		fireEvent.click(screen.getByRole("button", { name: /resume goal/i }));
+
+		expect(onResume).toHaveBeenCalledTimes(1);
+		// Crucially: Resume is NOT routed through mutateCodexGoal — it
+		// goes via the host's onResume callback so the resulting send-
+		// Message stream subscription catches the goal-continuation turn
+		// codex auto-spawns.
+		expect(apiMockState.mutateCodexGoal).not.toHaveBeenCalled();
+	});
+
+	it("hides the Resume button when paused but no onResume is provided", async () => {
+		renderWithGoal(pausedGoal()); // no onResume
+
+		await waitFor(() => {
+			expect(screen.getByTestId("codex-goal-banner")).toBeInTheDocument();
+		});
+		expect(screen.queryByRole("button", { name: /resume goal/i })).toBeNull();
+	});
+});

--- a/src/features/panel/codex-goal-banner.tsx
+++ b/src/features/panel/codex-goal-banner.tsx
@@ -3,13 +3,23 @@
  * floating overlay as `<SubmitQueueList />` so the two visually stack —
  * one banner + N queued submits + the composer below.
  *
- * Pause / Resume / Clear go straight to `mutateCodexGoal` so the
- * lifecycle ops never appear as user messages in the chat.
+ * Two button paths:
+ *   - Clear: out-of-band JSON-RPC via `mutateCodexGoal` so it doesn't
+ *     leave a user message in the chat.
+ *   - Resume: NOT a button. The banner shows a `/goal resume` hint and
+ *     the user types it as a normal slash command. Routing it through
+ *     the sendMessage path piggybacks on the resulting stream
+ *     subscription, which is what catches the goal-continuation turn
+ *     codex auto-spawns when the status flips back to active.
+ *
+ * Pause is also out-of-band but isn't a banner button — it's the
+ * Composer Stop button that triggers it, so an abort during an active
+ * goal doesn't immediately get re-spawned by codex's continuation loop.
  */
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Pause, Play, Target, X } from "lucide-react";
+import { Target, X } from "lucide-react";
 import { toast } from "sonner";
-import { ActionRowButton } from "@/components/action-row";
+import { Button } from "@/components/ui/button";
 import { type CodexGoalState, mutateCodexGoal } from "@/lib/api";
 import {
 	helmorQueryKeys,
@@ -37,8 +47,6 @@ function formatTokens(n: number): string {
 	return n.toString();
 }
 
-type Action = "pause" | "resume" | "clear";
-
 export function CodexGoalBanner({
 	sessionId,
 	hasQueueBelow,
@@ -56,37 +64,21 @@ export function CodexGoalBanner({
 	const queryKey = helmorQueryKeys.sessionCodexGoal(sessionId);
 	const { data: goal } = useQuery(sessionCodexGoalQueryOptions(sessionId));
 
-	const mutation = useMutation({
-		mutationFn: (action: Action) => mutateCodexGoal(sessionId, action),
-		onMutate: async (action) => {
-			// Optimistic flip so the banner reacts immediately even if the
-			// codex `thread/goal/updated` notification takes a moment to
-			// round-trip back through the pipeline.
+	const clearMutation = useMutation({
+		mutationFn: () => mutateCodexGoal(sessionId, "clear"),
+		onMutate: async () => {
 			await queryClient.cancelQueries({ queryKey });
 			const previous = queryClient.getQueryData<CodexGoalState | null>(
 				queryKey,
 			);
-			if (action === "clear") {
-				queryClient.setQueryData<CodexGoalState | null>(queryKey, null);
-			} else if (previous) {
-				queryClient.setQueryData<CodexGoalState | null>(queryKey, {
-					...previous,
-					status: action === "pause" ? "paused" : "active",
-				});
-			}
+			queryClient.setQueryData<CodexGoalState | null>(queryKey, null);
 			return { previous };
 		},
-		onSuccess: (_, action) => {
-			if (action === "pause") toast.success("Goal paused");
-			else if (action === "resume") toast.success("Goal resumed");
-			else if (action === "clear") toast.success("Goal cleared");
-		},
-		onError: (err: unknown, _action, context) => {
-			// Roll back the optimistic update.
+		onError: (err: unknown, _vars, context) => {
 			if (context?.previous !== undefined) {
 				queryClient.setQueryData(queryKey, context.previous);
 			}
-			toast.error(err instanceof Error ? err.message : "Failed to update goal");
+			toast.error(err instanceof Error ? err.message : "Failed to clear goal");
 		},
 		onSettled: () => {
 			void queryClient.invalidateQueries({ queryKey });
@@ -98,7 +90,8 @@ export function CodexGoalBanner({
 	const used = formatTokens(goal.tokensUsed);
 	const budget =
 		goal.tokenBudget != null ? formatTokens(goal.tokenBudget) : null;
-	const isPending = mutation.isPending || disabled;
+	const isPaused = goal.status === "paused";
+	const isPending = clearMutation.isPending || disabled;
 
 	return (
 		<div
@@ -106,13 +99,8 @@ export function CodexGoalBanner({
 			className={cn(
 				"pointer-events-auto flex items-center gap-2 border border-secondary/80 bg-background px-3 py-1 text-xs",
 				hasQueueBelow
-					? // Standalone pill — fully rounded, content-width, drop shadow
-						// to lift it visually off the queue row directly below.
-						"mx-auto w-fit max-w-[90%] rounded-md shadow-sm"
-					: // Glue to the composer top — same shape as SubmitQueueList's
-						// solo styling so a goal with no queue feels like a single
-						// continuous block above the input.
-						"mx-auto w-[90%] rounded-t-2xl border-b-0 py-1.5",
+					? "mx-auto w-fit max-w-[90%] rounded-md shadow-sm"
+					: "mx-auto w-[90%] rounded-t-2xl border-b-0 py-1.5",
 			)}
 		>
 			<Target
@@ -132,40 +120,30 @@ export function CodexGoalBanner({
 				{STATUS_LABEL[goal.status]}
 			</span>
 			<span className="shrink-0 text-[11px] tabular-nums text-muted-foreground/70">
-				{budget ? `${used} / ${budget}` : used}
+				Used: {budget ? `${used} / ${budget}` : used}
 			</span>
-			<div className="ml-1 flex shrink-0 items-center gap-1">
-				{goal.status === "active" && (
-					<ActionRowButton
-						type="button"
-						aria-label="Pause goal"
-						disabled={isPending}
-						onClick={() => mutation.mutate("pause")}
-					>
-						<Pause className="size-[13px] shrink-0" strokeWidth={1.8} />
-						<span>Pause</span>
-					</ActionRowButton>
-				)}
-				{goal.status === "paused" && (
-					<ActionRowButton
-						type="button"
-						aria-label="Resume goal"
-						disabled={isPending}
-						onClick={() => mutation.mutate("resume")}
-					>
-						<Play className="size-[13px] shrink-0" strokeWidth={1.8} />
-						<span>Resume</span>
-					</ActionRowButton>
-				)}
-				<ActionRowButton
+			{isPaused ? (
+				<span className="shrink-0 text-[11px] text-muted-foreground/80">
+					Type{" "}
+					<code className="rounded bg-muted px-1 py-0.5 text-[10px] font-medium text-foreground">
+						/goal resume
+					</code>{" "}
+					to continue
+				</span>
+			) : null}
+			<div className="ml-auto flex shrink-0 items-center gap-1">
+				<Button
 					type="button"
+					variant="ghost"
+					size="sm"
 					aria-label="Clear goal"
 					disabled={isPending}
-					onClick={() => mutation.mutate("clear")}
+					onClick={() => clearMutation.mutate()}
+					className="h-7 gap-1 rounded-md px-2 text-[12px] font-medium text-muted-foreground hover:text-foreground"
 				>
 					<X className="size-[13px] shrink-0" strokeWidth={1.8} />
 					<span>Clear</span>
-				</ActionRowButton>
+				</Button>
 			</div>
 		</div>
 	);

--- a/src/features/panel/codex-goal-banner.tsx
+++ b/src/features/panel/codex-goal-banner.tsx
@@ -2,11 +2,19 @@
  * Active Codex `/goal` indicator. Renders nothing for sessions without a
  * goal (Claude sessions, fresh Codex sessions, cleared goals). Listens to
  * `CodexGoalChanged` mutations through React Query — no manual subscription.
+ *
+ * Pause / Resume / Clear buttons call `mutateCodexGoal` directly so the
+ * lifecycle operations don't show up in the chat as user messages.
  */
-import { useQuery } from "@tanstack/react-query";
-import { Target } from "lucide-react";
-import type { CodexGoalState } from "@/lib/api";
-import { sessionCodexGoalQueryOptions } from "@/lib/query-client";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Pause, Play, Target, X } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { type CodexGoalState, mutateCodexGoal } from "@/lib/api";
+import {
+	helmorQueryKeys,
+	sessionCodexGoalQueryOptions,
+} from "@/lib/query-client";
 
 const STATUS_LABEL: Record<CodexGoalState["status"], string> = {
 	active: "active",
@@ -29,12 +37,28 @@ function formatTokens(n: number): string {
 }
 
 export function CodexGoalBanner({ sessionId }: { sessionId: string }) {
+	const queryClient = useQueryClient();
 	const { data: goal } = useQuery(sessionCodexGoalQueryOptions(sessionId));
+
+	const mutation = useMutation({
+		mutationFn: (action: "pause" | "resume" | "clear") =>
+			mutateCodexGoal(sessionId, action),
+		onSuccess: () => {
+			void queryClient.invalidateQueries({
+				queryKey: helmorQueryKeys.sessionCodexGoal(sessionId),
+			});
+		},
+		onError: (err: unknown) => {
+			toast.error(err instanceof Error ? err.message : "Failed to update goal");
+		},
+	});
+
 	if (!goal) return null;
 
 	const used = formatTokens(goal.tokensUsed);
 	const budget =
 		goal.tokenBudget != null ? formatTokens(goal.tokenBudget) : null;
+	const isPending = mutation.isPending;
 
 	return (
 		<div className="flex items-center gap-2 border-app-border border-b bg-app-base px-4 py-2 text-xs">
@@ -48,6 +72,42 @@ export function CodexGoalBanner({ sessionId }: { sessionId: string }) {
 			<span className="shrink-0 text-app-muted-foreground">
 				{budget ? `${used} / ${budget} tokens` : `${used} tokens`}
 			</span>
+			<div className="ml-auto flex shrink-0 items-center gap-1">
+				{goal.status === "active" && (
+					<Button
+						variant="ghost"
+						size="sm"
+						className="h-6 gap-1 px-2 text-xs"
+						disabled={isPending}
+						onClick={() => mutation.mutate("pause")}
+					>
+						<Pause className="size-3" />
+						Pause
+					</Button>
+				)}
+				{goal.status === "paused" && (
+					<Button
+						variant="ghost"
+						size="sm"
+						className="h-6 gap-1 px-2 text-xs"
+						disabled={isPending}
+						onClick={() => mutation.mutate("resume")}
+					>
+						<Play className="size-3" />
+						Resume
+					</Button>
+				)}
+				<Button
+					variant="ghost"
+					size="sm"
+					className="h-6 gap-1 px-2 text-xs"
+					disabled={isPending}
+					onClick={() => mutation.mutate("clear")}
+				>
+					<X className="size-3" />
+					Clear
+				</Button>
+			</div>
 		</div>
 	);
 }

--- a/src/features/panel/codex-goal-banner.tsx
+++ b/src/features/panel/codex-goal-banner.tsx
@@ -3,21 +3,21 @@
  * floating overlay as `<SubmitQueueList />` so the two visually stack —
  * one banner + N queued submits + the composer below.
  *
- * Two button paths:
+ * Three button paths:
  *   - Clear: out-of-band JSON-RPC via `mutateCodexGoal` so it doesn't
  *     leave a user message in the chat.
- *   - Resume: NOT a button. The banner shows a `/goal resume` hint and
- *     the user types it as a normal slash command. Routing it through
- *     the sendMessage path piggybacks on the resulting stream
- *     subscription, which is what catches the goal-continuation turn
- *     codex auto-spawns when the status flips back to active.
- *
- * Pause is also out-of-band but isn't a banner button — it's the
- * Composer Stop button that triggers it, so an abort during an active
- * goal doesn't immediately get re-spawned by codex's continuation loop.
+ *   - Resume: synthesises a `/goal resume` prompt and submits it through
+ *     the host-supplied callback, which routes through the sendMessage
+ *     path. The resulting stream subscription is what catches the
+ *     goal-continuation turn codex auto-spawns when status flips back
+ *     to active. Users can also type `/goal resume` themselves —
+ *     parsed identically.
+ *   - Pause is NOT a banner button; it's the Composer Stop button that
+ *     triggers it, so an abort during an active goal doesn't get
+ *     re-spawned by codex's continuation loop.
  */
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Target, X } from "lucide-react";
+import { Play, Target, X } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { type CodexGoalState, mutateCodexGoal } from "@/lib/api";
@@ -51,6 +51,7 @@ export function CodexGoalBanner({
 	sessionId,
 	hasQueueBelow,
 	disabled,
+	onResume,
 }: {
 	sessionId: string;
 	/** When the submit-queue list renders directly below us, the banner
@@ -59,6 +60,10 @@ export function CodexGoalBanner({
 	 *  the composer just like SubmitQueueList does on its own. */
 	hasQueueBelow?: boolean;
 	disabled?: boolean;
+	/** Resume button handler. The host injects `/goal resume` through
+	 *  the normal composer submit flow — see `container.tsx`. When
+	 *  omitted, the Resume button hides entirely. */
+	onResume?: () => void;
 }) {
 	const queryClient = useQueryClient();
 	const queryKey = helmorQueryKeys.sessionCodexGoal(sessionId);
@@ -122,16 +127,21 @@ export function CodexGoalBanner({
 			<span className="shrink-0 text-[11px] tabular-nums text-muted-foreground/70">
 				Used: {budget ? `${used} / ${budget}` : used}
 			</span>
-			{isPaused ? (
-				<span className="shrink-0 text-[11px] text-muted-foreground/80">
-					Type{" "}
-					<code className="rounded bg-muted px-1 py-0.5 text-[10px] font-medium text-foreground">
-						/goal resume
-					</code>{" "}
-					to continue
-				</span>
-			) : null}
 			<div className="ml-auto flex shrink-0 items-center gap-1">
+				{isPaused && onResume ? (
+					<Button
+						type="button"
+						variant="ghost"
+						size="sm"
+						aria-label="Resume goal"
+						disabled={isPending}
+						onClick={onResume}
+						className="h-7 gap-1 rounded-md px-2 text-[12px] font-medium text-muted-foreground hover:text-foreground"
+					>
+						<Play className="size-[13px] shrink-0" strokeWidth={1.8} />
+						<span>Resume</span>
+					</Button>
+				) : null}
 				<Button
 					type="button"
 					variant="ghost"

--- a/src/features/panel/codex-goal-banner.tsx
+++ b/src/features/panel/codex-goal-banner.tsx
@@ -9,7 +9,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Pause, Play, Target, X } from "lucide-react";
 import { toast } from "sonner";
-import { ActionRow, ActionRowButton } from "@/components/action-row";
+import { ActionRowButton } from "@/components/action-row";
 import { type CodexGoalState, mutateCodexGoal } from "@/lib/api";
 import {
 	helmorQueryKeys,
@@ -41,13 +41,9 @@ type Action = "pause" | "resume" | "clear";
 
 export function CodexGoalBanner({
 	sessionId,
-	hasQueueBelow,
 	disabled,
 }: {
 	sessionId: string;
-	/** When the submit-queue list renders directly below, the banner keeps
-	 *  its rounded top but should not double up on the bottom border. */
-	hasQueueBelow?: boolean;
 	disabled?: boolean;
 }) {
 	const queryClient = useQueryClient();
@@ -101,75 +97,60 @@ export function CodexGoalBanner({
 	return (
 		<div
 			data-testid="codex-goal-banner"
-			className={cn(
-				"pointer-events-auto relative z-0 mx-auto w-[90%] overflow-hidden rounded-t-2xl border border-b-0 border-secondary/80 bg-background",
-				// When queue is directly below, drop the bottom rounding so the
-				// next row meets us flush. SubmitQueueList already has no
-				// bottom border itself, so visually they stack as one block.
-				hasQueueBelow && "border-b-0",
-			)}
+			className="pointer-events-auto mx-auto flex w-fit max-w-[90%] items-center gap-2 rounded-md border border-secondary/80 bg-background px-3 py-1 text-xs shadow-sm"
 		>
-			<ActionRow
-				className="border-0 bg-transparent px-3 py-1 pb-0.5 pt-0.5"
-				leading={
-					<>
-						<Target
-							className="size-3.5 shrink-0 text-muted-foreground/70"
-							strokeWidth={1.8}
-							aria-hidden
-						/>
-						<span className="truncate text-[12px] font-medium tracking-[0.01em] text-foreground">
-							{goal.objective}
-						</span>
-						<span
-							className={cn(
-								"shrink-0 text-[11px] uppercase tracking-wider",
-								STATUS_TONE[goal.status],
-							)}
-						>
-							{STATUS_LABEL[goal.status]}
-						</span>
-						<span className="shrink-0 text-[11px] tabular-nums text-muted-foreground/70">
-							{budget ? `${used} / ${budget}` : used}
-						</span>
-					</>
-				}
-				trailing={
-					<>
-						{goal.status === "active" && (
-							<ActionRowButton
-								type="button"
-								aria-label="Pause goal"
-								disabled={isPending}
-								onClick={() => mutation.mutate("pause")}
-							>
-								<Pause className="size-[13px] shrink-0" strokeWidth={1.8} />
-								<span>Pause</span>
-							</ActionRowButton>
-						)}
-						{goal.status === "paused" && (
-							<ActionRowButton
-								type="button"
-								aria-label="Resume goal"
-								disabled={isPending}
-								onClick={() => mutation.mutate("resume")}
-							>
-								<Play className="size-[13px] shrink-0" strokeWidth={1.8} />
-								<span>Resume</span>
-							</ActionRowButton>
-						)}
-						<ActionRowButton
-							type="button"
-							aria-label="Clear goal"
-							disabled={isPending}
-							onClick={() => mutation.mutate("clear")}
-						>
-							<X className="size-[13px] shrink-0" strokeWidth={1.8} />
-							<span>Clear</span>
-						</ActionRowButton>
-					</>
-				}
+			<Target
+				className="size-3.5 shrink-0 text-muted-foreground/70"
+				strokeWidth={1.8}
+				aria-hidden
 			/>
+			<span className="truncate text-[12px] font-medium tracking-[0.01em] text-foreground">
+				{goal.objective}
+			</span>
+			<span
+				className={cn(
+					"shrink-0 text-[11px] uppercase tracking-wider",
+					STATUS_TONE[goal.status],
+				)}
+			>
+				{STATUS_LABEL[goal.status]}
+			</span>
+			<span className="shrink-0 text-[11px] tabular-nums text-muted-foreground/70">
+				{budget ? `${used} / ${budget}` : used}
+			</span>
+			<div className="ml-1 flex shrink-0 items-center gap-1">
+				{goal.status === "active" && (
+					<ActionRowButton
+						type="button"
+						aria-label="Pause goal"
+						disabled={isPending}
+						onClick={() => mutation.mutate("pause")}
+					>
+						<Pause className="size-[13px] shrink-0" strokeWidth={1.8} />
+						<span>Pause</span>
+					</ActionRowButton>
+				)}
+				{goal.status === "paused" && (
+					<ActionRowButton
+						type="button"
+						aria-label="Resume goal"
+						disabled={isPending}
+						onClick={() => mutation.mutate("resume")}
+					>
+						<Play className="size-[13px] shrink-0" strokeWidth={1.8} />
+						<span>Resume</span>
+					</ActionRowButton>
+				)}
+				<ActionRowButton
+					type="button"
+					aria-label="Clear goal"
+					disabled={isPending}
+					onClick={() => mutation.mutate("clear")}
+				>
+					<X className="size-[13px] shrink-0" strokeWidth={1.8} />
+					<span>Clear</span>
+				</ActionRowButton>
+			</div>
 		</div>
 	);
 }

--- a/src/features/panel/codex-goal-banner.tsx
+++ b/src/features/panel/codex-goal-banner.tsx
@@ -1,0 +1,53 @@
+/**
+ * Active Codex `/goal` indicator. Renders nothing for sessions without a
+ * goal (Claude sessions, fresh Codex sessions, cleared goals). Listens to
+ * `CodexGoalChanged` mutations through React Query — no manual subscription.
+ */
+import { useQuery } from "@tanstack/react-query";
+import { Target } from "lucide-react";
+import type { CodexGoalState } from "@/lib/api";
+import { sessionCodexGoalQueryOptions } from "@/lib/query-client";
+
+const STATUS_LABEL: Record<CodexGoalState["status"], string> = {
+	active: "active",
+	paused: "paused",
+	budgetLimited: "budget reached",
+	complete: "complete",
+};
+
+const STATUS_TONE: Record<CodexGoalState["status"], string> = {
+	active: "text-app-foreground",
+	paused: "text-app-muted-foreground",
+	budgetLimited: "text-amber-500",
+	complete: "text-emerald-500",
+};
+
+function formatTokens(n: number): string {
+	if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+	if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+	return n.toString();
+}
+
+export function CodexGoalBanner({ sessionId }: { sessionId: string }) {
+	const { data: goal } = useQuery(sessionCodexGoalQueryOptions(sessionId));
+	if (!goal) return null;
+
+	const used = formatTokens(goal.tokensUsed);
+	const budget =
+		goal.tokenBudget != null ? formatTokens(goal.tokenBudget) : null;
+
+	return (
+		<div className="flex items-center gap-2 border-app-border border-b bg-app-base px-4 py-2 text-xs">
+			<Target className="size-3.5 shrink-0 text-app-muted-foreground" />
+			<span className="truncate font-medium text-app-foreground">
+				{goal.objective}
+			</span>
+			<span className={`shrink-0 ${STATUS_TONE[goal.status]}`}>
+				{STATUS_LABEL[goal.status]}
+			</span>
+			<span className="shrink-0 text-app-muted-foreground">
+				{budget ? `${used} / ${budget} tokens` : `${used} tokens`}
+			</span>
+		</div>
+	);
+}

--- a/src/features/panel/codex-goal-banner.tsx
+++ b/src/features/panel/codex-goal-banner.tsx
@@ -41,9 +41,15 @@ type Action = "pause" | "resume" | "clear";
 
 export function CodexGoalBanner({
 	sessionId,
+	hasQueueBelow,
 	disabled,
 }: {
 	sessionId: string;
+	/** When the submit-queue list renders directly below us, the banner
+	 *  becomes a standalone pill so the two stack as visually distinct
+	 *  rows. With no queue below, the banner glues itself to the top of
+	 *  the composer just like SubmitQueueList does on its own. */
+	hasQueueBelow?: boolean;
 	disabled?: boolean;
 }) {
 	const queryClient = useQueryClient();
@@ -97,7 +103,17 @@ export function CodexGoalBanner({
 	return (
 		<div
 			data-testid="codex-goal-banner"
-			className="pointer-events-auto mx-auto flex w-fit max-w-[90%] items-center gap-2 rounded-md border border-secondary/80 bg-background px-3 py-1 text-xs shadow-sm"
+			className={cn(
+				"pointer-events-auto flex items-center gap-2 border border-secondary/80 bg-background px-3 py-1 text-xs",
+				hasQueueBelow
+					? // Standalone pill — fully rounded, content-width, drop shadow
+						// to lift it visually off the queue row directly below.
+						"mx-auto w-fit max-w-[90%] rounded-md shadow-sm"
+					: // Glue to the composer top — same shape as SubmitQueueList's
+						// solo styling so a goal with no queue feels like a single
+						// continuous block above the input.
+						"mx-auto w-[90%] rounded-t-2xl border-b-0 py-1.5",
+			)}
 		>
 			<Target
 				className="size-3.5 shrink-0 text-muted-foreground/70"

--- a/src/features/panel/codex-goal-banner.tsx
+++ b/src/features/panel/codex-goal-banner.tsx
@@ -17,7 +17,7 @@
  *     re-spawned by codex's continuation loop.
  */
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Play, Target, X } from "lucide-react";
+import { Goal, Play, X } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { type CodexGoalState, mutateCodexGoal } from "@/lib/api";
@@ -108,7 +108,7 @@ export function CodexGoalBanner({
 					: "mx-auto w-[90%] rounded-t-2xl border-b-0 py-1.5",
 			)}
 		>
-			<Target
+			<Goal
 				className="size-3.5 shrink-0 text-muted-foreground/70"
 				strokeWidth={1.8}
 				aria-hidden

--- a/src/features/panel/codex-goal-banner.tsx
+++ b/src/features/panel/codex-goal-banner.tsx
@@ -1,20 +1,21 @@
 /**
- * Active Codex `/goal` indicator. Renders nothing for sessions without a
- * goal (Claude sessions, fresh Codex sessions, cleared goals). Listens to
- * `CodexGoalChanged` mutations through React Query — no manual subscription.
+ * Active Codex `/goal` indicator. Sits above the composer in the same
+ * floating overlay as `<SubmitQueueList />` so the two visually stack —
+ * one banner + N queued submits + the composer below.
  *
- * Pause / Resume / Clear buttons call `mutateCodexGoal` directly so the
- * lifecycle operations don't show up in the chat as user messages.
+ * Pause / Resume / Clear go straight to `mutateCodexGoal` so the
+ * lifecycle ops never appear as user messages in the chat.
  */
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Pause, Play, Target, X } from "lucide-react";
 import { toast } from "sonner";
-import { Button } from "@/components/ui/button";
+import { ActionRow, ActionRowButton } from "@/components/action-row";
 import { type CodexGoalState, mutateCodexGoal } from "@/lib/api";
 import {
 	helmorQueryKeys,
 	sessionCodexGoalQueryOptions,
 } from "@/lib/query-client";
+import { cn } from "@/lib/utils";
 
 const STATUS_LABEL: Record<CodexGoalState["status"], string> = {
 	active: "active",
@@ -24,8 +25,8 @@ const STATUS_LABEL: Record<CodexGoalState["status"], string> = {
 };
 
 const STATUS_TONE: Record<CodexGoalState["status"], string> = {
-	active: "text-app-foreground",
-	paused: "text-app-muted-foreground",
+	active: "text-foreground",
+	paused: "text-muted-foreground",
 	budgetLimited: "text-amber-500",
 	complete: "text-emerald-500",
 };
@@ -36,20 +37,57 @@ function formatTokens(n: number): string {
 	return n.toString();
 }
 
-export function CodexGoalBanner({ sessionId }: { sessionId: string }) {
+type Action = "pause" | "resume" | "clear";
+
+export function CodexGoalBanner({
+	sessionId,
+	hasQueueBelow,
+	disabled,
+}: {
+	sessionId: string;
+	/** When the submit-queue list renders directly below, the banner keeps
+	 *  its rounded top but should not double up on the bottom border. */
+	hasQueueBelow?: boolean;
+	disabled?: boolean;
+}) {
 	const queryClient = useQueryClient();
+	const queryKey = helmorQueryKeys.sessionCodexGoal(sessionId);
 	const { data: goal } = useQuery(sessionCodexGoalQueryOptions(sessionId));
 
 	const mutation = useMutation({
-		mutationFn: (action: "pause" | "resume" | "clear") =>
-			mutateCodexGoal(sessionId, action),
-		onSuccess: () => {
-			void queryClient.invalidateQueries({
-				queryKey: helmorQueryKeys.sessionCodexGoal(sessionId),
-			});
+		mutationFn: (action: Action) => mutateCodexGoal(sessionId, action),
+		onMutate: async (action) => {
+			// Optimistic flip so the banner reacts immediately even if the
+			// codex `thread/goal/updated` notification takes a moment to
+			// round-trip back through the pipeline.
+			await queryClient.cancelQueries({ queryKey });
+			const previous = queryClient.getQueryData<CodexGoalState | null>(
+				queryKey,
+			);
+			if (action === "clear") {
+				queryClient.setQueryData<CodexGoalState | null>(queryKey, null);
+			} else if (previous) {
+				queryClient.setQueryData<CodexGoalState | null>(queryKey, {
+					...previous,
+					status: action === "pause" ? "paused" : "active",
+				});
+			}
+			return { previous };
 		},
-		onError: (err: unknown) => {
+		onSuccess: (_, action) => {
+			if (action === "pause") toast.success("Goal paused");
+			else if (action === "resume") toast.success("Goal resumed");
+			else if (action === "clear") toast.success("Goal cleared");
+		},
+		onError: (err: unknown, _action, context) => {
+			// Roll back the optimistic update.
+			if (context?.previous !== undefined) {
+				queryClient.setQueryData(queryKey, context.previous);
+			}
 			toast.error(err instanceof Error ? err.message : "Failed to update goal");
+		},
+		onSettled: () => {
+			void queryClient.invalidateQueries({ queryKey });
 		},
 	});
 
@@ -58,56 +96,80 @@ export function CodexGoalBanner({ sessionId }: { sessionId: string }) {
 	const used = formatTokens(goal.tokensUsed);
 	const budget =
 		goal.tokenBudget != null ? formatTokens(goal.tokenBudget) : null;
-	const isPending = mutation.isPending;
+	const isPending = mutation.isPending || disabled;
 
 	return (
-		<div className="flex items-center gap-2 border-app-border border-b bg-app-base px-4 py-2 text-xs">
-			<Target className="size-3.5 shrink-0 text-app-muted-foreground" />
-			<span className="truncate font-medium text-app-foreground">
-				{goal.objective}
-			</span>
-			<span className={`shrink-0 ${STATUS_TONE[goal.status]}`}>
-				{STATUS_LABEL[goal.status]}
-			</span>
-			<span className="shrink-0 text-app-muted-foreground">
-				{budget ? `${used} / ${budget} tokens` : `${used} tokens`}
-			</span>
-			<div className="ml-auto flex shrink-0 items-center gap-1">
-				{goal.status === "active" && (
-					<Button
-						variant="ghost"
-						size="sm"
-						className="h-6 gap-1 px-2 text-xs"
-						disabled={isPending}
-						onClick={() => mutation.mutate("pause")}
-					>
-						<Pause className="size-3" />
-						Pause
-					</Button>
-				)}
-				{goal.status === "paused" && (
-					<Button
-						variant="ghost"
-						size="sm"
-						className="h-6 gap-1 px-2 text-xs"
-						disabled={isPending}
-						onClick={() => mutation.mutate("resume")}
-					>
-						<Play className="size-3" />
-						Resume
-					</Button>
-				)}
-				<Button
-					variant="ghost"
-					size="sm"
-					className="h-6 gap-1 px-2 text-xs"
-					disabled={isPending}
-					onClick={() => mutation.mutate("clear")}
-				>
-					<X className="size-3" />
-					Clear
-				</Button>
-			</div>
+		<div
+			data-testid="codex-goal-banner"
+			className={cn(
+				"pointer-events-auto relative z-0 mx-auto w-[90%] overflow-hidden rounded-t-2xl border border-b-0 border-secondary/80 bg-background",
+				// When queue is directly below, drop the bottom rounding so the
+				// next row meets us flush. SubmitQueueList already has no
+				// bottom border itself, so visually they stack as one block.
+				hasQueueBelow && "border-b-0",
+			)}
+		>
+			<ActionRow
+				className="border-0 bg-transparent px-3 py-1 pb-0.5 pt-0.5"
+				leading={
+					<>
+						<Target
+							className="size-3.5 shrink-0 text-muted-foreground/70"
+							strokeWidth={1.8}
+							aria-hidden
+						/>
+						<span className="truncate text-[12px] font-medium tracking-[0.01em] text-foreground">
+							{goal.objective}
+						</span>
+						<span
+							className={cn(
+								"shrink-0 text-[11px] uppercase tracking-wider",
+								STATUS_TONE[goal.status],
+							)}
+						>
+							{STATUS_LABEL[goal.status]}
+						</span>
+						<span className="shrink-0 text-[11px] tabular-nums text-muted-foreground/70">
+							{budget ? `${used} / ${budget}` : used}
+						</span>
+					</>
+				}
+				trailing={
+					<>
+						{goal.status === "active" && (
+							<ActionRowButton
+								type="button"
+								aria-label="Pause goal"
+								disabled={isPending}
+								onClick={() => mutation.mutate("pause")}
+							>
+								<Pause className="size-[13px] shrink-0" strokeWidth={1.8} />
+								<span>Pause</span>
+							</ActionRowButton>
+						)}
+						{goal.status === "paused" && (
+							<ActionRowButton
+								type="button"
+								aria-label="Resume goal"
+								disabled={isPending}
+								onClick={() => mutation.mutate("resume")}
+							>
+								<Play className="size-[13px] shrink-0" strokeWidth={1.8} />
+								<span>Resume</span>
+							</ActionRowButton>
+						)}
+						<ActionRowButton
+							type="button"
+							aria-label="Clear goal"
+							disabled={isPending}
+							onClick={() => mutation.mutate("clear")}
+						>
+							<X className="size-[13px] shrink-0" strokeWidth={1.8} />
+							<span>Clear</span>
+						</ActionRowButton>
+					</>
+				}
+			/>
 		</div>
 	);
 }

--- a/src/features/panel/message-components/system-message.tsx
+++ b/src/features/panel/message-components/system-message.tsx
@@ -2,9 +2,9 @@ import { formatDistanceToNow } from "date-fns";
 import {
 	AlertCircle,
 	AlertTriangle,
+	Goal,
 	Info,
 	MessageSquareText,
-	Target,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -108,7 +108,7 @@ function SystemText({ text }: { text: string }) {
 	if (text.startsWith("Goal ")) {
 		return (
 			<span className="inline-flex items-center gap-1">
-				<Target className="size-3 shrink-0" strokeWidth={1.8} />
+				<Goal className="size-3 shrink-0" strokeWidth={1.8} />
 				{text}
 			</span>
 		);

--- a/src/features/panel/message-components/system-message.tsx
+++ b/src/features/panel/message-components/system-message.tsx
@@ -4,6 +4,7 @@ import {
 	AlertTriangle,
 	Info,
 	MessageSquareText,
+	Target,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -97,6 +98,18 @@ function SystemText({ text }: { text: string }) {
 			<span className="inline-flex items-center gap-1 text-destructive">
 				<AlertCircle className="size-3 shrink-0" strokeWidth={1.8} />
 				{text.slice(7)}
+			</span>
+		);
+	}
+	// Codex `/goal` lifecycle markers — narrated by
+	// `agents::streaming::codex_goal::goal_transition_label` on the
+	// backend ("Goal set" / "Goal paused" / etc.). Prefix-detect them
+	// here so they share an icon, same shape as the Error case above.
+	if (text.startsWith("Goal ")) {
+		return (
+			<span className="inline-flex items-center gap-1">
+				<Target className="size-3 shrink-0" strokeWidth={1.8} />
+				{text}
 			</span>
 		);
 	}

--- a/src/features/panel/thread-viewport.tsx
+++ b/src/features/panel/thread-viewport.tsx
@@ -21,6 +21,7 @@ import { measureSync } from "@/lib/perf-marks";
 import { hasUnresolvedPlanReview } from "@/lib/plan-review";
 import { useSettings } from "@/lib/settings";
 import type { WorkspaceScriptType } from "@/lib/workspace-script-actions";
+import { CodexGoalBanner } from "./codex-goal-banner";
 import { EmptyState, MemoConversationMessage } from "./message-components";
 
 export type PresentedSessionPane = {
@@ -109,8 +110,9 @@ export function ActiveThreadViewport({
 	return (
 		<div
 			ref={stackRef}
-			className="relative flex min-h-0 flex-1 overflow-hidden"
+			className="relative flex min-h-0 flex-1 flex-col overflow-hidden"
 		>
+			<CodexGoalBanner sessionId={pane.sessionId} />
 			<div className="relative z-10 flex min-h-0 min-w-0 flex-1">
 				<ChatThread
 					hasSession={hasSession}

--- a/src/features/panel/thread-viewport.tsx
+++ b/src/features/panel/thread-viewport.tsx
@@ -21,7 +21,6 @@ import { measureSync } from "@/lib/perf-marks";
 import { hasUnresolvedPlanReview } from "@/lib/plan-review";
 import { useSettings } from "@/lib/settings";
 import type { WorkspaceScriptType } from "@/lib/workspace-script-actions";
-import { CodexGoalBanner } from "./codex-goal-banner";
 import { EmptyState, MemoConversationMessage } from "./message-components";
 
 export type PresentedSessionPane = {
@@ -110,9 +109,8 @@ export function ActiveThreadViewport({
 	return (
 		<div
 			ref={stackRef}
-			className="relative flex min-h-0 flex-1 flex-col overflow-hidden"
+			className="relative flex min-h-0 flex-1 overflow-hidden"
 		>
-			<CodexGoalBanner sessionId={pane.sessionId} />
 			<div className="relative z-10 flex min-h-0 min-w-0 flex-1">
 				<ChatThread
 					hasSession={hasSession}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2365,11 +2365,15 @@ export async function getSessionCodexGoal(
 	}
 }
 
-/** Out-of-band Codex `/goal` lifecycle control — what the banner buttons
- *  call. `pause` / `resume` flip the goal status; `clear` removes it. */
+/** Out-of-band Codex `/goal` lifecycle control. `pause` is fired by the
+ *  Composer Stop button (so abort doesn't get re-spawned by codex's
+ *  continuation loop); `clear` is the banner's Clear button. Resume is
+ *  intentionally NOT here — it goes through `/goal resume` on the
+ *  sendMessage path so the resulting stream subscription catches the
+ *  goal-continuation turn codex auto-spawns. */
 export async function mutateCodexGoal(
 	sessionId: string,
-	action: "pause" | "resume" | "clear",
+	action: "pause" | "clear",
 ): Promise<void> {
 	await invoke("mutate_codex_goal", { sessionId, action });
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1096,6 +1096,7 @@ export type UiMutationEvent =
 	| { type: "workspaceChanged"; workspaceId: string }
 	| { type: "sessionListChanged"; workspaceId: string }
 	| { type: "contextUsageChanged"; sessionId: string }
+	| { type: "codexGoalChanged"; sessionId: string }
 	| { type: "workspaceFilesChanged"; workspaceId: string }
 	| { type: "workspaceGitStateChanged"; workspaceId: string }
 	| { type: "workspaceForgeChanged"; workspaceId: string }
@@ -2333,6 +2334,33 @@ export async function getSessionContextUsage(
 	return await invoke<string | null>("get_session_context_usage", {
 		sessionId,
 	});
+}
+
+/** Active Codex `/goal` payload as JSON. Null when no goal is set. */
+export type CodexGoalState = {
+	threadId: string;
+	objective: string;
+	status: "active" | "paused" | "budgetLimited" | "complete";
+	tokenBudget: number | null;
+	tokensUsed: number;
+	timeUsedSeconds: number;
+	createdAt: number;
+	updatedAt: number;
+};
+
+/** Read the active Codex `/goal` for one session. Null when no goal. */
+export async function getSessionCodexGoal(
+	sessionId: string,
+): Promise<CodexGoalState | null> {
+	const raw = await invoke<string | null>("get_session_codex_goal", {
+		sessionId,
+	});
+	if (!raw) return null;
+	try {
+		return JSON.parse(raw) as CodexGoalState;
+	} catch {
+		return null;
+	}
 }
 
 /** Read the account-global Codex rate-limit snapshot. Null until Codex has

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2364,6 +2364,15 @@ export async function getSessionCodexGoal(
 	}
 }
 
+/** Out-of-band Codex `/goal` lifecycle control — what the banner buttons
+ *  call. `pause` / `resume` flip the goal status; `clear` removes it. */
+export async function mutateCodexGoal(
+	sessionId: string,
+	action: "pause" | "resume" | "clear",
+): Promise<void> {
+	await invoke("mutate_codex_goal", { sessionId, action });
+}
+
 /** Read the account-global Codex rate-limit snapshot. Null until Codex has
  *  emitted at least one `account/rateLimits/updated` notification. */
 export async function getCodexRateLimits(): Promise<string | null> {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1098,6 +1098,7 @@ export type UiMutationEvent =
 	| { type: "sessionListChanged"; workspaceId: string }
 	| { type: "contextUsageChanged"; sessionId: string }
 	| { type: "codexGoalChanged"; sessionId: string }
+	| { type: "sessionMessagesAppended"; sessionId: string }
 	| { type: "workspaceFilesChanged"; workspaceId: string }
 	| { type: "workspaceGitStateChanged"; workspaceId: string }
 	| { type: "workspaceForgeChanged"; workspaceId: string }

--- a/src/lib/query-client.ts
+++ b/src/lib/query-client.ts
@@ -13,6 +13,7 @@ import {
 	getClaudeRateLimits,
 	getCodexRateLimits,
 	getLiveContextUsage,
+	getSessionCodexGoal,
 	getSessionContextUsage,
 	getWorkspaceAccountProfile,
 	getWorkspaceForge,
@@ -57,6 +58,8 @@ export const helmorQueryKeys = {
 		["workspaceSessions", workspaceId] as const,
 	sessionContextUsage: (sessionId: string) =>
 		["sessionContextUsage", sessionId] as const,
+	sessionCodexGoal: (sessionId: string) =>
+		["sessionCodexGoal", sessionId] as const,
 	codexRateLimits: ["codexRateLimits"] as const,
 	claudeRateLimits: ["claudeRateLimits"] as const,
 	claudeRichContextUsage: (
@@ -328,6 +331,15 @@ export function sessionContextUsageQueryOptions(sessionId: string) {
 	return queryOptions({
 		queryKey: helmorQueryKeys.sessionContextUsage(sessionId),
 		queryFn: () => getSessionContextUsage(sessionId),
+		staleTime: 0,
+	});
+}
+
+/** Active Codex `/goal` payload. Event-driven via `CodexGoalChanged`. */
+export function sessionCodexGoalQueryOptions(sessionId: string) {
+	return queryOptions({
+		queryKey: helmorQueryKeys.sessionCodexGoal(sessionId),
+		queryFn: () => getSessionCodexGoal(sessionId),
 		staleTime: 0,
 	});
 }

--- a/src/shell/hooks/use-ui-sync-bridge.ts
+++ b/src/shell/hooks/use-ui-sync-bridge.ts
@@ -68,6 +68,11 @@ function handleUiMutation(
 					query.queryKey[1] === event.sessionId,
 			});
 			return;
+		case "codexGoalChanged":
+			void queryClient.invalidateQueries({
+				queryKey: helmorQueryKeys.sessionCodexGoal(event.sessionId),
+			});
+			return;
 		case "workspaceFilesChanged":
 			void queryClient.invalidateQueries({
 				queryKey: helmorQueryKeys.workspaceGitActionStatus(event.workspaceId),

--- a/src/shell/hooks/use-ui-sync-bridge.ts
+++ b/src/shell/hooks/use-ui-sync-bridge.ts
@@ -73,6 +73,11 @@ function handleUiMutation(
 				queryKey: helmorQueryKeys.sessionCodexGoal(event.sessionId),
 			});
 			return;
+		case "sessionMessagesAppended":
+			void queryClient.invalidateQueries({
+				queryKey: helmorQueryKeys.sessionMessages(event.sessionId),
+			});
+			return;
 		case "workspaceFilesChanged":
 			void queryClient.invalidateQueries({
 				queryKey: helmorQueryKeys.workspaceGitActionStatus(event.workspaceId),


### PR DESCRIPTION
## Summary

Two big upstream agent moves landed in one branch:

1. **Claude Code** is now distributed as a single self-contained native binary (`@anthropic-ai/claude-code-darwin-{arm64,x64}`) instead of `cli.js` + a separate `bun` interpreter.
2. **Codex** got the new `thread/goal/*` JSON-RPC API (added in 0.126+), letting users set persistent goals the agent autonomously pursues across turns.

This PR ports Helmor onto both, plus a thread-header banner with inline pause / resume / clear buttons that drive goal lifecycle out-of-band (no chat-history pollution).

## What changed

### Bundled agent CLIs

- Bump `@anthropic-ai/claude-agent-sdk` and `@anthropic-ai/claude-code` from `0.2.111` / `2.1.111` to `0.2.126` / `2.1.126`.
- Bump `@openai/codex` from `0.124.0` to `0.128.0`.
- Switch the claude-code vendor staging from `cli.js` + bundled `bun` to a single self-contained native binary, matching how Codex is bundled. The new binary statically embeds ripgrep, audio-capture, and the JSC runtime, so `vendor/ripgrep/`, `vendor/audio-capture/`, and `vendor/bun/` are dropped entirely.
- The env contract `HELMOR_CLAUDE_CODE_CLI_PATH` + `HELMOR_BUN_PATH` collapses into a single `HELMOR_CLAUDE_CODE_BIN_PATH` pointing at `vendor/claude-code/claude`.
- Codex 0.128 ships ripgrep at `vendor/<triple>/path/rg`; the staging script copies it alongside the binary and the sidecar prepends that directory to the codex child's `PATH` on spawn (covers both dev and staged layouts).
- Add `CLAUDE_CODE_SHA256` + a new `CODEX_SHA256[\"0.128.0\"]` entry; cross-arch staging mirrors the existing Codex flow.
- `AGENTS.md` documents the bump procedure for both bundled agent CLIs.

### Codex `/goal` command

The slash command is intentionally minimal — only `/goal <objective>` is parsed. Lifecycle ops (pause / resume / clear) live as banner buttons because that's what real users reach for, and putting them in the prompt path would clutter chat history.

- `/goal <objective>` → sidecar parser → `thread/goal/set { objective }` RPC.
- After `set`, the codex app-server auto-starts the continuation turn server-side, so no extra `turn/start` call is needed from Helmor.
- Pause / Resume / Clear go through a new sidecar IPC method `mutateCodexGoal` and a new Tauri command `mutate_codex_goal`, which routes to:
  - Pause → `thread/goal/set { status: \"paused\" }`
  - Resume → `thread/goal/set { status: \"active\" }`
  - Clear → `thread/goal/clear`
- These never appear as user messages in the thread.

### Active-goal banner

- New `sessions.codex_goal_meta` column persists the active goal so it survives reload.
- Sidecar listens for `thread/goal/updated` / `thread/goal/cleared` notifications and forwards them as `codexGoalUpdated` events.
- Rust streaming layer persists the payload + broadcasts a new `CodexGoalChanged` `UiMutationEvent`; new `get_session_codex_goal` Tauri command reads it back.
- `<CodexGoalBanner />` renders at the top of `ActiveThreadViewport` showing `🎯 <objective>  <status>  X / Y tokens` plus context-aware buttons (Pause when active, Resume when paused, Clear always). Hides itself when no goal is set, so Claude sessions are unaffected.
- Token-budget input is intentionally **not** exposed in the slash command for now — the underlying `tokenBudget` field is still received from codex notifications and rendered read-only on the banner (showing `X / Y tokens` when codex provides a budget). Re-introducing a UI to set a budget is straightforward later.

## Test notes

- `bun run lint` / `bun run typecheck` clean.
- Frontend: 810 passing.
- Sidecar: 186 passing (includes parser unit tests).
- Rust: 849 lib + ~100 integration tests passing, including 5 new `codex_goal::tests`. `pipeline_streams.rs` snapshots are 0-drift after both bumps — SDK event shape is unchanged.
- Manually verify after merge: `bun run dev`, send a Codex prompt, try `/goal foo bar`, confirm banner appears + tokens advance. Click Pause → status flips to paused; Resume → active; Clear → banner disappears. None of these clicks appear as user messages.
- Cross-arch staging tested locally: `TAURI_TARGET_TRIPLE=x86_64-apple-darwin bun run stage-vendor` produces real x86_64 binaries for all four (claude / codex / gh / glab) with verified SHA256.

## Notes

- Goal API is marked `#[experimental]` upstream — wire shape can drift. SHA256 + version pins keep that explicit.
- Branch name (`nathan/fix-third-party-provider-tokens`) predates this work and doesn't reflect the diff. The original third-party-provider crash (#330) is fixed transitively by the claude-code bump (Anthropic's own fix landed between 2.1.111 and 2.1.126).