### PR TITLE
fix: remove open/close animation from sidebar workspace hover card

### DIFF
--- a/.changeset/calm-pandas-rest.md
+++ b/.changeset/calm-pandas-rest.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Remove the open/close animation on the sidebar workspace hover card so it appears and disappears instantly instead of fading and zooming.

--- a/src/components/ui/hover-card.tsx
+++ b/src/components/ui/hover-card.tsx
@@ -30,7 +30,7 @@ function HoverCardContent({
 				align={align}
 				sideOffset={sideOffset}
 				className={cn(
-					"z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-lg bg-popover p-2.5 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+					"z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-lg bg-popover p-2.5 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden",
 					className,
 				)}
 				{...props}


### PR DESCRIPTION
## What changed

Stripped the open/close animation classes (`animate-in`, `fade-in-0`, `zoom-in-95`, `animate-out`, `fade-out-0`, `zoom-out-95`, `duration-100`, and the `data-[side=*]:slide-in-from-*` variants) from `HoverCardContent` in `src/components/ui/hover-card.tsx`.

## Why

The sidebar workspace hover card was fading and zooming in/out on each hover, which felt sluggish for a UI element that appears frequently during navigation. Removing the animation makes it appear and disappear instantly, matching the snappier feel of the rest of the sidebar.

## Follow-up / test notes

- Hover over any workspace group in the sidebar to verify the card appears instantly without animation.
- No backend changes; no snapshot tests affected.