### PR TITLE
fix: pin model/effort/fast-mode on session row at create time for PR/MR and Review

### DIFF
--- a/.changeset/quiet-pandas-design.md
+++ b/.changeset/quiet-pandas-design.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix Settings → PR/MR (and Review) effort: it now actually applies to the new session, and is disabled for models that don't support effort levels (e.g. Haiku).

--- a/src-tauri/src/agents/catalog.rs
+++ b/src-tauri/src/agents/catalog.rs
@@ -9,7 +9,11 @@ pub struct AgentModelOption {
     pub cli_model: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider_key: Option<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    /// Always serialized (even when empty) so the frontend can
+    /// distinguish "model doesn't support effort" (`[]`) from "model
+    /// metadata not loaded yet" (`undefined`). The settings panel uses
+    /// the empty case to disable the effort dropdown.
+    #[serde(default)]
     pub effort_levels: Vec<String>,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub supports_fast_mode: bool,

--- a/src-tauri/src/cli/session.rs
+++ b/src-tauri/src/cli/session.rs
@@ -158,7 +158,12 @@ fn new(workspace_ref: &str, plan: bool, action_kind: Option<&str>, cli: &Cli) ->
         None => None,
     };
     let permission_mode = if plan { Some("plan") } else { None };
-    let response = sessions::create_session(&workspace_id, kind, permission_mode)?;
+    let response = sessions::create_session(
+        &workspace_id,
+        kind,
+        permission_mode,
+        crate::models::sessions::CreateSessionOverrides::default(),
+    )?;
     notify_ui_event(UiMutationEvent::SessionListChanged {
         workspace_id: workspace_id.clone(),
     });

--- a/src-tauri/src/commands/session_commands.rs
+++ b/src-tauri/src/commands/session_commands.rs
@@ -30,9 +30,21 @@ pub async fn create_session(
     workspace_id: String,
     action_kind: Option<ActionKind>,
     permission_mode: Option<String>,
+    model: Option<String>,
+    effort_level: Option<String>,
+    fast_mode: Option<bool>,
 ) -> CmdResult<sessions::CreateSessionResponse> {
     run_blocking(move || {
-        sessions::create_session(&workspace_id, action_kind, permission_mode.as_deref())
+        sessions::create_session(
+            &workspace_id,
+            action_kind,
+            permission_mode.as_deref(),
+            sessions::CreateSessionOverrides {
+                model: model.as_deref(),
+                effort_level: effort_level.as_deref(),
+                fast_mode,
+            },
+        )
     })
     .await
 }

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -198,7 +198,12 @@ fn dispatch_tool(name: &str, args: &Value) -> Result<String> {
                 .as_bool()
                 .and_then(|enabled| enabled.then_some("plan"));
             let ws_id = service::resolve_workspace_ref(ws_ref)?;
-            let resp = service::create_session(&ws_id, None, permission_mode)?;
+            let resp = service::create_session(
+                &ws_id,
+                None,
+                permission_mode,
+                crate::models::sessions::CreateSessionOverrides::default(),
+            )?;
             Ok(serde_json::to_string_pretty(&resp)?)
         }
         "helmor_send" => {

--- a/src-tauri/src/models/sessions.rs
+++ b/src-tauri/src/models/sessions.rs
@@ -346,23 +346,39 @@ fn default_session_title_for_action_kind_with_workspace(
     Ok(kind.default_title_for_change_request(change_request_name))
 }
 
+/// Optional per-session config carried at create time. Inspector helpers
+/// (Create PR/MR, Review) push the user's configured model/effort/fast-mode
+/// here so the new session row is born with the right values — the composer
+/// then reads them off the row via the normal `currentSession` chain instead
+/// of routing them through a transient pendingPromptForSession override.
+#[derive(Debug, Default, Clone)]
+pub struct CreateSessionOverrides<'a> {
+    pub model: Option<&'a str>,
+    pub effort_level: Option<&'a str>,
+    pub fast_mode: Option<bool>,
+}
+
 pub fn create_session(
     workspace_id: &str,
     action_kind: Option<ActionKind>,
     permission_mode: Option<&str>,
+    overrides: CreateSessionOverrides<'_>,
 ) -> Result<CreateSessionResponse> {
     let mut connection = db::write_conn()?;
 
-    // `model` is left NULL on create: the frontend owns model selection via
-    // `settings.defaultModelId` (kept valid by `useEnsureDefaultModel`), and
-    // the value gets persisted into `sessions.model` by the agent streaming
-    // finalizer on the first message. Reading settings here would be a
-    // redundant second source of truth.
-    let default_effort = settings::load_setting_value("app.default_effort")
-        .ok()
-        .flatten()
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| "high".to_string());
+    // Effort falls back to the user setting when the caller doesn't pin one
+    // (matches the historical behaviour). Callers that want to force a value
+    // — e.g. PR/MR creation using settings.prEffort — pass it via overrides.
+    let effort_level = match overrides.effort_level {
+        Some(value) if !value.is_empty() => value.to_string(),
+        _ => settings::load_setting_value("app.default_effort")
+            .ok()
+            .flatten()
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "high".to_string()),
+    };
+    let model = overrides.model.filter(|s| !s.is_empty());
+    let fast_mode = overrides.fast_mode.unwrap_or(false);
 
     let transaction = connection
         .transaction()
@@ -392,8 +408,8 @@ pub fn create_session(
     transaction
         .execute(
             r#"
-            INSERT INTO sessions (id, workspace_id, status, title, permission_mode, action_kind, model, effort_level)
-            VALUES (?1, ?2, 'idle', ?3, ?4, ?5, NULL, ?6)
+            INSERT INTO sessions (id, workspace_id, status, title, permission_mode, action_kind, model, effort_level, fast_mode)
+            VALUES (?1, ?2, 'idle', ?3, ?4, ?5, ?6, ?7, ?8)
             "#,
             (
                 &session_id,
@@ -401,7 +417,9 @@ pub fn create_session(
                 &title,
                 permission_mode.unwrap_or("default"),
                 action_kind,
-                &default_effort,
+                model,
+                &effort_level,
+                fast_mode as i64,
             ),
         )
         .context("Failed to create session")?;

--- a/src-tauri/src/service.rs
+++ b/src-tauri/src/service.rs
@@ -156,6 +156,7 @@ pub fn send_message(
                         .permission_mode
                         .as_deref()
                         .filter(|mode| *mode == "plan"),
+                    crate::models::sessions::CreateSessionOverrides::default(),
                 )?
                 .session_id
             }
@@ -197,6 +198,22 @@ pub fn send_message(
                (id, session_id, role, content, created_at, sent_at)
                VALUES (?1, ?2, 'user', ?3, ?4, ?4)"#,
             params![user_msg_id, session_id, user_content, timestamp],
+        )?;
+
+        // Pin the resolved model + (optional) permission_mode onto the
+        // session row before queuing. The App composer reads these off
+        // `currentSession` when it auto-submits the drained prompt — so
+        // without this the row still has model=NULL and the composer
+        // falls back to settings.defaultModelId, ignoring the CLI's
+        // --model / --plan override.
+        conn.execute(
+            "UPDATE sessions SET model = ?2, permission_mode = COALESCE(?3, permission_mode), updated_at = ?4 WHERE id = ?1",
+            params![
+                session_id,
+                model_id,
+                params.permission_mode.as_deref(),
+                timestamp,
+            ],
         )?;
 
         insert_pending_cli_send(
@@ -725,7 +742,13 @@ mod tests {
         )
         .unwrap();
 
-        let response = create_session("w1", None, Some("plan")).unwrap();
+        let response = create_session(
+            "w1",
+            None,
+            Some("plan"),
+            crate::models::sessions::CreateSessionOverrides::default(),
+        )
+        .unwrap();
         let permission_mode: String = conn
             .query_row(
                 "SELECT permission_mode FROM sessions WHERE id = ?1",
@@ -755,8 +778,13 @@ mod tests {
         )
         .unwrap();
 
-        let response =
-            create_session("w1", Some(crate::agents::ActionKind::CreatePr), None).unwrap();
+        let response = create_session(
+            "w1",
+            Some(crate::agents::ActionKind::CreatePr),
+            None,
+            crate::models::sessions::CreateSessionOverrides::default(),
+        )
+        .unwrap();
         let title: String = conn
             .query_row(
                 "SELECT title FROM sessions WHERE id = ?1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2122,11 +2122,12 @@ function AppShell({
 			handleSelectWorkspace(first.workspaceId);
 
 			setTimeout(() => {
+				// `model` + `permissionMode` are already pinned onto the
+				// session row by the backend's CLI-send path, so the composer
+				// reads them off `currentSession` when it auto-submits.
 				queuePendingPromptForSession({
 					sessionId: first.sessionId,
 					prompt: first.prompt,
-					modelId: first.modelId,
-					permissionMode: first.permissionMode,
 				});
 				handleSelectSession(first.sessionId);
 			}, 100);

--- a/src/features/commit/hooks/use-commit-lifecycle.test.tsx
+++ b/src/features/commit/hooks/use-commit-lifecycle.test.tsx
@@ -185,8 +185,16 @@ describe("useWorkspaceCommitLifecycle", () => {
 			await result.current.handleInspectorCommitAction("create-pr");
 		});
 
+		// create-pr without inspector overrides forwards null model /
+		// effortLevel / fastMode — meaning "follow workspace defaults" — so
+		// the session row stays clean and the composer's normal fallback
+		// chain (settings.defaultEffort / .defaultFastMode / inferred model)
+		// kicks in.
 		expect(apiMocks.createSession).toHaveBeenCalledWith("workspace-1", {
 			actionKind: "create-pr",
+			model: null,
+			effortLevel: null,
+			fastMode: null,
 		});
 		expect(result.current.pendingPromptForSession).toMatchObject({
 			sessionId: "session-action",
@@ -737,14 +745,17 @@ describe("useWorkspaceCommitLifecycle", () => {
 			});
 		});
 
-		// Review is an action session ("auto-created", fixed title), but it
-		// opts out of auto-hide via `isAutoHideableActionKind`.
+		// Review pins the configured model on the session row at create
+		// time so the composer reads it off `currentSession`. The pending
+		// prompt itself is now just `{ sessionId, prompt }`.
 		expect(apiMocks.createSession).toHaveBeenCalledWith("workspace-1", {
 			actionKind: "review",
+			model: "review-model",
+			effortLevel: null,
+			fastMode: null,
 		});
 		expect(result.current.pendingPromptForSession).toMatchObject({
 			sessionId: "session-action",
-			modelId: "review-model",
 		});
 		// New review prompt diffs against the target ref, no PR/MR machinery.
 		expect(result.current.pendingPromptForSession?.prompt ?? "").toContain(
@@ -781,9 +792,17 @@ describe("useWorkspaceCommitLifecycle", () => {
 			await result.current.handleInspectorReviewAction({ modelId: null });
 		});
 
+		// A null modelId means "follow workspace default" — it's forwarded
+		// to createSession as null so the row stays NULL and the composer's
+		// inferDefaultModelId chain takes over.
+		expect(apiMocks.createSession).toHaveBeenCalledWith("workspace-1", {
+			actionKind: "review",
+			model: null,
+			effortLevel: null,
+			fastMode: null,
+		});
 		expect(result.current.pendingPromptForSession).toMatchObject({
 			sessionId: "session-action",
-			modelId: null,
 		});
 	});
 

--- a/src/features/commit/hooks/use-commit-lifecycle.ts
+++ b/src/features/commit/hooks/use-commit-lifecycle.ts
@@ -132,14 +132,6 @@ type CommitLifecycle = {
 export type PendingPromptForSession = {
 	sessionId: string;
 	prompt: string;
-	modelId?: string | null;
-	/** Effort level override applied alongside `modelId` (e.g. Review helper
-	 *  uses settings.reviewEffort). Falls through if null. */
-	effort?: string | null;
-	/** Fast-mode override applied alongside `modelId` (Review helper uses
-	 *  settings.reviewFastMode). Falls through if null/undefined. */
-	fastMode?: boolean | null;
-	permissionMode?: string | null;
 	/** When true, submit must queue if a turn is already streaming —
 	 *  regardless of the user's `followUpBehavior` setting. Used for
 	 *  host-triggered prompts (e.g. git-pull conflict resolution) that
@@ -373,8 +365,15 @@ export function useWorkspaceCommitLifecycle({
 				return;
 			}
 			try {
+				// Pin the inspector helper's configured model/effort/fast-mode
+				// onto the new session row at creation time. The composer reads
+				// these off `currentSession` via the normal fallback chain, so
+				// no transient pendingPrompt override is needed for them.
 				const { sessionId } = await createSession(workspaceId, {
 					actionKind: mode,
+					model: overrides?.modelId ?? null,
+					effortLevel: overrides?.effort ?? null,
+					fastMode: overrides?.fastMode ?? null,
 				});
 				const repoPreferences = selectedRepoId
 					? await loadRepoPreferences(selectedRepoId)
@@ -401,13 +400,7 @@ export function useWorkspaceCommitLifecycle({
 						: current,
 				);
 
-				setPendingPromptForSession({
-					sessionId,
-					prompt,
-					modelId: overrides?.modelId ?? null,
-					effort: overrides?.effort ?? null,
-					fastMode: overrides?.fastMode ?? null,
-				});
+				setPendingPromptForSession({ sessionId, prompt });
 				onSelectSession(sessionId);
 			} catch (error) {
 				console.error("[commitButton] Failed to start session:", error);
@@ -464,6 +457,9 @@ export function useWorkspaceCommitLifecycle({
 				// independently in `isAutoHideableActionKind`.
 				const { sessionId } = await createSession(workspaceId, {
 					actionKind: "review",
+					model: modelId,
+					effortLevel: effort ?? null,
+					fastMode: fastMode ?? null,
 				});
 				const repoPreferences = selectedRepoId
 					? await loadRepoPreferences(selectedRepoId)
@@ -481,13 +477,7 @@ export function useWorkspaceCommitLifecycle({
 				await queryClient.invalidateQueries({
 					queryKey: helmorQueryKeys.workspaceSessions(workspaceId),
 				});
-				setPendingPromptForSession({
-					sessionId,
-					prompt,
-					modelId,
-					effort: effort ?? null,
-					fastMode: fastMode ?? null,
-				});
+				setPendingPromptForSession({ sessionId, prompt });
 				onSelectSession(sessionId);
 			} catch (error) {
 				console.error("[review] failed to start session:", error);

--- a/src/features/composer/container.test.tsx
+++ b/src/features/composer/container.test.tsx
@@ -550,7 +550,7 @@ describe("WorkspaceComposerContainer", () => {
 		});
 	});
 
-	it("auto-submits queued CLI prompts with queued model and permission mode", async () => {
+	it("auto-submits queued CLI prompts using the model + permission_mode pinned on the session row", async () => {
 		const queryClient = createHelmorQueryClient();
 		queryClient.setQueryData(
 			helmorQueryKeys.agentModelSections,
@@ -560,9 +560,16 @@ describe("WorkspaceComposerContainer", () => {
 			helmorQueryKeys.workspaceDetail("workspace-1"),
 			WORKSPACE_DETAIL,
 		);
+		// CLI-send path pins the resolved model + permissionMode onto the
+		// session row before queuing the prompt; the composer reads them off
+		// `currentSession` rather than off the (now prompt-only) handoff.
 		queryClient.setQueryData(
 			helmorQueryKeys.workspaceSessions("workspace-1"),
-			WORKSPACE_SESSIONS,
+			WORKSPACE_SESSIONS.map((session) =>
+				session.id === "session-1"
+					? { ...session, model: "gpt-5.4", permissionMode: "plan" }
+					: session,
+			),
 		);
 
 		const onSubmit = vi.fn();
@@ -592,8 +599,6 @@ describe("WorkspaceComposerContainer", () => {
 					pendingPromptForSession={{
 						sessionId: "session-1",
 						prompt: "Plan the fix",
-						modelId: "gpt-5.4",
-						permissionMode: "plan",
 					}}
 					onPendingPromptConsumed={onPendingPromptConsumed}
 				/>

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -167,18 +167,13 @@ type WorkspaceComposerContainerProps = {
 		editorStateSnapshot?: SerializedEditorState;
 	}) => void;
 	/** Prompt queued by an external caller to auto-submit once the displayed
-	 * session matches `sessionId`. */
+	 *  session matches `sessionId`. Per-session config (model / effort /
+	 *  fast-mode / permission mode) lives on the session row by the time
+	 *  this fires — the composer reads it off `currentSession` rather than
+	 *  having it ride along here. */
 	pendingPromptForSession?: {
 		sessionId: string;
 		prompt: string;
-		modelId?: string | null;
-		/** Effort level forced for this pending submit. Takes precedence over
-		 *  cached/session/default effort. */
-		effort?: string | null;
-		/** Fast-mode forced for this pending submit. Takes precedence over
-		 *  cached/session/default fast-mode. */
-		fastMode?: boolean | null;
-		permissionMode?: string | null;
 		/** Force queue (bypass `followUpBehavior`) if a turn is streaming. */
 		forceQueue?: boolean;
 	} | null;
@@ -459,46 +454,23 @@ export const WorkspaceComposerContainer = memo(
 		]
 			? null
 			: getShortcut(settings.shortcuts, "composer.toggleContextPanel");
-		const pendingOverrideActive =
-			pendingPromptForSession?.sessionId === displayedSessionId;
-		const pendingModel = useMemo(
-			() =>
-				pendingOverrideActive && pendingPromptForSession?.modelId
-					? findModelOption(modelSections, pendingPromptForSession.modelId)
-					: null,
-			[
-				displayedSessionId,
-				modelSections,
-				pendingOverrideActive,
-				pendingPromptForSession,
-			],
-		);
-		const effectiveModel = pendingModel ?? selectedModel;
+		const effectiveModel = selectedModel;
 		const effectiveSelectedModelId = effectiveModel?.id ?? selectedModelId;
 		const provider =
 			effectiveModel?.provider ?? currentSession?.agentType ?? "claude";
 		// "User-configured" = the session row carries an explicit model. Fresh
-		// sessions are created with `model = NULL` and snapshot defaults for
-		// effort/permission/fast (so reading those unconditionally would
-		// override the user's *current* settings); both the streaming
-		// finalizer and the saveForLater path set `model` once the user has
-		// actually picked one, which is the right moment to start trusting
-		// the row.
+		// sessions get `model = NULL` *unless* an inspector helper (Create
+		// PR/MR, Review) pinned one at create time — in which case
+		// effort/fastMode/permissionMode were pinned in the same INSERT, so
+		// trusting the row here picks them up. The streaming finalizer
+		// continues to overwrite these on every turn.
 		const sessionIsConfigured =
 			!isNewSession(currentSession) || Boolean(currentSession?.model);
 		const cachedEffort = effortLevels[composerContextKey];
 		const sessionEffort =
 			(sessionIsConfigured && currentSession?.effortLevel) || null;
-		const pendingEffort =
-			pendingOverrideActive && pendingPromptForSession?.effort
-				? pendingPromptForSession.effort
-				: null;
 		const rawEffort =
-			pendingEffort ??
-			cachedEffort ??
-			sessionEffort ??
-			settings.defaultEffort ??
-			"high";
+			cachedEffort ?? sessionEffort ?? settings.defaultEffort ?? "high";
 		const effortLevel = clampEffortToModel(
 			rawEffort,
 			effectiveSelectedModelId,
@@ -508,30 +480,16 @@ export const WorkspaceComposerContainer = memo(
 		const sessionPermissionMode = sessionIsConfigured
 			? currentSession?.permissionMode
 			: null;
-		const permissionMode =
+		const effectivePermissionMode =
 			cachedPermissionMode ??
 			(sessionPermissionMode === "plan" ? "plan" : "bypassPermissions");
-		const effectivePermissionMode =
-			pendingOverrideActive && pendingPromptForSession?.permissionMode
-				? pendingPromptForSession.permissionMode
-				: permissionMode;
 		const supportsFastMode = effectiveModel?.supportsFastMode === true;
 		const cachedFastMode = fastModes[composerContextKey];
 		const sessionFastMode = sessionIsConfigured
 			? currentSession?.fastMode
 			: undefined;
-		const pendingFastMode =
-			pendingOverrideActive &&
-			pendingPromptForSession?.fastMode !== undefined &&
-			pendingPromptForSession?.fastMode !== null
-				? pendingPromptForSession.fastMode
-				: undefined;
 		const fastMode = supportsFastMode
-			? (pendingFastMode ??
-				cachedFastMode ??
-				sessionFastMode ??
-				settings.defaultFastMode ??
-				false)
+			? (cachedFastMode ?? sessionFastMode ?? settings.defaultFastMode ?? false)
 			: false;
 		const showFastModePrelude = activeFastPreludes[composerContextKey] === true;
 		const loadingConversationContext =
@@ -873,10 +831,6 @@ export const WorkspaceComposerContainer = memo(
 			if (pendingPromptForSession.sessionId !== displayedSessionId) {
 				return;
 			}
-			if (pendingPromptForSession.modelId && !pendingModel) {
-				// Wait for the model sections query to resolve the queued model.
-				return;
-			}
 			if (!effectiveModel) {
 				// Wait for the model sections query to resolve.
 				return;
@@ -885,8 +839,6 @@ export const WorkspaceComposerContainer = memo(
 			const dispatchKey = [
 				pendingPromptForSession.sessionId,
 				pendingPromptForSession.prompt,
-				pendingPromptForSession.modelId ?? "",
-				pendingPromptForSession.permissionMode ?? "",
 				pendingPromptForSession.forceQueue ? "q" : "",
 			].join("|");
 			if (dispatchedPromptKeyRef.current === dispatchKey) {
@@ -915,7 +867,6 @@ export const WorkspaceComposerContainer = memo(
 			fastMode,
 			onPendingPromptConsumed,
 			onSubmit,
-			pendingModel,
 			pendingPromptForSession,
 			supportsFastMode,
 			workingDirectory,

--- a/src/features/conversation/index.tsx
+++ b/src/features/conversation/index.tsx
@@ -95,12 +95,14 @@ type WorkspaceConversationContainerProps = {
 	onSelectContextPreview?: () => void;
 	onCloseContextPreview?: () => void;
 	/** Prompt queued by an external caller (e.g. the inspector Git commit
-	 * button) to be auto-submitted once the displayed session matches. */
+	 *  button or a drained CLI send) to be auto-submitted once the displayed
+	 *  session matches. Per-session config (model / effort / fast-mode /
+	 *  permission mode) is pinned onto the session row at create time and
+	 *  read off `currentSession` by the composer — it intentionally does NOT
+	 *  ride along on this transient handoff. */
 	pendingPromptForSession?: {
 		sessionId: string;
 		prompt: string;
-		modelId?: string | null;
-		permissionMode?: string | null;
 		/** When true, submit must queue if a turn is already streaming,
 		 *  regardless of the user's `followUpBehavior` setting. */
 		forceQueue?: boolean;
@@ -306,26 +308,6 @@ export const WorkspaceConversationContainer = memo(
 			}
 			prevPlanReviewRef.current = hasPlanReview;
 		}, [hasPlanReview, composerContextKey]);
-
-		// Preset composer model when a pending prompt carries an explicit
-		// modelId (e.g. Review uses settings.reviewModelId). Without this
-		// the chip below the chat keeps showing the inferred default while the
-		// submit silently uses the queued modelId — mismatch the user sees.
-		useEffect(() => {
-			if (!pendingPromptForSession?.modelId) return;
-			const targetKey = getComposerContextKey(
-				displayedWorkspaceId,
-				pendingPromptForSession.sessionId,
-			);
-			setComposerModelSelections((current) =>
-				current[targetKey] === pendingPromptForSession.modelId
-					? current
-					: {
-							...current,
-							[targetKey]: pendingPromptForSession.modelId as string,
-						},
-			);
-		}, [pendingPromptForSession, displayedWorkspaceId]);
 
 		// Carry the StartPage composer config (model / effort / permission /
 		// fast) into the new workspace's session contextKey. The start surface

--- a/src/features/settings/index.tsx
+++ b/src/features/settings/index.tsx
@@ -202,8 +202,16 @@ export const SettingsDialog = memo(function SettingsDialog({
 		modelSectionsQuery.data ?? [],
 		settings.defaultModelId,
 	);
-	const defaultEffortLevels =
-		selectedDefaultModel?.effortLevels ?? FALLBACK_EFFORT_LEVELS;
+	// `supportsEffort` keys off real model metadata (no fallback) — Haiku
+	// reports `effortLevels: []`, and the wire format may also drop the
+	// field entirely when empty. Either way, `?.length ?? 0` resolves to
+	// 0 → disabled. The fallback list is only used to keep the dropdown
+	// from rendering empty while metadata is still loading.
+	const defaultModelSupportsEffort =
+		(selectedDefaultModel?.effortLevels?.length ?? 0) > 0;
+	const defaultEffortLevels = defaultModelSupportsEffort
+		? (selectedDefaultModel?.effortLevels ?? FALLBACK_EFFORT_LEVELS)
+		: FALLBACK_EFFORT_LEVELS;
 	const defaultModelSupportsFastMode =
 		selectedDefaultModel?.supportsFastMode === true;
 	const defaultModelLabel =
@@ -224,8 +232,11 @@ export const SettingsDialog = memo(function SettingsDialog({
 	const reviewModelLabel =
 		effectiveReviewModel?.label ??
 		(modelSectionsQuery.isPending ? "Loading…" : "Select model");
-	const reviewEffortLevels =
-		effectiveReviewModel?.effortLevels ?? FALLBACK_EFFORT_LEVELS;
+	const reviewModelSupportsEffort =
+		(effectiveReviewModel?.effortLevels?.length ?? 0) > 0;
+	const reviewEffortLevels = reviewModelSupportsEffort
+		? (effectiveReviewModel?.effortLevels ?? FALLBACK_EFFORT_LEVELS)
+		: FALLBACK_EFFORT_LEVELS;
 	const reviewModelSupportsFastMode =
 		effectiveReviewModel?.supportsFastMode === true;
 	const effectiveReviewEffort =
@@ -241,8 +252,11 @@ export const SettingsDialog = memo(function SettingsDialog({
 	const prModelLabel =
 		effectivePrModel?.label ??
 		(modelSectionsQuery.isPending ? "Loading…" : "Select model");
-	const prEffortLevels =
-		effectivePrModel?.effortLevels ?? FALLBACK_EFFORT_LEVELS;
+	const prModelSupportsEffort =
+		(effectivePrModel?.effortLevels?.length ?? 0) > 0;
+	const prEffortLevels = prModelSupportsEffort
+		? (effectivePrModel?.effortLevels ?? FALLBACK_EFFORT_LEVELS)
+		: FALLBACK_EFFORT_LEVELS;
 	const prModelSupportsFastMode = effectivePrModel?.supportsFastMode === true;
 	const effectivePrEffort =
 		settings.prEffort ?? settings.defaultEffort ?? "high";
@@ -645,9 +659,13 @@ export const SettingsDialog = memo(function SettingsDialog({
 											</DropdownMenu>
 											<DropdownMenu>
 												<DropdownMenuTrigger
+													disabled={!defaultModelSupportsEffort}
 													className={cn(
-														"flex h-8 cursor-pointer items-center rounded-lg border border-border/50 bg-muted/30 px-3 text-[13px] text-foreground hover:bg-muted/50",
+														"flex h-8 items-center rounded-lg border border-border/50 bg-muted/30 px-3 text-[13px]",
 														"shrink-0 gap-1.5",
+														defaultModelSupportsEffort
+															? "cursor-pointer text-foreground hover:bg-muted/50"
+															: "cursor-not-allowed text-muted-foreground opacity-60",
 													)}
 												>
 													<span>
@@ -762,9 +780,13 @@ export const SettingsDialog = memo(function SettingsDialog({
 											</DropdownMenu>
 											<DropdownMenu>
 												<DropdownMenuTrigger
+													disabled={!reviewModelSupportsEffort}
 													className={cn(
-														"flex h-8 cursor-pointer items-center rounded-lg border border-border/50 bg-muted/30 px-3 text-[13px] text-foreground hover:bg-muted/50",
+														"flex h-8 items-center rounded-lg border border-border/50 bg-muted/30 px-3 text-[13px]",
 														"shrink-0 gap-1.5",
+														reviewModelSupportsEffort
+															? "cursor-pointer text-foreground hover:bg-muted/50"
+															: "cursor-not-allowed text-muted-foreground opacity-60",
 													)}
 												>
 													<span>{effortLabel(effectiveReviewEffort)}</span>
@@ -826,7 +848,7 @@ export const SettingsDialog = memo(function SettingsDialog({
 									</SettingsRow>
 									<SettingsRow
 										title="PR / MR model"
-										description="Model used when creating PRs and MRs"
+										description="Model for PRs and MRs"
 									>
 										<div className="flex w-[360px] items-center gap-2">
 											<DropdownMenu>
@@ -884,9 +906,13 @@ export const SettingsDialog = memo(function SettingsDialog({
 											</DropdownMenu>
 											<DropdownMenu>
 												<DropdownMenuTrigger
+													disabled={!prModelSupportsEffort}
 													className={cn(
-														"flex h-8 cursor-pointer items-center rounded-lg border border-border/50 bg-muted/30 px-3 text-[13px] text-foreground hover:bg-muted/50",
+														"flex h-8 items-center rounded-lg border border-border/50 bg-muted/30 px-3 text-[13px]",
 														"shrink-0 gap-1.5",
+														prModelSupportsEffort
+															? "cursor-pointer text-foreground hover:bg-muted/50"
+															: "cursor-not-allowed text-muted-foreground opacity-60",
 													)}
 												>
 													<span>{effortLabel(effectivePrEffort)}</span>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2564,12 +2564,25 @@ export async function createSession(
 	options?: {
 		actionKind?: ActionKind | null;
 		permissionMode?: string | null;
+		/** Pin the session row's `model` at creation. Inspector helpers
+		 *  (Create PR/MR, Review) push the user's configured model here so
+		 *  the composer reads it off the row instead of falling back to
+		 *  settings.defaultModelId. Leave null for the default flow. */
+		model?: string | null;
+		/** Pin `effort_level` at creation; null falls back to the user
+		 *  setting on the backend. */
+		effortLevel?: string | null;
+		/** Pin `fast_mode` at creation; null/undefined defaults to false. */
+		fastMode?: boolean | null;
 	},
 ): Promise<CreateSessionResponse> {
 	return invoke<CreateSessionResponse>("create_session", {
 		workspaceId,
 		actionKind: options?.actionKind ?? null,
 		permissionMode: options?.permissionMode ?? null,
+		model: options?.model ?? null,
+		effortLevel: options?.effortLevel ?? null,
+		fastMode: options?.fastMode ?? null,
 	});
 }
 


### PR DESCRIPTION
## What changed

- **`CreateSessionOverrides`** (new Rust struct): `create_session` now accepts an optional `model`, `effort_level`, and `fast_mode` to pin on the session row at INSERT time. All existing call sites pass `::default()` (no change in behavior).
- **Inspector helpers** (Create PR/MR, Review): `useWorkspaceCommitLifecycle` now forwards the user's configured model/effort/fast-mode into `createSession` instead of carrying them on the transient `pendingPromptForSession` handoff.
- **`pendingPromptForSession`**: Stripped down to `{ sessionId, prompt, forceQueue? }` — per-session config no longer rides on this object. The composer reads it off `currentSession` (the row) instead.
- **`effort_levels` serialization**: Removed `skip_serializing_if = "Vec::is_empty"` so the frontend always gets `[]` for models that don't support effort (e.g. Haiku), rather than `undefined`. Lets the Settings panel reliably disable the effort dropdown.
- **Settings effort dropdowns**: Disabled + styled `cursor-not-allowed` when the selected model has no effort levels.
- **CLI-drain path** (`App.tsx`): `modelId` / `permissionMode` are no longer forwarded through the pending-prompt handoff — they're already pinned on the session row by the backend's `service::send_message`.

## Why

The previous approach routed model/effort/fast-mode through a transient in-memory object (`pendingPromptForSession`). This caused two bugs:
1. The effort setting configured in Settings → PR/MR was silently ignored because the old path didn't include `effortLevel` in the handoff.
2. Models without effort support (Haiku) still showed an active effort dropdown in Settings because the empty `effort_levels` array was stripped from the wire format (`undefined` ≠ `[]`).

Pinning the values on the session row at creation is the cleaner approach: the composer's normal `currentSession` fallback chain picks them up without any special-case override logic.

## Test notes

- Existing frontend tests updated: `use-commit-lifecycle.test.tsx` and `composer/container.test.tsx` reflect the new `createSession` call shape and the simplified `pendingPromptForSession` type.
- Rust unit tests in `service.rs` updated to pass `CreateSessionOverrides::default()`.
- No pipeline snapshot changes expected (the accumulator/adapter are untouched).