### PR TITLE
fix: gate sidebar flushes during merge to prevent optimistic state clobber

### DIFF
--- a/.changeset/steady-otters-merge.md
+++ b/.changeset/steady-otters-merge.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix the sidebar bouncing a workspace back to in-review after you merge it: the optimistic move to Done now stays put while the merge round-trip is in flight, even if you switch to another workspace before it finishes.

--- a/src/features/commit/hooks/use-commit-lifecycle.ts
+++ b/src/features/commit/hooks/use-commit-lifecycle.ts
@@ -36,6 +36,11 @@ import {
 	helmorQueryKeys,
 	workspaceForgeQueryOptions,
 } from "@/lib/query-client";
+import {
+	beginSidebarMutation,
+	endSidebarMutation,
+	flushSidebarListsIfIdle,
+} from "@/lib/sidebar-mutation-gate";
 import { moveWorkspaceToGroup } from "@/lib/workspace-helpers";
 import type { PushWorkspaceToast } from "@/lib/workspace-toast-context";
 import type { CommitButtonState, WorkspaceCommitButtonMode } from "../button";
@@ -296,6 +301,10 @@ export function useWorkspaceCommitLifecycle({
 					mode === "merge" ? "done" : "canceled",
 				);
 
+				// Gate sidebar flushes during the forge round-trip — without
+				// this, mark-read on workspace-switch would refetch the
+				// still-pre-merge groups and clobber the optimistic row.
+				beginSidebarMutation();
 				void (async () => {
 					try {
 						const result =
@@ -327,6 +336,10 @@ export function useWorkspaceCommitLifecycle({
 									}
 								: prev,
 						);
+					} finally {
+						endSidebarMutation();
+						// Reconcile flushes skipped during the gate hold.
+						flushSidebarListsIfIdle(queryClient);
 					}
 				})();
 				return;


### PR DESCRIPTION
## What changed

- Wraps the async merge/push round-trip in `use-commit-lifecycle.ts` with `beginSidebarMutation()` / `endSidebarMutation()` guards.
- Calls `flushSidebarListsIfIdle(queryClient)` in the `finally` block to reconcile any sidebar refetches that were gated while the operation was in flight.

## Why

When a user merges a workspace and then quickly switches to another workspace, the `mark-read` path triggers a sidebar group refetch. Because the merge round-trip is async, this refetch would return the still-pre-merge groups and overwrite the optimistic "Done" row, causing the workspace card to visually jump back to "In Review" before eventually settling. Gating sidebar flushes during the round-trip keeps the optimistic state in place until the real result lands.

## Follow-up / test notes

- Manual test: merge a workspace, immediately click another workspace, confirm the merged card stays in Done.
- The `sidebar-mutation-gate` helpers are already unit-tested; no new tests needed for the lifecycle change.