### PR TITLE
feat(composer): editable long-text chips via hover preview

### DIFF
--- a/.changeset/nimble-otters-edit.md
+++ b/.changeset/nimble-otters-edit.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Make long-text chips in the composer editable from their hover preview.

--- a/src/components/inline-badge/index.tsx
+++ b/src/components/inline-badge/index.tsx
@@ -45,6 +45,11 @@ export type InlineBadgeProps = {
 	/** Optional remove action — when set, a trailing X button is rendered. */
 	onRemove?: () => void;
 	removeLabel?: string;
+	/**
+	 * 启用 text-kind preview 的就地编辑。失焦时调用一次，commit 新文本后
+	 * popover 自动关闭。仅当 preview.kind === "text" 时生效，其它类型忽略。
+	 */
+	onEdit?: (nextText: string) => void;
 	/** Extra classes on the outer wrapper. */
 	className?: string;
 	/** Extra classes on the label span. */
@@ -76,6 +81,7 @@ export function InlineBadge({
 	className,
 	labelClassName,
 	nonSelectable = true,
+	onEdit,
 }: InlineBadgeProps) {
 	const [open, setOpen] = useState(false);
 	const [loaderState, setLoaderState] = useState<LoaderState>({
@@ -83,10 +89,31 @@ export function InlineBadge({
 	});
 	const closeTimerRef = useRef<number | null>(null);
 	const hasFetchedRef = useRef(false);
+	// 编辑期间锁住 popover：textarea focus 时设为 true,
+	// 让 hover-leave 不会把正在编辑的卡片关掉
+	const editingRef = useRef(false);
+
+	const editHandlers = useMemo(() => {
+		if (!onEdit) return null;
+		return {
+			onEditFocus: () => {
+				editingRef.current = true;
+				if (closeTimerRef.current !== null) {
+					window.clearTimeout(closeTimerRef.current);
+					closeTimerRef.current = null;
+				}
+			},
+			onEditBlur: (nextText: string) => {
+				editingRef.current = false;
+				onEdit(nextText);
+				setOpen(false);
+			},
+		};
+	}, [onEdit]);
 
 	const syncPreviewContent = useMemo(
-		() => renderInlineBadgePreview(preview ?? null),
-		[preview],
+		() => renderInlineBadgePreview(preview ?? null, editHandlers),
+		[preview, editHandlers],
 	);
 	const hasSyncPreview = syncPreviewContent !== null;
 	const hasAsyncPreview = !preview && typeof previewLoader === "function";
@@ -99,13 +126,20 @@ export function InlineBadge({
 			case "loading":
 				return <PreviewLoadingFrame title={label} />;
 			case "ready":
-				return renderInlineBadgePreview(loaderState.payload);
+				return renderInlineBadgePreview(loaderState.payload, editHandlers);
 			case "error":
 				return <PreviewErrorFrame title={label} />;
 			default:
 				return <PreviewLoadingFrame title={label} />;
 		}
-	}, [hasSyncPreview, syncPreviewContent, hasAsyncPreview, loaderState, label]);
+	}, [
+		hasSyncPreview,
+		syncPreviewContent,
+		hasAsyncPreview,
+		loaderState,
+		label,
+		editHandlers,
+	]);
 
 	const clearCloseTimer = useCallback(() => {
 		if (closeTimerRef.current !== null) {
@@ -132,6 +166,7 @@ export function InlineBadge({
 
 	const scheduleClose = useCallback(() => {
 		if (!canPreview) return;
+		if (editingRef.current) return; // 编辑中不关
 		clearCloseTimer();
 		closeTimerRef.current = window.setTimeout(() => {
 			setOpen(false);

--- a/src/components/inline-badge/preview-renderers.tsx
+++ b/src/components/inline-badge/preview-renderers.tsx
@@ -1,16 +1,18 @@
 import { convertFileSrc } from "@tauri-apps/api/core";
-import type { ReactNode } from "react";
+import { type ReactNode, useEffect, useRef, useState } from "react";
 import { CodeBlock } from "@/components/ai/code-block";
 import type { ComposerPreviewPayload } from "@/lib/composer-insert";
 
 export type { ComposerPreviewPayload } from "@/lib/composer-insert";
 
-type PreviewRenderer<
-	T extends ComposerPreviewPayload = ComposerPreviewPayload,
-> = (payload: T) => ReactNode;
+export type InlineBadgePreviewEditHandlers = {
+	onEditFocus: () => void;
+	onEditBlur: (nextText: string) => void;
+};
 
 const PREVIEW_VIEWPORT_CLASS =
 	"h-[min(60vh,520px)] overflow-y-auto overflow-x-hidden";
+const EDITOR_VIEWPORT_CLASS = "h-[min(60vh,520px)]";
 
 function resolveLocalPreviewSrc(path: string) {
 	try {
@@ -41,57 +43,98 @@ function PreviewFrame({
 	);
 }
 
-const previewRenderers: {
-	[K in ComposerPreviewPayload["kind"]]: PreviewRenderer<
-		Extract<ComposerPreviewPayload, { kind: K }>
-	>;
-} = {
-	image: (payload) => (
+function EditableTextPreview({
+	payload,
+	editHandlers,
+}: {
+	payload: Extract<ComposerPreviewPayload, { kind: "text" }>;
+	editHandlers: InlineBadgePreviewEditHandlers;
+}) {
+	const [draft, setDraft] = useState(payload.text);
+	const draftRef = useRef(draft);
+	draftRef.current = draft;
+
+	// 外部 commit（onBlur 触发 lexical 更新）回流后,把本地 draft 同步成最新值。
+	// 编辑过程中不会触发,因为按键只更新本地 state,不动 lexical。
+	useEffect(() => {
+		setDraft(payload.text);
+	}, [payload.text]);
+
+	return (
 		<PreviewFrame
 			title={payload.title}
-			bodyClassName={`${PREVIEW_VIEWPORT_CLASS} flex items-center justify-center bg-[linear-gradient(180deg,color-mix(in_oklch,var(--sidebar)_85%,black_15%)_0%,var(--popover)_100%)] p-3`}
+			bodyClassName={`${EDITOR_VIEWPORT_CLASS} bg-[linear-gradient(180deg,color-mix(in_oklch,var(--sidebar)_84%,black_16%)_0%,var(--popover)_100%)]`}
 		>
-			<img
-				src={resolveLocalPreviewSrc(payload.path)}
-				alt={payload.title}
-				className="max-h-full max-w-full rounded-md object-contain shadow-sm"
+			<textarea
+				value={draft}
+				onChange={(e) => setDraft(e.target.value)}
+				onFocus={editHandlers.onEditFocus}
+				onBlur={() => editHandlers.onEditBlur(draftRef.current)}
+				// 阻止冒泡到外层 Lexical 编辑器
+				onKeyDown={(e) => e.stopPropagation()}
+				onKeyUp={(e) => e.stopPropagation()}
+				onPointerDown={(e) => e.stopPropagation()}
+				className="block h-full w-full resize-none whitespace-pre-wrap break-words border-0 bg-transparent px-3 py-3 font-mono text-[12px] leading-5 text-foreground/88 outline-none focus:outline-none"
+				spellCheck={false}
 			/>
 		</PreviewFrame>
-	),
-	text: (payload) => (
-		<PreviewFrame
-			title={payload.title}
-			bodyClassName={`${PREVIEW_VIEWPORT_CLASS} bg-[linear-gradient(180deg,color-mix(in_oklch,var(--sidebar)_84%,black_16%)_0%,var(--popover)_100%)] px-3 py-3`}
-		>
-			<pre className="whitespace-pre-wrap break-words font-mono text-[12px] leading-5 text-foreground/88">
-				{payload.text}
-			</pre>
-		</PreviewFrame>
-	),
-	code: (payload) => (
-		<PreviewFrame
-			title={payload.title}
-			bodyClassName={`${PREVIEW_VIEWPORT_CLASS} bg-[linear-gradient(180deg,color-mix(in_oklch,var(--sidebar)_84%,black_16%)_0%,var(--popover)_100%)]`}
-		>
-			<CodeBlock
-				code={payload.code}
-				language={payload.language}
-				wrapLines
-				variant="plain"
-				className="w-full min-w-0"
-			/>
-		</PreviewFrame>
-	),
-};
+	);
+}
 
 /** Render a preview payload. Returns null when payload is null. */
 export function renderInlineBadgePreview(
 	payload: ComposerPreviewPayload | null,
-) {
+	editHandlers?: InlineBadgePreviewEditHandlers | null,
+): ReactNode {
 	if (!payload) {
 		return null;
 	}
-	return previewRenderers[payload.kind](payload as never);
+	switch (payload.kind) {
+		case "image":
+			return (
+				<PreviewFrame
+					title={payload.title}
+					bodyClassName={`${PREVIEW_VIEWPORT_CLASS} flex items-center justify-center bg-[linear-gradient(180deg,color-mix(in_oklch,var(--sidebar)_85%,black_15%)_0%,var(--popover)_100%)] p-3`}
+				>
+					<img
+						src={resolveLocalPreviewSrc(payload.path)}
+						alt={payload.title}
+						className="max-h-full max-w-full rounded-md object-contain shadow-sm"
+					/>
+				</PreviewFrame>
+			);
+		case "text":
+			if (editHandlers) {
+				return (
+					<EditableTextPreview payload={payload} editHandlers={editHandlers} />
+				);
+			}
+			return (
+				<PreviewFrame
+					title={payload.title}
+					bodyClassName={`${PREVIEW_VIEWPORT_CLASS} bg-[linear-gradient(180deg,color-mix(in_oklch,var(--sidebar)_84%,black_16%)_0%,var(--popover)_100%)] px-3 py-3`}
+				>
+					<pre className="whitespace-pre-wrap break-words font-mono text-[12px] leading-5 text-foreground/88">
+						{payload.text}
+					</pre>
+				</PreviewFrame>
+			);
+		case "code":
+			return (
+				<PreviewFrame
+					title={payload.title}
+					bodyClassName={`${PREVIEW_VIEWPORT_CLASS} bg-[linear-gradient(180deg,color-mix(in_oklch,var(--sidebar)_84%,black_16%)_0%,var(--popover)_100%)]`}
+				>
+					<CodeBlock
+						code={payload.code}
+						language={payload.language}
+						wrapLines
+						variant="plain"
+						className="w-full min-w-0"
+					/>
+				</PreviewFrame>
+			);
+	}
 }
 
 /** Placeholder frame used when a lazy preview fails to load. */

--- a/src/features/composer/editor/custom-tag-badge-node.tsx
+++ b/src/features/composer/editor/custom-tag-badge-node.tsx
@@ -14,9 +14,10 @@ import type { ReactNode } from "react";
 import { InlineBadge } from "@/components/inline-badge";
 import { SourceIcon } from "@/features/inbox/source-icon";
 import { STATE_TONE_CLASS } from "@/features/inbox/state-tone";
-import type {
-	ComposerCustomTag,
-	ComposerPreviewPayload,
+import {
+	buildComposerPreviewLabel,
+	type ComposerCustomTag,
+	type ComposerPreviewPayload,
 } from "@/lib/composer-insert";
 import type {
 	ContextCardSource,
@@ -55,6 +56,8 @@ function ComposerCustomTagBadge({
 		/>
 	);
 
+	const isEditableText = customTag.preview?.kind === "text";
+
 	return (
 		<InlineBadge
 			icon={icon}
@@ -67,6 +70,16 @@ function ComposerCustomTagBadge({
 					if ($isCustomTagBadgeNode(node)) node.remove();
 				});
 			}}
+			onEdit={
+				isEditableText
+					? (nextText) => {
+							editor.update(() => {
+								const node = $getNodeByKey(nodeKey);
+								if ($isCustomTagBadgeNode(node)) node.setText(nextText);
+							});
+						}
+					: undefined
+			}
 		/>
 	);
 }
@@ -161,6 +174,22 @@ export class CustomTagBadgeNode extends DecoratorNode<ReactNode> {
 			...(this.__preview ? { preview: this.__preview } : {}),
 			...(this.__source ? { source: this.__source } : {}),
 			...(this.__stateTone ? { stateTone: this.__stateTone } : {}),
+		};
+	}
+
+	// 仅支持 text 类型预览的就地编辑：同步刷新 submitText / label / preview.text
+	setText(nextText: string): void {
+		const current = this.__preview;
+		if (!current || current.kind !== "text") return;
+		if (nextText === this.__submitText) return;
+		const writable = this.getWritable();
+		const nextLabel = buildComposerPreviewLabel(nextText, "text");
+		writable.__submitText = nextText;
+		writable.__label = nextLabel;
+		writable.__preview = {
+			kind: "text",
+			title: nextLabel,
+			text: nextText,
 		};
 	}
 


### PR DESCRIPTION
## Summary

Makes long-text chips in the composer editable directly from their hover preview popover. Previously the popover was read-only, so fixing a typo in a pasted snippet required deleting and re-pasting.

## What changed

- `InlineBadge`: new optional `onEdit?: (nextText: string) => void` prop. When supplied (and the preview is `kind: "text"`), the popover renders an editable `<textarea>` instead of a static `<pre>`. An `editingRef` locks the popover open while the textarea is focused so hover-leave doesn't close it mid-edit.
- `preview-renderers.tsx`: extracted `EditableTextPreview` for the editable variant. The renderer now takes optional `editHandlers`; `image` and `code` kinds are unchanged. Local `draft` state is committed once on blur to avoid touching Lexical on every keystroke.
- `custom-tag-badge-node.tsx`: wires `onEdit` to a new `CustomTagBadgeNode.setText(nextText)` mutator that synchronously refreshes `__submitText`, `__label`, and `__preview.text`. Only `text`-kind tags get the handler; `code` / `image` stay non-editable.
- Adds a patch-level changeset.

## Why

Users frequently paste long pieces of text as chips and then need to tweak them. Round-tripping through delete + re-paste loses any context the chip carries (preview metadata, source) — letting them edit in place is the natural UX.

## Test notes

- [ ] Hover a long-text chip → popover opens → click textarea → type → click outside → chip label and submit text reflect the edit.
- [ ] While the textarea is focused, moving the cursor outside the popover should NOT close it.
- [ ] Code-kind and image-kind chips should remain non-editable (no textarea, no `onEdit` plumbing).
- [ ] Typing in the textarea does not trigger Lexical updates per keystroke (one update on blur).
- [ ] Keyboard events (Enter, arrows, Backspace) inside the textarea do not bubble out to the parent Lexical editor.