### PR TITLE
fix: skip cross-repository PRs when resolving workspace PR for GitHub

### DIFF
--- a/.changeset/quiet-foxes-filter.md
+++ b/.changeset/quiet-foxes-filter.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix a bug where a workspace on a shared branch like `main` could be mis-associated with — and auto-canceled by — an unrelated fork pull request that happened to use the same branch name.

--- a/src-tauri/src/forge/github/actions.rs
+++ b/src-tauri/src/forge/github/actions.rs
@@ -24,10 +24,11 @@ use super::types::{
     GithubCheckRunDetail,
 };
 
+// `first: 10` leaves room for the cross-repo filter (see pull_request.rs).
 const ACTION_STATUS_QUERY: &str = r#"
 query($owner: String!, $name: String!, $head: String!) {
   repository(owner: $owner, name: $name) {
-    pullRequests(headRefName: $head, states: [OPEN, MERGED, CLOSED], first: 1, orderBy: {field: UPDATED_AT, direction: DESC}) {
+    pullRequests(headRefName: $head, states: [OPEN, MERGED, CLOSED], first: 10, orderBy: {field: UPDATED_AT, direction: DESC}) {
       nodes {
         url
         number
@@ -36,6 +37,7 @@ query($owner: String!, $name: String!, $head: String!) {
         merged
         reviewDecision
         mergeable
+        isCrossRepository
         commits(last: 1) {
           nodes {
             commit {
@@ -137,11 +139,16 @@ pub(super) fn query_workspace_pr_action_status(
             "GitHub repository was not returned",
         ));
     };
-    let Some(pr) = repository.pull_requests.nodes.into_iter().next() else {
+    let Some(pr) = pick_in_repo_action_pr(repository.pull_requests.nodes) else {
         return Ok(ForgeActionStatus::no_change_request());
     };
 
     Ok(build_action_status(pr))
+}
+
+/// Action-status counterpart to `pull_request::pick_in_repo_pr`.
+fn pick_in_repo_action_pr(nodes: Vec<ActionPullRequestNode>) -> Option<ActionPullRequestNode> {
+    nodes.into_iter().find(|node| !node.is_cross_repository)
 }
 
 /// REST-side companion: fetch the human-readable detail blob for a
@@ -670,6 +677,33 @@ mod tests {
         assert_eq!(format_duration(None, Some("2026-04-10T00:00:00Z")), None);
     }
 
+    fn make_action_node(number: i64, cross: bool) -> ActionPullRequestNode {
+        ActionPullRequestNode {
+            url: format!("https://github.com/octocat/hello-world/pull/{number}"),
+            number,
+            state: "OPEN".to_string(),
+            title: "Update".to_string(),
+            merged: false,
+            review_decision: None,
+            mergeable: None,
+            is_cross_repository: cross,
+            commits: ActionCommitConnection { nodes: vec![] },
+        }
+    }
+
+    #[test]
+    fn pick_in_repo_action_pr_skips_cross_repository_nodes() {
+        let nodes = vec![make_action_node(433, true), make_action_node(100, false)];
+        let picked = pick_in_repo_action_pr(nodes).expect("expected an in-repo PR");
+        assert_eq!(picked.number, 100);
+    }
+
+    #[test]
+    fn pick_in_repo_action_pr_returns_none_when_only_cross_repo_matches() {
+        let nodes = vec![make_action_node(433, true)];
+        assert!(pick_in_repo_action_pr(nodes).is_none());
+    }
+
     #[test]
     fn builds_action_status_with_review_and_mergeable_fields() {
         let status = build_action_status(ActionPullRequestNode {
@@ -680,6 +714,7 @@ mod tests {
             merged: false,
             review_decision: Some("CHANGES_REQUESTED".to_string()),
             mergeable: Some("CONFLICTING".to_string()),
+            is_cross_repository: false,
             commits: ActionCommitConnection {
                 nodes: vec![ActionPullRequestCommitNode {
                     commit: ActionCommitNode {
@@ -741,6 +776,7 @@ mod tests {
             merged: false,
             review_decision: None,
             mergeable: Some("MERGEABLE".to_string()),
+            is_cross_repository: false,
             commits: ActionCommitConnection {
                 nodes: vec![ActionPullRequestCommitNode {
                     commit: ActionCommitNode {

--- a/src-tauri/src/forge/github/pull_request.rs
+++ b/src-tauri/src/forge/github/pull_request.rs
@@ -11,16 +11,18 @@ use super::api::{run_graphql, run_graphql_raw, GraphqlOutcome};
 use super::context::GithubContext;
 use super::types::{GraphqlEnvelope, PullRequestNode};
 
+// `first: 10` leaves room for the cross-repo filter to find the in-repo match.
 const PR_LOOKUP_QUERY: &str = r#"
 query($owner: String!, $name: String!, $head: String!) {
   repository(owner: $owner, name: $name) {
-    pullRequests(headRefName: $head, states: [OPEN, MERGED, CLOSED], first: 1, orderBy: {field: UPDATED_AT, direction: DESC}) {
+    pullRequests(headRefName: $head, states: [OPEN, MERGED, CLOSED], first: 10, orderBy: {field: UPDATED_AT, direction: DESC}) {
       nodes {
         url
         number
         state
         title
         merged
+        isCrossRepository
       }
     }
   }
@@ -30,8 +32,8 @@ query($owner: String!, $name: String!, $head: String!) {
 const PR_NODE_ID_QUERY: &str = r#"
 query($owner: String!, $name: String!, $head: String!) {
   repository(owner: $owner, name: $name) {
-    pullRequests(headRefName: $head, states: [OPEN], first: 1) {
-      nodes { id, url, number, state, title, merged }
+    pullRequests(headRefName: $head, states: [OPEN], first: 5) {
+      nodes { id, url, number, state, title, merged, isCrossRepository }
     }
   }
 }
@@ -147,8 +149,13 @@ pub(super) fn find_workspace_pr(context: &GithubContext) -> Result<Option<Change
     Ok(parsed
         .data
         .and_then(|d| d.repository)
-        .and_then(|r| r.pull_requests.nodes.into_iter().next())
+        .and_then(|r| pick_in_repo_pr(r.pull_requests.nodes))
         .map(pr_info))
+}
+
+/// Drop fork PRs; `headRefName:` alone matches across forks.
+fn pick_in_repo_pr(nodes: Vec<PullRequestNode>) -> Option<PullRequestNode> {
+    nodes.into_iter().find(|node| !node.is_cross_repository)
 }
 
 /// Convert a GraphQL pull-request node into the public
@@ -182,7 +189,7 @@ pub(super) fn fetch_open_pr_node_id(context: &GithubContext) -> Result<Option<St
     Ok(parsed
         .data
         .and_then(|d| d.repository)
-        .and_then(|r| r.pull_requests.nodes.into_iter().next())
+        .and_then(|r| pick_in_repo_pr(r.pull_requests.nodes))
         .and_then(|n| n.id))
 }
 
@@ -289,6 +296,19 @@ mod tests {
             state: state.to_string(),
             title: "Update".to_string(),
             merged,
+            is_cross_repository: false,
+        }
+    }
+
+    fn make_node_with_cross_repo(state: &str, number: i64, cross: bool) -> PullRequestNode {
+        PullRequestNode {
+            id: None,
+            url: format!("https://github.com/octocat/hello-world/pull/{number}"),
+            number,
+            state: state.to_string(),
+            title: "Update".to_string(),
+            merged: false,
+            is_cross_repository: cross,
         }
     }
 
@@ -357,6 +377,33 @@ mod tests {
     #[test]
     fn pick_returns_none_when_all_disabled() {
         assert_eq!(AllowedMergeMethods::default().pick(), None);
+    }
+
+    // Regression: workspace on `main` got auto-canceled by a fork's closed `main` PR.
+    #[test]
+    fn pick_in_repo_pr_skips_cross_repository_nodes() {
+        let nodes = vec![
+            make_node_with_cross_repo("CLOSED", 433, true),
+            make_node_with_cross_repo("OPEN", 100, false),
+        ];
+        let picked = pick_in_repo_pr(nodes).expect("expected an in-repo PR");
+        assert_eq!(picked.number, 100);
+    }
+
+    #[test]
+    fn pick_in_repo_pr_returns_none_when_only_cross_repo_matches() {
+        let nodes = vec![make_node_with_cross_repo("CLOSED", 433, true)];
+        assert!(pick_in_repo_pr(nodes).is_none());
+    }
+
+    #[test]
+    fn pick_in_repo_pr_preserves_order_when_first_node_is_in_repo() {
+        let nodes = vec![
+            make_node_with_cross_repo("OPEN", 100, false),
+            make_node_with_cross_repo("CLOSED", 99, false),
+        ];
+        let picked = pick_in_repo_pr(nodes).expect("expected first in-repo PR");
+        assert_eq!(picked.number, 100);
     }
 
     #[test]

--- a/src-tauri/src/forge/github/types.rs
+++ b/src-tauri/src/forge/github/types.rs
@@ -29,6 +29,7 @@ pub(super) struct PullRequestConnection {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub(super) struct PullRequestNode {
     /// GraphQL node ID (e.g. "PR_kwDO..."). Only populated when the
     /// query explicitly selects `id`; the lookup query omits it so this
@@ -39,6 +40,9 @@ pub(super) struct PullRequestNode {
     pub state: String,
     pub title: String,
     pub merged: bool,
+    /// True when head is in a fork. `pullRequests(headRefName:)` matches
+    /// branch name only, so we drop these to avoid mis-association.
+    pub is_cross_repository: bool,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -80,6 +84,7 @@ pub(super) struct ActionPullRequestNode {
     pub merged: bool,
     pub review_decision: Option<String>,
     pub mergeable: Option<String>,
+    pub is_cross_repository: bool,
     pub commits: ActionCommitConnection,
 }
 


### PR DESCRIPTION
## What changed

- `PR_LOOKUP_QUERY` and `ACTION_STATUS_QUERY` now fetch `first: 10` PRs (up from 1) and include `isCrossRepository` in the selection set.
- New `pick_in_repo_pr` / `pick_in_repo_action_pr` helpers filter out fork PRs before picking the first match.
- `PullRequestNode` and `ActionPullRequestNode` gain an `is_cross_repository: bool` field; `PullRequestNode` gets `#[serde(rename_all = "camelCase")]` to deserialize it correctly.

## Why

GitHub's `pullRequests(headRefName: ...)` filter matches by branch name only — it returns PRs from forks that happen to use the same branch name (e.g. `main`). A workspace on `main` could be mis-associated with a closed fork PR, causing Helmor to show a stale state or auto-cancel the workspace.

## Test notes

- Unit tests added for `pick_in_repo_pr` and `pick_in_repo_action_pr` covering: cross-repo skipped, all-cross-repo returns `None`, and order preserved when first node is in-repo.
- Run `cd src-tauri && cargo test` to verify.