### PR TITLE
fix: preserve custom branch prefix and stabilize codex sub-agent labels

### DIFF
--- a/.changeset/quiet-spiders-fold.md
+++ b/.changeset/quiet-spiders-fold.md
@@ -1,0 +1,7 @@
+---
+"helmor": patch
+---
+
+Fix a few rough edges:
+- Custom workspace branch prefixes no longer auto-append a trailing `/`; the prefix you set is the prefix used.
+- Codex sub-agents now render with their real nickname throughout (spawn, wait, etc.) instead of switching names partway through, and no longer flash a no-name "Sub-agent" placeholder while spawning.

--- a/sidecar/src/codex-app-server-manager.ts
+++ b/sidecar/src/codex-app-server-manager.ts
@@ -541,10 +541,15 @@ export class CodexAppServerManager implements SessionManager {
 					return;
 				}
 
-				// Block briefly (≤2s) on a spawn-completed item so the
-				// nickname/role enrichment lands before the pipeline sees it.
-				if (n.method === "item/completed" && isSpawnAgentCompleted(n.params)) {
-					await enrichSpawnAgentItem(ctx.subAgentTracker, n);
+				// Block briefly (≤2s) on any collab item with known receivers
+				// so nickname/role enrichment lands before the pipeline sees
+				// it. Without this, wait/sendInput/etc. render with pool
+				// fallback nicknames that don't match what spawn showed.
+				if (
+					(n.method === "item/started" || n.method === "item/completed") &&
+					shouldEnrichCollabItem(n.params)
+				) {
+					await enrichCollabItem(ctx.subAgentTracker, n);
 				}
 
 				const flat = flattenNotification(n, ctx.providerThreadId);
@@ -1415,23 +1420,24 @@ function extractEventThreadId(n: JsonRpcNotification): string | null {
 	return typeof fromThread === "string" ? fromThread : null;
 }
 
-/** True for `collabAgentToolCall(spawnAgent, completed)`. */
-function isSpawnAgentCompleted(params: unknown): boolean {
+/** True for any `collabAgentToolCall` whose `receiverThreadIds` are
+ *  populated. spawnAgent's `item/started` has empty receivers (new thread
+ *  not created yet) so falls through; spawnAgent completed plus
+ *  wait/sendInput/resumeAgent/closeAgent at started AND completed match. */
+function shouldEnrichCollabItem(params: unknown): boolean {
 	if (!params || typeof params !== "object") return false;
 	const item = (params as Record<string, unknown>).item as
 		| Record<string, unknown>
 		| undefined;
-	return (
-		!!item &&
-		item.type === "collabAgentToolCall" &&
-		item.tool === "spawnAgent" &&
-		item.status === "completed"
-	);
+	if (!item || item.type !== "collabAgentToolCall") return false;
+	const receivers = item.receiverThreadIds;
+	return Array.isArray(receivers) && receivers.length > 0;
 }
 
 /** Resolve nickname/role for each receiverThreadId via `thread/read` and
- *  merge into `agentsStates`. Existing values win. */
-async function enrichSpawnAgentItem(
+ *  merge into `agentsStates`. Existing values win. Used for any collab
+ *  tool call (spawnAgent / sendInput / resumeAgent / wait / closeAgent). */
+async function enrichCollabItem(
 	tracker: SubAgentTracker,
 	n: JsonRpcNotification,
 ): Promise<void> {

--- a/src-tauri/src/pipeline/accumulator/codex.rs
+++ b/src-tauri/src/pipeline/accumulator/codex.rs
@@ -85,6 +85,14 @@ pub(super) fn handle_item_started(acc: &mut StreamAccumulator, _raw_line: &str, 
         );
     }
 
+    // Skip mid-flight render for collab tool calls — `item/started` has
+    // empty agentsStates / receiverThreadIds, so all the frontend can show
+    // is a "Sub-agent" placeholder that flickers off when completed lands.
+    // The entry stays in `codex_items` so abort/flush still works.
+    if item_type == "collab_agent_tool_call" {
+        return;
+    }
+
     let synthetic = serde_json::json!({"item": item});
     let synthetic_str = serde_json::to_string(&synthetic).unwrap_or_default();
     dispatch_item(acc, &synthetic_str, &synthetic, false);

--- a/src-tauri/tests/snapshots/pipeline_streams__stream_replay@codex__spawn-agents.jsonl.snap
+++ b/src-tauri/tests/snapshots/pipeline_streams__stream_replay@codex__spawn-agents.jsonl.snap
@@ -74,7 +74,6 @@ checkpoints:
       - text
       - text
       - tool-call
-      - tool-call
   - line_index: 38
     event_type: item/completed
     roles:
@@ -85,7 +84,6 @@ checkpoints:
       - tool-call
       - text
       - text
-      - tool-call
       - tool-call
   - line_index: 43
     event_type: item/completed
@@ -98,7 +96,6 @@ checkpoints:
       - text
       - text
       - tool-call
-      - tool-call
       - text
   - line_index: 49
     event_type: item/completed
@@ -110,7 +107,6 @@ checkpoints:
       - tool-call
       - text
       - text
-      - tool-call
       - tool-call
       - text
       - text
@@ -126,7 +122,6 @@ checkpoints:
       - text
       - text
       - tool-call
-      - tool-call
       - text
       - text
       - tool-call
@@ -140,7 +135,6 @@ checkpoints:
       - tool-call
       - text
       - text
-      - tool-call
       - tool-call
       - text
       - text
@@ -156,7 +150,6 @@ checkpoints:
       - tool-call
       - text
       - text
-      - tool-call
       - tool-call
       - text
       - text
@@ -176,27 +169,31 @@ checkpoints:
     roles:
       - assistant
       - system
+      - assistant
     last_part_types:
-      - text
+      - tool-call
   - line_index: 65
     event_type: item/completed
     roles:
       - assistant
       - system
+      - assistant
     last_part_types:
-      - text
+      - tool-call
   - line_index: 67
     event_type: turn/completed
     roles:
       - assistant
       - system
+      - assistant
     last_part_types:
-      - text
+      - tool-call
 final_state:
-  message_count: 2
+  message_count: 3
   roles:
     - assistant
     - system
+    - assistant
   total_parts: 14
 persisted_turns:
   turn_count: 13

--- a/src/features/workspace-start/index.tsx
+++ b/src/features/workspace-start/index.tsx
@@ -33,7 +33,7 @@ function defaultBranchPrefix(repo: RepositoryCreateOption | null): string {
 		case "username":
 			return repo.forgeLogin ? `${repo.forgeLogin}/` : "";
 		case "custom":
-			return repo.branchPrefixCustom ? `${repo.branchPrefixCustom}/` : "";
+			return repo.branchPrefixCustom ?? "";
 		case "none":
 			return "";
 		default:


### PR DESCRIPTION
## Summary

Two small UX fixes:

- **Custom workspace branch prefix**: when a user picks a `custom` branch prefix in repository settings, we no longer auto-append a trailing `/`. The string the user typed is the string we use, so prefixes like `wip-` or `nathan_` work as written instead of being silently rewritten to `wip-/` or `nathan_/`.
- **Codex sub-agent labels**: collab tool calls (`spawnAgent`, `wait`, `sendInput`, `resumeAgent`, `closeAgent`) are now enriched with the real nickname/role on both `item/started` and `item/completed`, not just on spawn-completed. Previously the first event would render with whatever fallback the agents-pool had on hand and then snap to the real nickname mid-turn. We also skip the mid-flight render of `collab_agent_tool_call` entirely on `item/started` — at that point `agentsStates`/`receiverThreadIds` are empty, so the only thing the frontend can display is a no-name "Sub-agent" placeholder that immediately flickers off when the completed event lands.

## Why

Both surfaced as visible flicker / wrong text in the UI. The branch-prefix one was the prefix string getting mangled before it reached git; the sub-agent one was the streaming pipeline showing partial state before enrichment caught up.

## Notes

- Pipeline snapshot `pipeline_streams__stream_replay@codex__spawn-agents` was regenerated to reflect that we now drop the started-side placeholder tool-call and that the final completed-side message count goes from 2 -> 3 (each completed sub-agent now lands as its own assistant message rather than collapsing into a placeholder).
- Changeset entry: `.changeset/quiet-spiders-fold.md` (patch).

## Test plan

- [ ] In repository settings, set a custom branch prefix without a trailing slash; confirm new workspace branches use the prefix verbatim.
- [ ] Run a Codex turn that spawns sub-agents; confirm the spawn / wait / sendInput rows all show the same real nickname from first paint, with no "Sub-agent" placeholder flash.
- [ ] `cd src-tauri && cargo test --tests` passes (pipeline snapshots clean).