### PR TITLE
fix: improve session title generation performance and reliability

### DIFF
--- a/.changeset/drop-claude-title-max-turns.md
+++ b/.changeset/drop-claude-title-max-turns.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Stop capping Claude session-title generation at one turn so titles no longer fail with `Reached maximum number of turns (1)`.

--- a/.changeset/fast-codex-title.md
+++ b/.changeset/fast-codex-title.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Speed up Codex session title and branch-name generation by using a smaller model and skipping reasoning.

--- a/sidecar/src/claude-session-manager.ts
+++ b/sidecar/src/claude-session-manager.ts
@@ -800,7 +800,6 @@ export class ClaudeSessionManager implements SessionManager {
 				thinking: { type: "disabled" },
 				settingSources: [],
 				tools: [],
-				maxTurns: 1,
 			},
 		});
 

--- a/sidecar/src/codex-app-server-manager.ts
+++ b/sidecar/src/codex-app-server-manager.ts
@@ -24,7 +24,11 @@ import { resolveGitAccessDirectories } from "./git-access.js";
 import { parseImageRefs } from "./images.js";
 import { prependLinkedDirectoriesContext } from "./linked-directories-context.js";
 import { errorDetails, logger } from "./logger.js";
-import { listProviderModels, modelSupportsFastMode } from "./model-catalog.js";
+import {
+	listProviderModels,
+	modelSupportsFastMode,
+	pickFastestCodexModel,
+} from "./model-catalog.js";
 import type {
 	GenerateTitleOptions,
 	ListSlashCommandsParams,
@@ -1024,6 +1028,8 @@ export class CodexAppServerManager implements SessionManager {
 	): Promise<void> {
 		const generateBranch = options?.generateBranch ?? true;
 		const cwd = process.cwd();
+		const model = options?.model?.trim() || pickFastestCodexModel();
+		const fastMode = modelSupportsFastMode("codex", model);
 		const server = new CodexAppServer({
 			binaryPath: CODEX_BIN_PATH,
 			cwd,
@@ -1043,9 +1049,13 @@ export class CodexAppServerManager implements SessionManager {
 			await server.sendRequest("initialize", HELMOR_CLIENT_INFO);
 			server.writeNotification("initialized");
 
+			const threadStartParams: Record<string, unknown> = {
+				model,
+				approvalPolicy: BYPASS_GRANULAR_POLICY,
+			};
 			const threadResponse = await server.sendRequest<Record<string, unknown>>(
 				"thread/start",
-				{},
+				threadStartParams,
 			);
 			const threadId = deepGet(threadResponse, "thread", "id") as
 				| string
@@ -1070,7 +1080,7 @@ export class CodexAppServerManager implements SessionManager {
 				);
 			});
 
-			await server.sendRequest("turn/start", {
+			const turnStartParams: Record<string, unknown> = {
 				threadId,
 				input: [
 					{
@@ -1083,7 +1093,12 @@ export class CodexAppServerManager implements SessionManager {
 						text_elements: [],
 					},
 				],
-			});
+				model,
+				effort: "minimal",
+				approvalPolicy: BYPASS_GRANULAR_POLICY,
+			};
+			if (fastMode) turnStartParams.serviceTier = "fast";
+			await server.sendRequest("turn/start", turnStartParams);
 
 			await done;
 			const { title, branchName } = parseTitleAndBranch(raw);

--- a/sidecar/src/model-catalog.ts
+++ b/sidecar/src/model-catalog.ts
@@ -92,3 +92,26 @@ export function modelSupportsFastMode(
 		(model) => model.id === modelId && model.supportsFastMode === true,
 	);
 }
+
+// Heuristic for lightweight background tasks (e.g. title generation):
+// pick the lowest version number in the catalog; when versions tie,
+// prefer a `-mini` variant. Older/smaller variants are usually fast and
+// cheap enough for a one-shot title prompt.
+export function pickFastestCodexModel(): string {
+	let best: { cliModel: string; version: number; isMini: boolean } | undefined;
+	for (const m of MODEL_CATALOG.codex) {
+		const match = m.id.match(/(\d+(?:\.\d+)?)/);
+		const version = match?.[1]
+			? Number.parseFloat(match[1])
+			: Number.POSITIVE_INFINITY;
+		const isMini = m.id.includes("mini");
+		if (
+			!best ||
+			version < best.version ||
+			(version === best.version && isMini && !best.isMini)
+		) {
+			best = { cliModel: m.cliModel, version, isMini };
+		}
+	}
+	return best?.cliModel ?? "gpt-5.2";
+}


### PR DESCRIPTION
## What changed

- **Drop `maxTurns: 1` from Claude title generation** (`claude-session-manager.ts`): the cap was causing title generation to fail with `Reached maximum number of turns (1)` in multi-turn SDK flows. Removing it lets the SDK complete normally.
- **Faster Codex title generation** (`codex-app-server-manager.ts`): title/branch-name generation now explicitly picks the smallest/oldest model in the catalog (`pickFastestCodexModel()`), sets `effort: "minimal"`, and enables `serviceTier: "fast"` when the model supports it. This reduces latency on an otherwise blocking background call.
- **`pickFastestCodexModel()` helper** (`model-catalog.ts`): selects the lowest-version model from the Codex catalog, preferring `-mini` variants on a tie. Falls back to `gpt-5.2` if the catalog is empty.

## Why

Title generation is a lightweight one-shot task that shouldn't consume full reasoning budget or risk artificial turn-limit failures. Both fixes reduce friction without changing any user-visible behavior.

## Test notes

- Sidecar unit tests: `bun run test:sidecar`
- No pipeline snapshot changes expected (title generation is post-pipeline)
- Manually verify a new Codex session generates a title without delay