### PR TITLE
fix: constrain Claude title generation

### DIFF
--- a/.changeset/quick-title-rename.md
+++ b/.changeset/quick-title-rename.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Make automatic session title and branch-name generation lighter so new chats spend less time preparing a rename.

--- a/sidecar/src/claude-session-manager.ts
+++ b/sidecar/src/claude-session-manager.ts
@@ -795,8 +795,12 @@ export class ClaudeSessionManager implements SessionManager {
 				pathToClaudeCodeExecutable: CLAUDE_BIN_PATH,
 				...(claudeEnv ? { env: claudeEnv } : {}),
 				model,
-				permissionMode: "plan",
+				permissionMode: "bypassPermissions",
 				allowDangerouslySkipPermissions: true,
+				thinking: { type: "disabled" },
+				settingSources: [],
+				tools: [],
+				maxTurns: 1,
 			},
 		});
 


### PR DESCRIPTION
## What changed
- Switched Claude title and branch-name generation to bypass permissions.
- Disabled thinking, settings sources, and tools for that request.
- Limited the generation request to one turn.
- Added a patch changeset for the lighter title-generation behavior.

## Why
Automatic session title and branch-name generation should be a small, bounded side task so new chats spend less time preparing a rename.

## Tests
- Pre-commit lint-staged ran Biome on the changed TypeScript file during commit.