### PR TITLE
fix(sidecar): resolve claude-code bin from platform sub-package

### DIFF
--- a/.changeset/swift-claude-spawn.md
+++ b/.changeset/swift-claude-spawn.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix a dev-mode EACCES crash on first sidecar spawn when the upstream Claude Code wrapper's postinstall stub wasn't replaced (Nix sandbox, multi-worktree setups, `--ignore-scripts` installs); release builds were unaffected.

--- a/sidecar/src/claude-session-manager.ts
+++ b/sidecar/src/claude-session-manager.ts
@@ -59,19 +59,10 @@ const SLASH_COMMANDS_TIMEOUT_MS = 20_000;
 const CONTEXT_USAGE_TIMEOUT_MS = 30_000;
 
 /**
- * Resolve the path to the Claude Code native binary, passed as
- * `pathToClaudeCodeExecutable` on every SDK `query()` call.
- *
- * Resolution order:
- *   1. `HELMOR_CLAUDE_CODE_BIN_PATH` — set by the Tauri host in release
- *      builds, pointing at the bundled copy inside
- *      `Helmor.app/Contents/Resources/vendor/claude-code/claude`.
- *   2. `createRequire` lookup of the wrapper package's `bin/claude.exe`,
- *      which `@anthropic-ai/claude-code/install.cjs` populates from the
- *      platform sub-package on `bun install`. Used in dev
- *      (`bun run src/index.ts`) and `bun test`. The `.exe` suffix is
- *      Anthropic's chosen filename across all platforms — it's not a
- *      Windows-only thing.
+ * Resolve the Claude Code native binary for `pathToClaudeCodeExecutable`.
+ * Prefers `HELMOR_CLAUDE_CODE_BIN_PATH` (release), then the platform
+ * sub-package (dev/test); falls back to the wrapper bin for `--omit=optional`.
+ * Mirrors the codex resolver in `codex-app-server-manager.ts`.
  */
 function resolveClaudeBinPath(): string {
 	const override = process.env.HELMOR_CLAUDE_CODE_BIN_PATH;
@@ -79,8 +70,33 @@ function resolveClaudeBinPath(): string {
 		return override;
 	}
 	const require = createRequire(import.meta.url);
-	const pkgJson = require.resolve("@anthropic-ai/claude-code/package.json");
-	return join(dirname(pkgJson), "bin", "claude.exe");
+	const binName = process.platform === "win32" ? "claude.exe" : "claude";
+	const platformPkg = `@anthropic-ai/claude-code-${claudePlatformShort()}`;
+	try {
+		const pkgJson = require.resolve(`${platformPkg}/package.json`);
+		return join(dirname(pkgJson), binName);
+	} catch {
+		const pkgJson = require.resolve("@anthropic-ai/claude-code/package.json");
+		return join(dirname(pkgJson), "bin", "claude.exe");
+	}
+}
+
+function claudePlatformShort(): string {
+	const arch = process.arch === "x64" ? "x64" : "arm64";
+	if (process.platform === "darwin") return `darwin-${arch}`;
+	if (process.platform === "win32") return `win32-${arch}`;
+	if (process.platform === "linux") {
+		// claude-code ships separate -musl variants; glibcVersionRuntime is absent on musl.
+		const report =
+			typeof process.report?.getReport === "function"
+				? (process.report.getReport() as {
+						header?: { glibcVersionRuntime?: string };
+					})
+				: null;
+		const musl = !!report && report.header?.glibcVersionRuntime === undefined;
+		return `linux-${arch}${musl ? "-musl" : ""}`;
+	}
+	return `${process.platform}-${arch}`;
 }
 
 const CLAUDE_BIN_PATH = resolveClaudeBinPath();


### PR DESCRIPTION
## Summary

Fixes a dev-mode `EACCES` crash on first sidecar spawn when the upstream `@anthropic-ai/claude-code` wrapper's `install.cjs` postinstall hook never ran (Nix sandbox, multi-worktree setups, `--ignore-scripts` installs). In those environments the wrapper's `bin/claude.exe` is left as the unexecutable JS stub, so spawning it via `pathToClaudeCodeExecutable` blows up.

## What changed

- `resolveClaudeBinPath()` in `sidecar/src/claude-session-manager.ts` now resolves the real native binary directly from the platform sub-package (`@anthropic-ai/claude-code-${platform}-${arch}`), mirroring how the codex resolver works.
- Falls back to the wrapper's `bin/claude.exe` when the platform sub-package isn't installed (e.g. `npm install --omit=optional`).
- Linux musl detection via `process.report.getReport().header.glibcVersionRuntime` so we pick up `linux-${arch}-musl` builds correctly.
- Trims the multi-paragraph comment down to a focused note + pointer to the codex resolver.
- Adds a patch-level changeset.

## Why

Release builds were unaffected because the Tauri host already sets `HELMOR_CLAUDE_CODE_BIN_PATH` to the bundled binary inside `Helmor.app/Contents/Resources/vendor/claude-code/`. Dev/test was the only path that depended on the wrapper's postinstall stub being replaced — and that's flaky in any sandboxed install. Going straight to the platform package skips that race entirely.

## Test plan

- [ ] `bun run dev` from a fresh `bun install` — first prompt streams without `EACCES`.
- [ ] `bun run test:sidecar` still green.
- [ ] Verify resolver still returns the wrapper bin when the platform sub-package is missing (simulate with `--omit=optional`).
- [ ] Sanity-check release build still uses `HELMOR_CLAUDE_CODE_BIN_PATH`.