### PR TITLE
fix(sidecar): replace sqlite3 native addon with bun:sqlite shim

### DIFF
--- a/.changeset/ynill-esxse-jplxy.md
+++ b/.changeset/ynill-esxse-jplxy.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix sidecar startup crash introduced in v0.20.0 where adding the Cursor provider caused the sidecar to exit immediately with "Invalid sidecar ready signal" due to a native sqlite3 addon that cannot load inside a compiled Bun binary.

--- a/sidecar/bun.lock
+++ b/sidecar/bun.lock
@@ -20,6 +20,9 @@
     "@anthropic-ai/claude-code",
     "sqlite3",
   ],
+  "patchedDependencies": {
+    "sqlite3@5.1.7": "patches/sqlite3@5.1.7.patch",
+  },
   "packages": {
     "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.126", "", { "dependencies": { "@anthropic-ai/sdk": "^0.81.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.126", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.126", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.126", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.126", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.126", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.126", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.126", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.126" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-4ZrVu0XUEwNG6wxvsLgppRAmSfAf3oeEMEUPhgazb0AXUUe/7W8MxwZKJWOffqSLWaNYzOt3ZCIL7NJY6toqWw=="],
 

--- a/sidecar/package.json
+++ b/sidecar/package.json
@@ -25,5 +25,8 @@
 	"trustedDependencies": [
 		"@anthropic-ai/claude-code",
 		"sqlite3"
-	]
+	],
+	"patchedDependencies": {
+		"sqlite3@5.1.7": "patches/sqlite3@5.1.7.patch"
+	}
 }

--- a/sidecar/patches/sqlite3@5.1.7.patch
+++ b/sidecar/patches/sqlite3@5.1.7.patch
@@ -1,0 +1,377 @@
+diff --git a/lib/sqlite3.js b/lib/sqlite3.js
+index 430a2b88a3c292dce638a860a166710177cd8cfb..b512025b408dc5c40cdd9808a33a5e58f17a5073 100644
+--- a/lib/sqlite3.js
++++ b/lib/sqlite3.js
+@@ -1,207 +1,187 @@
+-const path = require('path');
+-const sqlite3 = require('./sqlite3-binding.js');
+-const EventEmitter = require('events').EventEmitter;
+-module.exports = exports = sqlite3;
+-
+-function normalizeMethod (fn) {
+-    return function (sql) {
+-        let errBack;
+-        const args = Array.prototype.slice.call(arguments, 1);
+-
+-        if (typeof args[args.length - 1] === 'function') {
+-            const callback = args[args.length - 1];
+-            errBack = function(err) {
+-                if (err) {
+-                    callback(err);
+-                }
+-            };
+-        }
+-        const statement = new Statement(this, sql, errBack);
+-        return fn.call(this, statement, args);
+-    };
+-}
+-
+-function inherits(target, source) {
+-    for (const k in source.prototype)
+-        target.prototype[k] = source.prototype[k];
+-}
+-
+-sqlite3.cached = {
+-    Database: function(file, a, b) {
+-        if (file === '' || file === ':memory:') {
+-            // Don't cache special databases.
+-            return new Database(file, a, b);
+-        }
+-
+-        let db;
+-        file = path.resolve(file);
+-
+-        if (!sqlite3.cached.objects[file]) {
+-            db = sqlite3.cached.objects[file] = new Database(file, a, b);
+-        }
+-        else {
+-            // Make sure the callback is called.
+-            db = sqlite3.cached.objects[file];
+-            const callback = (typeof a === 'number') ? b : a;
+-            if (typeof callback === 'function') {
+-                function cb() { callback.call(db, null); }
+-                if (db.open) process.nextTick(cb);
+-                else db.once('open', cb);
+-            }
+-        }
+-
+-        return db;
+-    },
+-    objects: {}
+-};
++// bun:sqlite-backed shim — replaces native sqlite3 addon.
++// Loaded via bun patch so `bindings` never runs in bun --compile output.
++'use strict';
+ 
++const { Database: BunDB } = require('bun:sqlite');
++const { existsSync, mkdirSync } = require('node:fs');
++const { dirname } = require('node:path');
++const EventEmitter = require('events');
+ 
+-const Database = sqlite3.Database;
+-const Statement = sqlite3.Statement;
+-const Backup = sqlite3.Backup;
++function toError(e) {
++  return e instanceof Error ? e : new Error(String(e));
++}
+ 
+-inherits(Database, EventEmitter);
+-inherits(Statement, EventEmitter);
+-inherits(Backup, EventEmitter);
++function splitParamsCb(paramsOrCb, cb) {
++  return typeof paramsOrCb === 'function' ? [undefined, paramsOrCb] : [paramsOrCb, cb];
++}
+ 
+-// Database#prepare(sql, [bind1, bind2, ...], [callback])
+-Database.prototype.prepare = normalizeMethod(function(statement, params) {
+-    return params.length
+-        ? statement.bind.apply(statement, params)
+-        : statement;
+-});
++class Statement extends EventEmitter {
++  constructor(stmt) { super(); this._stmt = stmt; }
+ 
+-// Database#run(sql, [bind1, bind2, ...], [callback])
+-Database.prototype.run = normalizeMethod(function(statement, params) {
+-    statement.run.apply(statement, params).finalize();
++  run(paramsOrCb, cb) {
++    const [params, callback] = splitParamsCb(paramsOrCb, cb);
++    queueMicrotask(() => {
++      try {
++        params !== undefined ? this._stmt.run(params) : this._stmt.run();
++        callback && callback.call(this, null);
++      } catch (e) { callback && callback.call(this, toError(e)); }
++    });
+     return this;
+-});
+-
+-// Database#get(sql, [bind1, bind2, ...], [callback])
+-Database.prototype.get = normalizeMethod(function(statement, params) {
+-    statement.get.apply(statement, params).finalize();
++  }
++
++  get(paramsOrCb, cb) {
++    const [params, callback] = splitParamsCb(paramsOrCb, cb);
++    queueMicrotask(() => {
++      try {
++        const row = params !== undefined ? this._stmt.get(params) : this._stmt.get();
++        callback && callback.call(this, null, row);
++      } catch (e) { callback && callback.call(this, toError(e)); }
++    });
+     return this;
+-});
++  }
++
++  all(paramsOrCb, cb) {
++    const [params, callback] = splitParamsCb(paramsOrCb, cb);
++    queueMicrotask(() => {
++      try {
++        const rows = params !== undefined ? this._stmt.all(params) : this._stmt.all();
++        callback && callback.call(this, null, rows);
++      } catch (e) { callback && callback.call(this, toError(e)); }
++    });
++    return this;
++  }
++
++  each(paramsOrCb, cbOrDone, done) {
++    let params, rowCb, doneCb;
++    if (typeof paramsOrCb === 'function') { rowCb = paramsOrCb; doneCb = cbOrDone; }
++    else { params = paramsOrCb; rowCb = cbOrDone; doneCb = done; }
++    queueMicrotask(() => {
++      try {
++        const rows = params !== undefined ? this._stmt.all(params) : this._stmt.all();
++        for (const row of rows) rowCb && rowCb.call(this, null, row);
++        doneCb && doneCb.call(this, null);
++      } catch (e) { doneCb && doneCb.call(this, toError(e)); }
++    });
++    return this;
++  }
+ 
+-// Database#all(sql, [bind1, bind2, ...], [callback])
+-Database.prototype.all = normalizeMethod(function(statement, params) {
+-    statement.all.apply(statement, params).finalize();
++  finalize(cb) {
++    queueMicrotask(() => {
++      try { this._stmt.finalize(); cb && cb.call(this, null); }
++      catch (e) { cb && cb.call(this, toError(e)); }
++    });
+     return this;
+-});
++  }
+ 
+-// Database#each(sql, [bind1, bind2, ...], [callback], [complete])
+-Database.prototype.each = normalizeMethod(function(statement, params) {
+-    statement.each.apply(statement, params).finalize();
++  bind(_, cb) {
++    const callback = typeof _ === 'function' ? _ : cb;
++    queueMicrotask(() => callback && callback.call(this, null));
+     return this;
+-});
++  }
+ 
+-Database.prototype.map = normalizeMethod(function(statement, params) {
+-    statement.map.apply(statement, params).finalize();
++  reset(cb) {
++    queueMicrotask(() => cb && cb.call(this, null));
+     return this;
+-});
+-
+-// Database#backup(filename, [callback])
+-// Database#backup(filename, destName, sourceName, filenameIsDest, [callback])
+-Database.prototype.backup = function() {
+-    let backup;
+-    if (arguments.length <= 2) {
+-        // By default, we write the main database out to the main database of the named file.
+-        // This is the most likely use of the backup api.
+-        backup = new Backup(this, arguments[0], 'main', 'main', true, arguments[1]);
+-    } else {
+-        // Otherwise, give the user full control over the sqlite3_backup_init arguments.
+-        backup = new Backup(this, arguments[0], arguments[1], arguments[2], arguments[3], arguments[4]);
+-    }
+-    // Per the sqlite docs, exclude the following errors as non-fatal by default.
+-    backup.retryErrors = [sqlite3.BUSY, sqlite3.LOCKED];
+-    return backup;
+-};
++  }
++}
+ 
+-Statement.prototype.map = function() {
+-    const params = Array.prototype.slice.call(arguments);
+-    const callback = params.pop();
+-    params.push(function(err, rows) {
+-        if (err) return callback(err);
+-        const result = {};
+-        if (rows.length) {
+-            const keys = Object.keys(rows[0]);
+-            const key = keys[0];
+-            if (keys.length > 2) {
+-                // Value is an object
+-                for (let i = 0; i < rows.length; i++) {
+-                    result[rows[i][key]] = rows[i];
+-                }
+-            } else {
+-                const value = keys[1];
+-                // Value is a plain value
+-                for (let i = 0; i < rows.length; i++) {
+-                    result[rows[i][key]] = rows[i][value];
+-                }
+-            }
+-        }
+-        callback(err, result);
++class Database extends EventEmitter {
++  constructor(filename, modeOrCb, cb) {
++    super();
++    const callback = typeof modeOrCb === 'function' ? modeOrCb : cb;
++    try {
++      if (filename !== ':memory:') {
++        const dir = dirname(filename);
++        if (dir && dir !== '.' && !existsSync(dir)) mkdirSync(dir, { recursive: true });
++      }
++      this._db = new BunDB(filename);
++      this.open = true;
++      queueMicrotask(() => { callback && callback.call(this, null); this.emit('open'); });
++    } catch (e) {
++      this.open = false;
++      const err = toError(e);
++      queueMicrotask(() => { callback && callback.call(this, err); this.emit('error', err); });
++    }
++  }
++
++  run(sql, paramsOrCb, cb) {
++    const [params, callback] = splitParamsCb(paramsOrCb, cb);
++    queueMicrotask(() => {
++      try {
++        const stmt = this._db.prepare(sql);
++        params !== undefined ? stmt.run(params) : stmt.run();
++        callback && callback.call(this, null);
++      } catch (e) { callback && callback.call(this, toError(e)); }
+     });
+-    return this.all.apply(this, params);
+-};
++    return this;
++  }
++
++  get(sql, paramsOrCb, cb) {
++    const [params, callback] = splitParamsCb(paramsOrCb, cb);
++    queueMicrotask(() => {
++      try {
++        const stmt = this._db.prepare(sql);
++        const row = params !== undefined ? stmt.get(params) : stmt.get();
++        callback && callback.call(this, null, row);
++      } catch (e) { callback && callback.call(this, toError(e)); }
++    });
++    return this;
++  }
++
++  all(sql, paramsOrCb, cb) {
++    const [params, callback] = splitParamsCb(paramsOrCb, cb);
++    queueMicrotask(() => {
++      try {
++        const stmt = this._db.prepare(sql);
++        const rows = params !== undefined ? stmt.all(params) : stmt.all();
++        callback && callback.call(this, null, rows);
++      } catch (e) { callback && callback.call(this, toError(e)); }
++    });
++    return this;
++  }
++
++  each(sql, paramsOrCb, cbOrDone, done) {
++    let params, rowCb, doneCb;
++    if (typeof paramsOrCb === 'function') { rowCb = paramsOrCb; doneCb = cbOrDone; }
++    else { params = paramsOrCb; rowCb = cbOrDone; doneCb = done; }
++    queueMicrotask(() => {
++      try {
++        const stmt = this._db.prepare(sql);
++        const rows = params !== undefined ? stmt.all(params) : stmt.all();
++        for (const row of rows) rowCb && rowCb.call(this, null, row);
++        doneCb && doneCb.call(this, null);
++      } catch (e) { doneCb && doneCb.call(this, toError(e)); }
++    });
++    return this;
++  }
+ 
+-let isVerbose = false;
++  prepare(sql) { return new Statement(this._db.prepare(sql)); }
+ 
+-const supportedEvents = [ 'trace', 'profile', 'change' ];
++  exec(sql, cb) {
++    queueMicrotask(() => {
++      try { this._db.exec(sql); cb && cb.call(this, null); }
++      catch (e) { cb && cb.call(this, toError(e)); }
++    });
++    return this;
++  }
+ 
+-Database.prototype.addListener = Database.prototype.on = function(type) {
+-    const val = EventEmitter.prototype.addListener.apply(this, arguments);
+-    if (supportedEvents.indexOf(type) >= 0) {
+-        this.configure(type, true);
+-    }
+-    return val;
+-};
++  close(cb) {
++    queueMicrotask(() => {
++      try { this._db.close(); this.open = false; cb && cb.call(this, null); }
++      catch (e) { cb && cb.call(this, toError(e)); }
++    });
++  }
+ 
+-Database.prototype.removeListener = function(type) {
+-    const val = EventEmitter.prototype.removeListener.apply(this, arguments);
+-    if (supportedEvents.indexOf(type) >= 0 && !this._events[type]) {
+-        this.configure(type, false);
+-    }
+-    return val;
+-};
++  serialize(cb) { cb && cb(); }
++  parallelize(cb) { cb && cb(); }
++  configure() {}
++}
+ 
+-Database.prototype.removeAllListeners = function(type) {
+-    const val = EventEmitter.prototype.removeAllListeners.apply(this, arguments);
+-    if (supportedEvents.indexOf(type) >= 0) {
+-        this.configure(type, false);
+-    }
+-    return val;
++const sqlite3 = {
++  Database,
++  Statement,
++  cached: { Database, objects: {} },
++  verbose() { return sqlite3; },
+ };
+ 
+-// Save the stack trace over EIO callbacks.
+-sqlite3.verbose = function() {
+-    if (!isVerbose) {
+-        const trace = require('./trace');
+-        [
+-            'prepare',
+-            'get',
+-            'run',
+-            'all',
+-            'each',
+-            'map',
+-            'close',
+-            'exec'
+-        ].forEach(function (name) {
+-            trace.extendTrace(Database.prototype, name);
+-        });
+-        [
+-            'bind',
+-            'get',
+-            'run',
+-            'all',
+-            'each',
+-            'map',
+-            'reset',
+-            'finalize',
+-        ].forEach(function (name) {
+-            trace.extendTrace(Statement.prototype, name);
+-        });
+-        isVerbose = true;
+-    }
+-
+-    return sqlite3;
+-};
++module.exports = sqlite3;


### PR DESCRIPTION
## Problem

v0.20.0 introduced the Cursor provider (`@cursor/sdk`), which depends on `sqlite3` — a native Node addon. After `bun build --compile`, the `bindings` loader crashes at startup because it cannot find `package.json` inside `/$bunfs/root` (bun's virtual FS). The sidecar exits before it can send the ready signal, causing every operation to fail with **"Sidecar send failed: Invalid sidecar ready signal"**.

## Fix

Add a `bun patch` that replaces `sqlite3`'s CJS entry (`lib/sqlite3.js`) with a pure-JS shim backed by Bun's built-in `bun:sqlite`. The shim:

- Exposes the same `Database` / `Statement` callback API that `@cursor/sdk` uses internally
- Uses `queueMicrotask` to preserve sqlite3's async-callback contract
- Runs cleanly inside `bun --compile` binaries — zero native dependencies

`patches/sqlite3@5.1.7.patch` is automatically re-applied by `bun install`.

## Verification

```
$ dist/helmor-sidecar < /dev/null 2>&1
{"type":"ready","version":1}
```