### PR TITLE
feat(inspector): add right-click context menu to Changes section files

### DIFF
--- a/.changeset/changes-section-context-menu.md
+++ b/.changeset/changes-section-context-menu.md
@@ -1,0 +1,5 @@
+---
+"helmor": minor
+---
+
+Right-click a file in the inspector's Changes section to reveal it in Finder, copy its absolute path, copy its relative path, or copy its remote file URL on GitHub/GitLab/Bitbucket.

--- a/src-tauri/src/commands/system_commands.rs
+++ b/src-tauri/src/commands/system_commands.rs
@@ -883,6 +883,25 @@ pub async fn show_image_in_finder(path: String) -> CmdResult<()> {
 }
 
 #[tauri::command]
+pub async fn reveal_path_in_finder(path: String) -> CmdResult<()> {
+    run_blocking(move || {
+        let source = std::path::PathBuf::from(&path);
+        if source.exists() {
+            return reveal_file_in_finder(&source).context("Failed to reveal in Finder");
+        }
+        // File may have been deleted (e.g. a `D` change). Fall back to the
+        // closest existing ancestor so the user still gets a useful Finder
+        // window pointed at the right area of the workspace.
+        if let Some(parent) = source.ancestors().skip(1).find(|p| p.exists()) {
+            return open_directory_in_finder(parent)
+                .context("Failed to open parent directory in Finder");
+        }
+        Err(anyhow::anyhow!("Path not found: {}", source.display()))
+    })
+    .await
+}
+
+#[tauri::command]
 pub async fn copy_image_to_clipboard(path: String) -> CmdResult<()> {
     run_blocking(move || {
         let source = std::path::PathBuf::from(path);
@@ -910,6 +929,20 @@ fn reveal_file_in_finder(path: &std::path::Path) -> anyhow::Result<()> {
 #[cfg(not(target_os = "macos"))]
 fn reveal_file_in_finder(_path: &std::path::Path) -> anyhow::Result<()> {
     anyhow::bail!("Showing images in Finder is only supported on macOS")
+}
+
+#[cfg(target_os = "macos")]
+fn open_directory_in_finder(path: &std::path::Path) -> anyhow::Result<()> {
+    std::process::Command::new("open")
+        .arg(path)
+        .spawn()
+        .map(|_| ())
+        .context("open command failed")
+}
+
+#[cfg(not(target_os = "macos"))]
+fn open_directory_in_finder(_path: &std::path::Path) -> anyhow::Result<()> {
+    anyhow::bail!("Opening Finder is only supported on macOS")
 }
 
 #[cfg(target_os = "macos")]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -337,6 +337,7 @@ pub fn run() {
             commands::conductor_commands::import_conductor_workspaces,
             commands::system_commands::save_pasted_image,
             commands::system_commands::show_image_in_finder,
+            commands::system_commands::reveal_path_in_finder,
             commands::system_commands::copy_image_to_clipboard,
             commands::system_commands::request_quit,
             commands::system_commands::dev_reset_all_data,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2572,6 +2572,9 @@ function AppShell({
 												workspaceRemote={
 													selectedWorkspaceDetailQuery.data?.remote ?? null
 												}
+												workspaceRemoteUrl={
+													selectedWorkspaceDetailQuery.data?.remoteUrl ?? null
+												}
 												workspaceTargetBranch={(() => {
 													const d = selectedWorkspaceDetailQuery.data;
 													const target =

--- a/src/features/inspector/index.tsx
+++ b/src/features/inspector/index.tsx
@@ -37,6 +37,7 @@ type WorkspaceInspectorSidebarProps = {
 	workspaceBranch?: string | null;
 	workspaceTargetBranch?: string | null;
 	workspaceRemote?: string | null;
+	workspaceRemoteUrl?: string | null;
 	workspaceState?: string | null;
 	editorMode: boolean;
 	activeEditorPath?: string | null;
@@ -66,8 +67,10 @@ type WorkspaceInspectorSidebarProps = {
 export function WorkspaceInspectorSidebar({
 	workspaceId,
 	workspaceRootPath,
+	workspaceBranch,
 	workspaceTargetBranch,
 	workspaceRemote,
+	workspaceRemoteUrl,
 	workspaceState,
 	repoId,
 	editorMode,
@@ -381,6 +384,8 @@ export function WorkspaceInspectorSidebar({
 			<ChangesSection
 				workspaceId={workspaceId ?? null}
 				workspaceRootPath={workspaceRootPath ?? null}
+				workspaceBranch={workspaceBranch ?? null}
+				workspaceRemoteUrl={workspaceRemoteUrl ?? null}
 				workspaceTargetBranch={workspaceTargetBranch ?? null}
 				changes={changes}
 				editorMode={editorMode}

--- a/src/features/inspector/sections/changes.tsx
+++ b/src/features/inspector/sections/changes.tsx
@@ -7,7 +7,10 @@ import {
 import {
 	ChevronRightIcon,
 	CloudIcon,
+	CopyIcon,
+	FolderOpenIcon,
 	LaptopIcon,
+	LinkIcon,
 	ListIcon,
 	ListTreeIcon,
 	LoaderCircleIcon,
@@ -17,9 +20,17 @@ import {
 } from "lucide-react";
 import { motion, useReducedMotion } from "motion/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
 import { AnimatedShinyText } from "@/components/ui/animated-shiny-text";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+	ContextMenu,
+	ContextMenuContent,
+	ContextMenuItem,
+	ContextMenuSeparator,
+	ContextMenuTrigger,
+} from "@/components/ui/context-menu";
 import { NumberTicker } from "@/components/ui/number-ticker";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import type {
@@ -31,6 +42,7 @@ import {
 	continueWorkspaceFromTargetBranch,
 	discardWorkspaceFile,
 	type ForgeDetection,
+	revealPathInFinder,
 	stageWorkspaceFile,
 	unstageWorkspaceFile,
 } from "@/lib/api";
@@ -41,6 +53,7 @@ import {
 	workspaceForgeActionStatusQueryOptions,
 	workspaceForgeQueryOptions,
 } from "@/lib/query-client";
+import { buildRemoteFileUrl } from "@/lib/remote-file-url";
 import { cn } from "@/lib/utils";
 import { showWorkspaceBrokenToast } from "@/lib/workspace-broken-toast";
 import { useWorkspaceToast } from "@/lib/workspace-toast-context";
@@ -60,6 +73,8 @@ const STATUS_COLORS: Record<InspectorFileItem["status"], string> = {
 type ChangesSectionProps = {
 	workspaceId: string | null;
 	workspaceRootPath: string | null;
+	workspaceBranch: string | null;
+	workspaceRemoteUrl: string | null;
 	workspaceTargetBranch: string | null;
 	changes: InspectorFileItem[];
 	editorMode: boolean;
@@ -81,6 +96,8 @@ type ChangesSectionProps = {
 export function ChangesSection({
 	workspaceId,
 	workspaceRootPath,
+	workspaceBranch,
+	workspaceRemoteUrl,
 	workspaceTargetBranch,
 	changes,
 	editorMode,
@@ -401,6 +418,8 @@ export function ChangesSection({
 								activeEditorPath={activeEditorPath}
 								onOpenEditorFile={onOpenEditorFile}
 								flashingPaths={flashingPaths}
+								workspaceBranch={workspaceBranch}
+								workspaceRemoteUrl={workspaceRemoteUrl}
 							/>
 						)}
 						{unstagedChanges.length > 0 && (
@@ -426,6 +445,8 @@ export function ChangesSection({
 								activeEditorPath={activeEditorPath}
 								onOpenEditorFile={onOpenEditorFile}
 								flashingPaths={flashingPaths}
+								workspaceBranch={workspaceBranch}
+								workspaceRemoteUrl={workspaceRemoteUrl}
 							/>
 						)}
 					</>
@@ -445,6 +466,8 @@ export function ChangesSection({
 						activeEditorPath={activeEditorPath}
 						onOpenEditorFile={onOpenEditorFile}
 						flashingPaths={flashingPaths}
+						workspaceBranch={workspaceBranch}
+						workspaceRemoteUrl={workspaceRemoteUrl}
 					/>
 				)}
 
@@ -477,6 +500,8 @@ function ChangesGroup({
 	activeEditorPath,
 	onOpenEditorFile,
 	flashingPaths,
+	workspaceBranch,
+	workspaceRemoteUrl,
 }: {
 	label: string;
 	icon?: React.ReactNode;
@@ -494,6 +519,8 @@ function ChangesGroup({
 	activeEditorPath?: string | null;
 	onOpenEditorFile: (path: string, options?: DiffOpenOptions) => void;
 	flashingPaths: Set<string>;
+	workspaceBranch: string | null;
+	workspaceRemoteUrl: string | null;
 }) {
 	return (
 		<div>
@@ -552,6 +579,8 @@ function ChangesGroup({
 							action={action}
 							onStageAction={onStageAction}
 							onDiscard={onDiscard}
+							workspaceBranch={workspaceBranch}
+							workspaceRemoteUrl={workspaceRemoteUrl}
 						/>
 					) : (
 						<ChangesFlatView
@@ -563,6 +592,8 @@ function ChangesGroup({
 							action={action}
 							onStageAction={onStageAction}
 							onDiscard={onDiscard}
+							workspaceBranch={workspaceBranch}
+							workspaceRemoteUrl={workspaceRemoteUrl}
 						/>
 					)}
 				</div>
@@ -584,6 +615,8 @@ function BranchDiffSection({
 	activeEditorPath,
 	onOpenEditorFile,
 	flashingPaths,
+	workspaceBranch,
+	workspaceRemoteUrl,
 }: {
 	targetBranch: string | null;
 	count: number;
@@ -597,6 +630,8 @@ function BranchDiffSection({
 	activeEditorPath?: string | null;
 	onOpenEditorFile: (path: string, options?: DiffOpenOptions) => void;
 	flashingPaths: Set<string>;
+	workspaceBranch: string | null;
+	workspaceRemoteUrl: string | null;
 }) {
 	const handleOpenFile = useCallback(
 		(path: string, options?: DiffOpenOptions) => {
@@ -664,6 +699,8 @@ function BranchDiffSection({
 							activeEditorPath={activeEditorPath}
 							onOpenEditorFile={handleOpenFile}
 							flashingPaths={flashingPaths}
+							workspaceBranch={workspaceBranch}
+							workspaceRemoteUrl={workspaceRemoteUrl}
 						/>
 					) : (
 						<ChangesFlatView
@@ -672,6 +709,8 @@ function BranchDiffSection({
 							activeEditorPath={activeEditorPath}
 							onOpenEditorFile={handleOpenFile}
 							flashingPaths={flashingPaths}
+							workspaceBranch={workspaceBranch}
+							workspaceRemoteUrl={workspaceRemoteUrl}
 						/>
 					)}
 				</div>
@@ -724,6 +763,8 @@ function ChangesTreeView({
 	action,
 	onStageAction,
 	onDiscard,
+	workspaceBranch,
+	workspaceRemoteUrl,
 }: {
 	changes: InspectorFileItem[];
 	editorMode: boolean;
@@ -733,6 +774,8 @@ function ChangesTreeView({
 	action?: StageActionKind;
 	onStageAction?: (path: string) => void;
 	onDiscard?: (path: string) => void;
+	workspaceBranch: string | null;
+	workspaceRemoteUrl: string | null;
 }) {
 	const tree = buildTree(changes);
 	const [expanded, setExpanded] = useState<Set<string>>(
@@ -765,6 +808,8 @@ function ChangesTreeView({
 				action={action}
 				onStageAction={onStageAction}
 				onDiscard={onDiscard}
+				workspaceBranch={workspaceBranch}
+				workspaceRemoteUrl={workspaceRemoteUrl}
 			/>
 		</div>
 	);
@@ -793,6 +838,8 @@ function TreeNodeList({
 	action,
 	onStageAction,
 	onDiscard,
+	workspaceBranch,
+	workspaceRemoteUrl,
 }: {
 	nodes: Map<string, ReturnType<typeof buildTree>>;
 	expanded: Set<string>;
@@ -805,6 +852,8 @@ function TreeNodeList({
 	action?: StageActionKind;
 	onStageAction?: (path: string) => void;
 	onDiscard?: (path: string) => void;
+	workspaceBranch: string | null;
+	workspaceRemoteUrl: string | null;
 }) {
 	const sorted = [...nodes.values()].sort((left, right) => {
 		const leftIsFolder = left.children.size > 0 && !left.file;
@@ -864,6 +913,8 @@ function TreeNodeList({
 									action={action}
 									onStageAction={onStageAction}
 									onDiscard={onDiscard}
+									workspaceBranch={workspaceBranch}
+									workspaceRemoteUrl={workspaceRemoteUrl}
 								/>
 							)}
 						</div>
@@ -874,9 +925,8 @@ function TreeNodeList({
 				const selected = file?.absolutePath === activeEditorPath;
 				const isFlashing = !!file && flashingPaths.has(file.path);
 
-				return (
+				const row = (
 					<div
-						key={node.path}
 						className={cn(
 							"group/row flex cursor-pointer items-center gap-1 py-[1.5px] pr-2 text-muted-foreground transition-colors hover:bg-accent/60",
 							selected &&
@@ -918,6 +968,22 @@ function TreeNodeList({
 						)}
 					</div>
 				);
+
+				return (
+					<div key={node.path}>
+						{file ? (
+							<FileRowContextMenu
+								file={file}
+								workspaceBranch={workspaceBranch}
+								workspaceRemoteUrl={workspaceRemoteUrl}
+							>
+								{row}
+							</FileRowContextMenu>
+						) : (
+							row
+						)}
+					</div>
+				);
 			})}
 		</>
 	);
@@ -932,6 +998,8 @@ function ChangesFlatView({
 	action,
 	onStageAction,
 	onDiscard,
+	workspaceBranch,
+	workspaceRemoteUrl,
 }: {
 	changes: InspectorFileItem[];
 	editorMode: boolean;
@@ -941,6 +1009,8 @@ function ChangesFlatView({
 	action?: StageActionKind;
 	onStageAction?: (path: string) => void;
 	onDiscard?: (path: string) => void;
+	workspaceBranch: string | null;
+	workspaceRemoteUrl: string | null;
 }) {
 	const hasStage = !!action && !!onStageAction;
 	const hasDiscard = !!onDiscard;
@@ -949,79 +1019,85 @@ function ChangesFlatView({
 	return (
 		<div className="py-0.5">
 			{changes.map((change) => (
-				<div
+				<FileRowContextMenu
 					key={change.path}
-					className={cn(
-						"group/row flex cursor-pointer items-center gap-1.5 py-[1.5px] pl-2 pr-2 text-muted-foreground transition-colors hover:bg-accent/60",
-						change.absolutePath === activeEditorPath &&
-							(editorMode
-								? "bg-accent text-foreground"
-								: "bg-muted/60 text-foreground"),
-					)}
-					role="button"
-					tabIndex={0}
-					onClick={() =>
-						onOpenEditorFile(change.absolutePath, {
-							fileStatus: change.status,
-						})
-					}
-					onKeyDown={(event) => {
-						if (event.key === "Enter" || event.key === " ") {
-							event.preventDefault();
+					file={change}
+					workspaceBranch={workspaceBranch}
+					workspaceRemoteUrl={workspaceRemoteUrl}
+				>
+					<div
+						className={cn(
+							"group/row flex cursor-pointer items-center gap-1.5 py-[1.5px] pl-2 pr-2 text-muted-foreground transition-colors hover:bg-accent/60",
+							change.absolutePath === activeEditorPath &&
+								(editorMode
+									? "bg-accent text-foreground"
+									: "bg-muted/60 text-foreground"),
+						)}
+						role="button"
+						tabIndex={0}
+						onClick={() =>
 							onOpenEditorFile(change.absolutePath, {
 								fileStatus: change.status,
-							});
+							})
 						}
-					}}
-				>
-					<img
-						src={getMaterialFileIcon(change.name)}
-						alt=""
-						className="size-4 shrink-0"
-					/>
-					<span className="min-w-0 max-w-[60%] truncate">
-						<ShinyFlash active={flashingPaths.has(change.path)}>
-							{change.name}
-						</ShinyFlash>
-					</span>
-					<span
-						className={cn(
-							"min-w-0 flex-1 truncate text-right text-[10px] text-muted-foreground",
-							hasAction && "group-hover/row:hidden",
-						)}
+						onKeyDown={(event) => {
+							if (event.key === "Enter" || event.key === " ") {
+								event.preventDefault();
+								onOpenEditorFile(change.absolutePath, {
+									fileStatus: change.status,
+								});
+							}
+						}}
 					>
-						{change.path.includes("/")
-							? change.path.slice(0, change.path.lastIndexOf("/"))
-							: ""}
-					</span>
-					<span
-						className={cn(
-							"flex shrink-0 items-center gap-1 tabular-nums",
-							hasAction && "group-hover/row:hidden",
-						)}
-					>
-						<LineStats
-							insertions={change.insertions}
-							deletions={change.deletions}
+						<img
+							src={getMaterialFileIcon(change.name)}
+							alt=""
+							className="size-4 shrink-0"
 						/>
+						<span className="min-w-0 max-w-[60%] truncate">
+							<ShinyFlash active={flashingPaths.has(change.path)}>
+								{change.name}
+							</ShinyFlash>
+						</span>
 						<span
 							className={cn(
-								"inline-flex h-4 w-4 items-center justify-center text-[10px] font-semibold",
-								STATUS_COLORS[change.status],
+								"min-w-0 flex-1 truncate text-right text-[10px] text-muted-foreground",
+								hasAction && "group-hover/row:hidden",
 							)}
 						>
-							{change.status}
+							{change.path.includes("/")
+								? change.path.slice(0, change.path.lastIndexOf("/"))
+								: ""}
 						</span>
-					</span>
-					{hasAction && (
-						<RowHoverActions
-							path={change.path}
-							action={action}
-							onStageAction={onStageAction}
-							onDiscard={onDiscard}
-						/>
-					)}
-				</div>
+						<span
+							className={cn(
+								"flex shrink-0 items-center gap-1 tabular-nums",
+								hasAction && "group-hover/row:hidden",
+							)}
+						>
+							<LineStats
+								insertions={change.insertions}
+								deletions={change.deletions}
+							/>
+							<span
+								className={cn(
+									"inline-flex h-4 w-4 items-center justify-center text-[10px] font-semibold",
+									STATUS_COLORS[change.status],
+								)}
+							>
+								{change.status}
+							</span>
+						</span>
+						{hasAction && (
+							<RowHoverActions
+								path={change.path}
+								action={action}
+								onStageAction={onStageAction}
+								onDiscard={onDiscard}
+							/>
+						)}
+					</div>
+				</FileRowContextMenu>
 			))}
 		</div>
 	);
@@ -1165,6 +1241,83 @@ function ViewToggleButton({
 				<ListTreeIcon className="size-3.5" strokeWidth={1.8} />
 			)}
 		</RowIconButton>
+	);
+}
+
+async function copyToClipboard(value: string, label: string) {
+	try {
+		await navigator.clipboard.writeText(value);
+		toast.success(`${label} copied`, { description: value, duration: 2000 });
+	} catch {
+		toast.error(`Failed to copy ${label.toLowerCase()}`);
+	}
+}
+
+function FileRowContextMenu({
+	file,
+	workspaceBranch,
+	workspaceRemoteUrl,
+	children,
+}: {
+	file: InspectorFileItem;
+	workspaceBranch: string | null;
+	workspaceRemoteUrl: string | null;
+	children: React.ReactNode;
+}) {
+	const remoteFileUrl = useMemo(
+		() => buildRemoteFileUrl(workspaceRemoteUrl, workspaceBranch, file.path),
+		[file.path, workspaceBranch, workspaceRemoteUrl],
+	);
+
+	const handleReveal = useCallback(async () => {
+		try {
+			await revealPathInFinder(file.absolutePath);
+		} catch (error) {
+			const message =
+				error instanceof Error ? error.message : "Failed to reveal in Finder";
+			toast.error(message);
+		}
+	}, [file.absolutePath]);
+
+	const handleCopyAbsolute = useCallback(
+		() => copyToClipboard(file.absolutePath, "Path"),
+		[file.absolutePath],
+	);
+	const handleCopyRelative = useCallback(
+		() => copyToClipboard(file.path, "Relative path"),
+		[file.path],
+	);
+	const handleCopyRemoteUrl = useCallback(() => {
+		if (!remoteFileUrl) return;
+		void copyToClipboard(remoteFileUrl, "Remote file URL");
+	}, [remoteFileUrl]);
+
+	return (
+		<ContextMenu>
+			<ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
+			<ContextMenuContent className="min-w-52">
+				<ContextMenuItem onClick={() => void handleReveal()}>
+					<FolderOpenIcon />
+					<span>Reveal in Finder</span>
+				</ContextMenuItem>
+				<ContextMenuSeparator />
+				<ContextMenuItem onClick={handleCopyAbsolute}>
+					<CopyIcon />
+					<span>Copy Path</span>
+				</ContextMenuItem>
+				<ContextMenuItem onClick={handleCopyRelative}>
+					<CopyIcon />
+					<span>Copy Relative Path</span>
+				</ContextMenuItem>
+				<ContextMenuItem
+					onClick={handleCopyRemoteUrl}
+					disabled={!remoteFileUrl}
+				>
+					<LinkIcon />
+					<span>Copy Remote File URL</span>
+				</ContextMenuItem>
+			</ContextMenuContent>
+		</ContextMenu>
 	);
 }
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2088,6 +2088,10 @@ export async function showImageInFinder(path: string): Promise<void> {
 	await invoke("show_image_in_finder", { path });
 }
 
+export async function revealPathInFinder(path: string): Promise<void> {
+	await invoke("reveal_path_in_finder", { path });
+}
+
 export async function copyImageToClipboard(path: string): Promise<void> {
 	await invoke("copy_image_to_clipboard", { path });
 }

--- a/src/lib/remote-file-url.ts
+++ b/src/lib/remote-file-url.ts
@@ -1,0 +1,66 @@
+type ParsedRemote = {
+	host: string;
+	namespace: string;
+	repo: string;
+};
+
+function parseRemote(remote: string): ParsedRemote | null {
+	const trimmed = remote.trim();
+	if (!trimmed) return null;
+
+	let host: string;
+	let path: string;
+
+	const sshMatch = trimmed.match(/^(?:git@)?([^/:@]+):(.+)$/);
+	if (sshMatch && !trimmed.includes("://")) {
+		host = sshMatch[1];
+		path = sshMatch[2];
+	} else {
+		const schemeMatch = trimmed.match(
+			/^[a-z]+:\/\/(?:[^@/]+@)?([^/]+)\/(.+)$/i,
+		);
+		if (!schemeMatch) return null;
+		host = schemeMatch[1];
+		path = schemeMatch[2];
+	}
+
+	const cleaned = path.replace(/\/+$/, "").replace(/\.git$/i, "");
+	const lastSlash = cleaned.lastIndexOf("/");
+	if (lastSlash <= 0) return null;
+	const namespace = cleaned.slice(0, lastSlash);
+	const repo = cleaned.slice(lastSlash + 1);
+	if (!namespace || !repo) return null;
+
+	return { host: host.toLowerCase(), namespace, repo };
+}
+
+function encodePath(path: string): string {
+	return path
+		.split("/")
+		.map((segment) => encodeURIComponent(segment))
+		.join("/");
+}
+
+export function buildRemoteFileUrl(
+	remoteUrl: string | null | undefined,
+	branch: string | null | undefined,
+	relativePath: string,
+): string | null {
+	if (!remoteUrl || !branch || !relativePath) return null;
+	const parsed = parseRemote(remoteUrl);
+	if (!parsed) return null;
+
+	const { host, namespace, repo } = parsed;
+	const ref = encodeURIComponent(branch);
+	const file = encodePath(relativePath);
+	const base = `https://${host}/${namespace}/${repo}`;
+
+	if (host.includes("bitbucket.")) {
+		return `${base}/src/${ref}/${file}`;
+	}
+	if (host.includes("gitlab")) {
+		return `${base}/-/blob/${ref}/${file}`;
+	}
+	// Default to GitHub-style (covers github.com and GitHub Enterprise hosts).
+	return `${base}/blob/${ref}/${file}`;
+}


### PR DESCRIPTION
## Summary
- Right-click a file in the inspector's **Changes / Staged Changes / Remote** sections to access a context menu with **Reveal in Finder**, **Copy Path**, **Copy Relative Path**, and **Copy Remote File URL**.
- New Rust command `reveal_path_in_finder` (`open -R`) that falls back to the closest existing ancestor directory when the file was deleted.
- New `buildRemoteFileUrl` helper in `src/lib/remote-file-url.ts` parses SSH/HTTPS git remotes and emits `blob/` URLs for GitHub, `/-/blob/` for GitLab, and `/src/` for Bitbucket. The menu item is disabled when the remote / branch can't be resolved.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint` (biome + clippy with `-D warnings`)
- [x] `bun run test:frontend` — 824/824 pass
- [x] Manual: right-click on tree-view rows in Changes / Staged Changes / Remote, verify each menu item works (toast shows copied value, Finder reveals)
- [x] Manual: right-click on flat-view rows, same checks
- [x] Manual: deleted file (`D` status) — Reveal in Finder should still open the closest existing parent
- [x] Manual: workspace with no remote — Copy Remote File URL is disabled


https://github.com/user-attachments/assets/96ca0789-111e-4cdb-a960-85efa892112d




