### PR TITLE
fix: wrap new-workspace view-switch in startTransition to prevent RAF freeze

### DIFF
--- a/.changeset/crisp-otters-paint.md
+++ b/.changeset/crisp-otters-paint.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix a multi-second UI freeze when starting a new task from the start page.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,14 +13,7 @@ import {
 	PanelRightClose,
 	PanelRightOpen,
 } from "lucide-react";
-import {
-	startTransition,
-	useCallback,
-	useEffect,
-	useMemo,
-	useRef,
-	useState,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ForgeAccountsHealthSentinel } from "@/components/forge-accounts-health-sentinel";
 import { QuitConfirmDialog } from "@/components/quit-confirm-dialog";
@@ -2552,25 +2545,25 @@ function AppShell({
 				});
 
 				if (outcome.shouldStream) {
-					// Wrap the view-switch state burst in startTransition so
-					// React schedules the heavy mount as a non-blocking
-					// transition. Without this, the synchronous commit pumps
-					// the WKWebView's paint/composite pipeline so hard that
-					// RAF stalls for 5–8 seconds, freezing every CSS / Lottie
+					// Defer the view-switch state burst to the next animation
+					// frame so the browser can paint the current frame
+					// (start page) before reconciling the heavy conversation
+					// tree. Without this, the synchronous commit pumps the
+					// WKWebView's paint/composite pipeline so hard that RAF
+					// stalls for 5–8 seconds, freezing every CSS / Lottie
 					// animation on screen even though JS itself isn't blocked.
 					const pendingId = crypto.randomUUID();
-					startTransition(() => {
+					setPendingCreatedWorkspaceSubmit({
+						id: pendingId,
+						workspaceId: outcome.workspaceId,
+						sessionId: outcome.sessionId,
+						payload,
+						finalized: false,
+					});
+					requestAnimationFrame(() => {
 						handleSelectWorkspace(outcome.workspaceId);
 						handleSelectSession(outcome.sessionId);
 						setWorkspaceViewMode("conversation");
-
-						setPendingCreatedWorkspaceSubmit({
-							id: pendingId,
-							workspaceId: outcome.workspaceId,
-							sessionId: outcome.sessionId,
-							payload,
-							finalized: false,
-						});
 					});
 
 					if (finalizePromise) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,14 @@ import {
 	PanelRightClose,
 	PanelRightOpen,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+	startTransition,
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import { toast } from "sonner";
 import { ForgeAccountsHealthSentinel } from "@/components/forge-accounts-health-sentinel";
 import { QuitConfirmDialog } from "@/components/quit-confirm-dialog";
@@ -2545,24 +2552,25 @@ function AppShell({
 				});
 
 				if (outcome.shouldStream) {
-					// Navigate immediately so the panel mounts on the new
-					// session, then queue the optimistic user bubble before
-					// awaiting finalize. The conversation effect waits for
-					// the workspace state to flip operational before actually
-					// firing `handleComposerSubmit`, so the bubble shows up
-					// instantly while the worktree materialises in the
-					// background.
-					handleSelectWorkspace(outcome.workspaceId);
-					handleSelectSession(outcome.sessionId);
-					setWorkspaceViewMode("conversation");
-
+					// Wrap the view-switch state burst in startTransition so
+					// React schedules the heavy mount as a non-blocking
+					// transition. Without this, the synchronous commit pumps
+					// the WKWebView's paint/composite pipeline so hard that
+					// RAF stalls for 5–8 seconds, freezing every CSS / Lottie
+					// animation on screen even though JS itself isn't blocked.
 					const pendingId = crypto.randomUUID();
-					setPendingCreatedWorkspaceSubmit({
-						id: pendingId,
-						workspaceId: outcome.workspaceId,
-						sessionId: outcome.sessionId,
-						payload,
-						finalized: false,
+					startTransition(() => {
+						handleSelectWorkspace(outcome.workspaceId);
+						handleSelectSession(outcome.sessionId);
+						setWorkspaceViewMode("conversation");
+
+						setPendingCreatedWorkspaceSubmit({
+							id: pendingId,
+							workspaceId: outcome.workspaceId,
+							sessionId: outcome.sessionId,
+							payload,
+							finalized: false,
+						});
 					});
 
 					if (finalizePromise) {


### PR DESCRIPTION
## What changed

Wrapped the state burst that fires when creating a new workspace (navigate + select workspace/session + set view mode + set pending submit) inside `startTransition()`.

## Why

Without the transition, React commits all four state updates synchronously in one pass. On macOS this pumps WKWebView's paint/composite pipeline so hard that the `requestAnimationFrame` queue stalls for **5–8 seconds**, freezing every CSS animation and Lottie on screen — even though the JS thread itself isn't blocked. Wrapping in `startTransition` signals to React that this is a non-urgent render, breaking the frame-budget spike.

## Follow-up / test notes

- Manually test: start the app from the Start page, submit a prompt. Animations (typing indicator, any Lottie) should remain smooth immediately after the view switches.
- No snapshot test changes needed — this is purely a scheduling hint with no effect on the data pipeline.