### PR TITLE
fix: keep sidecar alive on transient EPIPE so Claude resume doesn't go blank

### DIFF
--- a/.changeset/sidecar-epipe-resilience.md
+++ b/.changeset/sidecar-epipe-resilience.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix Claude threads occasionally returning an empty response mid-conversation and losing context on retry.

--- a/sidecar/src/index.ts
+++ b/sidecar/src/index.ts
@@ -42,13 +42,24 @@ const managers: Record<Provider, SessionManager> = {
 	codex: codexManager,
 };
 
-// EPIPE = parent closed the pipe → exit cleanly. Without this, writes to
-// a dead pipe escalate to uncaughtException → the handler writes again →
-// zombie process that silently kills every in-flight RPC.
+// `parentGone` flips to true only when stdin EOFs — that's the
+// authoritative "Rust exited" signal. EPIPE on stdout, by contrast, can
+// fire transiently from any pipe in the process (Anthropic SDK child
+// processes, internal Bun async paths, etc.); using EPIPE alone as the
+// exit trigger silently kills every in-flight query whenever any of
+// those pipes blip (issues #398/#402). Set the flag here so the EPIPE
+// handlers below can distinguish the two.
+let parentGone = false;
+
 function handleStdioError(stream: "stdout" | "stderr") {
 	return (err: NodeJS.ErrnoException) => {
 		if (err.code === "EPIPE") {
-			process.exit(0);
+			if (parentGone) {
+				process.exit(0);
+			}
+			// Transient EPIPE while parent is still alive — drop this
+			// write. Don't escalate.
+			return;
 		}
 		// Report through the OTHER stream to avoid recursion.
 		if (stream === "stdout") {
@@ -99,10 +110,11 @@ setInterval(() => {
 // in-flight request gets notified, and keep the process alive.
 // ---------------------------------------------------------------------------
 
+// Don't `process.exit(0)` on EPIPE-coded errors here: any pipe in the
+// process (SDK child processes, internal Bun async work) can surface a
+// stray EPIPE, and exiting takes down every in-flight query with it
+// (issues #398/#402). The parent-died path is handled via stdin EOF.
 process.on("uncaughtException", (err) => {
-	if ((err as NodeJS.ErrnoException).code === "EPIPE") {
-		process.exit(0);
-	}
 	logger.error("uncaughtException", errorDetails(err));
 	try {
 		emitter.error(null, "Internal sidecar error", true);
@@ -110,9 +122,6 @@ process.on("uncaughtException", (err) => {
 });
 
 process.on("unhandledRejection", (reason) => {
-	if ((reason as NodeJS.ErrnoException | undefined)?.code === "EPIPE") {
-		process.exit(0);
-	}
 	logger.error("unhandledRejection", errorDetails(reason));
 	try {
 		emitter.error(null, "Internal sidecar error", true);
@@ -432,6 +441,12 @@ function trackHandler(p: Promise<void>): void {
 // ---------------------------------------------------------------------------
 
 const rl = createInterface({ input: process.stdin });
+// Authoritative "Rust exited" signal — flip the flag so any subsequent
+// EPIPE on stdout/stderr is treated as "drain to /dev/null then exit"
+// rather than "transient blip, ignore".
+rl.on("close", () => {
+	parentGone = true;
+});
 let requestCount = 0;
 
 for await (const line of rl) {

--- a/src-tauri/src/agents/streaming/active_streams.rs
+++ b/src-tauri/src/agents/streaming/active_streams.rs
@@ -17,12 +17,9 @@ pub(crate) struct ActiveStreamHandle {
     pub request_id: String,
     pub sidecar_session_id: String,
     pub provider: String,
-    /// Helmor session this stream belongs to. Used by
-    /// `try_register_for_session` to reject overlapping sends targeting
-    /// the same helmor session — without this guard, rapid retries can
-    /// stack concurrent `query()` calls against the same Claude resume
-    /// id and corrupt the conversation jsonl. `None` for streams that
-    /// don't carry a helmor session (e.g. one-off title generation).
+    /// Helmor session this stream belongs to. Drives the per-session
+    /// dedup in `try_register_for_session`. `None` for streams without
+    /// one (e.g. title generation).
     pub helmor_session_id: Option<String>,
 }
 
@@ -36,12 +33,9 @@ impl ActiveStreams {
         Self::default()
     }
 
-    /// Atomic check-and-insert: register `handle` only if no existing
-    /// entry already targets the same `helmor_session_id`. Returns
-    /// `true` on success, `false` if a stream is already in flight for
-    /// that session. When `helmor_session_id` is `None` this degrades to
-    /// an unconditional insert (call sites with no session can never
-    /// collide on session id).
+    /// Register `handle` iff no existing entry targets the same
+    /// `helmor_session_id`. `None` ids never collide. Returns `false`
+    /// when a stream is already in flight for the session.
     pub(super) fn try_register_for_session(&self, handle: ActiveStreamHandle) -> bool {
         let Ok(mut map) = self.inner.lock() else {
             return false;

--- a/src-tauri/src/agents/streaming/cleanup.rs
+++ b/src-tauri/src/agents/streaming/cleanup.rs
@@ -52,11 +52,9 @@ pub(crate) fn cleanup_abnormal_stream_exit(
         }
     };
 
-    // Clear the stored provider_session_id — the sidecar/SDK was killed
-    // mid-write, so the provider's conversation jsonl is likely corrupt
-    // (or at least undefined). Reusing the same id on the next send
-    // makes Claude return an immediate empty result that we'd misread
-    // as success, permanently bricking the thread (issue #398).
+    // SDK was killed mid-write; the provider's conversation jsonl may
+    // be corrupt. Drop the resume id so the next send starts fresh
+    // instead of replaying a broken target (issue #398).
     if let Err(error) = conn.execute(
         "UPDATE sessions SET provider_session_id = NULL WHERE id = ?1",
         rusqlite::params![ctx.helmor_session_id],

--- a/src-tauri/src/agents/streaming/mod.rs
+++ b/src-tauri/src/agents/streaming/mod.rs
@@ -162,12 +162,9 @@ pub(super) fn stream_via_sidecar(
         params,
     };
 
-    // Per-helmor-session lock — reject overlapping sends synchronously
-    // before we touch the sidecar. Without this, rapid-fire submits can
-    // stack concurrent Claude `query()` calls against the same `resume:`
-    // id and corrupt the underlying conversation jsonl, which then
-    // returns an immediate empty result on every subsequent send and
-    // permanently bricks the thread (see issue #398).
+    // Per-helmor-session lock — block overlapping sends so concurrent
+    // `query()` calls can't stack against the same `resume:` id and
+    // corrupt the conversation jsonl (issue #398).
     let registered = active_streams.try_register_for_session(ActiveStreamHandle {
         request_id: request_id.clone(),
         sidecar_session_id: sidecar_session_id.clone(),
@@ -525,16 +522,17 @@ pub(super) fn stream_via_sidecar(
                     let mut persisted = false;
                     let mut resolved_model = model_copy.cli_model.to_string();
                     let mut final_messages: Vec<ThreadMessageLike> = Vec::new();
-                    // Set when an `end` arrives with no real assistant content
-                    // on a stream that was attempting `resume:` against a
-                    // stored provider_session_id. Indicates the resume target
-                    // is stale/corrupt — we clear the stored id and surface
-                    // an Error to the user instead of silently emitting Done
-                    // and bricking the thread (issue #398).
+                    // Set on an empty `end` for a `resume:` stream — surface
+                    // an Error instead of silently committing a blank Done
+                    // (issue #398). We do NOT clear provider_session_id
+                    // here: a single empty response can be a transient API
+                    // blip, and dropping the resume id would lose the whole
+                    // conversation on retry (issue #402). The hard-evidence
+                    // clear lives in `cleanup_abnormal_stream_exit`.
                     let mut bad_resume_failure = false;
                     const BAD_RESUME_USER_MESSAGE: &str =
-                        "The previous conversation could not be resumed (the provider returned \
-                         an empty response). Cleared the stale session — please retry your message.";
+                        "The provider returned an empty response. Please try again. \
+                         If this keeps happening on this thread, start a new conversation.";
 
                     if let Some(mut pipeline_state) = pipeline.take() {
                         if is_aborted {
@@ -587,17 +585,10 @@ pub(super) fn stream_via_sidecar(
                             resolved_model = output.resolved_model.clone();
                         }
 
-                        // Empty-resume detection. When the SDK's `result`
-                        // arrives within milliseconds of `system.init` with
-                        // zero turns and no assistant text, the resume
-                        // target on disk is almost certainly stale or
-                        // corrupted (e.g. the sidecar was killed mid-write
-                        // on a prior turn). Treat as failure, NOT as a
-                        // successful empty completion. Skip resume_only
-                        // streams (deferred-tool answer submission can
-                        // legitimately produce no new text). Skip when no
-                        // resume id was sent (a brand new conversation
-                        // returning empty is a different kind of bug).
+                        // Empty result on a `resume:` stream → surface as
+                        // Error. Skip `resume_only` (deferred-tool answers
+                        // can legitimately be empty) and the no-resume
+                        // case.
                         let is_empty_resume = !is_aborted
                             && !resume_only
                             && resume_session_id.is_some()
@@ -607,18 +598,6 @@ pub(super) fn stream_via_sidecar(
                         if let (Some(ctx), Some(conn)) = (exchange_ctx.as_ref(), writer.as_ref()) {
                             if is_empty_resume {
                                 bad_resume_failure = true;
-                                // Clear the stale provider_session_id so the
-                                // next send starts a fresh Claude conversation
-                                // instead of replaying the same broken resume.
-                                if let Err(error) = conn.execute(
-                                    "UPDATE sessions SET provider_session_id = NULL WHERE id = ?1",
-                                    rusqlite::params![ctx.helmor_session_id],
-                                ) {
-                                    tracing::error!(
-                                        rid = %rid,
-                                        "Failed to clear stale provider_session_id: {error}"
-                                    );
-                                }
                                 match persist_error_message(
                                     conn,
                                     ctx,
@@ -644,7 +623,7 @@ pub(super) fn stream_via_sidecar(
                                     Err(error) => {
                                         tracing::error!(
                                             rid = %rid,
-                                            "Failed to finalize after bad resume: {error}"
+                                            "Failed to finalize after empty resume: {error}"
                                         );
                                     }
                                 }
@@ -707,10 +686,8 @@ pub(super) fn stream_via_sidecar(
                     );
 
                     if bad_resume_failure {
-                        // Route through `handle_error` so the state machine
-                        // ends in `Error` rather than `Done`, and the
-                        // frontend's error path runs (clears sending state,
-                        // does NOT mark the turn complete).
+                        // End in `Error` (not `Done`) so the frontend's
+                        // error path runs.
                         let raw = json!({
                             "type": "error",
                             "message": BAD_RESUME_USER_MESSAGE,


### PR DESCRIPTION
## Summary

Fix the recurring **empty Claude response mid-conversation** bug (issue #402) at its 0.17.0 root cause, and stop the previous safety net from wiping conversation context on retry.

### Root cause

PR #367 (0.17.0) added three EPIPE-coded `process.exit(0)` paths to the sidecar — `process.stdout.on('error')`, `uncaughtException`, `unhandledRejection`. The intent was clean shutdown when Rust dies. But EPIPE bubbles up from many internal pipes too (Anthropic SDK child processes, internal Bun async work, etc.), so a single transient blip would silently kill the entire sidecar — taking every in-flight `query()` with it. The user's main turn was killed mid-stream after `provider_session_id` had already been adopted from `system.init`, so the next message resumed against a half-written `~/.claude/projects/.../*.jsonl` and Claude returned an immediate empty `result` (~300ms after `system.init`). That looks to the user like a turn that just goes blank.

This is new in 0.17.0 — pre-0.17 the sidecar would just log and keep running.

### What this PR does

- **Detect parent liveness via stdin EOF.** `parentGone` only flips when stdin closes, which is the authoritative "Rust exited" signal. EPIPE-on-stdout while the parent is still alive is now treated as a transient blip and silently dropped, not as grounds to nuke every in-flight request.
- **Drop the EPIPE short-circuits in `uncaughtException` / `unhandledRejection`.** Those were the two most damaging paths — any deep async EPIPE in any SDK or library code would fire them.
- **Stop wiping `provider_session_id` on a single empty resume.** The 0.17.1 fix for #398 was over-eager: a transient empty turn is indistinguishable by event shape from a truly stale resume target, so clearing the resume id silently dropped the conversation context on retry (issue #402, exact symptom in the screenshot). The Error is still surfaced; the resume id is kept so retry continues the same conversation. The hard-evidence clear stays in `cleanup_abnormal_stream_exit` (heartbeat loss / sidecar disconnect), where we know the jsonl was actually cut off.

### Defense-in-depth still in place from 0.17.1

- Per-helmor-session lock on `try_register_for_session` (no overlapping sends per thread).
- `cleanup_abnormal_stream_exit` clears the resume id only when the sidecar actually exits abnormally.
- Empty-resume detection still surfaces a clear Error to the UI instead of silently committing a blank assistant turn.

Closes #402. Refs #398.

## Test plan

- [x] `cd src-tauri && cargo test --tests` — 924 + cleanup tests green
- [x] `cd src-tauri && cargo clippy --all-targets -- -D warnings` — clean
- [x] `cd sidecar && bun test` — 208 / 208 green
- [x] `bun run typecheck` — clean
- [x] Manual: send a normal turn, verify it streams and persists correctly
- [ ] Manual: simulate transient EPIPE during streaming — verify sidecar keeps running and the in-flight turn completes
- [ ] Manual: send a message that triggers an empty `result`, verify the Error surfaces and the next retry resumes the same conversation (no context loss)
- [ ] Manual: kill Rust process — verify sidecar exits cleanly via stdin EOF