### PR TITLE
fix: collapse just-finished reasoning blocks and fix virtual-list height gap

### DIFF
--- a/.changeset/loud-newts-dream.md
+++ b/.changeset/loud-newts-dream.md
@@ -1,0 +1,7 @@
+---
+"helmor": patch
+---
+
+Fix two related issues in long chat sessions:
+- Stop the empty space below the last message from growing as thinking blocks pile up.
+- Make finished thinking blocks fold up even when you switch away and come back.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -165,6 +165,7 @@ import {
 	WorkspaceToastProvider,
 } from "./lib/workspace-toast-context";
 import { StreamingFooterOverlapScenario } from "./test/e2e-scenarios/streaming-footer-overlap";
+import { StreamingReasoningGapScenario } from "./test/e2e-scenarios/streaming-reasoning-gap";
 
 const SETTINGS_RELOAD_EVENT = "helmor:reload-settings";
 const OPEN_SETTINGS_EVENT = "helmor:open-settings";
@@ -180,6 +181,10 @@ function App() {
 
 	if (e2eScenario === "streaming-footer-overlap") {
 		return <StreamingFooterOverlapScenario />;
+	}
+
+	if (e2eScenario === "streaming-reasoning-gap") {
+		return <StreamingReasoningGapScenario />;
 	}
 
 	return <MainApp />;

--- a/src/components/ai/reasoning.test.tsx
+++ b/src/components/ai/reasoning.test.tsx
@@ -1,0 +1,41 @@
+import { cleanup, render, within } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { Reasoning, ReasoningContent, ReasoningTrigger } from "./reasoning";
+
+function setup(lifecycle: "streaming" | "just-finished" | "historical") {
+	return render(
+		<Reasoning lifecycle={lifecycle}>
+			<ReasoningTrigger />
+			<ReasoningContent>{"some thought text"}</ReasoningContent>
+		</Reasoning>,
+	);
+}
+
+describe("<Reasoning />", () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	it("defaults open while streaming", () => {
+		const { container } = setup("streaming");
+		const trigger = within(container).getByRole("button");
+		expect(trigger.getAttribute("data-state")).toBe("open");
+	});
+
+	// Previously `just-finished` defaulted open, with an effect that
+	// collapsed it only when the user observed the live `streaming →
+	// !streaming` transition. Switching to another session and coming
+	// back left the block expanded — both surprising the user and
+	// inflating the layout estimator by `textHeight` per block.
+	it("defaults closed once streaming finished, regardless of mount path", () => {
+		const { container } = setup("just-finished");
+		const trigger = within(container).getByRole("button");
+		expect(trigger.getAttribute("data-state")).toBe("closed");
+	});
+
+	it("defaults closed for historical reloads", () => {
+		const { container } = setup("historical");
+		const trigger = within(container).getByRole("button");
+		expect(trigger.getAttribute("data-state")).toBe("closed");
+	});
+});

--- a/src/components/ai/reasoning.tsx
+++ b/src/components/ai/reasoning.tsx
@@ -62,10 +62,15 @@ export const Reasoning = memo(
 		children,
 		...props
 	}: ReasoningProps) => {
-		// Live blocks (streaming OR just-finished) default open; historical
-		// reloads default collapsed so a returning user isn't buried in
-		// past reasoning text.
-		const resolvedDefaultOpen = defaultOpen ?? lifecycle !== "historical";
+		// Only the actively-streaming block defaults open. `just-finished`
+		// and `historical` both default closed so the row's DOM state is
+		// the same regardless of whether the user was watching when the
+		// stream ended — previously a transition-only `setIsOpen(false)`
+		// effect collapsed live observers but left switched-away viewers
+		// with an expanded block, which both surprises users (per their
+		// "thinking 输出完之后自动收起" expectation) and inflates
+		// `totalRowsHeight` against the layout estimator.
+		const resolvedDefaultOpen = defaultOpen ?? lifecycle === "streaming";
 
 		const [isOpen, setIsOpen] = useControllableState({
 			prop: open,
@@ -89,8 +94,10 @@ export const Reasoning = memo(
 			}
 		}, [isStreaming, startTime, setDuration]);
 
-		// Auto-collapse when the reasoning block finishes streaming
-		// (streaming → just-finished or historical).
+		// Auto-collapse on the live `streaming → !streaming` transition so
+		// the user watching it finish sees the block tuck away. Fresh
+		// mounts as `just-finished` already start collapsed via the
+		// defaultOpen above, so the two paths converge.
 		const prevLifecycleRef = useRef(lifecycle);
 		useEffect(() => {
 			const prev = prevLifecycleRef.current;

--- a/src/features/panel/message-components.test.tsx
+++ b/src/features/panel/message-components.test.tsx
@@ -367,9 +367,14 @@ describe("MemoConversationMessage plan review", () => {
 		);
 
 		expect(screen.getByText("Thought for 4s")).toBeInTheDocument();
-		// The block should be open (not auto-collapsed) because the
-		// pipeline signaled a just-completed live reasoning run.
-		expect(screen.getByText("Figured it out quickly.")).toBeInTheDocument();
+		// `just-finished` blocks default closed now — matches what historical
+		// reloads do, so a session that finishes thinking while the user is
+		// switched to another workspace doesn't come back full of expanded
+		// reasoning walls. The text is still in the DOM (CollapsibleContent
+		// hides via attributes, not unmount), so query through the trigger's
+		// state instead of looking for the body text.
+		const trigger = screen.getByText("Thought for 4s").closest("button");
+		expect(trigger?.getAttribute("data-state")).toBe("closed");
 	});
 
 	it("keeps a historical reasoning block collapsed without a duration", () => {

--- a/src/lib/message-layout-estimator.test.ts
+++ b/src/lib/message-layout-estimator.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { ThreadMessageLike, ToolCallPart } from "./api";
+import type { ReasoningPart, ThreadMessageLike, ToolCallPart } from "./api";
 import { estimateThreadRowHeights } from "./message-layout-estimator";
 
 function makeTool(index: number): ToolCallPart {
@@ -11,6 +11,18 @@ function makeTool(index: number): ToolCallPart {
 		argsText: "",
 		result: index % 2 === 0 ? "line 1\nline 2\nline 3" : undefined,
 		streamingStatus: index === 3 ? "running" : "done",
+	};
+}
+
+function makeReasoning(
+	index: number,
+	streaming: boolean | undefined,
+): ReasoningPart {
+	return {
+		type: "reasoning",
+		id: `reasoning-${index}`,
+		text: `Reasoning step ${index}: ${"detailed thought ".repeat(60)}`,
+		streaming,
 	};
 }
 
@@ -41,5 +53,72 @@ describe("estimateThreadRowHeights", () => {
 		});
 
 		expect(height).toBeGreaterThan(150);
+	});
+
+	// Regression: previous estimator treated `just-finished` reasoning as
+	// expanded, but the `Reasoning` component renders it collapsed (default
+	// closed for non-streaming, with auto-collapse on the live transition).
+	// The mismatch inflated `totalRowsHeight` by ~textHeight per reasoning,
+	// producing a multi-screen gap below the last visible content.
+	it("treats just-finished reasoning as collapsed", () => {
+		const justFinishedRow: ThreadMessageLike = {
+			id: "assistant-just-finished",
+			role: "assistant",
+			streaming: true,
+			content: [
+				{ type: "text", id: "leading", text: "Working on it." },
+				...Array.from({ length: 8 }, (_, index) => makeReasoning(index, false)),
+				{
+					type: "tool-call",
+					toolCallId: "tool-final",
+					toolName: "Read",
+					args: { file_path: "/some/path.ts" },
+					argsText: "",
+					streamingStatus: "running",
+				},
+			],
+		};
+
+		const [collapsedHeight] = estimateThreadRowHeights([justFinishedRow], {
+			fontSize: 14,
+			paneWidth: 960,
+		});
+
+		// Same row, but reasoning blocks are still actively streaming. They
+		// should be measured as expanded — that's the legitimately tall
+		// case.
+		const streamingReasoningRow: ThreadMessageLike = {
+			...justFinishedRow,
+			content: justFinishedRow.content.map((part) =>
+				part.type === "reasoning" ? makeReasoning(0, true) : part,
+			),
+		};
+		const [streamingHeight] = estimateThreadRowHeights(
+			[streamingReasoningRow],
+			{ fontSize: 14, paneWidth: 960 },
+		);
+
+		// Each just-finished reasoning collapses to ~24px; expanded reasoning
+		// is hundreds of px tall, so the streaming variant should dominate.
+		expect(streamingHeight).toBeGreaterThan(collapsedHeight + 200);
+		// And the just-finished row should be on the order of (parts × 24px),
+		// not (parts × textHeight).
+		expect(collapsedHeight).toBeLessThan(400);
+	});
+
+	it("treats historical reasoning as collapsed", () => {
+		const historical: ThreadMessageLike = {
+			id: "assistant-historical",
+			role: "assistant",
+			content: Array.from({ length: 6 }, (_, index) =>
+				makeReasoning(index, undefined),
+			),
+		};
+		const [height] = estimateThreadRowHeights([historical], {
+			fontSize: 14,
+			paneWidth: 960,
+		});
+		// 6 collapsed reasoning summaries plus gaps and bottom padding.
+		expect(height).toBeLessThan(300);
 	});
 });

--- a/src/lib/message-layout-estimator.ts
+++ b/src/lib/message-layout-estimator.ts
@@ -178,26 +178,24 @@ function estimateAssistantPartHeight(
 }
 
 /**
- * Reasoning height has two regimes, matching what `ReasoningContent` actually
- * renders:
+ * Reasoning has two height regimes, matching what `ReasoningContent`
+ * actually renders:
  *
- *   - historical reload → collapsed by default → just the trigger (~24px).
- *   - streaming / just-finished → expanded by default → trigger + chrome +
- *     the wrapped-text height of the body. The body has no max-height
- *     anymore (was capturing wheel events), so it grows with the text;
- *     the virtual list reconciles via `resolveConversationRowHeight` +
- *     ResizeObserver.
- *
- * Keeps the estimate *monotonic* against the measured height:
- * `resolveConversationRowHeight` uses `max(measured, estimated)` while
- * streaming, so a slightly conservative estimate just means a harmless bit
- * of bottom padding if the live reasoning turns out to be short.
+ *   - `streaming` → expanded → trigger + chrome + wrapped text height.
+ *   - `just-finished` and `historical` → collapsed → just the trigger
+ *     (~24px). The `Reasoning` component now defaults `just-finished`
+ *     blocks closed (matching `historical`), so the DOM is the same
+ *     whether the user watched the stream finish or switched away and
+ *     came back. Aligning the estimate with that DOM keeps the
+ *     streaming row's `max(measured, estimated)` from inflating
+ *     `totalRowsHeight` — the source of the bottom gap below the last
+ *     visible content.
  */
 function estimateReasoningHeight(
 	part: ReasoningPart,
 	options: { fontSize: number; contentWidth: number },
 ) {
-	if (reasoningLifecycle(part) === "historical") {
+	if (reasoningLifecycle(part) !== "streaming") {
 		return REASONING_SUMMARY_HEIGHT;
 	}
 	const bodyWidth = Math.max(

--- a/src/test/e2e-scenarios/streaming-reasoning-gap.tsx
+++ b/src/test/e2e-scenarios/streaming-reasoning-gap.tsx
@@ -1,0 +1,241 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+	ActiveThreadViewport,
+	type PresentedSessionPane,
+} from "@/features/panel/thread-viewport";
+import type {
+	ExtendedMessagePart,
+	ReasoningPart,
+	ThreadMessageLike,
+	ToolCallPart,
+} from "@/lib/api";
+
+// Reproduces the bottom-gap bug.
+//
+// Root hypothesis: when a streaming assistant row contains many reasoning
+// parts, the auto-collapse in `<Reasoning>` shrinks the DOM while the
+// estimator still treats `just-finished` as expanded — so
+// `Math.max(measured, estimated)` for the streaming row inflates by the
+// full collapsed-vs-expanded delta (~textHeight per reasoning), and the
+// resulting `totalRowsHeight` produces a huge gap below the last visible
+// content.
+//
+// Scenario walks one reasoning at a time:
+//   step 0..N-1   reasoning N is streaming, 0..N-1 are just-finished
+//   final tool    a tool_use is appended after the last reasoning, mirroring
+//                 the user's "突然多了一个工具调用" trigger
+
+const SESSION_ID = "e2e-streaming-reasoning-gap";
+const HISTORY_COUNT = 16;
+const REASONING_STEPS = 10;
+const REASONING_TEXT = [
+	"The user is asking about the bottom-gap bug. Let me trace the layout pipeline first.",
+	"Looking at thread-viewport.tsx, totalRowsHeight is derived from absolute-positioned rows.",
+	"The estimator is in src/lib/message-layout-estimator.ts — it's keyed by message reference.",
+	"resolveConversationRowHeight does Math.max(measured, estimated) when streaming === true.",
+	"reasoning-lifecycle.ts maps wire-format streaming tri-state to UI state.",
+	"Reasoning component auto-collapses on streaming → not-streaming transition.",
+	"So the DOM state for just-finished is collapsed, but the estimator says expanded.",
+	"That's the mismatch — accumulated across many reasoning blocks it dwarfs the viewport.",
+	"Need to either: pessimistically estimate just-finished, or align the DOM by always collapsing.",
+	"Going with estimator change first; it's the safer fix and Math.max protects against undershoot.",
+].map(
+	(line, index) =>
+		// Pad each line so reasoning blocks are large enough to expose the gap.
+		`${line} ${"Padding sentence to make reasoning text visibly tall. ".repeat(8)}\n\nDeep dive #${index + 1}: ${"more diagnostic text ".repeat(20)}`,
+);
+
+function makeFiller(index: number): ThreadMessageLike {
+	const role = index % 3 === 0 ? "user" : "assistant";
+	if (role === "user") {
+		return {
+			id: `filler-user-${index}`,
+			role: "user",
+			content: [
+				{
+					type: "text",
+					id: `filler-user-${index}-text`,
+					text: `Question ${index}: keep the thread long enough to virtualize.`,
+				},
+			],
+		};
+	}
+	return {
+		id: `filler-assistant-${index}`,
+		role: "assistant",
+		content: [
+			{
+				type: "text",
+				id: `filler-assistant-${index}-text`,
+				text: `Reply ${index}. Historical content padding the scrollback.`,
+			},
+		],
+	};
+}
+
+function makeReasoningPart(index: number, streaming: boolean): ReasoningPart {
+	return {
+		type: "reasoning",
+		id: `reasoning-${index}`,
+		text: REASONING_TEXT[index] ?? `Reasoning step ${index}`,
+		streaming,
+		durationMs: streaming ? undefined : 4_500,
+	};
+}
+
+function makeFinalTool(): ToolCallPart {
+	return {
+		type: "tool-call",
+		toolCallId: "final-tool",
+		toolName: "Read",
+		args: {
+			file_path: "/Users/me/repo/src/lib/message-layout-estimator.ts",
+		},
+		argsText: "",
+		streamingStatus: "running",
+	};
+}
+
+function buildStreamingParts(
+	stepIndex: number,
+	includeTool: boolean,
+): ExtendedMessagePart[] {
+	const parts: ExtendedMessagePart[] = [
+		{
+			type: "text",
+			id: "leading-text",
+			text: "Working through this layered virtualization question now.",
+		},
+	];
+	for (let i = 0; i <= stepIndex; i += 1) {
+		const isLast = i === stepIndex;
+		parts.push(makeReasoningPart(i, isLast && !includeTool));
+	}
+	if (includeTool) {
+		parts.push(makeFinalTool());
+	}
+	return parts;
+}
+
+function buildMessages(
+	stepIndex: number,
+	includeTool: boolean,
+): ThreadMessageLike[] {
+	const history = Array.from({ length: HISTORY_COUNT }, (_, index) =>
+		makeFiller(index),
+	);
+	return [
+		...history,
+		{
+			id: "streaming-assistant",
+			role: "assistant",
+			streaming: true,
+			content: buildStreamingParts(stepIndex, includeTool),
+		},
+	];
+}
+
+export function StreamingReasoningGapScenario() {
+	// 0..REASONING_STEPS-1: reasoning N is streaming (others just-finished)
+	// REASONING_STEPS:      tool call appended; all reasoning is just-finished
+	const [stepIndex, setStepIndex] = useState(0);
+	const [autoAdvance, setAutoAdvance] = useState(true);
+	// `remountKey` simulates "user switched away and back": the viewport
+	// remounts with messages already in their current lifecycle state, so
+	// every Reasoning block mounts fresh as `just-finished` and the
+	// auto-collapse useEffect cannot observe a `streaming → !streaming`
+	// transition. This is the case the user is asking us to verify.
+	const [remountKey, setRemountKey] = useState(0);
+
+	useEffect(() => {
+		if (!autoAdvance) {
+			return;
+		}
+		const intervalId = window.setInterval(() => {
+			setStepIndex((current) =>
+				current >= REASONING_STEPS ? current : current + 1,
+			);
+		}, 1500);
+		return () => window.clearInterval(intervalId);
+	}, [autoAdvance]);
+
+	const includeTool = stepIndex >= REASONING_STEPS;
+
+	const pane = useMemo<PresentedSessionPane>(
+		() => ({
+			sessionId: SESSION_ID,
+			messages: buildMessages(
+				Math.min(stepIndex, REASONING_STEPS - 1),
+				includeTool,
+			),
+			sending: true,
+			hasLoaded: true,
+			presentationState: "presented",
+		}),
+		[stepIndex, includeTool],
+	);
+
+	return (
+		<div className="flex h-screen flex-col bg-background text-foreground">
+			<div className="flex items-center gap-3 border-b border-border/50 px-4 py-2 text-xs">
+				<span className="font-medium">Streaming Reasoning Gap</span>
+				<span className="text-muted-foreground">
+					step <span data-testid="step-index">{stepIndex}</span> /{" "}
+					{REASONING_STEPS}
+				</span>
+				<span className="text-muted-foreground">
+					{includeTool ? "tool appended" : "reasoning only"}
+				</span>
+				<button
+					type="button"
+					className="rounded border border-border/40 px-2 py-0.5 hover:bg-accent"
+					onClick={() => {
+						setAutoAdvance((current) => !current);
+					}}
+				>
+					{autoAdvance ? "pause" : "resume"}
+				</button>
+				<button
+					type="button"
+					className="rounded border border-border/40 px-2 py-0.5 hover:bg-accent"
+					onClick={() => {
+						setStepIndex(0);
+					}}
+				>
+					reset
+				</button>
+				<button
+					type="button"
+					className="rounded border border-border/40 px-2 py-0.5 hover:bg-accent"
+					onClick={() => {
+						setStepIndex((current) => Math.min(REASONING_STEPS, current + 1));
+					}}
+				>
+					next
+				</button>
+				<button
+					type="button"
+					className="rounded border border-accent-foreground/40 bg-accent/40 px-2 py-0.5 hover:bg-accent"
+					data-testid="remount"
+					onClick={() => {
+						setRemountKey((current) => current + 1);
+					}}
+				>
+					switch-away/back (remount)
+				</button>
+				<span className="text-muted-foreground">
+					remount=<span data-testid="remount-key">{remountKey}</span>
+				</span>
+			</div>
+			<div className="flex min-h-0 flex-1">
+				<div className="flex min-h-0 flex-1 flex-col">
+					<ActiveThreadViewport
+						key={`pane-${remountKey}`}
+						hasSession
+						pane={pane}
+					/>
+				</div>
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## What changed

- **`Reasoning` component** (`src/components/ai/reasoning.tsx`): `just-finished` blocks now default to collapsed, same as `historical`. Previously only `historical` was collapsed; `just-finished` defaulted open, meaning a user who switched away while a block was streaming would come back to an expanded wall of reasoning text.
- **Layout estimator** (`src/lib/message-layout-estimator.ts`): Updated the `estimateReasoningHeight` guard from `=== "historical"` → `!== "streaming"`. This aligns the estimated height with what the component actually renders, eliminating the spurious extra height that accumulated per reasoning block and caused a blank gap below the last visible message in long chat sessions.
- **E2E scenario** (`src/test/e2e-scenarios/streaming-reasoning-gap.tsx`): New scenario registered under `streaming-reasoning-gap` for manual visual verification via `?e2e_scenario=streaming-reasoning-gap`.

## Why it changed

Two bugs were intertwined:

1. `Reasoning` defaulted `just-finished` blocks open. The auto-collapse `useEffect` fires on the live `streaming → !streaming` transition, which collapses for live observers — but a user who navigated away and came back mounted the block fresh as `just-finished` with no prior `streaming` state, so the effect never fired and the block stayed open.
2. Because the component rendered `just-finished` as expanded, the estimator was also correct at the time — but the component was subsequently fixed so blocks should close, yet the estimator was not updated, leading to `totalRowsHeight` exceeding the true rendered height by `textHeight × N` (where N = number of reasoning blocks). The virtual list reserved excess space, creating the blank gap.

## Tests

- `src/lib/message-layout-estimator.test.ts`: two new cases — "treats just-finished reasoning as collapsed" and "treats historical reasoning as collapsed".
- `src/components/ai/reasoning.test.tsx`: new test file covering the `just-finished` default-closed behaviour.
- `src/features/panel/message-components.test.tsx`: updated existing assertion to match new closed-by-default behaviour for `just-finished` blocks.

## Follow-up

None required. The changeset (`loud-newts-dream.md`) is included for the release pipeline.