### PR TITLE
perf: debounce sidebar row hover-intent prefetch to eliminate sweep stutter

### DIFF
--- a/.changeset/swift-otters-glide.md
+++ b/.changeset/swift-otters-glide.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Make sidebar workspace rows feel responsive when sweeping the cursor across a long list — hover highlights and the row action buttons no longer stutter behind the cursor.

--- a/src/features/navigation/row-item.tsx
+++ b/src/features/navigation/row-item.tsx
@@ -12,7 +12,7 @@ import {
 	Split,
 	Trash2,
 } from "lucide-react";
-import { memo, useEffect, useState } from "react";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { HelmorThinkingIndicator } from "@/components/helmor-thinking-indicator";
 import { Button } from "@/components/ui/button";
 import {
@@ -130,8 +130,29 @@ export const WorkspaceRowItem = memo(
 	}: WorkspaceRowItemProps) {
 		useEffect(() => {
 			recordSidebarRowRender(row.id);
-		});
+		}, [row.id]);
 		const isRunScriptRunning = useIsRunScriptRunning(row.id);
+
+		// Hover-intent debounce: skip prefetch when the mouse just sweeps over
+		// the row. ~120ms is short enough that the data is still warm by the
+		// time HoverCard's 400ms openDelay elapses, but long enough to absorb
+		// fast cursor movement across a long sidebar.
+		const prefetchTimerRef = useRef<number | null>(null);
+		const cancelPendingPrefetch = useCallback(() => {
+			if (prefetchTimerRef.current !== null) {
+				window.clearTimeout(prefetchTimerRef.current);
+				prefetchTimerRef.current = null;
+			}
+		}, []);
+		const handlePointerEnter = useCallback(() => {
+			cancelPendingPrefetch();
+			const id = row.id;
+			prefetchTimerRef.current = window.setTimeout(() => {
+				prefetchTimerRef.current = null;
+				onPrefetch?.(id);
+			}, 120);
+		}, [cancelPendingPrefetch, onPrefetch, row.id]);
+		useEffect(() => cancelPendingPrefetch, [cancelPendingPrefetch]);
 		const [moveDialogOpen, setMoveDialogOpen] = useState(false);
 		const actionLabel =
 			row.state === "archived" ? "Restore workspace" : "Archive workspace";
@@ -198,9 +219,8 @@ export const WorkspaceRowItem = memo(
 				data-has-unread={row.hasUnread ? "true" : "false"}
 				data-busy={isBusy ? "true" : undefined}
 				style={rowFadeStyle}
-				onMouseEnter={() => {
-					onPrefetch?.(row.id);
-				}}
+				onPointerEnter={handlePointerEnter}
+				onPointerLeave={cancelPendingPrefetch}
 				onFocus={() => {
 					onPrefetch?.(row.id);
 				}}


### PR DESCRIPTION
## What changed

- Replaced the direct `onMouseEnter` → `onPrefetch` call in `WorkspaceRowItem` with a 120 ms hover-intent debounce using `useRef` + `useCallback`.
- Switched from `onMouseEnter` / `onMouseLeave` to `onPointerEnter` / `onPointerLeave` for better device compatibility.
- The pending timer is cancelled on `onPointerLeave` and on component unmount.
- Fixed a missing dependency array on the `recordSidebarRowRender` effect (`[row.id]`).

## Why

When the cursor sweeps across a long sidebar list, every row was firing `onPrefetch` immediately, causing a burst of React Query fetches. This made the sidebar feel sluggish — hover highlights and action buttons lagged behind the cursor. The 120 ms debounce is short enough that the data is still warm by the time HoverCard's 400 ms `openDelay` fires, but absorbs fast cursor movement.

## Test notes

- Manually tested: sweep cursor quickly across sidebar — no prefetch burst; hover and hold — card opens as normal.
- No snapshot tests affected (pipeline/accumulator untouched).