### PR TITLE
feat(composer): render attachment chips in queued submits

### DIFF
--- a/.changeset/queue-attachment-chips.md
+++ b/.changeset/queue-attachment-chips.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Render image and file attachments in queued follow-up messages as hover-preview chips, matching how they appear in the composer and sent chat bubbles instead of showing the raw `@/path/...` text.

--- a/src/components/file-mention-badge.tsx
+++ b/src/components/file-mention-badge.tsx
@@ -1,0 +1,71 @@
+/**
+ * Reusable inline chip for an `@<path>` mention. Picks image vs file
+ * preview by extension. Used by chat bubbles and the submit queue so
+ * both surfaces render attachments the same way the composer does.
+ */
+
+import { FileText, ImageIcon } from "lucide-react";
+import { useMemo } from "react";
+import {
+	createFilePreviewLoader,
+	InlineBadge,
+} from "@/components/inline-badge";
+import { basename, isImageExtensionPath } from "@/lib/path-util";
+import { cn } from "@/lib/utils";
+
+export type FileMentionBadgeProps = {
+	path: string;
+	/** Compact: 12px label / tighter padding. Defaults to false (14px). */
+	compact?: boolean;
+	className?: string;
+};
+
+export function FileMentionBadge({
+	path,
+	compact = false,
+	className,
+}: FileMentionBadgeProps) {
+	const fileName = basename(path);
+	const isImage = isImageExtensionPath(path);
+	const filePreviewLoader = useMemo(
+		() => (isImage ? undefined : createFilePreviewLoader(path)),
+		[isImage, path],
+	);
+
+	const wrapperClass = cn(compact && "text-[12px]", className);
+	const labelClass = compact ? "text-[12px]" : undefined;
+
+	if (isImage) {
+		return (
+			<InlineBadge
+				nonSelectable={false}
+				className={wrapperClass}
+				labelClassName={labelClass}
+				icon={
+					<ImageIcon
+						className="size-3.5 shrink-0 text-chart-3"
+						strokeWidth={1.8}
+					/>
+				}
+				label={fileName}
+				preview={{ kind: "image", title: fileName, path }}
+			/>
+		);
+	}
+
+	return (
+		<InlineBadge
+			nonSelectable={false}
+			className={wrapperClass}
+			labelClassName={labelClass}
+			icon={
+				<FileText
+					className="size-3.5 shrink-0 text-muted-foreground"
+					strokeWidth={1.8}
+				/>
+			}
+			label={fileName}
+			previewLoader={filePreviewLoader}
+		/>
+	);
+}

--- a/src/features/composer/submit-queue-list/index.tsx
+++ b/src/features/composer/submit-queue-list/index.tsx
@@ -1,15 +1,22 @@
 /** Queue overlay that sits above the composer without reserving layout space. */
 
 import { Clock, CornerDownLeft, Trash2 } from "lucide-react";
+import { useMemo } from "react";
 import { ActionRow } from "@/components/action-row";
+import { FileMentionBadge } from "@/components/file-mention-badge";
 import { Button } from "@/components/ui/button";
 import {
 	Tooltip,
 	TooltipContent,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
+import {
+	isFileMentionPart,
+	isTextPart,
+} from "@/features/panel/message-components/shared";
 import type { QueuedSubmit } from "@/lib/use-submit-queue";
 import { cn } from "@/lib/utils";
+import { splitTextWithFiles } from "@/lib/workspace-helpers";
 
 export type SubmitQueueListProps = {
 	items: readonly QueuedSubmit[];
@@ -57,7 +64,14 @@ function QueueRow({
 	onRemove: () => void;
 	disabled?: boolean;
 }) {
-	const preview = item.payload.prompt.trim();
+	const { prompt, imagePaths, filePaths } = item.payload;
+	// Reuse the chat-bubble splitter so attachment chips render the
+	// same way here as in the sent message.
+	const parts = useMemo(
+		() => splitTextWithFiles(prompt.trim(), filePaths, item.id, imagePaths),
+		[prompt, filePaths, imagePaths, item.id],
+	);
+
 	return (
 		<ActionRow
 			className={cn(
@@ -71,9 +85,28 @@ function QueueRow({
 						strokeWidth={1.8}
 						aria-hidden
 					/>
-					<span className="truncate text-[12px] font-medium tracking-[0.01em] text-foreground">
-						{preview}
-					</span>
+					<div className="flex min-w-0 items-center gap-0 overflow-hidden whitespace-nowrap text-[12px] font-medium tracking-[0.01em] text-foreground">
+						{parts.map((part, idx) => {
+							if (isTextPart(part)) {
+								return (
+									<span key={part.id ?? idx} className="shrink-0">
+										{part.text}
+									</span>
+								);
+							}
+							if (isFileMentionPart(part)) {
+								return (
+									<FileMentionBadge
+										key={part.id ?? idx}
+										path={part.path}
+										compact
+										className="shrink-0"
+									/>
+								);
+							}
+							return null;
+						})}
+					</div>
 				</>
 			}
 			trailing={

--- a/src/features/panel/message-components/user-message.tsx
+++ b/src/features/panel/message-components/user-message.tsx
@@ -1,55 +1,14 @@
-import { FileText, ImageIcon } from "lucide-react";
-import { useMemo } from "react";
-import {
-	createFilePreviewLoader,
-	InlineBadge,
-} from "@/components/inline-badge";
+import { FileMentionBadge } from "@/components/file-mention-badge";
 import type { MessagePart } from "@/lib/api";
-import { basename, isImageExtensionPath } from "@/lib/path-util";
 import { useSettings } from "@/lib/settings";
 import { CopyMessageButton } from "./copy-message";
 import type { RenderedMessage } from "./shared";
 import { isFileMentionPart, isTextPart } from "./shared";
 
 // Attachments arrive as structured `file-mention` parts (see
-// `splitTextWithFiles`); this renderer only routes to file vs image
-// badge by extension. Do not regex-scan text parts for `@<path>` —
-// it would truncate paths containing whitespace.
-
-function BubbleFileBadge({ path }: { path: string }) {
-	const fileName = basename(path);
-	const previewLoader = useMemo(() => createFilePreviewLoader(path), [path]);
-	return (
-		<InlineBadge
-			nonSelectable={false}
-			icon={
-				<FileText
-					className="size-3.5 shrink-0 text-muted-foreground"
-					strokeWidth={1.8}
-				/>
-			}
-			label={fileName}
-			previewLoader={previewLoader}
-		/>
-	);
-}
-
-function BubbleImageBadge({ path }: { path: string }) {
-	const fileName = basename(path);
-	return (
-		<InlineBadge
-			nonSelectable={false}
-			icon={
-				<ImageIcon
-					className="size-3.5 shrink-0 text-chart-3"
-					strokeWidth={1.8}
-				/>
-			}
-			label={fileName}
-			preview={{ kind: "image", title: fileName, path }}
-		/>
-	);
-}
+// `splitTextWithFiles`); the badge picks file vs image by extension.
+// Do not regex-scan text parts for `@<path>` — it would truncate
+// paths containing whitespace.
 
 export function ChatUserMessage({ message }: { message: RenderedMessage }) {
 	const parts = message.content as MessagePart[];
@@ -72,11 +31,7 @@ export function ChatUserMessage({ message }: { message: RenderedMessage }) {
 								return <span key={index}>{part.text}</span>;
 							}
 							if (isFileMentionPart(part)) {
-								return isImageExtensionPath(part.path) ? (
-									<BubbleImageBadge key={index} path={part.path} />
-								) : (
-									<BubbleFileBadge key={index} path={part.path} />
-								);
+								return <FileMentionBadge key={index} path={part.path} />;
 							}
 							return null;
 						})}


### PR DESCRIPTION
## Summary

- Extracted a reusable `FileMentionBadge` component that renders `@<path>` mentions as image or file chips with hover preview, used by both chat bubbles and the submit queue.
- Refactored `ChatUserMessage` to consume the new shared badge instead of declaring local `BubbleFileBadge` / `BubbleImageBadge` variants.
- Updated the submit queue overlay to split each queued prompt with `splitTextWithFiles` and render `file-mention` parts as chips, matching how attachments appear in the composer and sent message bubbles.

## Why

Previously, queued follow-up messages displayed attachments as raw `@/path/...` text, breaking visual continuity with the composer and sent bubbles. Centralizing the badge in one component keeps the three surfaces in sync going forward.

## Test plan

- [ ] Queue a follow-up with image and file attachments; confirm chips render with hover previews and don't truncate paths containing whitespace.
- [ ] Send the queued prompt and verify the same chips render in the chat bubble.
- [ ] `bun run lint` and `bun run typecheck` pass.