### PR TITLE
fix(inspector): show auto-run setup output in empty Setup tab

### DIFF
--- a/.changeset/quiet-pandas-listen.md
+++ b/.changeset/quiet-pandas-listen.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix new workspaces showing an empty Setup tab while the auto-run setup script was actually producing output.

--- a/src/features/inspector/sections/setup.tsx
+++ b/src/features/inspector/sections/setup.tsx
@@ -47,10 +47,29 @@ export function SetupTab({
 	useEffect(() => {
 		if (!workspaceId) return;
 
+		// Only true when attach() ran before any entry existed — i.e. the
+		// auto-run case. Flipped off after the first lazy-mount replay (or
+		// when attach finds an existing entry) so subsequent status changes
+		// don't re-clear and re-write the whole buffer.
+		let needsLazyMount = true;
+
 		const existing = attach(workspaceId, "setup", {
 			onChunk: (data) => termRef.current?.write(data),
 			onStatusChange: (s) => {
 				setStatus(s);
+				if (s !== "idle" && needsLazyMount) {
+					needsLazyMount = false;
+					setHasRun(true);
+					// Replay chunks buffered before TerminalOutput mounted.
+					requestAnimationFrame(() => {
+						const entry = getScriptState(workspaceId, "setup");
+						const t = termRef.current;
+						if (!entry || !t) return;
+						t.clear();
+						if (entry.truncated) t.write(TRUNCATION_NOTICE);
+						for (const chunk of entry.chunks) t.write(chunk);
+					});
+				}
 				if (s === "exited") {
 					const state = getScriptState(workspaceId, "setup");
 					if (state?.exitCode === 0) {
@@ -63,6 +82,7 @@ export function SetupTab({
 		});
 
 		if (existing) {
+			needsLazyMount = false;
 			setHasRun(true);
 			setStatus(existing.status);
 			const replay = () => {


### PR DESCRIPTION
## Summary

Fixes #451 — new workspaces sometimes showed an empty Setup tab even though the auto-run setup script was producing output. The terminal was attaching after the script had already started, so the buffered chunks never made it onto the screen.

## What changed

`SetupTab` now tracks a `needsLazyMount` flag inside its `attach()` effect:

- If `attach()` runs before any script entry exists (the auto-run case), the first non-`idle` status change flips `hasRun` to true, mounts the terminal, and replays the chunks already buffered in `getScriptState`.
- The flag flips off after the first replay (and immediately when `attach()` finds an existing entry), so later status transitions don't re-clear the terminal or re-write the whole buffer.

## Why

Previously the lazy mount only happened when `attach()` returned an existing entry. For brand-new workspaces the entry is created *by* the auto-run, so the `existing` branch was missed and the buffered output was silently dropped until the user manually re-ran setup.

## Test notes

- [ ] Open a new workspace that auto-runs a setup script and confirm the Setup tab shows live output from the start.
- [ ] Re-open an existing workspace whose setup already finished — output should still replay correctly without flicker.
- [ ] Toggle between tabs while setup is running; the Setup terminal should keep its buffer intact.