### PR TITLE
feat: add local-only commit action

### DIFF
--- a/.changeset/calm-taxis-promise.md
+++ b/.changeset/calm-taxis-promise.md
@@ -1,0 +1,5 @@
+---
+"helmor": minor
+---
+
+Add a separate Commit action in the inspector so you can create a local commit without pushing yet, with matching shortcut support and clearer failure handling when no commit is produced.

--- a/src-tauri/src/agents/action_kind.rs
+++ b/src-tauri/src/agents/action_kind.rs
@@ -20,6 +20,7 @@ use serde::{Deserialize, Serialize};
 pub enum ActionKind {
     CreatePr,
     Review,
+    Commit,
     CommitAndPush,
     Push,
     Fix,
@@ -35,6 +36,7 @@ impl ActionKind {
         match self {
             Self::CreatePr => "create-pr",
             Self::Review => "review",
+            Self::Commit => "commit",
             Self::CommitAndPush => "commit-and-push",
             Self::Push => "push",
             Self::Fix => "fix",
@@ -54,6 +56,7 @@ impl ActionKind {
         match self {
             Self::CreatePr => "Create PR",
             Self::Review => "Review",
+            Self::Commit => "Commit",
             Self::CommitAndPush => "Commit and Push",
             Self::Push => "Push",
             Self::Fix => "Fix CI",
@@ -101,6 +104,7 @@ impl FromStr for ActionKind {
         match s {
             "create-pr" => Ok(Self::CreatePr),
             "review" => Ok(Self::Review),
+            "commit" => Ok(Self::Commit),
             "commit-and-push" => Ok(Self::CommitAndPush),
             "push" => Ok(Self::Push),
             "fix" => Ok(Self::Fix),
@@ -138,6 +142,7 @@ mod tests {
     const ALL: &[ActionKind] = &[
         ActionKind::CreatePr,
         ActionKind::Review,
+        ActionKind::Commit,
         ActionKind::CommitAndPush,
         ActionKind::Push,
         ActionKind::Fix,

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -222,6 +222,13 @@ mod tests {
     }
 
     #[test]
+    fn marker_only_error_uses_fallback_message() {
+        let err = coded(ErrorCode::WorkspaceBroken);
+        assert_eq!(extract_code(&err), ErrorCode::WorkspaceBroken);
+        assert_eq!(outermost_message(&err), "Unknown error");
+    }
+
+    #[test]
     fn serializes_as_code_and_message() {
         let err: CommandError = coded(ErrorCode::WorkspaceNotFound)
             .context("Workspace not found: abc")

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1995,6 +1995,10 @@ function AppShell({
 				callback: () => void handleCommitAction("create-pr"),
 			},
 			{
+				id: "action.commit" as const,
+				callback: () => void handleInspectorCommitAction("commit"),
+			},
+			{
 				id: "action.commitAndPush" as const,
 				callback: () => void handleInspectorCommitAction("commit-and-push"),
 			},

--- a/src/features/commit/button.tsx
+++ b/src/features/commit/button.tsx
@@ -16,6 +16,7 @@ import { cn } from "@/lib/utils";
 export type CommitButtonState = "idle" | "busy" | "done" | "error" | "disabled";
 export type WorkspaceCommitButtonMode =
 	| "create-pr"
+	| "commit"
 	| "commit-and-push"
 	| "push"
 	| "fix"
@@ -49,6 +50,13 @@ const STATIC_STATE_LABELS: Record<
 	Exclude<WorkspaceCommitButtonMode, "create-pr" | "open-pr">,
 	Record<CommitButtonState, string>
 > = {
+	commit: {
+		idle: "Commit",
+		busy: "Committing...",
+		done: "Committed",
+		error: "Retry",
+		disabled: "Commit",
+	},
 	"commit-and-push": {
 		idle: "Commit and Push",
 		busy: "Committing...",
@@ -138,6 +146,15 @@ function getDefaultMenuItems(
 	mode: WorkspaceCommitButtonMode,
 	changeRequestName: string,
 ): WorkspaceCommitAction[] {
+	if (mode === "commit") {
+		return [
+			{
+				id: "commit-manually",
+				label: "Commit manually",
+			},
+		];
+	}
+
 	if (mode === "commit-and-push") {
 		return [
 			{
@@ -242,6 +259,8 @@ function getModeClassName(
 function getModeIcon(mode: WorkspaceCommitButtonMode) {
 	switch (mode) {
 		case "create-pr":
+			return null;
+		case "commit":
 			return null;
 		case "commit-and-push":
 		case "push":
@@ -348,23 +367,25 @@ export function WorkspaceCommitButton({
 		mainLabel ?? getCommitButtonLabel(mode, currentState, changeRequestName);
 	const mainIcon = getModeIcon(mode);
 	const optionsAriaLabel =
-		mode === "commit-and-push"
-			? "Commit and push options"
-			: mode === "push"
-				? "Push options"
-				: mode === "fix"
-					? "Fix CI options"
-					: mode === "resolve-conflicts"
-						? "Resolve conflicts options"
-						: mode === "merge"
-							? "Merge options"
-							: mode === "open-pr"
-								? `Open ${changeRequestName} options`
-								: mode === "merged"
-									? "Merged options"
-									: mode === "closed"
-										? "Closed options"
-										: `Create ${changeRequestName} options`;
+		mode === "commit"
+			? "Commit options"
+			: mode === "commit-and-push"
+				? "Commit and push options"
+				: mode === "push"
+					? "Push options"
+					: mode === "fix"
+						? "Fix CI options"
+						: mode === "resolve-conflicts"
+							? "Resolve conflicts options"
+							: mode === "merge"
+								? "Merge options"
+								: mode === "open-pr"
+									? `Open ${changeRequestName} options`
+									: mode === "merged"
+										? "Merged options"
+										: mode === "closed"
+											? "Closed options"
+											: `Create ${changeRequestName} options`;
 
 	const mainButton = (
 		<Button

--- a/src/features/commit/hooks/use-commit-lifecycle.test.tsx
+++ b/src/features/commit/hooks/use-commit-lifecycle.test.tsx
@@ -18,6 +18,7 @@ const apiMocks = vi.hoisted(() => ({
 	hideSession: vi.fn(),
 	loadRepoPreferences: vi.fn(),
 	loadAutoCloseActionKinds: vi.fn(),
+	loadWorkspaceGitActionStatus: vi.fn(),
 	refreshWorkspaceChangeRequest: vi.fn(),
 	mergeWorkspaceChangeRequest: vi.fn(),
 	pushWorkspaceToRemote: vi.fn(),
@@ -33,6 +34,7 @@ vi.mock("@/lib/api", async (importOriginal) => {
 		hideSession: apiMocks.hideSession,
 		loadRepoPreferences: apiMocks.loadRepoPreferences,
 		loadAutoCloseActionKinds: apiMocks.loadAutoCloseActionKinds,
+		loadWorkspaceGitActionStatus: apiMocks.loadWorkspaceGitActionStatus,
 		refreshWorkspaceChangeRequest: apiMocks.refreshWorkspaceChangeRequest,
 		mergeWorkspaceChangeRequest: apiMocks.mergeWorkspaceChangeRequest,
 		pushWorkspaceToRemote: apiMocks.pushWorkspaceToRemote,
@@ -76,6 +78,7 @@ describe("useWorkspaceCommitLifecycle", () => {
 		apiMocks.hideSession.mockReset();
 		apiMocks.loadRepoPreferences.mockReset();
 		apiMocks.loadAutoCloseActionKinds.mockReset();
+		apiMocks.loadWorkspaceGitActionStatus.mockReset();
 		apiMocks.refreshWorkspaceChangeRequest.mockReset();
 		apiMocks.mergeWorkspaceChangeRequest.mockReset();
 		apiMocks.pushWorkspaceToRemote.mockReset();
@@ -83,6 +86,11 @@ describe("useWorkspaceCommitLifecycle", () => {
 		apiMocks.createSession.mockResolvedValue({ sessionId: "session-action" });
 		apiMocks.loadRepoPreferences.mockResolvedValue({});
 		apiMocks.loadAutoCloseActionKinds.mockResolvedValue(["create-pr"]);
+		apiMocks.loadWorkspaceGitActionStatus.mockResolvedValue({
+			...EMPTY_GIT_ACTION_STATUS,
+			pushStatus: "unpublished",
+			aheadOfRemoteCount: 1,
+		});
 		apiMocks.refreshWorkspaceChangeRequest.mockResolvedValue({
 			number: 53,
 			title: "Fix overflow",
@@ -403,6 +411,166 @@ describe("useWorkspaceCommitLifecycle", () => {
 			queryKey: helmorQueryKeys.workspaceChangeRequest("workspace-1"),
 		});
 		expect(pushToast).not.toHaveBeenCalled();
+	});
+
+	it("completes a commit action session without checking for a PR", async () => {
+		const queryClient = new QueryClient({
+			defaultOptions: {
+				queries: {
+					retry: false,
+				},
+			},
+		});
+		const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries");
+		const onSelectSession = vi.fn();
+
+		const { result, rerender } = renderHook(
+			({
+				completedSessionIds,
+				busySessionIds,
+			}: {
+				completedSessionIds: Set<string>;
+				busySessionIds: Set<string>;
+			}) =>
+				useWorkspaceCommitLifecycle({
+					queryClient,
+					selectedWorkspaceId: "workspace-1",
+					selectedWorkspaceIdRef: { current: "workspace-1" },
+					selectedRepoId: "repo-1",
+					changeRequest: null,
+					forgeActionStatus: EMPTY_FORGE_ACTION_STATUS,
+					workspaceGitActionStatus: {
+						...EMPTY_GIT_ACTION_STATUS,
+						uncommittedCount: 2,
+					},
+					completedSessionIds,
+					interactionRequiredSessionIds: new Set<string>(),
+					busySessionIds,
+					onSelectSession,
+				}),
+			{
+				initialProps: {
+					completedSessionIds: new Set<string>(),
+					busySessionIds: new Set<string>(),
+				},
+				wrapper: createWrapper(queryClient),
+			},
+		);
+
+		await act(async () => {
+			await result.current.handleInspectorCommitAction("commit");
+		});
+
+		expect(apiMocks.createSession).toHaveBeenCalledWith("workspace-1", {
+			actionKind: "commit",
+		});
+		expect(result.current.pendingPromptForSession?.prompt ?? "").toContain(
+			"Do not push",
+		);
+		expect(onSelectSession).toHaveBeenCalledWith("session-action");
+
+		act(() => {
+			result.current.handlePendingPromptConsumed();
+		});
+
+		rerender({
+			completedSessionIds: new Set<string>(),
+			busySessionIds: new Set(["session-action"]),
+		});
+		rerender({
+			completedSessionIds: new Set(["session-action"]),
+			busySessionIds: new Set<string>(),
+		});
+
+		await waitFor(() => {
+			expect(result.current.commitButtonState).toBe("done");
+		});
+		expect(apiMocks.loadWorkspaceGitActionStatus).toHaveBeenCalledWith(
+			"workspace-1",
+		);
+		expect(apiMocks.refreshWorkspaceChangeRequest).not.toHaveBeenCalled();
+		await waitFor(() => {
+			expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+				queryKey: helmorQueryKeys.workspaceGitActionStatus("workspace-1"),
+			});
+		});
+	});
+
+	it("shows an error when a commit session completes without producing a local commit", async () => {
+		const queryClient = new QueryClient({
+			defaultOptions: {
+				queries: {
+					retry: false,
+				},
+			},
+		});
+		const pushToast = vi.fn();
+		apiMocks.loadWorkspaceGitActionStatus.mockResolvedValue({
+			...EMPTY_GIT_ACTION_STATUS,
+			uncommittedCount: 2,
+			pushStatus: "unknown",
+			aheadOfRemoteCount: 0,
+		});
+
+		const { result, rerender } = renderHook(
+			({
+				completedSessionIds,
+				busySessionIds,
+			}: {
+				completedSessionIds: Set<string>;
+				busySessionIds: Set<string>;
+			}) =>
+				useWorkspaceCommitLifecycle({
+					queryClient,
+					selectedWorkspaceId: "workspace-1",
+					selectedWorkspaceIdRef: { current: "workspace-1" },
+					selectedRepoId: "repo-1",
+					changeRequest: null,
+					forgeActionStatus: EMPTY_FORGE_ACTION_STATUS,
+					workspaceGitActionStatus: {
+						...EMPTY_GIT_ACTION_STATUS,
+						uncommittedCount: 2,
+					},
+					completedSessionIds,
+					interactionRequiredSessionIds: new Set<string>(),
+					busySessionIds,
+					onSelectSession: vi.fn(),
+					pushToast,
+				}),
+			{
+				initialProps: {
+					completedSessionIds: new Set<string>(),
+					busySessionIds: new Set<string>(),
+				},
+				wrapper: createWrapper(queryClient),
+			},
+		);
+
+		await act(async () => {
+			await result.current.handleInspectorCommitAction("commit");
+		});
+
+		act(() => {
+			result.current.handlePendingPromptConsumed();
+		});
+
+		rerender({
+			completedSessionIds: new Set<string>(),
+			busySessionIds: new Set(["session-action"]),
+		});
+		rerender({
+			completedSessionIds: new Set(["session-action"]),
+			busySessionIds: new Set<string>(),
+		});
+
+		await waitFor(() => {
+			expect(result.current.commitButtonState).toBe("error");
+		});
+		expect(pushToast).toHaveBeenCalledWith(
+			"Commit session finished, but Git status does not show a new local commit.",
+			"Commit failed",
+			"destructive",
+		);
 	});
 
 	it("shows a destructive workspace toast when push fails", async () => {

--- a/src/features/commit/hooks/use-commit-lifecycle.ts
+++ b/src/features/commit/hooks/use-commit-lifecycle.ts
@@ -16,6 +16,7 @@ import {
 	hideSession,
 	loadAutoCloseActionKinds,
 	loadRepoPreferences,
+	loadWorkspaceGitActionStatus,
 	mergeWorkspaceChangeRequest,
 	pushWorkspaceToRemote,
 	refreshWorkspaceChangeRequest,
@@ -98,6 +99,8 @@ function getActionFailureTitle(
 	switch (mode) {
 		case "create-pr":
 			return `Create ${changeRequestName} failed`;
+		case "commit":
+			return "Commit failed";
 		case "commit-and-push":
 			return "Commit and push failed";
 		case "push":
@@ -599,6 +602,30 @@ export function useWorkspaceCommitLifecycle({
 		const workspaceId = current.workspaceId;
 		void (async () => {
 			try {
+				if (current.mode === "commit") {
+					const latestGitStatus =
+						await loadWorkspaceGitActionStatus(workspaceId);
+					queryClient.setQueryData(
+						helmorQueryKeys.workspaceGitActionStatus(workspaceId),
+						latestGitStatus,
+					);
+					const commitVerified =
+						latestGitStatus.uncommittedCount === 0 &&
+						(latestGitStatus.pushStatus === "unpublished" ||
+							(latestGitStatus.aheadOfRemoteCount ?? 0) > 0);
+					if (!commitVerified) {
+						throw new Error(
+							"Commit session finished, but Git status does not show a new local commit.",
+						);
+					}
+					setCommitLifecycle((prev) => {
+						if (!prev || prev.workspaceId !== workspaceId) return prev;
+						return { ...prev, phase: "done" };
+					});
+					refreshWorkspaceRemoteStatus(workspaceId);
+					return;
+				}
+
 				console.log(
 					"[commitButton] calling refreshWorkspaceChangeRequest",
 					workspaceId,

--- a/src/features/inspector/index.test.tsx
+++ b/src/features/inspector/index.test.tsx
@@ -186,10 +186,10 @@ describe("WorkspaceInspectorSidebar Actions section", () => {
 		renderInspector({ onCommitAction });
 
 		await screen.findByText("2 uncommitted changes");
-		await user.click(screen.getByRole("button", { name: "Commit and push" }));
+		await user.click(screen.getByRole("button", { name: "Commit" }));
 		await user.click(screen.getByRole("button", { name: "Resolve" }));
 
-		expect(onCommitAction).toHaveBeenCalledWith("commit-and-push");
+		expect(onCommitAction).toHaveBeenCalledWith("commit");
 		expect(onCommitAction).toHaveBeenCalledWith("resolve-conflicts");
 	});
 
@@ -500,7 +500,7 @@ describe("WorkspaceInspectorSidebar Actions section", () => {
 		renderInspector({ commitButtonState: "busy" });
 
 		expect(
-			await screen.findByRole("button", { name: "Commit and push" }),
+			await screen.findByRole("button", { name: "Commit" }),
 		).toBeDisabled();
 	});
 
@@ -533,7 +533,7 @@ describe("WorkspaceInspectorSidebar Actions section", () => {
 		expect(pushButton).not.toHaveTextContent("Push");
 	});
 
-	it("shows a neutral loading spinner on commit-and-push while that lifecycle is busy", async () => {
+	it("shows a neutral loading spinner on commit while that lifecycle is busy", async () => {
 		apiMocks.loadWorkspaceGitActionStatus.mockResolvedValue({
 			uncommittedCount: 2,
 			conflictCount: 0,
@@ -544,7 +544,7 @@ describe("WorkspaceInspectorSidebar Actions section", () => {
 		});
 
 		renderInspector({
-			commitButtonMode: "commit-and-push",
+			commitButtonMode: "commit",
 			commitButtonState: "busy",
 		});
 
@@ -557,7 +557,7 @@ describe("WorkspaceInspectorSidebar Actions section", () => {
 		expect(
 			commitButton.querySelector(".animate-spin.text-current"),
 		).toBeInTheDocument();
-		expect(commitButton).not.toHaveTextContent("Commit and push");
+		expect(commitButton).not.toHaveTextContent("Commit");
 	});
 
 	it("shows a neutral loading spinner on pull while sync is pending", async () => {

--- a/src/features/inspector/sections/actions.tsx
+++ b/src/features/inspector/sections/actions.tsx
@@ -68,6 +68,8 @@ interface GitStatusItem {
 
 function loadingActionLabel(label: string): string {
 	switch (label) {
+		case "Commit":
+			return "Committing";
 		case "Push":
 			return "Pushing";
 		case "Pull":
@@ -629,9 +631,9 @@ function buildGitRows(
 							: `${uncommittedCount} uncommitted changes`,
 					status: "pending",
 					action: {
-						label: "Commit and push",
+						label: "Commit",
 						kind: "commit",
-						mode: "commit-and-push",
+						mode: "commit",
 					},
 				},
 		gitStatus.pushStatus === "unpublished"

--- a/src/features/inspector/sections/git-section-header.stories.tsx
+++ b/src/features/inspector/sections/git-section-header.stories.tsx
@@ -40,6 +40,7 @@ function changeRequestForMode(
 	switch (mode) {
 		case "create-pr":
 			return null;
+		case "commit":
 		case "commit-and-push":
 		case "push":
 		case "resolve-conflicts":
@@ -55,13 +56,19 @@ function changeRequestForMode(
 }
 
 function hasChangesForMode(mode: WorkspaceCommitButtonMode): boolean {
-	return mode === "create-pr" || mode === "commit-and-push" || mode === "push";
+	return (
+		mode === "create-pr" ||
+		mode === "commit" ||
+		mode === "commit-and-push" ||
+		mode === "push"
+	);
 }
 
 // ── Constants ─────────────────────────────────────────────────────────
 
 const ALL_MODES: WorkspaceCommitButtonMode[] = [
 	"create-pr",
+	"commit",
 	"commit-and-push",
 	"push",
 	"resolve-conflicts",
@@ -82,6 +89,7 @@ const ALL_STATES: CommitButtonState[] = [
 
 const MODE_LABELS: Record<WorkspaceCommitButtonMode, string> = {
 	"create-pr": "Create PR",
+	commit: "Commit",
 	"commit-and-push": "Commit & Push",
 	push: "Push",
 	"resolve-conflicts": "Resolve Conflicts",

--- a/src/features/inspector/sections/git-section-header.tsx
+++ b/src/features/inspector/sections/git-section-header.tsx
@@ -53,6 +53,8 @@ function getShortcutIdForCommitMode(
 	switch (mode) {
 		case "create-pr":
 			return "action.createPr";
+		case "commit":
+			return "action.commit";
 		case "commit-and-push":
 			return "action.commitAndPush";
 		case "fix":

--- a/src/features/shortcuts/registry.ts
+++ b/src/features/shortcuts/registry.ts
@@ -111,6 +111,14 @@ export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
 		editable: true,
 	},
 	{
+		id: "action.commit",
+		title: "Commit",
+		group: "Actions",
+		defaultHotkey: null,
+		scopes: ["app"],
+		editable: true,
+	},
+	{
 		id: "action.commitAndPush",
 		title: "Commit and push",
 		group: "Actions",

--- a/src/features/shortcuts/types.ts
+++ b/src/features/shortcuts/types.ts
@@ -21,6 +21,7 @@ export type ShortcutId =
 	| "zoom.reset"
 	| "global.hotkey"
 	| "action.createPr"
+	| "action.commit"
 	| "action.commitAndPush"
 	| "action.pullLatest"
 	| "action.mergePr"

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -50,6 +50,7 @@ export type PrSyncState = "none" | "open" | "closed" | "merged";
 export type ActionKind =
 	| "create-pr"
 	| "review"
+	| "commit"
 	| "commit-and-push"
 	| "push"
 	| "fix"

--- a/src/lib/commit-button-prompts.test.ts
+++ b/src/lib/commit-button-prompts.test.ts
@@ -168,6 +168,14 @@ describe("buildCommitButtonPrompt", () => {
 		expect(githubPrompt).toContain("Commit and push all uncommitted work");
 	});
 
+	it("uses pure local-git instructions for commit without pushing", () => {
+		const prompt = buildCommitButtonPrompt("commit", null, null, GITHUB_FORGE);
+
+		expect(prompt).toContain("Commit all uncommitted work");
+		expect(prompt).toContain("Do not push");
+		expect(prompt).not.toContain("git push");
+	});
+
 	it("substitutes the workspace remote into the commit-and-push prompt", () => {
 		const prompt = buildCommitButtonPrompt(
 			"commit-and-push",

--- a/src/lib/commit-button-prompts.ts
+++ b/src/lib/commit-button-prompts.ts
@@ -13,7 +13,7 @@ type ButtonActionMode = Exclude<
 type ActionSessionMode = ButtonActionMode | "review";
 
 // Modes that delegate to a `RepoPreferenceKey`. The other action modes
-// (`commit-and-push`, `open-pr`) have no user-facing preference slot — they're
+// (`commit`, `commit-and-push`, `open-pr`) have no user-facing preference slot — they're
 // rendered inline below.
 type PreferenceBackedMode =
 	| "create-pr"
@@ -41,6 +41,18 @@ export function buildCommitButtonPrompt(
 	const remoteName =
 		remote && remote.trim().length > 0 ? remote.trim() : "origin";
 	switch (mode) {
+		case "commit":
+			// Pure local git — no push and no forge involved.
+			return `Commit all uncommitted work in this workspace without pushing.
+
+	Do the following, in order:
+	1. Run \`git status\` and \`git diff\` to survey what's changed.
+	2. Stage everything that should ship with \`git add -A\`.
+	3. Commit with a concise, Conventional-Commits-style message (\`feat:\`, \`fix:\`, \`refactor:\`, etc.) summarizing the change.
+	4. Report the resulting commit SHA.
+
+Don't stop to ask for confirmation — execute each step automatically. Do not push. If a pre-commit hook fails, report the failure and stop.`;
+
 		case "commit-and-push":
 			// Pure git — no forge involved.
 			return `Commit and push all uncommitted work in this workspace.
@@ -80,6 +92,7 @@ export function isActionSessionMode(
 ): mode is ButtonActionMode {
 	return (
 		mode === "create-pr" ||
+		mode === "commit" ||
 		mode === "commit-and-push" ||
 		mode === "fix" ||
 		mode === "resolve-conflicts" ||
@@ -107,6 +120,8 @@ export function describeActionKind(actionKind: string): string {
 			return "Create PR";
 		case "review":
 			return "Review";
+		case "commit":
+			return "Commit";
 		case "commit-and-push":
 			return "Commit and Push";
 		case "fix":


### PR DESCRIPTION
## What changed
- Added a dedicated Commit action in the inspector and command palette shortcuts so users can create a local commit without pushing.
- Wired the new action through the backend action enum, frontend commit button modes, prompt generation, and lifecycle verification.
- Added tests for the new prompt, UI labels, action wiring, and the post-commit status check.

## Why
- The previous flow always bundled commit and push together, which made it hard to stop after creating a local commit.
- This split gives the inspector an explicit local-commit path while keeping the existing commit-and-push behavior intact.

## Validation
- Pre-commit hook ran `biome check --write`, `cargo fmt`, and `cargo clippy -- -D warnings`.
- I did not run the full frontend or Rust test suites separately.