### PR TITLE
feat(forge): smooth add-repo and Connect CTA flows

### DIFF
--- a/.changeset/kind-deer-connect.md
+++ b/.changeset/kind-deer-connect.md
@@ -1,0 +1,7 @@
+---
+"helmor": minor
+---
+
+Smooth out the add-repo and forge connect flows:
+- Adding a repository now lands on the start page with the new repo selected, instead of auto-creating a workspace.
+- Fix the GitHub / GitLab "Connect" button staying stuck after sign-in for accounts whose token can read the repo but doesn't expose membership in the API response.

--- a/src-tauri/src/cli/repo.rs
+++ b/src-tauri/src/cli/repo.rs
@@ -101,12 +101,9 @@ fn show(repo_ref: &str, cli: &Cli) -> Result<()> {
 fn add(path: &str, cli: &Cli) -> Result<()> {
     let response = service::add_repository_from_local_path(path)?;
     let mut events = vec![UiMutationEvent::RepositoryListChanged];
-    if response.created_workspace_id.is_some() {
-        events.push(UiMutationEvent::WorkspaceListChanged);
+    if let Some(workspace_id) = response.selected_workspace_id.clone() {
+        events.push(UiMutationEvent::WorkspaceChanged { workspace_id });
     }
-    events.push(UiMutationEvent::WorkspaceChanged {
-        workspace_id: response.selected_workspace_id.clone(),
-    });
     notify_ui_events(events);
     output::print(cli, &response, |r| {
         let mut lines = Vec::new();
@@ -115,10 +112,12 @@ fn add(path: &str, cli: &Cli) -> Result<()> {
         } else {
             lines.push(format!("Repository already exists: {}", r.repository_id));
         }
-        if let Some(ref ws_id) = r.created_workspace_id {
-            lines.push(format!("Created workspace  {ws_id}"));
+        match r.selected_workspace_id.as_deref() {
+            Some(ws_id) => lines.push(format!("Selected workspace {ws_id}")),
+            None => lines.push(
+                "No workspace selected — use `helmor workspace create` to start one.".to_string(),
+            ),
         }
-        lines.push(format!("Selected workspace {}", r.selected_workspace_id));
         lines.join("\n")
     })
 }

--- a/src-tauri/src/commands/tests/repository.rs
+++ b/src-tauri/src/commands/tests/repository.rs
@@ -20,7 +20,11 @@ fn list_repositories_filters_hidden_and_sorts_by_display_order() {
 }
 
 #[test]
-fn add_repository_from_local_path_adds_repo_and_first_workspace() {
+fn add_repository_from_local_path_persists_repo_without_creating_workspace() {
+    // Adding a repo no longer auto-creates a workspace — the start page
+    // owns that handoff. We assert: repo row inserted, branch/remote
+    // captured, response carries `selected_workspace_id: None` so the
+    // UI knows to land on start.
     let _guard = TEST_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -36,12 +40,8 @@ fn add_repository_from_local_path_adds_repo_and_first_workspace() {
     let connection = Connection::open(harness.db_path()).unwrap();
     let (repo_count, workspace_count, session_count): (i64, i64, i64) = connection
         .query_row(
-            r#"SELECT (SELECT COUNT(*) FROM repos WHERE root_path = ?1), (SELECT COUNT(*) FROM workspaces WHERE repository_id = ?2), (SELECT COUNT(*) FROM sessions WHERE workspace_id = ?3)"#,
-            (
-                normalized_repo_root.as_str(),
-                &response.repository_id,
-                response.created_workspace_id.as_deref().unwrap(),
-            ),
+            r#"SELECT (SELECT COUNT(*) FROM repos WHERE root_path = ?1), (SELECT COUNT(*) FROM workspaces WHERE repository_id = ?2), (SELECT COUNT(*) FROM sessions s JOIN workspaces w ON w.id = s.workspace_id WHERE w.repository_id = ?2)"#,
+            (normalized_repo_root.as_str(), &response.repository_id),
             |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
         )
         .unwrap();
@@ -52,20 +52,12 @@ fn add_repository_from_local_path_adds_repo_and_first_workspace() {
             |row| Ok((row.get(0)?, row.get(1)?)),
         )
         .unwrap();
-    let created_workspace_state: String = connection
-        .query_row(
-            "SELECT state FROM workspaces WHERE id = ?1",
-            [response.selected_workspace_id.as_str()],
-            |row| row.get(0),
-        )
-        .unwrap();
 
     assert!(response.created_repository);
+    assert_eq!(response.selected_workspace_id, None);
     assert_eq!(repo_count, 1);
-    assert_eq!(workspace_count, 1);
-    assert_eq!(session_count, 1);
-    assert_eq!(response.created_workspace_state, WorkspaceState::Ready);
-    assert_eq!(created_workspace_state, "ready");
+    assert_eq!(workspace_count, 0);
+    assert_eq!(session_count, 0);
     assert_eq!(default_branch, "main");
     assert_eq!(remote, Some("origin".to_string()));
 }
@@ -90,11 +82,30 @@ fn add_repository_from_local_path_focuses_existing_workspace_for_duplicate_repo(
         .unwrap();
 
     assert!(!response.created_repository);
-    assert_eq!(response.created_workspace_id, None);
-    assert_eq!(response.selected_workspace_id, created.created_workspace_id);
-    assert_eq!(response.created_workspace_state, WorkspaceState::Ready);
+    assert_eq!(
+        response.selected_workspace_id.as_deref(),
+        Some(created.created_workspace_id.as_str())
+    );
     assert_eq!(repo_count, 1);
     assert_eq!(workspace_count, 1);
+}
+
+#[test]
+fn add_repository_from_local_path_re_add_with_only_archived_workspaces_lands_on_start() {
+    // Re-adding a repo whose only workspace is archived should NOT
+    // auto-create a fresh one — the user picks via the start page.
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let harness = CreateTestHarness::new();
+    let created = workspaces::create_workspace_from_repo_impl(&harness.repo_id).unwrap();
+    workspaces::archive_workspace_impl(&created.created_workspace_id).unwrap();
+
+    let response =
+        repos::add_repository_from_local_path(harness.source_repo_root.to_str().unwrap()).unwrap();
+
+    assert!(!response.created_repository);
+    assert_eq!(response.selected_workspace_id, None);
 }
 
 #[test]

--- a/src-tauri/src/forge/accounts.rs
+++ b/src-tauri/src/forge/accounts.rs
@@ -49,6 +49,29 @@ impl AuthCheck {
     }
 }
 
+/// Three-tier repo-access verdict. Auto-bind prefers `Push`; falls back
+/// to `Probable` only when *no* candidate has `Push`. `None` means the
+/// API definitively says we can't reach this repo with this login.
+///
+/// `Probable` covers the (surprisingly common) case where the API
+/// returns 200 but doesn't expose membership-based push permission:
+/// admin-via-instance on self-hosted GitLab, SAML-SSO tokens that
+/// haven't been authorized for an org on GitHub, fine-grained PATs
+/// without `repository.metadata` scope, shared-with groups not
+/// reflected in `permissions`, etc. We'd rather bind one of these and
+/// surface a real `git push` error than show "Connect" forever when
+/// the user clearly has access (issue #350).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RepoAccess {
+    /// API explicitly confirmed push permission.
+    Push,
+    /// 200 but `permissions` field is missing / has no concrete data.
+    /// Bind only when no `Push` candidate exists.
+    Probable,
+    /// 404 / auth rejected / explicit no-push verdict.
+    None,
+}
+
 /// Provider-agnostic account operations. Each method may interpret
 /// `host` / `login` slightly differently — GitLab ignores `login` since
 /// it has at most one account per host, while GitHub uses `(host,
@@ -68,9 +91,10 @@ pub(crate) trait ForgeAccountBackend: Sync {
     /// failures as `Indeterminate`, never `LoggedOut`.
     fn check_auth(&self, host: &str, login: &str) -> AuthCheck;
 
-    /// 200 → `Ok(true)`, 404 / auth-rejected → `Ok(false)`, anything
-    /// else → `Err`.
-    fn repo_accessible(&self, host: &str, login: &str, owner: &str, name: &str) -> Result<bool>;
+    /// 200 with explicit push → `RepoAccess::Push`. 200 without
+    /// membership data → `RepoAccess::Probable` (auto-bind fallback).
+    /// 404 / auth-rejected → `RepoAccess::None`. Anything else → `Err`.
+    fn repo_access(&self, host: &str, login: &str, owner: &str, name: &str) -> Result<RepoAccess>;
 
     /// Display profile for a single `(host, login)`. Hits the same
     /// per-process cache as [`list_accounts`] so spot-fetches (e.g. the
@@ -161,7 +185,7 @@ pub fn workspace_account_profile(workspace_id: &str) -> Result<Option<ForgeAccou
 // ---------------- Auto-bind ----------------
 
 /// Resolved forge identity for a repo: provider, host, owner, name. The
-/// caller probes `repo_accessible` against candidate logins (auto-bind)
+/// caller probes `repo_access` against candidate logins (auto-bind)
 /// or runs CLI commands once a login is bound.
 #[derive(Debug, Clone)]
 pub(crate) struct RepoForgeTarget {
@@ -227,16 +251,19 @@ pub(crate) fn auto_bind_repo_account(repo_id: &str) -> Result<Option<String>> {
         return Ok(None);
     }
 
-    // Probe every candidate so we can both pick a winner *and*
-    // surface a warning when more than one account claims access —
-    // first-match-wins is fine in practice but the user should know
-    // they have an ambiguous binding so they can override it from
-    // Settings → Repository if the auto-pick is wrong.
-    let mut accessible: Vec<String> = Vec::new();
+    // Tier the candidates: explicit push permission wins; "200 but
+    // permissions field missing/null" is a fallback used only when no
+    // push-confirmed candidate exists. This prevents the
+    // "permissions-missing relaxation" from silently binding a
+    // read-only account when a push-capable account is also logged in
+    // on the same host (multi-account GitHub case).
+    let mut confirmed: Vec<String> = Vec::new();
+    let mut probable: Vec<String> = Vec::new();
     for login in &candidates {
-        match backend.repo_accessible(&target.host, login, &target.owner, &target.name) {
-            Ok(true) => accessible.push(login.clone()),
-            Ok(false) => continue,
+        match backend.repo_access(&target.host, login, &target.owner, &target.name) {
+            Ok(RepoAccess::Push) => confirmed.push(login.clone()),
+            Ok(RepoAccess::Probable) => probable.push(login.clone()),
+            Ok(RepoAccess::None) => continue,
             Err(error) => {
                 tracing::warn!(
                     repo_id,
@@ -247,17 +274,22 @@ pub(crate) fn auto_bind_repo_account(repo_id: &str) -> Result<Option<String>> {
             }
         }
     }
-    let Some(chosen) = accessible.first().cloned() else {
-        return Ok(None);
+    let (chosen, tier) = match confirmed.first().cloned() {
+        Some(login) => (login, "push"),
+        None => match probable.first().cloned() {
+            Some(login) => (login, "probable"),
+            None => return Ok(None),
+        },
     };
-    if accessible.len() > 1 {
+    if confirmed.len() + probable.len() > 1 {
         tracing::warn!(
             repo_id,
             provider = target.provider.as_storage_str(),
             host = %target.host,
             chosen = %chosen,
-            candidates = ?accessible,
-            "Multiple logged-in accounts can access this repo — picked the first; user can override from Settings → Repository"
+            confirmed = ?confirmed,
+            probable = ?probable,
+            "Multiple logged-in accounts can access this repo — picked one; user can override from Settings → Repository"
         );
     }
     repos::update_repository_forge_login(repo_id, Some(&chosen))?;
@@ -266,6 +298,7 @@ pub(crate) fn auto_bind_repo_account(repo_id: &str) -> Result<Option<String>> {
         provider = target.provider.as_storage_str(),
         host = %target.host,
         login = %chosen,
+        tier,
         "Auto-bound repo to forge account"
     );
     Ok(Some(chosen))

--- a/src-tauri/src/forge/github/accounts.rs
+++ b/src-tauri/src/forge/github/accounts.rs
@@ -11,7 +11,7 @@ use anyhow::{anyhow, Context, Result};
 use serde::Deserialize;
 use std::collections::HashMap;
 
-use crate::forge::accounts::{AuthCheck, ForgeAccount, ForgeAccountBackend};
+use crate::forge::accounts::{AuthCheck, ForgeAccount, ForgeAccountBackend, RepoAccess};
 use crate::forge::command::{command_detail, run_command, run_command_with_env, CommandOutput};
 use crate::forge::types::ForgeProvider;
 
@@ -35,8 +35,8 @@ impl ForgeAccountBackend for GithubAccountBackend {
         check_github_auth(host, login)
     }
 
-    fn repo_accessible(&self, host: &str, login: &str, owner: &str, name: &str) -> Result<bool> {
-        github_repo_accessible(host, login, owner, name)
+    fn repo_access(&self, host: &str, login: &str, owner: &str, name: &str) -> Result<RepoAccess> {
+        github_repo_access(host, login, owner, name)
     }
 
     fn fetch_profile(&self, host: &str, login: &str) -> Result<ForgeAccount> {
@@ -449,15 +449,12 @@ mod profile_cache {
     }
 }
 
-/// "Can this account *push* to this repo?" — read access alone isn't
-/// enough for auto-bind because Helmor commits and pushes via the
-/// bound account; we'd be misleading the user by binding to a login
-/// they can only browse with. GitHub's authenticated
-/// `GET /repos/{owner}/{repo}` returns a `permissions` object whose
-/// `push` flag we honour. (Anonymous responses don't carry that
-/// field, but we always go through `run_cli_with_login` so the
-/// request is authenticated.)
-fn github_repo_accessible(host: &str, login: &str, owner: &str, name: &str) -> Result<bool> {
+/// Probe push access for `(host, login, owner, name)` via authenticated
+/// `GET /repos/{owner}/{repo}`. `permissions.push == true` → `Push`.
+/// `permissions` missing entirely → `Probable` (SAML SSO not authorized,
+/// fine-grained PAT without `repository.metadata`, etc. — issue #350).
+/// 404 / auth rejected → `None`.
+fn github_repo_access(host: &str, login: &str, owner: &str, name: &str) -> Result<RepoAccess> {
     let path = format!("/repos/{owner}/{name}");
     let args = [
         "api",
@@ -472,7 +469,7 @@ fn github_repo_accessible(host: &str, login: &str, owner: &str, name: &str) -> R
     if !output.success {
         let detail = command_detail(&output);
         if looks_like_not_found(&detail) || looks_like_unauthenticated(&detail) {
-            return Ok(false);
+            return Ok(RepoAccess::None);
         }
         return Err(anyhow!("`gh api {path}` failed for {login}: {detail}"));
     }
@@ -480,15 +477,22 @@ fn github_repo_accessible(host: &str, login: &str, owner: &str, name: &str) -> R
         .with_context(|| format!("Failed to decode `gh api {path}` for {login}"))
 }
 
-/// `Ok(true)` when GitHub's `GET /repos/{owner}/{repo}` response
-/// carries `permissions.push == true`. Anonymous responses lack the
-/// `permissions` object entirely → `Ok(false)`. Pure JSON shape —
-/// split out so the threshold ("push, not just pull") has explicit
-/// test coverage.
-fn parse_repo_push_permission(stdout: &str) -> Result<bool> {
+/// Decode `permissions` from a successful `GET /repos/{owner}/{repo}`
+/// response into a [`RepoAccess`] verdict. Pure JSON shape — split out
+/// so the threshold ("push, not just pull") has explicit test coverage.
+fn parse_repo_push_permission(stdout: &str) -> Result<RepoAccess> {
     let parsed: GithubRepoPermissionsResponse = serde_json::from_str(stdout)
         .with_context(|| "Failed to decode `gh api /repos/...` payload".to_string())?;
-    Ok(parsed.permissions.is_some_and(|p| p.push))
+    Ok(match parsed.permissions {
+        Some(p) if p.push => RepoAccess::Push,
+        Some(_) => RepoAccess::None,
+        // Authenticated request, 200, but no `permissions` object —
+        // GitHub Enterprise quirks, SSO-blocked tokens, fine-grained
+        // PATs without metadata scope. Auto-bind treats this as a
+        // fallback candidate so users like #350 don't get stuck on
+        // the Connect CTA.
+        None => RepoAccess::Probable,
+    })
 }
 
 #[derive(Debug, Deserialize)]
@@ -722,37 +726,48 @@ mod tests {
     // ---------------- parse_repo_push_permission ----------------
 
     #[test]
-    fn parse_repo_push_permission_true_when_push_set() {
+    fn parse_repo_push_permission_push_when_push_set() {
         // Authenticated `GET /repos/{owner}/{repo}` returns
         // `permissions: { push: true }` for collaborators with write
-        // access. Auto-bind needs *push* not just pull.
+        // access.
         let stdout = r#"{
             "id": 1,
             "name": "hello-world",
             "permissions": { "admin": false, "push": true, "pull": true }
         }"#;
-        assert!(parse_repo_push_permission(stdout).unwrap());
+        assert_eq!(
+            parse_repo_push_permission(stdout).unwrap(),
+            RepoAccess::Push
+        );
     }
 
     #[test]
-    fn parse_repo_push_permission_false_when_only_pull() {
-        // Read-only collaborators / public-repo browsers — must not
-        // be auto-bound, since Helmor pushes via the bound account.
+    fn parse_repo_push_permission_none_when_only_pull() {
+        // Read-only collaborators / public-repo browsers — explicit no.
         let stdout = r#"{
             "id": 1,
             "name": "hello-world",
             "permissions": { "admin": false, "push": false, "pull": true }
         }"#;
-        assert!(!parse_repo_push_permission(stdout).unwrap());
+        assert_eq!(
+            parse_repo_push_permission(stdout).unwrap(),
+            RepoAccess::None
+        );
     }
 
     #[test]
-    fn parse_repo_push_permission_false_when_permissions_missing() {
-        // Anonymous responses (or scopes that don't expose the
-        // `permissions` object) — treat as "not writeable" rather
-        // than failing the probe.
+    fn parse_repo_push_permission_probable_when_permissions_missing() {
+        // SAML-SSO tokens that haven't been org-authorized, fine-grained
+        // PATs without `repository.metadata`, GHES quirks — the request
+        // is authenticated and 200 but the `permissions` object is
+        // missing. Surface as `Probable` so auto-bind picks us up when
+        // no push-confirmed candidate exists. Was previously
+        // (incorrectly) `false`, which is the root cause of issue #350.
         let stdout = r#"{ "id": 1, "name": "hello-world" }"#;
-        assert!(!parse_repo_push_permission(stdout).unwrap());
+        assert_eq!(
+            parse_repo_push_permission(stdout).unwrap(),
+            RepoAccess::Probable
+        );
     }
 
     #[test]

--- a/src-tauri/src/forge/gitlab/accounts.rs
+++ b/src-tauri/src/forge/gitlab/accounts.rs
@@ -10,7 +10,7 @@
 use anyhow::{anyhow, Context, Result};
 use serde::Deserialize;
 
-use crate::forge::accounts::{AuthCheck, ForgeAccount, ForgeAccountBackend};
+use crate::forge::accounts::{AuthCheck, ForgeAccount, ForgeAccountBackend, RepoAccess};
 use crate::forge::command::{command_detail, run_command, CommandOutput};
 use crate::forge::types::ForgeProvider;
 
@@ -79,8 +79,8 @@ impl ForgeAccountBackend for GitlabAccountBackend {
         check_gitlab_auth(host, login)
     }
 
-    fn repo_accessible(&self, host: &str, _login: &str, owner: &str, name: &str) -> Result<bool> {
-        gitlab_repo_accessible(host, owner, name)
+    fn repo_access(&self, host: &str, _login: &str, owner: &str, name: &str) -> Result<RepoAccess> {
+        gitlab_repo_access(host, owner, name)
     }
 
     fn fetch_profile(&self, host: &str, login: &str) -> Result<ForgeAccount> {
@@ -445,18 +445,15 @@ fn fetch_gitlab_profile(host: &str) -> Result<GitlabUserResponse> {
     Ok(parsed)
 }
 
-/// "Can this account *push* to this project?" — read access alone
-/// isn't enough; auto-bind would surface a login that can only
-/// browse, which would silently fail the moment Helmor tries to
-/// commit. `GET /projects/:id` returns a `permissions` object with
-/// a direct `project_access` and an inherited `group_access`,
-/// either of which is enough — we take the higher of the two and
-/// require Developer (30+), the lowest tier that can push to
-/// unprotected branches. Maintainers (40) and Owners (50)
-/// naturally satisfy this. Reporters (20) and Guests (10) don't.
+/// `GET /projects/:id` returns a `permissions` object with a direct
+/// `project_access` and an inherited `group_access`. We take the
+/// higher of the two and require Developer (30+) for `Push`.
+/// Reporters (20) / Guests (10) → `None`. The `Probable` tier
+/// handles the "permissions present but no concrete data" case
+/// (admin, shared groups, scope-limited tokens) — see [`RepoAccess`].
 const GITLAB_DEVELOPER_ACCESS_LEVEL: i32 = 30;
 
-fn gitlab_repo_accessible(host: &str, owner: &str, name: &str) -> Result<bool> {
+fn gitlab_repo_access(host: &str, owner: &str, name: &str) -> Result<RepoAccess> {
     let path = format!(
         "projects/{}",
         encode_path_component(&format!("{owner}/{name}"))
@@ -466,7 +463,7 @@ fn gitlab_repo_accessible(host: &str, owner: &str, name: &str) -> Result<bool> {
     if !output.success {
         let detail = command_detail(&output);
         if looks_like_missing_error(&detail) || looks_like_auth_error(&detail) {
-            return Ok(false);
+            return Ok(RepoAccess::None);
         }
         return Err(anyhow!("`glab api {path}` failed: {detail}"));
     }
@@ -474,31 +471,41 @@ fn gitlab_repo_accessible(host: &str, owner: &str, name: &str) -> Result<bool> {
         .with_context(|| format!("Failed to decode `glab api {path}`"))
 }
 
-/// `Ok(true)` when the higher of `project_access` / `group_access`
-/// is at least Developer (30). Pure JSON shape — split out so the
-/// access-level threshold ("Developer can push to unprotected
-/// branches") has explicit test coverage independent of the CLI.
-fn parse_project_push_permission(stdout: &str) -> Result<bool> {
+/// Decode `permissions` from a successful `GET /projects/:id` response
+/// into a [`RepoAccess`] verdict. Split out so the threshold logic has
+/// explicit test coverage independent of the CLI.
+fn parse_project_push_permission(stdout: &str) -> Result<RepoAccess> {
     let parsed: GitlabProjectPermissionsResponse = serde_json::from_str(stdout)
         .with_context(|| "Failed to decode `glab api projects/...` payload".to_string())?;
-    let highest = parsed
+    let project_level = parsed
         .permissions
         .as_ref()
-        .map(|p| {
-            let project = p
-                .project_access
-                .as_ref()
-                .and_then(|a| a.access_level)
-                .unwrap_or(0);
-            let group = p
-                .group_access
-                .as_ref()
-                .and_then(|a| a.access_level)
-                .unwrap_or(0);
-            project.max(group)
-        })
-        .unwrap_or(0);
-    Ok(highest >= GITLAB_DEVELOPER_ACCESS_LEVEL)
+        .and_then(|p| p.project_access.as_ref())
+        .and_then(|a| a.access_level);
+    let group_level = parsed
+        .permissions
+        .as_ref()
+        .and_then(|p| p.group_access.as_ref())
+        .and_then(|a| a.access_level);
+    tracing::debug!(
+        permissions_present = parsed.permissions.is_some(),
+        project_access_level = ?project_level,
+        group_access_level = ?group_level,
+        threshold = GITLAB_DEVELOPER_ACCESS_LEVEL,
+        "parse_project_push_permission: parsed access levels"
+    );
+    // No permissions object, or both access fields absent → can't tell
+    // membership from the API. Fall back to `Probable` so auto-bind
+    // can still bind us when no push-confirmed candidate exists.
+    if project_level.is_none() && group_level.is_none() {
+        return Ok(RepoAccess::Probable);
+    }
+    let highest = project_level.unwrap_or(0).max(group_level.unwrap_or(0));
+    Ok(if highest >= GITLAB_DEVELOPER_ACCESS_LEVEL {
+        RepoAccess::Push
+    } else {
+        RepoAccess::None
+    })
 }
 
 #[derive(Debug, Deserialize)]
@@ -655,10 +662,12 @@ mod tests {
     //
     // GitLab access levels (constants are GitLab's, not ours):
     //   10 Guest, 20 Reporter, 30 Developer, 40 Maintainer, 50 Owner.
-    // Auto-bind needs *push*, so the threshold is Developer (30).
+    // Push threshold is Developer (30). Below that → `None`. Above →
+    // `Push`. Permissions present but with no concrete access data
+    // (admin / shared groups / scope-limited tokens) → `Probable`.
 
     #[test]
-    fn parse_project_push_permission_true_for_developer_via_project_access() {
+    fn parse_project_push_permission_push_for_developer_via_project_access() {
         let stdout = r#"{
             "id": 1,
             "permissions": {
@@ -666,42 +675,53 @@ mod tests {
                 "group_access": null
             }
         }"#;
-        assert!(parse_project_push_permission(stdout).unwrap());
+        assert_eq!(
+            parse_project_push_permission(stdout).unwrap(),
+            RepoAccess::Push
+        );
     }
 
     #[test]
-    fn parse_project_push_permission_true_for_maintainer() {
+    fn parse_project_push_permission_push_for_maintainer() {
         let stdout = r#"{
             "permissions": {
                 "project_access": {"access_level": 40, "notification_level": 3},
                 "group_access": null
             }
         }"#;
-        assert!(parse_project_push_permission(stdout).unwrap());
+        assert_eq!(
+            parse_project_push_permission(stdout).unwrap(),
+            RepoAccess::Push
+        );
     }
 
     #[test]
-    fn parse_project_push_permission_false_for_reporter() {
-        // Reporter (20) — read-only on most workflows. Must NOT be
-        // auto-bound or push will silently fail.
+    fn parse_project_push_permission_none_for_reporter() {
+        // Reporter (20) — read-only on most workflows. Explicit no.
         let stdout = r#"{
             "permissions": {
                 "project_access": {"access_level": 20, "notification_level": 3},
                 "group_access": null
             }
         }"#;
-        assert!(!parse_project_push_permission(stdout).unwrap());
+        assert_eq!(
+            parse_project_push_permission(stdout).unwrap(),
+            RepoAccess::None
+        );
     }
 
     #[test]
-    fn parse_project_push_permission_false_for_guest() {
+    fn parse_project_push_permission_none_for_guest() {
         let stdout = r#"{
             "permissions": {
                 "project_access": {"access_level": 10, "notification_level": 0},
                 "group_access": null
             }
         }"#;
-        assert!(!parse_project_push_permission(stdout).unwrap());
+        assert_eq!(
+            parse_project_push_permission(stdout).unwrap(),
+            RepoAccess::None
+        );
     }
 
     #[test]
@@ -716,28 +736,42 @@ mod tests {
                 "group_access": {"access_level": 40}
             }
         }"#;
-        assert!(parse_project_push_permission(stdout).unwrap());
+        assert_eq!(
+            parse_project_push_permission(stdout).unwrap(),
+            RepoAccess::Push
+        );
     }
 
     #[test]
-    fn parse_project_push_permission_handles_null_access_levels() {
-        // Both blocks present but with `access_level: null` — treat
-        // as 0 (no permission), don't blow up.
+    fn parse_project_push_permission_probable_when_access_levels_null() {
+        // The case from the wild: instance admin / shared-with group /
+        // scope-limited PAT — `permissions` is present but both blocks
+        // carry `access_level: null`. Surface as `Probable` so the
+        // auto-bind tier picks us up when no push-confirmed candidate
+        // exists. Was previously (incorrectly) `false`, leaving the
+        // user stuck with the Connect CTA forever.
         let stdout = r#"{
             "permissions": {
                 "project_access": {"access_level": null},
                 "group_access": {"access_level": null}
             }
         }"#;
-        assert!(!parse_project_push_permission(stdout).unwrap());
+        assert_eq!(
+            parse_project_push_permission(stdout).unwrap(),
+            RepoAccess::Probable
+        );
     }
 
     #[test]
-    fn parse_project_push_permission_false_when_permissions_missing() {
-        // Anonymous response or scope without `permissions` — treat
-        // as not pushable. Mirrors the GitHub side.
+    fn parse_project_push_permission_probable_when_permissions_missing() {
+        // Same rationale as the null-blocks case above — the API
+        // returned 200 (so the user can at least read), it just
+        // didn't tell us about membership.
         let stdout = r#"{ "id": 1, "name": "x" }"#;
-        assert!(!parse_project_push_permission(stdout).unwrap());
+        assert_eq!(
+            parse_project_push_permission(stdout).unwrap(),
+            RepoAccess::Probable
+        );
     }
 
     #[test]

--- a/src-tauri/src/models/repos.rs
+++ b/src-tauri/src/models/repos.rs
@@ -7,10 +7,7 @@ use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::{
-    git_ops, helpers,
-    workspace_state::{self, WorkspaceState},
-};
+use crate::{git_ops, helpers, workspace_state};
 
 use super::db;
 
@@ -42,14 +39,23 @@ pub struct AddRepositoryDefaults {
     pub last_clone_directory: Option<String>,
 }
 
+/// Response from `add_repository_from_local_path` / `clone_repository_from_url`.
+///
+/// `selected_workspace_id`:
+/// - `Some(id)` only when the repo was already in the DB AND has a visible
+///   (non-archived) workspace — the UI focuses that workspace.
+/// - `None` for newly-added repos and for re-adds where every workspace is
+///   archived. The UI lands on the start page with the new repo selected
+///   so the user can pick the source branch + workspace mode themselves.
+///
+/// We deliberately no longer auto-create a workspace at add-repo time —
+/// the start page replaced that flow.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AddRepositoryResponse {
     pub repository_id: String,
     pub created_repository: bool,
-    pub selected_workspace_id: String,
-    pub created_workspace_id: Option<String>,
-    pub created_workspace_state: WorkspaceState,
+    pub selected_workspace_id: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -908,19 +914,6 @@ fn normalize_repo_preference(value: Option<&str>) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
-pub(crate) fn delete_repository(repo_id: &str) -> Result<()> {
-    let connection = db::write_conn()?;
-    let deleted_rows = connection
-        .execute("DELETE FROM repos WHERE id = ?1", [repo_id])
-        .with_context(|| format!("Failed to delete repository {repo_id}"))?;
-
-    if deleted_rows != 1 {
-        bail!("Repository delete affected {deleted_rows} rows for {repo_id}");
-    }
-
-    Ok(())
-}
-
 /// Delete a repository and all related data (workspaces, sessions, messages, etc.)
 pub fn delete_repository_cascade(repo_id: &str) -> Result<()> {
     let mut connection = db::write_conn()?;
@@ -1075,31 +1068,17 @@ pub fn add_repository_from_local_path(folder_path: &str) -> Result<AddRepository
             .map_err(|e| anyhow::anyhow!(e))?;
     }
 
+    // Re-add path: focus an existing visible workspace if one exists,
+    // otherwise fall through to the start-page hand-off (None).
     if let Some(repository) = load_repository_by_root_path(&normalized_root_path)? {
-        if let Some((selected_workspace_id, selected_workspace_state)) =
+        let selected_workspace_id =
             crate::workspaces::select_visible_workspace_for_repo(&repository.id)
                 .map_err(|e| anyhow::anyhow!(e))?
-        {
-            return Ok(AddRepositoryResponse {
-                repository_id: repository.id,
-                created_repository: false,
-                selected_workspace_id,
-                created_workspace_id: None,
-                created_workspace_state: selected_workspace_state,
-            });
-        }
-
-        let create_response = crate::workspaces::create_workspace_from_repo_impl(&repository.id)
-            .map_err(|error| {
-                anyhow::anyhow!("Repository already exists, but workspace create failed: {error}")
-            })?;
-
+                .map(|(workspace_id, _)| workspace_id);
         return Ok(AddRepositoryResponse {
             repository_id: repository.id,
             created_repository: false,
-            selected_workspace_id: create_response.selected_workspace_id.clone(),
-            created_workspace_id: Some(create_response.created_workspace_id),
-            created_workspace_state: create_response.created_state,
+            selected_workspace_id,
         });
     }
 
@@ -1137,21 +1116,11 @@ pub fn add_repository_from_local_path(folder_path: &str) -> Result<AddRepository
         }
     }
 
-    let create_result = crate::workspaces::create_workspace_from_repo_impl(&repository_id);
-
-    match create_result {
-        Ok(create_response) => Ok(AddRepositoryResponse {
-            repository_id,
-            created_repository: true,
-            selected_workspace_id: create_response.selected_workspace_id.clone(),
-            created_workspace_id: Some(create_response.created_workspace_id),
-            created_workspace_state: create_response.created_state,
-        }),
-        Err(error) => {
-            let _ = delete_repository(&repository_id);
-            bail!("First workspace create failed: {error}");
-        }
-    }
+    Ok(AddRepositoryResponse {
+        repository_id,
+        created_repository: true,
+        selected_workspace_id: None,
+    })
 }
 
 /// Lightweight git root resolution — no network calls, just local git commands.

--- a/src/App.add-repo.test.tsx
+++ b/src/App.add-repo.test.tsx
@@ -66,35 +66,22 @@ describe("App add repository flow", () => {
 			lastCloneDirectory: "/tmp/test-repos",
 		});
 		dialogMocks.open.mockResolvedValue("/tmp/test-repos/added-repo");
-		apiMocks.loadWorkspaceGroups.mockImplementation(async () => [
+		// Add-repo no longer auto-creates a workspace, so the workspace
+		// list stays unchanged after an add. New repos surface via
+		// `listRepositories`, not via a fresh workspace row.
+		apiMocks.loadWorkspaceGroups.mockResolvedValue([
 			{
 				id: "progress",
 				label: "In progress",
 				tone: "progress",
-				rows: addRepoRuntime.added
-					? [
-							{
-								id: "workspace-existing",
-								title: "Existing workspace",
-								repoName: "helmor-core",
-								state: "ready",
-							},
-							{
-								id: "workspace-added",
-								title: "Acamar",
-								directoryName: "acamar",
-								repoName: "added-repo",
-								state: "ready",
-							},
-						]
-					: [
-							{
-								id: "workspace-existing",
-								title: "Existing workspace",
-								repoName: "helmor-core",
-								state: "ready",
-							},
-						],
+				rows: [
+					{
+						id: "workspace-existing",
+						title: "Existing workspace",
+						repoName: "helmor-core",
+						state: "ready",
+					},
+				],
 			},
 		]);
 		apiMocks.loadArchivedWorkspaces.mockResolvedValue([]);
@@ -230,12 +217,13 @@ describe("App add repository flow", () => {
 		apiMocks.addRepositoryFromLocalPath.mockImplementation(async () => {
 			addRepoRuntime.added = true;
 
+			// New behavior: backend hands back `selectedWorkspaceId: null`
+			// for newly-added repos. UI lands on start page with this
+			// repo selected, no auto-create.
 			return {
 				repositoryId: "repo-added",
 				createdRepository: true,
-				selectedWorkspaceId: "workspace-added",
-				createdWorkspaceId: "workspace-added",
-				createdWorkspaceState: "ready",
+				selectedWorkspaceId: null,
 			};
 		});
 	});
@@ -244,7 +232,7 @@ describe("App add repository flow", () => {
 		cleanup();
 	});
 
-	it("opens the native folder picker and adds a repository", async () => {
+	it("opens the native folder picker and lands on the start page with the new repo selected", async () => {
 		const user = userEvent.setup();
 
 		render(<App />);
@@ -267,18 +255,15 @@ describe("App add repository flow", () => {
 				"/tmp/test-repos/added-repo",
 			);
 		});
+		// The new repo shows up in the sidebar's repository list.
 		await waitFor(() => {
-			expect(apiMocks.loadWorkspaceDetail).toHaveBeenCalledWith(
-				"workspace-added",
-			);
+			expect(apiMocks.listRepositories).toHaveBeenCalled();
 		});
-		await waitFor(() => {
-			expect(apiMocks.loadSessionThreadMessages).toHaveBeenCalledWith(
-				"session-added",
-			);
-		});
-
-		expect(screen.getByText("Acamar")).toBeInTheDocument();
+		// We should NOT auto-create a workspace, so no auto-load of one.
+		expect(apiMocks.loadWorkspaceDetail).not.toHaveBeenCalledWith(
+			"workspace-added",
+		);
+		expect(screen.queryByText("Acamar")).not.toBeInTheDocument();
 	});
 
 	it("treats picker cancel as a no-op", async () => {
@@ -306,8 +291,6 @@ describe("App add repository flow", () => {
 			repositoryId: "repo-existing",
 			createdRepository: false,
 			selectedWorkspaceId: "workspace-existing",
-			createdWorkspaceId: null,
-			createdWorkspaceState: "ready",
 		});
 
 		render(<App />);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2407,6 +2407,22 @@ function AppShell({
 		},
 		[appSettings.kanbanViewState, updateSettings],
 	);
+	// Add-repo no longer auto-creates a workspace — when the backend
+	// hands back `selectedWorkspaceId: null`, drop into the start page
+	// with the freshly added repo selected.
+	const handleAddRepositoryNeedsStart = useCallback(
+		(repositoryId: string) => {
+			setStartRepositoryId(repositoryId);
+			void updateSettings({
+				kanbanViewState: {
+					...appSettings.kanbanViewState,
+					repoId: repositoryId,
+				},
+			});
+			handleOpenWorkspaceStart();
+		},
+		[appSettings.kanbanViewState, handleOpenWorkspaceStart, updateSettings],
+	);
 	useEffect(() => {
 		setStartPreviewCard(null);
 	}, [startRepository?.id]);
@@ -2657,6 +2673,9 @@ function AppShell({
 														addRepositoryShortcut={addRepositoryShortcut}
 														onSelectWorkspace={handleSelectWorkspace}
 														onOpenNewWorkspace={handleOpenWorkspaceStart}
+														onAddRepositoryNeedsStart={
+															handleAddRepositoryNeedsStart
+														}
 														onMoveLocalToWorktree={handleMoveLocalToWorktree}
 														pushWorkspaceToast={pushWorkspaceToast}
 													/>

--- a/src/features/navigation/container.tsx
+++ b/src/features/navigation/container.tsx
@@ -15,6 +15,7 @@ type WorkspacesSidebarContainerProps = {
 	addRepositoryShortcut?: string | null;
 	onSelectWorkspace: (workspaceId: string | null) => void;
 	onOpenNewWorkspace?: () => void;
+	onAddRepositoryNeedsStart?: (repositoryId: string) => void;
 	onMoveLocalToWorktree?: (workspaceId: string) => void;
 	pushWorkspaceToast: (
 		description: string,
@@ -37,6 +38,7 @@ export const WorkspacesSidebarContainer = memo(
 		addRepositoryShortcut,
 		onSelectWorkspace,
 		onOpenNewWorkspace,
+		onAddRepositoryNeedsStart,
 		onMoveLocalToWorktree,
 		pushWorkspaceToast,
 	}: WorkspacesSidebarContainerProps) {
@@ -65,6 +67,7 @@ export const WorkspacesSidebarContainer = memo(
 			autoSelectEnabled,
 			onSelectWorkspace,
 			onOpenNewWorkspace,
+			onAddRepositoryNeedsStart,
 			pushWorkspaceToast,
 		});
 

--- a/src/features/navigation/hooks/use-controller.ts
+++ b/src/features/navigation/hooks/use-controller.ts
@@ -81,6 +81,13 @@ type UseWorkspacesSidebarControllerArgs = {
 	autoSelectEnabled?: boolean;
 	onSelectWorkspace: (workspaceId: string | null) => void;
 	onOpenNewWorkspace?: () => void;
+	/**
+	 * Called after a successful add-repo when the backend hands us a
+	 * `selectedWorkspaceId: null` — newly added repo, or re-add with only
+	 * archived workspaces. UI lands on the start page with this repo
+	 * preselected.
+	 */
+	onAddRepositoryNeedsStart?: (repositoryId: string) => void;
 	pushWorkspaceToast: WorkspaceToastFn;
 };
 
@@ -91,6 +98,7 @@ export function useWorkspacesSidebarController({
 	autoSelectEnabled = true,
 	onSelectWorkspace,
 	onOpenNewWorkspace,
+	onAddRepositoryNeedsStart,
 	pushWorkspaceToast,
 }: UseWorkspacesSidebarControllerArgs) {
 	const queryClient = useQueryClient();
@@ -1000,18 +1008,33 @@ export function useWorkspacesSidebarController({
 	const applyAddRepositoryResponse = useCallback(
 		async (response: AddRepositoryResponse) => {
 			await refetchNavigation();
-			prefetchWorkspace(response.selectedWorkspaceId);
-			onSelectWorkspace(response.selectedWorkspaceId);
-
+			if (response.selectedWorkspaceId) {
+				// Re-add of an existing repo with a visible workspace —
+				// jump straight to it, same as before.
+				prefetchWorkspace(response.selectedWorkspaceId);
+				onSelectWorkspace(response.selectedWorkspaceId);
+				if (!response.createdRepository) {
+					pushWorkspaceToast(
+						"Switched to the existing workspace.",
+						"Repository already added",
+						"default",
+					);
+				}
+				return;
+			}
+			// No visible workspace to focus → land on the start page with
+			// the new repo selected so the user picks branch + mode.
+			onAddRepositoryNeedsStart?.(response.repositoryId);
 			if (!response.createdRepository) {
 				pushWorkspaceToast(
-					"Switched to the existing workspace.",
+					"Repository already added — opened the start page so you can spin up a workspace.",
 					"Repository already added",
 					"default",
 				);
 			}
 		},
 		[
+			onAddRepositoryNeedsStart,
 			onSelectWorkspace,
 			prefetchWorkspace,
 			pushWorkspaceToast,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -268,9 +268,13 @@ export type ForgeDetection = {
 export type AddRepositoryResponse = {
 	repositoryId: string;
 	createdRepository: boolean;
-	selectedWorkspaceId: string;
-	createdWorkspaceId?: string | null;
-	createdWorkspaceState: WorkspaceState;
+	/**
+	 * `string` only when the repo was already in the DB and has a visible
+	 * workspace — UI focuses it. `null` for newly-added repos and re-adds
+	 * with only archived workspaces — UI lands on the start page with this
+	 * repo selected.
+	 */
+	selectedWorkspaceId: string | null;
 };
 
 export type WorkspaceDetail = {


### PR DESCRIPTION
## Summary

Two related quality-of-life fixes around adding repositories and binding forge accounts:

- **Add-repo no longer auto-creates a workspace.** The backend now returns `selectedWorkspaceId: null` for newly-added repos (and re-adds where every workspace is archived). The UI lands on the start page with the new repo selected so the user picks the source branch + workspace mode themselves. Re-adds of repos with a visible workspace still focus that workspace, same as before.
- **Connect CTA no longer gets stuck after sign-in** for accounts whose token can read the repo but doesn't expose membership in the API response. Replaces the boolean `repo_accessible` probe with a three-tier `RepoAccess::{Push, Probable, None}` verdict. Auto-bind prefers `Push`; only falls back to `Probable` when no push-confirmed candidate exists. `Probable` covers SAML SSO not org-authorized, fine-grained PATs without `repository.metadata`, GHES quirks, GitLab admin-via-instance / shared-with groups, and scope-limited tokens. Closes #350.

## Why

Add-repo auto-creating a workspace was the wrong default — users often want to choose their source branch / mode rather than be dropped into a freshly-spawned workspace they then have to abandon. The Connect CTA bug was an absolute regression: on the affected accounts the user could push fine via git, but the in-app probe returned a false-negative and showed Connect forever.

## What changed

**Backend (`src-tauri/`)**
- `forge/accounts.rs` — new `RepoAccess` enum; `auto_bind_repo_account` tiers candidates `Push` → `Probable` → `None`.
- `forge/github/accounts.rs`, `forge/gitlab/accounts.rs` — `repo_accessible` → `repo_access`. GitHub: missing `permissions` object → `Probable`. GitLab: `permissions` present but both `project_access` / `group_access` absent → `Probable`. Below Developer (30) → `None`.
- `models/repos.rs` — `AddRepositoryResponse.selectedWorkspaceId` is now `Option<String>`. Drops the auto-`create_workspace_from_repo_impl` call and the `created_workspace_id` / `created_workspace_state` fields. Removes the now-unused `delete_repository` helper.
- `cli/repo.rs` — CLI `add` command updated to print "Selected workspace …" only when one was actually focused, otherwise points to `helmor workspace create`.
- `commands/tests/repository.rs` — rewritten test asserts no workspace is created on add; new test covers re-add when only archived workspaces exist (must also land on start).

**Frontend (`src/`)**
- `lib/api.ts` — `AddRepositoryResponse.selectedWorkspaceId: string | null`; drops `createdWorkspaceId` / `createdWorkspaceState`.
- `App.tsx` — new `handleAddRepositoryNeedsStart` callback wires the start-page hand-off.
- `features/navigation/container.tsx`, `hooks/use-controller.ts` — `applyAddRepositoryResponse` branches on `selectedWorkspaceId`: focus existing workspace if present, otherwise call `onAddRepositoryNeedsStart` with toast copy adjusted accordingly.
- `App.add-repo.test.tsx` — updated to assert the new behavior (no auto-load, no "Acamar" workspace).

Includes a minor changeset (`.changeset/kind-deer-connect.md`).

## Test plan

- [ ] `bun run test` — all three suites green (frontend / sidecar / rust)
- [ ] `bun run lint` — biome + clippy clean
- [ ] Manual: add a fresh repo from the picker → confirm we land on the start page with that repo selected, not a freshly-spawned workspace
- [ ] Manual: re-add a repo that has a visible workspace → confirm we focus it, toast says "Switched to the existing workspace"
- [ ] Manual: re-add a repo whose only workspace is archived → confirm we land on start page, toast says "opened the start page"
- [ ] Manual (issue #350 repro): sign in with an account that has push access but whose `permissions` field is missing/null → confirm Connect CTA disappears after auto-bind