### PR TITLE
fix(inspector): stabilize vertical panel resizing

### DIFF
--- a/.changeset/fresh-geese-resize.md
+++ b/.changeset/fresh-geese-resize.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix the right inspector sidebar so Actions and Terminal resize, collapse, and expand cleanly without losing their headers or leaving visual gaps.

--- a/src/components/ui/vertical-split-layout.test.ts
+++ b/src/components/ui/vertical-split-layout.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from "vitest";
+import {
+	clampVerticalSplitSizes,
+	closeVerticalSplitPanel,
+	getInitialVerticalSplitSizes,
+	getPrimaryPanelSize,
+	openVerticalSplitPanel,
+	resizeVerticalSplitPanel,
+	type VerticalSplitPanelConfig,
+} from "./vertical-split-layout";
+
+const panels: VerticalSplitPanelConfig[] = [
+	{ id: "changes", open: true, minSize: 96, defaultSize: 240 },
+	{ id: "actions", open: true, minSize: 72, defaultSize: 160 },
+	{ id: "terminal", open: false, minSize: 96, defaultSize: 180 },
+];
+
+const baseConfig = {
+	containerSize: 600,
+	headerSize: 33,
+	minPrimarySize: 96,
+	primaryPanelId: "changes",
+	panels,
+	sizes: {
+		actions: 160,
+		terminal: 180,
+	},
+};
+
+describe("vertical split layout", () => {
+	it("initializes panel sizes from defaults", () => {
+		expect(getInitialVerticalSplitSizes(panels)).toEqual({
+			changes: 240,
+			actions: 160,
+			terminal: 180,
+		});
+	});
+
+	it("derives the primary panel size from remaining body capacity", () => {
+		expect(getPrimaryPanelSize(baseConfig)).toBe(341);
+	});
+
+	it("moves the actions divider up by shrinking the primary and growing actions", () => {
+		const next = resizeVerticalSplitPanel({
+			...baseConfig,
+			deltaY: -80,
+			panelId: "actions",
+		});
+
+		expect(next).toEqual({
+			actions: 240,
+			terminal: 180,
+		});
+	});
+
+	it("stops moving the actions divider up when the primary reaches its minimum", () => {
+		const next = resizeVerticalSplitPanel({
+			...baseConfig,
+			deltaY: -500,
+			panelId: "actions",
+		});
+
+		expect(next).toEqual({
+			actions: 405,
+			terminal: 180,
+		});
+		expect(
+			getPrimaryPanelSize({
+				...baseConfig,
+				sizes: next,
+			}),
+		).toBe(96);
+	});
+
+	it("moves the actions divider down by shrinking actions before terminal", () => {
+		const openPanels = panels.map((panel) =>
+			panel.id === "terminal" ? { ...panel, open: true } : panel,
+		);
+		const next = resizeVerticalSplitPanel({
+			...baseConfig,
+			panels: openPanels,
+			deltaY: 300,
+			panelId: "actions",
+		});
+
+		expect(next).toEqual({
+			actions: 72,
+			terminal: 96,
+		});
+	});
+
+	it("moves the terminal divider down by shrinking terminal and growing actions", () => {
+		const openPanels = panels.map((panel) =>
+			panel.id === "terminal" ? { ...panel, open: true } : panel,
+		);
+		const next = resizeVerticalSplitPanel({
+			...baseConfig,
+			panels: openPanels,
+			deltaY: 60,
+			panelId: "terminal",
+		});
+
+		expect(next).toEqual({
+			actions: 220,
+			terminal: 120,
+		});
+	});
+
+	it("moves the terminal divider up by shrinking actions then primary", () => {
+		const openPanels = panels.map((panel) =>
+			panel.id === "terminal" ? { ...panel, open: true } : panel,
+		);
+		const next = resizeVerticalSplitPanel({
+			...baseConfig,
+			panels: openPanels,
+			deltaY: -300,
+			panelId: "terminal",
+		});
+
+		expect(next).toEqual({
+			actions: 72,
+			terminal: 333,
+		});
+		expect(
+			getPrimaryPanelSize({
+				...baseConfig,
+				panels: openPanels,
+				sizes: next,
+			}),
+		).toBe(96);
+	});
+
+	it("opens a secondary panel to fill available space", () => {
+		const next = openVerticalSplitPanel({
+			...baseConfig,
+			panelId: "terminal",
+		});
+
+		expect(next).toEqual({
+			actions: 72,
+			terminal: 333,
+		});
+	});
+
+	it("compresses open secondary panels to minimum when opening another panel", () => {
+		const next = openVerticalSplitPanel({
+			...baseConfig,
+			sizes: {
+				actions: 405,
+				terminal: 180,
+			},
+			panelId: "terminal",
+		});
+
+		expect(next).toEqual({
+			actions: 72,
+			terminal: 333,
+		});
+		expect(
+			getPrimaryPanelSize({
+				...baseConfig,
+				panels: panels.map((panel) =>
+					panel.id === "terminal" ? { ...panel, open: true } : panel,
+				),
+				sizes: next,
+			}),
+		).toBe(96);
+	});
+
+	it("transfers a closed lower panel's space to the open panel above it", () => {
+		const openPanels = panels.map((panel) =>
+			panel.id === "terminal" ? { ...panel, open: true } : panel,
+		);
+		const next = closeVerticalSplitPanel({
+			...baseConfig,
+			panels: openPanels,
+			sizes: {
+				actions: 160,
+				terminal: 180,
+			},
+			panelId: "terminal",
+		});
+
+		expect(next).toEqual({
+			actions: 340,
+			terminal: 180,
+		});
+	});
+
+	it("lets the primary panel absorb closed space when no open secondary panel is above", () => {
+		const actionsClosedPanels = panels.map((panel) =>
+			panel.id === "actions" ? { ...panel, open: false } : panel,
+		);
+		const next = closeVerticalSplitPanel({
+			...baseConfig,
+			panels: actionsClosedPanels.map((panel) =>
+				panel.id === "terminal" ? { ...panel, open: true } : panel,
+			),
+			sizes: {
+				actions: 160,
+				terminal: 180,
+			},
+			panelId: "terminal",
+		});
+
+		expect(next).toEqual({
+			actions: 160,
+			terminal: 180,
+		});
+	});
+
+	it("clamps open panels on container resize without overflowing the primary minimum", () => {
+		const openPanels = panels.map((panel) =>
+			panel.id === "terminal" ? { ...panel, open: true } : panel,
+		);
+		const next = clampVerticalSplitSizes({
+			...baseConfig,
+			containerSize: 420,
+			panels: openPanels,
+			sizes: {
+				actions: 240,
+				terminal: 220,
+			},
+		});
+
+		expect(next).toEqual({
+			actions: 129,
+			terminal: 96,
+		});
+		expect(
+			getPrimaryPanelSize({
+				...baseConfig,
+				containerSize: 420,
+				panels: openPanels,
+				sizes: next,
+			}),
+		).toBe(96);
+	});
+});

--- a/src/components/ui/vertical-split-layout.test.ts
+++ b/src/components/ui/vertical-split-layout.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
 	clampVerticalSplitSizes,
-	closeVerticalSplitPanel,
 	getInitialVerticalSplitSizes,
 	getPrimaryPanelSize,
 	openVerticalSplitPanel,
@@ -130,19 +129,34 @@ describe("vertical split layout", () => {
 		).toBe(96);
 	});
 
-	it("opens a secondary panel to fill available space", () => {
+	it("opens a secondary panel at its remembered size and leaves siblings untouched", () => {
 		const next = openVerticalSplitPanel({
 			...baseConfig,
 			panelId: "terminal",
 		});
 
+		// Terminal returns to its remembered size (180), actions stays put,
+		// and the primary auto-shrinks to absorb the difference.
 		expect(next).toEqual({
-			actions: 72,
-			terminal: 333,
+			actions: 160,
+			terminal: 180,
 		});
 	});
 
-	it("compresses open secondary panels to minimum when opening another panel", () => {
+	it("falls back to defaultSize when opening a panel with no remembered size", () => {
+		const next = openVerticalSplitPanel({
+			...baseConfig,
+			sizes: { actions: 160 },
+			panelId: "terminal",
+		});
+
+		expect(next).toEqual({
+			actions: 160,
+			terminal: 180,
+		});
+	});
+
+	it("shrinks other secondary panels only as much as needed to fit the remembered size", () => {
 		const next = openVerticalSplitPanel({
 			...baseConfig,
 			sizes: {
@@ -152,9 +166,12 @@ describe("vertical split layout", () => {
 			panelId: "terminal",
 		});
 
+		// actions had absorbed extra space from a previous close. Opening
+		// terminal at its remembered 180 only takes back what's needed —
+		// it doesn't crush actions all the way to its 72px minimum.
 		expect(next).toEqual({
-			actions: 72,
-			terminal: 333,
+			actions: 225,
+			terminal: 180,
 		});
 		expect(
 			getPrimaryPanelSize({
@@ -167,45 +184,21 @@ describe("vertical split layout", () => {
 		).toBe(96);
 	});
 
-	it("transfers a closed lower panel's space to the open panel above it", () => {
-		const openPanels = panels.map((panel) =>
-			panel.id === "terminal" ? { ...panel, open: true } : panel,
-		);
-		const next = closeVerticalSplitPanel({
+	it("clamps the remembered size when it would push the primary below its minimum", () => {
+		const next = openVerticalSplitPanel({
 			...baseConfig,
-			panels: openPanels,
 			sizes: {
 				actions: 160,
-				terminal: 180,
+				terminal: 1000,
 			},
 			panelId: "terminal",
 		});
 
+		// Remembered 1000 is clamped so primary keeps its 96px floor.
+		// bodyBudget(405) - actions.minSize(72) = 333.
 		expect(next).toEqual({
-			actions: 340,
-			terminal: 180,
-		});
-	});
-
-	it("lets the primary panel absorb closed space when no open secondary panel is above", () => {
-		const actionsClosedPanels = panels.map((panel) =>
-			panel.id === "actions" ? { ...panel, open: false } : panel,
-		);
-		const next = closeVerticalSplitPanel({
-			...baseConfig,
-			panels: actionsClosedPanels.map((panel) =>
-				panel.id === "terminal" ? { ...panel, open: true } : panel,
-			),
-			sizes: {
-				actions: 160,
-				terminal: 180,
-			},
-			panelId: "terminal",
-		});
-
-		expect(next).toEqual({
-			actions: 160,
-			terminal: 180,
+			actions: 72,
+			terminal: 333,
 		});
 	});
 

--- a/src/components/ui/vertical-split-layout.ts
+++ b/src/components/ui/vertical-split-layout.ts
@@ -142,6 +142,9 @@ export function clampVerticalSplitSizes({
 	return nextSizes;
 }
 
+// Open at the panel's remembered size (its `defaultSize` on first open,
+// or the size it was last resized to). Only shrink other open secondary
+// panels when there's actual overflow — never compress them preemptively.
 export function openVerticalSplitPanel({
 	panelId,
 	...config
@@ -164,46 +167,32 @@ export function openVerticalSplitPanel({
 		(total, item) => total + item.minSize,
 		0,
 	);
-	const maxSize = Math.max(panel.minSize, bodyBudget - otherMinSize);
-	const nextSizes = {
-		...config.sizes,
-		[panelId]: maxSize,
-	};
 
-	for (const item of otherOpenSecondaryPanels) {
-		nextSizes[item.id] = item.minSize;
+	const remembered = getPanelSize(panel, config.sizes);
+	const maxAllowed = Math.max(panel.minSize, bodyBudget - otherMinSize);
+	const target = Math.min(maxAllowed, Math.max(panel.minSize, remembered));
+
+	const nextSizes = { ...config.sizes, [panelId]: target };
+
+	let overflow =
+		otherOpenSecondaryPanels.reduce(
+			(total, item) => total + getPanelSize(item, nextSizes),
+			0,
+		) +
+		target -
+		bodyBudget;
+	for (
+		let index = otherOpenSecondaryPanels.length - 1;
+		index >= 0 && overflow > 0;
+		index -= 1
+	) {
+		const item = otherOpenSecondaryPanels[index];
+		if (!item) continue;
+		const currentSize = getPanelSize(item, nextSizes);
+		const reduction = Math.min(overflow, currentSize - item.minSize);
+		nextSizes[item.id] = currentSize - reduction;
+		overflow -= reduction;
 	}
 
 	return nextSizes;
-}
-
-export function closeVerticalSplitPanel({
-	panelId,
-	...config
-}: VerticalSplitLayoutConfig & {
-	panelId: VerticalSplitPanelId;
-}): VerticalSplitPanelSizeState {
-	if (panelId === config.primaryPanelId) return config.sizes;
-
-	const panelIndex = config.panels.findIndex((item) => item.id === panelId);
-	const panel = config.panels[panelIndex];
-	if (!panel?.open) return config.sizes;
-
-	let previousOpenSecondaryPanel: VerticalSplitPanelConfig | undefined;
-	for (let index = panelIndex - 1; index >= 0; index -= 1) {
-		const item = config.panels[index];
-		if (item && item.id !== config.primaryPanelId && item.open) {
-			previousOpenSecondaryPanel = item;
-			break;
-		}
-	}
-
-	if (!previousOpenSecondaryPanel) return config.sizes;
-
-	return {
-		...config.sizes,
-		[previousOpenSecondaryPanel.id]:
-			getPanelSize(previousOpenSecondaryPanel, config.sizes) +
-			getPanelSize(panel, config.sizes),
-	};
 }

--- a/src/components/ui/vertical-split-layout.ts
+++ b/src/components/ui/vertical-split-layout.ts
@@ -1,0 +1,209 @@
+export type VerticalSplitPanelId = string;
+
+export type VerticalSplitPanelConfig = {
+	id: VerticalSplitPanelId;
+	open: boolean;
+	minSize: number;
+	defaultSize: number;
+};
+
+export type VerticalSplitPanelSizeState = Record<VerticalSplitPanelId, number>;
+
+export type VerticalSplitLayoutConfig = {
+	containerSize: number;
+	headerSize: number;
+	minPrimarySize: number;
+	primaryPanelId: VerticalSplitPanelId;
+	panels: VerticalSplitPanelConfig[];
+	sizes: VerticalSplitPanelSizeState;
+};
+
+function getBodyCapacity({
+	containerSize,
+	headerSize,
+	panels,
+}: Pick<VerticalSplitLayoutConfig, "containerSize" | "headerSize" | "panels">) {
+	return Math.max(0, containerSize - headerSize * panels.length);
+}
+
+function getPanelSize(
+	panel: VerticalSplitPanelConfig,
+	sizes: VerticalSplitPanelSizeState,
+) {
+	return sizes[panel.id] ?? panel.defaultSize;
+}
+
+export function getInitialVerticalSplitSizes(
+	panels: VerticalSplitPanelConfig[],
+): VerticalSplitPanelSizeState {
+	return Object.fromEntries(
+		panels.map((panel) => [panel.id, panel.defaultSize]),
+	);
+}
+
+export function getPrimaryPanelSize({
+	containerSize,
+	headerSize,
+	minPrimarySize,
+	primaryPanelId,
+	panels,
+	sizes,
+}: VerticalSplitLayoutConfig): number {
+	const bodyCapacity = getBodyCapacity({ containerSize, headerSize, panels });
+	const openSecondarySize = panels
+		.filter((panel) => panel.id !== primaryPanelId && panel.open)
+		.reduce((total, panel) => total + getPanelSize(panel, sizes), 0);
+
+	return Math.max(minPrimarySize, bodyCapacity - openSecondarySize);
+}
+
+export function resizeVerticalSplitPanel({
+	panelId,
+	deltaY,
+	...config
+}: VerticalSplitLayoutConfig & {
+	panelId: VerticalSplitPanelId;
+	deltaY: number;
+}): VerticalSplitPanelSizeState {
+	const dividerIndex = config.panels.findIndex((item) => item.id === panelId);
+	if (dividerIndex <= 0 || deltaY === 0) return config.sizes;
+
+	const primarySize = getPrimaryPanelSize(config);
+	const nextSizes = { ...config.sizes };
+	const openUpperPanels = config.panels
+		.slice(0, dividerIndex)
+		.filter((item) => item.open);
+	const openLowerPanels = config.panels
+		.slice(dividerIndex)
+		.filter((item) => item.open);
+	const donors = deltaY < 0 ? [...openUpperPanels].reverse() : openLowerPanels;
+	const recipients =
+		deltaY < 0 ? openLowerPanels : [...openUpperPanels].reverse();
+
+	let remaining = Math.abs(deltaY);
+	let released = 0;
+	const getSize = (panel: VerticalSplitPanelConfig) =>
+		panel.id === config.primaryPanelId
+			? primarySize
+			: getPanelSize(panel, nextSizes);
+	const getMinSize = (panel: VerticalSplitPanelConfig) =>
+		panel.id === config.primaryPanelId ? config.minPrimarySize : panel.minSize;
+
+	for (const donor of donors) {
+		if (remaining <= 0) break;
+		const available = Math.max(0, getSize(donor) - getMinSize(donor));
+		const reduction = Math.min(available, remaining);
+		if (reduction <= 0) continue;
+		if (donor.id !== config.primaryPanelId) {
+			nextSizes[donor.id] = getSize(donor) - reduction;
+		}
+		released += reduction;
+		remaining -= reduction;
+	}
+
+	const recipient = recipients[0];
+	if (recipient && released > 0 && recipient.id !== config.primaryPanelId) {
+		nextSizes[recipient.id] = getSize(recipient) + released;
+	}
+
+	return nextSizes;
+}
+
+export function clampVerticalSplitSizes({
+	...config
+}: VerticalSplitLayoutConfig): VerticalSplitPanelSizeState {
+	const bodyCapacity = getBodyCapacity(config);
+	const bodyBudget = Math.max(0, bodyCapacity - config.minPrimarySize);
+	const openSecondaryPanels = config.panels.filter(
+		(item) => item.id !== config.primaryPanelId && item.open,
+	);
+	const nextSizes = { ...config.sizes };
+
+	for (const item of openSecondaryPanels) {
+		nextSizes[item.id] = Math.max(item.minSize, getPanelSize(item, nextSizes));
+	}
+
+	let overflow =
+		openSecondaryPanels.reduce(
+			(total, item) => total + getPanelSize(item, nextSizes),
+			0,
+		) - bodyBudget;
+
+	for (let index = openSecondaryPanels.length - 1; index >= 0; index -= 1) {
+		if (overflow <= 0) break;
+		const item = openSecondaryPanels[index];
+		if (!item) continue;
+		const currentSize = getPanelSize(item, nextSizes);
+		const reduction = Math.min(overflow, currentSize - item.minSize);
+		nextSizes[item.id] = currentSize - reduction;
+		overflow -= reduction;
+	}
+
+	return nextSizes;
+}
+
+export function openVerticalSplitPanel({
+	panelId,
+	...config
+}: Omit<VerticalSplitLayoutConfig, "panels"> & {
+	panelId: VerticalSplitPanelId;
+	panels: VerticalSplitPanelConfig[];
+}): VerticalSplitPanelSizeState {
+	if (panelId === config.primaryPanelId) return config.sizes;
+
+	const panel = config.panels.find((item) => item.id === panelId);
+	if (!panel) return config.sizes;
+
+	const bodyCapacity = getBodyCapacity(config);
+	const bodyBudget = Math.max(0, bodyCapacity - config.minPrimarySize);
+	const otherOpenSecondaryPanels = config.panels.filter(
+		(item) =>
+			item.id !== config.primaryPanelId && item.id !== panelId && item.open,
+	);
+	const otherMinSize = otherOpenSecondaryPanels.reduce(
+		(total, item) => total + item.minSize,
+		0,
+	);
+	const maxSize = Math.max(panel.minSize, bodyBudget - otherMinSize);
+	const nextSizes = {
+		...config.sizes,
+		[panelId]: maxSize,
+	};
+
+	for (const item of otherOpenSecondaryPanels) {
+		nextSizes[item.id] = item.minSize;
+	}
+
+	return nextSizes;
+}
+
+export function closeVerticalSplitPanel({
+	panelId,
+	...config
+}: VerticalSplitLayoutConfig & {
+	panelId: VerticalSplitPanelId;
+}): VerticalSplitPanelSizeState {
+	if (panelId === config.primaryPanelId) return config.sizes;
+
+	const panelIndex = config.panels.findIndex((item) => item.id === panelId);
+	const panel = config.panels[panelIndex];
+	if (!panel?.open) return config.sizes;
+
+	let previousOpenSecondaryPanel: VerticalSplitPanelConfig | undefined;
+	for (let index = panelIndex - 1; index >= 0; index -= 1) {
+		const item = config.panels[index];
+		if (item && item.id !== config.primaryPanelId && item.open) {
+			previousOpenSecondaryPanel = item;
+			break;
+		}
+	}
+
+	if (!previousOpenSecondaryPanel) return config.sizes;
+
+	return {
+		...config.sizes,
+		[previousOpenSecondaryPanel.id]:
+			getPanelSize(previousOpenSecondaryPanel, config.sizes) +
+			getPanelSize(panel, config.sizes),
+	};
+}

--- a/src/components/ui/vertical-split-panel-group.tsx
+++ b/src/components/ui/vertical-split-panel-group.tsx
@@ -1,0 +1,50 @@
+import { forwardRef, type ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export type VerticalSplitPanelGroupPanel = {
+	id: string;
+	open: boolean;
+	resizable?: boolean;
+	node: ReactNode;
+};
+
+type VerticalSplitPanelGroupProps = {
+	panels: VerticalSplitPanelGroupPanel[];
+	renderResizeHandle: (panelId: string) => ReactNode;
+	className?: string;
+};
+
+export const VerticalSplitPanelGroup = forwardRef<
+	HTMLDivElement,
+	VerticalSplitPanelGroupProps
+>(function VerticalSplitPanelGroup(
+	{ panels, renderResizeHandle, className },
+	ref,
+) {
+	return (
+		<div ref={ref} className={cn("flex h-full min-h-0 flex-col", className)}>
+			{panels.map((panel) => (
+				<PanelSlot
+					key={panel.id}
+					panel={panel}
+					renderResizeHandle={renderResizeHandle}
+				/>
+			))}
+		</div>
+	);
+});
+
+function PanelSlot({
+	panel,
+	renderResizeHandle,
+}: {
+	panel: VerticalSplitPanelGroupPanel;
+	renderResizeHandle: (panelId: string) => ReactNode;
+}) {
+	return (
+		<>
+			{panel.open && panel.resizable ? renderResizeHandle(panel.id) : null}
+			{panel.node}
+		</>
+	);
+}

--- a/src/features/inspector/hooks/use-inspector.ts
+++ b/src/features/inspector/hooks/use-inspector.ts
@@ -9,7 +9,6 @@ import {
 } from "react";
 import {
 	clampVerticalSplitSizes,
-	closeVerticalSplitPanel,
 	getInitialVerticalSplitSizes,
 	openVerticalSplitPanel,
 	resizeVerticalSplitPanel,
@@ -35,8 +34,6 @@ const INSPECTOR_TERMINAL_PANEL_ID = "terminal";
 const MIN_INSPECTOR_PRIMARY_HEIGHT = 128;
 const MIN_INSPECTOR_ACTIONS_HEIGHT = 112;
 const MIN_INSPECTOR_TERMINAL_HEIGHT = 160;
-const DEFAULT_INSPECTOR_ACTIONS_HEIGHT = 160;
-const DEFAULT_INSPECTOR_TERMINAL_HEIGHT = 180;
 
 type UseWorkspaceInspectorSidebarArgs = {
 	workspaceRootPath?: string | null;
@@ -64,13 +61,15 @@ export function useWorkspaceInspectorSidebar({
 				id: INSPECTOR_ACTIONS_PANEL_ID,
 				open: actionsOpen,
 				minSize: MIN_INSPECTOR_ACTIONS_HEIGHT,
-				defaultSize: DEFAULT_INSPECTOR_ACTIONS_HEIGHT,
+				// First open uses minSize. Resizing then "remembers" the user's
+				// last height so subsequent toggles restore it.
+				defaultSize: MIN_INSPECTOR_ACTIONS_HEIGHT,
 			},
 			{
 				id: INSPECTOR_TERMINAL_PANEL_ID,
 				open: tabsOpen,
 				minSize: MIN_INSPECTOR_TERMINAL_HEIGHT,
-				defaultSize: DEFAULT_INSPECTOR_TERMINAL_HEIGHT,
+				defaultSize: MIN_INSPECTOR_TERMINAL_HEIGHT,
 			},
 		],
 		[actionsOpen, tabsOpen],
@@ -207,19 +206,11 @@ export function useWorkspaceInspectorSidebar({
 		});
 	}, [changesQuery.data]);
 
+	// Closing only flips `open`; sizes stay in `panelSizes` so reopening
+	// restores the panel's last height. The primary panel auto-grows via
+	// `getPrimaryPanelSize`, which only sums open secondary panels.
 	const handleToggleTabs = useCallback(() => {
 		if (tabsOpen) {
-			setPanelSizes((current) =>
-				closeVerticalSplitPanel({
-					containerSize: containerRef.current?.clientHeight ?? 0,
-					headerSize: INSPECTOR_SECTION_HEADER_HEIGHT,
-					minPrimarySize: MIN_INSPECTOR_PRIMARY_HEIGHT,
-					primaryPanelId: INSPECTOR_PRIMARY_PANEL_ID,
-					panels: inspectorPanels,
-					sizes: current,
-					panelId: INSPECTOR_TERMINAL_PANEL_ID,
-				}),
-			);
 			setTabsOpen(false);
 			return;
 		}
@@ -239,17 +230,6 @@ export function useWorkspaceInspectorSidebar({
 
 	const handleToggleActions = useCallback(() => {
 		if (actionsOpen) {
-			setPanelSizes((current) =>
-				closeVerticalSplitPanel({
-					containerSize: containerRef.current?.clientHeight ?? 0,
-					headerSize: INSPECTOR_SECTION_HEADER_HEIGHT,
-					minPrimarySize: MIN_INSPECTOR_PRIMARY_HEIGHT,
-					primaryPanelId: INSPECTOR_PRIMARY_PANEL_ID,
-					panels: inspectorPanels,
-					sizes: current,
-					panelId: INSPECTOR_ACTIONS_PANEL_ID,
-				}),
-			);
 			setActionsOpen(false);
 			return;
 		}
@@ -345,8 +325,7 @@ export function useWorkspaceInspectorSidebar({
 
 	return {
 		actionsHeight:
-			panelSizes[INSPECTOR_ACTIONS_PANEL_ID] ??
-			DEFAULT_INSPECTOR_ACTIONS_HEIGHT,
+			panelSizes[INSPECTOR_ACTIONS_PANEL_ID] ?? MIN_INSPECTOR_ACTIONS_HEIGHT,
 		actionsOpen,
 		actionsRef,
 		activeTab,
@@ -363,8 +342,7 @@ export function useWorkspaceInspectorSidebar({
 		scriptsLoaded,
 		setActiveTab,
 		tabsBodyHeight:
-			panelSizes[INSPECTOR_TERMINAL_PANEL_ID] ??
-			DEFAULT_INSPECTOR_TERMINAL_HEIGHT,
+			panelSizes[INSPECTOR_TERMINAL_PANEL_ID] ?? MIN_INSPECTOR_TERMINAL_HEIGHT,
 		tabsOpen,
 		tabsWrapperRef,
 	};

--- a/src/features/inspector/hooks/use-inspector.ts
+++ b/src/features/inspector/hooks/use-inspector.ts
@@ -7,29 +7,36 @@ import {
 	useRef,
 	useState,
 } from "react";
-import { flushSync } from "react-dom";
+import {
+	clampVerticalSplitSizes,
+	closeVerticalSplitPanel,
+	getInitialVerticalSplitSizes,
+	openVerticalSplitPanel,
+	resizeVerticalSplitPanel,
+	type VerticalSplitPanelConfig,
+	type VerticalSplitPanelId,
+	type VerticalSplitPanelSizeState,
+} from "@/components/ui/vertical-split-layout";
 import { loadRepoScripts, type RepoScripts } from "@/lib/api";
 import type { InspectorFileItem } from "@/lib/editor-session";
 import { workspaceChangesQueryOptions } from "@/lib/query-client";
-import {
-	DEFAULT_TABS_BODY_HEIGHT,
-	MIN_SECTION_HEIGHT,
-	TABS_ANIMATION_MS,
-	TABS_EASING,
-} from "../layout";
+import { INSPECTOR_SECTION_HEADER_HEIGHT } from "../layout";
 import { getScriptState, startScript, stopScript } from "../script-store";
-
-const DEFAULT_CHANGES_RATIO = 0.6;
-const DEFAULT_ACTIONS_RATIO = 0.4;
-
-type ResizeTarget = "actions" | "tabs";
 
 type ResizeState = {
 	pointerY: number;
-	initialChangesHeight: number;
-	initialActionsHeight: number;
-	target: ResizeTarget;
+	initialSizes: VerticalSplitPanelSizeState;
+	target: VerticalSplitPanelId;
 };
+
+const INSPECTOR_PRIMARY_PANEL_ID = "changes";
+const INSPECTOR_ACTIONS_PANEL_ID = "actions";
+const INSPECTOR_TERMINAL_PANEL_ID = "terminal";
+const MIN_INSPECTOR_PRIMARY_HEIGHT = 128;
+const MIN_INSPECTOR_ACTIONS_HEIGHT = 112;
+const MIN_INSPECTOR_TERMINAL_HEIGHT = 160;
+const DEFAULT_INSPECTOR_ACTIONS_HEIGHT = 160;
+const DEFAULT_INSPECTOR_TERMINAL_HEIGHT = 180;
 
 type UseWorkspaceInspectorSidebarArgs = {
 	workspaceRootPath?: string | null;
@@ -42,10 +49,35 @@ export function useWorkspaceInspectorSidebar({
 	workspaceId,
 	repoId,
 }: UseWorkspaceInspectorSidebarArgs) {
+	const [actionsOpen, setActionsOpen] = useState(true);
 	const [tabsOpen, setTabsOpen] = useState(false);
 	const [activeTab, setActiveTab] = useState("setup");
-	const [changesHeight, setChangesHeight] = useState(0);
-	const [actionsHeight, setActionsHeight] = useState(0);
+	const inspectorPanels = useMemo<VerticalSplitPanelConfig[]>(
+		() => [
+			{
+				id: INSPECTOR_PRIMARY_PANEL_ID,
+				open: true,
+				minSize: MIN_INSPECTOR_PRIMARY_HEIGHT,
+				defaultSize: 240,
+			},
+			{
+				id: INSPECTOR_ACTIONS_PANEL_ID,
+				open: actionsOpen,
+				minSize: MIN_INSPECTOR_ACTIONS_HEIGHT,
+				defaultSize: DEFAULT_INSPECTOR_ACTIONS_HEIGHT,
+			},
+			{
+				id: INSPECTOR_TERMINAL_PANEL_ID,
+				open: tabsOpen,
+				minSize: MIN_INSPECTOR_TERMINAL_HEIGHT,
+				defaultSize: DEFAULT_INSPECTOR_TERMINAL_HEIGHT,
+			},
+		],
+		[actionsOpen, tabsOpen],
+	);
+	const [panelSizes, setPanelSizes] = useState<VerticalSplitPanelSizeState>(
+		() => getInitialVerticalSplitSizes(inspectorPanels),
+	);
 	const [resizeState, setResizeState] = useState<ResizeState | null>(null);
 
 	const containerRef = useRef<HTMLDivElement>(null);
@@ -54,19 +86,39 @@ export function useWorkspaceInspectorSidebar({
 
 	useEffect(() => {
 		const element = containerRef.current;
-		if (!element || changesHeight > 0) {
-			return;
-		}
+		if (!element) return;
 
-		const overhead = 36 * 3 + 8 * 2;
-		const available = Math.max(0, element.clientHeight - overhead);
-		const resizableAvailable = Math.max(
-			MIN_SECTION_HEIGHT * 2,
-			available - DEFAULT_TABS_BODY_HEIGHT,
-		);
-		setChangesHeight(Math.round(resizableAvailable * DEFAULT_CHANGES_RATIO));
-		setActionsHeight(Math.round(resizableAvailable * DEFAULT_ACTIONS_RATIO));
-	}, [changesHeight]);
+		let frameId: number | null = null;
+		const resizeObserver = new ResizeObserver((entries) => {
+			const entry = entries[0];
+			if (!entry) return;
+			if (frameId !== null) {
+				cancelAnimationFrame(frameId);
+			}
+			frameId = requestAnimationFrame(() => {
+				frameId = null;
+				const containerSize = entry.contentRect.height;
+				setPanelSizes((current) =>
+					clampVerticalSplitSizes({
+						containerSize,
+						headerSize: INSPECTOR_SECTION_HEADER_HEIGHT,
+						minPrimarySize: MIN_INSPECTOR_PRIMARY_HEIGHT,
+						primaryPanelId: INSPECTOR_PRIMARY_PANEL_ID,
+						panels: inspectorPanels,
+						sizes: current,
+					}),
+				);
+			});
+		});
+
+		resizeObserver.observe(element);
+		return () => {
+			if (frameId !== null) {
+				cancelAnimationFrame(frameId);
+			}
+			resizeObserver.disconnect();
+		};
+	}, [inspectorPanels]);
 
 	const repoScriptsQuery = useQuery({
 		queryKey: ["repoScripts", repoId, workspaceId],
@@ -97,8 +149,8 @@ export function useWorkspaceInspectorSidebar({
 	}, [repoId, workspaceId, repoScripts]);
 
 	const isResizing = resizeState !== null;
-	const isActionsResizing = resizeState?.target === "actions";
-	const isTabsResizing = resizeState?.target === "tabs";
+	const isActionsResizing = resizeState?.target === INSPECTOR_ACTIONS_PANEL_ID;
+	const isTabsResizing = resizeState?.target === INSPECTOR_TERMINAL_PANEL_ID;
 
 	const changesQuery = useQuery({
 		...workspaceChangesQueryOptions(workspaceRootPath ?? ""),
@@ -156,107 +208,93 @@ export function useWorkspaceInspectorSidebar({
 	}, [changesQuery.data]);
 
 	const handleToggleTabs = useCallback(() => {
-		const tabsElement = tabsWrapperRef.current;
-		const actionsElement = actionsRef.current;
-		if (!tabsElement) {
-			setTabsOpen((current) => !current);
-			return;
-		}
-
-		const tabsFrom = tabsElement.offsetHeight;
-		const actionsFrom = actionsElement?.offsetHeight ?? 0;
-
-		// Lock current sizes before flushSync so the className swap doesn't
-		// produce a one-frame layout jump (tabs gains flex-1, actions loses
-		// it). Same task = no paint between lock/unlock/measure.
-		tabsElement.style.height = `${tabsFrom}px`;
-		tabsElement.style.flex = "none";
-		if (actionsElement) {
-			actionsElement.style.height = `${actionsFrom}px`;
-			actionsElement.style.flex = "none";
-		}
-
-		flushSync(() => setTabsOpen((current) => !current));
-
-		// Unlock briefly to measure target sizes, then animateSection re-locks.
-		tabsElement.style.height = "";
-		tabsElement.style.flex = "";
-		if (actionsElement) {
-			actionsElement.style.height = "";
-			actionsElement.style.flex = "";
-		}
-		const tabsTo = tabsElement.offsetHeight;
-		const actionsTo = actionsElement?.offsetHeight ?? 0;
-		if (tabsFrom === tabsTo) {
-			return;
-		}
-
-		const options = { duration: TABS_ANIMATION_MS, easing: TABS_EASING };
-
-		const animateSection = (element: HTMLElement, from: number, to: number) => {
-			element.style.overflow = "hidden";
-			element.style.flex = "none";
-			element.style.height = `${from}px`;
-			const animation = element.animate(
-				[{ height: `${from}px` }, { height: `${to}px` }],
-				options,
+		if (tabsOpen) {
+			setPanelSizes((current) =>
+				closeVerticalSplitPanel({
+					containerSize: containerRef.current?.clientHeight ?? 0,
+					headerSize: INSPECTOR_SECTION_HEADER_HEIGHT,
+					minPrimarySize: MIN_INSPECTOR_PRIMARY_HEIGHT,
+					primaryPanelId: INSPECTOR_PRIMARY_PANEL_ID,
+					panels: inspectorPanels,
+					sizes: current,
+					panelId: INSPECTOR_TERMINAL_PANEL_ID,
+				}),
 			);
-			animation.onfinish = animation.oncancel = () => {
-				element.style.overflow = "";
-				element.style.flex = "";
-				element.style.height = "";
-			};
-		};
-
-		animateSection(tabsElement, tabsFrom, tabsTo);
-		if (actionsElement && actionsFrom !== actionsTo) {
-			animateSection(actionsElement, actionsFrom, actionsTo);
+			setTabsOpen(false);
+			return;
 		}
-	}, []);
+		setPanelSizes((current) =>
+			openVerticalSplitPanel({
+				containerSize: containerRef.current?.clientHeight ?? 0,
+				headerSize: INSPECTOR_SECTION_HEADER_HEIGHT,
+				minPrimarySize: MIN_INSPECTOR_PRIMARY_HEIGHT,
+				primaryPanelId: INSPECTOR_PRIMARY_PANEL_ID,
+				panels: inspectorPanels,
+				sizes: current,
+				panelId: INSPECTOR_TERMINAL_PANEL_ID,
+			}),
+		);
+		setTabsOpen(true);
+	}, [inspectorPanels, tabsOpen]);
+
+	const handleToggleActions = useCallback(() => {
+		if (actionsOpen) {
+			setPanelSizes((current) =>
+				closeVerticalSplitPanel({
+					containerSize: containerRef.current?.clientHeight ?? 0,
+					headerSize: INSPECTOR_SECTION_HEADER_HEIGHT,
+					minPrimarySize: MIN_INSPECTOR_PRIMARY_HEIGHT,
+					primaryPanelId: INSPECTOR_PRIMARY_PANEL_ID,
+					panels: inspectorPanels,
+					sizes: current,
+					panelId: INSPECTOR_ACTIONS_PANEL_ID,
+				}),
+			);
+			setActionsOpen(false);
+			return;
+		}
+		setPanelSizes((current) =>
+			openVerticalSplitPanel({
+				containerSize: containerRef.current?.clientHeight ?? 0,
+				headerSize: INSPECTOR_SECTION_HEADER_HEIGHT,
+				minPrimarySize: MIN_INSPECTOR_PRIMARY_HEIGHT,
+				primaryPanelId: INSPECTOR_PRIMARY_PANEL_ID,
+				panels: inspectorPanels,
+				sizes: current,
+				panelId: INSPECTOR_ACTIONS_PANEL_ID,
+			}),
+		);
+		setActionsOpen(true);
+	}, [actionsOpen, inspectorPanels]);
 
 	useEffect(() => {
 		if (!resizeState) {
 			return;
 		}
 
-		let pendingChanges: number | null = null;
-		let pendingActions: number | null = null;
+		let pendingSizes: VerticalSplitPanelSizeState | null = null;
 		let animationFrameId: number | null = null;
 		const flush = () => {
 			animationFrameId = null;
-			if (pendingChanges !== null) {
-				const next = pendingChanges;
-				pendingChanges = null;
-				setChangesHeight(next);
-			}
-			if (pendingActions !== null) {
-				const next = pendingActions;
-				pendingActions = null;
-				setActionsHeight(next);
+			if (pendingSizes !== null) {
+				const next = pendingSizes;
+				pendingSizes = null;
+				setPanelSizes(next);
 			}
 		};
 
 		const handleMouseMove = (event: globalThis.MouseEvent) => {
 			const deltaY = event.clientY - resizeState.pointerY;
-
-			if (resizeState.target === "actions") {
-				const nextChanges = Math.max(
-					MIN_SECTION_HEIGHT,
-					resizeState.initialChangesHeight + deltaY,
-				);
-				const actualDelta = nextChanges - resizeState.initialChangesHeight;
-				const nextActions = Math.max(
-					MIN_SECTION_HEIGHT,
-					resizeState.initialActionsHeight - actualDelta,
-				);
-				pendingChanges = nextChanges;
-				pendingActions = nextActions;
-			} else {
-				pendingActions = Math.max(
-					MIN_SECTION_HEIGHT,
-					resizeState.initialActionsHeight + deltaY,
-				);
-			}
+			pendingSizes = resizeVerticalSplitPanel({
+				containerSize: containerRef.current?.clientHeight ?? 0,
+				headerSize: INSPECTOR_SECTION_HEADER_HEIGHT,
+				minPrimarySize: MIN_INSPECTOR_PRIMARY_HEIGHT,
+				primaryPanelId: INSPECTOR_PRIMARY_PANEL_ID,
+				panels: inspectorPanels,
+				sizes: resizeState.initialSizes,
+				panelId: resizeState.target,
+				deltaY,
+			});
 
 			if (animationFrameId === null) {
 				animationFrameId = window.requestAnimationFrame(flush);
@@ -289,31 +327,34 @@ export function useWorkspaceInspectorSidebar({
 			window.removeEventListener("mousemove", handleMouseMove);
 			window.removeEventListener("mouseup", handleMouseUp);
 		};
-	}, [resizeState]);
+	}, [inspectorPanels, resizeState]);
 
 	const handleResizeStart = useCallback(
-		(target: ResizeTarget) => (event: ReactMouseEvent<HTMLDivElement>) => {
-			if (event.button !== 0) return;
-			event.preventDefault();
-			setResizeState({
-				pointerY: event.clientY,
-				initialChangesHeight: changesHeight,
-				initialActionsHeight: actionsHeight,
-				target,
-			});
-		},
-		[actionsHeight, changesHeight],
+		(target: VerticalSplitPanelId) =>
+			(event: ReactMouseEvent<HTMLDivElement>) => {
+				if (event.button !== 0) return;
+				event.preventDefault();
+				setResizeState({
+					pointerY: event.clientY,
+					initialSizes: panelSizes,
+					target,
+				});
+			},
+		[panelSizes],
 	);
 
 	return {
-		actionsHeight,
+		actionsHeight:
+			panelSizes[INSPECTOR_ACTIONS_PANEL_ID] ??
+			DEFAULT_INSPECTOR_ACTIONS_HEIGHT,
+		actionsOpen,
 		actionsRef,
 		activeTab,
 		changes,
-		changesHeight,
 		containerRef,
 		flashingPaths,
 		handleResizeStart,
+		handleToggleActions,
 		handleToggleTabs,
 		isActionsResizing,
 		isResizing,
@@ -321,6 +362,9 @@ export function useWorkspaceInspectorSidebar({
 		repoScripts,
 		scriptsLoaded,
 		setActiveTab,
+		tabsBodyHeight:
+			panelSizes[INSPECTOR_TERMINAL_PANEL_ID] ??
+			DEFAULT_INSPECTOR_TERMINAL_HEIGHT,
 		tabsOpen,
 		tabsWrapperRef,
 	};

--- a/src/features/inspector/index.tsx
+++ b/src/features/inspector/index.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { VerticalSplitPanelGroup } from "@/components/ui/vertical-split-panel-group";
 import type {
 	CommitButtonState,
 	WorkspaceCommitButtonMode,
@@ -85,13 +86,14 @@ export function WorkspaceInspectorSidebar({
 }: WorkspaceInspectorSidebarProps) {
 	const {
 		actionsHeight,
+		actionsOpen,
 		actionsRef,
 		activeTab,
 		changes,
-		changesHeight,
 		containerRef,
 		flashingPaths,
 		handleResizeStart,
+		handleToggleActions,
 		handleToggleTabs,
 		isActionsResizing,
 		isResizing,
@@ -99,6 +101,7 @@ export function WorkspaceInspectorSidebar({
 		repoScripts,
 		scriptsLoaded,
 		setActiveTab,
+		tabsBodyHeight,
 		tabsOpen,
 		tabsWrapperRef,
 	} = useWorkspaceInspectorSidebar({
@@ -368,101 +371,114 @@ export function WorkspaceInspectorSidebar({
 	const handleOpenSettings = onOpenSettings ?? (() => {});
 
 	return (
-		<div
+		<VerticalSplitPanelGroup
 			ref={containerRef}
-			className={cn(
-				"flex h-full min-h-0 flex-col bg-sidebar",
-				isResizing && "select-none",
-			)}
-		>
-			<ChangesSection
-				bodyHeight={changesHeight}
-				workspaceId={workspaceId ?? null}
-				workspaceRootPath={workspaceRootPath ?? null}
-				workspaceTargetBranch={workspaceTargetBranch ?? null}
-				changes={changes}
-				editorMode={editorMode}
-				activeEditorPath={activeEditorPath}
-				onOpenEditorFile={onOpenEditorFile}
-				flashingPaths={flashingPaths}
-				onCommitAction={onCommitAction}
-				commitButtonMode={commitButtonMode}
-				commitButtonState={commitButtonState}
-				changeRequest={changeRequest ?? null}
-				forgeIsRefreshing={forgeIsRefreshing}
-			/>
-
-			<HorizontalResizeHandle
-				onMouseDown={handleResizeStart("actions")}
-				isActive={isActionsResizing}
-			/>
-
-			<ActionsSection
-				workspaceId={workspaceId ?? null}
-				workspaceState={workspaceState ?? null}
-				repoId={repoId ?? null}
-				workspaceRemote={workspaceRemote ?? null}
-				sectionRef={actionsRef}
-				bodyHeight={actionsHeight}
-				expanded={!tabsOpen}
-				onCommitAction={onCommitAction}
-				onReviewAction={onReviewAction}
-				currentSessionId={currentSessionId ?? null}
-				onQueuePendingPromptForSession={onQueuePendingPromptForSession}
-				commitButtonMode={commitButtonMode}
-				commitButtonState={commitButtonState}
-				changeRequest={changeRequest ?? null}
-			/>
-
-			{tabsOpen && (
+			className={cn("bg-sidebar", isResizing && "select-none")}
+			panels={[
+				{
+					id: "changes",
+					open: true,
+					node: (
+						<ChangesSection
+							workspaceId={workspaceId ?? null}
+							workspaceRootPath={workspaceRootPath ?? null}
+							workspaceTargetBranch={workspaceTargetBranch ?? null}
+							changes={changes}
+							editorMode={editorMode}
+							activeEditorPath={activeEditorPath}
+							onOpenEditorFile={onOpenEditorFile}
+							flashingPaths={flashingPaths}
+							onCommitAction={onCommitAction}
+							commitButtonMode={commitButtonMode}
+							commitButtonState={commitButtonState}
+							changeRequest={changeRequest ?? null}
+							forgeIsRefreshing={forgeIsRefreshing}
+						/>
+					),
+				},
+				{
+					id: "actions",
+					open: actionsOpen,
+					resizable: true,
+					node: (
+						<ActionsSection
+							workspaceId={workspaceId ?? null}
+							workspaceState={workspaceState ?? null}
+							repoId={repoId ?? null}
+							workspaceRemote={workspaceRemote ?? null}
+							sectionRef={actionsRef}
+							open={actionsOpen}
+							onToggle={handleToggleActions}
+							bodyHeight={actionsHeight}
+							isResizing={isResizing}
+							onCommitAction={onCommitAction}
+							onReviewAction={onReviewAction}
+							currentSessionId={currentSessionId ?? null}
+							onQueuePendingPromptForSession={onQueuePendingPromptForSession}
+							commitButtonMode={commitButtonMode}
+							commitButtonState={commitButtonState}
+							changeRequest={changeRequest ?? null}
+						/>
+					),
+				},
+				{
+					id: "terminal",
+					open: tabsOpen,
+					resizable: true,
+					node: (
+						<InspectorTabsSection
+							wrapperRef={tabsWrapperRef}
+							open={tabsOpen}
+							onToggle={handleToggleTabs}
+							activeTab={activeTab}
+							onTabChange={setActiveTab}
+							tabActions={runTabActions}
+							setupScriptState={setupScriptState}
+							runScriptState={runScriptState}
+							terminalInstances={terminalInstances}
+							onAddTerminal={handleAddTerminal}
+							onCloseTerminal={handleCloseTerminal}
+							onToggleTerminalHoverZoom={handleToggleTerminalHoverZoom}
+							canSpawnTerminal={canSpawnTerminal}
+							canHoverExpand={canHoverExpand}
+							bodyHeight={tabsBodyHeight}
+							isResizing={isResizing}
+						>
+							<SetupTab
+								repoId={repoId ?? null}
+								workspaceId={workspaceId ?? null}
+								setupScript={repoScripts?.setupScript ?? null}
+								isActive={activeTab === "setup"}
+								onOpenSettings={handleOpenSettings}
+							/>
+							<RunTab
+								repoId={repoId ?? null}
+								workspaceId={workspaceId ?? null}
+								runScript={repoScripts?.runScript ?? null}
+								isActive={activeTab === "run"}
+								onOpenSettings={handleOpenSettings}
+								onStatusChange={setRunStatus}
+								onUrlsChange={setRunUrls}
+							/>
+							{terminalInstances.map((instance) => (
+								<TerminalInstancePanel
+									key={instance.id}
+									repoId={repoId ?? null}
+									workspaceId={workspaceId ?? null}
+									instance={instance}
+									isActive={activeTab === instance.id}
+								/>
+							))}
+						</InspectorTabsSection>
+					),
+				},
+			]}
+			renderResizeHandle={(panelId) => (
 				<HorizontalResizeHandle
-					onMouseDown={handleResizeStart("tabs")}
-					isActive={isTabsResizing}
+					onMouseDown={handleResizeStart(panelId)}
+					isActive={panelId === "actions" ? isActionsResizing : isTabsResizing}
 				/>
 			)}
-
-			<InspectorTabsSection
-				wrapperRef={tabsWrapperRef}
-				open={tabsOpen}
-				onToggle={handleToggleTabs}
-				activeTab={activeTab}
-				onTabChange={setActiveTab}
-				tabActions={runTabActions}
-				setupScriptState={setupScriptState}
-				runScriptState={runScriptState}
-				terminalInstances={terminalInstances}
-				onAddTerminal={handleAddTerminal}
-				onCloseTerminal={handleCloseTerminal}
-				onToggleTerminalHoverZoom={handleToggleTerminalHoverZoom}
-				canSpawnTerminal={canSpawnTerminal}
-				canHoverExpand={canHoverExpand}
-			>
-				<SetupTab
-					repoId={repoId ?? null}
-					workspaceId={workspaceId ?? null}
-					setupScript={repoScripts?.setupScript ?? null}
-					isActive={activeTab === "setup"}
-					onOpenSettings={handleOpenSettings}
-				/>
-				<RunTab
-					repoId={repoId ?? null}
-					workspaceId={workspaceId ?? null}
-					runScript={repoScripts?.runScript ?? null}
-					isActive={activeTab === "run"}
-					onOpenSettings={handleOpenSettings}
-					onStatusChange={setRunStatus}
-					onUrlsChange={setRunUrls}
-				/>
-				{terminalInstances.map((instance) => (
-					<TerminalInstancePanel
-						key={instance.id}
-						repoId={repoId ?? null}
-						workspaceId={workspaceId ?? null}
-						instance={instance}
-						isActive={activeTab === instance.id}
-					/>
-				))}
-			</InspectorTabsSection>
-		</div>
+		/>
 	);
 }

--- a/src/features/inspector/layout.test.tsx
+++ b/src/features/inspector/layout.test.tsx
@@ -32,6 +32,7 @@ describe("InspectorTabsSection", () => {
 				onCloseTerminal={vi.fn()}
 				onToggleTerminalHoverZoom={vi.fn()}
 				canSpawnTerminal={false}
+				bodyHeight={128}
 				canHoverExpand
 			>
 				<div>Terminal body</div>
@@ -78,6 +79,7 @@ describe("InspectorTabsSection", () => {
 				onCloseTerminal={vi.fn()}
 				onToggleTerminalHoverZoom={vi.fn()}
 				canSpawnTerminal={false}
+				bodyHeight={128}
 				canHoverExpand
 			>
 				<div>Terminal body</div>
@@ -112,6 +114,7 @@ describe("InspectorTabsSection", () => {
 				onCloseTerminal={vi.fn()}
 				onToggleTerminalHoverZoom={vi.fn()}
 				canSpawnTerminal={false}
+				bodyHeight={128}
 				canHoverExpand={false}
 			>
 				<div>Placeholder body</div>

--- a/src/features/inspector/layout.tsx
+++ b/src/features/inspector/layout.tsx
@@ -1,4 +1,5 @@
 import { ChevronDown, Plus, X, ZoomIn, ZoomOut } from "lucide-react";
+import { motion, useReducedMotion } from "motion/react";
 import {
 	createContext,
 	useCallback,
@@ -39,6 +40,7 @@ export const RESIZE_HIT_AREA = 10;
 export const TABS_ANIMATION_MS = 350;
 /** Apple-style easing — used consistently across panel toggle, chevron, and hover-zoom. */
 export const TABS_EASING = "cubic-bezier(0.32, 0.72, 0, 1)";
+export const TABS_EASING_CURVE = [0.32, 0.72, 0, 1] as const;
 
 /** 300ms is the industry-standard hover-intent threshold (VSCode/Material). */
 export const TABS_HOVER_ACTIVATION_MS = 300;
@@ -50,7 +52,8 @@ const TABS_BLUR_FADE_MS = 120;
 /** Hold blur slightly past the transition so xterm's late re-fit stays hidden. */
 export const TABS_BLUR_HOLD_UNTIL_MS = TABS_HOVER_TRANSITION_MS - 50;
 /** 32px header (h-8) + 1px section border-b. */
-const TABS_WRAPPER_COLLAPSED_MIN_HEIGHT_PX = 33;
+export const INSPECTOR_SECTION_HEADER_HEIGHT = 33;
+const TABS_WRAPPER_COLLAPSED_MIN_HEIGHT_PX = INSPECTOR_SECTION_HEADER_HEIGHT;
 
 export const INSPECTOR_SECTION_HEADER_CLASS =
 	"flex h-8 min-w-0 shrink-0 items-center justify-between border-b border-border/60 bg-muted/25 px-3";
@@ -127,6 +130,8 @@ type InspectorTabsSectionProps = {
 	onToggleTerminalHoverZoom: (instanceId: string, disabled: boolean) => void;
 	/** False when there's no repo/workspace context — disables the "+" button. */
 	canSpawnTerminal: boolean;
+	bodyHeight: number;
+	isResizing?: boolean;
 	/**
 	 * Gate for the hover-to-zoom effect. When false, hovering the body does
 	 * nothing — used so we only zoom when there's actual terminal output worth
@@ -150,11 +155,18 @@ export function InspectorTabsSection({
 	onCloseTerminal,
 	onToggleTerminalHoverZoom,
 	canSpawnTerminal,
+	bodyHeight,
+	isResizing,
 	canHoverExpand,
 	children,
 }: InspectorTabsSectionProps) {
 	const { settings } = useSettings();
 	const newTerminalShortcut = getShortcut(settings.shortcuts, "terminal.new");
+	const shouldReduceMotion = useReducedMotion();
+	const panelTransition = {
+		duration: isResizing || shouldReduceMotion ? 0 : TABS_ANIMATION_MS / 1000,
+		ease: TABS_EASING_CURVE,
+	};
 	// `isHoverExpanded` drives the CSS transitions we CAN interpolate
 	// (width / height / box-shadow). Flipping it to `false` immediately starts
 	// the shrink animation.
@@ -459,20 +471,24 @@ export function InspectorTabsSection({
 	}, [open, onAddTerminal, onToggle]);
 
 	return (
-		<div
+		<motion.div
 			ref={wrapperRef}
 			className={cn(
 				"relative flex min-h-0 shrink-0 flex-col",
-				open && "flex-1",
+				!isZoomPresented && "overflow-hidden",
 			)}
+			initial={false}
+			animate={{
+				height: TABS_WRAPPER_COLLAPSED_MIN_HEIGHT_PX + (open ? bodyHeight : 0),
+			}}
+			transition={panelTransition}
 			style={{
 				// The real content lives inside the absolutely-positioned child
 				// below, which contributes nothing to layout. Reserve header
 				// height when the panel is closed so the parent flex column
 				// keeps a stable footprint for us.
-				minHeight: open
-					? undefined
-					: `${TABS_WRAPPER_COLLAPSED_MIN_HEIGHT_PX}px`,
+				minHeight: `${TABS_WRAPPER_COLLAPSED_MIN_HEIGHT_PX}px`,
+				willChange: isResizing ? undefined : "height",
 			}}
 		>
 			<div
@@ -495,6 +511,7 @@ export function InspectorTabsSection({
 					isZoomPresented && "z-50",
 				)}
 				style={{
+					top: isHoverExpanded ? undefined : 0,
 					width: isHoverExpanded ? zoomedSize : "100%",
 					height: isHoverExpanded ? zoomedSize : "100%",
 					// Cap the zoomed box to a fraction of the viewport so a
@@ -568,6 +585,7 @@ export function InspectorTabsSection({
 							className={cn(
 								INSPECTOR_SECTION_HEADER_CLASS,
 								"relative z-10 items-stretch pt-0",
+								!open && "border-b-transparent",
 							)}
 						>
 							<div
@@ -815,7 +833,7 @@ export function InspectorTabsSection({
 					</div>
 				</section>
 			</div>
-		</div>
+		</motion.div>
 	);
 }
 

--- a/src/features/inspector/sections/actions.tsx
+++ b/src/features/inspector/sections/actions.tsx
@@ -3,10 +3,12 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import {
 	ArrowUpRightIcon,
 	CheckIcon,
+	ChevronDown,
 	EyeIcon,
 	LoaderCircleIcon,
 	TriangleIcon,
 } from "lucide-react";
+import { motion, useReducedMotion } from "motion/react";
 import { useCallback, useState } from "react";
 import { toast } from "sonner";
 import {
@@ -47,7 +49,11 @@ import { resolveRepoPreferencePrompt } from "@/lib/repo-preferences-prompts";
 import { cn } from "@/lib/utils";
 import {
 	INSPECTOR_SECTION_HEADER_CLASS,
+	INSPECTOR_SECTION_HEADER_HEIGHT,
 	INSPECTOR_SECTION_TITLE_CLASS,
+	TABS_ANIMATION_MS,
+	TABS_EASING,
+	TABS_EASING_CURVE,
 } from "../layout";
 
 interface GitStatusItem {
@@ -103,8 +109,10 @@ type ActionsSectionProps = {
 	repoId?: string | null;
 	workspaceRemote?: string | null;
 	sectionRef?: React.RefObject<HTMLElement | null>;
+	open: boolean;
+	onToggle: () => void;
 	bodyHeight: number;
-	expanded: boolean;
+	isResizing?: boolean;
 	onCommitAction?: (mode: WorkspaceCommitButtonMode) => Promise<void>;
 	onReviewAction?: () => Promise<void>;
 	currentSessionId?: string | null;
@@ -154,8 +162,10 @@ export function ActionsSection({
 	repoId,
 	workspaceRemote,
 	sectionRef,
+	open,
+	onToggle,
 	bodyHeight,
-	expanded,
+	isResizing,
 	onCommitAction,
 	onReviewAction,
 	currentSessionId,
@@ -167,6 +177,11 @@ export function ActionsSection({
 	const queryClient = useQueryClient();
 	const [syncPending, setSyncPending] = useState(false);
 	const [reviewPending, setReviewPending] = useState(false);
+	const shouldReduceMotion = useReducedMotion();
+	const panelTransition = {
+		duration: isResizing || shouldReduceMotion ? 0 : TABS_ANIMATION_MS / 1000,
+		ease: TABS_EASING_CURVE,
+	};
 	const forgeQuery = useQuery({
 		...workspaceForgeQueryOptions(workspaceId ?? "__none__"),
 		enabled: workspaceId !== null,
@@ -213,9 +228,6 @@ export function ActionsSection({
 	);
 	const sortedDeployments = sortActionItems(forgeStatus.deployments);
 	const sortedChecks = sortActionItems(forgeStatus.checks);
-	const bottomSpacerHeight = expanded
-		? 0
-		: Math.max(0, Math.round(bodyHeight * 0.3));
 	const actionDisabled = commitButtonState === "busy";
 	const queueSyncResolutionPrompt = useCallback(
 		async (result: SyncWorkspaceTargetResponse) => {
@@ -321,183 +333,209 @@ export function ActionsSection({
 		[workspaceId],
 	);
 	return (
-		<section
+		<motion.section
 			ref={sectionRef}
 			aria-label="Inspector section Actions"
 			className={cn(
-				"flex min-h-0 flex-col overflow-hidden border-b border-border/60 bg-sidebar",
-				expanded && "flex-1",
+				"flex min-h-0 shrink-0 flex-col overflow-hidden border-b border-border/60 bg-sidebar transition-colors",
 			)}
+			initial={false}
+			animate={{
+				height: INSPECTOR_SECTION_HEADER_HEIGHT + (open ? bodyHeight : 0),
+			}}
+			transition={panelTransition}
+			style={{
+				willChange: isResizing ? undefined : "height",
+			}}
 		>
-			<div className={INSPECTOR_SECTION_HEADER_CLASS}>
+			<div
+				className={cn(
+					INSPECTOR_SECTION_HEADER_CLASS,
+					"transition-colors",
+					!open && "border-b-transparent",
+				)}
+			>
 				<span className={INSPECTOR_SECTION_TITLE_CLASS}>Actions</span>
+				<Button
+					type="button"
+					aria-label="Toggle inspector actions section"
+					onClick={onToggle}
+					variant="ghost"
+					size="icon-sm"
+					className="shrink-0 text-muted-foreground hover:bg-accent/60 hover:text-foreground"
+				>
+					<ChevronDown
+						className="size-3.5"
+						strokeWidth={1.9}
+						style={{
+							transform: open ? "rotate(0deg)" : "rotate(-90deg)",
+							transition: `transform ${TABS_ANIMATION_MS}ms ${TABS_EASING}`,
+						}}
+					/>
+				</Button>
 			</div>
 
-			<ScrollArea
-				aria-label="Actions panel body"
-				className={cn(
-					"min-h-0 bg-muted/18 text-[11.5px]",
-					expanded && "flex-1",
-				)}
-				style={expanded ? undefined : { height: `${bodyHeight}px` }}
-			>
-				{showHelpersGroup && (
-					<>
+			{open && (
+				<div className="min-h-0">
+					<ScrollArea
+						aria-label="Actions panel body"
+						className="min-h-0 bg-muted/18 text-[11.5px]"
+						style={{ height: `${bodyHeight}px` }}
+					>
+						{showHelpersGroup && (
+							<>
+								<div className="px-2.5 pb-1 pt-2">
+									<span className="text-[10.5px] font-medium tracking-wide text-muted-foreground">
+										Helpers
+									</span>
+								</div>
+								{showReviewHelper && (
+									<div className="flex items-center gap-1.5 px-2.5 py-[3px] text-muted-foreground transition-colors hover:bg-accent/60">
+										<EyeIcon
+											aria-hidden="true"
+											className="size-3 shrink-0"
+											strokeWidth={2}
+										/>
+										<span className="truncate">Review changes</span>
+										<button
+											type="button"
+											onClick={() => void handleReviewChanges()}
+											disabled={reviewPending || workspaceId === null}
+											aria-busy={reviewPending ? true : undefined}
+											aria-label={reviewPending ? "Reviewing" : undefined}
+											className="ml-auto shrink-0 cursor-pointer text-[10.5px] text-primary transition-colors hover:text-primary/80 disabled:cursor-not-allowed disabled:opacity-50"
+										>
+											<span className="inline-flex items-center gap-1">
+												{reviewPending ? (
+													<LoaderCircleIcon
+														aria-hidden="true"
+														className="size-3 animate-spin text-current opacity-70"
+														strokeWidth={2}
+													/>
+												) : null}
+												{reviewPending ? null : "Review"}
+											</span>
+										</button>
+									</div>
+								)}
+							</>
+						)}
 						<div className="px-2.5 pb-1 pt-2">
 							<span className="text-[10.5px] font-medium tracking-wide text-muted-foreground">
-								Helpers
+								Git
 							</span>
 						</div>
-						{showReviewHelper && (
-							<div className="flex items-center gap-1.5 px-2.5 py-[3px] text-muted-foreground transition-colors hover:bg-accent/60">
-								<EyeIcon
-									aria-hidden="true"
-									className="size-3 shrink-0"
-									strokeWidth={2}
-								/>
-								<span className="truncate">Review changes</span>
-								<button
-									type="button"
-									onClick={() => void handleReviewChanges()}
-									disabled={reviewPending || workspaceId === null}
-									aria-busy={reviewPending ? true : undefined}
-									aria-label={reviewPending ? "Reviewing" : undefined}
-									className="ml-auto shrink-0 cursor-pointer text-[10.5px] text-primary transition-colors hover:text-primary/80 disabled:cursor-not-allowed disabled:opacity-50"
+						{gitRows.map((item) => {
+							const action = item.action;
+							const isCommitActionBusy =
+								action?.kind === "commit" &&
+								action.mode != null &&
+								commitButtonMode === action.mode &&
+								commitButtonState === "busy";
+							const isSyncActionBusy = action?.kind === "sync" && syncPending;
+							const isActionBusy = isCommitActionBusy || isSyncActionBusy;
+							return (
+								<div
+									key={item.label}
+									className="flex items-center gap-1.5 px-2.5 py-[3px] text-muted-foreground transition-colors hover:bg-accent/60"
 								>
-									<span className="inline-flex items-center gap-1">
-										{reviewPending ? (
-											<LoaderCircleIcon
-												aria-hidden="true"
-												className="size-3 animate-spin text-current opacity-70"
-												strokeWidth={2}
-											/>
-										) : null}
-										{reviewPending ? null : "Review"}
+									<StatusIcon status={item.status} />
+									<span className="truncate">{item.label}</span>
+									{action && (
+										<button
+											type="button"
+											onClick={() => {
+												if (
+													(action.kind === "commit" && actionDisabled) ||
+													(action.kind === "sync" && syncPending)
+												) {
+													return;
+												}
+												if (action.kind === "sync") {
+													void handleSync();
+													return;
+												}
+												void onCommitAction?.(action.mode!);
+											}}
+											className="ml-auto shrink-0 cursor-pointer text-[10.5px] text-primary transition-colors hover:text-primary/80 disabled:cursor-not-allowed disabled:opacity-50"
+											disabled={
+												action.kind === "commit" ? actionDisabled : syncPending
+											}
+											aria-busy={isActionBusy ? true : undefined}
+											aria-label={
+												isActionBusy
+													? loadingActionLabel(action.label)
+													: undefined
+											}
+										>
+											<span className="inline-flex items-center gap-1">
+												{isActionBusy ? (
+													<LoaderCircleIcon
+														aria-hidden="true"
+														className="size-3 animate-spin text-current opacity-70"
+														strokeWidth={2}
+													/>
+												) : null}
+												{isActionBusy ? null : action.label}
+											</span>
+										</button>
+									)}
+								</div>
+							);
+						})}
+
+						{reviewRows.length > 0 && (
+							<>
+								<div className="px-2.5 pb-1 pt-2.5">
+									<span className="text-[10.5px] font-medium tracking-wide text-muted-foreground">
+										Review
 									</span>
-								</button>
-							</div>
+								</div>
+								{reviewRows.map((item) => (
+									<div
+										key={item.label}
+										className="flex items-center gap-1.5 px-2.5 py-[3px] text-muted-foreground transition-colors hover:bg-accent/60"
+									>
+										<StatusIcon status={item.status} />
+										<span className="truncate">{item.label}</span>
+									</div>
+								))}
+							</>
 						)}
-					</>
-				)}
-				<div className="px-2.5 pb-1 pt-2">
-					<span className="text-[10.5px] font-medium tracking-wide text-muted-foreground">
-						Git
-					</span>
-				</div>
-				{gitRows.map((item) => {
-					const action = item.action;
-					const isCommitActionBusy =
-						action?.kind === "commit" &&
-						action.mode != null &&
-						commitButtonMode === action.mode &&
-						commitButtonState === "busy";
-					const isSyncActionBusy = action?.kind === "sync" && syncPending;
-					const isActionBusy = isCommitActionBusy || isSyncActionBusy;
-					return (
-						<div
-							key={item.label}
-							className="flex items-center gap-1.5 px-2.5 py-[3px] text-muted-foreground transition-colors hover:bg-accent/60"
-						>
-							<StatusIcon status={item.status} />
-							<span className="truncate">{item.label}</span>
-							{action && (
-								<button
-									type="button"
-									onClick={() => {
-										if (
-											(action.kind === "commit" && actionDisabled) ||
-											(action.kind === "sync" && syncPending)
-										) {
-											return;
-										}
-										if (action.kind === "sync") {
-											void handleSync();
-											return;
-										}
-										void onCommitAction?.(action.mode!);
-									}}
-									className="ml-auto shrink-0 cursor-pointer text-[10.5px] text-primary transition-colors hover:text-primary/80 disabled:cursor-not-allowed disabled:opacity-50"
-									disabled={
-										action.kind === "commit" ? actionDisabled : syncPending
-									}
-									aria-busy={isActionBusy ? true : undefined}
-									aria-label={
-										isActionBusy ? loadingActionLabel(action.label) : undefined
-									}
-								>
-									<span className="inline-flex items-center gap-1">
-										{isActionBusy ? (
-											<LoaderCircleIcon
-												aria-hidden="true"
-												className="size-3 animate-spin text-current opacity-70"
-												strokeWidth={2}
-											/>
-										) : null}
-										{isActionBusy ? null : action.label}
+
+						{sortedDeployments.length > 0 && (
+							<>
+								<div className="px-2.5 pb-1 pt-2.5">
+									<span className="text-[10.5px] font-medium tracking-wide text-muted-foreground">
+										Deployments
 									</span>
-								</button>
-							)}
-						</div>
-					);
-				})}
+								</div>
+								{sortedDeployments.map((item) => (
+									<ActionStatusRow key={item.id} item={item} />
+								))}
+							</>
+						)}
 
-				{reviewRows.length > 0 && (
-					<>
-						<div className="px-2.5 pb-1 pt-2.5">
-							<span className="text-[10.5px] font-medium tracking-wide text-muted-foreground">
-								Review
-							</span>
-						</div>
-						{reviewRows.map((item) => (
-							<div
-								key={item.label}
-								className="flex items-center gap-1.5 px-2.5 py-[3px] text-muted-foreground transition-colors hover:bg-accent/60"
-							>
-								<StatusIcon status={item.status} />
-								<span className="truncate">{item.label}</span>
-							</div>
-						))}
-					</>
-				)}
-
-				{sortedDeployments.length > 0 && (
-					<>
-						<div className="px-2.5 pb-1 pt-2.5">
-							<span className="text-[10.5px] font-medium tracking-wide text-muted-foreground">
-								Deployments
-							</span>
-						</div>
-						{sortedDeployments.map((item) => (
-							<ActionStatusRow key={item.id} item={item} />
-						))}
-					</>
-				)}
-
-				{sortedChecks.length > 0 && (
-					<>
-						<div className="px-2.5 pb-1 pt-2.5">
-							<span className="text-[10.5px] font-medium tracking-wide text-muted-foreground">
-								Checks
-							</span>
-						</div>
-						{sortedChecks.map((item) => (
-							<ActionStatusRow
-								key={item.id}
-								item={item}
-								onInsertToComposer={handleInsertCheck}
-							/>
-						))}
-					</>
-				)}
-				{bottomSpacerHeight > 0 && (
-					<div
-						aria-hidden="true"
-						className="shrink-0"
-						style={{ height: `${bottomSpacerHeight}px` }}
-					/>
-				)}
-			</ScrollArea>
-		</section>
+						{sortedChecks.length > 0 && (
+							<>
+								<div className="px-2.5 pb-1 pt-2.5">
+									<span className="text-[10.5px] font-medium tracking-wide text-muted-foreground">
+										Checks
+									</span>
+								</div>
+								{sortedChecks.map((item) => (
+									<ActionStatusRow
+										key={item.id}
+										item={item}
+										onInsertToComposer={handleInsertCheck}
+									/>
+								))}
+							</>
+						)}
+					</ScrollArea>
+				</div>
+			)}
+		</motion.section>
 	);
 }
 

--- a/src/features/inspector/sections/changes.tsx
+++ b/src/features/inspector/sections/changes.tsx
@@ -52,7 +52,6 @@ const STATUS_COLORS: Record<InspectorFileItem["status"], string> = {
 };
 
 type ChangesSectionProps = {
-	bodyHeight: number;
 	workspaceId: string | null;
 	workspaceRootPath: string | null;
 	workspaceTargetBranch: string | null;
@@ -70,7 +69,6 @@ type ChangesSectionProps = {
 };
 
 export function ChangesSection({
-	bodyHeight,
 	workspaceId,
 	workspaceRootPath,
 	workspaceTargetBranch,
@@ -340,8 +338,7 @@ export function ChangesSection({
 	return (
 		<section
 			aria-label="Inspector section Git"
-			className="flex min-h-0 flex-col overflow-hidden border-b border-border/60 bg-sidebar"
-			style={{ height: `${bodyHeight}px` }}
+			className="flex min-h-0 flex-1 flex-col overflow-hidden border-b border-border/60 bg-sidebar"
 		>
 			<GitSectionHeader
 				commitButtonMode={commitButtonMode}


### PR DESCRIPTION
## What changed
- Stabilized the right Inspector sidebar vertical resize behavior for the Changes, Actions, and Terminal sections.
- Added constrained panel sizing so Actions and Terminal can resize, collapse, and expand without losing their usable headers.
- Kept the Review changes helper available inside the Actions section after rebasing onto main.

## Why
The right Inspector sidebar could get into a broken lower-right layout state when the Terminal / Actions area was dragged downward. Once the panel was pushed far enough down, the Terminal header or resize handle could become inaccessible, making it impossible to pull the Terminal panel back up.

Before:

<!-- Upload the screenshot here, then replace this placeholder with the GitHub image markdown. -->
<!-- Example: ![Terminal panel stuck near the bottom of the Inspector sidebar](https://github.com/user-attachments/assets/...) -->

## Follow-up / tests
- Added unit coverage for the vertical split sizing behavior.
- Updated Inspector layout coverage.
- Ran `bun x vitest run src/components/ui/vertical-split-layout.test.ts src/features/inspector/layout.test.tsx`.
- Ran `bun run typecheck`.
