### PR TITLE
fix(sidecar): pass macOS proxy settings to Codex

### DIFF
--- a/.changeset/steady-codex-proxies.md
+++ b/.changeset/steady-codex-proxies.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix repeated Codex reconnect attempts on macOS proxy setups by passing system proxy settings through to Helmor's embedded Codex app-server.

--- a/sidecar/src/codex-app-server.test.ts
+++ b/sidecar/src/codex-app-server.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "bun:test";
+import {
+	applyMacSystemProxySettings,
+	buildCodexAppServerArgs,
+} from "./codex-app-server.js";
+
+describe("buildCodexAppServerArgs", () => {
+	test("disables Codex native notifications without disabling websocket transport", () => {
+		expect(buildCodexAppServerArgs()).toEqual([
+			"app-server",
+			"-c",
+			"notify=[]",
+		]);
+	});
+});
+
+describe("applyMacSystemProxySettings", () => {
+	test("fills proxy env from enabled macOS system proxy settings", () => {
+		const env: NodeJS.ProcessEnv = {};
+
+		applyMacSystemProxySettings(
+			env,
+			`
+<dictionary> {
+  HTTPEnable : 1
+  HTTPPort : 7890
+  HTTPProxy : 127.0.0.1
+  HTTPSEnable : 1
+  HTTPSPort : 7890
+  HTTPSProxy : 127.0.0.1
+  SOCKSEnable : 1
+  SOCKSPort : 7890
+  SOCKSProxy : 127.0.0.1
+}
+`,
+		);
+
+		expect(env.HTTP_PROXY).toBe("http://127.0.0.1:7890");
+		expect(env.HTTPS_PROXY).toBe("http://127.0.0.1:7890");
+		expect(env.ALL_PROXY).toBe("socks5://127.0.0.1:7890");
+	});
+
+	test("fills no_proxy from macOS proxy exceptions", () => {
+		const env: NodeJS.ProcessEnv = {};
+
+		applyMacSystemProxySettings(
+			env,
+			`
+<dictionary> {
+  ExceptionsList : <array> {
+    0 : 127.0.0.1
+    1 : localhost
+    2 : *.local
+  }
+  HTTPEnable : 1
+  HTTPPort : 7890
+  HTTPProxy : 127.0.0.1
+}
+`,
+		);
+
+		expect(env.NO_PROXY).toBe("127.0.0.1,localhost,.local");
+	});
+
+	test("preserves explicit proxy env values", () => {
+		const env: NodeJS.ProcessEnv = {
+			HTTPS_PROXY: "http://proxy.example:8080",
+		};
+
+		applyMacSystemProxySettings(
+			env,
+			`
+<dictionary> {
+  HTTPSEnable : 1
+  HTTPSPort : 7890
+  HTTPSProxy : 127.0.0.1
+}
+`,
+		);
+
+		expect(env.HTTPS_PROXY).toBe("http://proxy.example:8080");
+	});
+
+	test("fills missing proxy env values when another proxy env already exists", () => {
+		const env: NodeJS.ProcessEnv = {
+			HTTP_PROXY: "http://proxy.example:8080",
+		};
+
+		applyMacSystemProxySettings(
+			env,
+			`
+<dictionary> {
+  HTTPEnable : 1
+  HTTPPort : 7890
+  HTTPProxy : 127.0.0.1
+  HTTPSEnable : 1
+  HTTPSPort : 7890
+  HTTPSProxy : 127.0.0.1
+}
+`,
+		);
+
+		expect(env.HTTP_PROXY).toBe("http://proxy.example:8080");
+		expect(env.HTTPS_PROXY).toBe("http://127.0.0.1:7890");
+	});
+
+	test("preserves explicit no_proxy env values", () => {
+		const env: NodeJS.ProcessEnv = {
+			NO_PROXY: "metadata.google.internal",
+		};
+
+		applyMacSystemProxySettings(
+			env,
+			`
+<dictionary> {
+  ExceptionsList : <array> {
+    0 : 127.0.0.1
+  }
+}
+`,
+		);
+
+		expect(env.NO_PROXY).toBe("metadata.google.internal");
+	});
+});

--- a/sidecar/src/codex-app-server.ts
+++ b/sidecar/src/codex-app-server.ts
@@ -6,7 +6,11 @@
  * plumbing and notification/request callbacks.
  */
 
-import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import {
+	type ChildProcessWithoutNullStreams,
+	execFileSync,
+	spawn,
+} from "node:child_process";
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import readline from "node:readline";
@@ -100,7 +104,116 @@ function buildCodexEnv(binaryPath: string): NodeJS.ProcessEnv {
 		const sep = process.platform === "win32" ? ";" : ":";
 		env.PATH = `${pathDir}${sep}${env.PATH ?? ""}`;
 	}
+	applyMacSystemProxyEnv(env);
 	return env;
+}
+
+function applyMacSystemProxyEnv(env: NodeJS.ProcessEnv): void {
+	if (process.platform !== "darwin") return;
+
+	try {
+		applyMacSystemProxySettings(
+			env,
+			execFileSync("/usr/sbin/scutil", ["--proxy"], {
+				encoding: "utf8",
+				timeout: 1_000,
+				stdio: ["ignore", "pipe", "ignore"],
+			}),
+		);
+	} catch (err) {
+		logger.debug("failed to read macOS proxy settings for Codex", {
+			err: String(err),
+		});
+	}
+}
+
+export function applyMacSystemProxySettings(
+	env: NodeJS.ProcessEnv,
+	settings: string,
+): void {
+	const values = parseMacProxySettings(settings);
+	const httpProxy = buildProxyUrl(
+		"http",
+		values.HTTPEnable,
+		values.HTTPProxy,
+		values.HTTPPort,
+	);
+	const httpsProxy = buildProxyUrl(
+		"http",
+		values.HTTPSEnable,
+		values.HTTPSProxy,
+		values.HTTPSPort,
+	);
+	const socksProxy = buildProxyUrl(
+		"socks5",
+		values.SOCKSEnable,
+		values.SOCKSProxy,
+		values.SOCKSPort,
+	);
+	const noProxy = buildNoProxy(values.ExceptionsList);
+
+	if (httpProxy && !hasAnyEnv(env, ["HTTP_PROXY", "http_proxy"])) {
+		env.HTTP_PROXY = httpProxy;
+	}
+	if (httpsProxy && !hasAnyEnv(env, ["HTTPS_PROXY", "https_proxy"])) {
+		env.HTTPS_PROXY = httpsProxy;
+	}
+	if (socksProxy && !hasAnyEnv(env, ["ALL_PROXY", "all_proxy"])) {
+		env.ALL_PROXY = socksProxy;
+	}
+	if (noProxy && !hasAnyEnv(env, ["NO_PROXY", "no_proxy"])) {
+		env.NO_PROXY = noProxy;
+	}
+}
+
+function parseMacProxySettings(
+	settings: string,
+): Record<string, string | string[]> {
+	const values: Record<string, string | string[]> = {};
+	const exceptions: string[] = [];
+	for (const line of settings.split(/\r?\n/)) {
+		const exceptionMatch = line.match(/^\s*\d+\s*:\s*(.+?)\s*$/);
+		if (exceptionMatch?.[1]) {
+			exceptions.push(exceptionMatch[1]);
+			continue;
+		}
+
+		const match = line.match(
+			/^\s*([A-Za-z]+(?:Enable|Proxy|Port))\s*:\s*(.+?)\s*$/,
+		);
+		if (match?.[1] && match[2]) {
+			values[match[1]] = match[2];
+		}
+	}
+	if (exceptions.length > 0) values.ExceptionsList = exceptions;
+	return values;
+}
+
+function buildProxyUrl(
+	scheme: "http" | "socks5",
+	enabled: string | string[] | undefined,
+	host: string | string[] | undefined,
+	port: string | string[] | undefined,
+): string | undefined {
+	if (enabled !== "1" || typeof host !== "string" || typeof port !== "string") {
+		return undefined;
+	}
+	return `${scheme}://${host}:${port}`;
+}
+
+function buildNoProxy(
+	exceptions: string | string[] | undefined,
+): string | undefined {
+	if (!Array.isArray(exceptions)) return undefined;
+	const noProxy = exceptions
+		.map((entry) => entry.trim())
+		.filter(Boolean)
+		.map((entry) => (entry.startsWith("*.") ? entry.slice(1) : entry));
+	return noProxy.length > 0 ? noProxy.join(",") : undefined;
+}
+
+function hasAnyEnv(env: NodeJS.ProcessEnv, keys: string[]): boolean {
+	return keys.some((key) => Boolean(env[key]));
 }
 
 export class CodexAppServer {


### PR DESCRIPTION
## What changed
- Pass enabled macOS system HTTP, HTTPS, SOCKS, and proxy exception settings into Helmor's embedded Codex app-server environment.
- Preserve explicitly configured proxy environment variables instead of overwriting them.
- Add sidecar tests for Codex app-server args and macOS proxy parsing, plus a patch changeset.

## Why it changed
Codex app-server could repeatedly reconnect on macOS setups that rely on system proxy settings because the spawned sidecar process did not inherit those proxy values.
<img width="644" height="252" alt="CleanShot 2026-05-04 at 17 35 42@2x" src="https://github.com/user-attachments/assets/ebb17a1b-eb89-4df2-a2db-9fef3a51e52a" />


## Follow-up / test notes
- Ran `cd sidecar && bun test src/codex-app-server.test.ts`.
- `git push -u origin HEAD` failed with 403 for `dohooo/helmor`, so the branch was pushed to the writable fork remote and this PR uses the explicit fork head.