### PR TITLE
refactor(inspector): replace Review PR button with general Review changes helper

### DIFF
--- a/.changeset/review-pr-button.md
+++ b/.changeset/review-pr-button.md
@@ -2,4 +2,4 @@
 "helmor": minor
 ---
 
-Add a Review PR button to the inspector — when a workspace has an open pull request, click it to spin up a new chat that reads the PR diff and posts the review back in the chat. The default review prompt and the model used by the button are both configurable from Settings.
+Replace the PR-only "Review PR" header button with a general "Review changes" helper in the inspector — appears whenever the workspace has uncommitted changes or local commits ahead of the target branch (works before the first push), and Review now has its own model, effort level, and fast-mode controls in Settings (each falls back to the default when unset).

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "helmor",

--- a/src-tauri/src/agents/action_kind.rs
+++ b/src-tauri/src/agents/action_kind.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "kebab-case")]
 pub enum ActionKind {
     CreatePr,
-    ReviewPr,
+    Review,
     CommitAndPush,
     Push,
     Fix,
@@ -34,7 +34,7 @@ impl ActionKind {
     pub const fn as_str(&self) -> &'static str {
         match self {
             Self::CreatePr => "create-pr",
-            Self::ReviewPr => "review-pr",
+            Self::Review => "review",
             Self::CommitAndPush => "commit-and-push",
             Self::Push => "push",
             Self::Fix => "fix",
@@ -53,7 +53,7 @@ impl ActionKind {
     pub const fn default_title(&self) -> &'static str {
         match self {
             Self::CreatePr => "Create PR",
-            Self::ReviewPr => "Review PR",
+            Self::Review => "Review",
             Self::CommitAndPush => "Commit and Push",
             Self::Push => "Push",
             Self::Fix => "Fix CI",
@@ -71,7 +71,6 @@ impl ActionKind {
     pub fn default_title_for_change_request(&self, change_request_name: &str) -> String {
         match self {
             Self::CreatePr => format!("Create {change_request_name}"),
-            Self::ReviewPr => format!("Review {change_request_name}"),
             Self::OpenPr => format!("Open {change_request_name}"),
             _ => self.default_title().to_string(),
         }
@@ -101,7 +100,7 @@ impl FromStr for ActionKind {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "create-pr" => Ok(Self::CreatePr),
-            "review-pr" => Ok(Self::ReviewPr),
+            "review" => Ok(Self::Review),
             "commit-and-push" => Ok(Self::CommitAndPush),
             "push" => Ok(Self::Push),
             "fix" => Ok(Self::Fix),
@@ -138,7 +137,7 @@ mod tests {
 
     const ALL: &[ActionKind] = &[
         ActionKind::CreatePr,
-        ActionKind::ReviewPr,
+        ActionKind::Review,
         ActionKind::CommitAndPush,
         ActionKind::Push,
         ActionKind::Fix,

--- a/src-tauri/src/cli/workspace.rs
+++ b/src-tauri/src/cli/workspace.rs
@@ -266,6 +266,7 @@ fn status(workspace_ref: &str, cli: &Cli) -> Result<()> {
             behind_target_count: 0,
             remote_tracking_ref: None,
             ahead_of_remote_count: 0,
+            ahead_of_target_count: 0,
             push_status: git_ops::WorkspacePushStatus::Unpublished,
         };
         return output::print(cli, &status, format_status);

--- a/src-tauri/src/commands/editor_commands.rs
+++ b/src-tauri/src/commands/editor_commands.rs
@@ -100,6 +100,7 @@ pub async fn get_workspace_git_action_status(
             behind_target_count: 0,
             remote_tracking_ref: None,
             ahead_of_remote_count: 0,
+            ahead_of_target_count: 0,
             push_status: git_ops::WorkspacePushStatus::Unpublished,
         };
         // Non-operational workspaces (Initializing / Archived) have no live

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -22,6 +22,14 @@ pub struct WorkspaceGitActionStatus {
     pub behind_target_count: u32,
     pub remote_tracking_ref: Option<String>,
     pub ahead_of_remote_count: u32,
+    /// How many commits this branch is ahead of its **target** branch's
+    /// remote-tracking ref (e.g. `origin/main`). Unlike `ahead_of_remote_count`
+    /// — which reads as 0 for unpublished branches because there is no upstream
+    /// — this measures user-introduced commits regardless of push state, so
+    /// frontends can tell "fresh empty branch" from "has unpushed work" even
+    /// before the first `git push`. 0 when the target branch ref can't be
+    /// resolved.
+    pub ahead_of_target_count: u32,
     pub push_status: WorkspacePushStatus,
 }
 
@@ -728,6 +736,8 @@ pub fn workspace_action_status(
         .map(ToOwned::to_owned);
     let (sync_status, behind_target_count) =
         workspace_sync_status(workspace_dir, remote, sync_target_branch.as_deref());
+    let ahead_of_target_count =
+        commits_ahead_of_target(workspace_dir, remote, sync_target_branch.as_deref());
     let remote_tracking_ref = resolve_remote_tracking_ref(workspace_dir, remote);
     let ahead_of_remote_count = remote_tracking_ref
         .as_deref()
@@ -743,8 +753,35 @@ pub fn workspace_action_status(
         behind_target_count,
         remote_tracking_ref,
         ahead_of_remote_count,
+        ahead_of_target_count,
         push_status,
     })
+}
+
+/// Count commits this workspace's HEAD has on top of the *target* branch's
+/// remote-tracking ref. Unlike `ahead_of_remote_count` (which compares to
+/// `current_upstream_ref` and is 0 for unpublished branches), this works even
+/// before the first push — useful for "does the user have anything to review"
+/// signals.
+fn commits_ahead_of_target(
+    workspace_dir: &Path,
+    remote: Option<&str>,
+    target_branch: Option<&str>,
+) -> u32 {
+    let Some(remote) = remote.map(str::trim).filter(|value| !value.is_empty()) else {
+        return 0;
+    };
+    let Some(target_branch) = target_branch
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return 0;
+    };
+    if !verify_remote_ref_exists(workspace_dir, remote, target_branch).unwrap_or(false) {
+        return 0;
+    }
+    let target_ref = format!("refs/remotes/{remote}/{target_branch}");
+    commits_ahead_of(workspace_dir, &target_ref).unwrap_or(0)
 }
 
 fn workspace_sync_status(
@@ -1303,7 +1340,41 @@ mod tests {
 
         assert_eq!(status.remote_tracking_ref, None);
         assert_eq!(status.ahead_of_remote_count, 0);
+        // Fresh branch identical to origin/main — nothing to review yet.
+        assert_eq!(status.ahead_of_target_count, 0);
         assert_eq!(status.push_status, WorkspacePushStatus::Unpublished);
+    }
+
+    #[test]
+    fn workspace_action_status_reports_ahead_of_target_for_unpublished_branch_with_commits() {
+        // Branch is unpublished (no upstream) but has local commits past
+        // origin/main. `ahead_of_remote_count` is 0 here (no upstream),
+        // but `ahead_of_target_count` must surface the unpushed work.
+        let (_origin, clone) = init_repo_with_remote();
+        run(clone.path(), &["checkout", "-b", "feature/local-only"]);
+        std::fs::write(clone.path().join("local.txt"), "local\n").unwrap();
+        run(clone.path(), &["add", "local.txt"]);
+        run(clone.path(), &["commit", "-m", "local-only commit"]);
+
+        let status = workspace_action_status(clone.path(), Some("origin"), Some("main")).unwrap();
+
+        assert_eq!(status.push_status, WorkspacePushStatus::Unpublished);
+        assert_eq!(status.ahead_of_remote_count, 0);
+        assert_eq!(status.ahead_of_target_count, 1);
+    }
+
+    #[test]
+    fn workspace_action_status_reports_ahead_of_target_for_published_branch() {
+        // Sanity: `ahead_of_target_count` works when the branch HAS an
+        // upstream too (shouldn't depend on `pushStatus`).
+        let (_origin, clone) = init_repo_with_remote();
+        std::fs::write(clone.path().join("pushed.txt"), "pushed\n").unwrap();
+        run(clone.path(), &["add", "pushed.txt"]);
+        run(clone.path(), &["commit", "-m", "pushed commit"]);
+
+        let status = workspace_action_status(clone.path(), Some("origin"), Some("main")).unwrap();
+
+        assert_eq!(status.ahead_of_target_count, 1);
     }
 
     #[test]

--- a/src-tauri/src/models/repos.rs
+++ b/src-tauri/src/models/repos.rs
@@ -631,7 +631,7 @@ pub struct RepoScripts {
 #[serde(rename_all = "camelCase")]
 pub struct RepoPreferences {
     pub create_pr: Option<String>,
-    pub review_pr: Option<String>,
+    pub review: Option<String>,
     pub fix_errors: Option<String>,
     pub resolve_conflicts: Option<String>,
     pub branch_rename: Option<String>,
@@ -812,7 +812,7 @@ pub fn load_repo_preferences(repo_id: &str) -> Result<RepoPreferences> {
             r#"
             SELECT
               custom_prompt_create_pr,
-              custom_prompt_review_pr,
+              custom_prompt_review,
               custom_prompt_fix_errors,
               custom_prompt_resolve_merge_conflicts,
               custom_prompt_rename_branch,
@@ -827,7 +827,7 @@ pub fn load_repo_preferences(repo_id: &str) -> Result<RepoPreferences> {
         .query_row([repo_id], |row| {
             Ok(RepoPreferences {
                 create_pr: row.get(0)?,
-                review_pr: row.get(1)?,
+                review: row.get(1)?,
                 fix_errors: row.get(2)?,
                 resolve_conflicts: row.get(3)?,
                 branch_rename: row.get(4)?,
@@ -845,7 +845,7 @@ pub fn update_repo_preferences(repo_id: &str, preferences: &RepoPreferences) -> 
             UPDATE repos
             SET
               custom_prompt_create_pr = ?1,
-              custom_prompt_review_pr = ?2,
+              custom_prompt_review = ?2,
               custom_prompt_fix_errors = ?3,
               custom_prompt_resolve_merge_conflicts = ?4,
               custom_prompt_rename_branch = ?5,
@@ -855,7 +855,7 @@ pub fn update_repo_preferences(repo_id: &str, preferences: &RepoPreferences) -> 
             "#,
             rusqlite::params![
                 normalize_repo_preference(preferences.create_pr.as_deref()),
-                normalize_repo_preference(preferences.review_pr.as_deref()),
+                normalize_repo_preference(preferences.review.as_deref()),
                 normalize_repo_preference(preferences.fix_errors.as_deref()),
                 normalize_repo_preference(preferences.resolve_conflicts.as_deref()),
                 normalize_repo_preference(preferences.branch_rename.as_deref()),
@@ -1396,10 +1396,10 @@ mod tests {
     }
 
     #[test]
-    fn repo_preferences_round_trips_review_pr() {
-        let env = crate::testkit::TestEnv::new("repos-prefs-review-pr");
+    fn repo_preferences_round_trips_review() {
+        let env = crate::testkit::TestEnv::new("repos-prefs-review");
         let repo = ResolvedRepositoryInput {
-            name: "review-pr-repo".to_string(),
+            name: "review-repo".to_string(),
             normalized_root_path: env.root.join("review-repo").display().to_string(),
             remote: None,
             remote_url: None,
@@ -1410,18 +1410,18 @@ mod tests {
 
         // Default load returns None for the new field.
         let initial = load_repo_preferences(&repo_id).unwrap();
-        assert_eq!(initial.review_pr, None);
+        assert_eq!(initial.review, None);
 
         // Round-trip a non-empty review prompt.
         let prefs = RepoPreferences {
-            review_pr: Some("Focus on SQL injections and missing tests.".to_string()),
+            review: Some("Focus on SQL injections and missing tests.".to_string()),
             ..RepoPreferences::default()
         };
         update_repo_preferences(&repo_id, &prefs).unwrap();
 
         let loaded = load_repo_preferences(&repo_id).unwrap();
         assert_eq!(
-            loaded.review_pr.as_deref(),
+            loaded.review.as_deref(),
             Some("Focus on SQL injections and missing tests.")
         );
         // Other prompt slots remain untouched.
@@ -1430,11 +1430,11 @@ mod tests {
 
         // Whitespace-only override is normalized back to None.
         let blanked = RepoPreferences {
-            review_pr: Some("   ".to_string()),
+            review: Some("   ".to_string()),
             ..RepoPreferences::default()
         };
         update_repo_preferences(&repo_id, &blanked).unwrap();
         let cleared = load_repo_preferences(&repo_id).unwrap();
-        assert_eq!(cleared.review_pr, None);
+        assert_eq!(cleared.review, None);
     }
 }

--- a/src-tauri/src/schema.rs
+++ b/src-tauri/src/schema.rs
@@ -221,23 +221,44 @@ fn run_migrations(connection: &Connection) -> Result<()> {
             .context("Failed to add action_kind column")?;
     }
 
-    // Migration: add custom_prompt_review_pr column for the Review PR action
-    // (mirrors custom_prompt_create_pr — repo-level prompt override).
-    let has_repos_table_for_review: bool = connection
+    // Migration: ensure repos.custom_prompt_review exists.
+    //
+    // The column was originally introduced as `custom_prompt_review_pr`
+    // alongside the (removed) "Review PR" header button. The button is now
+    // a generic "Review changes" helper, so the column was renamed to
+    // `custom_prompt_review`. Three start states must converge cleanly:
+    //   1. Brand-new DB — CREATE TABLE already adds `custom_prompt_review`.
+    //   2. Old DB that picked up the previous migration — has the legacy
+    //      `custom_prompt_review_pr`. RENAME preserves any user-saved prompt.
+    //   3. Old DB that pre-dates either migration — neither column exists,
+    //      so we ADD the new one.
+    let has_repos_table: bool = connection
         .prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'repos'")
         .and_then(|mut stmt| stmt.exists([]))
         .unwrap_or(false);
-    if has_repos_table_for_review {
-        let has_review_col: bool = connection
+    if has_repos_table {
+        let has_new_col: bool = connection
+            .prepare("SELECT 1 FROM pragma_table_info('repos') WHERE name = 'custom_prompt_review'")
+            .and_then(|mut stmt| stmt.exists([]))
+            .unwrap_or(false);
+        let has_legacy_col: bool = connection
             .prepare(
                 "SELECT 1 FROM pragma_table_info('repos') WHERE name = 'custom_prompt_review_pr'",
             )
             .and_then(|mut stmt| stmt.exists([]))
             .unwrap_or(false);
-        if !has_review_col {
-            connection
-                .execute_batch("ALTER TABLE repos ADD COLUMN custom_prompt_review_pr TEXT")
-                .context("Failed to add custom_prompt_review_pr column")?;
+        if !has_new_col {
+            if has_legacy_col {
+                connection
+                    .execute_batch(
+                        "ALTER TABLE repos RENAME COLUMN custom_prompt_review_pr TO custom_prompt_review",
+                    )
+                    .context("Failed to rename custom_prompt_review_pr -> custom_prompt_review")?;
+            } else {
+                connection
+                    .execute_batch("ALTER TABLE repos ADD COLUMN custom_prompt_review TEXT")
+                    .context("Failed to add custom_prompt_review column")?;
+            }
         }
     }
 
@@ -516,7 +537,7 @@ CREATE TABLE IF NOT EXISTS repos (
     run_script TEXT,
     remote TEXT,
     custom_prompt_create_pr TEXT,
-    custom_prompt_review_pr TEXT,
+    custom_prompt_review TEXT,
     custom_prompt_rename_branch TEXT,
     custom_prompt_general TEXT,
     hidden INTEGER DEFAULT 0,

--- a/src-tauri/tests/schema_migrations.rs
+++ b/src-tauri/tests/schema_migrations.rs
@@ -16,11 +16,11 @@ fn repos_branch_prefix_columns(connection: &rusqlite::Connection) -> Vec<(String
         .unwrap()
 }
 
-fn repos_review_pr_columns(connection: &rusqlite::Connection) -> Vec<(String, String)> {
+fn repos_review_columns(connection: &rusqlite::Connection) -> Vec<(String, String)> {
     let mut statement = connection
         .prepare(
             "SELECT name, type FROM pragma_table_info('repos')
-             WHERE name = 'custom_prompt_review_pr'
+             WHERE name IN ('custom_prompt_review', 'custom_prompt_review_pr')
              ORDER BY cid",
         )
         .unwrap();
@@ -58,9 +58,9 @@ fn repos_branch_prefix_override_migration_is_idempotent() {
 }
 
 #[test]
-fn repos_review_pr_migration_is_idempotent() {
+fn repos_review_migration_adds_column_when_missing() {
     let connection = rusqlite::Connection::open_in_memory().unwrap();
-    // Bare repos table missing the new custom_prompt_review_pr column.
+    // Bare repos table missing both the legacy and new review columns.
     connection
         .execute_batch(
             r#"
@@ -81,7 +81,48 @@ fn repos_review_pr_migration_is_idempotent() {
     schema::ensure_schema(&connection).unwrap();
 
     assert_yaml_snapshot!(
-        "repos_review_pr_migration",
-        repos_review_pr_columns(&connection)
+        "repos_review_migration_add",
+        repos_review_columns(&connection)
+    );
+}
+
+#[test]
+fn repos_review_migration_renames_legacy_column() {
+    let connection = rusqlite::Connection::open_in_memory().unwrap();
+    // Old DB shape: legacy custom_prompt_review_pr is present, the new
+    // custom_prompt_review is not. The migration must rename so any user
+    // prompt persisted under the old column is preserved.
+    connection
+        .execute_batch(
+            r#"
+            CREATE TABLE repos (
+                id TEXT PRIMARY KEY,
+                name TEXT,
+                default_branch TEXT,
+                root_path TEXT,
+                custom_prompt_review_pr TEXT,
+                created_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+            INSERT INTO repos (id, name, custom_prompt_review_pr)
+            VALUES ('r1', 'demo', 'keep me');
+            "#,
+        )
+        .unwrap();
+
+    schema::ensure_schema(&connection).unwrap();
+    schema::ensure_schema(&connection).unwrap();
+
+    let preserved: Option<String> = connection
+        .query_row(
+            "SELECT custom_prompt_review FROM repos WHERE id = 'r1'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(preserved.as_deref(), Some("keep me"));
+
+    assert_yaml_snapshot!(
+        "repos_review_migration_rename",
+        repos_review_columns(&connection)
     );
 }

--- a/src-tauri/tests/snapshots/schema_migrations__repos_review_migration_add.snap
+++ b/src-tauri/tests/snapshots/schema_migrations__repos_review_migration_add.snap
@@ -1,0 +1,6 @@
+---
+source: tests/schema_migrations.rs
+expression: repos_review_columns(&connection)
+---
+- - custom_prompt_review
+  - TEXT

--- a/src-tauri/tests/snapshots/schema_migrations__repos_review_migration_rename.snap
+++ b/src-tauri/tests/snapshots/schema_migrations__repos_review_migration_rename.snap
@@ -1,0 +1,6 @@
+---
+source: tests/schema_migrations.rs
+expression: repos_review_columns(&connection)
+---
+- - custom_prompt_review
+  - TEXT

--- a/src-tauri/tests/snapshots/schema_migrations__repos_review_pr_migration.snap
+++ b/src-tauri/tests/snapshots/schema_migrations__repos_review_pr_migration.snap
@@ -1,6 +1,0 @@
----
-source: tests/schema_migrations.rs
-expression: repos_review_pr_columns(&connection)
----
-- - custom_prompt_review_pr
-  - TEXT

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1454,7 +1454,7 @@ function AppShell({
 		commitButtonMode,
 		commitButtonState,
 		handleInspectorCommitAction,
-		handleInspectorReviewPrAction,
+		handleInspectorReviewAction,
 		handlePendingPromptConsumed,
 		pendingPromptForSession,
 		queuePendingPromptForSession,
@@ -2584,11 +2584,17 @@ function AppShell({
 												activeEditorPath={editorSession?.path ?? null}
 												onOpenEditorFile={handleOpenEditorFile}
 												onCommitAction={handleInspectorCommitAction}
-												onReviewPrAction={() =>
-													handleInspectorReviewPrAction({
+												onReviewAction={() =>
+													handleInspectorReviewAction({
 														modelId:
-															appSettings.reviewPrModelId ??
+															appSettings.reviewModelId ??
 															appSettings.defaultModelId,
+														effort:
+															appSettings.reviewEffort ??
+															appSettings.defaultEffort,
+														fastMode:
+															appSettings.reviewFastMode ??
+															appSettings.defaultFastMode,
 													})
 												}
 												currentSessionId={displayedSessionId}

--- a/src/features/commit/hooks/use-commit-lifecycle.test.tsx
+++ b/src/features/commit/hooks/use-commit-lifecycle.test.tsx
@@ -47,6 +47,7 @@ const EMPTY_GIT_ACTION_STATUS: WorkspaceGitActionStatus = {
 	behindTargetCount: 0,
 	remoteTrackingRef: null,
 	aheadOfRemoteCount: 0,
+	aheadOfTargetCount: 0,
 	pushStatus: "unknown",
 };
 
@@ -699,7 +700,7 @@ describe("useWorkspaceCommitLifecycle", () => {
 		).toBe("review");
 	});
 
-	it("queues a review prompt with the configured modelId when handleInspectorReviewPrAction runs", async () => {
+	it("queues a review prompt with the configured modelId when handleInspectorReviewAction runs", async () => {
 		const queryClient = new QueryClient({
 			defaultOptions: { queries: { retry: false } },
 		});
@@ -731,13 +732,15 @@ describe("useWorkspaceCommitLifecycle", () => {
 		);
 
 		await act(async () => {
-			await result.current.handleInspectorReviewPrAction({
+			await result.current.handleInspectorReviewAction({
 				modelId: "review-model",
 			});
 		});
 
+		// Review is an action session ("auto-created", fixed title), but it
+		// opts out of auto-hide via `isAutoHideableActionKind`.
 		expect(apiMocks.createSession).toHaveBeenCalledWith("workspace-1", {
-			actionKind: "review-pr",
+			actionKind: "review",
 		});
 		expect(result.current.pendingPromptForSession).toMatchObject({
 			sessionId: "session-action",
@@ -774,7 +777,7 @@ describe("useWorkspaceCommitLifecycle", () => {
 		);
 
 		await act(async () => {
-			await result.current.handleInspectorReviewPrAction({ modelId: null });
+			await result.current.handleInspectorReviewAction({ modelId: null });
 		});
 
 		expect(result.current.pendingPromptForSession).toMatchObject({
@@ -783,7 +786,7 @@ describe("useWorkspaceCommitLifecycle", () => {
 		});
 	});
 
-	it("ignores handleInspectorReviewPrAction when no workspace is selected", async () => {
+	it("ignores handleInspectorReviewAction when no workspace is selected", async () => {
 		const queryClient = new QueryClient({
 			defaultOptions: { queries: { retry: false } },
 		});
@@ -808,7 +811,7 @@ describe("useWorkspaceCommitLifecycle", () => {
 		);
 
 		await act(async () => {
-			await result.current.handleInspectorReviewPrAction({
+			await result.current.handleInspectorReviewAction({
 				modelId: "review-model",
 			});
 		});

--- a/src/features/commit/hooks/use-commit-lifecycle.test.tsx
+++ b/src/features/commit/hooks/use-commit-lifecycle.test.tsx
@@ -746,8 +746,9 @@ describe("useWorkspaceCommitLifecycle", () => {
 			sessionId: "session-action",
 			modelId: "review-model",
 		});
+		// New review prompt diffs against the target ref, no PR/MR machinery.
 		expect(result.current.pendingPromptForSession?.prompt ?? "").toContain(
-			"Review the open",
+			"Review the changes on this branch relative to `origin/main`",
 		);
 		expect(onSelectSession).toHaveBeenCalledWith("session-action");
 	});

--- a/src/features/commit/hooks/use-commit-lifecycle.ts
+++ b/src/features/commit/hooks/use-commit-lifecycle.ts
@@ -133,6 +133,12 @@ export type PendingPromptForSession = {
 	sessionId: string;
 	prompt: string;
 	modelId?: string | null;
+	/** Effort level override applied alongside `modelId` (e.g. Review helper
+	 *  uses settings.reviewEffort). Falls through if null. */
+	effort?: string | null;
+	/** Fast-mode override applied alongside `modelId` (Review helper uses
+	 *  settings.reviewFastMode). Falls through if null/undefined. */
+	fastMode?: boolean | null;
 	permissionMode?: string | null;
 	/** When true, submit must queue if a turn is already streaming —
 	 *  regardless of the user's `followUpBehavior` setting. Used for
@@ -421,17 +427,30 @@ export function useWorkspaceCommitLifecycle({
 		[],
 	);
 
-	const handleInspectorReviewPrAction = useCallback(
-		async ({ modelId }: { modelId: string | null }) => {
+	const handleInspectorReviewAction = useCallback(
+		async ({
+			modelId,
+			effort,
+			fastMode,
+		}: {
+			modelId: string | null;
+			effort?: string | null;
+			fastMode?: boolean | null;
+		}) => {
 			const workspaceId = selectedWorkspaceIdRef.current;
 			if (!workspaceId) {
-				console.warn("[reviewPr] action ignored: no selected workspace");
+				console.warn("[review] action ignored: no selected workspace");
 				return;
 			}
-			console.log("[reviewPr] begin", { workspaceId, modelId });
+			console.log("[review] begin", { workspaceId, modelId, effort, fastMode });
 			try {
+				// Review is auto-created (so it gets a fixed "Review" title
+				// instead of an LLM-generated one), but it's NOT auto-hideable
+				// — the review output is *for the user to read*, so the
+				// session must stay around. The auto-hide gate is enforced
+				// independently in `isAutoHideableActionKind`.
 				const { sessionId } = await createSession(workspaceId, {
-					actionKind: "review-pr",
+					actionKind: "review",
 				});
 				const repoPreferences = selectedRepoId
 					? await loadRepoPreferences(selectedRepoId)
@@ -440,7 +459,7 @@ export function useWorkspaceCommitLifecycle({
 					.ensureQueryData(workspaceForgeQueryOptions(workspaceId))
 					.catch(() => null);
 				const prompt = buildCommitButtonPrompt(
-					"review-pr",
+					"review",
 					repoPreferences,
 					selectedWorkspaceTargetBranch,
 					forge,
@@ -449,19 +468,24 @@ export function useWorkspaceCommitLifecycle({
 				await queryClient.invalidateQueries({
 					queryKey: helmorQueryKeys.workspaceSessions(workspaceId),
 				});
-				setPendingPromptForSession({ sessionId, prompt, modelId });
+				setPendingPromptForSession({
+					sessionId,
+					prompt,
+					modelId,
+					effort: effort ?? null,
+					fastMode: fastMode ?? null,
+				});
 				onSelectSession(sessionId);
 			} catch (error) {
-				console.error("[reviewPr] failed to start session:", error);
+				console.error("[review] failed to start session:", error);
 				pushToast?.(
 					getErrorMessage(error, "Unable to start review."),
-					`Review ${changeRequestName} failed`,
+					"Review failed",
 					"destructive",
 				);
 			}
 		},
 		[
-			changeRequestName,
 			onSelectSession,
 			pushToast,
 			queryClient,
@@ -718,7 +742,7 @@ export function useWorkspaceCommitLifecycle({
 		commitButtonMode,
 		commitButtonState,
 		handleInspectorCommitAction,
-		handleInspectorReviewPrAction,
+		handleInspectorReviewAction,
 		handlePendingPromptConsumed,
 		pendingPromptForSession,
 		queuePendingPromptForSession,

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -24,6 +24,7 @@ import {
 	saveAutoCloseActionKinds,
 	setWorkspaceLinkedDirectories,
 } from "@/lib/api";
+import { isAutoHideableActionKind } from "@/lib/commit-button-prompts";
 import type {
 	ComposerCustomTag,
 	ResolvedComposerInsertRequest,
@@ -133,6 +134,12 @@ type WorkspaceComposerContainerProps = {
 		sessionId: string;
 		prompt: string;
 		modelId?: string | null;
+		/** Effort level forced for this pending submit. Takes precedence over
+		 *  cached/session/default effort. */
+		effort?: string | null;
+		/** Fast-mode forced for this pending submit. Takes precedence over
+		 *  cached/session/default fast-mode. */
+		fastMode?: boolean | null;
 		permissionMode?: string | null;
 		/** Force queue (bypass `followUpBehavior`) if a turn is streaming. */
 		forceQueue?: boolean;
@@ -369,8 +376,16 @@ export const WorkspaceComposerContainer = memo(
 		// For new sessions, use user setting; for existing sessions with history, use session's effort
 		const sessionEffort =
 			(!isNewSession(currentSession) && currentSession?.effortLevel) || null;
+		const pendingEffort =
+			pendingOverrideActive && pendingPromptForSession?.effort
+				? pendingPromptForSession.effort
+				: null;
 		const rawEffort =
-			cachedEffort ?? sessionEffort ?? settings.defaultEffort ?? "high";
+			pendingEffort ??
+			cachedEffort ??
+			sessionEffort ??
+			settings.defaultEffort ??
+			"high";
 		const effortLevel = clampEffortToModel(
 			rawEffort,
 			effectiveSelectedModelId,
@@ -396,8 +411,18 @@ export const WorkspaceComposerContainer = memo(
 		const sessionFastMode = !isNewSession(currentSession)
 			? currentSession?.fastMode
 			: undefined;
+		const pendingFastMode =
+			pendingOverrideActive &&
+			pendingPromptForSession?.fastMode !== undefined &&
+			pendingPromptForSession?.fastMode !== null
+				? pendingPromptForSession.fastMode
+				: undefined;
 		const fastMode = supportsFastMode
-			? (cachedFastMode ?? sessionFastMode ?? settings.defaultFastMode ?? false)
+			? (pendingFastMode ??
+				cachedFastMode ??
+				sessionFastMode ??
+				settings.defaultFastMode ??
+				false)
 			: false;
 		const showFastModePrelude = activeFastPreludes[composerContextKey] === true;
 		const loadingConversationContext =
@@ -431,7 +456,12 @@ export const WorkspaceComposerContainer = memo(
 			[autoCloseQuery.data],
 		);
 		const sessionActionKind = currentSession?.actionKind ?? null;
-		const isActionSession = Boolean(sessionActionKind);
+		// "Action session" here drives the Auto-Close composer affordance.
+		// Some kinds (e.g. "review") are auto-created but explicitly NOT
+		// auto-hideable — they exist for the user to read — so we hide the
+		// toggle UI for them.
+		const isActionSession =
+			sessionActionKind !== null && isAutoHideableActionKind(sessionActionKind);
 		const autoCloseEnabled = sessionActionKind
 			? autoCloseActionKinds.has(sessionActionKind)
 			: false;

--- a/src/features/conversation/index.tsx
+++ b/src/features/conversation/index.tsx
@@ -200,7 +200,7 @@ export const WorkspaceConversationContainer = memo(
 		}, [hasPlanReview, composerContextKey]);
 
 		// Preset composer model when a pending prompt carries an explicit
-		// modelId (e.g. Review PR uses settings.reviewPrModelId). Without this
+		// modelId (e.g. Review uses settings.reviewModelId). Without this
 		// the chip below the chat keeps showing the inferred default while the
 		// submit silently uses the queued modelId — mismatch the user sees.
 		useEffect(() => {

--- a/src/features/inspector/index.test.tsx
+++ b/src/features/inspector/index.test.tsx
@@ -51,6 +51,7 @@ function cleanGitStatus(): WorkspaceGitActionStatus {
 		behindTargetCount: 0,
 		remoteTrackingRef: "refs/remotes/origin/main",
 		aheadOfRemoteCount: 0,
+		aheadOfTargetCount: 0,
 		pushStatus: "published",
 	};
 }

--- a/src/features/inspector/index.tsx
+++ b/src/features/inspector/index.tsx
@@ -43,7 +43,7 @@ type WorkspaceInspectorSidebarProps = {
 	onOpenEditorFile(path: string, options?: DiffOpenOptions): void;
 	onOpenMockReview?: (path: string) => void;
 	onCommitAction?: (mode: WorkspaceCommitButtonMode) => Promise<void>;
-	onReviewPrAction?: () => Promise<void>;
+	onReviewAction?: () => Promise<void>;
 	currentSessionId?: string | null;
 	onQueuePendingPromptForSession?: (request: {
 		sessionId: string;
@@ -74,7 +74,7 @@ export function WorkspaceInspectorSidebar({
 	activeEditorPath,
 	onOpenEditorFile,
 	onCommitAction,
-	onReviewPrAction,
+	onReviewAction,
 	currentSessionId,
 	onQueuePendingPromptForSession,
 	commitButtonMode,
@@ -386,7 +386,6 @@ export function WorkspaceInspectorSidebar({
 				onOpenEditorFile={onOpenEditorFile}
 				flashingPaths={flashingPaths}
 				onCommitAction={onCommitAction}
-				onReviewPrAction={onReviewPrAction}
 				commitButtonMode={commitButtonMode}
 				commitButtonState={commitButtonState}
 				changeRequest={changeRequest ?? null}
@@ -407,6 +406,7 @@ export function WorkspaceInspectorSidebar({
 				bodyHeight={actionsHeight}
 				expanded={!tabsOpen}
 				onCommitAction={onCommitAction}
+				onReviewAction={onReviewAction}
 				currentSessionId={currentSessionId ?? null}
 				onQueuePendingPromptForSession={onQueuePendingPromptForSession}
 				commitButtonMode={commitButtonMode}

--- a/src/features/inspector/sections/actions.tsx
+++ b/src/features/inspector/sections/actions.tsx
@@ -3,6 +3,7 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import {
 	ArrowUpRightIcon,
 	CheckIcon,
+	EyeIcon,
 	LoaderCircleIcon,
 	TriangleIcon,
 } from "lucide-react";
@@ -82,6 +83,7 @@ const EMPTY_GIT_ACTION_STATUS: WorkspaceGitActionStatus = {
 	behindTargetCount: 0,
 	remoteTrackingRef: null,
 	aheadOfRemoteCount: 0,
+	aheadOfTargetCount: 0,
 	pushStatus: "unknown",
 };
 
@@ -104,6 +106,7 @@ type ActionsSectionProps = {
 	bodyHeight: number;
 	expanded: boolean;
 	onCommitAction?: (mode: WorkspaceCommitButtonMode) => Promise<void>;
+	onReviewAction?: () => Promise<void>;
 	currentSessionId?: string | null;
 	onQueuePendingPromptForSession?: (request: {
 		sessionId: string;
@@ -154,6 +157,7 @@ export function ActionsSection({
 	bodyHeight,
 	expanded,
 	onCommitAction,
+	onReviewAction,
 	currentSessionId,
 	onQueuePendingPromptForSession,
 	commitButtonMode,
@@ -162,6 +166,7 @@ export function ActionsSection({
 }: ActionsSectionProps) {
 	const queryClient = useQueryClient();
 	const [syncPending, setSyncPending] = useState(false);
+	const [reviewPending, setReviewPending] = useState(false);
 	const forgeQuery = useQuery({
 		...workspaceForgeQueryOptions(workspaceId ?? "__none__"),
 		enabled: workspaceId !== null,
@@ -179,6 +184,21 @@ export function ActionsSection({
 	});
 	const gitStatus = gitStatusQuery.data ?? EMPTY_GIT_ACTION_STATUS;
 	const forgeStatus = forgeStatusQuery.data ?? EMPTY_FORGE_ACTION_STATUS;
+	// "Reviewable" = the user actually has changes of their own to review.
+	// Two signals add up:
+	//   - `uncommittedCount` — dirty working tree.
+	//   - `aheadOfTargetCount` — commits past the target branch's remote ref.
+	//
+	// We deliberately do NOT use `aheadOfRemoteCount` (it reads as 0 on
+	// unpublished branches, missing the local-only-commits case) or the
+	// "branch unpublished" signal (a brand-new workspace branched from main
+	// is unpublished too, but has no user changes — must not show Review).
+	const hasReviewableChanges =
+		gitStatus.uncommittedCount > 0 || gitStatus.aheadOfTargetCount > 0;
+	const showReviewHelper = Boolean(onReviewAction) && hasReviewableChanges;
+	// Helpers group hides entirely when no helper has anything to do. New
+	// helpers should `||` into this — never render an empty group header.
+	const showHelpersGroup = showReviewHelper;
 	const changeRequestName = forgeQuery.data?.labels.changeRequestName ?? "PR";
 	const providerName = forgeQuery.data?.labels.providerName ?? "Forge";
 	// Auth-flip invalidation lives in the sync bridge — no frontend edge-detect.
@@ -266,6 +286,17 @@ export function ActionsSection({
 			setSyncPending(false);
 		}
 	}, [queryClient, queueSyncResolutionPrompt, syncPending, workspaceId]);
+	const handleReviewChanges = useCallback(async () => {
+		if (!onReviewAction || reviewPending) {
+			return;
+		}
+		setReviewPending(true);
+		try {
+			await onReviewAction();
+		} finally {
+			setReviewPending(false);
+		}
+	}, [onReviewAction, reviewPending]);
 	const handleInsertCheck = useCallback(
 		async (item: ForgeActionItem) => {
 			if (!workspaceId) {
@@ -310,6 +341,44 @@ export function ActionsSection({
 				)}
 				style={expanded ? undefined : { height: `${bodyHeight}px` }}
 			>
+				{showHelpersGroup && (
+					<>
+						<div className="px-2.5 pb-1 pt-2">
+							<span className="text-[10.5px] font-medium tracking-wide text-muted-foreground">
+								Helpers
+							</span>
+						</div>
+						{showReviewHelper && (
+							<div className="flex items-center gap-1.5 px-2.5 py-[3px] text-muted-foreground transition-colors hover:bg-accent/60">
+								<EyeIcon
+									aria-hidden="true"
+									className="size-3 shrink-0"
+									strokeWidth={2}
+								/>
+								<span className="truncate">Review changes</span>
+								<button
+									type="button"
+									onClick={() => void handleReviewChanges()}
+									disabled={reviewPending || workspaceId === null}
+									aria-busy={reviewPending ? true : undefined}
+									aria-label={reviewPending ? "Reviewing" : undefined}
+									className="ml-auto shrink-0 cursor-pointer text-[10.5px] text-primary transition-colors hover:text-primary/80 disabled:cursor-not-allowed disabled:opacity-50"
+								>
+									<span className="inline-flex items-center gap-1">
+										{reviewPending ? (
+											<LoaderCircleIcon
+												aria-hidden="true"
+												className="size-3 animate-spin text-current opacity-70"
+												strokeWidth={2}
+											/>
+										) : null}
+										{reviewPending ? null : "Review"}
+									</span>
+								</button>
+							</div>
+						)}
+					</>
+				)}
 				<div className="px-2.5 pb-1 pt-2">
 					<span className="text-[10.5px] font-medium tracking-wide text-muted-foreground">
 						Git

--- a/src/features/inspector/sections/changes.tsx
+++ b/src/features/inspector/sections/changes.tsx
@@ -62,7 +62,6 @@ type ChangesSectionProps = {
 	onOpenEditorFile: (path: string, options?: DiffOpenOptions) => void;
 	flashingPaths: Set<string>;
 	onCommitAction?: (mode: WorkspaceCommitButtonMode) => Promise<void>;
-	onReviewPrAction?: () => Promise<void>;
 	commitButtonMode?: WorkspaceCommitButtonMode;
 	commitButtonState?: CommitButtonState;
 	changeRequest: ChangeRequestInfo | null;
@@ -81,7 +80,6 @@ export function ChangesSection({
 	onOpenEditorFile,
 	flashingPaths,
 	onCommitAction,
-	onReviewPrAction,
 	commitButtonMode = "create-pr",
 	commitButtonState,
 	changeRequest,
@@ -360,7 +358,6 @@ export function ChangesSection({
 					changeRequest ? () => void openUrl(changeRequest.url) : undefined
 				}
 				onCommit={handleCommitButtonClick}
-				onReviewPr={onReviewPrAction}
 				onContinueWorkspace={handleContinueWorkspace}
 			/>
 

--- a/src/features/inspector/sections/git-section-header.test.tsx
+++ b/src/features/inspector/sections/git-section-header.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, screen } from "@testing-library/react";
+import { cleanup, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ChangeRequestInfo, ForgeDetection } from "@/lib/api";
 import { renderWithProviders } from "@/test/render-with-providers";
@@ -222,65 +222,5 @@ describe("GitSectionHeader forge onboarding", () => {
 				screen.queryByTestId("git-header-shimmer"),
 			).not.toBeInTheDocument();
 		}
-	});
-
-	it("hides the Review PR button when there is no change request", () => {
-		renderWithProviders(
-			<GitSectionHeader
-				commitButtonMode="create-pr"
-				commitButtonState="idle"
-				changeRequest={null}
-				hasChanges
-				changeRequestName="PR"
-				forgeDetection={githubDetection()}
-				forgeRemoteState="ok"
-				workspaceId="workspace-1"
-				onReviewPr={vi.fn()}
-			/>,
-		);
-
-		expect(
-			screen.queryByRole("button", { name: /Review PR/i }),
-		).not.toBeInTheDocument();
-	});
-
-	it("hides the Review PR button when the change request is not open", () => {
-		renderWithProviders(
-			<GitSectionHeader
-				commitButtonMode="merged"
-				commitButtonState="idle"
-				changeRequest={{ ...changeRequest, state: "MERGED", isMerged: true }}
-				changeRequestName="MR"
-				forgeDetection={gitlabDetection()}
-				forgeRemoteState="ok"
-				workspaceId="workspace-1"
-				onReviewPr={vi.fn()}
-			/>,
-		);
-
-		expect(
-			screen.queryByRole("button", { name: /Review MR/i }),
-		).not.toBeInTheDocument();
-	});
-
-	it("shows the Review PR button on an open PR and fires onReviewPr on click", () => {
-		const onReviewPr = vi.fn();
-		renderWithProviders(
-			<GitSectionHeader
-				commitButtonMode="merge"
-				commitButtonState="idle"
-				changeRequest={changeRequest}
-				changeRequestName="MR"
-				forgeDetection={gitlabDetection()}
-				forgeRemoteState="ok"
-				workspaceId="workspace-1"
-				onReviewPr={onReviewPr}
-			/>,
-		);
-
-		const reviewButton = screen.getByRole("button", { name: /Review MR/i });
-		expect(reviewButton).toBeInTheDocument();
-		fireEvent.click(reviewButton);
-		expect(onReviewPr).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/features/inspector/sections/git-section-header.tsx
+++ b/src/features/inspector/sections/git-section-header.tsx
@@ -89,7 +89,6 @@ export type GitSectionHeaderProps = {
 	workspaceId?: string | null;
 	onChangeRequestClick?: () => void;
 	onCommit?: () => void | Promise<void>;
-	onReviewPr?: () => void | Promise<void>;
 	onContinueWorkspace?: () => void | Promise<void>;
 	isContinuingWorkspace?: boolean;
 	className?: string;
@@ -107,7 +106,6 @@ export function GitSectionHeader({
 	workspaceId = null,
 	onChangeRequestClick,
 	onCommit,
-	onReviewPr,
 	onContinueWorkspace,
 	isContinuingWorkspace = false,
 	className,
@@ -377,29 +375,6 @@ export function GitSectionHeader({
 									{CONTINUE_LABEL}
 								</span>
 							</Button>
-						)}
-						{changeRequest?.state === "OPEN" && onReviewPr && (
-							<Tooltip>
-								<TooltipTrigger asChild>
-									<Button
-										type="button"
-										variant="outline"
-										size="xs"
-										className="shrink-0 self-center font-normal"
-										onClick={onReviewPr}
-									>
-										Review {changeRequestName}
-									</Button>
-								</TooltipTrigger>
-								<TooltipContent
-									side="bottom"
-									className="flex max-w-[320px] items-center gap-2 rounded-md px-2 py-1 text-[12px] leading-tight"
-								>
-									<span className="truncate">
-										Start a new chat that reviews this {changeRequestName}.
-									</span>
-								</TooltipContent>
-							</Tooltip>
 						)}
 						<div ref={commitButtonRef} className="flex shrink-0 items-center">
 							<Tooltip>

--- a/src/features/settings/index.tsx
+++ b/src/features/settings/index.tsx
@@ -197,14 +197,6 @@ export const SettingsDialog = memo(function SettingsDialog({
 		modelSectionsQuery.data ?? [],
 		settings.defaultModelId,
 	);
-	const selectedReviewPrModel = findModelOption(
-		modelSectionsQuery.data ?? [],
-		settings.reviewPrModelId,
-	);
-	const reviewPrModelLabel = settings.reviewPrModelId
-		? (selectedReviewPrModel?.label ??
-			(modelSectionsQuery.isPending ? "Loading…" : "Select model"))
-		: "Use default";
 	const defaultEffortLevels =
 		selectedDefaultModel?.effortLevels ?? FALLBACK_EFFORT_LEVELS;
 	const defaultModelSupportsFastMode =
@@ -212,6 +204,29 @@ export const SettingsDialog = memo(function SettingsDialog({
 	const defaultModelLabel =
 		selectedDefaultModel?.label ??
 		(modelSectionsQuery.isPending ? "Loading…" : "Select model");
+	// Review row mirrors the Default row's three-control combo *exactly*.
+	// `null` on a Review setting means "follow the default" — we resolve it
+	// here so the Review controls read identically to the Default ones,
+	// without a "Use default" affordance. Selecting the same value as the
+	// default snaps Review back to `null` (still following) so the user
+	// can return to follow-mode just by re-picking the default value.
+	const effectiveReviewModelId =
+		settings.reviewModelId ?? settings.defaultModelId;
+	const effectiveReviewModel = findModelOption(
+		modelSectionsQuery.data ?? [],
+		effectiveReviewModelId,
+	);
+	const reviewModelLabel =
+		effectiveReviewModel?.label ??
+		(modelSectionsQuery.isPending ? "Loading…" : "Select model");
+	const reviewEffortLevels =
+		effectiveReviewModel?.effortLevels ?? FALLBACK_EFFORT_LEVELS;
+	const reviewModelSupportsFastMode =
+		effectiveReviewModel?.supportsFastMode === true;
+	const effectiveReviewEffort =
+		settings.reviewEffort ?? settings.defaultEffort ?? "high";
+	const effectiveReviewFastMode =
+		settings.reviewFastMode ?? settings.defaultFastMode;
 	// Auto-clamp effort when model changes — but only after model metadata
 	// has actually loaded, otherwise the fallback levels silently kill max/xhigh.
 	useEffect(() => {
@@ -657,8 +672,8 @@ export const SettingsDialog = memo(function SettingsDialog({
 										</div>
 									</SettingsRow>
 									<SettingsRow
-										title="Review PR model"
-										description="Model used by the Review PR button. When unset, falls back to the default model above."
+										title="Review model"
+										description="Model for code review"
 									>
 										<div className="flex w-[360px] items-center gap-2">
 											<DropdownMenu>
@@ -669,14 +684,12 @@ export const SettingsDialog = memo(function SettingsDialog({
 													)}
 												>
 													<span className="flex min-w-0 items-center gap-1.5">
-														{selectedReviewPrModel ? (
-															<ModelIcon
-																model={selectedReviewPrModel}
-																className="size-[13px] shrink-0"
-															/>
-														) : null}
+														<ModelIcon
+															model={effectiveReviewModel}
+															className="size-[13px] shrink-0"
+														/>
 														<span className="min-w-0 truncate whitespace-nowrap">
-															{reviewPrModelLabel}
+															{reviewModelLabel}
 														</span>
 													</span>
 													<ChevronDown className="size-3 shrink-0 opacity-40" />
@@ -686,19 +699,19 @@ export const SettingsDialog = memo(function SettingsDialog({
 													sideOffset={4}
 													className="min-w-[10rem]"
 												>
-													<DropdownMenuItem
-														onClick={() =>
-															updateSettings({ reviewPrModelId: null })
-														}
-														className="gap-2 text-muted-foreground"
-													>
-														Use default
-													</DropdownMenuItem>
 													{allModels.map((m) => (
 														<DropdownMenuItem
 															key={m.id}
 															onClick={() =>
-																updateSettings({ reviewPrModelId: m.id })
+																updateSettings({
+																	// Picking the same value as the
+																	// default snaps Review back to `null`
+																	// (still following the default).
+																	reviewModelId:
+																		m.id === settings.defaultModelId
+																			? null
+																			: m.id,
+																})
 															}
 															className="gap-2"
 														>
@@ -708,6 +721,68 @@ export const SettingsDialog = memo(function SettingsDialog({
 													))}
 												</DropdownMenuContent>
 											</DropdownMenu>
+											<DropdownMenu>
+												<DropdownMenuTrigger
+													className={cn(
+														"flex h-8 cursor-pointer items-center rounded-lg border border-border/50 bg-muted/30 px-3 text-[13px] text-foreground hover:bg-muted/50",
+														"shrink-0 gap-1.5",
+													)}
+												>
+													<span>{effortLabel(effectiveReviewEffort)}</span>
+													<ChevronDown className="size-3 opacity-40" />
+												</DropdownMenuTrigger>
+												<DropdownMenuContent
+													align="end"
+													sideOffset={4}
+													className="min-w-[8rem]"
+												>
+													{reviewEffortLevels.map((l) => (
+														<DropdownMenuItem
+															key={l}
+															onClick={() =>
+																updateSettings({
+																	reviewEffort:
+																		l === settings.defaultEffort ? null : l,
+																})
+															}
+														>
+															{effortLabel(l)}
+														</DropdownMenuItem>
+													))}
+												</DropdownMenuContent>
+											</DropdownMenu>
+											<div
+												className={cn(
+													"flex h-8 cursor-pointer items-center rounded-lg border border-border/50 bg-muted/30 px-3 text-[13px] text-foreground hover:bg-muted/50",
+													"shrink-0 gap-2",
+												)}
+											>
+												<span
+													className={
+														reviewModelSupportsFastMode
+															? "text-[13px] text-foreground"
+															: "text-[13px] text-muted-foreground"
+													}
+												>
+													Fast mode
+												</span>
+												<Switch
+													checked={
+														reviewModelSupportsFastMode &&
+														effectiveReviewFastMode
+													}
+													disabled={!reviewModelSupportsFastMode}
+													onCheckedChange={(checked) =>
+														updateSettings({
+															reviewFastMode:
+																checked === settings.defaultFastMode
+																	? null
+																	: checked,
+														})
+													}
+													aria-label="Review fast mode"
+												/>
+											</div>
 										</div>
 									</SettingsRow>
 									<ClaudeCustomProvidersPanel />

--- a/src/features/settings/panels/repository-preferences-section.tsx
+++ b/src/features/settings/panels/repository-preferences-section.tsx
@@ -25,7 +25,7 @@ import {
 
 const PREFERENCE_KEYS: RepoPreferenceKey[] = [
 	"createPr",
-	"reviewPr",
+	"review",
 	"fixErrors",
 	"resolveConflicts",
 	"branchRename",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -49,7 +49,7 @@ export type PrSyncState = "none" | "open" | "closed" | "merged";
  */
 export type ActionKind =
 	| "create-pr"
-	| "review-pr"
+	| "review"
 	| "commit-and-push"
 	| "push"
 	| "fix"
@@ -1467,6 +1467,10 @@ export type WorkspaceGitActionStatus = {
 	behindTargetCount: number;
 	remoteTrackingRef?: string | null;
 	aheadOfRemoteCount: number;
+	/** Commits this branch has on top of its target branch's remote ref
+	 *  (e.g. `origin/main`). Stays accurate for unpublished branches —
+	 *  unlike `aheadOfRemoteCount`, which reads as 0 without an upstream. */
+	aheadOfTargetCount: number;
 	pushStatus?: WorkspacePushStatus;
 };
 
@@ -2406,7 +2410,7 @@ export type RepoScripts = {
 
 export type RepoPreferences = {
 	createPr?: string | null;
-	reviewPr?: string | null;
+	review?: string | null;
 	fixErrors?: string | null;
 	resolveConflicts?: string | null;
 	branchRename?: string | null;

--- a/src/lib/commit-button-logic.test.ts
+++ b/src/lib/commit-button-logic.test.ts
@@ -64,6 +64,7 @@ function makeGitActionStatus(
 		behindTargetCount: 0,
 		remoteTrackingRef: "refs/remotes/origin/main",
 		aheadOfRemoteCount: 0,
+		aheadOfTargetCount: 0,
 		pushStatus: "published",
 		...overrides,
 	};

--- a/src/lib/commit-button-prompts.test.ts
+++ b/src/lib/commit-button-prompts.test.ts
@@ -200,8 +200,8 @@ describe("buildCommitButtonPrompt", () => {
 		expect(prompt).not.toContain("<remote>");
 	});
 
-	it("returns the review-pr built-in prompt for the GitHub default", () => {
-		const prompt = buildCommitButtonPrompt("review-pr", null);
+	it("returns the review built-in prompt for the GitHub default", () => {
+		const prompt = buildCommitButtonPrompt("review", null);
 		expect(prompt).toContain("Review the open pull request");
 		expect(prompt).toContain("IN THIS CHAT ONLY");
 		// Reads PR via gh, never posts back on the PR.
@@ -211,12 +211,7 @@ describe("buildCommitButtonPrompt", () => {
 	});
 
 	it("uses GitLab review commands when the forge is GitLab", () => {
-		const prompt = buildCommitButtonPrompt(
-			"review-pr",
-			null,
-			null,
-			GITLAB_FORGE,
-		);
+		const prompt = buildCommitButtonPrompt("review", null, null, GITLAB_FORGE);
 		expect(prompt).toContain("Review the open merge request");
 		expect(prompt).toContain("`glab mr view`");
 		expect(prompt).toContain("`glab mr diff`");
@@ -224,10 +219,10 @@ describe("buildCommitButtonPrompt", () => {
 		expect(prompt).not.toContain("`gh pr diff`");
 	});
 
-	it("appends review-pr preferences after the built-in prompt", () => {
+	it("appends review preferences after the built-in prompt", () => {
 		expect(
-			buildCommitButtonPrompt("review-pr", {
-				reviewPr: "Focus on security regressions.",
+			buildCommitButtonPrompt("review", {
+				review: "Focus on security regressions.",
 			}),
 		).toContain("### User Preferences\n\nFocus on security regressions.");
 	});

--- a/src/lib/commit-button-prompts.test.ts
+++ b/src/lib/commit-button-prompts.test.ts
@@ -200,30 +200,52 @@ describe("buildCommitButtonPrompt", () => {
 		expect(prompt).not.toContain("<remote>");
 	});
 
-	it("returns the review built-in prompt for the GitHub default", () => {
-		const prompt = buildCommitButtonPrompt("review", null);
-		expect(prompt).toContain("Review the open pull request");
+	it("diffs against the target ref and stays chat-only by default", () => {
+		const prompt = buildCommitButtonPrompt(
+			"review",
+			null,
+			"main",
+			null,
+			"origin",
+		);
+		expect(prompt).toContain("relative to `origin/main`");
+		expect(prompt).toContain("git diff origin/main...HEAD");
 		expect(prompt).toContain("IN THIS CHAT ONLY");
-		// Reads PR via gh, never posts back on the PR.
-		expect(prompt).toContain("`gh pr view");
-		expect(prompt).toContain("`gh pr diff`");
-		expect(prompt).toContain("Do NOT post anything on the PR itself");
+		expect(prompt).toContain("Do NOT modify files");
+		// Forge-agnostic — never touches gh/glab.
+		expect(prompt).not.toContain("pull request");
+		expect(prompt).not.toContain("merge request");
+		expect(prompt).not.toContain("gh pr");
+		expect(prompt).not.toContain("glab mr");
 	});
 
-	it("uses GitLab review commands when the forge is GitLab", () => {
-		const prompt = buildCommitButtonPrompt("review", null, null, GITLAB_FORGE);
-		expect(prompt).toContain("Review the open merge request");
-		expect(prompt).toContain("`glab mr view`");
-		expect(prompt).toContain("`glab mr diff`");
-		expect(prompt).not.toContain("`gh pr view");
-		expect(prompt).not.toContain("`gh pr diff`");
+	it("produces the same review prompt regardless of forge (GitLab vs GitHub)", () => {
+		const githubPrompt = buildCommitButtonPrompt(
+			"review",
+			null,
+			"main",
+			null,
+			"origin",
+		);
+		const gitlabPrompt = buildCommitButtonPrompt(
+			"review",
+			null,
+			"main",
+			GITLAB_FORGE,
+			"origin",
+		);
+		expect(gitlabPrompt).toBe(githubPrompt);
 	});
 
 	it("appends review preferences after the built-in prompt", () => {
 		expect(
-			buildCommitButtonPrompt("review", {
-				review: "Focus on security regressions.",
-			}),
+			buildCommitButtonPrompt(
+				"review",
+				{ review: "Focus on security regressions." },
+				"main",
+				null,
+				"origin",
+			),
 		).toContain("### User Preferences\n\nFocus on security regressions.");
 	});
 });

--- a/src/lib/commit-button-prompts.ts
+++ b/src/lib/commit-button-prompts.ts
@@ -1,5 +1,5 @@
 import type { WorkspaceCommitButtonMode } from "@/features/commit/button";
-import type { ForgeDetection, RepoPreferences } from "@/lib/api";
+import type { ActionKind, ForgeDetection, RepoPreferences } from "@/lib/api";
 import { forgePromptDialect } from "@/lib/forge-dialect";
 import {
 	type RepoPreferenceKey,
@@ -10,14 +10,14 @@ type ButtonActionMode = Exclude<
 	WorkspaceCommitButtonMode,
 	"push" | "merge" | "closed" | "merged"
 >;
-type ActionSessionMode = ButtonActionMode | "review-pr";
+type ActionSessionMode = ButtonActionMode | "review";
 
 // Modes that delegate to a `RepoPreferenceKey`. The other action modes
 // (`commit-and-push`, `open-pr`) have no user-facing preference slot — they're
 // rendered inline below.
 type PreferenceBackedMode =
 	| "create-pr"
-	| "review-pr"
+	| "review"
 	| "fix"
 	| "resolve-conflicts";
 
@@ -26,7 +26,7 @@ const ACTION_MODE_TO_PREFERENCE_KEY: Record<
 	RepoPreferenceKey
 > = {
 	"create-pr": "createPr",
-	"review-pr": "reviewPr",
+	review: "review",
 	fix: "fixErrors",
 	"resolve-conflicts": "resolveConflicts",
 };
@@ -62,7 +62,7 @@ Use \`${dialect.reopenCommand}\` + \`${dialect.commentCommand}\`. Report the ${d
 		}
 
 		case "create-pr":
-		case "review-pr":
+		case "review":
 		case "fix":
 		case "resolve-conflicts":
 			return resolveRepoPreferencePrompt({
@@ -87,12 +87,26 @@ export function isActionSessionMode(
 	);
 }
 
+/** Whether a session created with this `ActionKind` is eligible for the
+ *  auto-hide flow (i.e. can be silently hidden once its post-stream verifier
+ *  passes). Auto-created action sessions still get fixed titles, but only a
+ *  subset are *also* auto-hideable.
+ *
+ *  Review is intentionally excluded: its whole reason to exist is to surface
+ *  a code-review *for the user to read*, so the session must stay visible.
+ *  The user's opt-in list (`loadAutoCloseActionKinds`) is filtered through
+ *  this gate at every hide call site (and the composer's "Auto Close"
+ *  toggle is hidden for non-hideable kinds). */
+export function isAutoHideableActionKind(kind: ActionKind): boolean {
+	return kind !== "review";
+}
+
 export function describeActionKind(actionKind: string): string {
 	switch (actionKind) {
 		case "create-pr":
 			return "Create PR";
-		case "review-pr":
-			return "Review PR";
+		case "review":
+			return "Review";
 		case "commit-and-push":
 			return "Commit and Push";
 		case "fix":

--- a/src/lib/forge-dialect.ts
+++ b/src/lib/forge-dialect.ts
@@ -16,16 +16,6 @@ export type ForgePromptDialect = {
 	reopenCommand: string;
 	/** Comment on a PR/MR, e.g. "gh pr comment" / "glab mr note". */
 	commentCommand: string;
-	/** Inspect a PR/MR, e.g. "gh pr view --json …" / "glab mr view". */
-	viewCommand: string;
-	/** Read the full diff of a PR/MR, e.g. "gh pr diff" / "glab mr diff". */
-	diffCommand: string;
-	/** Submit a review (forge command that posts a review with inline
-	 *  comments). For GitHub this is `gh pr review`; for GitLab there is no
-	 *  first-class equivalent in `glab`, so we point to the closest option
-	 *  (`glab mr note`) and the agent is expected to add per-line context
-	 *  in the body. */
-	reviewCommand: string;
 	/** List CI runs, e.g. "gh run list" / "glab ci list". */
 	ciListCommand: string;
 	/** Inspect a CI run, e.g. "gh run view" / "glab ci view". */
@@ -43,10 +33,6 @@ const GITHUB_DIALECT: ForgePromptDialect = {
 	createCommand: (branch) => `gh pr create --base ${branch}`,
 	reopenCommand: "gh pr reopen",
 	commentCommand: "gh pr comment",
-	viewCommand:
-		"gh pr view --json title,body,state,baseRefName,headRefName,url,number",
-	diffCommand: "gh pr diff",
-	reviewCommand: "gh pr review --comment",
 	ciListCommand: "gh run list",
 	ciViewCommand: "gh run view",
 	ciSystemName: "CI",
@@ -60,9 +46,6 @@ const GITLAB_DIALECT: ForgePromptDialect = {
 	createCommand: (branch) => `glab mr create --target-branch ${branch}`,
 	reopenCommand: "glab mr reopen",
 	commentCommand: "glab mr note",
-	viewCommand: "glab mr view",
-	diffCommand: "glab mr diff",
-	reviewCommand: "glab mr note",
 	ciListCommand: "glab ci list",
 	ciViewCommand: "glab ci view",
 	ciSystemName: "GitLab CI",

--- a/src/lib/repo-preferences-prompts.test.ts
+++ b/src/lib/repo-preferences-prompts.test.ts
@@ -167,9 +167,9 @@ describe("repo preference prompts", () => {
 		);
 	});
 
-	it("returns the review-pr default prompt when no override is set", () => {
+	it("returns the review default prompt when no override is set", () => {
 		const prompt = resolveRepoPreferencePrompt({
-			key: "reviewPr",
+			key: "review",
 			repoPreferences: {},
 		});
 		expect(prompt).toContain("Review the open pull request");
@@ -178,10 +178,10 @@ describe("repo preference prompts", () => {
 		expect(prompt).not.toContain("### User Preferences");
 	});
 
-	it("appends review-pr overrides after the built-in prompt", () => {
+	it("appends review overrides after the built-in prompt", () => {
 		const prompt = resolveRepoPreferencePrompt({
-			key: "reviewPr",
-			repoPreferences: { reviewPr: "Always check for missing tests." },
+			key: "review",
+			repoPreferences: { review: "Always check for missing tests." },
 		});
 		expect(prompt).toContain("Review the open pull request");
 		expect(prompt).toContain(
@@ -189,9 +189,9 @@ describe("repo preference prompts", () => {
 		);
 	});
 
-	it("uses the GitLab dialect in the review-pr prompt when forge is GitLab", () => {
+	it("uses the GitLab dialect in the review prompt when forge is GitLab", () => {
 		const prompt = resolveRepoPreferencePrompt({
-			key: "reviewPr",
+			key: "review",
 			repoPreferences: {},
 			forge: GITLAB_FORGE,
 		});
@@ -200,8 +200,8 @@ describe("repo preference prompts", () => {
 		expect(prompt).not.toContain("`gh pr diff`");
 	});
 
-	it("uses generic prose in the review-pr preview", () => {
-		const preview = resolveRepoPreferencePreview("reviewPr", {});
+	it("uses generic prose in the review preview", () => {
+		const preview = resolveRepoPreferencePreview("review", {});
 		expect(preview).toContain("Review the open pull request");
 		expect(preview).toContain("IN THIS CHAT ONLY");
 	});

--- a/src/lib/repo-preferences-prompts.test.ts
+++ b/src/lib/repo-preferences-prompts.test.ts
@@ -167,14 +167,23 @@ describe("repo preference prompts", () => {
 		);
 	});
 
-	it("returns the review default prompt when no override is set", () => {
+	it("returns the review default prompt diffing against the target ref when no override is set", () => {
 		const prompt = resolveRepoPreferencePrompt({
 			key: "review",
 			repoPreferences: {},
+			targetBranch: "main",
+			remote: "origin",
 		});
-		expect(prompt).toContain("Review the open pull request");
+		expect(prompt).toContain("relative to `origin/main`");
 		expect(prompt).toContain("IN THIS CHAT ONLY");
-		expect(prompt).toContain("`gh pr diff`");
+		expect(prompt).toContain("git diff origin/main...HEAD");
+		// Forge-agnostic — no PR / MR machinery.
+		expect(prompt).not.toContain("pull request");
+		expect(prompt).not.toContain("merge request");
+		expect(prompt).not.toContain("gh pr");
+		expect(prompt).not.toContain("glab mr");
+		// Side-effect ban must be explicit.
+		expect(prompt).toContain("Do NOT modify files");
 		expect(prompt).not.toContain("### User Preferences");
 	});
 
@@ -182,27 +191,46 @@ describe("repo preference prompts", () => {
 		const prompt = resolveRepoPreferencePrompt({
 			key: "review",
 			repoPreferences: { review: "Always check for missing tests." },
+			targetBranch: "main",
+			remote: "origin",
 		});
-		expect(prompt).toContain("Review the open pull request");
+		expect(prompt).toContain("git diff origin/main...HEAD");
 		expect(prompt).toContain(
 			"### User Preferences\n\nAlways check for missing tests.",
 		);
 	});
 
-	it("uses the GitLab dialect in the review prompt when forge is GitLab", () => {
-		const prompt = resolveRepoPreferencePrompt({
+	it("is forge-agnostic — same prompt regardless of GitLab vs GitHub", () => {
+		const githubPrompt = resolveRepoPreferencePrompt({
 			key: "review",
 			repoPreferences: {},
+			targetBranch: "main",
+			remote: "origin",
+		});
+		const gitlabPrompt = resolveRepoPreferencePrompt({
+			key: "review",
+			repoPreferences: {},
+			targetBranch: "main",
+			remote: "origin",
 			forge: GITLAB_FORGE,
 		});
-		expect(prompt).toContain("Review the open merge request");
-		expect(prompt).toContain("`glab mr diff`");
-		expect(prompt).not.toContain("`gh pr diff`");
+		expect(gitlabPrompt).toBe(githubPrompt);
 	});
 
-	it("uses generic prose in the review preview", () => {
+	it("throws when the review prompt is built without a target branch", () => {
+		expect(() =>
+			resolveRepoPreferencePrompt({
+				key: "review",
+				repoPreferences: {},
+				remote: "origin",
+			}),
+		).toThrow(/target branch/i);
+	});
+
+	it("uses generic prose in the review preview (no live workspace ref)", () => {
 		const preview = resolveRepoPreferencePreview("review", {});
-		expect(preview).toContain("Review the open pull request");
+		expect(preview).toContain("relative to the target branch");
 		expect(preview).toContain("IN THIS CHAT ONLY");
+		expect(preview).not.toContain("origin/");
 	});
 });

--- a/src/lib/repo-preferences-prompts.ts
+++ b/src/lib/repo-preferences-prompts.ts
@@ -68,17 +68,30 @@ Do the following, in order:
 
 Don't stop to ask for confirmation — execute each step automatically. If you hit an unrecoverable error (e.g. merge conflict, pre-push hook failure), report it clearly so I can intervene.`;
 
-const REVIEW_PREVIEW = `Review the open pull request on this branch and report the review IN THIS CHAT ONLY.
+const REVIEW_PREVIEW = `Review the changes on this branch relative to the target branch and report the review IN THIS CHAT ONLY.
 
-Do the following, in order:
-1. Inspect the pull request metadata (title, description, target branch, current state) using the relevant forge CLI.
-2. Read the full diff for the pull request — every changed file, not just a summary.
-3. Evaluate the change across five axes: correctness, readability, architecture, security, performance. Note any concrete risks (off-by-one, missing null checks, race conditions, injection vectors, N+1 queries, missing tests, unclear naming, leaked abstractions).
-4. Write the review as a single chat message in this conversation. Structure it as: a one-line verdict, a short summary, then a bulleted list of findings ordered by severity with exact file paths and line numbers.
+Scope — review BOTH together:
+1. Committed work past the target: \`git diff <target>...HEAD\`.
+2. Uncommitted work in the worktree: \`git status\`, \`git diff\`, and \`git diff --staged\`.
+Do not review code outside this diff. Read enough surrounding context to judge a change, but don't audit unrelated files.
 
-Do NOT post anything on the pull request itself — no review submissions, no comments, no approvals, no merge, no request-changes. The review lives in this chat only so the author can read it here and act.
+Look for, in priority order:
+- Correctness: logic errors, off-by-one, null/undefined access, wrong control flow, missing error handling, broken invariants.
+- Security: injection, secret leakage, missing authz, unsafe deserialization, path traversal.
+- Edge cases: empty / large input, concurrency, retry & idempotency, resource cleanup.
+- Maintainability: unclear naming, dead code, leaky abstractions, missing tests for non-trivial branches.
+- Performance: only when something is materially wrong (N+1, blocking I/O on a hot path) — not micro-optimizations.
 
-Don't stop to ask for confirmation — execute each step automatically. If the pull request can't be found or the diff is empty, say so directly in chat.`;
+Only flag what a thoughtful human reviewer would actually fix. Skip nits, taste, and speculation.
+
+Output one chat message:
+- One-line verdict (e.g. "Looks good", "One blocking issue", "Two security concerns — needs changes").
+- One short paragraph summarising what the change does.
+- Findings as a bulleted list, ordered blocking → major → minor. Each: severity tag, exact \`path/to/file.ext:LINE\`, what's wrong, one-sentence fix.
+
+Do NOT modify files, stage, commit, push, or call any forge review API. The review lives in this chat — the user will read it and act.
+
+If the diff is empty, say so in one line and stop.`;
 
 const RESOLVE_CONFLICTS_PREVIEW = `This branch has merge conflicts with its target branch. Resolve them.
 
@@ -112,17 +125,37 @@ Do the following, in order:
 Don't stop to ask for confirmation — execute each step automatically. If you hit an unrecoverable error (e.g. merge conflict, pre-push hook failure), report it clearly so I can intervene.`;
 }
 
-function reviewPrompt(dialect: ForgePromptDialect): string {
-	return `Review the open ${dialect.changeRequestFullName} on this branch and report the review IN THIS CHAT ONLY.
+function reviewPrompt(
+	targetBranch?: string | null,
+	remote?: string | null,
+): string {
+	const branch = requireTargetBranch("review", targetBranch);
+	const remoteName = normalizeRemote(remote);
+	const targetRef = `${remoteName}/${branch}`;
+	return `Review the changes on this branch relative to \`${targetRef}\` and report the review IN THIS CHAT ONLY.
 
-Do the following, in order:
-1. Use \`${dialect.viewCommand}\` (or equivalent) to read the ${dialect.changeRequestName} title, description, target branch, and state. Use \`${dialect.diffCommand}\` to read the full diff for every changed file.
-2. Evaluate the change across five axes: correctness, readability, architecture, security, performance. Look for concrete risks — off-by-one, missing null checks, race conditions, injection vectors, N+1 queries, missing tests, unclear naming, leaked abstractions.
-3. Write the review as a single chat message in this conversation. Structure it as: a one-line verdict, a short summary, then a bulleted list of findings ordered by severity with exact file paths and line numbers.
+Scope — review BOTH together:
+1. Committed work past the target: \`git diff ${targetRef}...HEAD\`.
+2. Uncommitted work in the worktree: \`git status\`, \`git diff\`, and \`git diff --staged\`.
+Do not review code outside this diff. Read enough surrounding context to judge a change, but don't audit unrelated files.
 
-Do NOT post anything on the ${dialect.changeRequestName} itself — no \`${dialect.reviewCommand}\`, no \`${dialect.commentCommand}\`, no approvals, no merge, no request-changes. The review lives in this chat only so the author can read it here and act.
+Look for, in priority order:
+- Correctness: logic errors, off-by-one, null/undefined access, wrong control flow, missing error handling, broken invariants.
+- Security: injection, secret leakage, missing authz, unsafe deserialization, path traversal.
+- Edge cases: empty / large input, concurrency, retry & idempotency, resource cleanup.
+- Maintainability: unclear naming, dead code, leaky abstractions, missing tests for non-trivial branches.
+- Performance: only when something is materially wrong (N+1, blocking I/O on a hot path) — not micro-optimizations.
 
-Don't stop to ask for confirmation — execute each step automatically. If the ${dialect.changeRequestName} can't be found or the diff is empty, say so directly in chat.`;
+Only flag what a thoughtful human reviewer would actually fix. Skip nits, taste, and speculation.
+
+Output one chat message:
+- One-line verdict (e.g. "Looks good", "One blocking issue", "Two security concerns — needs changes").
+- One short paragraph summarising what the change does.
+- Findings as a bulleted list, ordered blocking → major → minor. Each: severity tag, exact \`path/to/file.ext:LINE\`, what's wrong, one-sentence fix.
+
+Do NOT modify files, stage, commit, push, or call any forge review API. The review lives in this chat — the user will read it and act.
+
+If the diff is empty, say so in one line and stop.`;
 }
 
 function fixErrorsPrompt(dialect: ForgePromptDialect): string {
@@ -228,7 +261,7 @@ function appendUserPreferences(
 }
 
 function requireTargetBranch(
-	key: "createPr" | "resolveConflicts",
+	key: "createPr" | "review" | "resolveConflicts",
 	targetBranch?: string | null,
 ): string {
 	const branch = targetBranch?.trim();
@@ -282,7 +315,7 @@ export function resolveRepoPreferencePrompt({
 			);
 		case "review":
 			return appendUserPreferences(
-				reviewPrompt(forgePromptDialect(forge)),
+				reviewPrompt(targetBranch, remote),
 				resolvedOverride,
 			);
 		case "fixErrors":

--- a/src/lib/repo-preferences-prompts.ts
+++ b/src/lib/repo-preferences-prompts.ts
@@ -8,7 +8,7 @@ const TARGET_REF_PLACEHOLDER = "$" + "{TARGET_REF}";
 
 export type RepoPreferenceKey =
 	| "createPr"
-	| "reviewPr"
+	| "review"
 	| "fixErrors"
 	| "resolveConflicts"
 	| "branchRename"
@@ -68,7 +68,7 @@ Do the following, in order:
 
 Don't stop to ask for confirmation — execute each step automatically. If you hit an unrecoverable error (e.g. merge conflict, pre-push hook failure), report it clearly so I can intervene.`;
 
-const REVIEW_PR_PREVIEW = `Review the open pull request on this branch and report the review IN THIS CHAT ONLY.
+const REVIEW_PREVIEW = `Review the open pull request on this branch and report the review IN THIS CHAT ONLY.
 
 Do the following, in order:
 1. Inspect the pull request metadata (title, description, target branch, current state) using the relevant forge CLI.
@@ -112,7 +112,7 @@ Do the following, in order:
 Don't stop to ask for confirmation — execute each step automatically. If you hit an unrecoverable error (e.g. merge conflict, pre-push hook failure), report it clearly so I can intervene.`;
 }
 
-function reviewPrPrompt(dialect: ForgePromptDialect): string {
+function reviewPrompt(dialect: ForgePromptDialect): string {
 	return `Review the open ${dialect.changeRequestFullName} on this branch and report the review IN THIS CHAT ONLY.
 
 Do the following, in order:
@@ -172,7 +172,7 @@ export const DEFAULT_REPO_PREFERENCE_PROMPTS: Record<
 	string
 > = {
 	createPr: CREATE_PR_PREVIEW,
-	reviewPr: REVIEW_PR_PREVIEW,
+	review: REVIEW_PREVIEW,
 	fixErrors: fixErrorsPrompt(PREVIEW_DIALECT),
 	resolveConflicts: RESOLVE_CONFLICTS_PREVIEW,
 	branchRename: DEFAULT_BRANCH_RENAME_PROMPT,
@@ -181,7 +181,7 @@ export const DEFAULT_REPO_PREFERENCE_PROMPTS: Record<
 
 export const REPO_PREFERENCE_LABELS: Record<RepoPreferenceKey, string> = {
 	createPr: "Create PR preferences",
-	reviewPr: "Review PR preferences",
+	review: "Review preferences",
 	fixErrors: "Fix errors preferences",
 	resolveConflicts: "Resolve conflicts preferences",
 	branchRename: "Branch rename preferences",
@@ -191,8 +191,8 @@ export const REPO_PREFERENCE_LABELS: Record<RepoPreferenceKey, string> = {
 export const REPO_PREFERENCE_DESCRIPTIONS: Record<RepoPreferenceKey, string> = {
 	createPr:
 		"Add custom instructions sent to the agent when you click the Create PR button.",
-	reviewPr:
-		"Add custom instructions sent to the agent when you click the Review PR button.",
+	review:
+		"Add custom instructions sent to the agent when you click Review in the inspector.",
 	fixErrors:
 		"Add custom instructions sent to the agent when you click the Fix errors button.",
 	resolveConflicts:
@@ -280,9 +280,9 @@ export function resolveRepoPreferencePrompt({
 				createPrPrompt(forgePromptDialect(forge), targetBranch, remote),
 				resolvedOverride,
 			);
-		case "reviewPr":
+		case "review":
 			return appendUserPreferences(
-				reviewPrPrompt(forgePromptDialect(forge)),
+				reviewPrompt(forgePromptDialect(forge)),
 				resolvedOverride,
 			);
 		case "fixErrors":

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -28,9 +28,15 @@ export type AppSettings = {
 	lastWorkspaceId: string | null;
 	lastSessionId: string | null;
 	defaultModelId: string | null;
-	/** Model used when the inspector "Review PR" button creates a session.
+	/** Model used when the inspector "Review changes" helper creates a session.
 	 *  When null, falls back to `defaultModelId`. */
-	reviewPrModelId: string | null;
+	reviewModelId: string | null;
+	/** Effort level for the Review helper. When null, falls back to
+	 *  `defaultEffort`. */
+	reviewEffort: string | null;
+	/** Fast-mode flag for the Review helper. When null, falls back to
+	 *  `defaultFastMode`. */
+	reviewFastMode: boolean | null;
 	defaultEffort: string | null;
 	defaultFastMode: boolean;
 	/** Webview zoom factor. 1.0 = 100%. Range 0.5–2.0. */
@@ -61,7 +67,9 @@ export const DEFAULT_SETTINGS: AppSettings = {
 	lastWorkspaceId: null,
 	lastSessionId: null,
 	defaultModelId: null,
-	reviewPrModelId: null,
+	reviewModelId: null,
+	reviewEffort: null,
+	reviewFastMode: null,
 	defaultEffort: "high",
 	defaultFastMode: false,
 	zoomLevel: 1.0,
@@ -99,7 +107,9 @@ const SETTINGS_KEY_MAP: Record<
 	lastWorkspaceId: "app.last_workspace_id",
 	lastSessionId: "app.last_session_id",
 	defaultModelId: "app.default_model_id",
-	reviewPrModelId: "app.review_pr_model_id",
+	reviewModelId: "app.review_model_id",
+	reviewEffort: "app.review_effort",
+	reviewFastMode: "app.review_fast_mode",
 	defaultEffort: "app.default_effort",
 	defaultFastMode: "app.default_fast_mode",
 	zoomLevel: "app.zoom_level",
@@ -162,7 +172,9 @@ export async function loadSettings(): Promise<AppSettings> {
 	try {
 		const raw = await invoke<Record<string, string>>("get_app_settings");
 		const rawDefaultModelId = raw[SETTINGS_KEY_MAP.defaultModelId];
-		const rawReviewPrModelId = raw[SETTINGS_KEY_MAP.reviewPrModelId];
+		const rawReviewModelId = raw[SETTINGS_KEY_MAP.reviewModelId];
+		const rawReviewEffort = raw[SETTINGS_KEY_MAP.reviewEffort];
+		const rawReviewFastMode = raw[SETTINGS_KEY_MAP.reviewFastMode];
 		return {
 			fontSize: raw[SETTINGS_KEY_MAP.fontSize]
 				? Number(raw[SETTINGS_KEY_MAP.fontSize])
@@ -186,10 +198,20 @@ export async function loadSettings(): Promise<AppSettings> {
 				rawDefaultModelId && rawDefaultModelId !== "default"
 					? rawDefaultModelId
 					: DEFAULT_SETTINGS.defaultModelId,
-			reviewPrModelId:
-				rawReviewPrModelId && rawReviewPrModelId !== "default"
-					? rawReviewPrModelId
-					: DEFAULT_SETTINGS.reviewPrModelId,
+			reviewModelId:
+				rawReviewModelId && rawReviewModelId !== "default"
+					? rawReviewModelId
+					: DEFAULT_SETTINGS.reviewModelId,
+			reviewEffort:
+				rawReviewEffort && rawReviewEffort !== ""
+					? rawReviewEffort
+					: DEFAULT_SETTINGS.reviewEffort,
+			reviewFastMode:
+				rawReviewFastMode === "true"
+					? true
+					: rawReviewFastMode === "false"
+						? false
+						: DEFAULT_SETTINGS.reviewFastMode,
 			defaultEffort:
 				raw[SETTINGS_KEY_MAP.defaultEffort] || DEFAULT_SETTINGS.defaultEffort,
 			defaultFastMode:


### PR DESCRIPTION
## Summary

- Replace the PR-only **Review PR** header button with a general **Review changes** helper inside the inspector's Actions section. The helper appears whenever the workspace has uncommitted changes or local commits ahead of the target branch — meaning Review now works on unpublished branches *before* the first push, not just on open PRs.
- Give Review its own **model / effort / fast-mode** controls in Settings, mirroring the Default row's three-control combo. Each control falls back to the corresponding default when unset; picking the same value as the default snaps Review back to follow-mode (`null`).
- Plumb `effort` and `fastMode` through `pendingPromptForSession` so the queued submit honors the Review-specific overrides instead of silently using the chip-resolved defaults.

## Why

The original "Review PR" button only appeared on open PRs/MRs, which missed the most common review need: *"I just finished some work on this branch, look at it before I push."* Generalizing to "Review changes" covers both states with a single signal (`uncommittedCount > 0 || aheadOfTargetCount > 0`). Existing forge-aware prompt copy (`gh pr view`/`glab mr view`) is reused — a published branch with an open PR still gets PR-aware review prose; an unpublished branch falls back to local-diff review.

## Notable details

- New `WorkspaceGitActionStatus.aheadOfTargetCount` field — distinct from `aheadOfRemoteCount` because the latter reads as 0 on unpublished branches (no upstream), so it can't tell "fresh empty branch" from "branch with unpushed commits."
- Action kind renamed `review-pr` → `review`, and the `custom_prompt_review_pr` column renamed to `custom_prompt_review`. The schema migration handles all three start states (new DB / old DB with legacy column / old DB pre-dating either) and preserves any saved prompt under the legacy name. New snapshot tests cover both the add and rename paths.
- New `isAutoHideableActionKind` gate explicitly excludes `review` from the auto-hide flow — review output is *for the user to read*, so the session must stay visible. The composer's "Auto Close" toggle is hidden for non-hideable kinds.
- `WorkspaceComposerContainer` now factors pending-prompt overrides for effort and fast-mode ahead of cached/session/default fallbacks, so the chip the user sees matches the queued submit.

## Test plan

- [ ] `bun run test` — frontend, sidecar, Rust suites all pass.
- [ ] `cd src-tauri && cargo test --tests` — schema migration tests cover the add + rename paths; pipeline snapshots unchanged.
- [ ] Manual: dirty workspace pre-push → "Review changes" appears in Helpers → click → new chat opens, reviews local diff with `gh pr view` / `glab mr view` skipped on unpublished branches.
- [ ] Manual: workspace with open PR → "Review changes" still appears (uncommitted or ahead-of-target), prompt still uses forge CLI.
- [ ] Manual: brand-new workspace identical to `origin/main` → Helpers group hidden.
- [ ] Manual: Settings → Review row → change model, effort, fast-mode independently; reselecting the default value snaps each back to "follow default."
- [ ] Manual: existing user who saved a "Review PR preferences" prompt → after upgrade, prompt round-trips under the new "Review preferences" label (rename migration).