### PR TITLE
fix: eliminate workspace cwd race causing first agent turn at wrong path

### DIFF
--- a/.changeset/quiet-frogs-paint.md
+++ b/.changeset/quiet-frogs-paint.md
@@ -1,0 +1,7 @@
+---
+"helmor": patch
+---
+
+Fix two issues with workspace working-directory handling:
+- Stop the first message in a newly-created workspace from running with the wrong directory, which caused the second turn to fail with "The provider returned an empty response."
+- Refuse to start an agent turn when the working directory is missing, instead of silently falling back to the app's process cwd.

--- a/src-tauri/src/agents.rs
+++ b/src-tauri/src/agents.rs
@@ -10,6 +10,7 @@ use crate::error::CommandError;
 pub mod action_kind;
 mod builtin_claude_providers;
 mod catalog;
+pub(crate) mod claude_project_files;
 mod custom_providers;
 mod persistence;
 mod queries;

--- a/src-tauri/src/agents/claude_project_files.rs
+++ b/src-tauri/src/agents/claude_project_files.rs
@@ -1,0 +1,247 @@
+//! Helpers for Claude Code's per-cwd session storage layout.
+//!
+//! Claude Code persists each session as
+//! `~/.claude/projects/<encoded-cwd>/<provider_session_id>.jsonl` plus an
+//! optional sibling directory `<provider_session_id>/` that holds tool
+//! results, subagent transcripts, etc. The encoded directory is derived
+//! from the cwd, so any operation that changes a workspace's cwd
+//! (Conductor import, local→worktree conversion, etc.) makes existing
+//! sessions invisible to a `resume:` call until we copy the files into
+//! the new project dir.
+
+use std::path::{Path, PathBuf};
+
+use crate::workspace::helpers as ws_helpers;
+
+/// Encode a filesystem path into Claude Code's project directory name.
+/// Claude uses `path.replace(/[\/.]/g, '-')`.
+pub fn encode_project_dir(path: &Path) -> String {
+    path.display().to_string().replace(['/', '.'], "-")
+}
+
+/// Resolve `~/.claude/projects` from `$HOME`. Returns `None` when HOME is
+/// unset or the directory does not exist (fresh install — nothing to do).
+fn claude_projects_root() -> Option<PathBuf> {
+    let home = std::env::var_os("HOME").map(PathBuf::from)?;
+    let root = home.join(".claude").join("projects");
+    if root.is_dir() {
+        Some(root)
+    } else {
+        None
+    }
+}
+
+/// Copy the Claude session `.jsonl` (and matching `<id>/` subdirectory,
+/// if present) for each provider session id from `old_cwd`'s project dir
+/// into `new_cwd`'s project dir.
+///
+/// Best-effort: missing source files are skipped silently (Codex sessions,
+/// fresh sessions with no first turn yet, sessions truncated by the user,
+/// etc.). Per-file errors are logged and counted; this never returns an
+/// error so callers can run it inline with their primary operation
+/// without rollback.
+///
+/// Returns the number of session IDs whose `.jsonl` was successfully
+/// copied (the sibling `<id>/` dir, if any, is copied opportunistically
+/// and does not affect the returned count).
+pub fn migrate_session_files(old_cwd: &Path, new_cwd: &Path, session_ids: &[String]) -> usize {
+    let Some(projects_root) = claude_projects_root() else {
+        return 0;
+    };
+    migrate_session_files_at(&projects_root, old_cwd, new_cwd, session_ids)
+}
+
+/// Same as [`migrate_session_files`] but takes the projects root
+/// explicitly. Exists for unit testing without env mutation.
+pub(crate) fn migrate_session_files_at(
+    projects_root: &Path,
+    old_cwd: &Path,
+    new_cwd: &Path,
+    session_ids: &[String],
+) -> usize {
+    if session_ids.is_empty() || old_cwd == new_cwd {
+        return 0;
+    }
+
+    let src_dir = projects_root.join(encode_project_dir(old_cwd));
+    let dst_dir = projects_root.join(encode_project_dir(new_cwd));
+
+    if !src_dir.is_dir() {
+        return 0;
+    }
+
+    let mut copied = 0usize;
+    for sid in session_ids {
+        let jsonl_name = format!("{sid}.jsonl");
+        let src_jsonl = src_dir.join(&jsonl_name);
+        if !src_jsonl.is_file() {
+            continue;
+        }
+
+        // Lazy-create dst. If creation fails, give up — every subsequent
+        // copy would fail too.
+        if !dst_dir.exists() {
+            if let Err(error) = std::fs::create_dir_all(&dst_dir) {
+                tracing::error!(
+                    dst = %dst_dir.display(),
+                    error = %error,
+                    "Failed to create Claude project dir for session migration",
+                );
+                return copied;
+            }
+        }
+
+        let dst_jsonl = dst_dir.join(&jsonl_name);
+        match std::fs::copy(&src_jsonl, &dst_jsonl) {
+            Ok(_) => copied += 1,
+            Err(error) => {
+                tracing::error!(
+                    src = %src_jsonl.display(),
+                    dst = %dst_jsonl.display(),
+                    error = %error,
+                    "Failed to copy Claude session jsonl",
+                );
+                continue;
+            }
+        }
+
+        // Sibling dir holds tool results / subagent transcripts. Optional.
+        let src_subdir = src_dir.join(sid);
+        if src_subdir.is_dir() {
+            let dst_subdir = dst_dir.join(sid);
+            if dst_subdir.exists() {
+                let _ = std::fs::remove_dir_all(&dst_subdir);
+            }
+            if let Err(error) = ws_helpers::copy_dir_all(&src_subdir, &dst_subdir) {
+                tracing::warn!(
+                    src = %src_subdir.display(),
+                    dst = %dst_subdir.display(),
+                    error = %error,
+                    "Failed to copy Claude session sidecar dir",
+                );
+            }
+        }
+    }
+
+    if copied > 0 {
+        tracing::info!(
+            count = copied,
+            src = %src_dir.display(),
+            dst = %dst_dir.display(),
+            "Migrated Claude session files",
+        );
+    }
+    copied
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn encode_project_dir_replaces_slashes_and_dots() {
+        let path = PathBuf::from("/Users/me/conductor/workspaces/repo/ws");
+        assert_eq!(
+            encode_project_dir(&path),
+            "-Users-me-conductor-workspaces-repo-ws"
+        );
+
+        let path2 = PathBuf::from("/Users/me/helmor-dev/workspaces/repo/ws");
+        assert_eq!(
+            encode_project_dir(&path2),
+            "-Users-me-helmor-dev-workspaces-repo-ws"
+        );
+    }
+
+    #[test]
+    fn migrate_session_files_copies_only_listed_ids() {
+        let projects = TempDir::new().unwrap();
+        let old_cwd = PathBuf::from("/tmp/fake/local-repo");
+        let new_cwd = PathBuf::from("/tmp/fake/worktree");
+
+        let src = projects.path().join(encode_project_dir(&old_cwd));
+        fs::create_dir_all(&src).unwrap();
+
+        // Two sessions we own, plus a third unrelated session in the
+        // same project dir (e.g. user ran `claude` from the terminal).
+        fs::write(src.join("aaa.jsonl"), b"session-a-content").unwrap();
+        fs::write(src.join("bbb.jsonl"), b"session-b-content").unwrap();
+        fs::write(src.join("unrelated.jsonl"), b"DO NOT COPY").unwrap();
+        // Sidecar dir for aaa with one tool-result file.
+        fs::create_dir_all(src.join("aaa").join("tool-results")).unwrap();
+        fs::write(src.join("aaa/tool-results/r1.json"), b"{}").unwrap();
+
+        let copied = migrate_session_files_at(
+            projects.path(),
+            &old_cwd,
+            &new_cwd,
+            &["aaa".to_string(), "bbb".to_string()],
+        );
+        assert_eq!(copied, 2);
+
+        let dst = projects.path().join(encode_project_dir(&new_cwd));
+        assert!(dst.join("aaa.jsonl").is_file());
+        assert!(dst.join("bbb.jsonl").is_file());
+        assert!(
+            !dst.join("unrelated.jsonl").exists(),
+            "must not leak unrelated session files",
+        );
+        assert!(
+            dst.join("aaa/tool-results/r1.json").is_file(),
+            "sidecar dir for the migrated session should be copied",
+        );
+    }
+
+    #[test]
+    fn migrate_session_files_skips_missing_source_jsonls() {
+        let projects = TempDir::new().unwrap();
+        let old_cwd = PathBuf::from("/tmp/fake/a");
+        let new_cwd = PathBuf::from("/tmp/fake/b");
+
+        let src = projects.path().join(encode_project_dir(&old_cwd));
+        fs::create_dir_all(&src).unwrap();
+        fs::write(src.join("present.jsonl"), b"ok").unwrap();
+
+        // Asking to migrate one present + one absent id: only the
+        // present one should land in dst, no error.
+        let copied = migrate_session_files_at(
+            projects.path(),
+            &old_cwd,
+            &new_cwd,
+            &["present".to_string(), "absent".to_string()],
+        );
+        assert_eq!(copied, 1);
+
+        let dst = projects.path().join(encode_project_dir(&new_cwd));
+        assert!(dst.join("present.jsonl").is_file());
+        assert!(!dst.join("absent.jsonl").exists());
+    }
+
+    #[test]
+    fn migrate_session_files_is_noop_when_source_dir_missing() {
+        let projects = TempDir::new().unwrap();
+        let copied = migrate_session_files_at(
+            projects.path(),
+            &PathBuf::from("/tmp/fake/a"),
+            &PathBuf::from("/tmp/fake/b"),
+            &["xxx".to_string()],
+        );
+        assert_eq!(copied, 0);
+    }
+
+    #[test]
+    fn migrate_session_files_is_noop_when_cwd_unchanged() {
+        let projects = TempDir::new().unwrap();
+        let same = PathBuf::from("/tmp/fake/repo");
+        let dir = projects.path().join(encode_project_dir(&same));
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("xxx.jsonl"), b"_").unwrap();
+
+        assert_eq!(
+            migrate_session_files_at(projects.path(), &same, &same, &["xxx".to_string()]),
+            0
+        );
+    }
+}

--- a/src-tauri/src/agents/support.rs
+++ b/src-tauri/src/agents/support.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 #[cfg(test)]
 use serde_json::Value;
 
@@ -49,25 +49,29 @@ pub(super) fn parse_codex_output(
 }
 
 pub(super) fn resolve_working_directory(provided: Option<&str>) -> Result<PathBuf> {
-    if let Some(path) = non_empty(provided) {
-        let directory = PathBuf::from(path);
-        // Provided path MUST exist — silently falling back to the helmor
-        // process's cwd would spawn the agent CLI in `/` (or the app bundle)
-        // and pollute session_messages with nonsense output. Tag the error
-        // with `WorkspaceBroken` so the frontend can offer "Permanently
-        // Delete" instead of a generic failure toast.
-        if !directory.is_dir() {
-            return Err(
-                crate::error::coded(crate::error::ErrorCode::WorkspaceBroken).context(format!(
-                    "Workspace directory is missing: {}",
-                    directory.display()
-                )),
-            );
-        }
-        return Ok(directory);
+    // No silent fallback to `std::env::current_dir()`. macOS GUI launches
+    // start at `/`, and a missing cwd silently bound to `/` would write
+    // the agent's transcript into the wrong project bucket — the next
+    // resume can't find the conversation and returns empty (issue: first
+    // turn writes to cwd=/, second turn fails with bad_resume_failure).
+    // Every legitimate sender resolves cwd from the workspace; force
+    // anything else to error so the bug shows up immediately.
+    let Some(path) = non_empty(provided) else {
+        return Err(
+            crate::error::coded(crate::error::ErrorCode::WorkspaceBroken)
+                .context("workingDirectory is required but was not provided"),
+        );
+    };
+    let directory = PathBuf::from(path);
+    if !directory.is_dir() {
+        return Err(
+            crate::error::coded(crate::error::ErrorCode::WorkspaceBroken).context(format!(
+                "Workspace directory is missing: {}",
+                directory.display()
+            )),
+        );
     }
-
-    std::env::current_dir().context("Failed to resolve working directory")
+    Ok(directory)
 }
 
 #[cfg(test)]
@@ -109,16 +113,25 @@ mod tests {
     }
 
     #[test]
-    fn resolve_working_directory_blank_string_falls_back_to_cwd() {
-        let resolved = resolve_working_directory(Some("   ")).unwrap();
-        // Blank counts as "no path provided" — must equal current cwd.
-        assert_eq!(resolved, std::env::current_dir().unwrap());
+    fn resolve_working_directory_blank_string_is_workspace_broken() {
+        // Blank counts as "no path provided". The previous implementation
+        // silently fell back to `std::env::current_dir()` (== `/` for a
+        // packaged macOS GUI launch), which made the agent CLI write its
+        // transcript into the wrong project bucket. Now it errors loudly
+        // so the bug surfaces on the first send instead of poisoning
+        // resume on the second.
+        let err = resolve_working_directory(Some("   ")).unwrap_err();
+        let code = crate::error::extract_code(&err);
+        assert_eq!(code, crate::error::ErrorCode::WorkspaceBroken);
+        assert!(format!("{err:#}").contains("workingDirectory is required"));
     }
 
     #[test]
-    fn resolve_working_directory_none_falls_back_to_cwd() {
-        let resolved = resolve_working_directory(None).unwrap();
-        assert_eq!(resolved, std::env::current_dir().unwrap());
+    fn resolve_working_directory_none_is_workspace_broken() {
+        let err = resolve_working_directory(None).unwrap_err();
+        let code = crate::error::extract_code(&err);
+        assert_eq!(code, crate::error::ErrorCode::WorkspaceBroken);
+        assert!(format!("{err:#}").contains("workingDirectory is required"));
     }
 
     #[test]

--- a/src-tauri/src/commands/tests/workspace_creation.rs
+++ b/src-tauri/src/commands/tests/workspace_creation.rs
@@ -95,6 +95,13 @@ fn prepare_local_workspace_keeps_current_branch_when_source_is_none() {
     assert_eq!(response.state, WorkspaceState::Ready);
     assert_eq!(response.branch, "main");
     assert_eq!(response.directory_name, "");
+    // Local mode: prepare returns the cwd immediately so the start-page
+    // submit flow can pin it onto the pending payload without waiting for
+    // the workspaceDetail React Query to settle.
+    assert_eq!(
+        response.working_directory.as_deref(),
+        Some(harness.source_repo_root.display().to_string()).as_deref(),
+    );
 
     let connection = Connection::open(harness.db_path()).unwrap();
     let (mode_str, state_str, branch, init_parent, target_branch): (
@@ -289,6 +296,13 @@ fn finalize_workspace_from_repo_no_ops_for_local_workspace() {
     let finalized = workspaces::finalize_workspace_from_repo_impl(&prepared.workspace_id).unwrap();
 
     assert_eq!(finalized.final_state, WorkspaceState::Ready);
+    // Local short-circuit still returns the cwd (== repo root). Without
+    // this, the frontend submit flow couldn't reuse the same payload-patch
+    // path for both modes.
+    assert_eq!(
+        finalized.working_directory,
+        harness.source_repo_root.display().to_string(),
+    );
     let _ = WorkspaceMode::Worktree; // sanity: enum is in scope
 }
 
@@ -473,11 +487,17 @@ fn prepare_workspace_inserts_initializing_row_without_creating_worktree() {
         .unwrap();
     assert_eq!(session_workspace_id, prepared.workspace_id);
 
-    // Worktree has NOT been created yet — that's Phase 2's job.
+    // Worktree has NOT been created yet — that's Phase 2's job. The cwd
+    // field is therefore None at prepare time; the caller MUST wait for
+    // finalize before reading the path.
     let workspace_dir = harness.workspace_dir(&prepared.directory_name);
     assert!(
         !workspace_dir.exists(),
         "Phase 1 must not create the worktree"
+    );
+    assert!(
+        prepared.working_directory.is_none(),
+        "worktree mode prepare must not return a cwd before finalize",
     );
 
     // Repo scripts came from the source repo root's helmor.json (worktree
@@ -510,6 +530,13 @@ fn finalize_workspace_transitions_initializing_to_ready_and_creates_worktree() {
 
     assert_eq!(finalized.workspace_id, prepared.workspace_id);
     assert_eq!(finalized.final_state, WorkspaceState::Ready);
+    // After finalize, the worktree dir is materialised — backend hands the
+    // path back so the frontend can submit the first turn against the
+    // correct cwd, no React Query refetch round-trip required.
+    assert_eq!(
+        finalized.working_directory,
+        workspace_dir.display().to_string()
+    );
 
     // Worktree exists after Phase 2.
     assert!(workspace_dir.join(".git").exists());

--- a/src-tauri/src/import.rs
+++ b/src-tauri/src/import.rs
@@ -551,12 +551,6 @@ fn delete_imported_workspace_records(workspace_id: &str) -> Result<()> {
     }
 }
 
-/// Encode a filesystem path into a Claude Code project directory name.
-/// Claude uses `path.replace('/', '-').replace('.', '-')`.
-fn encode_claude_project_dir(path: &Path) -> String {
-    path.display().to_string().replace(['/', '.'], "-")
-}
-
 /// Copy Claude Code session .jsonl files from the Conductor project dir
 /// to the Helmor project dir so that imported sessions can be resumed.
 fn copy_claude_sessions_for_workspace(
@@ -584,8 +578,12 @@ fn copy_claude_sessions_for_workspace(
         .join(repo_name)
         .join(directory_name);
 
-    let src_dir = claude_projects.join(encode_claude_project_dir(&conductor_ws_path));
-    let dst_dir = claude_projects.join(encode_claude_project_dir(&helmor_ws_path));
+    let src_dir = claude_projects.join(crate::agents::claude_project_files::encode_project_dir(
+        &conductor_ws_path,
+    ));
+    let dst_dir = claude_projects.join(crate::agents::claude_project_files::encode_project_dir(
+        &helmor_ws_path,
+    ));
 
     if !src_dir.is_dir() {
         return;
@@ -1205,17 +1203,6 @@ mod tests {
             Some("real-claude-uuid-123"),
             "claude_session_id should be mapped to provider_session_id"
         );
-    }
-
-    #[test]
-    fn encode_claude_project_dir_encodes_correctly() {
-        let path = PathBuf::from("/Users/me/conductor/workspaces/repo/ws");
-        let encoded = encode_claude_project_dir(&path);
-        assert_eq!(encoded, "-Users-me-conductor-workspaces-repo-ws");
-
-        let path2 = PathBuf::from("/Users/me/helmor-dev/workspaces/repo/ws");
-        let encoded2 = encode_claude_project_dir(&path2);
-        assert_eq!(encoded2, "-Users-me-helmor-dev-workspaces-repo-ws");
     }
 
     #[test]

--- a/src-tauri/src/models/sessions.rs
+++ b/src-tauri/src/models/sessions.rs
@@ -100,6 +100,24 @@ pub fn list_session_historical_records(session_id: &str) -> Result<Vec<Historica
     list_session_historical_records_with_connection(&connection, session_id)
 }
 
+/// All `provider_session_id`s belonging to a workspace's Claude sessions.
+/// Includes hidden sessions — they can be unhidden and resumed later, so
+/// migrators (e.g. local→worktree cwd change) need to cover them too.
+pub fn list_claude_provider_session_ids(workspace_id: &str) -> Result<Vec<String>> {
+    let connection = db::read_conn()?;
+    let mut statement = connection.prepare(
+        r#"
+            SELECT provider_session_id
+            FROM sessions
+            WHERE workspace_id = ?1
+              AND agent_type = 'claude'
+              AND provider_session_id IS NOT NULL
+            "#,
+    )?;
+    let rows = statement.query_map([workspace_id], |row| row.get::<_, String>(0))?;
+    Ok(rows.collect::<std::result::Result<Vec<_>, _>>()?)
+}
+
 fn adjacent_visible_session_id(
     transaction: &Transaction<'_>,
     workspace_id: &str,

--- a/src-tauri/src/workspace/lifecycle.rs
+++ b/src-tauri/src/workspace/lifecycle.rs
@@ -76,6 +76,16 @@ pub struct PrepareWorkspaceResponse {
     /// may refetch to pick up any `helmor.json` overrides copied into the
     /// worktree, but for a freshly cloned workspace these match exactly.
     pub repo_scripts: repos::RepoScripts,
+    /// CWD the agent CLI should run in for the very first turn. Local mode
+    /// fills this with `repo.root_path` (on disk already); worktree mode
+    /// returns `None` here — the worktree directory doesn't exist until
+    /// Phase 2, so callers MUST wait for `FinalizeWorkspaceResponse
+    /// .working_directory`. Returning the cwd alongside the row metadata
+    /// lets the start-page submit flow skip the workspaceDetail query
+    /// round-trip that previously raced finalize and let the first turn
+    /// run with cwd=`/`, writing transcripts into the wrong Claude
+    /// project bucket and breaking subsequent resume.
+    pub working_directory: Option<String>,
 }
 
 /// Response from the slow Phase 2 (git worktree + scaffold + setup probe).
@@ -86,6 +96,11 @@ pub struct PrepareWorkspaceResponse {
 pub struct FinalizeWorkspaceResponse {
     pub workspace_id: String,
     pub final_state: WorkspaceState,
+    /// CWD the agent CLI should run in. Always populated when finalize
+    /// succeeds — local mode echoes the repo root, worktree mode returns
+    /// the freshly-materialised worktree path. The frontend writes this
+    /// onto the pending submit payload before flipping `finalized=true`.
+    pub working_directory: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -200,6 +215,8 @@ pub fn prepare_workspace_from_repo_impl(
         default_branch: base_branch,
         state: WorkspaceState::Initializing,
         repo_scripts,
+        // Worktree dir doesn't exist yet — finalize fills this in.
+        working_directory: None,
     })
 }
 
@@ -305,6 +322,10 @@ pub fn prepare_local_workspace_impl(
         default_branch: target_branch,
         state: WorkspaceState::Ready,
         repo_scripts,
+        // Local mode operates directly on the repo root — already on disk,
+        // safe to return immediately so the caller doesn't need to wait
+        // for finalize (which is a no-op for local).
+        working_directory: Some(repo_root.display().to_string()),
     })
 }
 
@@ -325,18 +346,22 @@ pub fn finalize_workspace_from_repo_impl(workspace_id: &str) -> Result<FinalizeW
     // path below, where a failure would route into
     // `cleanup_failed_created_workspace(repo_root, root_path, ...)`.
     if record.mode == WorkspaceMode::Local {
+        let working_directory = helpers::workspace_path(&record)?.display().to_string();
         return Ok(FinalizeWorkspaceResponse {
             workspace_id: workspace_id.to_string(),
             final_state: record.state,
+            working_directory,
         });
     }
 
     match record.state {
         WorkspaceState::Initializing => {}
         WorkspaceState::Ready | WorkspaceState::SetupPending => {
+            let working_directory = helpers::workspace_path(&record)?.display().to_string();
             return Ok(FinalizeWorkspaceResponse {
                 workspace_id: workspace_id.to_string(),
                 final_state: record.state,
+                working_directory,
             });
         }
         _ => {
@@ -423,6 +448,8 @@ pub fn finalize_workspace_from_repo_impl(workspace_id: &str) -> Result<FinalizeW
         Ok(FinalizeWorkspaceResponse {
             workspace_id: workspace_id.to_string(),
             final_state,
+            // Worktree dir was just materialised — safe to hand back.
+            working_directory: workspace_dir.display().to_string(),
         })
     })();
 
@@ -592,6 +619,30 @@ pub fn move_local_workspace_to_worktree_impl(
         &head_branch,
         &timestamp,
     )?;
+
+    // 7. Carry over Claude Code's per-cwd session jsonls so resume keeps
+    // working after the cwd flips from the local repo to the worktree.
+    // Best-effort: a copy failure here just degrades to a one-shot
+    // "empty resume" error on the next turn — not worth rolling back the
+    // whole worktree creation. Codex sessions are cwd-independent so
+    // they need no migration.
+    match crate::models::sessions::list_claude_provider_session_ids(workspace_id) {
+        Ok(ids) if !ids.is_empty() => {
+            crate::agents::claude_project_files::migrate_session_files(
+                &repo_root,
+                &workspace_dir,
+                &ids,
+            );
+        }
+        Ok(_) => {}
+        Err(error) => {
+            tracing::warn!(
+                workspace_id,
+                %error,
+                "Failed to list Claude sessions for cwd migration",
+            );
+        }
+    }
 
     Ok(MoveLocalToWorktreeResponse {
         workspace_id: workspace_id.to_string(),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2530,21 +2530,26 @@ function AppShell({
 					);
 					setStartPendingNewBranch(null);
 				}
-				const { finalizePromise, outcome, workspaceId, sessionId } =
-					await createWorkspaceFromStartComposer({
-						repoId: startRepository.id,
-						sourceBranch: startSourceBranch,
-						mode: startMode,
-						submitMode: options?.startSubmitMode ?? "startNow",
-						editorStateSnapshot: payload.editorStateSnapshot,
-						composerConfig: {
-							modelId: payload.model.id,
-							effortLevel: payload.effortLevel,
-							permissionMode: payload.permissionMode,
-							fastMode: payload.fastMode,
-						},
-						linkedDirectories: startPendingLinkedDirectories,
-					});
+				const {
+					finalizePromise,
+					outcome,
+					workspaceId,
+					sessionId,
+					preparedWorkingDirectory,
+				} = await createWorkspaceFromStartComposer({
+					repoId: startRepository.id,
+					sourceBranch: startSourceBranch,
+					mode: startMode,
+					submitMode: options?.startSubmitMode ?? "startNow",
+					editorStateSnapshot: payload.editorStateSnapshot,
+					composerConfig: {
+						modelId: payload.model.id,
+						effortLevel: payload.effortLevel,
+						permissionMode: payload.permissionMode,
+						fastMode: payload.fastMode,
+					},
+					linkedDirectories: startPendingLinkedDirectories,
+				});
 				// Picks belonged to the in-flight create; clear regardless of
 				// outcome so the next start-page session begins clean.
 				setStartPendingLinkedDirectories(EMPTY_STRING_LIST);
@@ -2566,7 +2571,18 @@ function AppShell({
 						id: pendingId,
 						workspaceId: outcome.workspaceId,
 						sessionId: outcome.sessionId,
-						payload,
+						// Local mode already has the cwd; worktree mode patches
+						// it onto the payload below once finalize materialises
+						// the worktree dir. Either way the payload is the
+						// single source of truth — the consumer never falls
+						// back to `workspaceRootPath` (which races the
+						// workspaceDetail React Query and was producing a
+						// transient cwd=null on the first turn).
+						payload: {
+							...payload,
+							workingDirectory:
+								preparedWorkingDirectory ?? payload.workingDirectory,
+						},
 						finalized: false,
 					});
 					requestAnimationFrame(() => {
@@ -2575,9 +2591,12 @@ function AppShell({
 						setWorkspaceViewMode("conversation");
 					});
 
+					let finalizedWorkingDirectory: string | null =
+						preparedWorkingDirectory;
 					if (finalizePromise) {
 						try {
-							await finalizePromise;
+							const finalized = await finalizePromise;
+							finalizedWorkingDirectory = finalized.workingDirectory;
 						} catch (error) {
 							// Clear the optimistic bubble so the user doesn't
 							// see a message that never actually got sent.
@@ -2600,7 +2619,20 @@ function AppShell({
 					// the workspaceDetail React Query refetch round-trip.
 					setPendingCreatedWorkspaceSubmit((current) =>
 						current?.id === pendingId
-							? { ...current, finalized: true }
+							? {
+									...current,
+									payload: {
+										...current.payload,
+										// Worktree path only exists post-finalize;
+										// patch payload right before we let the
+										// effect fire so the first turn never sees
+										// a null cwd.
+										workingDirectory:
+											finalizedWorkingDirectory ??
+											current.payload.workingDirectory,
+									},
+									finalized: true,
+								}
 							: current,
 					);
 					void queryClient.invalidateQueries({

--- a/src/features/conversation/index.test.tsx
+++ b/src/features/conversation/index.test.tsx
@@ -66,6 +66,7 @@ function renderContainer(
 		finalized?: boolean;
 		busySessionIds?: Set<string>;
 		stoppableSessionIds?: Set<string>;
+		workspaceRootPath?: string | null;
 	} = {},
 ) {
 	const queryClient = new QueryClient({
@@ -92,7 +93,11 @@ function renderContainer(
 				onPendingCreatedWorkspaceSubmitConsumed={onConsumed}
 				busySessionIds={options.busySessionIds}
 				stoppableSessionIds={options.stoppableSessionIds}
-				workspaceRootPath="/tmp/new-workspace"
+				workspaceRootPath={
+					options.workspaceRootPath === undefined
+						? "/tmp/new-workspace"
+						: options.workspaceRootPath
+				}
 				composerOnly
 			/>
 		</QueryClientProvider>,
@@ -107,13 +112,17 @@ describe("WorkspaceConversationContainer", () => {
 
 	it("dispatches a created workspace submit through the normal send path", async () => {
 		const onConsumed = vi.fn();
+		// App.tsx is now responsible for patching `workingDirectory` onto the
+		// payload (from prepare/finalize response) before flipping
+		// `finalized=true`. This test mirrors that contract: payload arrives
+		// already populated; conversation/index.tsx must dispatch it as-is.
 		const pendingPayload: ComposerSubmitPayload = {
 			prompt: "Build this now",
 			imagePaths: [],
 			filePaths: [],
 			customTags: [],
 			model: MODEL,
-			workingDirectory: null,
+			workingDirectory: "/tmp/new-workspace",
 			effortLevel: "high",
 			permissionMode: "default",
 			fastMode: false,
@@ -123,10 +132,7 @@ describe("WorkspaceConversationContainer", () => {
 
 		await waitFor(() => {
 			expect(streamingMocks.handleComposerSubmit).toHaveBeenCalledWith(
-				{
-					...pendingPayload,
-					workingDirectory: "/tmp/new-workspace",
-				},
+				pendingPayload,
 				{
 					sessionId: "session-1",
 					workspaceId: "workspace-1",
@@ -135,6 +141,44 @@ describe("WorkspaceConversationContainer", () => {
 			);
 		});
 		expect(onConsumed).toHaveBeenCalledWith("pending-1");
+	});
+
+	it("uses payload.workingDirectory verbatim even when workspaceRootPath is null", async () => {
+		// Regression: previously, when the workspaceDetail React Query was
+		// still in-flight on first send (very common for local-mode submits
+		// where finalize is a no-op), `workspaceRootPath` was null and the
+		// container fell back to `payload.workingDirectory` — but the start
+		// composer always seeded that as null too. The result was
+		// `workingDirectory: null` reaching the agent, the CLI defaulting to
+		// process cwd `/`, and the second turn failing with
+		// `bad_resume_failure` because the transcript was written to the
+		// wrong project bucket. With the fix, App.tsx always patches the
+		// payload from prepare/finalize before flipping `finalized=true`.
+		const onConsumed = vi.fn();
+		const pendingPayload: ComposerSubmitPayload = {
+			prompt: "Build this now",
+			imagePaths: [],
+			filePaths: [],
+			customTags: [],
+			model: MODEL,
+			workingDirectory: "/Users/me/repos/foo",
+			effortLevel: "high",
+			permissionMode: "default",
+			fastMode: false,
+		};
+
+		renderContainer(pendingPayload, onConsumed, { workspaceRootPath: null });
+
+		await waitFor(() => {
+			expect(streamingMocks.handleComposerSubmit).toHaveBeenCalledWith(
+				pendingPayload,
+				{
+					sessionId: "session-1",
+					workspaceId: "workspace-1",
+					contextKey: "session:session-1",
+				},
+			);
+		});
 	});
 
 	it("does not show composer stop while the session is only pending finalize", () => {

--- a/src/features/conversation/index.tsx
+++ b/src/features/conversation/index.tsx
@@ -432,22 +432,18 @@ export const WorkspaceConversationContainer = memo(
 				pendingCreatedWorkspaceSubmit.id;
 
 			void (async () => {
-				await handleComposerSubmit(
-					{
-						...pendingCreatedWorkspaceSubmit.payload,
-						workingDirectory:
-							workspaceRootPath ??
-							pendingCreatedWorkspaceSubmit.payload.workingDirectory,
-					},
-					{
-						sessionId: pendingCreatedWorkspaceSubmit.sessionId,
-						workspaceId: pendingCreatedWorkspaceSubmit.workspaceId,
-						contextKey: getComposerContextKey(
-							pendingCreatedWorkspaceSubmit.workspaceId,
-							pendingCreatedWorkspaceSubmit.sessionId,
-						),
-					},
-				);
+				// `payload.workingDirectory` is patched by App.tsx with the
+				// cwd returned from prepare/finalize, so the first turn never
+				// races the workspaceDetail React Query — no need to fall
+				// back to `workspaceRootPath` here.
+				await handleComposerSubmit(pendingCreatedWorkspaceSubmit.payload, {
+					sessionId: pendingCreatedWorkspaceSubmit.sessionId,
+					workspaceId: pendingCreatedWorkspaceSubmit.workspaceId,
+					contextKey: getComposerContextKey(
+						pendingCreatedWorkspaceSubmit.workspaceId,
+						pendingCreatedWorkspaceSubmit.sessionId,
+					),
+				});
 				onPendingCreatedWorkspaceSubmitConsumed?.(
 					pendingCreatedWorkspaceSubmit.id,
 				);
@@ -458,7 +454,6 @@ export const WorkspaceConversationContainer = memo(
 			handleComposerSubmit,
 			onPendingCreatedWorkspaceSubmitConsumed,
 			pendingCreatedWorkspaceSubmit,
-			workspaceRootPath,
 		]);
 		const relevantPendingInsertRequests = pendingInsertRequests.filter(
 			(request) => {

--- a/src/features/workspace-start/create-workspace.test.ts
+++ b/src/features/workspace-start/create-workspace.test.ts
@@ -35,7 +35,12 @@ describe("createWorkspaceFromStartComposer", () => {
 		},
 	} as unknown as SerializedEditorState;
 
-	function resetMocks() {
+	function resetMocks(
+		preparedWorkingDirectory: string | null = null,
+		finalizedWorkingDirectory:
+			| string
+			| undefined = "/Users/me/helmor/workspaces/foo/bar",
+	) {
 		apiMocks.prepareWorkspaceFromRepo.mockReset();
 		apiMocks.finalizeWorkspaceFromRepo.mockReset();
 		apiMocks.setWorkspaceStatus.mockReset();
@@ -44,10 +49,12 @@ describe("createWorkspaceFromStartComposer", () => {
 		apiMocks.prepareWorkspaceFromRepo.mockResolvedValue({
 			workspaceId: "workspace-1",
 			initialSessionId: "session-1",
+			workingDirectory: preparedWorkingDirectory,
 		});
 		apiMocks.finalizeWorkspaceFromRepo.mockResolvedValue({
 			workspaceId: "workspace-1",
 			finalState: "ready",
+			workingDirectory: finalizedWorkingDirectory,
 		});
 		apiMocks.setWorkspaceStatus.mockResolvedValue(undefined);
 		draftMocks.persistSessionDraft.mockResolvedValue(undefined);
@@ -83,6 +90,8 @@ describe("createWorkspaceFromStartComposer", () => {
 		expect(result.workspaceId).toBe("workspace-1");
 		expect(result.sessionId).toBe("session-1");
 		expect(result.finalizePromise).toBeInstanceOf(Promise);
+		// Worktree mode: prepare cwd is null, only finalize knows the path.
+		expect(result.preparedWorkingDirectory).toBeNull();
 	});
 
 	it("saves the new workspace to backlog with the composer draft", async () => {
@@ -116,6 +125,26 @@ describe("createWorkspaceFromStartComposer", () => {
 			outcome: { shouldStream: false },
 			workspaceId: "workspace-1",
 			sessionId: "session-1",
+			preparedWorkingDirectory: null,
 		});
+	});
+
+	it("returns local mode cwd from prepare without waiting for finalize", async () => {
+		// Local mode: backend hands cwd back from prepare immediately
+		// (it's just `repo.root_path` — already on disk). The caller pins
+		// this onto the pending submit payload before flipping
+		// `finalized=true`, eliminating the workspaceDetail React Query
+		// race that previously left the first turn with cwd=null.
+		resetMocks("/Users/me/repos/local-only");
+
+		const result = await createWorkspaceFromStartComposer({
+			repoId: "repo-1",
+			sourceBranch: "main",
+			mode: "local",
+			submitMode: "startNow",
+			editorStateSnapshot,
+		});
+
+		expect(result.preparedWorkingDirectory).toBe("/Users/me/repos/local-only");
 	});
 });

--- a/src/features/workspace-start/create-workspace.ts
+++ b/src/features/workspace-start/create-workspace.ts
@@ -19,6 +19,11 @@ export type WorkspaceStartCreateResult = {
 	workspaceId: string;
 	sessionId: string;
 	finalizePromise?: Promise<FinalizeWorkspaceResponse>;
+	/** CWD already known after Phase 1 (local mode populates it from repo
+	 *  root_path; worktree mode is null until finalize completes). The
+	 *  caller pins this onto the pending-submit payload so the very first
+	 *  agent turn never races the workspaceDetail React Query. */
+	preparedWorkingDirectory: string | null;
 };
 
 export async function createWorkspaceFromStartComposer({
@@ -79,6 +84,7 @@ export async function createWorkspaceFromStartComposer({
 			outcome: { shouldStream: false },
 			workspaceId: prepared.workspaceId,
 			sessionId: prepared.initialSessionId,
+			preparedWorkingDirectory: prepared.workingDirectory,
 		};
 	}
 
@@ -86,6 +92,7 @@ export async function createWorkspaceFromStartComposer({
 		finalizePromise: finalizeWorkspaceFromRepo(prepared.workspaceId),
 		workspaceId: prepared.workspaceId,
 		sessionId: prepared.initialSessionId,
+		preparedWorkingDirectory: prepared.workingDirectory,
 		outcome: {
 			shouldStream: true,
 			workspaceId: prepared.workspaceId,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -387,11 +387,17 @@ export type PrepareWorkspaceResponse = {
 	defaultBranch: string;
 	state: WorkspaceState;
 	repoScripts: RepoScripts;
+	/** CWD the agent CLI must run in. Local mode: filled with `repo.root_path`
+	 *  immediately. Worktree mode: null until finalize materialises the
+	 *  worktree — callers MUST then read `FinalizeWorkspaceResponse.workingDirectory`. */
+	workingDirectory: string | null;
 };
 
 export type FinalizeWorkspaceResponse = {
 	workspaceId: string;
 	finalState: WorkspaceState;
+	/** CWD the agent CLI must run in. Always populated when finalize succeeds. */
+	workingDirectory: string;
 };
 
 export type MarkWorkspaceReadResponse = undefined;


### PR DESCRIPTION
## What changed

Three interconnected fixes:

**Backend (Rust)**
- `workspace/lifecycle.rs`: `PrepareWorkspaceResponse` now includes `working_directory` (local mode fills it immediately from `repo.root_path`; worktree mode returns `None` until finalize). `FinalizeWorkspaceResponse` always includes the final `working_directory` once the worktree is materialised.
- `agents/support.rs`: `resolve_working_directory` now **errors loudly** (`WorkspaceBroken`) instead of silently falling back to `std::env::current_dir()`. On a macOS GUI launch, that fallback resolved to `/`, so the agent CLI was writing transcripts into the wrong Claude project bucket.
- `agents/claude_project_files.rs` (new): `encode_project_dir` (extracted from `import.rs`) + `migrate_session_files` — copies session `.jsonl` files and sidecar dirs from the old cwd's project dir to the new one when a workspace converts from local→worktree mode.
- `models/sessions.rs`: `list_claude_provider_session_ids` — fetches all Claude `provider_session_id`s for a workspace (used by the migration above).
- `import.rs`: Uses shared `encode_project_dir` instead of a local copy.

**Frontend (TypeScript)**
- `lib/api.ts`: Adds `workingDirectory: string | null` to `PrepareWorkspaceResponse` and `workingDirectory: string` to `FinalizeWorkspaceResponse`.
- `features/workspace-start/create-workspace.ts`: Exposes `preparedWorkingDirectory` in `WorkspaceStartCreateResult`.
- `App.tsx`: Patches `workingDirectory` onto the pending-submit payload from `prepare`/`finalize` responses **before** flipping `finalized=true`. The first agent turn now always has the correct cwd regardless of whether the `workspaceDetail` React Query has settled.
- `features/conversation/index.tsx`: Removes the `workspaceRootPath` fallback — the payload is already authoritative.

## Why it changed

Root cause: when a user submitted a first message in a brand-new workspace, `workspaceRootPath` was sometimes `null` because the `workspaceDetail` React Query hadn't refetched yet. The fallback in `conversation/index.tsx` silently resolved to `payload.workingDirectory`, which the start composer also left as `null`. The agent CLI then defaulted to process cwd (`/`), wrote its transcript into `~/.claude/projects/-/…`, and the second turn failed with "The provider returned an empty response" because `resume:` looked in the wrong project bucket.

## Test notes

- Existing Rust integration tests (`cargo test --tests`) pass — snapshot tests were not affected (pipeline shape unchanged).
- New unit tests: `resolve_working_directory_{blank,none}_is_workspace_broken`, `migrate_session_files_*` (4 cases), `working_directory` assertions in `workspace_creation.rs`.
- Frontend: `create-workspace.test.ts` covers `preparedWorkingDirectory` for both modes; `conversation/index.test.tsx` adds a regression test asserting the payload is used verbatim even when `workspaceRootPath` is null.