### PR TITLE
fix(inspector): restore ghost rendering for non-actionable commit button

### DIFF
--- a/.changeset/quiet-merge-ghost.md
+++ b/.changeset/quiet-merge-ghost.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Quiet down the inspector's commit button in non-actionable PR states — while mergeability is still being computed and after a PR is merged or closed — so they all share a muted ghost look instead of a faded-out solid CTA.

--- a/src/features/commit/button.test.tsx
+++ b/src/features/commit/button.test.tsx
@@ -1,0 +1,55 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { WorkspaceCommitButton } from "./button";
+
+afterEach(() => {
+	cleanup();
+});
+
+// Regression guard: 17134e3 originally rendered merged + closed as ghost
+// (transparent bg + accent border/text). 380febc accidentally flipped
+// merged to filled `#8957E5`, closed followed. Both must stay outline +
+// transparent + pure accent so they read as "settled" alongside the
+// matching PR badge / Continue button instead of as a loud filled CTA.
+describe("WorkspaceCommitButton ghost variants", () => {
+	it("renders merged as accent ghost (outline + transparent bg + pure accent)", () => {
+		render(<WorkspaceCommitButton mode="merged" state="idle" />);
+		const btn = screen.getByRole("button", { name: /merged/i });
+		expect(btn).toHaveAttribute("data-variant", "outline");
+		expect(btn.className).toContain("bg-transparent");
+		expect(btn.className).toContain(
+			"border-[var(--workspace-pr-merged-accent)]",
+		);
+		expect(btn.className).toContain("text-[var(--workspace-pr-merged-accent)]");
+	});
+
+	it("renders closed as accent ghost (outline + transparent bg + pure accent)", () => {
+		render(<WorkspaceCommitButton mode="closed" state="idle" />);
+		const btn = screen.getByRole("button", { name: /closed/i });
+		expect(btn).toHaveAttribute("data-variant", "outline");
+		expect(btn.className).toContain("bg-transparent");
+		expect(btn.className).toContain(
+			"border-[var(--workspace-pr-closed-accent)]",
+		);
+		expect(btn.className).toContain("text-[var(--workspace-pr-closed-accent)]");
+	});
+
+	it("renders merge + disabled as green ghost (mergeability computing)", () => {
+		render(<WorkspaceCommitButton mode="merge" state="disabled" />);
+		const btn = screen.getByRole("button", { name: /merge/i });
+		// Same shape as merged/closed — outline + transparent + pure accent.
+		expect(btn).toHaveAttribute("data-variant", "outline");
+		expect(btn.className).toContain("bg-transparent");
+		expect(btn.className).toContain("border-[var(--workspace-pr-open-accent)]");
+		expect(btn.className).toContain("text-[var(--workspace-pr-open-accent)]");
+	});
+
+	it("renders merge + idle as filled green CTA (actionable)", () => {
+		render(<WorkspaceCommitButton mode="merge" state="idle" />);
+		const btn = screen.getByRole("button", { name: /merge/i });
+		expect(btn).toHaveAttribute("data-variant", "default");
+		expect(btn.className).toContain("workspace-pr-open-accent");
+		// Filled CTA — no transparent bg.
+		expect(btn.className).not.toContain("bg-transparent");
+	});
+});

--- a/src/features/commit/button.tsx
+++ b/src/features/commit/button.tsx
@@ -181,31 +181,59 @@ type ActionButtonVariant = "default" | "secondary" | "outline" | "destructive";
 
 function getButtonVariant(
 	mode: WorkspaceCommitButtonMode,
+	state: CommitButtonState | undefined,
 ): ActionButtonVariant {
+	// Non-actionable states all share the "muted ghost" look (outline +
+	// transparent bg + muted accent), regardless of mode:
+	//   • merged / closed — settled ghost (PR finalized).
+	//   • merge + disabled — mergeability is still computing.
+	// Filled CTA is reserved for actively-actionable modes only.
+	if (mode === "merged" || mode === "closed") return "outline";
+	if (mode === "merge" && state === "disabled") return "outline";
 	switch (mode) {
 		case "fix":
-		case "closed":
 		case "resolve-conflicts":
 		case "merge":
-		case "merged":
 			return "default";
 		default:
 			return "outline";
 	}
 }
 
-/** Mode-specific button color overrides (layered on top of the variant). */
-function getModeClassName(mode: WorkspaceCommitButtonMode): string | undefined {
+/** Mode-specific button color overrides (layered on top of the variant).
+ *
+ * Two visual families:
+ *  - **Filled CTA** for actionable modes (fix / resolve-conflicts / merge).
+ *  - **Muted ghost** for non-actionable modes — transparent bg, muted
+ *    accent border + text. Used for both settled ghost states (merged /
+ *    closed) and the transient merge-disabled state (mergeability still
+ *    computing). Keeping these in one shape so wrapper-level opacity
+ *    tricks aren't needed.
+ */
+function getModeClassName(
+	mode: WorkspaceCommitButtonMode,
+	state: CommitButtonState | undefined,
+): string | undefined {
+	// Computing mergeability: render the merge button as a green ghost so
+	// it visually pairs with merged/closed (and the open-accent PR badge
+	// next to it) instead of a faded-out solid CTA.
+	if (mode === "merge" && state === "disabled") {
+		return "border-[var(--workspace-pr-open-accent)] bg-transparent text-[var(--workspace-pr-open-accent)] transition-[background-color,border-color,color,box-shadow,opacity] duration-300 ease-out hover:bg-transparent hover:text-[var(--workspace-pr-open-accent)]";
+	}
 	switch (mode) {
 		case "fix":
-		case "closed":
 			return "bg-clip-border bg-[var(--workspace-pr-closed-accent)] text-white transition-[background-color,border-color,color,box-shadow,opacity] duration-300 ease-out hover:bg-[var(--workspace-pr-closed-accent)]";
 		case "resolve-conflicts":
 			return "bg-clip-border bg-[var(--workspace-pr-conflicts-accent)] text-white transition-[background-color,border-color,color,box-shadow,opacity] duration-300 ease-out hover:bg-[var(--workspace-pr-conflicts-accent)]";
 		case "merge":
 			return "bg-clip-border bg-[var(--workspace-pr-open-accent)] text-white transition-[background-color,border-color,color,box-shadow,opacity] duration-300 ease-out hover:bg-[var(--workspace-pr-open-accent)]";
+		// Ghost: outline + transparent + the same pure accent the PR badge
+		// and Continue button use, so all three pieces in the bar share
+		// one color.
 		case "merged":
-			return "bg-clip-border bg-[var(--workspace-pr-merged-accent)] text-white transition-[background-color,border-color,color,box-shadow,opacity] duration-300 ease-out hover:bg-[var(--workspace-pr-merged-accent)]";
+			return "border-[var(--workspace-pr-merged-accent)] bg-transparent text-[var(--workspace-pr-merged-accent)] transition-[background-color,border-color,color,box-shadow,opacity] duration-300 ease-out hover:bg-transparent hover:text-[var(--workspace-pr-merged-accent)]";
+		case "closed":
+			return "border-[var(--workspace-pr-closed-accent)] bg-transparent text-[var(--workspace-pr-closed-accent)] transition-[background-color,border-color,color,box-shadow,opacity] duration-300 ease-out hover:bg-transparent hover:text-[var(--workspace-pr-closed-accent)]";
 		default:
 			return undefined;
 	}
@@ -262,8 +290,8 @@ export function WorkspaceCommitButton({
 	const currentState = isControlled ? state : internalState;
 	const isBusy = currentState === "busy";
 	const isGhostMode = mode === "merged" || mode === "closed";
-	const buttonVariant = getButtonVariant(mode);
-	const modeClassName = getModeClassName(mode);
+	const buttonVariant = getButtonVariant(mode, currentState);
+	const modeClassName = getModeClassName(mode, currentState);
 
 	const setState = (nextState: CommitButtonState) => {
 		onStateChange?.(nextState);


### PR DESCRIPTION
## Summary

- The commit button at the top-right of the inspector was rendering as a loud filled CTA for **merged** / **closed** PRs and while **mergeability was still computing** — making settled / waiting states visually indistinguishable from actionable ones.
- Restored the original ghost rendering (outline + transparent bg + pure accent) for these three states. Now the PR badge, Continue button, and commit button share one muted accent color, so the whole bar reads as a single "settled" unit.

## Root cause

[`380febc`](https://github.com/dohooo/helmor/commit/380febc) (PR merge/close lifecycle) accidentally flipped `merged` from `semanticButtonVars("done", "ghost")` to a filled `#8957E5`; `closed` followed the same pattern. `merge` + `state="disabled"` (mergeability `UNKNOWN`) had never gotten ghost treatment, so it inherited the filled CTA look too.

## Fix

`src/features/commit/button.tsx`:

- `getButtonVariant(mode, state)` now returns `outline` for `merged` / `closed` / `merge+disabled`.
- `getModeClassName(mode, state)` returns `border-[accent] bg-transparent text-[accent]` for the same trio. The accent matches the PR badge and Continue button so the three pieces sit in one color.

## Test plan

- [x] `bun run typecheck`
- [x] `bun x vitest run src/features/commit/button.test.tsx src/features/inspector/sections/git-section-header.test.tsx` (11 / 11)
- [x] `bun x biome check` — clean
- [x] Visual: previewed `merged` (purple) and `merge+disabled` (green) with both rendering as muted ghost matching the rest of the bar
- [ ] Sanity-check `closed` (red) variant in the inspector