### PR TITLE
fix: sync GitHub PRs after branch rename

### DIFF
--- a/.changeset/steady-branches-sync.md
+++ b/.changeset/steady-branches-sync.md
@@ -2,4 +2,4 @@
 "helmor": patch
 ---
 
-Keep existing GitHub pull requests linked after a local branch rename by resolving PR status from the branch's upstream ref.
+Keep existing GitHub pull requests and GitLab merge requests linked after a local branch rename by resolving the change-request status from the branch's upstream ref.

--- a/.changeset/steady-branches-sync.md
+++ b/.changeset/steady-branches-sync.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Keep existing GitHub pull requests linked after a local branch rename by resolving PR status from the branch's upstream ref.

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "helmor",

--- a/src-tauri/src/forge/branch.rs
+++ b/src-tauri/src/forge/branch.rs
@@ -1,0 +1,66 @@
+//! Shared helpers for resolving the branch name a forge API should query
+//! against. Both `forge::github::context` and `forge::gitlab::context`
+//! consume these so the providers stay aligned on workspaces whose local
+//! branch name differs from upstream (e.g. after `git branch -m` or
+//! `git push HEAD:refs/heads/<other>`).
+
+use crate::{git_ops, models::workspaces::WorkspaceRecord};
+
+/// Resolve the branch name to use as the forge's PR/MR head reference.
+/// Returns the upstream branch name when the workspace has a
+/// remote-tracking ref, otherwise falls back to the local branch name.
+/// Second tuple element is `true` when a remote-tracking ref was found.
+pub(in crate::forge) fn forge_head_branch_for(
+    record: &WorkspaceRecord,
+    local_branch: &str,
+) -> (String, bool) {
+    let Some(remote_tracking_ref) = workspace_remote_tracking_ref(record) else {
+        return (local_branch.to_string(), false);
+    };
+    let head_branch = remote_tracking_branch_name(&remote_tracking_ref)
+        .unwrap_or(local_branch)
+        .to_string();
+    (head_branch, true)
+}
+
+fn remote_tracking_branch_name(remote_tracking_ref: &str) -> Option<&str> {
+    remote_tracking_ref
+        .split_once('/')
+        .map(|(_, branch)| branch)
+        .filter(|branch| !branch.is_empty())
+}
+
+fn workspace_remote_tracking_ref(record: &WorkspaceRecord) -> Option<String> {
+    let Ok(workspace_dir) =
+        crate::data_dir::workspace_dir(&record.repo_name, &record.directory_name)
+    else {
+        return None;
+    };
+    if !workspace_dir.exists() {
+        return None;
+    }
+    git_ops::resolve_remote_tracking_ref(&workspace_dir, record.remote.as_deref())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn remote_tracking_branch_name_strips_remote_prefix() {
+        assert_eq!(
+            remote_tracking_branch_name("origin/feature/login"),
+            Some("feature/login"),
+        );
+    }
+
+    #[test]
+    fn remote_tracking_branch_name_returns_none_for_empty_branch() {
+        assert_eq!(remote_tracking_branch_name("origin/"), None);
+    }
+
+    #[test]
+    fn remote_tracking_branch_name_returns_none_when_no_slash() {
+        assert_eq!(remote_tracking_branch_name("origin"), None);
+    }
+}

--- a/src-tauri/src/forge/github/context.rs
+++ b/src-tauri/src/forge/github/context.rs
@@ -7,9 +7,10 @@
 
 use anyhow::{bail, Result};
 
-use crate::{git_ops, models::workspaces as workspace_models, workspace_state::WorkspaceState};
+use crate::{models::workspaces as workspace_models, workspace_state::WorkspaceState};
 
 use super::api::parse_github_remote;
+use crate::forge::branch::forge_head_branch_for;
 
 /// Snapshot of every value the GitHub backend needs once we've decided
 /// the workspace looks viable enough to query. The pre-flight in
@@ -104,7 +105,7 @@ pub(super) fn load_github_context(
         return Ok(GithubResolution::Unauthenticated);
     }
 
-    let (branch, has_remote_tracking) = pr_head_branch_for(&record, &branch);
+    let (branch, has_remote_tracking) = forge_head_branch_for(&record, &branch);
 
     Ok(GithubResolution::Ready(GithubContext {
         owner,
@@ -139,41 +140,10 @@ fn login_definitely_logged_out(login: &str) -> bool {
         .is_definitely_logged_out()
 }
 
-fn pr_head_branch_for(
-    record: &workspace_models::WorkspaceRecord,
-    local_branch: &str,
-) -> (String, bool) {
-    let Some(remote_tracking_ref) = workspace_remote_tracking_ref(record) else {
-        return (local_branch.to_string(), false);
-    };
-    let head_branch = remote_tracking_branch_name(&remote_tracking_ref)
-        .unwrap_or(local_branch)
-        .to_string();
-    (head_branch, true)
-}
-
-fn remote_tracking_branch_name(remote_tracking_ref: &str) -> Option<&str> {
-    remote_tracking_ref
-        .split_once('/')
-        .map(|(_, branch)| branch)
-        .filter(|branch| !branch.is_empty())
-}
-
-fn workspace_remote_tracking_ref(record: &workspace_models::WorkspaceRecord) -> Option<String> {
-    let Ok(workspace_dir) =
-        crate::data_dir::workspace_dir(&record.repo_name, &record.directory_name)
-    else {
-        return None;
-    };
-    if !workspace_dir.exists() {
-        return None;
-    }
-    git_ops::resolve_remote_tracking_ref(&workspace_dir, record.remote.as_deref())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::git_ops;
     use rusqlite::Connection;
 
     /// Insert a repo row with the given remote URL + optional forge_login

--- a/src-tauri/src/forge/github/context.rs
+++ b/src-tauri/src/forge/github/context.rs
@@ -1,6 +1,6 @@
 //! Resolves the per-workspace preconditions every GitHub call needs:
-//! workspace row, owner+repo from the remote URL, current branch, the
-//! bound forge account login, and whether the local branch has a
+//! workspace row, owner+repo from the remote URL, the PR head branch,
+//! the bound forge account login, and whether the local branch has a
 //! remote-tracking ref. Higher-level entry points (`mod.rs`,
 //! `pull_request`, `actions`) consume a `GithubContext` instead of
 //! re-deriving these values four times.
@@ -18,6 +18,9 @@ use super::api::parse_github_remote;
 pub(super) struct GithubContext {
     pub owner: String,
     pub name: String,
+    /// Branch name to pass as GitHub's `headRefName`. If the local
+    /// branch tracks a differently named remote branch, this is the
+    /// upstream branch name rather than the local branch name.
     pub branch: String,
     /// gh account login bound to this repo. Always non-empty (NULL
     /// rows short-circuit before a context is ever produced).
@@ -101,7 +104,7 @@ pub(super) fn load_github_context(
         return Ok(GithubResolution::Unauthenticated);
     }
 
-    let has_remote_tracking = workspace_branch_has_remote_tracking(&record);
+    let (branch, has_remote_tracking) = pr_head_branch_for(&record, &branch);
 
     Ok(GithubResolution::Ready(GithubContext {
         owner,
@@ -136,17 +139,36 @@ fn login_definitely_logged_out(login: &str) -> bool {
         .is_definitely_logged_out()
 }
 
-/// `true` when the workspace's local branch has a remote-tracking ref.
-fn workspace_branch_has_remote_tracking(record: &workspace_models::WorkspaceRecord) -> bool {
+fn pr_head_branch_for(
+    record: &workspace_models::WorkspaceRecord,
+    local_branch: &str,
+) -> (String, bool) {
+    let Some(remote_tracking_ref) = workspace_remote_tracking_ref(record) else {
+        return (local_branch.to_string(), false);
+    };
+    let head_branch = remote_tracking_branch_name(&remote_tracking_ref)
+        .unwrap_or(local_branch)
+        .to_string();
+    (head_branch, true)
+}
+
+fn remote_tracking_branch_name(remote_tracking_ref: &str) -> Option<&str> {
+    remote_tracking_ref
+        .split_once('/')
+        .map(|(_, branch)| branch)
+        .filter(|branch| !branch.is_empty())
+}
+
+fn workspace_remote_tracking_ref(record: &workspace_models::WorkspaceRecord) -> Option<String> {
     let Ok(workspace_dir) =
         crate::data_dir::workspace_dir(&record.repo_name, &record.directory_name)
     else {
-        return false;
+        return None;
     };
     if !workspace_dir.exists() {
-        return false;
+        return None;
     }
-    git_ops::resolve_remote_tracking_ref(&workspace_dir, record.remote.as_deref()).is_some()
+    git_ops::resolve_remote_tracking_ref(&workspace_dir, record.remote.as_deref())
 }
 
 #[cfg(test)]
@@ -354,6 +376,68 @@ mod tests {
         // context back so the caller can decide whether to short-circuit
         // on `has_remote_tracking`.
         assert!(!ctx.has_remote_tracking);
+    }
+
+    #[test]
+    fn uses_upstream_branch_name_when_local_branch_was_renamed() {
+        let env = crate::testkit::TestEnv::new("github-ctx-renamed-local-branch");
+        let origin = crate::testkit::GitTestRepo::init();
+        let workspace_dir = crate::data_dir::workspace_dir("Repo", "workspace-dir").unwrap();
+        std::fs::create_dir_all(workspace_dir.parent().unwrap()).unwrap();
+        git_ops::run_git(
+            [
+                "clone",
+                &origin.path().display().to_string(),
+                &workspace_dir.display().to_string(),
+            ],
+            None,
+        )
+        .unwrap();
+        git_ops::run_git(
+            ["config", "user.email", "helmor@example.com"],
+            Some(&workspace_dir),
+        )
+        .unwrap();
+        git_ops::run_git(["config", "user.name", "Helmor Test"], Some(&workspace_dir)).unwrap();
+        git_ops::run_git(
+            ["checkout", "-b", "feature/local-name"],
+            Some(&workspace_dir),
+        )
+        .unwrap();
+        git_ops::run_git(
+            [
+                "push",
+                "--set-upstream",
+                "origin",
+                "HEAD:refs/heads/feature/remote-name",
+            ],
+            Some(&workspace_dir),
+        )
+        .unwrap();
+
+        let conn = env.db_connection();
+        insert_repo(
+            &conn,
+            "r-renamed",
+            "Repo",
+            Some("git@github.com:octocat/hello-world.git"),
+            Some("octocat"),
+        );
+        insert_workspace(
+            &conn,
+            "w-renamed",
+            "r-renamed",
+            "ready",
+            Some("feature/local-name"),
+        );
+        drop(conn);
+
+        let resolution = load_github_context("w-renamed", HostAuthCheck::Skip).unwrap();
+        let GithubResolution::Ready(ctx) = resolution else {
+            panic!("expected Ready");
+        };
+        assert_eq!(ctx.branch, "feature/remote-name");
+        assert!(ctx.has_remote_tracking);
     }
 
     #[test]

--- a/src-tauri/src/forge/gitlab/context.rs
+++ b/src-tauri/src/forge/gitlab/context.rs
@@ -5,13 +5,17 @@
 
 use anyhow::{bail, Result};
 
+use crate::forge::branch::forge_head_branch_for;
 use crate::forge::remote::{parse_remote, ParsedRemote};
-use crate::models::workspaces::{self as workspace_models, WorkspaceRecord};
-use crate::{git_ops, workspace_state::WorkspaceState};
+use crate::models::workspaces as workspace_models;
+use crate::workspace_state::WorkspaceState;
 
 pub(super) struct GitlabContext {
     pub(super) remote: ParsedRemote,
     pub(super) full_path: String,
+    /// Branch name to pass as GitLab's `source_branch`. If the local
+    /// branch tracks a differently named remote branch, this is the
+    /// upstream branch name rather than the local branch name.
     pub(super) branch: String,
     pub(super) published: bool,
     /// Bound glab account. Always non-empty — `Unauthenticated`
@@ -64,7 +68,7 @@ pub(super) fn load_gitlab_context(workspace_id: &str) -> Result<GitlabResolution
         return Ok(GitlabResolution::Unauthenticated);
     };
 
-    let published = workspace_branch_has_remote_tracking(&record);
+    let (branch, published) = forge_head_branch_for(&record, &branch);
     let full_path = format!("{}/{}", remote.namespace, remote.repo);
 
     Ok(GitlabResolution::Ready(GitlabContext {
@@ -76,21 +80,10 @@ pub(super) fn load_gitlab_context(workspace_id: &str) -> Result<GitlabResolution
     }))
 }
 
-fn workspace_branch_has_remote_tracking(record: &WorkspaceRecord) -> bool {
-    let Ok(workspace_dir) =
-        crate::data_dir::workspace_dir(&record.repo_name, &record.directory_name)
-    else {
-        return false;
-    };
-    if !workspace_dir.exists() {
-        return false;
-    }
-    git_ops::resolve_remote_tracking_ref(&workspace_dir, record.remote.as_deref()).is_some()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::git_ops;
     use rusqlite::Connection;
 
     fn insert_repo(
@@ -283,5 +276,66 @@ mod tests {
     fn errors_when_workspace_does_not_exist() {
         let _env = crate::testkit::TestEnv::new("gitlab-ctx-missing");
         assert!(load_gitlab_context("does-not-exist").is_err());
+    }
+
+    #[test]
+    fn uses_upstream_branch_name_when_local_branch_was_renamed() {
+        let env = crate::testkit::TestEnv::new("gitlab-ctx-renamed-local-branch");
+        let origin = crate::testkit::GitTestRepo::init();
+        let workspace_dir = crate::data_dir::workspace_dir("Repo", "workspace-dir").unwrap();
+        std::fs::create_dir_all(workspace_dir.parent().unwrap()).unwrap();
+        git_ops::run_git(
+            [
+                "clone",
+                &origin.path().display().to_string(),
+                &workspace_dir.display().to_string(),
+            ],
+            None,
+        )
+        .unwrap();
+        git_ops::run_git(
+            ["config", "user.email", "helmor@example.com"],
+            Some(&workspace_dir),
+        )
+        .unwrap();
+        git_ops::run_git(["config", "user.name", "Helmor Test"], Some(&workspace_dir)).unwrap();
+        git_ops::run_git(
+            ["checkout", "-b", "feature/local-name"],
+            Some(&workspace_dir),
+        )
+        .unwrap();
+        git_ops::run_git(
+            [
+                "push",
+                "--set-upstream",
+                "origin",
+                "HEAD:refs/heads/feature/remote-name",
+            ],
+            Some(&workspace_dir),
+        )
+        .unwrap();
+
+        let conn = env.db_connection();
+        insert_repo(
+            &conn,
+            "r-renamed",
+            "Repo",
+            Some("git@gitlab.com:acme/repo.git"),
+            Some("alice"),
+        );
+        insert_workspace(
+            &conn,
+            "w-renamed",
+            "r-renamed",
+            "ready",
+            Some("feature/local-name"),
+        );
+        drop(conn);
+
+        let GitlabResolution::Ready(ctx) = load_gitlab_context("w-renamed").unwrap() else {
+            panic!("expected Ready");
+        };
+        assert_eq!(ctx.branch, "feature/remote-name");
+        assert!(ctx.published);
     }
 }

--- a/src-tauri/src/forge/mod.rs
+++ b/src-tauri/src/forge/mod.rs
@@ -21,6 +21,7 @@
 
 pub(crate) mod accounts;
 pub(crate) mod avatar_cache;
+mod branch;
 mod bundled;
 mod cli_status;
 mod command;


### PR DESCRIPTION
## What changed
- Resolve GitHub PR status from a branch's upstream ref when the local workspace branch has been renamed.
- Keep the existing local branch fallback when no remote-tracking ref is available.
- Add a regression test covering local and upstream branch names diverging.
- Add a patch changeset for the user-visible PR status fix.

## Why it changed
Renamed local branches could lose their link to an existing GitHub pull request because Helmor queried GitHub with the local branch name instead of the upstream branch name.

## Follow-up / test notes
- Pre-commit ran cargo fmt and cargo clippy with -D warnings successfully.
- No additional manual follow-up noted.