### PR TITLE
feat(settings): mark active model with checkmark in pickers

### DIFF
--- a/.changeset/calm-pandas-wave.md
+++ b/.changeset/calm-pandas-wave.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Show a green checkmark next to the currently selected model in the Settings default-model and review-model pickers, so the active choice is obvious even when the model name is truncated.

--- a/src/features/settings/index.tsx
+++ b/src/features/settings/index.tsx
@@ -1,5 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
+	CheckCircle2,
 	ChevronDown,
 	Minus,
 	Monitor,
@@ -605,10 +606,19 @@ export const SettingsDialog = memo(function SettingsDialog({
 															onClick={() =>
 																updateSettings({ defaultModelId: m.id })
 															}
-															className="gap-2"
+															className="justify-between gap-2"
 														>
-															<ModelIcon model={m} className="size-4" />
-															{m.label}
+															<span className="flex min-w-0 items-center gap-2">
+																<ModelIcon model={m} className="size-4" />
+																{m.label}
+															</span>
+															<CheckCircle2
+																className={cn(
+																	"size-3.5 shrink-0 text-emerald-500",
+																	m.id !== settings.defaultModelId &&
+																		"invisible",
+																)}
+															/>
 														</DropdownMenuItem>
 													))}
 												</DropdownMenuContent>
@@ -713,10 +723,19 @@ export const SettingsDialog = memo(function SettingsDialog({
 																			: m.id,
 																})
 															}
-															className="gap-2"
+															className="justify-between gap-2"
 														>
-															<ModelIcon model={m} className="size-4" />
-															{m.label}
+															<span className="flex min-w-0 items-center gap-2">
+																<ModelIcon model={m} className="size-4" />
+																{m.label}
+															</span>
+															<CheckCircle2
+																className={cn(
+																	"size-3.5 shrink-0 text-emerald-500",
+																	m.id !== effectiveReviewModelId &&
+																		"invisible",
+																)}
+															/>
 														</DropdownMenuItem>
 													))}
 												</DropdownMenuContent>


### PR DESCRIPTION
## Summary

- Add a green `CheckCircle2` indicator next to the currently selected model in the Settings default-model and review-model dropdowns.
- Switch the affected `DropdownMenuItem`s to `justify-between` and wrap the icon + label in a `min-w-0` flex container so long names truncate cleanly while leaving room for the checkmark.
- Use `invisible` (rather than conditional rendering) for non-active rows so every entry has consistent vertical rhythm.

## Why

Without an explicit indicator, the active model can be hard to identify when labels are long enough to truncate — there's no visual cue distinguishing "this is the one you picked" from the rest of the list. A persistent checkmark slot makes the active choice obvious at a glance.

## Test plan

- [ ] `bun run lint`
- [ ] Open Settings → Models. Verify the active default model and active review model each show the green check; switching the selection moves the check.
- [ ] Confirm rows with long model names still align/truncate without overlap on the checkmark.