### PR TITLE
Fix branch rename spacing

### DIFF
--- a/.changeset/calm-branch-renames.md
+++ b/.changeset/calm-branch-renames.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix workspace header branch renames so spaces are converted to hyphens and invalid branch names show the underlying Git error.

--- a/src/features/panel/branch-rename.test.ts
+++ b/src/features/panel/branch-rename.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { normalizeBranchRenameInput } from "./branch-rename";
+
+describe("normalizeBranchRenameInput", () => {
+	it("trims surrounding whitespace", () => {
+		expect(normalizeBranchRenameInput("  feature/foo  ")).toBe("feature/foo");
+	});
+
+	it("converts whitespace runs to hyphens", () => {
+		expect(normalizeBranchRenameInput("fix broken branch rename")).toBe(
+			"fix-broken-branch-rename",
+		);
+		expect(normalizeBranchRenameInput("fix\tbroken\nbranch")).toBe(
+			"fix-broken-branch",
+		);
+	});
+
+	it("leaves non-whitespace branch characters for git to validate", () => {
+		expect(normalizeBranchRenameInput("feature/foo_bar")).toBe(
+			"feature/foo_bar",
+		);
+	});
+});

--- a/src/features/panel/branch-rename.ts
+++ b/src/features/panel/branch-rename.ts
@@ -1,0 +1,5 @@
+const WHITESPACE_RE = /\s+/g;
+
+export function normalizeBranchRenameInput(value: string): string {
+	return value.trim().replace(WHITESPACE_RE, "-");
+}

--- a/src/features/panel/header.tsx
+++ b/src/features/panel/header.tsx
@@ -59,6 +59,7 @@ import {
 	type WorkspaceDetail,
 	type WorkspaceSessionSummary,
 } from "@/lib/api";
+import { extractError } from "@/lib/errors";
 import { initialsFor } from "@/lib/initials";
 import {
 	helmorQueryKeys,
@@ -71,6 +72,7 @@ import {
 	type WorkspaceBranchTone,
 } from "@/lib/workspace-helpers";
 import { useWorkspaceToast } from "@/lib/workspace-toast-context";
+import { normalizeBranchRenameInput } from "./branch-rename";
 import { seedNewSessionInCache } from "./session-cache";
 import { closeWorkspaceSession } from "./session-close";
 import type { SessionCloseRequest } from "./use-confirm-session-close";
@@ -188,8 +190,8 @@ export const WorkspacePanelHeader = memo(function WorkspacePanelHeader({
 		if (editingBranch === null || !workspace) {
 			return;
 		}
-		const trimmed = editingBranch.trim();
-		if (trimmed && trimmed !== workspace.branch) {
+		const normalized = normalizeBranchRenameInput(editingBranch);
+		if (normalized && normalized !== workspace.branch) {
 			const detailKey = helmorQueryKeys.workspaceDetail(workspace.id);
 			const previous = queryClient.getQueryData<WorkspaceDetail | null>(
 				detailKey,
@@ -197,21 +199,18 @@ export const WorkspacePanelHeader = memo(function WorkspacePanelHeader({
 			if (previous) {
 				queryClient.setQueryData<WorkspaceDetail | null>(detailKey, {
 					...previous,
-					branch: trimmed,
+					branch: normalized,
 				});
 			}
 			try {
-				await renameWorkspaceBranch(workspace.id, trimmed);
+				await renameWorkspaceBranch(workspace.id, normalized);
 				onWorkspaceChanged?.();
 			} catch (error: unknown) {
 				if (previous) {
 					queryClient.setQueryData<WorkspaceDetail | null>(detailKey, previous);
 				}
-				pushToast(
-					error instanceof Error ? error.message : String(error),
-					"Branch rename failed",
-					"destructive",
-				);
+				const { message } = extractError(error, "Unable to rename branch.");
+				pushToast(message, "Branch rename failed", "destructive");
 			}
 		}
 		setEditingBranch(null);


### PR DESCRIPTION
Fixes https://github.com/dohooo/helmor/issues/371

Branch renames from the workspace header now normalize whitespace to hyphens before calling Git, so names like `fix branch rename` become `fix-branch-rename` instead of failing as invalid refs.

This also preserves Helmor's structured Tauri error message in the branch rename toast, so genuinely invalid branch names still show a useful failure.