### PR TITLE
fix: carry Start page composer config into new workspace

### DIFF
--- a/.changeset/quiet-foxes-carry.md
+++ b/.changeset/quiet-foxes-carry.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Carry the Start page composer picks (model, effort, plan mode, fast mode) into the new workspace so Start Now and Save for Later no longer fall back to defaults.

--- a/src-tauri/src/commands/session_commands.rs
+++ b/src-tauri/src/commands/session_commands.rs
@@ -213,6 +213,7 @@ pub async fn update_session_settings(
     model: Option<String>,
     effort_level: Option<String>,
     permission_mode: Option<String>,
+    fast_mode: Option<bool>,
 ) -> CmdResult<()> {
     run_blocking(move || {
         let connection = db::write_conn()?;
@@ -222,10 +223,11 @@ pub async fn update_session_settings(
                 UPDATE sessions SET
                   model = COALESCE(?2, model),
                   effort_level = COALESCE(?3, effort_level),
-                  permission_mode = COALESCE(?4, permission_mode)
+                  permission_mode = COALESCE(?4, permission_mode),
+                  fast_mode = COALESCE(?5, fast_mode)
                 WHERE id = ?1
                 "#,
-                rusqlite::params![session_id, model, effort_level, permission_mode],
+                rusqlite::params![session_id, model, effort_level, permission_mode, fast_mode],
             )
             .context("Failed to update session settings")?;
         Ok(())

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2492,6 +2492,12 @@ function AppShell({
 						mode: startMode,
 						submitMode: options?.startSubmitMode ?? "startNow",
 						editorStateSnapshot: payload.editorStateSnapshot,
+						composerConfig: {
+							modelId: payload.model.id,
+							effortLevel: payload.effortLevel,
+							permissionMode: payload.permissionMode,
+							fastMode: payload.fastMode,
+						},
 					});
 
 				void queryClient.invalidateQueries({

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -438,10 +438,18 @@ export const WorkspaceComposerContainer = memo(
 		const effectiveSelectedModelId = effectiveModel?.id ?? selectedModelId;
 		const provider =
 			effectiveModel?.provider ?? currentSession?.agentType ?? "claude";
+		// "User-configured" = the session row carries an explicit model. Fresh
+		// sessions are created with `model = NULL` and snapshot defaults for
+		// effort/permission/fast (so reading those unconditionally would
+		// override the user's *current* settings); both the streaming
+		// finalizer and the saveForLater path set `model` once the user has
+		// actually picked one, which is the right moment to start trusting
+		// the row.
+		const sessionIsConfigured =
+			!isNewSession(currentSession) || Boolean(currentSession?.model);
 		const cachedEffort = effortLevels[composerContextKey];
-		// For new sessions, use user setting; for existing sessions with history, use session's effort
 		const sessionEffort =
-			(!isNewSession(currentSession) && currentSession?.effortLevel) || null;
+			(sessionIsConfigured && currentSession?.effortLevel) || null;
 		const pendingEffort =
 			pendingOverrideActive && pendingPromptForSession?.effort
 				? pendingPromptForSession.effort
@@ -458,7 +466,7 @@ export const WorkspaceComposerContainer = memo(
 			modelSections,
 		);
 		const cachedPermissionMode = permissionModes[composerContextKey];
-		const sessionPermissionMode = !isNewSession(currentSession)
+		const sessionPermissionMode = sessionIsConfigured
 			? currentSession?.permissionMode
 			: null;
 		const permissionMode =
@@ -470,7 +478,7 @@ export const WorkspaceComposerContainer = memo(
 				: permissionMode;
 		const supportsFastMode = effectiveModel?.supportsFastMode === true;
 		const cachedFastMode = fastModes[composerContextKey];
-		const sessionFastMode = !isNewSession(currentSession)
+		const sessionFastMode = sessionIsConfigured
 			? currentSession?.fastMode
 			: undefined;
 		const pendingFastMode =

--- a/src/features/conversation/index.tsx
+++ b/src/features/conversation/index.tsx
@@ -327,6 +327,39 @@ export const WorkspaceConversationContainer = memo(
 			);
 		}, [pendingPromptForSession, displayedWorkspaceId]);
 
+		// Carry the StartPage composer config (model / effort / permission /
+		// fast) into the new workspace's session contextKey. The start surface
+		// stores these under `start:repo:<repoId>` in a *different* container
+		// instance that unmounts on the surface swap, so without this seed the
+		// chips on the new workspace fall back to settings defaults until
+		// backend persistence updates the session row at end of turn — and any
+		// follow-up sent before that catches up loses the user's choices.
+		useEffect(() => {
+			if (!pendingCreatedWorkspaceSubmit) return;
+			const { workspaceId, sessionId, payload } = pendingCreatedWorkspaceSubmit;
+			const targetKey = getComposerContextKey(workspaceId, sessionId);
+			setComposerModelSelections((current) =>
+				current[targetKey]
+					? current
+					: { ...current, [targetKey]: payload.model.id },
+			);
+			setComposerEffortLevels((current) =>
+				current[targetKey]
+					? current
+					: { ...current, [targetKey]: payload.effortLevel },
+			);
+			setComposerPermissionModes((current) =>
+				current[targetKey]
+					? current
+					: { ...current, [targetKey]: payload.permissionMode },
+			);
+			setComposerFastModes((current) =>
+				targetKey in current
+					? current
+					: { ...current, [targetKey]: payload.fastMode },
+			);
+		}, [pendingCreatedWorkspaceSubmit]);
+
 		const handleSelectModel = useCallback(
 			(contextKey: string, modelId: string) => {
 				setComposerModelSelections((current) => ({

--- a/src/features/workspace-start/create-workspace.ts
+++ b/src/features/workspace-start/create-workspace.ts
@@ -6,6 +6,7 @@ import {
 	finalizeWorkspaceFromRepo,
 	prepareWorkspaceFromRepo,
 	setWorkspaceStatus,
+	updateSessionSettings,
 	type WorkspaceMode,
 } from "@/lib/api";
 import { getComposerContextKey } from "@/lib/workspace-helpers";
@@ -25,12 +26,23 @@ export async function createWorkspaceFromStartComposer({
 	mode,
 	submitMode,
 	editorStateSnapshot,
+	composerConfig,
 }: {
 	repoId: string;
 	sourceBranch: string;
 	mode: WorkspaceMode;
 	submitMode: WorkspaceStartSubmitMode;
 	editorStateSnapshot?: SerializedEditorState;
+	/** StartPage composer picks. On `saveForLater` we persist these to the
+	 *  session row so the backlog session reflects the user's choices when
+	 *  they later open it; on `startNow` they ride along inside the submit
+	 *  payload, so this field is unused in that branch. */
+	composerConfig?: {
+		modelId?: string;
+		effortLevel?: string;
+		permissionMode?: string;
+		fastMode?: boolean;
+	};
 }): Promise<WorkspaceStartCreateResult> {
 	const prepared = await prepareWorkspaceFromRepo(repoId, sourceBranch, mode);
 
@@ -39,6 +51,14 @@ export async function createWorkspaceFromStartComposer({
 			finalizeWorkspaceFromRepo(prepared.workspaceId),
 			editorStateSnapshot
 				? persistSessionDraft(prepared.initialSessionId, editorStateSnapshot)
+				: Promise.resolve(),
+			composerConfig
+				? updateSessionSettings(prepared.initialSessionId, {
+						model: composerConfig.modelId,
+						effortLevel: composerConfig.effortLevel,
+						permissionMode: composerConfig.permissionMode,
+						fastMode: composerConfig.fastMode,
+					})
 				: Promise.resolve(),
 		]);
 		await setWorkspaceStatus(prepared.workspaceId, "backlog");

--- a/src/features/workspace-start/create-workspace.ts
+++ b/src/features/workspace-start/create-workspace.ts
@@ -33,10 +33,8 @@ export async function createWorkspaceFromStartComposer({
 	mode: WorkspaceMode;
 	submitMode: WorkspaceStartSubmitMode;
 	editorStateSnapshot?: SerializedEditorState;
-	/** StartPage composer picks. On `saveForLater` we persist these to the
-	 *  session row so the backlog session reflects the user's choices when
-	 *  they later open it; on `startNow` they ride along inside the submit
-	 *  payload, so this field is unused in that branch. */
+	/** StartPage composer picks. Only persisted to the session row on
+	 *  saveForLater; startNow consumes them via the submit payload. */
 	composerConfig?: {
 		modelId?: string;
 		effortLevel?: string;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2022,6 +2022,7 @@ export async function updateSessionSettings(
 		model?: string;
 		effortLevel?: string;
 		permissionMode?: string;
+		fastMode?: boolean;
 	},
 ): Promise<void> {
 	await invoke("update_session_settings", {
@@ -2029,6 +2030,7 @@ export async function updateSessionSettings(
 		model: settings.model ?? null,
 		effortLevel: settings.effortLevel ?? null,
 		permissionMode: settings.permissionMode ?? null,
+		fastMode: settings.fastMode ?? null,
 	});
 }
 

--- a/src/lib/workspace-helpers.ts
+++ b/src/lib/workspace-helpers.ts
@@ -526,12 +526,13 @@ export function inferDefaultModelId(
 ): string | null {
 	const allOptions = modelSections.flatMap((section) => section.options);
 
-	// Existing session with history → respect whatever model it used
-	if (!isNewSession(session)) {
-		const sessionModel = session?.model ?? null;
-		if (sessionModel && findModelOption(modelSections, sessionModel)) {
-			return sessionModel;
-		}
+	// If the session row carries an explicit model — either from history
+	// (streaming finalizer) or from a saveForLater pre-config — respect it.
+	// Fresh sessions are created with `model = NULL` so this safely falls
+	// through to the user's current settings default below.
+	const sessionModel = session?.model ?? null;
+	if (sessionModel && findModelOption(modelSections, sessionModel)) {
+		return sessionModel;
 	}
 
 	// New session or no valid session model → user setting is the only source.


### PR DESCRIPTION
## Summary

When creating a workspace from the Start page, the composer's model / effort / permission / fast-mode picks were being dropped on the way into the new workspace's session — both the **Start Now** and **Save for Later** flows would fall back to settings defaults until backend persistence eventually caught up. Any follow-up sent before that catch-up lost the user's choices entirely.

## What changed

- **Backend**: `update_session_settings` now also accepts `fast_mode`, written to the `sessions` row (`src-tauri/src/commands/session_commands.rs`). Mirrored in `lib/api.ts`.
- **Save for Later**: `createWorkspaceFromStartComposer` takes a new `composerConfig` argument and persists `{model, effortLevel, permissionMode, fastMode}` onto the freshly created backlog session, so when the user opens it later the chips reflect their original picks.
- **Start Now**: `App.tsx` forwards the same composer config in the submit payload, and the conversation container seeds the new workspace's composer context (`workspace:<id>:<sessionId>`) with those values on first paint — the StartPage's `start:repo:<repoId>` container unmounts on surface swap, so without the seed the chips would briefly fall back to defaults.
- **Composer/helpers**: `WorkspaceComposerContainer` and `inferDefaultModelId` now treat a session as "configured" whenever it carries an explicit `model` (not just when it has history). Fresh sessions are created with `model = NULL`, so this safely falls through to settings defaults; once the user has actually picked one, we trust the row.

## Why

Fresh sessions start with `model = NULL` plus snapshot defaults for effort/permission/fast. Reading those columns unconditionally would override the user's *current* picks; reading them only when there's history meant **`saveForLater` couldn't pre-config the row**. Keying off "session has explicit model" is the right gate — both the streaming finalizer and the new save-for-later path set `model` once, and only then do we trust the persisted config.

## Test plan

- [ ] Start page → pick non-default model / effort / permission / fast → **Start Now** → first turn streams with the chosen config; chips on the new workspace match.
- [ ] Start page → same picks → **Save for Later** → reopen the backlog workspace → composer chips reflect the picks.
- [ ] Existing workspaces with prior chat history still respect the model their last turn used.
- [ ] `bun run typecheck && bun run lint && bun run test`.