### PR TITLE
fix: abort button becomes a no-op after navigating away from a running session

### DIFF
--- a/.changeset/eager-sloths-abort.md
+++ b/.changeset/eager-sloths-abort.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix a bug where the composer's abort button would sometimes do nothing after navigating away from a running session and back.

--- a/src-tauri/src/agents.rs
+++ b/src-tauri/src/agents.rs
@@ -29,7 +29,8 @@ pub use self::slash_commands::SlashCommandCache;
 pub use self::streaming::{
     abort_all_active_streams_blocking, bridge_aborted_event, bridge_done_event, bridge_error_event,
     bridge_permission_request_event, bridge_user_input_request_event, build_send_message_params,
-    lookup_workspace_linked_directories, ActiveStreams, BuildSendMessageParamsInput,
+    lookup_workspace_linked_directories, ActiveStreamSummary, ActiveStreams,
+    BuildSendMessageParamsInput,
 };
 
 use self::persistence::{
@@ -247,6 +248,19 @@ fn resolve_stream_working_directory(
 pub struct AgentStopRequest {
     pub session_id: String,
     pub provider: Option<String>,
+}
+
+/// Snapshot of currently in-flight agent streams for the UI. Source of
+/// truth is `ActiveStreams`; the UI re-fetches this whenever a
+/// `UiMutationEvent::ActiveStreamsChanged` arrives. The frontend uses
+/// it to drive the abort button visibility and per-session busy badges
+/// — replacing the prior hook-local `sessionRunStates` that drifted on
+/// container unmount/remount.
+#[tauri::command]
+pub async fn list_active_streams(
+    active_streams: tauri::State<'_, ActiveStreams>,
+) -> CmdResult<Vec<ActiveStreamSummary>> {
+    Ok(active_streams.snapshot_for_ui())
 }
 
 #[tauri::command]

--- a/src-tauri/src/agents/streaming/active_streams.rs
+++ b/src-tauri/src/agents/streaming/active_streams.rs
@@ -5,11 +5,18 @@
 //! stopSession to every sidecar request and wait briefly for them to
 //! drain. The event loop in `streaming/mod.rs` registers/unregisters
 //! handles around its lifetime; nothing else mutates the map.
+//!
+//! It's also the source of truth the UI mirrors via
+//! `list_active_streams` + `UiMutationEvent::ActiveStreamsChanged`. The
+//! abort button visibility / "session is busy" derivation in the
+//! frontend reads off that snapshot, so the event-loop call sites must
+//! publish the event after every register/unregister.
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+use serde::Serialize;
 use uuid::Uuid;
 
 #[derive(Debug, Clone)]
@@ -19,8 +26,23 @@ pub(crate) struct ActiveStreamHandle {
     pub provider: String,
     /// Helmor session this stream belongs to. Drives the per-session
     /// dedup in `try_register_for_session`. `None` for streams without
-    /// one (e.g. title generation).
+    /// one (e.g. title generation) — those do NOT surface in the UI
+    /// snapshot.
     pub helmor_session_id: Option<String>,
+    /// Workspace owning the helmor session, looked up at registration
+    /// time. `None` for streams without a helmor session, or when the
+    /// session row hasn't been written yet (rare boot race).
+    pub workspace_id: Option<String>,
+}
+
+/// UI-facing projection of an active stream — the only fields the
+/// frontend needs to drive the abort button + busy badge.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ActiveStreamSummary {
+    pub session_id: String,
+    pub workspace_id: Option<String>,
+    pub provider: String,
 }
 
 #[derive(Default)]
@@ -62,6 +84,26 @@ impl ActiveStreams {
         self.inner
             .lock()
             .map(|map| map.values().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    /// UI-facing snapshot. Filters out anonymous streams (title gen
+    /// etc.) since the frontend only needs to track turns it can
+    /// render an abort button for.
+    pub fn snapshot_for_ui(&self) -> Vec<ActiveStreamSummary> {
+        self.inner
+            .lock()
+            .map(|map| {
+                map.values()
+                    .filter_map(|h| {
+                        h.helmor_session_id.as_ref().map(|sid| ActiveStreamSummary {
+                            session_id: sid.clone(),
+                            workspace_id: h.workspace_id.clone(),
+                            provider: h.provider.clone(),
+                        })
+                    })
+                    .collect()
+            })
             .unwrap_or_default()
     }
 
@@ -132,5 +174,51 @@ pub fn abort_all_active_streams_blocking(
             remaining,
             "Graceful shutdown — timeout, streams still active"
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn handle(request_id: &str, helmor_session_id: Option<&str>) -> ActiveStreamHandle {
+        ActiveStreamHandle {
+            request_id: request_id.to_string(),
+            sidecar_session_id: format!("sidecar-{request_id}"),
+            provider: "claude".to_string(),
+            helmor_session_id: helmor_session_id.map(str::to_string),
+            workspace_id: helmor_session_id.map(|sid| format!("ws-{sid}")),
+        }
+    }
+
+    #[test]
+    fn snapshot_for_ui_omits_anonymous_streams() {
+        let streams = ActiveStreams::new();
+        assert!(streams.try_register_for_session(handle("r1", Some("s1"))));
+        assert!(streams.try_register_for_session(handle("r2", None)));
+
+        let snap = streams.snapshot_for_ui();
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].session_id, "s1");
+        assert_eq!(snap[0].workspace_id.as_deref(), Some("ws-s1"));
+        assert_eq!(snap[0].provider, "claude");
+    }
+
+    #[test]
+    fn unregister_removes_from_snapshot() {
+        let streams = ActiveStreams::new();
+        assert!(streams.try_register_for_session(handle("r1", Some("s1"))));
+        streams.unregister("r1");
+        assert!(streams.snapshot_for_ui().is_empty());
+    }
+
+    #[test]
+    fn duplicate_helmor_session_id_is_rejected() {
+        let streams = ActiveStreams::new();
+        assert!(streams.try_register_for_session(handle("r1", Some("s1"))));
+        assert!(!streams.try_register_for_session(handle("r2", Some("s1"))));
+        // Anonymous streams never collide.
+        assert!(streams.try_register_for_session(handle("r3", None)));
+        assert!(streams.try_register_for_session(handle("r4", None)));
     }
 }

--- a/src-tauri/src/agents/streaming/active_streams.rs
+++ b/src-tauri/src/agents/streaming/active_streams.rs
@@ -25,9 +25,10 @@ pub(crate) struct ActiveStreamHandle {
     pub sidecar_session_id: String,
     pub provider: String,
     /// Helmor session this stream belongs to. Drives the per-session
-    /// dedup in `try_register_for_session`. `None` for streams without
-    /// one (e.g. title generation) — those do NOT surface in the UI
-    /// snapshot.
+    /// dedup in `try_register_for_session`. `Option<_>` is defensive —
+    /// today every registered handle comes from `stream_via_sidecar`
+    /// and carries a Some, but the type leaves room for an anonymous
+    /// stream path (which would NOT surface in `snapshot_for_ui`).
     pub helmor_session_id: Option<String>,
     /// Workspace owning the helmor session, looked up at registration
     /// time. `None` for streams without a helmor session, or when the
@@ -87,9 +88,10 @@ impl ActiveStreams {
             .unwrap_or_default()
     }
 
-    /// UI-facing snapshot. Filters out anonymous streams (title gen
-    /// etc.) since the frontend only needs to track turns it can
-    /// render an abort button for.
+    /// UI-facing snapshot. Drops handles without a `helmor_session_id`
+    /// — the frontend keys everything off the helmor session, so a
+    /// session-less entry would be unaddressable on the wire. Today
+    /// every registered handle has one; this is purely defensive.
     pub fn snapshot_for_ui(&self) -> Vec<ActiveStreamSummary> {
         self.inner
             .lock()

--- a/src-tauri/src/agents/streaming/mod.rs
+++ b/src-tauri/src/agents/streaming/mod.rs
@@ -72,23 +72,29 @@ pub(super) fn stream_via_sidecar(
         "stream_via_sidecar"
     );
 
-    let resume_session_id = request.session_id.clone().or_else(|| {
+    // Single read against `sessions` for both lookups we need below:
+    // resume-session matching (provider_session_id + agent_type) and the
+    // workspace_id we stamp onto the active-streams handle. Two queries
+    // would borrow the read pool twice on the hot path of every send.
+    let session_row: Option<(Option<String>, Option<String>, Option<String>)> =
         request.helmor_session_id.as_deref().and_then(|hsid| {
             let conn = crate::models::db::read_conn().ok()?;
-            let (stored_sid, stored_provider): (Option<String>, Option<String>) = conn
-                .query_row(
-                    "SELECT provider_session_id, agent_type FROM sessions WHERE id = ?1",
-                    [hsid],
-                    |row| Ok((row.get(0)?, row.get(1)?)),
-                )
-                .ok()?;
-            let sid = stored_sid?;
-            if stored_provider.unwrap_or_default() == model.provider {
-                Some(sid)
-            } else {
-                None
-            }
-        })
+            conn.query_row(
+                "SELECT provider_session_id, agent_type, workspace_id FROM sessions WHERE id = ?1",
+                [hsid],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .ok()
+        });
+
+    let resume_session_id = request.session_id.clone().or_else(|| {
+        let (stored_sid, stored_provider, _) = session_row.as_ref()?;
+        let sid = stored_sid.clone()?;
+        if stored_provider.clone().unwrap_or_default() == model.provider {
+            Some(sid)
+        } else {
+            None
+        }
     });
 
     tracing::debug!(
@@ -161,19 +167,12 @@ pub(super) fn stream_via_sidecar(
         params,
     };
 
-    // Look up the owning workspace once at registration time so the UI
-    // snapshot can show "this workspace is busy" without each frontend
-    // having to thread workspace_id through the wire.
-    let workspace_id_for_handle = request.helmor_session_id.as_deref().and_then(|hsid| {
-        let conn = crate::models::db::read_conn().ok()?;
-        conn.query_row(
-            "SELECT workspace_id FROM sessions WHERE id = ?1",
-            [hsid],
-            |row| row.get::<_, Option<String>>(0),
-        )
-        .ok()
-        .flatten()
-    });
+    // Workspace for the UI's "this workspace is busy" badge —
+    // pulled out of the same `session_row` we already read above so
+    // we don't borrow the read pool a second time on every send.
+    let workspace_id_for_handle = session_row
+        .as_ref()
+        .and_then(|(_, _, workspace_id)| workspace_id.clone());
 
     // Per-helmor-session lock — block overlapping sends so concurrent
     // `query()` calls can't stack against the same `resume:` id and

--- a/src-tauri/src/agents/streaming/mod.rs
+++ b/src-tauri/src/agents/streaming/mod.rs
@@ -24,7 +24,7 @@ mod state;
 mod event_loop_tests;
 
 pub(crate) use active_streams::ActiveStreamHandle;
-pub use active_streams::{abort_all_active_streams_blocking, ActiveStreams};
+pub use active_streams::{abort_all_active_streams_blocking, ActiveStreamSummary, ActiveStreams};
 pub use bridges::{
     bridge_aborted_event, bridge_done_event, bridge_error_event, bridge_permission_request_event,
     bridge_user_input_request_event,
@@ -161,6 +161,20 @@ pub(super) fn stream_via_sidecar(
         params,
     };
 
+    // Look up the owning workspace once at registration time so the UI
+    // snapshot can show "this workspace is busy" without each frontend
+    // having to thread workspace_id through the wire.
+    let workspace_id_for_handle = request.helmor_session_id.as_deref().and_then(|hsid| {
+        let conn = crate::models::db::read_conn().ok()?;
+        conn.query_row(
+            "SELECT workspace_id FROM sessions WHERE id = ?1",
+            [hsid],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .ok()
+        .flatten()
+    });
+
     // Per-helmor-session lock — block overlapping sends so concurrent
     // `query()` calls can't stack against the same `resume:` id and
     // corrupt the conversation jsonl (issue #398).
@@ -169,6 +183,7 @@ pub(super) fn stream_via_sidecar(
         sidecar_session_id: sidecar_session_id.clone(),
         provider: model.provider.to_string(),
         helmor_session_id: request.helmor_session_id.clone(),
+        workspace_id: workspace_id_for_handle,
     });
     if !registered {
         tracing::warn!(
@@ -181,12 +196,19 @@ pub(super) fn stream_via_sidecar(
         )
         .into());
     }
+    // Notify the UI that the active-streams set changed. Anonymous
+    // streams (helmor_session_id == None) are filtered out of the
+    // snapshot the frontend reads, but we still publish — the
+    // frontend's invalidate is cheap and the alternative (branch on
+    // visibility here) couples this call site to UI policy.
+    crate::ui_sync::publish(&app, crate::ui_sync::UiMutationEvent::ActiveStreamsChanged);
 
     let rx = sidecar.subscribe(&request_id);
 
     if let Err(error) = sidecar.send(&sidecar_req) {
         sidecar.unsubscribe(&request_id);
         active_streams.unregister(&request_id);
+        crate::ui_sync::publish(&app, crate::ui_sync::UiMutationEvent::ActiveStreamsChanged);
         return Err(anyhow::anyhow!("Sidecar send failed: {error}").into());
     }
 
@@ -1097,6 +1119,7 @@ pub(super) fn stream_via_sidecar(
         );
         sidecar_state.unsubscribe(&rid);
         active_streams_state.unregister(&rid);
+        crate::ui_sync::publish(&app, crate::ui_sync::UiMutationEvent::ActiveStreamsChanged);
     });
 
     Ok(())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -213,6 +213,7 @@ pub fn run() {
             agents::list_agent_model_sections,
             agents::send_agent_message_stream,
             agents::stop_agent_stream,
+            agents::list_active_streams,
             agents::steer_agent_stream,
             agents::respond_to_permission_request,
             agents::respond_to_user_input,

--- a/src-tauri/src/ui_sync/events.rs
+++ b/src-tauri/src/ui_sync/events.rs
@@ -53,6 +53,11 @@ pub enum UiMutationEvent {
         model_id: Option<String>,
         permission_mode: Option<String>,
     },
+    /// The set of in-flight agent streams changed (a turn started or
+    /// ended). Carries no payload — frontends invalidate and re-fetch
+    /// `list_active_streams`. See `agents::streaming::active_streams` for
+    /// the source of truth this notification mirrors.
+    ActiveStreamsChanged,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -126,6 +131,7 @@ mod tests {
                 model_id: None,
                 permission_mode: None,
             },
+            UiMutationEvent::ActiveStreamsChanged,
         ];
         for event in cases {
             let s = serde_json::to_string(&event).unwrap();
@@ -154,6 +160,10 @@ mod tests {
             (
                 UiMutationEvent::RepositoryListChanged,
                 "repositoryListChanged",
+            ),
+            (
+                UiMutationEvent::ActiveStreamsChanged,
+                "activeStreamsChanged",
             ),
         ];
         for (event, expected) in cases {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -113,6 +113,7 @@ import { ComposerInsertProvider } from "./lib/composer-insert-context";
 import type { DiffOpenOptions, EditorSessionState } from "./lib/editor-session";
 import { isMarkdownPath, isPathWithinRoot } from "./lib/editor-session";
 import {
+	activeStreamsQueryOptions,
 	archivedWorkspacesQueryOptions,
 	createHelmorQueryClient,
 	detectedEditorsQueryOptions,
@@ -130,12 +131,11 @@ import {
 	workspaceSessionsQueryOptions,
 } from "./lib/query-client";
 import {
+	buildSessionRunStates,
 	deriveBusySessionIds,
 	deriveBusyWorkspaceIds,
 	deriveStoppableSessionIds,
-	nextSessionRunStates,
 	type SessionRunState,
-	withPendingFinalizeRunState,
 } from "./lib/session-run-state";
 import { SessionRunStatesProvider } from "./lib/session-run-state-context";
 import {
@@ -481,33 +481,31 @@ function AppShell({
 	const [editorSession, setEditorSession] = useState<EditorSessionState | null>(
 		null,
 	);
-	const [sessionRunStates, setSessionRunStates] = useState<
-		Map<string, SessionRunState>
-	>(() => new Map());
-	const handleSessionRunStateChange = useCallback(
-		(sessionId: string, workspaceId: string | null, sending: boolean) => {
-			setSessionRunStates((current) =>
-				nextSessionRunStates(current, {
-					sessionId,
-					workspaceId,
-					running: sending,
-				}),
-			);
-		},
-		[],
-	);
 	const [pendingComposerInserts, setPendingComposerInserts] = useState<
 		ResolvedComposerInsertRequest[]
 	>([]);
 	const [pendingCreatedWorkspaceSubmit, setPendingCreatedWorkspaceSubmit] =
 		useState<PendingCreatedWorkspaceSubmit | null>(null);
-	const effectiveSessionRunStates = useMemo(
+	// Source of truth for "which sessions are running": the Rust
+	// `ActiveStreams` registry, mirrored here via React Query and kept
+	// fresh by `UiMutationEvent::ActiveStreamsChanged`. We layer the
+	// StartPage's optimistic "creating workspace" marker on top so the
+	// panel can show a busy spinner before the real stream registers.
+	const activeStreamsQuery = useQuery(activeStreamsQueryOptions());
+	const effectiveSessionRunStates = useMemo<
+		ReadonlyMap<string, SessionRunState>
+	>(
 		() =>
-			withPendingFinalizeRunState(
-				sessionRunStates,
-				pendingCreatedWorkspaceSubmit,
+			buildSessionRunStates(
+				activeStreamsQuery.data ?? [],
+				pendingCreatedWorkspaceSubmit
+					? {
+							sessionId: pendingCreatedWorkspaceSubmit.sessionId,
+							workspaceId: pendingCreatedWorkspaceSubmit.workspaceId,
+						}
+					: null,
 			),
-		[sessionRunStates, pendingCreatedWorkspaceSubmit],
+		[activeStreamsQuery.data, pendingCreatedWorkspaceSubmit],
 	);
 	const effectiveBusySessionIds = useMemo(
 		() => deriveBusySessionIds(effectiveSessionRunStates),
@@ -2951,9 +2949,6 @@ function AppShell({
 														onResolveDisplayedSession={
 															handleResolveDisplayedSession
 														}
-														onSessionRunStateChange={
-															handleSessionRunStateChange
-														}
 														onInteractionSessionsChange={
 															handleInteractionSessionsChange
 														}
@@ -3013,7 +3008,6 @@ function AppShell({
 													onResolveDisplayedSession={
 														handleResolveDisplayedSession
 													}
-													onSessionRunStateChange={handleSessionRunStateChange}
 													onInteractionSessionsChange={
 														handleInteractionSessionsChange
 													}

--- a/src/features/conversation/hooks/use-streaming.test.tsx
+++ b/src/features/conversation/hooks/use-streaming.test.tsx
@@ -491,27 +491,11 @@ describe("useConversationStreaming", () => {
 		expect(apiMocks.startAgentMessageStream).not.toHaveBeenCalled();
 	});
 
-	it("reports sending as incremental session lifecycle events so sibling containers cannot clear it", async () => {
+	it("scopes the local sending flag to its own context key so siblings stay idle", async () => {
 		const streamCallbacks: Array<(event: unknown) => void> = [];
 		apiMocks.startAgentMessageStream.mockImplementation(
 			async (_payload: unknown, onEvent: (event: unknown) => void) => {
 				streamCallbacks.push(onEvent);
-			},
-		);
-
-		const activeSessions = new Set<string>();
-		const sessionWorkspaceMap = new Map<string, string>();
-		const onSessionRunStateChange = vi.fn(
-			(sessionId: string, workspaceId: string | null, sending: boolean) => {
-				if (sending) {
-					activeSessions.add(sessionId);
-					if (workspaceId) {
-						sessionWorkspaceMap.set(sessionId, workspaceId);
-					}
-					return;
-				}
-				activeSessions.delete(sessionId);
-				sessionWorkspaceMap.delete(sessionId);
 			},
 		);
 
@@ -526,7 +510,6 @@ describe("useConversationStreaming", () => {
 					selectionPending: false,
 					followUpBehavior: "steer",
 					submitQueue: noopSubmitQueue,
-					onSessionRunStateChange,
 				}),
 				emptySibling: useConversationStreaming({
 					composerContextKey: "start:repo:repo-1",
@@ -536,7 +519,6 @@ describe("useConversationStreaming", () => {
 					selectionPending: false,
 					followUpBehavior: "steer",
 					submitQueue: noopSubmitQueue,
-					onSessionRunStateChange,
 				}),
 			}),
 			{ wrapper: Wrapper },
@@ -556,11 +538,10 @@ describe("useConversationStreaming", () => {
 			});
 		});
 
-		expect(activeSessions).toEqual(new Set(["session-1"]));
-		expect(new Set(sessionWorkspaceMap.values())).toEqual(
-			new Set(["workspace-1"]),
-		);
+		expect(result.current.running.isSending).toBe(true);
+		expect(result.current.running.busySessionIds.has("session-1")).toBe(true);
 		expect(result.current.emptySibling.isSending).toBe(false);
+		expect(result.current.emptySibling.busySessionIds.size).toBe(0);
 
 		act(() => {
 			streamCallbacks[0]({
@@ -574,8 +555,8 @@ describe("useConversationStreaming", () => {
 			});
 		});
 
-		expect(activeSessions).toEqual(new Set());
-		expect(sessionWorkspaceMap.size).toBe(0);
+		expect(result.current.running.isSending).toBe(false);
+		expect(result.current.running.busySessionIds.size).toBe(0);
 	});
 
 	it("sends the repo general preference via promptPrefix on the first prompt only", async () => {

--- a/src/features/conversation/hooks/use-streaming.test.tsx
+++ b/src/features/conversation/hooks/use-streaming.test.tsx
@@ -40,6 +40,16 @@ const apiMocks = vi.hoisted(() => ({
 	stopAgentStream: vi.fn(),
 }));
 
+// `listActiveStreams` is intentionally NOT mocked here. The hook reads it
+// via React Query, where `activeStreamsQueryOptions` provides
+// `initialData: []`, and `src/test/setup.ts`'s default invoke mock
+// returns `undefined` for unhandled commands — both paths produce an
+// empty array, which matches "no backend-tracked streams" for these
+// unit tests. If a future test wants to assert the backend-truth abort
+// path (e.g. that `handleStopStream` picks up a `provider` published by
+// the Rust registry rather than the local optimistic fallback), mock
+// `listActiveStreams` explicitly here so the default doesn't silently
+// swallow the assertion.
 vi.mock("@/lib/api", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("@/lib/api")>();
 

--- a/src/features/conversation/hooks/use-streaming.ts
+++ b/src/features/conversation/hooks/use-streaming.ts
@@ -33,6 +33,7 @@ import {
 import type { ComposerCustomTag } from "@/lib/composer-insert";
 import { extractError, isRecoverableByPurge } from "@/lib/errors";
 import {
+	activeStreamsQueryOptions,
 	agentModelSectionsQueryOptions,
 	helmorQueryKeys,
 	sessionThreadMessagesQueryOptions,
@@ -139,11 +140,6 @@ type UseConversationStreamingArgs = {
 	/** App-level queue handle (read + mutate). Shared across session /
 	 *  workspace switches so the queue survives navigation. */
 	submitQueue: SubmitQueueApi;
-	onSessionRunStateChange?: (
-		sessionId: string,
-		workspaceId: string | null,
-		sending: boolean,
-	) => void;
 	onInteractionSessionsChange?: (
 		sessionWorkspaceMap: Map<string, string>,
 		interactionCounts: Map<string, number>,
@@ -161,7 +157,6 @@ export function useConversationStreaming({
 	selectionPending,
 	followUpBehavior,
 	submitQueue,
-	onSessionRunStateChange,
 	onInteractionSessionsChange,
 	onSessionCompleted,
 	onSessionAborted,
@@ -257,6 +252,13 @@ export function useConversationStreaming({
 	);
 
 	const modelSectionsQuery = useQuery(agentModelSectionsQueryOptions());
+	// Backend-truth list of in-flight streams. Used by `handleStopStream`
+	// so abort works even after the conversation container unmount/remount
+	// race that would clear `activeSessionByContext`. Stays in sync via
+	// `UiMutationEvent::ActiveStreamsChanged` → `helmorQueryKeys.activeStreams`
+	// invalidation in the ui-sync bridge.
+	const activeStreamsQuery = useQuery(activeStreamsQueryOptions());
+	const activeStreams = activeStreamsQuery.data ?? [];
 	const selectedProvider = useMemo(() => {
 		if (!displayedSelectedModelId) return null;
 		const sections = modelSectionsQuery.data ?? [];
@@ -275,8 +277,6 @@ export function useConversationStreaming({
 		return ids;
 	}, [sendingContextKeys]);
 
-	const onSessionRunStateChangeRef = useRef(onSessionRunStateChange);
-	onSessionRunStateChangeRef.current = onSessionRunStateChange;
 	const onInteractionSessionsChangeRef = useRef(onInteractionSessionsChange);
 	onInteractionSessionsChangeRef.current = onInteractionSessionsChange;
 	const onSessionCompletedRef = useRef(onSessionCompleted);
@@ -446,17 +446,31 @@ export function useConversationStreaming({
 	);
 
 	const handleStopStream = useCallback(async () => {
-		const activeSession = activeSessionByContext[composerContextKey];
-		if (!activeSession) {
+		// Source of truth: the backend's active-streams registry,
+		// mirrored via React Query. Looking up by displayed session id
+		// (rather than `activeSessionByContext`) keeps abort working
+		// after a conversation-container unmount/remount, which used to
+		// silently drop the click.
+		const sessionId = composerContextKey.startsWith("session:")
+			? composerContextKey.slice("session:".length)
+			: null;
+		if (!sessionId) {
 			return;
 		}
-		const sessionId = activeSession.stopSessionId;
-		const goal =
-			activeSession.provider === "codex"
-				? queryClient.getQueryData<CodexGoalState | null>(
-						helmorQueryKeys.sessionCodexGoal(sessionId),
-					)
-				: null;
+		const activeStream = activeStreams.find(
+			(stream) => stream.sessionId === sessionId,
+		);
+		// Fall back to the local registry only when the backend hasn't
+		// surfaced the stream yet (e.g. the optimistic phase of a
+		// freshly-started turn). This is purely belt-and-suspenders —
+		// the active-streams event lands on the same tick as registration.
+		const provider =
+			activeStream?.provider ??
+			activeSessionByContext[composerContextKey]?.provider ??
+			null;
+		if (!provider) {
+			return;
+		}
 
 		// For codex sessions with an active goal, flip the goal to paused
 		// FIRST so codex doesn't auto-spawn a fresh continuation turn the
@@ -465,16 +479,21 @@ export function useConversationStreaming({
 		// (mutateCodexGoal is best-effort on the sidecar side too — if a
 		// race somehow kills the child first it just no-ops.) The user
 		// resumes by typing `/goal resume`.
-		if (goal && goal.status === "active") {
-			try {
-				await mutateCodexGoal(sessionId, "pause");
-			} catch {
-				// Surfaced via toast inside mutateCodexGoal already; don't
-				// block the abort.
+		if (provider === "codex") {
+			const goal = queryClient.getQueryData<CodexGoalState | null>(
+				helmorQueryKeys.sessionCodexGoal(sessionId),
+			);
+			if (goal && goal.status === "active") {
+				try {
+					await mutateCodexGoal(sessionId, "pause");
+				} catch {
+					// Surfaced via toast inside mutateCodexGoal already; don't
+					// block the abort.
+				}
 			}
 		}
-		await stopAgentStream(sessionId, activeSession.provider);
-	}, [activeSessionByContext, composerContextKey, queryClient]);
+		await stopAgentStream(sessionId, provider);
+	}, [activeSessionByContext, activeStreams, composerContextKey, queryClient]);
 
 	const handlePermissionResponse = useCallback(
 		(
@@ -507,64 +526,36 @@ export function useConversationStreaming({
 		[composerContextKey],
 	);
 
-	const publishSendingState = useCallback(
-		(
-			contextKey: string,
-			workspaceId: string | null | undefined,
-			sending: boolean,
-		) => {
-			if (!contextKey.startsWith("session:")) {
-				return;
-			}
-			onSessionRunStateChangeRef.current?.(
-				contextKey.slice(8),
-				workspaceId ?? null,
-				sending,
-			);
-		},
-		[],
-	);
-
+	// `sendingContextKeys` is the local "this context is mid-send" flag —
+	// drives the composer's send-vs-steer routing and the queue-drain
+	// effect. Cross-container truth (busy/stoppable badges) lives in the
+	// `activeStreams` React Query feed instead, sourced from Rust.
 	const markSendingState = useCallback(
 		(contextKey: string, workspaceId: string | null | undefined) => {
-			const previousWorkspaceId =
-				sendingWorkspaceMapRef.current.get(contextKey) ?? null;
 			if (workspaceId) {
 				sendingWorkspaceMapRef.current.set(contextKey, workspaceId);
 			}
-			const nextWorkspaceId =
-				sendingWorkspaceMapRef.current.get(contextKey) ?? workspaceId ?? null;
 			if (sendingContextKeysRef.current.has(contextKey)) {
-				if (nextWorkspaceId !== previousWorkspaceId) {
-					publishSendingState(contextKey, nextWorkspaceId, true);
-				}
 				return;
 			}
 
 			sendingContextKeysRef.current = new Set(sendingContextKeysRef.current);
 			sendingContextKeysRef.current.add(contextKey);
-			publishSendingState(contextKey, nextWorkspaceId, true);
 			setSendingContextKeys(sendingContextKeysRef.current);
 		},
-		[publishSendingState],
+		[],
 	);
 
-	const pauseSendingState = useCallback(
-		(contextKey: string) => {
-			const workspaceId =
-				sendingWorkspaceMapRef.current.get(contextKey) ?? null;
-			sendingWorkspaceMapRef.current.delete(contextKey);
-			if (!sendingContextKeysRef.current.has(contextKey)) {
-				return;
-			}
+	const pauseSendingState = useCallback((contextKey: string) => {
+		sendingWorkspaceMapRef.current.delete(contextKey);
+		if (!sendingContextKeysRef.current.has(contextKey)) {
+			return;
+		}
 
-			sendingContextKeysRef.current = new Set(sendingContextKeysRef.current);
-			sendingContextKeysRef.current.delete(contextKey);
-			publishSendingState(contextKey, workspaceId, false);
-			setSendingContextKeys(sendingContextKeysRef.current);
-		},
-		[publishSendingState],
-	);
+		sendingContextKeysRef.current = new Set(sendingContextKeysRef.current);
+		sendingContextKeysRef.current.delete(contextKey);
+		setSendingContextKeys(sendingContextKeysRef.current);
+	}, []);
 
 	const clearSendingState = useCallback(
 		(contextKey: string) => {

--- a/src/features/conversation/index.tsx
+++ b/src/features/conversation/index.tsx
@@ -74,11 +74,6 @@ type WorkspaceConversationContainerProps = {
 	sessionSelectionHistory?: string[];
 	onSelectSession: (sessionId: string | null) => void;
 	onResolveDisplayedSession: (sessionId: string | null) => void;
-	onSessionRunStateChange?: (
-		sessionId: string,
-		workspaceId: string | null,
-		sending: boolean,
-	) => void;
 	onInteractionSessionsChange?: (
 		sessionWorkspaceMap: Map<string, string>,
 		interactionCounts: Map<string, number>,
@@ -166,7 +161,6 @@ export const WorkspaceConversationContainer = memo(
 		sessionSelectionHistory = [],
 		onSelectSession,
 		onResolveDisplayedSession,
-		onSessionRunStateChange,
 		onInteractionSessionsChange,
 		busySessionIds,
 		stoppableSessionIds,
@@ -257,7 +251,6 @@ export const WorkspaceConversationContainer = memo(
 			selectionPending,
 			followUpBehavior: settings.followUpBehavior,
 			submitQueue: submitQueueApi,
-			onSessionRunStateChange,
 			onInteractionSessionsChange,
 			onSessionCompleted,
 			onSessionAborted,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1393,7 +1393,8 @@ export type UiMutationEvent =
 			prompt: string;
 			modelId: string | null;
 			permissionMode: string | null;
-	  };
+	  }
+	| { type: "activeStreamsChanged" };
 
 export async function listenGitBranchChanged(
 	callback: (payload: GitBranchChangedPayload) => void,
@@ -2418,6 +2419,22 @@ export async function stopAgentStream(
 	await invoke("stop_agent_stream", {
 		request: { sessionId, provider: provider ?? null },
 	});
+}
+
+/** UI projection of a registered, in-flight agent stream. Mirror of
+ *  `agents::streaming::ActiveStreamSummary` on the Rust side. */
+export type ActiveStreamSummary = {
+	sessionId: string;
+	workspaceId: string | null;
+	provider: string;
+};
+
+/** Snapshot of currently in-flight agent streams. The frontend derives
+ *  `busy / stoppable / busy-workspace` Sets from this list. Refetched
+ *  whenever a `UiMutationEvent::ActiveStreamsChanged` lands via the
+ *  ui-sync bridge. */
+export async function listActiveStreams(): Promise<ActiveStreamSummary[]> {
+	return await invoke<ActiveStreamSummary[]>("list_active_streams");
 }
 
 export type AgentSteerRequest = {

--- a/src/lib/query-client.ts
+++ b/src/lib/query-client.ts
@@ -18,6 +18,7 @@ import {
 	getSessionContextUsage,
 	getWorkspaceAccountProfile,
 	getWorkspaceForge,
+	listActiveStreams,
 	listForgeAccounts,
 	listGithubLabels,
 	listRepositories,
@@ -129,6 +130,7 @@ export const helmorQueryKeys = {
 		["workspaceLinkedDirectories", workspaceId] as const,
 	workspaceCandidateDirectories: (excludeWorkspaceId: string | null) =>
 		["workspaceCandidateDirectories", excludeWorkspaceId ?? ""] as const,
+	activeStreams: ["activeStreams"] as const,
 };
 
 /** Persistence is opt-in per `queryOptions` via `meta: { persist: true }`.
@@ -311,6 +313,21 @@ export function repositoriesQueryOptions() {
 		initialDataUpdatedAt: 0,
 		staleTime: 0,
 		meta: PERSIST_META,
+	});
+}
+
+/** Snapshot of in-flight agent streams (source of truth = Rust
+ *  `ActiveStreams`). Drives abort-button visibility + busy badges; the
+ *  ui-sync bridge invalidates this on `activeStreamsChanged`. NOT
+ *  persisted — running streams are by definition tied to this app run,
+ *  rehydrating stale state across restarts would mislead the UI. */
+export function activeStreamsQueryOptions() {
+	return queryOptions({
+		queryKey: helmorQueryKeys.activeStreams,
+		queryFn: listActiveStreams,
+		initialData: [],
+		initialDataUpdatedAt: 0,
+		staleTime: 0,
 	});
 }
 

--- a/src/lib/session-run-state.test.ts
+++ b/src/lib/session-run-state.test.ts
@@ -1,19 +1,23 @@
 import { describe, expect, it } from "vitest";
 import {
+	buildSessionRunStates,
 	deriveBusySessionIds,
 	deriveBusyWorkspaceIds,
 	deriveStoppableSessionIds,
-	nextSessionRunStates,
-	withPendingFinalizeRunState,
 } from "./session-run-state";
 
 describe("session run state", () => {
-	it("derives session and workspace loading from a single lifecycle map", () => {
-		const states = nextSessionRunStates(new Map(), {
-			sessionId: "session-1",
-			workspaceId: "workspace-1",
-			running: true,
-		});
+	it("derives session and workspace busy sets from active streams", () => {
+		const states = buildSessionRunStates(
+			[
+				{
+					sessionId: "session-1",
+					workspaceId: "workspace-1",
+					provider: "claude",
+				},
+			],
+			null,
+		);
 
 		expect(Array.from(deriveBusySessionIds(states))).toEqual(["session-1"]);
 		expect(Array.from(deriveBusyWorkspaceIds(states))).toEqual(["workspace-1"]);
@@ -23,7 +27,7 @@ describe("session run state", () => {
 	});
 
 	it("keeps pending finalize busy but not stoppable", () => {
-		const states = withPendingFinalizeRunState(new Map(), {
+		const states = buildSessionRunStates([], {
 			sessionId: "session-pending",
 			workspaceId: "workspace-pending",
 		});
@@ -36,33 +40,45 @@ describe("session run state", () => {
 	});
 
 	it("does not let pending finalize downgrade an already streaming session", () => {
-		const streaming = nextSessionRunStates(new Map(), {
-			sessionId: "session-1",
-			workspaceId: "workspace-1",
-			running: true,
-		});
-		const states = withPendingFinalizeRunState(streaming, {
-			sessionId: "session-1",
-			workspaceId: "workspace-1",
-		});
+		const states = buildSessionRunStates(
+			[
+				{
+					sessionId: "session-1",
+					workspaceId: "workspace-1",
+					provider: "claude",
+				},
+			],
+			{ sessionId: "session-1", workspaceId: "workspace-1" },
+		);
 
 		expect(deriveStoppableSessionIds(states).has("session-1")).toBe(true);
 	});
 
-	it("removes terminal sessions from derived loading sets", () => {
-		const streaming = nextSessionRunStates(new Map(), {
-			sessionId: "session-1",
-			workspaceId: "workspace-1",
-			running: true,
-		});
-		const states = nextSessionRunStates(streaming, {
-			sessionId: "session-1",
-			workspaceId: "workspace-1",
-			running: false,
-		});
+	it("removes terminal sessions when active streams clears", () => {
+		const initial = buildSessionRunStates(
+			[
+				{
+					sessionId: "session-1",
+					workspaceId: "workspace-1",
+					provider: "claude",
+				},
+			],
+			null,
+		);
+		expect(initial.size).toBe(1);
 
-		expect(deriveBusySessionIds(states).size).toBe(0);
+		const cleared = buildSessionRunStates([], null);
+		expect(deriveBusySessionIds(cleared).size).toBe(0);
+		expect(deriveBusyWorkspaceIds(cleared).size).toBe(0);
+		expect(deriveStoppableSessionIds(cleared).size).toBe(0);
+	});
+
+	it("ignores a workspace_id of null on a streaming session for the busy-workspace set", () => {
+		const states = buildSessionRunStates(
+			[{ sessionId: "session-1", workspaceId: null, provider: "claude" }],
+			null,
+		);
+		expect(deriveBusySessionIds(states).has("session-1")).toBe(true);
 		expect(deriveBusyWorkspaceIds(states).size).toBe(0);
-		expect(deriveStoppableSessionIds(states).size).toBe(0);
 	});
 });

--- a/src/lib/session-run-state.ts
+++ b/src/lib/session-run-state.ts
@@ -1,55 +1,48 @@
+import type { ActiveStreamSummary } from "./api";
+
 export type SessionRunPhase = "pendingFinalize" | "streaming";
 
 export type SessionRunState = {
 	sessionId: string;
 	workspaceId: string | null;
+	provider: string | null;
 	phase: SessionRunPhase;
 	canStop: boolean;
 };
 
 export type SessionRunStateMap = Map<string, SessionRunState>;
 
-export function nextSessionRunStates(
-	current: ReadonlyMap<string, SessionRunState>,
-	update: {
-		sessionId: string;
-		workspaceId: string | null;
-		running: boolean;
-	},
+/** Merge backend truth (`activeStreams`) with the StartPage optimistic
+ *  "this session is being created" marker (`pending`). The pending
+ *  finalize entry is busy-but-not-stoppable: the workspace doesn't exist
+ *  yet so there's no stream to abort, but the panel header should still
+ *  show a loading spinner for the optimistic user bubble.
+ *
+ *  Streaming wins over pending — once the real stream registers, the
+ *  same sessionId flips to canStop=true. */
+export function buildSessionRunStates(
+	activeStreams: readonly ActiveStreamSummary[],
+	pending: { sessionId: string; workspaceId: string } | null,
 ): SessionRunStateMap {
-	const next = new Map(current);
-	if (!update.running) {
-		next.delete(update.sessionId);
-		return next;
+	const next: SessionRunStateMap = new Map();
+	for (const stream of activeStreams) {
+		next.set(stream.sessionId, {
+			sessionId: stream.sessionId,
+			workspaceId: stream.workspaceId,
+			provider: stream.provider,
+			phase: "streaming",
+			canStop: true,
+		});
 	}
-
-	next.set(update.sessionId, {
-		sessionId: update.sessionId,
-		workspaceId: update.workspaceId,
-		phase: "streaming",
-		canStop: true,
-	});
-	return next;
-}
-
-export function withPendingFinalizeRunState(
-	current: ReadonlyMap<string, SessionRunState>,
-	pending: {
-		sessionId: string;
-		workspaceId: string;
-	} | null,
-): SessionRunStateMap {
-	const next = new Map(current);
-	if (!pending || next.has(pending.sessionId)) {
-		return next;
+	if (pending && !next.has(pending.sessionId)) {
+		next.set(pending.sessionId, {
+			sessionId: pending.sessionId,
+			workspaceId: pending.workspaceId,
+			provider: null,
+			phase: "pendingFinalize",
+			canStop: false,
+		});
 	}
-
-	next.set(pending.sessionId, {
-		sessionId: pending.sessionId,
-		workspaceId: pending.workspaceId,
-		phase: "pendingFinalize",
-		canStop: false,
-	});
 	return next;
 }
 

--- a/src/lib/session-run-state.ts
+++ b/src/lib/session-run-state.ts
@@ -5,7 +5,6 @@ export type SessionRunPhase = "pendingFinalize" | "streaming";
 export type SessionRunState = {
 	sessionId: string;
 	workspaceId: string | null;
-	provider: string | null;
 	phase: SessionRunPhase;
 	canStop: boolean;
 };
@@ -29,7 +28,6 @@ export function buildSessionRunStates(
 		next.set(stream.sessionId, {
 			sessionId: stream.sessionId,
 			workspaceId: stream.workspaceId,
-			provider: stream.provider,
 			phase: "streaming",
 			canStop: true,
 		});
@@ -38,7 +36,6 @@ export function buildSessionRunStates(
 		next.set(pending.sessionId, {
 			sessionId: pending.sessionId,
 			workspaceId: pending.workspaceId,
-			provider: null,
 			phase: "pendingFinalize",
 			canStop: false,
 		});

--- a/src/shell/hooks/use-ui-sync-bridge.ts
+++ b/src/shell/hooks/use-ui-sync-bridge.ts
@@ -188,6 +188,11 @@ function handleUiMutation(
 		case "pendingCliSendQueued":
 			void options.processPendingCliSends();
 			return;
+		case "activeStreamsChanged":
+			void queryClient.invalidateQueries({
+				queryKey: helmorQueryKeys.activeStreams,
+			});
+			return;
 	}
 }
 


### PR DESCRIPTION
## What changed

- Added `ActiveStreamSummary` type and `snapshot_for_ui()` method to `ActiveStreams` (Rust).
- New `list_active_streams` Tauri command exposes the snapshot to the frontend.
- Rust backend now broadcasts `UiMutationEvent::ActiveStreamsChanged` whenever a stream starts or stops.
- Frontend: replaced hook-local `sessionRunStates` in `use-streaming` with a React Query cache (`useActiveStreamSummaries`) populated by the new command, invalidated by the bridge event.
- `session-run-state.ts` is now a thin lens over that query result instead of managing its own in-memory map.

## Why

Previously the abort button state lived inside `use-streaming` — which is mounted per conversation container. Navigating away unmounted the hook, dropping all run-state. When the user navigated back the button would re-appear (because the stream was still active in the backend) but had nothing to abort because the frontend state was gone.

The fix makes the backend the single source of truth and the frontend a read-only subscriber, so abort works correctly regardless of how many times the user navigates.

## Test notes

- Existing `use-streaming` tests updated to match the new signature (no `setSessionRunState` arg).
- `session-run-state.test.ts` updated for the new query-backed shape.
- Manual: start a session, navigate to another workspace, navigate back — abort button should still fire correctly.