### PR TITLE
feat(inspector): persist panel layout preferences across restarts

### DIFF
--- a/src/features/inspector/hooks/use-inspector.ts
+++ b/src/features/inspector/hooks/use-inspector.ts
@@ -10,7 +10,19 @@ import {
 import { loadRepoScripts, type RepoScripts } from "@/lib/api";
 import type { InspectorFileItem } from "@/lib/editor-session";
 import { workspaceChangesQueryOptions } from "@/lib/query-client";
-import { INSPECTOR_SECTION_HEADER_HEIGHT } from "../layout";
+import {
+	getInitialActionsOpen,
+	getInitialActiveTab,
+	getInitialChangesHeight,
+	getInitialTabsHeight,
+	getInitialTabsOpen,
+	INSPECTOR_ACTIONS_OPEN_STORAGE_KEY,
+	INSPECTOR_ACTIVE_TAB_STORAGE_KEY,
+	INSPECTOR_CHANGES_HEIGHT_STORAGE_KEY,
+	INSPECTOR_SECTION_HEADER_HEIGHT,
+	INSPECTOR_TABS_HEIGHT_STORAGE_KEY,
+	INSPECTOR_TABS_OPEN_STORAGE_KEY,
+} from "../layout";
 import { getScriptState, startScript, stopScript } from "../script-store";
 
 // Inspector layout model
@@ -111,14 +123,17 @@ export function useWorkspaceInspectorSidebar({
 	workspaceId,
 	repoId,
 }: UseWorkspaceInspectorSidebarArgs) {
-	const [actionsOpen, setActionsOpen] = useState(true);
-	const [tabsOpen, setTabsOpen] = useState(false);
-	const [activeTab, setActiveTab] = useState("setup");
+	const [actionsOpen, setActionsOpen] = useState(getInitialActionsOpen);
+	const [tabsOpen, setTabsOpen] = useState(getInitialTabsOpen);
+	const [activeTab, setActiveTab] = useState(getInitialActiveTab);
 
 	const [containerHeight, setContainerHeight] = useState(0);
-	const [storedChangesBody, setStoredChangesBody] =
-		useState(DEFAULT_CHANGES_BODY);
-	const [storedTabsBody, setStoredTabsBody] = useState(DEFAULT_TABS_BODY);
+	const [storedChangesBody, setStoredChangesBody] = useState(() =>
+		getInitialChangesHeight(DEFAULT_CHANGES_BODY),
+	);
+	const [storedTabsBody, setStoredTabsBody] = useState(() =>
+		getInitialTabsHeight(DEFAULT_TABS_BODY),
+	);
 	const [resizeState, setResizeState] = useState<ResizeState | null>(null);
 
 	const containerRef = useRef<HTMLDivElement>(null);
@@ -163,6 +178,73 @@ export function useWorkspaceInspectorSidebar({
 			}),
 		[bodyBudget, actionsOpen, tabsOpen, storedChangesBody, storedTabsBody],
 	);
+
+	useEffect(() => {
+		try {
+			window.localStorage.setItem(
+				INSPECTOR_ACTIONS_OPEN_STORAGE_KEY,
+				String(actionsOpen),
+			);
+		} catch (error) {
+			console.error(
+				`[helmor] actions open save failed for "${INSPECTOR_ACTIONS_OPEN_STORAGE_KEY}"`,
+				error,
+			);
+		}
+	}, [actionsOpen]);
+
+	useEffect(() => {
+		try {
+			window.localStorage.setItem(
+				INSPECTOR_TABS_OPEN_STORAGE_KEY,
+				String(tabsOpen),
+			);
+		} catch (error) {
+			console.error(
+				`[helmor] tabs open save failed for "${INSPECTOR_TABS_OPEN_STORAGE_KEY}"`,
+				error,
+			);
+		}
+	}, [tabsOpen]);
+
+	useEffect(() => {
+		try {
+			window.localStorage.setItem(INSPECTOR_ACTIVE_TAB_STORAGE_KEY, activeTab);
+		} catch (error) {
+			console.error(
+				`[helmor] active tab save failed for "${INSPECTOR_ACTIVE_TAB_STORAGE_KEY}"`,
+				error,
+			);
+		}
+	}, [activeTab]);
+
+	useEffect(() => {
+		try {
+			window.localStorage.setItem(
+				INSPECTOR_CHANGES_HEIGHT_STORAGE_KEY,
+				String(storedChangesBody),
+			);
+		} catch (error) {
+			console.error(
+				`[helmor] changes height save failed for "${INSPECTOR_CHANGES_HEIGHT_STORAGE_KEY}"`,
+				error,
+			);
+		}
+	}, [storedChangesBody]);
+
+	useEffect(() => {
+		try {
+			window.localStorage.setItem(
+				INSPECTOR_TABS_HEIGHT_STORAGE_KEY,
+				String(storedTabsBody),
+			);
+		} catch (error) {
+			console.error(
+				`[helmor] tabs height save failed for "${INSPECTOR_TABS_HEIGHT_STORAGE_KEY}"`,
+				error,
+			);
+		}
+	}, [storedTabsBody]);
 
 	const repoScriptsQuery = useQuery({
 		queryKey: ["repoScripts", repoId, workspaceId],

--- a/src/features/inspector/layout.tsx
+++ b/src/features/inspector/layout.tsx
@@ -55,6 +55,92 @@ export const TABS_BLUR_HOLD_UNTIL_MS = TABS_HOVER_TRANSITION_MS - 50;
 export const INSPECTOR_SECTION_HEADER_HEIGHT = 33;
 const TABS_WRAPPER_COLLAPSED_MIN_HEIGHT_PX = INSPECTOR_SECTION_HEADER_HEIGHT;
 
+// Inspector layout persistence
+export const INSPECTOR_ACTIONS_OPEN_STORAGE_KEY =
+	"helmor.workspaceInspectorActionsOpen";
+export const INSPECTOR_TABS_OPEN_STORAGE_KEY =
+	"helmor.workspaceInspectorTabsOpen";
+export const INSPECTOR_ACTIVE_TAB_STORAGE_KEY =
+	"helmor.workspaceInspectorActiveTab";
+export const INSPECTOR_CHANGES_HEIGHT_STORAGE_KEY =
+	"helmor.workspaceInspectorChangesHeight";
+export const INSPECTOR_TABS_HEIGHT_STORAGE_KEY =
+	"helmor.workspaceInspectorTabsHeight";
+
+export function getInitialActionsOpen(): boolean {
+	if (typeof window === "undefined") {
+		return true; // default: Actions open
+	}
+	try {
+		const stored = window.localStorage.getItem(
+			INSPECTOR_ACTIONS_OPEN_STORAGE_KEY,
+		);
+		if (!stored) return true;
+		return stored === "true";
+	} catch {
+		return true;
+	}
+}
+
+export function getInitialTabsOpen(): boolean {
+	if (typeof window === "undefined") {
+		return false; // default: Tabs collapsed
+	}
+	try {
+		const stored = window.localStorage.getItem(INSPECTOR_TABS_OPEN_STORAGE_KEY);
+		if (!stored) return false;
+		return stored === "true";
+	} catch {
+		return false;
+	}
+}
+
+export function getInitialActiveTab(): string {
+	if (typeof window === "undefined") {
+		return "setup";
+	}
+	try {
+		const stored = window.localStorage.getItem(
+			INSPECTOR_ACTIVE_TAB_STORAGE_KEY,
+		);
+		return stored || "setup";
+	} catch {
+		return "setup";
+	}
+}
+
+export function getInitialChangesHeight(defaultHeight: number): number {
+	if (typeof window === "undefined") {
+		return defaultHeight;
+	}
+	try {
+		const stored = window.localStorage.getItem(
+			INSPECTOR_CHANGES_HEIGHT_STORAGE_KEY,
+		);
+		if (!stored) return defaultHeight;
+		const parsed = Number.parseInt(stored, 10);
+		return Number.isFinite(parsed) ? parsed : defaultHeight;
+	} catch {
+		return defaultHeight;
+	}
+}
+
+export function getInitialTabsHeight(defaultHeight: number): number {
+	if (typeof window === "undefined") {
+		return defaultHeight;
+	}
+	try {
+		const stored = window.localStorage.getItem(
+			INSPECTOR_TABS_HEIGHT_STORAGE_KEY,
+		);
+		if (!stored) return defaultHeight;
+		const parsed = Number.parseInt(stored, 10);
+		return Number.isFinite(parsed) ? parsed : defaultHeight;
+	} catch {
+		return defaultHeight;
+	}
+}
+
 export const INSPECTOR_SECTION_HEADER_CLASS =
 	"flex h-8 min-w-0 shrink-0 items-center justify-between border-b border-border/60 bg-muted/25 px-3";
 export const INSPECTOR_SECTION_TITLE_CLASS =


### PR DESCRIPTION
Add localStorage persistence for right-hand inspector panel configuration:
- Panel heights (Changes and Tabs sections)
- Open/collapsed states (Actions and Tabs sections)
- Active tab selection (Setup/Run/Terminal)

Implementation follows existing patterns from shell/layout.ts and use-panels.ts:
- Storage keys use helmor.workspaceInspector* namespace
- getInitial*() helpers handle reads with fallbacks
- useEffect hooks persist changes with error handling

Defaults are preserved for users without saved preferences. Invalid terminal IDs fall back to "setup" via existing validation logic.

Fixes #378