### PR TITLE
fix(sidecar): auto-enable codex goals feature before /goal turns

### DIFF
--- a/.changeset/auto-enable-codex-goals.md
+++ b/.changeset/auto-enable-codex-goals.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix `/goal` silently failing when Codex's experimental goals feature is disabled.

--- a/sidecar/src/codex-app-server-manager.ts
+++ b/sidecar/src/codex-app-server-manager.ts
@@ -16,6 +16,7 @@ import {
 	type JsonRpcNotification,
 	type JsonRpcRequest,
 } from "./codex-app-server.js";
+import { ensureCodexGoalsFeatureEnabled } from "./codex-config.js";
 import { buildCodexStoredMeta } from "./context-usage.js";
 import type { SidecarEmitter } from "./emitter.js";
 import { resolveGitAccessDirectories } from "./git-access.js";
@@ -384,10 +385,22 @@ export class CodexAppServerManager implements SessionManager {
 			promptLen: prompt.length,
 		});
 
+		// `/goal` needs `[features] goals = true` in `~/.codex/config.toml`.
+		// Codex reads its config once at startup, so the pre-flight runs
+		// before `ensureContext` and recycles any stale process.
+		const goalCommand = parseGoalCommand(prompt);
+		let effectiveResume = resume;
+		if (goalCommand) {
+			effectiveResume = await this.ensureCodexGoalsReady(
+				sessionId,
+				effectiveResume,
+			);
+		}
+
 		const ctx = await this.ensureContext(
 			sessionId,
 			workDir,
-			resume,
+			effectiveResume,
 			model,
 			permissionMode,
 			effectiveFastMode,
@@ -407,7 +420,6 @@ export class CodexAppServerManager implements SessionManager {
 			prompt,
 			resolvedAdditionalDirectories,
 		);
-		const goalCommand = parseGoalCommand(prompt);
 		const isCompactCommand = !goalCommand && prompt.trim() === "/compact";
 		const input = buildTurnInput(promptWithContext, images);
 		const turnStartParams: Record<string, unknown> = {
@@ -916,6 +928,51 @@ export class CodexAppServerManager implements SessionManager {
 				...errorDetails(err),
 			});
 		}
+	}
+
+	// ── ensureCodexGoalsReady ────────────────────────────────────────────
+
+	// Writes `[features] goals = true` if missing, then recycles any stale
+	// codex process so the new config takes effect. Returns a resume thread
+	// id (caller's wins; otherwise the stale ctx's). Best-effort — IO
+	// failures are logged and the caller falls through to codex's own error.
+	private async ensureCodexGoalsReady(
+		sessionId: string,
+		callerResume: string | undefined,
+	): Promise<string | undefined> {
+		let result: Awaited<ReturnType<typeof ensureCodexGoalsFeatureEnabled>>;
+		try {
+			result = await ensureCodexGoalsFeatureEnabled();
+		} catch (err) {
+			logger.error("ensureCodexGoalsFeatureEnabled failed", errorDetails(err));
+			return callerResume;
+		}
+		if (result.kind !== "modified") return callerResume;
+
+		const stale = this.sessions.get(sessionId);
+		if (!stale) {
+			logger.info("Enabled codex goals feature", {
+				sessionId,
+				path: result.path,
+			});
+			return callerResume;
+		}
+
+		logger.info("Enabled codex goals feature; recycling stale session", {
+			sessionId,
+			path: result.path,
+			providerThreadId: stale.providerThreadId ?? "(none)",
+		});
+		const reuseThread = stale.providerThreadId ?? undefined;
+		stale.server.kill();
+		this.sessions.delete(sessionId);
+		for (const [id, p] of this.pendingApprovals) {
+			if (p.sessionId === sessionId) this.pendingApprovals.delete(id);
+		}
+		for (const [id, p] of this.pendingUserInputs) {
+			if (p.sessionId === sessionId) this.pendingUserInputs.delete(id);
+		}
+		return callerResume ?? reuseThread;
 	}
 
 	// ── stopSession / shutdown ───────────────────────────────────────────

--- a/sidecar/src/codex-config.test.ts
+++ b/sidecar/src/codex-config.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from "bun:test";
+import { readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	ensureCodexGoalsFeatureEnabled,
+	injectGoalsFeature,
+} from "./codex-config.js";
+
+describe("injectGoalsFeature", () => {
+	test("creates a fresh file body when content is null", () => {
+		expect(injectGoalsFeature(null)).toBe("[features]\ngoals = true\n");
+	});
+
+	test("creates a fresh file body when content is empty", () => {
+		expect(injectGoalsFeature("")).toBe("[features]\ngoals = true\n");
+	});
+
+	test("returns null when goals = true is already present", () => {
+		const input = "[features]\ngoals = true\n";
+		expect(injectGoalsFeature(input)).toBeNull();
+	});
+
+	test("returns null when goals = true sits among other feature flags", () => {
+		const input = "[features]\nmcp = true\ngoals = true\nother = false\n";
+		expect(injectGoalsFeature(input)).toBeNull();
+	});
+
+	test("appends [features] section with a blank-line separator", () => {
+		const input = "[other]\nfoo = 1\n";
+		const out = injectGoalsFeature(input);
+		expect(out).toBe("[other]\nfoo = 1\n\n[features]\ngoals = true\n");
+	});
+
+	test("appends [features] section when file lacks trailing newline", () => {
+		const input = "[other]\nfoo = 1";
+		const out = injectGoalsFeature(input);
+		expect(out).toBe("[other]\nfoo = 1\n\n[features]\ngoals = true\n");
+	});
+
+	test("inserts goals key under existing [features] section", () => {
+		const input = "[features]\nmcp = true\n\n[other]\nfoo = 1\n";
+		const out = injectGoalsFeature(input);
+		expect(out).toBe(
+			"[features]\ngoals = true\nmcp = true\n\n[other]\nfoo = 1\n",
+		);
+	});
+
+	test("inserts goals key when [features] is the only section", () => {
+		const input = "[features]\nmcp = true\n";
+		const out = injectGoalsFeature(input);
+		expect(out).toBe("[features]\ngoals = true\nmcp = true\n");
+	});
+
+	test("flips goals = false to true in place", () => {
+		const input = "[features]\ngoals = false\nmcp = true\n";
+		const out = injectGoalsFeature(input);
+		expect(out).toBe("[features]\ngoals = true\nmcp = true\n");
+	});
+
+	test("ignores `goals` keys inside other sections", () => {
+		const input = "[other]\ngoals = true\n\n[features]\nmcp = true\n";
+		const out = injectGoalsFeature(input);
+		expect(out).toBe(
+			"[other]\ngoals = true\n\n[features]\ngoals = true\nmcp = true\n",
+		);
+	});
+
+	test("treats subtables like [features.something] as ending the section", () => {
+		const input = "[features]\n[features.experimental]\nfoo = 1\n";
+		const out = injectGoalsFeature(input);
+		expect(out).toBe(
+			"[features]\ngoals = true\n[features.experimental]\nfoo = 1\n",
+		);
+	});
+
+	test("preserves CRLF line endings", () => {
+		const input = "[other]\r\nfoo = 1\r\n";
+		const out = injectGoalsFeature(input);
+		expect(out).toBe(
+			"[other]\r\nfoo = 1\r\n\r\n[features]\r\ngoals = true\r\n",
+		);
+	});
+
+	test("preserves comments inside [features]", () => {
+		const input = "[features]\n# experimental knobs\nmcp = true\n";
+		const out = injectGoalsFeature(input);
+		expect(out).toBe(
+			"[features]\ngoals = true\n# experimental knobs\nmcp = true\n",
+		);
+	});
+});
+
+describe("ensureCodexGoalsFeatureEnabled", () => {
+	test("creates the config file when missing", async () => {
+		const dir = await mkTmpDir();
+		const path = join(dir, "config.toml");
+		const result = await ensureCodexGoalsFeatureEnabled(path);
+		expect(result).toEqual({ kind: "modified", path });
+		expect(await readFile(path, "utf8")).toBe("[features]\ngoals = true\n");
+	});
+
+	test("flips an existing disabled flag", async () => {
+		const dir = await mkTmpDir();
+		const path = join(dir, "config.toml");
+		await writeFile(path, "[features]\ngoals = false\n", "utf8");
+		const result = await ensureCodexGoalsFeatureEnabled(path);
+		expect(result).toEqual({ kind: "modified", path });
+		expect(await readFile(path, "utf8")).toBe("[features]\ngoals = true\n");
+	});
+
+	test("reports alreadyEnabled when config is correct", async () => {
+		const dir = await mkTmpDir();
+		const path = join(dir, "config.toml");
+		await writeFile(path, "[features]\ngoals = true\n", "utf8");
+		const result = await ensureCodexGoalsFeatureEnabled(path);
+		expect(result).toEqual({ kind: "alreadyEnabled", path });
+	});
+});
+
+async function mkTmpDir(): Promise<string> {
+	const { mkdtemp } = await import("node:fs/promises");
+	return mkdtemp(join(tmpdir(), "helmor-codex-config-"));
+}

--- a/sidecar/src/codex-config.ts
+++ b/sidecar/src/codex-config.ts
@@ -1,0 +1,88 @@
+// Edits `~/.codex/config.toml` to flip on the experimental `goals` feature.
+// `thread/goal/set` errors with "goals feature is disabled" when the flag
+// is missing.
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+export type EnableGoalsResult =
+	| { kind: "alreadyEnabled"; path: string }
+	| { kind: "modified"; path: string };
+
+export function codexConfigPath(): string {
+	const override = process.env.CODEX_HOME?.trim();
+	const home =
+		override && override.length > 0 ? override : join(homedir(), ".codex");
+	return join(home, "config.toml");
+}
+
+export async function ensureCodexGoalsFeatureEnabled(
+	path: string = codexConfigPath(),
+): Promise<EnableGoalsResult> {
+	let original: string | null = null;
+	try {
+		original = await readFile(path, "utf8");
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") throw err;
+	}
+
+	const updated = injectGoalsFeature(original);
+	if (updated === null) {
+		return { kind: "alreadyEnabled", path };
+	}
+
+	await mkdir(dirname(path), { recursive: true });
+	await writeFile(path, updated, "utf8");
+	return { kind: "modified", path };
+}
+
+// Line-based mutator: only touches the `goals` key under the top-level
+// `[features]` table. Returns null when no rewrite is needed. Inline-table
+// (`features = { goals = true }`) and dotted-key (`features.goals = true`)
+// forms aren't detected — codex's error path implies neither is set.
+export function injectGoalsFeature(content: string | null): string | null {
+	if (content === null || content === "") {
+		return "[features]\ngoals = true\n";
+	}
+
+	const eol = content.includes("\r\n") ? "\r\n" : "\n";
+	const lines = content.split(/\r?\n/);
+
+	let featuresStart = -1;
+	for (let i = 0; i < lines.length; i++) {
+		if ((lines[i] ?? "").trim() === "[features]") {
+			featuresStart = i;
+			break;
+		}
+	}
+
+	if (featuresStart === -1) {
+		const trailingNewline = /\r?\n$/.test(content);
+		const sep = trailingNewline ? "" : eol;
+		const blank = content.length === 0 ? "" : eol;
+		return `${content}${sep}${blank}[features]${eol}goals = true${eol}`;
+	}
+
+	let goalsLine = -1;
+	for (let i = featuresStart + 1; i < lines.length; i++) {
+		const trimmed = (lines[i] ?? "").trim();
+		if (trimmed.startsWith("[") && trimmed.endsWith("]")) break;
+		const keyMatch = trimmed.match(/^([A-Za-z0-9_-]+)\s*=/);
+		if (keyMatch && keyMatch[1] === "goals") {
+			goalsLine = i;
+			break;
+		}
+	}
+
+	if (goalsLine !== -1) {
+		const existing = lines[goalsLine] ?? "";
+		const value = existing.split("=").slice(1).join("=").trim();
+		if (value === "true") return null;
+		lines[goalsLine] = "goals = true";
+		return lines.join(eol);
+	}
+
+	lines.splice(featuresStart + 1, 0, "goals = true");
+	return lines.join(eol);
+}

--- a/sidecar/test/codex-app-server-manager.test.ts
+++ b/sidecar/test/codex-app-server-manager.test.ts
@@ -20,9 +20,17 @@ const serverState = {
 	 *  `turn/started` and `turn/completed` (e.g. `thread/tokenUsage/updated`). */
 	beforeTurnCompleted: null as null | (() => void),
 	exitAfterTurnStarted: false,
+	instances: [] as MockCodexAppServer[],
 };
 const gitAccessState = {
 	directories: [] as string[],
+};
+const codexConfigState = {
+	result: {
+		kind: "alreadyEnabled" as "alreadyEnabled" | "modified",
+		path: "/fake/.codex/config.toml",
+	},
+	calls: 0,
 };
 
 class MockCodexAppServer {
@@ -32,6 +40,7 @@ class MockCodexAppServer {
 		onExit: (code: number | null, signal: string | null) => void;
 	}) {
 		serverState.onExit = opts.onExit;
+		serverState.instances.push(this);
 	}
 
 	async sendRequest(method: string, params: unknown): Promise<unknown> {
@@ -40,6 +49,25 @@ class MockCodexAppServer {
 		if (method === "initialize") return {};
 		if (method === "thread/start") {
 			return { thread: { id: "thread-1" } };
+		}
+		if (method === "thread/resume") {
+			const threadId =
+				(params as { threadId?: string } | undefined)?.threadId ??
+				"thread-resumed";
+			return { thread: { id: threadId } };
+		}
+		if (method === "thread/goal/set") {
+			queueMicrotask(() => {
+				serverState.onNotification?.({
+					method: "turn/started",
+					params: { turn: { id: "turn-goal-1" } },
+				});
+				serverState.onNotification?.({
+					method: "turn/completed",
+					params: { turn: { id: "turn-goal-1" } },
+				});
+			});
+			return {};
 		}
 		if (method === "turn/start") {
 			queueMicrotask(() => {
@@ -89,6 +117,14 @@ mock.module("../src/git-access.js", () => ({
 	resolveGitAccessDirectories: async () => [...gitAccessState.directories],
 }));
 
+mock.module("../src/codex-config.js", () => ({
+	ensureCodexGoalsFeatureEnabled: async () => {
+		codexConfigState.calls += 1;
+		return { ...codexConfigState.result };
+	},
+	codexConfigPath: () => codexConfigState.result.path,
+}));
+
 const { CodexAppServerManager } = await import(
 	"../src/codex-app-server-manager.js"
 );
@@ -102,7 +138,13 @@ describe("CodexAppServerManager", () => {
 		serverState.onExit = null;
 		serverState.beforeTurnCompleted = null;
 		serverState.exitAfterTurnStarted = false;
+		serverState.instances = [];
 		gitAccessState.directories = [];
+		codexConfigState.result = {
+			kind: "alreadyEnabled",
+			path: "/fake/.codex/config.toml",
+		};
+		codexConfigState.calls = 0;
 		emitter = createSidecarEmitter(() => {});
 	});
 
@@ -657,5 +699,202 @@ describe("parseGoalCommand", () => {
 			kind: "set",
 			objective: "clear",
 		});
+	});
+});
+
+describe("CodexAppServerManager goal pre-flight", () => {
+	let emitter: SidecarEmitter;
+
+	beforeEach(() => {
+		serverState.requests = [];
+		serverState.onNotification = null;
+		serverState.onExit = null;
+		serverState.beforeTurnCompleted = null;
+		serverState.exitAfterTurnStarted = false;
+		serverState.instances = [];
+		gitAccessState.directories = [];
+		codexConfigState.result = {
+			kind: "alreadyEnabled",
+			path: "/fake/.codex/config.toml",
+		};
+		codexConfigState.calls = 0;
+		emitter = createSidecarEmitter(() => {});
+	});
+
+	test("/goal pre-flight: no-op when codex config already enables goals", async () => {
+		const manager = new CodexAppServerManager();
+		codexConfigState.result = {
+			kind: "alreadyEnabled",
+			path: "/fake/.codex/config.toml",
+		};
+
+		await manager.sendMessage(
+			"REQ-goal-noop",
+			{
+				sessionId: "s-goal-noop",
+				prompt: "/goal review the diff",
+				model: "gpt-5.4",
+				cwd: "/tmp",
+				resume: undefined,
+				permissionMode: undefined,
+				effortLevel: "medium",
+				fastMode: false,
+				images: [],
+			},
+			emitter,
+		);
+
+		expect(codexConfigState.calls).toBe(1);
+		expect(serverState.instances).toHaveLength(1);
+		expect(serverState.instances[0]?.killed).toBe(false);
+		const goalSet = serverState.requests.find(
+			(r) => r.method === "thread/goal/set",
+		);
+		expect(goalSet?.params).toMatchObject({
+			threadId: "thread-1",
+			objective: "review the diff",
+		});
+	});
+
+	test("/goal pre-flight: recycles stale codex and resumes its thread when toml had to be modified", async () => {
+		const manager = new CodexAppServerManager();
+
+		// Seed a session so a stale ctx exists for the recycle.
+		codexConfigState.result = {
+			kind: "alreadyEnabled",
+			path: "/fake/.codex/config.toml",
+		};
+		await manager.sendMessage(
+			"REQ-seed",
+			{
+				sessionId: "s-goal-recycle",
+				prompt: "warm-up",
+				model: "gpt-5.4",
+				cwd: "/tmp",
+				resume: undefined,
+				permissionMode: undefined,
+				effortLevel: "medium",
+				fastMode: false,
+				images: [],
+			},
+			emitter,
+		);
+		expect(serverState.instances).toHaveLength(1);
+		const stale = serverState.instances[0];
+
+		// Pretend the helper had to flip the flag.
+		codexConfigState.result = {
+			kind: "modified",
+			path: "/fake/.codex/config.toml",
+		};
+		serverState.requests = [];
+
+		await manager.sendMessage(
+			"REQ-goal-recycle",
+			{
+				sessionId: "s-goal-recycle",
+				prompt: "/goal say hi",
+				model: "gpt-5.4",
+				cwd: "/tmp",
+				// No caller resume → pre-flight reuses the stale thread.
+				resume: undefined,
+				permissionMode: undefined,
+				effortLevel: "medium",
+				fastMode: false,
+				images: [],
+			},
+			emitter,
+		);
+
+		expect(stale?.killed).toBe(true);
+		expect(serverState.instances).toHaveLength(2);
+		expect(serverState.instances[1]?.killed).toBe(false);
+
+		const resume = serverState.requests.find(
+			(r) => r.method === "thread/resume",
+		);
+		expect(resume?.params).toMatchObject({ threadId: "thread-1" });
+
+		const goalSet = serverState.requests.find(
+			(r) => r.method === "thread/goal/set",
+		);
+		expect(goalSet?.params).toMatchObject({
+			threadId: "thread-1",
+			objective: "say hi",
+		});
+	});
+
+	test("/goal pre-flight: caller-provided resume wins over stale providerThreadId", async () => {
+		const manager = new CodexAppServerManager();
+
+		codexConfigState.result = {
+			kind: "alreadyEnabled",
+			path: "/fake/.codex/config.toml",
+		};
+		await manager.sendMessage(
+			"REQ-seed-2",
+			{
+				sessionId: "s-goal-explicit",
+				prompt: "warm-up",
+				model: "gpt-5.4",
+				cwd: "/tmp",
+				resume: undefined,
+				permissionMode: undefined,
+				effortLevel: "medium",
+				fastMode: false,
+				images: [],
+			},
+			emitter,
+		);
+
+		codexConfigState.result = {
+			kind: "modified",
+			path: "/fake/.codex/config.toml",
+		};
+		serverState.requests = [];
+
+		// Caller's resume wins over the in-memory stale id.
+		await manager.sendMessage(
+			"REQ-goal-explicit",
+			{
+				sessionId: "s-goal-explicit",
+				prompt: "/goal something",
+				model: "gpt-5.4",
+				cwd: "/tmp",
+				resume: "thread-from-rust",
+				permissionMode: undefined,
+				effortLevel: "medium",
+				fastMode: false,
+				images: [],
+			},
+			emitter,
+		);
+
+		const resume = serverState.requests.find(
+			(r) => r.method === "thread/resume",
+		);
+		expect(resume?.params).toMatchObject({ threadId: "thread-from-rust" });
+	});
+
+	test("/goal pre-flight: skipped for non-/goal prompts", async () => {
+		const manager = new CodexAppServerManager();
+
+		await manager.sendMessage(
+			"REQ-plain",
+			{
+				sessionId: "s-plain",
+				prompt: "just a regular question",
+				model: "gpt-5.4",
+				cwd: "/tmp",
+				resume: undefined,
+				permissionMode: undefined,
+				effortLevel: "medium",
+				fastMode: false,
+				images: [],
+			},
+			emitter,
+		);
+
+		expect(codexConfigState.calls).toBe(0);
 	});
 });


### PR DESCRIPTION
## Summary

`/goal` was silently failing whenever `~/.codex/config.toml` didn't have `[features] goals = true`. Codex's `thread/goal/set` returns "goals feature is disabled", but we never surfaced this to the user — the prompt just looked dead.

This PR adds a pre-flight that runs only on `/goal` prompts:

- New `sidecar/src/codex-config.ts` exposes `ensureCodexGoalsFeatureEnabled()`, a line-based TOML editor that flips on the flag without rewriting the user's other settings. Handles a missing file, a missing `[features]` section, an existing `goals = false`, CRLF endings, comments, and subtables.
- `CodexAppServerManager` calls the helper before `ensureContext` when the prompt is a `/goal`. If the helper actually had to modify the file, the manager kills the stale codex process (which loaded the old config at startup) and resumes the previous thread so the in-flight conversation isn't lost.
- Caller-supplied `resume` always wins; otherwise we fall back to the stale ctx's `providerThreadId`.
- IO failures are logged and best-effort — we still hand off to codex so its own error can surface.

## Why

Codex reads its config exactly once at process start, so just writing the TOML isn't enough — we have to recycle the running server too. Doing this lazily on `/goal` (instead of on every send) keeps the cost off the hot path for normal prompts.

## Test notes

- `sidecar/src/codex-config.test.ts` — 13 unit tests covering the TOML mutator and the file-level `ensureCodexGoalsFeatureEnabled` helper (missing file, disabled flag flip, already-enabled).
- `sidecar/test/codex-app-server-manager.test.ts` — 4 new integration tests covering the pre-flight: no-op when already enabled, stale-process recycle + thread resume on modify, caller resume precedence, and skip for non-`/goal` prompts.
- `.changeset/auto-enable-codex-goals.md` — patch changeset.

Run locally: `cd sidecar && bun test`.