### PR TITLE
chore(scripts): align verify-bundled-cli with native-binary CLI layout

### DIFF
--- a/scripts/verify-bundled-cli.sh
+++ b/scripts/verify-bundled-cli.sh
@@ -42,37 +42,31 @@ echo "Bundled CLI smoke check passed."
 # users see "bad CPU type in executable" (#293).
 EXPECTED_ARCH="$(lipo -archs "${CLI_PATH}")"
 case "${EXPECTED_ARCH}" in
-  arm64)  CC_VENDOR_ARCH="arm64-darwin" ;;
-  x86_64) CC_VENDOR_ARCH="x64-darwin" ;;
+  arm64|x86_64) ;;
   *)
     echo "Unexpected helmor-cli arch '${EXPECTED_ARCH}' (want arm64 or x86_64)"
     exit 1
     ;;
 esac
 
+# claude-code + codex are now single self-contained native binaries (ripgrep
+# / audio-capture are statically embedded), so there's nothing to verify
+# under their sub-paths anymore.
 VENDOR_ROOT="${APP_BUNDLE}/Contents/Resources/vendor"
 VENDOR_BINARIES=(
   "${VENDOR_ROOT}/gh/gh"
   "${VENDOR_ROOT}/glab/glab"
-  "${VENDOR_ROOT}/bun/bun"
   "${VENDOR_ROOT}/codex/codex"
-  "${VENDOR_ROOT}/claude-code/vendor/ripgrep/${CC_VENDOR_ARCH}/rg"
-  "${VENDOR_ROOT}/claude-code/vendor/audio-capture/${CC_VENDOR_ARCH}/audio-capture.node"
+  "${VENDOR_ROOT}/claude-code/claude"
 )
 
 echo "Verifying vendor binary archs (expect ${EXPECTED_ARCH})..."
 mismatches=0
 for bin in "${VENDOR_BINARIES[@]}"; do
   if [[ ! -e "${bin}" ]]; then
-    # ripgrep / audio-capture are optional features — skip if not staged.
-    case "${bin}" in
-      *ripgrep*|*audio-capture*) continue ;;
-      *)
-        echo "  MISSING ${bin}"
-        mismatches=$((mismatches + 1))
-        continue
-        ;;
-    esac
+    echo "  MISSING ${bin}"
+    mismatches=$((mismatches + 1))
+    continue
   fi
   actual="$(lipo -archs "${bin}" 2>/dev/null || echo "?")"
   if [[ "${actual}" != "${EXPECTED_ARCH}" ]]; then


### PR DESCRIPTION
## Summary

Updates `scripts/verify-bundled-cli.sh` to match the post-native-binary vendor layout introduced in #356.

## What changed

- Drop the `arm64-darwin` / `x64-darwin` sub-path mapping — claude-code no longer ships per-arch `ripgrep` / `audio-capture` sidecars under `claude-code/vendor/...`.
- Verify the single self-contained `claude-code/claude` binary instead.
- Remove `bun/bun` from the vendor binary list (no longer staged at runtime).
- Drop the special-case "skip if missing" branch for ripgrep / audio-capture since those paths no longer exist.

## Why

After #356 both `claude-code` and `codex` are single `bun build --compile` native binaries with statically embedded helpers. The old verification script was looking for files that aren't staged anymore, so the smoke check was effectively dead code (and would warn on missing optional paths).

## Test notes

- [ ] `bun run build` + run `scripts/verify-bundled-cli.sh` against the produced `.app` to confirm all listed binaries resolve and the arch check passes for both arm64 and x64 builds.