### PR TITLE
feat(editor): render markdown files with source/preview toggle

### DIFF
--- a/.changeset/cozy-markdown-preview.md
+++ b/.changeset/cozy-markdown-preview.md
@@ -1,0 +1,5 @@
+---
+"helmor": minor
+---
+
+Render Markdown files in the in-app editor with a Source/Preview toggle, so AI-generated specs and other `.md` files can be reviewed as formatted documents instead of raw source.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -108,7 +108,7 @@ import {
 } from "./lib/composer-insert";
 import { ComposerInsertProvider } from "./lib/composer-insert-context";
 import type { DiffOpenOptions, EditorSessionState } from "./lib/editor-session";
-import { isPathWithinRoot } from "./lib/editor-session";
+import { isMarkdownPath, isPathWithinRoot } from "./lib/editor-session";
 import {
 	archivedWorkspacesQueryOptions,
 	createHelmorQueryClient,
@@ -1060,6 +1060,8 @@ function AppShell({
 				fileStatus: status,
 				originalRef: options?.originalRef,
 				modifiedRef: options?.modifiedRef,
+				// Diff click is "see what changed" — default to source even for .md.
+				viewMode: isMarkdownPath(path) ? "source" : undefined,
 			});
 		},
 		[
@@ -1101,16 +1103,28 @@ function AppShell({
 			}
 
 			setWorkspaceViewMode("editor");
-			setEditorSession((current) => ({
-				kind: "file",
-				path,
-				line,
-				column,
-				dirty: current?.path === path ? current.dirty : false,
-				originalText: current?.path === path ? current.originalText : undefined,
-				modifiedText: current?.path === path ? current.modifiedText : undefined,
-				mtimeMs: current?.path === path ? current.mtimeMs : undefined,
-			}));
+			setEditorSession((current) => {
+				const samePath = current?.path === path;
+				// Chat-link open of a markdown file: default to preview (reading the
+				// rendered output). Preserve user's explicit toggle if reopening the
+				// same file. Non-markdown paths leave viewMode unset.
+				const viewMode = isMarkdownPath(path)
+					? samePath && current?.viewMode
+						? current.viewMode
+						: "preview"
+					: undefined;
+				return {
+					kind: "file",
+					path,
+					line,
+					column,
+					dirty: samePath ? current.dirty : false,
+					originalText: samePath ? current.originalText : undefined,
+					modifiedText: samePath ? current.modifiedText : undefined,
+					mtimeMs: samePath ? current.mtimeMs : undefined,
+					viewMode,
+				};
+			});
 		},
 		[
 			confirmDiscardEditorChanges,

--- a/src/features/editor/index.test.tsx
+++ b/src/features/editor/index.test.tsx
@@ -1,4 +1,11 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -77,6 +84,15 @@ vi.mock("@/lib/monaco-runtime", () => ({
 	syncVirtualFile: runtimeMocks.syncVirtualFile,
 }));
 
+// Avoid loading the heavy streamdown bundle in jsdom — render a stub that
+// just exposes the source so we can assert preview content was passed in.
+vi.mock("@/components/streamdown-loader", () => ({
+	LazyStreamdown: ({ children }: { children?: string }) => (
+		<div data-testid="streamdown-stub">{children}</div>
+	),
+	preloadStreamdown: vi.fn(),
+}));
+
 import { WorkspaceEditorSurface } from "./index";
 
 function EditorSurfaceHarness({
@@ -152,6 +168,168 @@ describe("WorkspaceEditorSurface", () => {
 					modifiedText: "const value = 2;\n",
 				}),
 			);
+		});
+	});
+
+	it("does not show the markdown toggle for non-markdown files", async () => {
+		const onChangeSpy = vi.fn();
+
+		apiMocks.readEditorFile.mockResolvedValue({
+			path: "/tmp/helmor-workspace/src/App.tsx",
+			content: "const value = 1;\n",
+			mtimeMs: 10,
+		});
+
+		render(
+			<TooltipProvider delayDuration={0}>
+				<EditorSurfaceHarness
+					initialSession={{
+						kind: "file",
+						path: "/tmp/helmor-workspace/src/App.tsx",
+					}}
+					onChangeSpy={onChangeSpy}
+				/>
+			</TooltipProvider>,
+		);
+
+		await waitFor(() => {
+			expect(runtimeMocks.createFileEditor).toHaveBeenCalled();
+		});
+
+		expect(screen.queryByLabelText("Markdown view mode")).toBeNull();
+	});
+
+	it("shows source/preview toggle for .md files and starts in source mode by default", async () => {
+		const onChangeSpy = vi.fn();
+
+		apiMocks.readEditorFile.mockResolvedValue({
+			path: "/tmp/helmor-workspace/SPEC.md",
+			content: "# Title\n\nbody",
+			mtimeMs: 10,
+		});
+
+		render(
+			<TooltipProvider delayDuration={0}>
+				<EditorSurfaceHarness
+					initialSession={{
+						kind: "file",
+						path: "/tmp/helmor-workspace/SPEC.md",
+					}}
+					onChangeSpy={onChangeSpy}
+				/>
+			</TooltipProvider>,
+		);
+
+		await waitFor(() => {
+			expect(screen.getByLabelText("Markdown view mode")).toBeInTheDocument();
+		});
+
+		const sourceItem = screen.getByRole("tab", { name: "Source" });
+		const previewItem = screen.getByRole("tab", { name: "Preview" });
+		expect(sourceItem).toHaveAttribute("data-state", "active");
+		expect(previewItem).toHaveAttribute("data-state", "inactive");
+		expect(screen.queryByLabelText("Markdown preview")).toBeNull();
+	});
+
+	it("starts in preview mode when the session has viewMode: preview", async () => {
+		const onChangeSpy = vi.fn();
+
+		render(
+			<TooltipProvider delayDuration={0}>
+				<EditorSurfaceHarness
+					initialSession={{
+						kind: "file",
+						path: "/tmp/helmor-workspace/SPEC.md",
+						viewMode: "preview",
+						originalText: "# Hello\n",
+						modifiedText: "# Hello\n",
+					}}
+					onChangeSpy={onChangeSpy}
+				/>
+			</TooltipProvider>,
+		);
+
+		const previewRegion = await screen.findByLabelText("Markdown preview");
+		expect(previewRegion).toBeInTheDocument();
+		expect(screen.getByTestId("streamdown-stub")).toHaveTextContent("# Hello");
+
+		// Monaco host stays mounted but is hidden.
+		const canvas = screen.getByLabelText("Editor canvas");
+		expect(canvas).toHaveAttribute("aria-hidden", "true");
+	});
+
+	it("toggles between source and preview when the user clicks the buttons", async () => {
+		const onChangeSpy = vi.fn();
+		const user = userEvent.setup();
+
+		apiMocks.readEditorFile.mockResolvedValue({
+			path: "/tmp/helmor-workspace/SPEC.md",
+			content: "# Title\n",
+			mtimeMs: 10,
+		});
+
+		render(
+			<TooltipProvider delayDuration={0}>
+				<EditorSurfaceHarness
+					initialSession={{
+						kind: "file",
+						path: "/tmp/helmor-workspace/SPEC.md",
+					}}
+					onChangeSpy={onChangeSpy}
+				/>
+			</TooltipProvider>,
+		);
+
+		await waitFor(() => {
+			expect(runtimeMocks.createFileEditor).toHaveBeenCalled();
+		});
+
+		await user.click(screen.getByRole("tab", { name: "Preview" }));
+
+		await waitFor(() => {
+			expect(screen.getByLabelText("Markdown preview")).toBeInTheDocument();
+		});
+		expect(screen.getByTestId("streamdown-stub")).toHaveTextContent("# Title");
+
+		await user.click(screen.getByRole("tab", { name: "Source" }));
+
+		await waitFor(() => {
+			expect(screen.queryByLabelText("Markdown preview")).toBeNull();
+		});
+	});
+
+	it("toggles preview via ⌘⇧V keyboard shortcut", async () => {
+		const onChangeSpy = vi.fn();
+
+		render(
+			<TooltipProvider delayDuration={0}>
+				<EditorSurfaceHarness
+					initialSession={{
+						kind: "file",
+						path: "/tmp/helmor-workspace/SPEC.md",
+						viewMode: "source",
+						originalText: "# Hi",
+						modifiedText: "# Hi",
+					}}
+					onChangeSpy={onChangeSpy}
+				/>
+			</TooltipProvider>,
+		);
+
+		await waitFor(() => {
+			expect(runtimeMocks.createFileEditor).toHaveBeenCalled();
+		});
+
+		fireEvent.keyDown(window, { key: "V", metaKey: true, shiftKey: true });
+
+		await waitFor(() => {
+			expect(screen.getByLabelText("Markdown preview")).toBeInTheDocument();
+		});
+
+		fireEvent.keyDown(window, { key: "v", metaKey: true, shiftKey: true });
+
+		await waitFor(() => {
+			expect(screen.queryByLabelText("Markdown preview")).toBeNull();
 		});
 	});
 

--- a/src/features/editor/index.tsx
+++ b/src/features/editor/index.tsx
@@ -1,16 +1,38 @@
-import { X } from "lucide-react";
+import { Eye, FileCode, X } from "lucide-react";
 import {
 	type MutableRefObject,
+	Suspense,
 	useEffect,
 	useLayoutEffect,
+	useMemo,
 	useRef,
 	useState,
 } from "react";
 import { TrafficLightSpacer } from "@/components/chrome/traffic-light-spacer";
+import { LazyStreamdown } from "@/components/streamdown-loader";
 import { Button } from "@/components/ui/button";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ShortcutDisplay } from "@/features/shortcuts/shortcut-display";
-import type { EditorSessionState } from "@/lib/editor-session";
+import {
+	type EditorSessionState,
+	type EditorViewMode,
+	isMarkdownPath,
+} from "@/lib/editor-session";
 import { describeUnknownError } from "@/lib/workspace-helpers";
+
+// Refined segmented-tab look: no tray, soft glassy pill on the active state.
+// Hover only changes text color (no bg) — otherwise hover-on-inactive sits next
+// to active-bg and the boundary blurs. Active is the ONLY trigger with a bg.
+const SEGMENT_CLASS = [
+	"h-5 gap-1 rounded-[5px] px-1.5 py-0 text-[10.5px] font-normal tracking-tight",
+	"border-transparent bg-transparent text-muted-foreground/70 shadow-none",
+	"hover:bg-transparent hover:text-foreground",
+	"data-active:bg-foreground/[0.10] data-active:text-foreground data-active:border-transparent data-active:shadow-none",
+	"aria-selected:bg-foreground/[0.10] aria-selected:text-foreground aria-selected:border-transparent aria-selected:shadow-none",
+	"dark:data-active:bg-foreground/[0.10] dark:data-active:border-transparent",
+	"dark:aria-selected:bg-foreground/[0.10] dark:aria-selected:border-transparent",
+	"[&_svg:not([class*='size-'])]:size-2.5",
+].join(" ");
 
 type WorkspaceEditorSurfaceProps = {
 	editorSession: EditorSessionState;
@@ -66,6 +88,15 @@ export function WorkspaceEditorSurface({
 		editorSession.modifiedText !== undefined;
 	const closeLabel =
 		editorSession.kind === "diff" ? "Close diff view" : "Close editor view";
+	const isMarkdown = isMarkdownPath(editorSession.path);
+	const viewMode: EditorViewMode = isMarkdown
+		? (editorSession.viewMode ?? "source")
+		: "source";
+	const showPreview = isMarkdown && viewMode === "preview";
+	const previewContent = useMemo(() => {
+		if (!showPreview) return "";
+		return editorSession.modifiedText ?? editorSession.originalText ?? "";
+	}, [showPreview, editorSession.modifiedText, editorSession.originalText]);
 
 	useEffect(() => {
 		if (
@@ -161,6 +192,27 @@ export function WorkspaceEditorSurface({
 		window.addEventListener("keydown", handleKeyDown);
 		return () => window.removeEventListener("keydown", handleKeyDown);
 	}, [onExit]);
+
+	// ⌘⇧V toggles markdown preview, mirroring VS Code's "Markdown: Toggle Preview".
+	useEffect(() => {
+		if (!isMarkdown) return;
+		const handleKeyDown = (event: KeyboardEvent) => {
+			const isToggle =
+				(event.metaKey || event.ctrlKey) &&
+				event.shiftKey &&
+				event.key.toLowerCase() === "v";
+			if (!isToggle) return;
+			event.preventDefault();
+			const next: EditorViewMode =
+				viewMode === "preview" ? "source" : "preview";
+			onChangeSessionRef.current({
+				...latestSessionRef.current,
+				viewMode: next,
+			});
+		};
+		window.addEventListener("keydown", handleKeyDown);
+		return () => window.removeEventListener("keydown", handleKeyDown);
+	}, [isMarkdown, viewMode]);
 
 	// useLayoutEffect: run model swap BEFORE browser paint to avoid flicker.
 	// The fast path returns NO cleanup — we keep the editor instance alive across
@@ -378,6 +430,15 @@ export function WorkspaceEditorSurface({
 		editorSession.originalText,
 	]);
 
+	const handleViewModeChange = (next: string) => {
+		if (next !== "source" && next !== "preview") return;
+		if (next === viewMode) return;
+		onChangeSession({
+			...editorSession,
+			viewMode: next,
+		});
+	};
+
 	return (
 		<section
 			aria-label="Workspace editor surface"
@@ -393,7 +454,26 @@ export function WorkspaceEditorSurface({
 
 				<div className="min-w-0 flex-1" data-tauri-drag-region />
 
-				<div className="flex shrink-0 items-center pr-2">
+				<div className="flex shrink-0 items-center gap-2 pr-2">
+					{isMarkdown && (
+						<Tabs
+							value={viewMode}
+							onValueChange={handleViewModeChange}
+							aria-label="Markdown view mode"
+						>
+							{/* No tray: bg-transparent + p-0. Pill highlight only on the active trigger. */}
+							<TabsList className="h-5 gap-0 bg-transparent p-0">
+								<TabsTrigger value="source" className={SEGMENT_CLASS}>
+									<FileCode strokeWidth={1.8} />
+									Source
+								</TabsTrigger>
+								<TabsTrigger value="preview" className={SEGMENT_CLASS}>
+									<Eye strokeWidth={1.8} />
+									Preview
+								</TabsTrigger>
+							</TabsList>
+						</Tabs>
+					)}
 					<Button
 						type="button"
 						variant="ghost"
@@ -409,11 +489,38 @@ export function WorkspaceEditorSurface({
 			</div>
 
 			<div className="relative flex min-h-0 flex-1 bg-background">
+				{/* Monaco host stays mounted in preview mode so model + dirty state survive toggling. */}
 				<div
 					ref={editorHostRef}
 					aria-label="Editor canvas"
 					className="h-full min-h-0 flex-1"
+					aria-hidden={showPreview}
+					style={showPreview ? { visibility: "hidden" } : undefined}
 				/>
+
+				{showPreview && (
+					<div
+						aria-label="Markdown preview"
+						className="absolute inset-0 overflow-y-auto bg-background"
+					>
+						<div className="conversation-markdown mx-auto max-w-3xl break-words px-8 py-6 text-[13px] leading-6 text-foreground">
+							<Suspense
+								fallback={
+									<pre className="whitespace-pre-wrap break-words font-mono text-muted-foreground">
+										{previewContent}
+									</pre>
+								}
+							>
+								<LazyStreamdown
+									className="conversation-streamdown"
+									mode="static"
+								>
+									{previewContent}
+								</LazyStreamdown>
+							</Suspense>
+						</div>
+					</div>
+				)}
 
 				{surfaceStatus.kind === "error" && (
 					<div className="absolute inset-0 flex items-center justify-center bg-background">

--- a/src/lib/editor-session.test.ts
+++ b/src/lib/editor-session.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { isMarkdownPath } from "./editor-session";
+
+describe("isMarkdownPath", () => {
+	it("matches common markdown extensions", () => {
+		expect(isMarkdownPath("README.md")).toBe(true);
+		expect(isMarkdownPath("docs/spec.markdown")).toBe(true);
+		expect(isMarkdownPath("blog/post.mdx")).toBe(true);
+	});
+
+	it("is case-insensitive", () => {
+		expect(isMarkdownPath("README.MD")).toBe(true);
+		expect(isMarkdownPath("CHANGELOG.Md")).toBe(true);
+	});
+
+	it("rejects non-markdown extensions", () => {
+		expect(isMarkdownPath("App.tsx")).toBe(false);
+		expect(isMarkdownPath("notes.txt")).toBe(false);
+		expect(isMarkdownPath("config.json")).toBe(false);
+		expect(isMarkdownPath("noextension")).toBe(false);
+	});
+
+	it("does not match files that merely contain '.md' in the name", () => {
+		expect(isMarkdownPath("md-utils.ts")).toBe(false);
+		expect(isMarkdownPath("foo.md.bak")).toBe(false);
+	});
+});

--- a/src/lib/editor-session.ts
+++ b/src/lib/editor-session.ts
@@ -6,6 +6,9 @@ export type DiffOpenOptions = {
 	modifiedRef?: string;
 };
 
+/** "source" = Monaco editor; "preview" = rendered streamdown view. Only meaningful for markdown paths. */
+export type EditorViewMode = "source" | "preview";
+
 export type EditorSessionState = {
 	kind: "file" | "diff";
 	path: string;
@@ -22,7 +25,16 @@ export type EditorSessionState = {
 	originalRef?: string;
 	/** Git ref for the modified (right) side. Omit to read from working tree. */
 	modifiedRef?: string;
+	/** Markdown view mode. Ignored for non-markdown paths. */
+	viewMode?: EditorViewMode;
 };
+
+const MARKDOWN_EXTENSIONS = [".md", ".markdown", ".mdx"];
+
+export function isMarkdownPath(path: string): boolean {
+	const lower = path.toLowerCase();
+	return MARKDOWN_EXTENSIONS.some((ext) => lower.endsWith(ext));
+}
 
 export type InspectorFileItem = {
 	path: string;


### PR DESCRIPTION
## Summary
- implement #395 
- Add a Source/Preview toggle to the in-app editor for `.md`, `.markdown`, and `.mdx` files. Preview renders via the existing `streamdown` pipeline (lazy-loaded, Suspense-fallback to plain pre).
- New `EditorViewMode` (`"source" | "preview"`) on `EditorSessionState`. Default behavior: chat-link opens of markdown default to **preview** (reading mode), while diff-click opens default to **source** (see-what-changed mode). User's explicit toggle is preserved across reopens of the same path.
- ⌘⇧V (Ctrl+Shift+V on non-mac) toggles preview, mirroring VS Code's "Markdown: Toggle Preview".
- Monaco host stays mounted while in preview (hidden via `visibility: hidden` + `aria-hidden`) so model + dirty state survive toggling.
- Refined segmented-tab styling for the toggle (transparent tray, soft pill on active state) so it sits cleanly in the editor toolbar.

https://github.com/user-attachments/assets/30eb8e82-ca9d-42da-8141-4d23bafdc443

## Why

AI-generated specs and other markdown artifacts are common in workspaces. Reading them as raw source is a poor experience — Preview lets users review formatted output without leaving the editor, while Source remains the default for diff/edit flows.

## Test plan

- [x] `bun run test:frontend` — new unit tests cover `isMarkdownPath` and the editor surface (toggle visibility, default mode, click toggling, ⌘⇧V keyboard shortcut, preview content wiring).
- [ ] Manual: open a `.md` file from chat link → preview by default; open via diff click → source by default; ⌘⇧V toggles; close + reopen preserves last mode for same path.
- [ ] Manual: open a non-markdown file (e.g. `.tsx`) → toggle is hidden, no behavior change.
- [ ] Manual: dirty state in source survives a preview round-trip.