### PR TITLE
fix(settings): decouple Default/Review/PR-MR model rows and fix effort clamping

### DIFF
--- a/.changeset/calm-eels-wander.md
+++ b/.changeset/calm-eels-wander.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix the Default / Review / PR-MR model rows in Settings so each row's model, effort, and fast mode are independent and clamp consistently when the model changes.

--- a/src/features/settings/index.tsx
+++ b/src/features/settings/index.tsx
@@ -9,7 +9,7 @@ import {
 	Settings,
 	Sun,
 } from "lucide-react";
-import { memo, useEffect, useState } from "react";
+import { memo, useEffect, useRef, useState } from "react";
 import { ModelIcon } from "@/components/model-icon";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
@@ -39,13 +39,18 @@ import {
 import { getShortcut } from "@/features/shortcuts/registry";
 import { ShortcutsSettingsPanel } from "@/features/shortcuts/settings-panel";
 import { InlineShortcutDisplay } from "@/features/shortcuts/shortcut-display";
-import { isConductorAvailable, type RepositoryCreateOption } from "@/lib/api";
+import {
+	type AgentModelOption,
+	type AgentModelSection,
+	isConductorAvailable,
+	type RepositoryCreateOption,
+} from "@/lib/api";
 import {
 	agentModelSectionsQueryOptions,
 	helmorQueryKeys,
 	repositoriesQueryOptions,
 } from "@/lib/query-client";
-import type { DarkTheme, ThemeMode } from "@/lib/settings";
+import type { AppSettings, DarkTheme, ThemeMode } from "@/lib/settings";
 import { resolveTheme, useSettings } from "@/lib/settings";
 import { cn } from "@/lib/utils";
 import { clampEffort, findModelOption } from "@/lib/workspace-helpers";
@@ -198,89 +203,51 @@ export const SettingsDialog = memo(function SettingsDialog({
 		...agentModelSectionsQueryOptions(),
 		enabled: open,
 	});
-	const allModels = (modelSectionsQuery.data ?? []).flatMap((s) => s.options);
-	const selectedDefaultModel = findModelOption(
-		modelSectionsQuery.data ?? [],
-		settings.defaultModelId,
-	);
-	// `supportsEffort` keys off real model metadata (no fallback) — Haiku
-	// reports `effortLevels: []`, and the wire format may also drop the
-	// field entirely when empty. Either way, `?.length ?? 0` resolves to
-	// 0 → disabled. The fallback list is only used to keep the dropdown
-	// from rendering empty while metadata is still loading.
-	const defaultModelSupportsEffort =
-		(selectedDefaultModel?.effortLevels?.length ?? 0) > 0;
-	const defaultEffortLevels = defaultModelSupportsEffort
-		? (selectedDefaultModel?.effortLevels ?? FALLBACK_EFFORT_LEVELS)
-		: FALLBACK_EFFORT_LEVELS;
-	const defaultModelSupportsFastMode =
-		selectedDefaultModel?.supportsFastMode === true;
-	const defaultModelLabel =
-		selectedDefaultModel?.label ??
-		(modelSectionsQuery.isPending ? "Loading…" : "Select model");
-	// Review row mirrors the Default row's three-control combo *exactly*.
-	// `null` on a Review setting means "follow the default" — we resolve it
-	// here so the Review controls read identically to the Default ones,
-	// without a "Use default" affordance. Selecting the same value as the
-	// default snaps Review back to `null` (still following) so the user
-	// can return to follow-mode just by re-picking the default value.
-	const effectiveReviewModelId =
-		settings.reviewModelId ?? settings.defaultModelId;
-	const effectiveReviewModel = findModelOption(
-		modelSectionsQuery.data ?? [],
-		effectiveReviewModelId,
-	);
-	const reviewModelLabel =
-		effectiveReviewModel?.label ??
-		(modelSectionsQuery.isPending ? "Loading…" : "Select model");
-	const reviewModelSupportsEffort =
-		(effectiveReviewModel?.effortLevels?.length ?? 0) > 0;
-	const reviewEffortLevels = reviewModelSupportsEffort
-		? (effectiveReviewModel?.effortLevels ?? FALLBACK_EFFORT_LEVELS)
-		: FALLBACK_EFFORT_LEVELS;
-	const reviewModelSupportsFastMode =
-		effectiveReviewModel?.supportsFastMode === true;
-	const effectiveReviewEffort =
-		settings.reviewEffort ?? settings.defaultEffort ?? "high";
-	const effectiveReviewFastMode =
-		settings.reviewFastMode ?? settings.defaultFastMode;
-	// PR/MR row mirrors the same follow-the-default convention as Review.
-	const effectivePrModelId = settings.prModelId ?? settings.defaultModelId;
-	const effectivePrModel = findModelOption(
-		modelSectionsQuery.data ?? [],
-		effectivePrModelId,
-	);
-	const prModelLabel =
-		effectivePrModel?.label ??
-		(modelSectionsQuery.isPending ? "Loading…" : "Select model");
-	const prModelSupportsEffort =
-		(effectivePrModel?.effortLevels?.length ?? 0) > 0;
-	const prEffortLevels = prModelSupportsEffort
-		? (effectivePrModel?.effortLevels ?? FALLBACK_EFFORT_LEVELS)
-		: FALLBACK_EFFORT_LEVELS;
-	const prModelSupportsFastMode = effectivePrModel?.supportsFastMode === true;
-	const effectivePrEffort =
-		settings.prEffort ?? settings.defaultEffort ?? "high";
-	const effectivePrFastMode = settings.prFastMode ?? settings.defaultFastMode;
-	// Auto-clamp effort when model changes — but only after model metadata
-	// has actually loaded, otherwise the fallback levels silently kill max/xhigh.
+	const modelSections = modelSectionsQuery.data ?? [];
+	const allModels = modelSections.flatMap((s) => s.options);
+
+	// Materialize null Review/PR fields once per dialog open. Each model row
+	// (default / review / pr) owns its three controls (model, effort, fast
+	// mode) independently — `null` was the legacy "follow default" sentinel,
+	// but that coupling caused review/pr displays to flip whenever the
+	// default row changed. We promote nulls to explicit copies of the
+	// current default values so the three rows are fully decoupled going
+	// forward. Wait until `defaultModelId` is set so we don't materialize
+	// to `null` on first launch.
+	const hasMaterialized = useRef(false);
 	useEffect(() => {
-		if (!selectedDefaultModel) return;
-		const current = settings.defaultEffort ?? "high";
-		if (
-			defaultEffortLevels.length > 0 &&
-			!defaultEffortLevels.includes(current)
-		) {
-			updateSettings({
-				defaultEffort: clampEffort(current, defaultEffortLevels),
-			});
+		if (!open) {
+			hasMaterialized.current = false;
+			return;
 		}
-	}, [
-		selectedDefaultModel,
-		settings.defaultEffort,
-		defaultEffortLevels,
-		updateSettings,
-	]);
+		if (hasMaterialized.current) return;
+		if (settings.defaultModelId === null) return;
+
+		const patch: Partial<AppSettings> = {};
+		if (settings.reviewModelId === null) {
+			patch.reviewModelId = settings.defaultModelId;
+		}
+		if (settings.reviewEffort === null) {
+			patch.reviewEffort = settings.defaultEffort;
+		}
+		if (settings.reviewFastMode === null) {
+			patch.reviewFastMode = settings.defaultFastMode;
+		}
+		if (settings.prModelId === null) {
+			patch.prModelId = settings.defaultModelId;
+		}
+		if (settings.prEffort === null) {
+			patch.prEffort = settings.defaultEffort;
+		}
+		if (settings.prFastMode === null) {
+			patch.prFastMode = settings.defaultFastMode;
+		}
+
+		hasMaterialized.current = true;
+		if (Object.keys(patch).length > 0) {
+			void updateSettings(patch);
+		}
+	}, [open, settings, updateSettings]);
 
 	useEffect(() => {
 		if (open) {
@@ -607,371 +574,73 @@ export const SettingsDialog = memo(function SettingsDialog({
 
 							{activeSection === "model" && (
 								<SettingsGroup>
-									<SettingsRow
+									<ModelSettingRow
 										title="Default model"
 										description="Model for new chats"
-									>
-										<div className="flex w-[360px] items-center gap-2">
-											<DropdownMenu>
-												<DropdownMenuTrigger
-													className={cn(
-														"flex h-8 cursor-pointer items-center justify-between rounded-lg border border-border/50 bg-muted/30 px-3 text-[13px] text-foreground hover:bg-muted/50",
-														"min-w-0 flex-1 gap-1.5",
-													)}
-												>
-													<span className="flex min-w-0 items-center gap-1.5">
-														<ModelIcon
-															model={selectedDefaultModel}
-															className="size-[13px] shrink-0"
-														/>
-														<span className="min-w-0 truncate whitespace-nowrap">
-															{defaultModelLabel}
-														</span>
-													</span>
-													<ChevronDown className="size-3 shrink-0 opacity-40" />
-												</DropdownMenuTrigger>
-												<DropdownMenuContent
-													align="end"
-													sideOffset={4}
-													className="min-w-[10rem]"
-												>
-													{allModels.map((m) => (
-														<DropdownMenuItem
-															key={m.id}
-															onClick={() =>
-																updateSettings({ defaultModelId: m.id })
-															}
-															className="justify-between gap-2"
-														>
-															<span className="flex min-w-0 items-center gap-2">
-																<ModelIcon model={m} className="size-4" />
-																{m.label}
-															</span>
-															<CheckCircle2
-																className={cn(
-																	"size-3.5 shrink-0 text-emerald-500",
-																	m.id !== settings.defaultModelId &&
-																		"invisible",
-																)}
-															/>
-														</DropdownMenuItem>
-													))}
-												</DropdownMenuContent>
-											</DropdownMenu>
-											<DropdownMenu>
-												<DropdownMenuTrigger
-													disabled={!defaultModelSupportsEffort}
-													className={cn(
-														"flex h-8 items-center rounded-lg border border-border/50 bg-muted/30 px-3 text-[13px]",
-														"shrink-0 gap-1.5",
-														defaultModelSupportsEffort
-															? "cursor-pointer text-foreground hover:bg-muted/50"
-															: "cursor-not-allowed text-muted-foreground opacity-60",
-													)}
-												>
-													<span>
-														{effortLabel(settings.defaultEffort ?? "high")}
-													</span>
-													<ChevronDown className="size-3 opacity-40" />
-												</DropdownMenuTrigger>
-												<DropdownMenuContent
-													align="end"
-													sideOffset={4}
-													className="min-w-[8rem]"
-												>
-													{defaultEffortLevels.map((l) => (
-														<DropdownMenuItem
-															key={l}
-															onClick={() =>
-																updateSettings({ defaultEffort: l })
-															}
-														>
-															{effortLabel(l)}
-														</DropdownMenuItem>
-													))}
-												</DropdownMenuContent>
-											</DropdownMenu>
-											<div
-												className={cn(
-													"flex h-8 cursor-pointer items-center rounded-lg border border-border/50 bg-muted/30 px-3 text-[13px] text-foreground hover:bg-muted/50",
-													"shrink-0 gap-2",
-												)}
-											>
-												<span
-													className={
-														defaultModelSupportsFastMode
-															? "text-[13px] text-foreground"
-															: "text-[13px] text-muted-foreground"
-													}
-												>
-													Fast mode
-												</span>
-												<Switch
-													checked={
-														defaultModelSupportsFastMode &&
-														settings.defaultFastMode
-													}
-													disabled={!defaultModelSupportsFastMode}
-													onCheckedChange={(checked) =>
-														updateSettings({ defaultFastMode: checked })
-													}
-													aria-label="Default fast mode"
-												/>
-											</div>
-										</div>
-									</SettingsRow>
-									<SettingsRow
+										models={allModels}
+										modelSections={modelSections}
+										isLoadingModels={modelSectionsQuery.isPending}
+										// Each row reads its own state directly. The `?? default*`
+										// fallbacks here only cover the brief moment between
+										// dialog open and `hasMaterialized` running — once the
+										// migration lands, stored values are explicit and these
+										// fallbacks no-op.
+										modelId={settings.defaultModelId}
+										effort={settings.defaultEffort}
+										fastMode={settings.defaultFastMode}
+										ariaPrefix="Default"
+										onChange={(p) => {
+											const patch: Partial<AppSettings> = {};
+											if (p.modelId !== undefined)
+												patch.defaultModelId = p.modelId;
+											if (p.effort !== undefined)
+												patch.defaultEffort = p.effort;
+											if (p.fastMode !== undefined)
+												patch.defaultFastMode = p.fastMode;
+											void updateSettings(patch);
+										}}
+									/>
+									<ModelSettingRow
 										title="Review model"
 										description="Model for code review"
-									>
-										<div className="flex w-[360px] items-center gap-2">
-											<DropdownMenu>
-												<DropdownMenuTrigger
-													className={cn(
-														"flex h-8 cursor-pointer items-center justify-between rounded-lg border border-border/50 bg-muted/30 px-3 text-[13px] text-foreground hover:bg-muted/50",
-														"min-w-0 flex-1 gap-1.5",
-													)}
-												>
-													<span className="flex min-w-0 items-center gap-1.5">
-														<ModelIcon
-															model={effectiveReviewModel}
-															className="size-[13px] shrink-0"
-														/>
-														<span className="min-w-0 truncate whitespace-nowrap">
-															{reviewModelLabel}
-														</span>
-													</span>
-													<ChevronDown className="size-3 shrink-0 opacity-40" />
-												</DropdownMenuTrigger>
-												<DropdownMenuContent
-													align="end"
-													sideOffset={4}
-													className="min-w-[10rem]"
-												>
-													{allModels.map((m) => (
-														<DropdownMenuItem
-															key={m.id}
-															onClick={() =>
-																updateSettings({
-																	// Picking the same value as the
-																	// default snaps Review back to `null`
-																	// (still following the default).
-																	reviewModelId:
-																		m.id === settings.defaultModelId
-																			? null
-																			: m.id,
-																})
-															}
-															className="justify-between gap-2"
-														>
-															<span className="flex min-w-0 items-center gap-2">
-																<ModelIcon model={m} className="size-4" />
-																{m.label}
-															</span>
-															<CheckCircle2
-																className={cn(
-																	"size-3.5 shrink-0 text-emerald-500",
-																	m.id !== effectiveReviewModelId &&
-																		"invisible",
-																)}
-															/>
-														</DropdownMenuItem>
-													))}
-												</DropdownMenuContent>
-											</DropdownMenu>
-											<DropdownMenu>
-												<DropdownMenuTrigger
-													disabled={!reviewModelSupportsEffort}
-													className={cn(
-														"flex h-8 items-center rounded-lg border border-border/50 bg-muted/30 px-3 text-[13px]",
-														"shrink-0 gap-1.5",
-														reviewModelSupportsEffort
-															? "cursor-pointer text-foreground hover:bg-muted/50"
-															: "cursor-not-allowed text-muted-foreground opacity-60",
-													)}
-												>
-													<span>{effortLabel(effectiveReviewEffort)}</span>
-													<ChevronDown className="size-3 opacity-40" />
-												</DropdownMenuTrigger>
-												<DropdownMenuContent
-													align="end"
-													sideOffset={4}
-													className="min-w-[8rem]"
-												>
-													{reviewEffortLevels.map((l) => (
-														<DropdownMenuItem
-															key={l}
-															onClick={() =>
-																updateSettings({
-																	reviewEffort:
-																		l === settings.defaultEffort ? null : l,
-																})
-															}
-														>
-															{effortLabel(l)}
-														</DropdownMenuItem>
-													))}
-												</DropdownMenuContent>
-											</DropdownMenu>
-											<div
-												className={cn(
-													"flex h-8 cursor-pointer items-center rounded-lg border border-border/50 bg-muted/30 px-3 text-[13px] text-foreground hover:bg-muted/50",
-													"shrink-0 gap-2",
-												)}
-											>
-												<span
-													className={
-														reviewModelSupportsFastMode
-															? "text-[13px] text-foreground"
-															: "text-[13px] text-muted-foreground"
-													}
-												>
-													Fast mode
-												</span>
-												<Switch
-													checked={
-														reviewModelSupportsFastMode &&
-														effectiveReviewFastMode
-													}
-													disabled={!reviewModelSupportsFastMode}
-													onCheckedChange={(checked) =>
-														updateSettings({
-															reviewFastMode:
-																checked === settings.defaultFastMode
-																	? null
-																	: checked,
-														})
-													}
-													aria-label="Review fast mode"
-												/>
-											</div>
-										</div>
-									</SettingsRow>
-									<SettingsRow
+										models={allModels}
+										modelSections={modelSections}
+										isLoadingModels={modelSectionsQuery.isPending}
+										modelId={settings.reviewModelId ?? settings.defaultModelId}
+										effort={settings.reviewEffort ?? settings.defaultEffort}
+										fastMode={
+											settings.reviewFastMode ?? settings.defaultFastMode
+										}
+										ariaPrefix="Review"
+										onChange={(p) => {
+											const patch: Partial<AppSettings> = {};
+											if (p.modelId !== undefined)
+												patch.reviewModelId = p.modelId;
+											if (p.effort !== undefined) patch.reviewEffort = p.effort;
+											if (p.fastMode !== undefined)
+												patch.reviewFastMode = p.fastMode;
+											void updateSettings(patch);
+										}}
+									/>
+									<ModelSettingRow
 										title="PR / MR model"
 										description="Model for PRs and MRs"
-									>
-										<div className="flex w-[360px] items-center gap-2">
-											<DropdownMenu>
-												<DropdownMenuTrigger
-													className={cn(
-														"flex h-8 cursor-pointer items-center justify-between rounded-lg border border-border/50 bg-muted/30 px-3 text-[13px] text-foreground hover:bg-muted/50",
-														"min-w-0 flex-1 gap-1.5",
-													)}
-												>
-													<span className="flex min-w-0 items-center gap-1.5">
-														<ModelIcon
-															model={effectivePrModel}
-															className="size-[13px] shrink-0"
-														/>
-														<span className="min-w-0 truncate whitespace-nowrap">
-															{prModelLabel}
-														</span>
-													</span>
-													<ChevronDown className="size-3 shrink-0 opacity-40" />
-												</DropdownMenuTrigger>
-												<DropdownMenuContent
-													align="end"
-													sideOffset={4}
-													className="min-w-[10rem]"
-												>
-													{allModels.map((m) => (
-														<DropdownMenuItem
-															key={m.id}
-															onClick={() =>
-																updateSettings({
-																	// Picking the same value as the
-																	// default snaps PR back to `null`
-																	// (still following the default).
-																	prModelId:
-																		m.id === settings.defaultModelId
-																			? null
-																			: m.id,
-																})
-															}
-															className="justify-between gap-2"
-														>
-															<span className="flex min-w-0 items-center gap-2">
-																<ModelIcon model={m} className="size-4" />
-																{m.label}
-															</span>
-															<CheckCircle2
-																className={cn(
-																	"size-3.5 shrink-0 text-emerald-500",
-																	m.id !== effectivePrModelId && "invisible",
-																)}
-															/>
-														</DropdownMenuItem>
-													))}
-												</DropdownMenuContent>
-											</DropdownMenu>
-											<DropdownMenu>
-												<DropdownMenuTrigger
-													disabled={!prModelSupportsEffort}
-													className={cn(
-														"flex h-8 items-center rounded-lg border border-border/50 bg-muted/30 px-3 text-[13px]",
-														"shrink-0 gap-1.5",
-														prModelSupportsEffort
-															? "cursor-pointer text-foreground hover:bg-muted/50"
-															: "cursor-not-allowed text-muted-foreground opacity-60",
-													)}
-												>
-													<span>{effortLabel(effectivePrEffort)}</span>
-													<ChevronDown className="size-3 opacity-40" />
-												</DropdownMenuTrigger>
-												<DropdownMenuContent
-													align="end"
-													sideOffset={4}
-													className="min-w-[8rem]"
-												>
-													{prEffortLevels.map((l) => (
-														<DropdownMenuItem
-															key={l}
-															onClick={() =>
-																updateSettings({
-																	prEffort:
-																		l === settings.defaultEffort ? null : l,
-																})
-															}
-														>
-															{effortLabel(l)}
-														</DropdownMenuItem>
-													))}
-												</DropdownMenuContent>
-											</DropdownMenu>
-											<div
-												className={cn(
-													"flex h-8 cursor-pointer items-center rounded-lg border border-border/50 bg-muted/30 px-3 text-[13px] text-foreground hover:bg-muted/50",
-													"shrink-0 gap-2",
-												)}
-											>
-												<span
-													className={
-														prModelSupportsFastMode
-															? "text-[13px] text-foreground"
-															: "text-[13px] text-muted-foreground"
-													}
-												>
-													Fast mode
-												</span>
-												<Switch
-													checked={
-														prModelSupportsFastMode && effectivePrFastMode
-													}
-													disabled={!prModelSupportsFastMode}
-													onCheckedChange={(checked) =>
-														updateSettings({
-															prFastMode:
-																checked === settings.defaultFastMode
-																	? null
-																	: checked,
-														})
-													}
-													aria-label="PR / MR fast mode"
-												/>
-											</div>
-										</div>
-									</SettingsRow>
+										models={allModels}
+										modelSections={modelSections}
+										isLoadingModels={modelSectionsQuery.isPending}
+										modelId={settings.prModelId ?? settings.defaultModelId}
+										effort={settings.prEffort ?? settings.defaultEffort}
+										fastMode={settings.prFastMode ?? settings.defaultFastMode}
+										ariaPrefix="PR / MR"
+										onChange={(p) => {
+											const patch: Partial<AppSettings> = {};
+											if (p.modelId !== undefined) patch.prModelId = p.modelId;
+											if (p.effort !== undefined) patch.prEffort = p.effort;
+											if (p.fastMode !== undefined)
+												patch.prFastMode = p.fastMode;
+											void updateSettings(patch);
+										}}
+									/>
 									<ClaudeCustomProvidersPanel />
 									<CursorProviderPanel />
 								</SettingsGroup>
@@ -1040,6 +709,161 @@ export const SettingsDialog = memo(function SettingsDialog({
 function effortLabel(level: string): string {
 	if (level === "xhigh") return "Extra High";
 	return level.charAt(0).toUpperCase() + level.slice(1);
+}
+
+type ModelRowChange = {
+	modelId?: string;
+	effort?: string;
+	fastMode?: boolean;
+};
+
+/// One row of the Model settings panel: model picker + effort picker + fast
+/// mode switch. Shared by Default / Review / PR-MR rows so they all carry the
+/// same clamp + display logic. Each row is fully independent — the parent
+/// passes its row's own (modelId, effort, fastMode) and gets back a partial
+/// patch on any change.
+function ModelSettingRow({
+	title,
+	description,
+	models,
+	modelSections,
+	isLoadingModels,
+	modelId,
+	effort,
+	fastMode,
+	ariaPrefix,
+	onChange,
+}: {
+	title: string;
+	description: string;
+	models: AgentModelOption[];
+	modelSections: AgentModelSection[];
+	isLoadingModels: boolean;
+	modelId: string | null;
+	effort: string | null;
+	fastMode: boolean;
+	ariaPrefix: string;
+	onChange: (patch: ModelRowChange) => void;
+}) {
+	const selected = findModelOption(modelSections, modelId);
+	// Key off real model metadata — Haiku reports `effortLevels: []`, and
+	// the wire format may also drop the field entirely when empty. Either
+	// way `?.length ?? 0` resolves to 0 → disabled. The fallback list only
+	// keeps the dropdown from rendering empty while metadata is loading.
+	const supportsEffort = (selected?.effortLevels?.length ?? 0) > 0;
+	const effortLevels = supportsEffort
+		? (selected?.effortLevels ?? FALLBACK_EFFORT_LEVELS)
+		: FALLBACK_EFFORT_LEVELS;
+	const supportsFastMode = selected?.supportsFastMode === true;
+	const label =
+		selected?.label ?? (isLoadingModels ? "Loading…" : "Select model");
+	const displayEffort = effort ?? "high";
+
+	// Auto-clamp effort when model changes — but only after model metadata
+	// has actually loaded, otherwise the fallback levels silently kill
+	// max/xhigh.
+	useEffect(() => {
+		if (!selected) return;
+		if (!effort) return;
+		if (effortLevels.length > 0 && !effortLevels.includes(effort)) {
+			onChange({ effort: clampEffort(effort, effortLevels) });
+		}
+	}, [selected, effort, effortLevels, onChange]);
+
+	return (
+		<SettingsRow title={title} description={description}>
+			<div className="flex w-[360px] items-center gap-2">
+				<DropdownMenu>
+					<DropdownMenuTrigger
+						className={cn(
+							"flex h-8 cursor-pointer items-center justify-between rounded-lg border border-border/50 bg-muted/30 px-3 text-[13px] text-foreground hover:bg-muted/50",
+							"min-w-0 flex-1 gap-1.5",
+						)}
+					>
+						<span className="flex min-w-0 items-center gap-1.5">
+							<ModelIcon model={selected} className="size-[13px] shrink-0" />
+							<span className="min-w-0 truncate whitespace-nowrap">
+								{label}
+							</span>
+						</span>
+						<ChevronDown className="size-3 shrink-0 opacity-40" />
+					</DropdownMenuTrigger>
+					<DropdownMenuContent
+						align="end"
+						sideOffset={4}
+						className="min-w-[10rem]"
+					>
+						{models.map((m) => (
+							<DropdownMenuItem
+								key={m.id}
+								onClick={() => onChange({ modelId: m.id })}
+								className="justify-between gap-2"
+							>
+								<span className="flex min-w-0 items-center gap-2">
+									<ModelIcon model={m} className="size-4" />
+									{m.label}
+								</span>
+								<CheckCircle2
+									className={cn(
+										"size-3.5 shrink-0 text-emerald-500",
+										m.id !== modelId && "invisible",
+									)}
+								/>
+							</DropdownMenuItem>
+						))}
+					</DropdownMenuContent>
+				</DropdownMenu>
+				<DropdownMenu>
+					<DropdownMenuTrigger
+						disabled={!supportsEffort}
+						className={cn(
+							"flex h-8 items-center rounded-lg border border-border/50 bg-muted/30 px-3 text-[13px]",
+							"shrink-0 gap-1.5",
+							supportsEffort
+								? "cursor-pointer text-foreground hover:bg-muted/50"
+								: "cursor-not-allowed text-muted-foreground opacity-60",
+						)}
+					>
+						<span>{effortLabel(displayEffort)}</span>
+						<ChevronDown className="size-3 opacity-40" />
+					</DropdownMenuTrigger>
+					<DropdownMenuContent
+						align="end"
+						sideOffset={4}
+						className="min-w-[8rem]"
+					>
+						{effortLevels.map((l) => (
+							<DropdownMenuItem key={l} onClick={() => onChange({ effort: l })}>
+								{effortLabel(l)}
+							</DropdownMenuItem>
+						))}
+					</DropdownMenuContent>
+				</DropdownMenu>
+				<div
+					className={cn(
+						"flex h-8 cursor-pointer items-center rounded-lg border border-border/50 bg-muted/30 px-3 text-[13px] text-foreground hover:bg-muted/50",
+						"shrink-0 gap-2",
+					)}
+				>
+					<span
+						className={
+							supportsFastMode
+								? "text-[13px] text-foreground"
+								: "text-[13px] text-muted-foreground"
+						}
+					>
+						Fast mode
+					</span>
+					<Switch
+						checked={supportsFastMode && fastMode}
+						disabled={!supportsFastMode}
+						onCheckedChange={(checked) => onChange({ fastMode: checked })}
+						aria-label={`${ariaPrefix} fast mode`}
+					/>
+				</div>
+			</div>
+		</SettingsRow>
+	);
 }
 
 export function SettingsButton({


### PR DESCRIPTION
closes #450 

## Summary

The Settings → Model panel has three rows (Default / Review / PR-MR) that each let the user pick a model, effort level, and fast-mode toggle. Previously Review/PR rows used `null` as a "follow default" sentinel, which coupled their displayed values to the Default row — changing the default silently flipped what Review/PR showed. The effort auto-clamp also only ran on the Default row, so picking a Haiku-style model in Review/PR could leave it stuck on an unsupported `xhigh`.

## What changed

- Extracted the three near-identical row JSX blocks into a single `ModelSettingRow` component (model picker + effort picker + fast-mode switch).
- Each row now reads its own `(modelId, effort, fastMode)` directly and emits a partial patch on change — fully decoupled from the Default row.
- Auto-clamp `useEffect` lives inside `ModelSettingRow`, so it runs for every row, not just Default.
- Added a one-time `useEffect` (gated by a `hasMaterialized` ref) that promotes any legacy `null` Review/PR fields to explicit copies of the current default values when the dialog opens — a no-op migration so existing users don't see their settings reset.

Net diff: **+272 / -443**, mostly removing the duplicated JSX.

## Why

- User-visible bug: changing the Default model used to silently retarget Review/PR rows.
- Effort clamping was inconsistent across rows.
- 1000+ lines of triplicated JSX in `settings/index.tsx` made future tweaks risky.

## Test notes

- Open Settings → Model with stored `null` Review/PR fields → all three rows render with explicit values; toggling Default no longer mutates Review/PR.
- Switch a row to a model that doesn't support the current effort (e.g. Haiku from `xhigh`) → effort clamps to a supported level for that row only.
- Switch to a model without fast-mode support → switch is disabled and shows muted.
- Reopen the dialog after closing → row state is preserved (no re-materialization).