### PR TITLE
Prevent inspector startup animation

### DIFF
--- a/.changeset/quiet-panels-arrive.md
+++ b/.changeset/quiet-panels-arrive.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix the right inspector sidebar so its panels no longer animate from an initial zero-height state when Helmor first renders or switches back from the Context panel.

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -123,6 +123,18 @@ describe("App", () => {
 		const user = userEvent.setup();
 		render(<App />);
 		await screen.findByRole("main", { name: "Application shell" });
+		const tabsToggle = screen.getByLabelText("Toggle inspector tabs section");
+		const tabsChevron = tabsToggle.querySelector("svg");
+		const actionsChevron = screen
+			.getByLabelText("Toggle inspector actions section")
+			.querySelector("svg");
+
+		expect(tabsChevron).toHaveStyle({
+			transition: "transform 0ms cubic-bezier(0.32, 0.72, 0, 1)",
+		});
+		expect(actionsChevron).toHaveStyle({
+			transition: "transform 0ms cubic-bezier(0.32, 0.72, 0, 1)",
+		});
 
 		// Default: tabs section collapsed; changes + actions bodies present.
 		expect(screen.getByLabelText("Changes panel body")).toBeInTheDocument();
@@ -132,20 +144,60 @@ describe("App", () => {
 		).not.toBeInTheDocument();
 
 		// Clicking the toggle expands the tabs body.
-		await user.click(screen.getByLabelText("Toggle inspector tabs section"));
+		await user.click(tabsToggle);
 
 		expect(screen.getByLabelText("Changes panel body")).toBeInTheDocument();
 		expect(screen.getByLabelText("Actions panel body")).toBeInTheDocument();
 		expect(screen.getByLabelText("Inspector tabs body")).toBeInTheDocument();
+		expect(tabsChevron).toHaveStyle({
+			transition: "transform 350ms cubic-bezier(0.32, 0.72, 0, 1)",
+		});
 
 		// Clicking again collapses it back.
-		await user.click(screen.getByLabelText("Toggle inspector tabs section"));
+		await user.click(tabsToggle);
 
 		expect(screen.getByLabelText("Changes panel body")).toBeInTheDocument();
 		expect(screen.getByLabelText("Actions panel body")).toBeInTheDocument();
 		expect(
 			screen.queryByLabelText("Inspector tabs body"),
 		).not.toBeInTheDocument();
+	});
+
+	it("measures the inspector height before the first visible frame", async () => {
+		const getBoundingClientRect = vi
+			.spyOn(HTMLElement.prototype, "getBoundingClientRect")
+			.mockReturnValue({
+				x: 0,
+				y: 0,
+				width: 336,
+				height: 900,
+				top: 0,
+				right: 336,
+				bottom: 900,
+				left: 0,
+				toJSON: () => ({}),
+			});
+
+		try {
+			render(<App />);
+			await screen.findByRole("main", { name: "Application shell" });
+
+			await waitFor(() => {
+				expect(screen.getByLabelText("Inspector section Git")).toHaveStyle({
+					height: "273px",
+				});
+			});
+			expect(screen.getByLabelText("Inspector section Actions")).toHaveStyle({
+				height: "594px",
+			});
+			const tabsWrapper = screen.getByLabelText("Inspector section Tabs")
+				.parentElement?.parentElement;
+			expect(tabsWrapper).toHaveStyle({
+				height: "33px",
+			});
+		} finally {
+			getBoundingClientRect.mockRestore();
+		}
 	});
 
 	it("resizes the sidebar and persists the width", async () => {

--- a/src/features/inspector/hooks/use-inspector.ts
+++ b/src/features/inspector/hooks/use-inspector.ts
@@ -3,6 +3,7 @@ import {
 	type MouseEvent as ReactMouseEvent,
 	useCallback,
 	useEffect,
+	useLayoutEffect,
 	useMemo,
 	useRef,
 	useState,
@@ -22,6 +23,7 @@ import {
 	INSPECTOR_SECTION_HEADER_HEIGHT,
 	INSPECTOR_TABS_HEIGHT_STORAGE_KEY,
 	INSPECTOR_TABS_OPEN_STORAGE_KEY,
+	TABS_ANIMATION_MS,
 } from "../layout";
 import { getScriptState, startScript, stopScript } from "../script-store";
 
@@ -135,10 +137,37 @@ export function useWorkspaceInspectorSidebar({
 		getInitialTabsHeight(DEFAULT_TABS_BODY),
 	);
 	const [resizeState, setResizeState] = useState<ResizeState | null>(null);
+	const [isPanelToggleAnimating, setIsPanelToggleAnimating] = useState(false);
 
 	const containerRef = useRef<HTMLDivElement>(null);
 	const tabsWrapperRef = useRef<HTMLDivElement>(null);
 	const actionsRef = useRef<HTMLElement>(null);
+	const panelToggleTimerRef = useRef<number | null>(null);
+
+	const beginPanelToggleAnimation = useCallback(() => {
+		if (panelToggleTimerRef.current !== null) {
+			window.clearTimeout(panelToggleTimerRef.current);
+		}
+		setIsPanelToggleAnimating(true);
+		panelToggleTimerRef.current = window.setTimeout(() => {
+			panelToggleTimerRef.current = null;
+			setIsPanelToggleAnimating(false);
+		}, TABS_ANIMATION_MS + 50);
+	}, []);
+
+	useEffect(() => {
+		return () => {
+			if (panelToggleTimerRef.current !== null) {
+				window.clearTimeout(panelToggleTimerRef.current);
+			}
+		};
+	}, []);
+
+	useLayoutEffect(() => {
+		const element = containerRef.current;
+		if (!element) return;
+		setContainerHeight(element.getBoundingClientRect().height);
+	}, []);
 
 	useEffect(() => {
 		const element = containerRef.current;
@@ -332,12 +361,14 @@ export function useWorkspaceInspectorSidebar({
 	}, [changesQuery.data]);
 
 	const handleToggleTabs = useCallback(() => {
+		beginPanelToggleAnimation();
 		setTabsOpen((open) => !open);
-	}, []);
+	}, [beginPanelToggleAnimation]);
 
 	const handleToggleActions = useCallback(() => {
+		beginPanelToggleAnimation();
 		setActionsOpen((open) => !open);
-	}, []);
+	}, [beginPanelToggleAnimation]);
 
 	useEffect(() => {
 		if (!resizeState) {
@@ -445,6 +476,7 @@ export function useWorkspaceInspectorSidebar({
 		handleToggleActions,
 		handleToggleTabs,
 		isActionsResizing,
+		isPanelToggleAnimating,
 		isResizing,
 		isTabsResizing,
 		repoScripts,

--- a/src/features/inspector/index.tsx
+++ b/src/features/inspector/index.tsx
@@ -99,6 +99,7 @@ export function WorkspaceInspectorSidebar({
 		handleToggleActions,
 		handleToggleTabs,
 		isActionsResizing,
+		isPanelToggleAnimating,
 		isResizing,
 		isTabsResizing,
 		repoScripts,
@@ -398,6 +399,7 @@ export function WorkspaceInspectorSidebar({
 				changeRequest={changeRequest ?? null}
 				forgeIsRefreshing={forgeIsRefreshing}
 				bodyHeight={changesHeight}
+				animatePanelToggle={isPanelToggleAnimating}
 				isResizing={isResizing}
 			/>
 			{actionsOpen ? (
@@ -423,6 +425,7 @@ export function WorkspaceInspectorSidebar({
 				commitButtonMode={commitButtonMode}
 				commitButtonState={commitButtonState}
 				changeRequest={changeRequest ?? null}
+				animatePanelToggle={isPanelToggleAnimating}
 			/>
 			{tabsOpen ? (
 				<HorizontalResizeHandle
@@ -446,6 +449,7 @@ export function WorkspaceInspectorSidebar({
 				canSpawnTerminal={canSpawnTerminal}
 				canHoverExpand={canHoverExpand}
 				bodyHeight={tabsBodyHeight}
+				animatePanelToggle={isPanelToggleAnimating}
 				isResizing={isResizing}
 			>
 				<SetupTab

--- a/src/features/inspector/layout.tsx
+++ b/src/features/inspector/layout.tsx
@@ -217,6 +217,8 @@ type InspectorTabsSectionProps = {
 	/** False when there's no repo/workspace context — disables the "+" button. */
 	canSpawnTerminal: boolean;
 	bodyHeight: number;
+	/** Enables the height transition only for explicit panel toggles. */
+	animatePanelToggle?: boolean;
 	isResizing?: boolean;
 	/**
 	 * Gate for the hover-to-zoom effect. When false, hovering the body does
@@ -242,6 +244,7 @@ export function InspectorTabsSection({
 	onToggleTerminalHoverZoom,
 	canSpawnTerminal,
 	bodyHeight,
+	animatePanelToggle = false,
 	isResizing,
 	canHoverExpand,
 	children,
@@ -250,9 +253,14 @@ export function InspectorTabsSection({
 	const newTerminalShortcut = getShortcut(settings.shortcuts, "terminal.new");
 	const shouldReduceMotion = useReducedMotion();
 	const panelTransition = {
-		duration: isResizing || shouldReduceMotion ? 0 : TABS_ANIMATION_MS / 1000,
+		duration:
+			animatePanelToggle && !isResizing && !shouldReduceMotion
+				? TABS_ANIMATION_MS / 1000
+				: 0,
 		ease: TABS_EASING_CURVE,
 	};
+	const chevronTransitionMs =
+		animatePanelToggle && !shouldReduceMotion ? TABS_ANIMATION_MS : 0;
 	// `isHoverExpanded` drives the CSS transitions we CAN interpolate
 	// (width / height / box-shadow). Flipping it to `false` immediately starts
 	// the shrink animation.
@@ -895,7 +903,7 @@ export function InspectorTabsSection({
 										strokeWidth={1.9}
 										style={{
 											transform: open ? "rotate(0deg)" : "rotate(-90deg)",
-											transition: `transform ${TABS_ANIMATION_MS}ms ${TABS_EASING}`,
+											transition: `transform ${chevronTransitionMs}ms ${TABS_EASING}`,
 										}}
 									/>
 								</Button>

--- a/src/features/inspector/sections/actions.tsx
+++ b/src/features/inspector/sections/actions.tsx
@@ -112,6 +112,7 @@ type ActionsSectionProps = {
 	open: boolean;
 	onToggle: () => void;
 	bodyHeight: number;
+	animatePanelToggle?: boolean;
 	isResizing?: boolean;
 	onCommitAction?: (mode: WorkspaceCommitButtonMode) => Promise<void>;
 	onReviewAction?: () => Promise<void>;
@@ -165,6 +166,7 @@ export function ActionsSection({
 	open,
 	onToggle,
 	bodyHeight,
+	animatePanelToggle = false,
 	isResizing,
 	onCommitAction,
 	onReviewAction,
@@ -179,9 +181,14 @@ export function ActionsSection({
 	const [reviewPending, setReviewPending] = useState(false);
 	const shouldReduceMotion = useReducedMotion();
 	const panelTransition = {
-		duration: isResizing || shouldReduceMotion ? 0 : TABS_ANIMATION_MS / 1000,
+		duration:
+			animatePanelToggle && !isResizing && !shouldReduceMotion
+				? TABS_ANIMATION_MS / 1000
+				: 0,
 		ease: TABS_EASING_CURVE,
 	};
+	const chevronTransitionMs =
+		animatePanelToggle && !shouldReduceMotion ? TABS_ANIMATION_MS : 0;
 	const forgeQuery = useQuery({
 		...workspaceForgeQueryOptions(workspaceId ?? "__none__"),
 		enabled: workspaceId !== null,
@@ -369,7 +376,7 @@ export function ActionsSection({
 						strokeWidth={1.9}
 						style={{
 							transform: open ? "rotate(0deg)" : "rotate(-90deg)",
-							transition: `transform ${TABS_ANIMATION_MS}ms ${TABS_EASING}`,
+							transition: `transform ${chevronTransitionMs}ms ${TABS_EASING}`,
 						}}
 					/>
 				</Button>

--- a/src/features/inspector/sections/changes.tsx
+++ b/src/features/inspector/sections/changes.tsx
@@ -89,6 +89,8 @@ type ChangesSectionProps = {
 	forgeIsRefreshing?: boolean;
 	/** Height of the changes body (excluding the section header). */
 	bodyHeight: number;
+	/** Enables the height transition only for explicit panel toggles. */
+	animatePanelToggle?: boolean;
 	/** Suppresses the height transition while the user is dragging a divider. */
 	isResizing?: boolean;
 };
@@ -110,11 +112,15 @@ export function ChangesSection({
 	changeRequest,
 	forgeIsRefreshing = false,
 	bodyHeight,
+	animatePanelToggle = false,
 	isResizing,
 }: ChangesSectionProps) {
 	const shouldReduceMotion = useReducedMotion();
 	const panelTransition = {
-		duration: isResizing || shouldReduceMotion ? 0 : TABS_ANIMATION_MS / 1000,
+		duration:
+			animatePanelToggle && !isResizing && !shouldReduceMotion
+				? TABS_ANIMATION_MS / 1000
+				: 0,
 		ease: TABS_EASING_CURVE,
 	};
 	const queryClient = useQueryClient();


### PR DESCRIPTION
## What changed
- Measure the inspector sidebar height in a layout effect so initial panel sizes are available before the visible render.
- Gate inspector panel height and chevron transitions behind explicit user toggles instead of applying them on startup/resizes.
- Add App test coverage for the no-startup-transition state and initial measured panel heights.

## Why it changed
The inspector could animate from its fallback dimensions on startup, making the sidebar feel like it was sliding into place during initial render. The change keeps first paint static while preserving animation for deliberate panel toggles.

## Follow-up / test notes
- Ran `bun x vitest run src/App.test.tsx`.