### PR TITLE
chore: rename package to helmor111222

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "helmor111",
+	"name": "helmor111222",
 	"description": "The local-first IDE for coding agent orchestration.",
 	"private": true,
 	"version": "0.12.2",


### PR DESCRIPTION
## What changed
Updated the `name` field in `package.json` from `helmor111` to `helmor111222`.

## Why
Test/iteration on the package name field; no functional change.

## Follow-up / test notes
- Pure metadata change in `package.json`.
- No code paths affected; `bun run typecheck`/`lint`/`test` not required, but safe to run.