### PR TITLE
feat: add PR/MR model selector and fix /add-dir flows

### DIFF
--- a/.changeset/calm-keys-listen.md
+++ b/.changeset/calm-keys-listen.md
@@ -1,0 +1,7 @@
+---
+"helmor": patch
+---
+
+Two `/add-dir` fixes:
+- Claude turns no longer fail with `Not logged in / Authentication failed` after linking extra directories.
+- The Start page's `/add-dir` popup now lists candidate workspaces, matching the in-workspace behavior instead of only offering "Browse folder…".

--- a/.changeset/gentle-rivers-link.md
+++ b/.changeset/gentle-rivers-link.md
@@ -1,0 +1,7 @@
+---
+"helmor": minor
+---
+
+Two workspace-creation and PR/MR helper improvements:
+- Fix `/add-dir` on the Start page so "Browse folder…" actually opens the directory picker, and apply the picks to the workspace it creates.
+- Add a dedicated model / effort / fast-mode selector for the inspector's Create PR/MR action, so PR / MR generation can use a different setup than the default agent turn.

--- a/sidecar/src/claude-session-manager.ts
+++ b/sidecar/src/claude-session-manager.ts
@@ -101,6 +101,21 @@ function claudePlatformShort(): string {
 
 const CLAUDE_BIN_PATH = resolveClaudeBinPath();
 
+// SDK's `env` option REPLACES process.env when set (per its docstring:
+// "Defaults to process.env"). Without spreading process.env back in, the
+// spawned claude-code child loses HOME / PATH / cached OAuth creds and
+// reports "Not logged in". Returns undefined when no overrides are
+// supplied so the SDK keeps its default-process.env path.
+function mergeQueryEnv(
+	...overrides: (Record<string, string> | undefined)[]
+): { [key: string]: string | undefined } | undefined {
+	const present = overrides.filter(
+		(o): o is Record<string, string> => o !== undefined,
+	);
+	if (present.length === 0) return undefined;
+	return Object.assign({}, process.env, ...present);
+}
+
 interface LiveSession {
 	readonly query: Query;
 	readonly abortController: AbortController;
@@ -428,10 +443,7 @@ export class ClaudeSessionManager implements SessionManager {
 			additionalDirectories.length > 0
 				? { CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: "1" }
 				: undefined;
-		const queryEnv =
-			claudeEnv || additionalDirectoryEnv
-				? { ...claudeEnv, ...additionalDirectoryEnv }
-				: undefined;
+		const queryEnv = mergeQueryEnv(claudeEnv, additionalDirectoryEnv);
 
 		const q = query({
 			prompt: isResumeOnly ? "" : promptSource,
@@ -810,6 +822,7 @@ export class ClaudeSessionManager implements SessionManager {
 			additionalDirectories.length > 0
 				? { CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: "1" }
 				: undefined;
+		const queryEnv = mergeQueryEnv(additionalDirectoryEnv);
 
 		let resolveDone: () => void = () => undefined;
 		const donePromise = new Promise<void>((resolve) => {
@@ -837,7 +850,7 @@ export class ClaudeSessionManager implements SessionManager {
 				pathToClaudeCodeExecutable: CLAUDE_BIN_PATH,
 				cwd: cwd || undefined,
 				...(additionalDirectories.length > 0 ? { additionalDirectories } : {}),
-				...(additionalDirectoryEnv ? { env: additionalDirectoryEnv } : {}),
+				...(queryEnv ? { env: queryEnv } : {}),
 				permissionMode: "bypassPermissions",
 				allowDangerouslySkipPermissions: true,
 				includePartialMessages: false,

--- a/sidecar/test/claude-session-manager.test.ts
+++ b/sidecar/test/claude-session-manager.test.ts
@@ -755,6 +755,50 @@ describe("ClaudeSessionManager.sendMessage", () => {
 		expect(content).toContain("summarize what's in these projects");
 	});
 
+	test("preserves process.env when /add-dir adds an env override", async () => {
+		const userDir = makeTempDir("helmor-claude-env-preserve-");
+		// Sentinel set in the parent (sidecar) env that the spawned
+		// claude-code child must inherit. Without ...process.env in the
+		// merge, the SDK passes only { CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: "1" }
+		// and the child loses HOME/credentials → "Not logged in".
+		const sentinelKey = "HELMOR_TEST_ENV_SENTINEL";
+		const sentinelValue = `sentinel-${Date.now()}`;
+		const prevSentinel = process.env[sentinelKey];
+		process.env[sentinelKey] = sentinelValue;
+
+		try {
+			mockQueryImpl = () =>
+				asyncIterableFrom([{ type: "result", result: "ok" }]);
+
+			await manager.sendMessage(
+				"REQ-ENV-PRESERVE",
+				{
+					sessionId: "s-env-preserve",
+					prompt: "ok",
+					model: "opus-1m",
+					cwd: undefined,
+					resume: undefined,
+					permissionMode: "bypassPermissions",
+					effortLevel: undefined,
+					fastMode: undefined,
+					images: [],
+					additionalDirectories: [userDir],
+				},
+				emitter,
+			);
+
+			const env = (
+				lastQueryArgs as { options?: { env?: Record<string, string> } }
+			).options?.env;
+			expect(env?.CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD).toBe("1");
+			expect(env?.[sentinelKey]).toBe(sentinelValue);
+			expect(env?.HOME).toBe(process.env.HOME);
+		} finally {
+			if (prevSentinel === undefined) delete process.env[sentinelKey];
+			else process.env[sentinelKey] = prevSentinel;
+		}
+	});
+
 	test("listSlashCommands forwards additionalDirectories and env", async () => {
 		const workspaceDir = makeTempDir("helmor-claude-slash-");
 		const linkedDir = makeTempDir("helmor-claude-slash-linked-");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,7 @@ import {
 	TooltipProvider,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
+import type { WorkspaceCommitButtonMode } from "@/features/commit/button";
 import { useWorkspaceCommitLifecycle } from "@/features/commit/hooks/use-commit-lifecycle";
 import { hydrateDraftCache } from "@/features/composer/draft-storage";
 import {
@@ -169,6 +170,7 @@ const SETTINGS_RELOAD_EVENT = "helmor:reload-settings";
 const OPEN_SETTINGS_EVENT = "helmor:open-settings";
 type WorkspaceViewMode = "conversation" | "editor" | "start";
 const EMPTY_SESSION_RUN_STATES = new Map<string, SessionRunState>();
+const EMPTY_STRING_LIST: readonly string[] = [];
 
 function App() {
 	const e2eScenario =
@@ -1561,6 +1563,31 @@ function AppShell({
 		pushToast: pushWorkspaceToast,
 	});
 
+	// Wrapper that injects the configured PR/MR model overrides for the
+	// "create-pr" mode so the action runs on the user's preferred PR model
+	// (with effort + fast-mode falling back to defaults when null).
+	const handleCommitAction = useCallback(
+		(mode: WorkspaceCommitButtonMode) => {
+			if (mode === "create-pr") {
+				return handleInspectorCommitAction(mode, {
+					modelId: appSettings.prModelId ?? appSettings.defaultModelId,
+					effort: appSettings.prEffort ?? appSettings.defaultEffort,
+					fastMode: appSettings.prFastMode ?? appSettings.defaultFastMode,
+				});
+			}
+			return handleInspectorCommitAction(mode);
+		},
+		[
+			handleInspectorCommitAction,
+			appSettings.prModelId,
+			appSettings.prEffort,
+			appSettings.prFastMode,
+			appSettings.defaultModelId,
+			appSettings.defaultEffort,
+			appSettings.defaultFastMode,
+		],
+	);
+
 	const handleSessionCompleted = useCallback(
 		(sessionId: string, workspaceId: string) => {
 			setSettledSessionIds((prev) => {
@@ -1965,7 +1992,7 @@ function AppShell({
 			},
 			{
 				id: "action.createPr" as const,
-				callback: () => void handleInspectorCommitAction("create-pr"),
+				callback: () => void handleCommitAction("create-pr"),
 			},
 			{
 				id: "action.commitAndPush" as const,
@@ -2033,6 +2060,7 @@ function AppShell({
 			handleCloseSelectedSession,
 			handleCopyWorkspacePath,
 			handleCreateSession,
+			handleCommitAction,
 			handleInspectorCommitAction,
 			handleNavigateSessions,
 			handleNavigateWorkspaces,
@@ -2292,10 +2320,17 @@ function AppShell({
 	const [startPendingNewBranch, setStartPendingNewBranch] = useState<
 		string | null
 	>(null);
+	// Directories the user picked via /add-dir on the start page before any
+	// workspace exists. Applied via `setWorkspaceLinkedDirectories` once the
+	// workspace is created (see `handleStartComposerPrepare`). Cleared on
+	// repo switch — the picks were intent-bound to a specific repo.
+	const [startPendingLinkedDirectories, setStartPendingLinkedDirectories] =
+		useState<readonly string[]>(EMPTY_STRING_LIST);
 	const [startMode, setStartMode] = useState<WorkspaceMode>("worktree");
 	useEffect(() => {
 		setStartSourceBranchOverride(null);
 		setStartPendingNewBranch(null);
+		setStartPendingLinkedDirectories(EMPTY_STRING_LIST);
 		setStartMode("worktree");
 	}, [startRepositoryId]);
 	// In local mode the picker should default to whatever branch the
@@ -2498,7 +2533,11 @@ function AppShell({
 							permissionMode: payload.permissionMode,
 							fastMode: payload.fastMode,
 						},
+						linkedDirectories: startPendingLinkedDirectories,
 					});
+				// Picks belonged to the in-flight create; clear regardless of
+				// outcome so the next start-page session begins clean.
+				setStartPendingLinkedDirectories(EMPTY_STRING_LIST);
 
 				void queryClient.invalidateQueries({
 					queryKey: helmorQueryKeys.workspaceGroups,
@@ -2580,6 +2619,7 @@ function AppShell({
 			startSourceBranch,
 			startMode,
 			startPendingNewBranch,
+			startPendingLinkedDirectories,
 		],
 	);
 
@@ -2597,6 +2637,15 @@ function AppShell({
 	const startComposerInsertTarget = useMemo(
 		() => ({ contextKey: startComposerContextKey }),
 		[startComposerContextKey],
+	);
+	const startLinkedDirectoriesController = useMemo(
+		() => ({
+			directories: startPendingLinkedDirectories,
+			onChange: (next: readonly string[]) => {
+				setStartPendingLinkedDirectories(next);
+			},
+		}),
+		[startPendingLinkedDirectories],
 	);
 	const rightSidebarAvailable =
 		workspaceViewMode !== "start" || rightSidebarMode === "context";
@@ -2895,6 +2944,9 @@ function AppShell({
 														contextPanelOpen={contextPanelOpen}
 														onToggleContextPanel={handleToggleContextPanel}
 														composerStartSubmitMenu
+														composerLinkedDirectoriesController={
+															startLinkedDirectoriesController
+														}
 													/>
 												</WorkspaceStartPage>
 											) : (
@@ -3299,7 +3351,7 @@ function AppShell({
 														editorMode={workspaceViewMode === "editor"}
 														activeEditorPath={editorSession?.path ?? null}
 														onOpenEditorFile={handleOpenEditorFile}
-														onCommitAction={handleInspectorCommitAction}
+														onCommitAction={handleCommitAction}
 														onReviewAction={() =>
 															handleInspectorReviewAction({
 																modelId:

--- a/src/features/commit/hooks/use-commit-lifecycle.ts
+++ b/src/features/commit/hooks/use-commit-lifecycle.ts
@@ -222,7 +222,14 @@ export function useWorkspaceCommitLifecycle({
 	);
 
 	const handleInspectorCommitAction = useCallback(
-		async (mode: WorkspaceCommitButtonMode) => {
+		async (
+			mode: WorkspaceCommitButtonMode,
+			overrides?: {
+				modelId?: string | null;
+				effort?: string | null;
+				fastMode?: boolean | null;
+			},
+		) => {
 			const workspaceId = selectedWorkspaceIdRef.current;
 			if (!workspaceId) {
 				console.warn("[commitButton] action ignored: no selected workspace");
@@ -394,7 +401,13 @@ export function useWorkspaceCommitLifecycle({
 						: current,
 				);
 
-				setPendingPromptForSession({ sessionId, prompt });
+				setPendingPromptForSession({
+					sessionId,
+					prompt,
+					modelId: overrides?.modelId ?? null,
+					effort: overrides?.effort ?? null,
+					fastMode: overrides?.fastMode ?? null,
+				});
 				onSelectSession(sessionId);
 			} catch (error) {
 				console.error("[commitButton] Failed to start session:", error);

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -194,6 +194,15 @@ type WorkspaceComposerContainerProps = {
 	contextPanelOpen?: boolean;
 	onToggleContextPanel?: () => void;
 	startSubmitMenu?: boolean;
+	/** External owner of the linked-directories list. When provided, the
+	 *  composer reads from `directories` and writes via `onChange` instead of
+	 *  the workspace-scoped query/mutation. Used by the start-page composer
+	 *  where no workspace exists yet — picks accumulate in a parent-owned
+	 *  pending list and get applied at workspace creation time. */
+	linkedDirectoriesController?: {
+		directories: readonly string[];
+		onChange: (next: readonly string[]) => void;
+	} | null;
 };
 
 const noopDeferredToolResponse: DeferredToolResponseHandler = () => {};
@@ -243,6 +252,7 @@ export const WorkspaceComposerContainer = memo(
 		contextPanelOpen = false,
 		onToggleContextPanel,
 		startSubmitMenu = false,
+		linkedDirectoriesController = null,
 	}: WorkspaceComposerContainerProps) {
 		const queryClient = useQueryClient();
 		const { settings, updateSettings } = useSettings();
@@ -274,19 +284,25 @@ export const WorkspaceComposerContainer = memo(
 			...workspaceLinkedDirectoriesQueryOptions(
 				displayedWorkspaceId ?? "__none__",
 			),
-			enabled: Boolean(displayedWorkspaceId),
+			// Skip the query when an external controller is supplying the list
+			// (start page) — the controller is the source of truth there.
+			enabled: Boolean(displayedWorkspaceId) && !linkedDirectoriesController,
 		});
-		const linkedDirectories =
-			linkedDirectoriesQuery.data ?? EMPTY_LINKED_DIRECTORIES;
+		const linkedDirectories: readonly string[] = linkedDirectoriesController
+			? linkedDirectoriesController.directories
+			: (linkedDirectoriesQuery.data ?? EMPTY_LINKED_DIRECTORIES);
 
 		// Candidate workspaces the /add-dir popup offers as quick picks.
 		// Excludes the currently-active workspace (you're already in it —
-		// linking self to self is a no-op).
+		// linking self to self is a no-op). On the start page no workspace
+		// is selected yet but a controller is in play; pass null exclude so
+		// the backend returns every workspace.
 		const candidateDirectoriesQuery = useQuery({
 			...workspaceCandidateDirectoriesQueryOptions(
 				displayedWorkspaceId ?? null,
 			),
-			enabled: Boolean(displayedWorkspaceId),
+			enabled:
+				Boolean(displayedWorkspaceId) || Boolean(linkedDirectoriesController),
 		});
 		const candidateDirectories =
 			candidateDirectoriesQuery.data ?? EMPTY_CANDIDATE_DIRECTORIES;
@@ -324,16 +340,32 @@ export const WorkspaceComposerContainer = memo(
 			},
 		});
 
+		// One-stop commit: routes to the parent controller when present,
+		// otherwise to the workspace-scoped mutation. Returns false when
+		// neither path is available (no workspace and no controller — should
+		// not happen in practice, but keeps the call sites honest).
+		const commitLinkedDirectories = useCallback(
+			(next: readonly string[]): boolean => {
+				if (linkedDirectoriesController) {
+					linkedDirectoriesController.onChange(next);
+					return true;
+				}
+				if (!displayedWorkspaceId) return false;
+				linkedDirectoriesMutation.mutate([...next]);
+				return true;
+			},
+			[
+				linkedDirectoriesController,
+				displayedWorkspaceId,
+				linkedDirectoriesMutation,
+			],
+		);
+
 		const handleRemoveLinkedDirectory = useCallback(
 			(path: string) => {
-				if (!displayedWorkspaceId) return;
-				// `mutate` (not `mutateAsync`) sends errors through the
-				// `onError` callback configured above — no need to catch.
-				linkedDirectoriesMutation.mutate(
-					linkedDirectories.filter((d) => d !== path),
-				);
+				commitLinkedDirectories(linkedDirectories.filter((d) => d !== path));
 			},
-			[displayedWorkspaceId, linkedDirectories, linkedDirectoriesMutation],
+			[commitLinkedDirectories, linkedDirectories],
 		);
 
 		// Handle a pick from the AddDirTypeaheadPlugin popup. For
@@ -342,7 +374,9 @@ export const WorkspaceComposerContainer = memo(
 		// the popup). For "browse" we open the native directory picker.
 		const handlePickAddDir = useCallback(
 			async (entry: AddDirPickerEntry) => {
-				if (!displayedWorkspaceId) return;
+				// Either a real workspace or a parent-supplied controller is
+				// required — without one of them there's nowhere to commit.
+				if (!displayedWorkspaceId && !linkedDirectoriesController) return;
 				if (entry.kind === "browse") {
 					let picked: string | null = null;
 					try {
@@ -361,19 +395,22 @@ export const WorkspaceComposerContainer = memo(
 					}
 					if (!picked) return;
 					if (linkedDirectories.includes(picked)) return;
-					linkedDirectoriesMutation.mutate([...linkedDirectories, picked]);
+					commitLinkedDirectories([...linkedDirectories, picked]);
 					return;
 				}
 				const path = entry.candidate.absolutePath;
 				if (entry.alreadyLinked) {
-					linkedDirectoriesMutation.mutate(
-						linkedDirectories.filter((d) => d !== path),
-					);
+					commitLinkedDirectories(linkedDirectories.filter((d) => d !== path));
 				} else {
-					linkedDirectoriesMutation.mutate([...linkedDirectories, path]);
+					commitLinkedDirectories([...linkedDirectories, path]);
 				}
 			},
-			[displayedWorkspaceId, linkedDirectories, linkedDirectoriesMutation],
+			[
+				displayedWorkspaceId,
+				linkedDirectoriesController,
+				linkedDirectories,
+				commitLinkedDirectories,
+			],
 		);
 
 		const modelSections = modelSectionsQuery.data ?? EMPTY_MODEL_SECTIONS;
@@ -1065,7 +1102,11 @@ export const WorkspaceComposerContainer = memo(
 						workspaceRootPath={workingDirectory}
 						linkedDirectories={linkedDirectories}
 						onRemoveLinkedDirectory={handleRemoveLinkedDirectory}
-						linkedDirectoriesDisabled={linkedDirectoriesMutation.isPending}
+						linkedDirectoriesDisabled={
+							linkedDirectoriesController
+								? false
+								: linkedDirectoriesMutation.isPending
+						}
 						addDirCandidates={candidateDirectories}
 						onPickAddDir={handlePickAddDir}
 						contextPanelOpen={contextPanelOpen}

--- a/src/features/conversation/index.tsx
+++ b/src/features/conversation/index.tsx
@@ -150,6 +150,14 @@ type WorkspaceConversationContainerProps = {
 	contextPanelOpen?: boolean;
 	onToggleContextPanel?: () => void;
 	composerStartSubmitMenu?: boolean;
+	/** Pre-workspace linked-directories controller. Forwarded to the
+	 *  composer; see `WorkspaceComposerContainerProps.linkedDirectoriesController`.
+	 *  Used by the start-page composer to collect /add-dir picks before any
+	 *  workspace exists. */
+	composerLinkedDirectoriesController?: {
+		directories: readonly string[];
+		onChange: (next: readonly string[]) => void;
+	} | null;
 };
 
 export const WorkspaceConversationContainer = memo(
@@ -195,6 +203,7 @@ export const WorkspaceConversationContainer = memo(
 		contextPanelOpen = false,
 		onToggleContextPanel,
 		composerStartSubmitMenu = false,
+		composerLinkedDirectoriesController = null,
 	}: WorkspaceConversationContainerProps) {
 		const [composerModelSelections, setComposerModelSelections] = useState<
 			Record<string, string>
@@ -614,6 +623,7 @@ export const WorkspaceConversationContainer = memo(
 						contextPanelOpen={contextPanelOpen}
 						onToggleContextPanel={onToggleContextPanel}
 						startSubmitMenu={composerStartSubmitMenu}
+						linkedDirectoriesController={composerLinkedDirectoriesController}
 					/>
 				</div>
 			</FileLinkProvider>

--- a/src/features/settings/index.tsx
+++ b/src/features/settings/index.tsx
@@ -232,6 +232,21 @@ export const SettingsDialog = memo(function SettingsDialog({
 		settings.reviewEffort ?? settings.defaultEffort ?? "high";
 	const effectiveReviewFastMode =
 		settings.reviewFastMode ?? settings.defaultFastMode;
+	// PR/MR row mirrors the same follow-the-default convention as Review.
+	const effectivePrModelId = settings.prModelId ?? settings.defaultModelId;
+	const effectivePrModel = findModelOption(
+		modelSectionsQuery.data ?? [],
+		effectivePrModelId,
+	);
+	const prModelLabel =
+		effectivePrModel?.label ??
+		(modelSectionsQuery.isPending ? "Loading…" : "Select model");
+	const prEffortLevels =
+		effectivePrModel?.effortLevels ?? FALLBACK_EFFORT_LEVELS;
+	const prModelSupportsFastMode = effectivePrModel?.supportsFastMode === true;
+	const effectivePrEffort =
+		settings.prEffort ?? settings.defaultEffort ?? "high";
+	const effectivePrFastMode = settings.prFastMode ?? settings.defaultFastMode;
 	// Auto-clamp effort when model changes — but only after model metadata
 	// has actually loaded, otherwise the fallback levels silently kill max/xhigh.
 	useEffect(() => {
@@ -805,6 +820,127 @@ export const SettingsDialog = memo(function SettingsDialog({
 														})
 													}
 													aria-label="Review fast mode"
+												/>
+											</div>
+										</div>
+									</SettingsRow>
+									<SettingsRow
+										title="PR / MR model"
+										description="Model used when creating PRs and MRs"
+									>
+										<div className="flex w-[360px] items-center gap-2">
+											<DropdownMenu>
+												<DropdownMenuTrigger
+													className={cn(
+														"flex h-8 cursor-pointer items-center justify-between rounded-lg border border-border/50 bg-muted/30 px-3 text-[13px] text-foreground hover:bg-muted/50",
+														"min-w-0 flex-1 gap-1.5",
+													)}
+												>
+													<span className="flex min-w-0 items-center gap-1.5">
+														<ModelIcon
+															model={effectivePrModel}
+															className="size-[13px] shrink-0"
+														/>
+														<span className="min-w-0 truncate whitespace-nowrap">
+															{prModelLabel}
+														</span>
+													</span>
+													<ChevronDown className="size-3 shrink-0 opacity-40" />
+												</DropdownMenuTrigger>
+												<DropdownMenuContent
+													align="end"
+													sideOffset={4}
+													className="min-w-[10rem]"
+												>
+													{allModels.map((m) => (
+														<DropdownMenuItem
+															key={m.id}
+															onClick={() =>
+																updateSettings({
+																	// Picking the same value as the
+																	// default snaps PR back to `null`
+																	// (still following the default).
+																	prModelId:
+																		m.id === settings.defaultModelId
+																			? null
+																			: m.id,
+																})
+															}
+															className="justify-between gap-2"
+														>
+															<span className="flex min-w-0 items-center gap-2">
+																<ModelIcon model={m} className="size-4" />
+																{m.label}
+															</span>
+															<CheckCircle2
+																className={cn(
+																	"size-3.5 shrink-0 text-emerald-500",
+																	m.id !== effectivePrModelId && "invisible",
+																)}
+															/>
+														</DropdownMenuItem>
+													))}
+												</DropdownMenuContent>
+											</DropdownMenu>
+											<DropdownMenu>
+												<DropdownMenuTrigger
+													className={cn(
+														"flex h-8 cursor-pointer items-center rounded-lg border border-border/50 bg-muted/30 px-3 text-[13px] text-foreground hover:bg-muted/50",
+														"shrink-0 gap-1.5",
+													)}
+												>
+													<span>{effortLabel(effectivePrEffort)}</span>
+													<ChevronDown className="size-3 opacity-40" />
+												</DropdownMenuTrigger>
+												<DropdownMenuContent
+													align="end"
+													sideOffset={4}
+													className="min-w-[8rem]"
+												>
+													{prEffortLevels.map((l) => (
+														<DropdownMenuItem
+															key={l}
+															onClick={() =>
+																updateSettings({
+																	prEffort:
+																		l === settings.defaultEffort ? null : l,
+																})
+															}
+														>
+															{effortLabel(l)}
+														</DropdownMenuItem>
+													))}
+												</DropdownMenuContent>
+											</DropdownMenu>
+											<div
+												className={cn(
+													"flex h-8 cursor-pointer items-center rounded-lg border border-border/50 bg-muted/30 px-3 text-[13px] text-foreground hover:bg-muted/50",
+													"shrink-0 gap-2",
+												)}
+											>
+												<span
+													className={
+														prModelSupportsFastMode
+															? "text-[13px] text-foreground"
+															: "text-[13px] text-muted-foreground"
+													}
+												>
+													Fast mode
+												</span>
+												<Switch
+													checked={
+														prModelSupportsFastMode && effectivePrFastMode
+													}
+													disabled={!prModelSupportsFastMode}
+													onCheckedChange={(checked) =>
+														updateSettings({
+															prFastMode:
+																checked === settings.defaultFastMode
+																	? null
+																	: checked,
+														})
+													}
+													aria-label="PR / MR fast mode"
 												/>
 											</div>
 										</div>

--- a/src/features/workspace-start/create-workspace.ts
+++ b/src/features/workspace-start/create-workspace.ts
@@ -5,6 +5,7 @@ import {
 	type FinalizeWorkspaceResponse,
 	finalizeWorkspaceFromRepo,
 	prepareWorkspaceFromRepo,
+	setWorkspaceLinkedDirectories,
 	setWorkspaceStatus,
 	updateSessionSettings,
 	type WorkspaceMode,
@@ -27,6 +28,7 @@ export async function createWorkspaceFromStartComposer({
 	submitMode,
 	editorStateSnapshot,
 	composerConfig,
+	linkedDirectories,
 }: {
 	repoId: string;
 	sourceBranch: string;
@@ -41,8 +43,21 @@ export async function createWorkspaceFromStartComposer({
 		permissionMode?: string;
 		fastMode?: boolean;
 	};
+	/** Pre-workspace `/add-dir` picks. Written onto the freshly-prepared
+	 *  workspace row immediately so the conversation-mode composer (which
+	 *  reads the workspace-scoped query) sees them on first mount. */
+	linkedDirectories?: readonly string[];
 }): Promise<WorkspaceStartCreateResult> {
 	const prepared = await prepareWorkspaceFromRepo(repoId, sourceBranch, mode);
+
+	// Persist pending /add-dir picks before kicking off finalize. The DB
+	// write is fast and the column is just a property of the existing
+	// workspace row — no need to wait for materialise.
+	if (linkedDirectories && linkedDirectories.length > 0) {
+		await setWorkspaceLinkedDirectories(prepared.workspaceId, [
+			...linkedDirectories,
+		]);
+	}
 
 	if (submitMode === "saveForLater") {
 		await Promise.all([

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -168,6 +168,16 @@ export type AppSettings = {
 	/** Fast-mode flag for the Review helper. When null, falls back to
 	 *  `defaultFastMode`. */
 	reviewFastMode: boolean | null;
+	/** Model used when the inspector "Create PR/MR" action starts a session.
+	 *  Applies to both GitHub PRs and GitLab MRs. When null, falls back to
+	 *  `defaultModelId`. */
+	prModelId: string | null;
+	/** Effort level for the Create PR/MR helper. When null, falls back to
+	 *  `defaultEffort`. */
+	prEffort: string | null;
+	/** Fast-mode flag for the Create PR/MR helper. When null, falls back to
+	 *  `defaultFastMode`. */
+	prFastMode: boolean | null;
 	defaultEffort: string | null;
 	defaultFastMode: boolean;
 	/** Webview zoom factor. 1.0 = 100%. Range 0.5–2.0. */
@@ -216,6 +226,9 @@ export const DEFAULT_SETTINGS: AppSettings = {
 	reviewModelId: null,
 	reviewEffort: null,
 	reviewFastMode: null,
+	prModelId: null,
+	prEffort: null,
+	prFastMode: null,
 	defaultEffort: "high",
 	defaultFastMode: false,
 	zoomLevel: 1.0,
@@ -261,6 +274,9 @@ const SETTINGS_KEY_MAP: Record<
 	reviewModelId: "app.review_model_id",
 	reviewEffort: "app.review_effort",
 	reviewFastMode: "app.review_fast_mode",
+	prModelId: "app.pr_model_id",
+	prEffort: "app.pr_effort",
+	prFastMode: "app.pr_fast_mode",
 	defaultEffort: "app.default_effort",
 	defaultFastMode: "app.default_fast_mode",
 	zoomLevel: "app.zoom_level",
@@ -576,6 +592,9 @@ export async function loadSettings(): Promise<AppSettings> {
 		const rawReviewModelId = raw[SETTINGS_KEY_MAP.reviewModelId];
 		const rawReviewEffort = raw[SETTINGS_KEY_MAP.reviewEffort];
 		const rawReviewFastMode = raw[SETTINGS_KEY_MAP.reviewFastMode];
+		const rawPrModelId = raw[SETTINGS_KEY_MAP.prModelId];
+		const rawPrEffort = raw[SETTINGS_KEY_MAP.prEffort];
+		const rawPrFastMode = raw[SETTINGS_KEY_MAP.prFastMode];
 		return {
 			fontSize: raw[SETTINGS_KEY_MAP.fontSize]
 				? Number(raw[SETTINGS_KEY_MAP.fontSize])
@@ -625,6 +644,20 @@ export async function loadSettings(): Promise<AppSettings> {
 					: rawReviewFastMode === "false"
 						? false
 						: DEFAULT_SETTINGS.reviewFastMode,
+			prModelId:
+				rawPrModelId && rawPrModelId !== "default"
+					? rawPrModelId
+					: DEFAULT_SETTINGS.prModelId,
+			prEffort:
+				rawPrEffort && rawPrEffort !== ""
+					? rawPrEffort
+					: DEFAULT_SETTINGS.prEffort,
+			prFastMode:
+				rawPrFastMode === "true"
+					? true
+					: rawPrFastMode === "false"
+						? false
+						: DEFAULT_SETTINGS.prFastMode,
 			defaultEffort:
 				raw[SETTINGS_KEY_MAP.defaultEffort] || DEFAULT_SETTINGS.defaultEffort,
 			defaultFastMode:


### PR DESCRIPTION
## Summary

Two themes shipped together because they share the `/add-dir` and create-PR code paths:

### PR / MR model selector (minor)
- implement #414
- New settings row under the per-helper model overrides (next to **Review**) for choosing model / effort / fast-mode used when the inspector's **Create PR/MR** action kicks off a session.
- Wires `prModelId` / `prEffort` / `prFastMode` (with `null = follow default`) through `AppSettings`, `SETTINGS_KEY_MAP`, and `loadSettings`.
- `App.tsx` now wraps `handleInspectorCommitAction` so the `create-pr` mode passes the configured overrides into `useWorkspaceCommitLifecycle`, which threads them onto `setPendingPromptForSession`.

### `/add-dir` fixes (patch)
- **Sidecar auth regression**: the SDK's `query({ env })` option *replaces* `process.env` rather than merging. Linking a directory then setting `CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1` was wiping `HOME` / `PATH` / cached OAuth creds, so subsequent turns failed with "Not logged in / Authentication failed". New `mergeQueryEnv` helper spreads `process.env` back in (and returns `undefined` when there are no overrides so the SDK keeps its default path). Applied to both `sendMessage` and `listSlashCommands`. Covered by a new test that asserts `HOME` and a sentinel env var survive the merge.
- **Start-page `/add-dir`**: previously only offered "Browse folder…" because the candidate query was gated on `displayedWorkspaceId`. The composer now accepts an optional `linkedDirectoriesController` prop; `App.tsx` owns a `startPendingLinkedDirectories` list, the composer reads/writes through the controller instead of the workspace-scoped query/mutation, and `createWorkspaceFromStartComposer` calls `setWorkspaceLinkedDirectories` immediately after `prepareWorkspaceFromRepo` so the picks are persisted on the freshly-created workspace before finalize. Pending list is cleared on repo switch and after submit.

## Why

- Users wanted a different (often cheaper / faster) model for boilerplate PR/MR descriptions than their default agent turn — same pattern we already have for Review.
- The auth regression made `/add-dir` unusable for any account using OAuth (most of them).
- The Start-page picker behavior didn't match the in-workspace one, and picks made before workspace creation were silently dropped.

## Test plan

- [ ] `bun run test:sidecar` — new `preserves process.env when /add-dir adds an env override` test passes.
- [ ] Manually link an extra directory via `/add-dir` in a Claude session, send a turn, confirm no "Not logged in" error.
- [ ] On the Start page, type `/add-dir`, confirm candidate workspaces appear (not just "Browse folder…"); pick one + create the workspace; confirm the directory is linked on the new workspace.
- [ ] Open Settings → Models, change the **PR / MR** row's model / effort / fast-mode, click the inspector's Create PR action, confirm the resulting session uses the configured model.
- [ ] Setting **PR / MR** model back to the same value as the default should snap it back to "follow default" (null).