### PR TITLE
fix(workspace): make archive cleanup robust to repeat archives and failures

### DIFF
--- a/.changeset/quiet-rivers-fold.md
+++ b/.changeset/quiet-rivers-fold.md
@@ -1,0 +1,7 @@
+---
+"helmor": patch
+---
+
+Tighten up the workspace archive flow:
+- Fix archive failing with "Directory not empty" when archiving a workspace that was just restored in the same session, by giving each trash directory a unique name instead of reusing the process-id suffix.
+- Offer "Permanently Delete" as a recovery action whenever archive fails, matching the restore-failure behavior, so a stuck cleanup never leaves the workspace unremovable until app restart.

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "helmor",

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -5,9 +5,12 @@ use std::{
     fs,
     path::{Path, PathBuf},
     process::{Command, Output, Stdio},
-    sync::mpsc,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        mpsc,
+    },
     thread,
-    time::Duration,
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use crate::error::{AnyhowCodedExt, ErrorCode};
@@ -430,14 +433,32 @@ pub fn remove_worktree(repo_root: &Path, workspace_dir: &Path) -> Result<()> {
 }
 
 /// Rename `dir` to a `.trash-*` sibling so the caller can treat it as gone.
+///
+/// The suffix combines PID + nanos + a per-process counter so we never collide
+/// with a leftover trash dir from an earlier archive in the same process (e.g.
+/// archive → restore → archive of the same workspace before the background
+/// cleanup finishes).
 fn renamed_to_trash(dir: &Path) -> Result<PathBuf> {
+    static TRASH_SEQ: AtomicU64 = AtomicU64::new(0);
+
     let parent = dir
         .parent()
         .with_context(|| format!("No parent for {}", dir.display()))?;
     let name = dir
         .file_name()
         .with_context(|| format!("No filename for {}", dir.display()))?;
-    let trash_name = format!(".trash-{}-{}", name.to_string_lossy(), std::process::id());
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let seq = TRASH_SEQ.fetch_add(1, Ordering::Relaxed);
+    let trash_name = format!(
+        ".trash-{}-{}-{}-{}",
+        name.to_string_lossy(),
+        std::process::id(),
+        nanos,
+        seq,
+    );
     let trash_dir = parent.join(&trash_name);
     fs::rename(dir, &trash_dir).with_context(|| {
         format!(

--- a/src/features/navigation/hooks/use-controller.ts
+++ b/src/features/navigation/hooks/use-controller.ts
@@ -223,6 +223,18 @@ export function useWorkspacesSidebarController({
 		[pushWorkspaceToast],
 	);
 
+	// Forward-ref so the rollback can call into the recovery toast helper that
+	// is defined below (they form a cycle: the helper depends on
+	// `handleDeleteWorkspace`, which is defined later still).
+	const pushPermanentDeleteRecoveryToastRef = useRef<
+		(
+			workspaceId: string,
+			title: string,
+			error: unknown,
+			fallbackMessage: string,
+		) => void
+	>(() => {});
+
 	const rollbackArchivedWorkspace = useCallback(
 		(workspaceId: string, error: unknown, fallbackMessage: string) => {
 			updateArchivingWorkspaceId(workspaceId, false);
@@ -242,14 +254,18 @@ export function useWorkspacesSidebarController({
 				flushSidebarLists();
 			}
 
-			pushWorkspaceErrorToast(
+			// Always offer the permanent-delete escape hatch on archive failure —
+			// matches the restore-failure path. The user already chose to drop
+			// this workspace; if cleanup hits a snag (e.g. trash-dir collision,
+			// stale worktree) they need a way out without restarting the app.
+			pushPermanentDeleteRecoveryToastRef.current(
 				workspaceId,
 				"Archive failed",
 				error,
 				fallbackMessage,
 			);
 		},
-		[flushSidebarLists, pushWorkspaceErrorToast, updateArchivingWorkspaceId],
+		[flushSidebarLists, updateArchivingWorkspaceId],
 	);
 
 	useEffect(() => {
@@ -1169,6 +1185,12 @@ export function useWorkspacesSidebarController({
 	useEffect(() => {
 		handleDeleteWorkspaceRef.current = handleDeleteWorkspace;
 	}, [handleDeleteWorkspace]);
+
+	// Keep the forward-ref used by `rollbackArchivedWorkspace` in sync.
+	useEffect(() => {
+		pushPermanentDeleteRecoveryToastRef.current =
+			pushPermanentDeleteRecoveryToast;
+	}, [pushPermanentDeleteRecoveryToast]);
 
 	const notifyBranchRename = useCallback(
 		(rename: { original: string; actual: string }) => {


### PR DESCRIPTION
## Summary

Tightens up the workspace archive flow so it survives two scenarios that currently strand a workspace until app restart:

- **Trash-dir name collision.** `renamed_to_trash` previously used `.trash-<name>-<pid>`, so archiving a workspace that had just been restored in the same session could fail with `Directory not empty` if the prior archive's background cleanup hadn't finished yet. The suffix now combines PID + nanos + a per-process atomic counter, guaranteeing uniqueness within a single Helmor process.
- **No recovery on archive failure.** The restore-failure path already offered a "Permanently Delete" toast as an escape hatch; the archive-failure path only surfaced a plain error toast. If cleanup snagged (collision, stale worktree, etc.), the user had no way out without restarting the app. Archive now uses the same recovery toast helper. A small forward-ref dance is needed because `pushPermanentDeleteRecoveryToast` is defined after `rollbackArchivedWorkspace` and itself depends on `handleDeleteWorkspace`.

## Why

Hit during normal archive → restore → archive cycles on the same workspace; the second archive failed and the only available toast action was a generic error, leaving the sidebar entry stuck.

## Notes / follow-up

- Includes a patch-level changeset (`.changeset/quiet-rivers-fold.md`).
- `bun.lock` picked up a `configVersion: 0` field from a recent bun upgrade — included so the lockfile stops re-dirtying the tree.
- Pre-commit hooks (biome, clippy, cargo fmt) all green.

## Test plan

- [ ] Archive a workspace, restore it, archive it again — confirm the second archive succeeds (no "Directory not empty").
- [ ] Force an archive failure (e.g. lock the workspace dir) and confirm the toast offers "Permanently Delete" and the action works.
- [ ] Sidebar archive count and selection reset behavior unchanged on the happy path.