### PR TITLE
fix(repos): reject local-only repositories with a clear error

### DIFF
--- a/.changeset/clear-local-only-repo-error.md
+++ b/.changeset/clear-local-only-repo-error.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Show a clear "Local-only repositories are not supported." message when adding a Git repository that has no remote configured.

--- a/src-tauri/src/models/repos.rs
+++ b/src-tauri/src/models/repos.rs
@@ -968,6 +968,9 @@ pub fn resolve_repository_from_local_path(folder_path: &str) -> Result<ResolvedR
         })?;
 
     let remote = resolve_repository_remote(normalized_root)?;
+    if remote.is_none() {
+        bail!("Local-only repositories are not supported.");
+    }
     let remote_url = match remote.as_deref() {
         Some(remote_name) => Some(resolve_repository_remote_url(normalized_root, remote_name)?),
         None => None,


### PR DESCRIPTION
## Summary

- When adding a Git repository whose working tree has no remote configured, surface a clear `Local-only repositories are not supported.` error instead of silently proceeding with `remote_url = None`.
- Adds a changeset entry describing the user-facing behavior.

## Why

`resolve_repository_from_local_path` previously allowed a `None` remote to flow through, which produced opaque downstream failures (e.g. provider detection / branch sync) for users who pointed Helmor at a folder that wasn't pushed to a remote yet. Bailing early at the resolve step gives the user an actionable message.

## Test plan

- [ ] Try adding a freshly `git init`'d folder with no remote — confirm the dialog shows `Local-only repositories are not supported.`
- [ ] Add a normal repo with an `origin` remote — confirm it still resolves and binds as before.
- [ ] `cd src-tauri && cargo clippy --all-targets -- -D warnings`