### PR TITLE
fix: keep context-usage ring stable when switching active model

### DIFF
--- a/.changeset/steady-context-ring.md
+++ b/.changeset/steady-context-ring.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix the context-usage ring resetting to zero when switching the active model.

--- a/.codex/skills/helmor-release/SKILL.md
+++ b/.codex/skills/helmor-release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: helmor-release
-description: Prepare Helmor releases by inspecting the current branch, drafting a concise user-facing Changesets entry first (bump + body — a single sentence when one fits, or summary line + bullets when there are multiple distinct changes), writing it to `.changeset/`, and then showing the user the result with a short menu of adjustments they can pick from. Use when the user wants to cut a release, write a changeset, decide patch/minor/major, draft GitHub release notes, or summarize branch changes into release-ready language.
+description: Prepare Helmor releases by inspecting the current branch, drafting a concise user-facing Changesets entry first (bump + body — keep it as short as possible: a single sentence by default, summary + bullets only when there are multiple distinct user-visible items), writing it to `.changeset/`, and then showing the user the result with a short menu of adjustments they can pick from. Use when the user wants to cut a release, write a changeset, decide patch/minor/major, draft GitHub release notes, or summarize branch changes into release-ready language.
 ---
 
 # Helmor Release
@@ -21,7 +21,7 @@ Use this skill to turn a branch's real changes into a clean `.changeset/*.md` en
 
    Prefer a conservative bump (`patch` unless there is a clear new user-visible capability). If you genuinely cannot decide the bump from the diff alone, default to `patch` and flag it in the confirmation step.
 
-   **Brevity bias.** Do not pad. If the change is "fix X" or "give Y more room", a single sentence is the right answer — do not invent bullets to fill a template. Reserve the summary+bullets shape for releases that genuinely have ≥2 distinct user-visible items worth enumerating.
+   **Brevity bias.** Aim for the shortest sentence that names the user-visible change — if a clause can be dropped without losing meaning, drop it. Reserve summary+bullets for releases with ≥2 distinct user-visible items.
 4. Write the changeset to a single file under `.changeset/` right away. Do not wait for approval before creating the file — the user will adjust from a real draft, not a hypothetical one.
 5. Then, and only then, show the user what you created and offer the adjustment menu described in "Confirmation Style".
 
@@ -41,7 +41,7 @@ Example (Shape A — single sentence):
 I've written .changeset/brave-otters-smile.md:
 
   bump: patch
-  body: Give sidebar workspace titles the full row width at rest, and overlay archive/restore/delete buttons on hover with the title fading out beneath them.
+  body: Fix the context-usage ring resetting to zero when switching the active model.
 
 If you want to adjust anything, tell me which:
   1. Version bump (currently: patch — say "make it minor" / "make it major")
@@ -102,7 +102,7 @@ Do not:
 
 The body has **two allowed shapes**. Pick the smallest one that fits.
 
-**Shape A — single sentence.** Use this when one self-contained sentence captures the entire user-visible change. This is the default for most patch-level fixes and small polish PRs.
+**Shape A — single sentence.** Use this when one self-contained sentence captures the entire user-visible change. This is the default for most patch-level fixes and small polish PRs. Keep it as short as possible.
 
 **Shape B — summary line + bullets.** Use this only when there are ≥2 distinct user-visible changes worth enumerating. The first line is a prose summary (usually ending with `:`); each concrete change is a `- ` sub-item underneath.
 

--- a/src-tauri/src/agents/streaming/context_usage.rs
+++ b/src-tauri/src/agents/streaming/context_usage.rs
@@ -45,6 +45,15 @@ pub(super) fn write_context_usage_meta(
     Ok(ContextUsageWriteOutcome::Wrote(session_id.to_string()))
 }
 
+/// Frontend-driven write: persist a verified meta blob (e.g. from a
+/// trustworthy hover-time live fetch) and broadcast the same
+/// `ContextUsageChanged` event the sidecar path uses, so observers in
+/// other windows refresh without us touching their query cache directly.
+pub(crate) fn persist_context_usage_meta(app: &AppHandle, session_id: &str, meta: &str) {
+    let raw = serde_json::json!({ "sessionId": session_id, "meta": meta });
+    persist_context_usage_event(app, &raw);
+}
+
 /// Persist a `contextUsageUpdated` event and broadcast `ContextUsageChanged`.
 /// Payload-free — the frontend refetches via React Query on invalidation.
 pub(super) fn persist_context_usage_event(app: &AppHandle, raw: &Value) {

--- a/src-tauri/src/agents/streaming/mod.rs
+++ b/src-tauri/src/agents/streaming/mod.rs
@@ -15,7 +15,7 @@ mod active_streams;
 mod bridges;
 mod cleanup;
 pub(crate) mod codex_goal;
-mod context_usage;
+pub(crate) mod context_usage;
 mod params;
 mod session_id;
 mod state;

--- a/src-tauri/src/commands/session_commands.rs
+++ b/src-tauri/src/commands/session_commands.rs
@@ -81,6 +81,27 @@ pub async fn get_session_context_usage(session_id: String) -> CmdResult<Option<S
     run_blocking(move || sessions::get_session_context_usage(&session_id)).await
 }
 
+/// Frontend-initiated write of `context_usage_meta`. Used when a
+/// trustworthy Claude hover fetch returns fresher numbers than the
+/// last persisted turn-end record — promotes them into the DB so the
+/// ring stays accurate across cold starts.
+#[tauri::command]
+pub async fn set_session_context_usage(
+    app: tauri::AppHandle,
+    session_id: String,
+    meta: String,
+) -> CmdResult<()> {
+    run_blocking(move || {
+        crate::agents::streaming::context_usage::persist_context_usage_meta(
+            &app,
+            &session_id,
+            &meta,
+        );
+        Ok(())
+    })
+    .await
+}
+
 #[tauri::command]
 pub async fn get_session_codex_goal(session_id: String) -> CmdResult<Option<String>> {
     run_blocking(move || sessions::get_session_codex_goal(&session_id)).await

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -303,6 +303,7 @@ pub fn run() {
             commands::session_commands::delete_session,
             commands::session_commands::list_hidden_sessions,
             commands::session_commands::get_session_context_usage,
+            commands::session_commands::set_session_context_usage,
             commands::session_commands::get_session_codex_goal,
             commands::session_commands::mutate_codex_goal,
             commands::session_commands::list_session_drafts,

--- a/src/features/composer/context-usage-ring/index.test.tsx
+++ b/src/features/composer/context-usage-ring/index.test.tsx
@@ -11,6 +11,7 @@ import { useUiSyncBridge } from "@/shell/hooks/use-ui-sync-bridge";
 const apiMockState = vi.hoisted(() => ({
 	getSessionContextUsage: vi.fn(),
 	getLiveContextUsage: vi.fn(),
+	setSessionContextUsage: vi.fn(),
 	subscribeUiMutations: vi.fn(),
 	unlistenUiMutations: vi.fn(),
 	capturedCallback: null as null | ((event: unknown) => void),
@@ -22,6 +23,7 @@ vi.mock("@/lib/api", async () => {
 		...actual,
 		getSessionContextUsage: apiMockState.getSessionContextUsage,
 		getLiveContextUsage: apiMockState.getLiveContextUsage,
+		setSessionContextUsage: apiMockState.setSessionContextUsage,
 		subscribeUiMutations: apiMockState.subscribeUiMutations,
 	};
 });
@@ -69,6 +71,8 @@ describe("ContextUsageRing end-to-end with UI sync bridge", () => {
 	beforeEach(() => {
 		apiMockState.getSessionContextUsage.mockReset();
 		apiMockState.getLiveContextUsage.mockReset();
+		apiMockState.setSessionContextUsage.mockReset();
+		apiMockState.setSessionContextUsage.mockResolvedValue(undefined);
 		apiMockState.subscribeUiMutations.mockReset();
 		apiMockState.unlistenUiMutations.mockReset();
 		apiMockState.capturedCallback = null;
@@ -159,7 +163,9 @@ describe("ContextUsageRing end-to-end with UI sync bridge", () => {
 		expect(apiMockState.getSessionContextUsage).toHaveBeenCalledTimes(1);
 	});
 
-	it("degrades to tokensOnly aria-label when composer's model differs from the recorded one", async () => {
+	it("keeps showing the recorded percentage when composer's model differs from the recorded one", async () => {
+		// Switching the composer's model in-place must not blank the ring —
+		// the last recorded usage stays visible until the next turn refreshes it.
 		apiMockState.getSessionContextUsage.mockResolvedValue(
 			JSON.stringify({
 				modelId: "gpt-5.4",
@@ -169,14 +175,13 @@ describe("ContextUsageRing end-to-end with UI sync bridge", () => {
 			}),
 		);
 
-		const { findByRole, queryByRole } = render(
+		const { findByRole } = render(
 			<Harness
 				sessionId="session-mismatch"
 				composerModelId="gpt-5.5-preview"
 			/>,
 		);
 
-		await findByRole("button", { name: "Context usage" });
-		expect(queryByRole("button", { name: /2%/i })).toBeNull();
+		await findByRole("button", { name: /context usage 2%/i });
 	});
 });

--- a/src/features/composer/context-usage-ring/index.tsx
+++ b/src/features/composer/context-usage-ring/index.tsx
@@ -1,10 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
 	HoverCard,
 	HoverCardContent,
 	HoverCardTrigger,
 } from "@/components/ui/hover-card";
+import { setSessionContextUsage } from "@/lib/api";
 import {
 	claudeRichContextUsageQueryOptions,
 	sessionContextUsageQueryOptions,
@@ -12,6 +13,7 @@ import {
 import { CONTEXT_USAGE_AUTO_REVEAL_THRESHOLD } from "@/lib/settings";
 import { cn } from "@/lib/utils";
 import {
+	isTrustedRich,
 	parseClaudeRichMeta,
 	parseStoredMeta,
 	resolveContextUsageDisplay,
@@ -28,7 +30,7 @@ type Props = {
 	cwd: string | null;
 	/** Only Claude supports the rich hover breakdown. */
 	agentType: "claude" | "codex" | "cursor" | null;
-	/** Composer's current model id; used for rich fetches and stale checks. */
+	/** Composer's current model id; used as the rich-fetch cache key. */
 	composerModelId: string | null;
 	alwaysShow: boolean;
 	disabled?: boolean;
@@ -78,9 +80,34 @@ export function ContextUsageRing({
 	const rich = useMemo(() => parseClaudeRichMeta(richJson), [richJson]);
 
 	const display = useMemo(
-		() => resolveContextUsageDisplay(baseline, rich, composerModelId),
-		[baseline, rich, composerModelId],
+		() => resolveContextUsageDisplay(baseline, rich),
+		[baseline, rich],
 	);
+
+	// Promote a trustworthy rich fetch back to the DB so cold starts
+	// see the freshest numbers. The backend broadcasts
+	// `ContextUsageChanged`, which invalidates the baseline query and
+	// brings everyone in sync. Skip when baseline already matches.
+	useEffect(() => {
+		if (!isTrustedRich(rich)) return;
+		if (
+			baseline &&
+			baseline.modelId === rich.modelId &&
+			baseline.usedTokens === rich.usedTokens &&
+			baseline.maxTokens === rich.maxTokens
+		) {
+			return;
+		}
+		void setSessionContextUsage(
+			sessionId,
+			JSON.stringify({
+				modelId: rich.modelId,
+				usedTokens: rich.usedTokens,
+				maxTokens: rich.maxTokens,
+				percentage: rich.percentage,
+			}),
+		);
+	}, [rich, baseline, sessionId]);
 
 	const visible =
 		alwaysShow ||

--- a/src/features/composer/context-usage-ring/parse.test.ts
+++ b/src/features/composer/context-usage-ring/parse.test.ts
@@ -109,13 +109,13 @@ describe("resolveContextUsageDisplay", () => {
 	};
 
 	it("returns `empty` when baseline + rich are both null", () => {
-		expect(resolveContextUsageDisplay(null, null, CLAUDE_MODEL)).toEqual({
+		expect(resolveContextUsageDisplay(null, null)).toEqual({
 			kind: "empty",
 		});
 	});
 
-	it("returns `full` when baseline model matches composer", () => {
-		const res = resolveContextUsageDisplay(baselineClaude, null, CLAUDE_MODEL);
+	it("returns `full` from the baseline record", () => {
+		const res = resolveContextUsageDisplay(baselineClaude, null);
 		expect(res).toEqual({
 			kind: "full",
 			modelId: CLAUDE_MODEL,
@@ -127,40 +127,16 @@ describe("resolveContextUsageDisplay", () => {
 		});
 	});
 
-	it("returns `tokensOnly` when composer switched to a different model", () => {
-		const res = resolveContextUsageDisplay(
-			baselineClaude,
-			null,
-			"claude-sonnet-4-5",
-		);
-		expect(res).toEqual({
-			kind: "tokensOnly",
-			recordedModelId: CLAUDE_MODEL,
-			usedTokens: 50_000,
-		});
-	});
-
-	it("treats null composerModelId as match (avoids flash of tokensOnly during mount)", () => {
-		const res = resolveContextUsageDisplay(baselineClaude, null, null);
+	it("keeps showing the recorded usage even after the composer switched models", () => {
+		// Composer model ≠ recorded model is no longer treated as a mismatch:
+		// the ring keeps the last-known % until the next turn refreshes it.
+		const res = resolveContextUsageDisplay(baselineClaude, null);
 		expect(res.kind).toBe("full");
+		if (res.kind !== "full") throw new Error("unreachable");
+		expect(res.percentage).toBe(25);
 	});
 
-	it("legacy baseline (empty modelId) degrades to tokensOnly when composer has a model", () => {
-		const legacy: StoredContextUsageMeta = {
-			modelId: "",
-			usedTokens: 10_000,
-			maxTokens: 200_000,
-			percentage: 5,
-		};
-		const res = resolveContextUsageDisplay(legacy, null, CLAUDE_MODEL);
-		expect(res).toEqual({
-			kind: "tokensOnly",
-			recordedModelId: "",
-			usedTokens: 10_000,
-		});
-	});
-
-	it("rich overrides baseline values when both present and model matches", () => {
+	it("trusted rich (non-zero used/max) drives the ring", () => {
 		const rich: ClaudeRichContextUsage = {
 			modelId: CLAUDE_MODEL,
 			usedTokens: 60_000,
@@ -169,7 +145,7 @@ describe("resolveContextUsageDisplay", () => {
 			isAutoCompactEnabled: true,
 			categories: [{ name: "Messages", tokens: 60_000 }],
 		};
-		const res = resolveContextUsageDisplay(baselineClaude, rich, CLAUDE_MODEL);
+		const res = resolveContextUsageDisplay(baselineClaude, rich);
 		expect(res.kind).toBe("full");
 		if (res.kind !== "full") throw new Error("unreachable");
 		expect(res.usedTokens).toBe(60_000);
@@ -177,12 +153,61 @@ describe("resolveContextUsageDisplay", () => {
 		expect(res.rich).toBe(rich);
 	});
 
+	it("zeroed rich is rejected; baseline keeps the ring intact", () => {
+		// Hover-time live fetch can come back with zeroed totals (e.g.
+		// resume against a stale provider session id after a model
+		// switch). Letting it through would visually blank the ring.
+		const rich: ClaudeRichContextUsage = {
+			modelId: "claude-sonnet-4-5",
+			usedTokens: 0,
+			maxTokens: 0,
+			percentage: 0,
+			isAutoCompactEnabled: false,
+			categories: [],
+		};
+		const res = resolveContextUsageDisplay(baselineClaude, rich);
+		expect(res.kind).toBe("full");
+		if (res.kind !== "full") throw new Error("unreachable");
+		expect(res.usedTokens).toBe(50_000);
+		expect(res.percentage).toBe(25);
+		// Rich is still attached so the popover can render whatever
+		// non-zero categories it carried (here: none).
+		expect(res.rich).toBe(rich);
+	});
+
+	it("trusted rich is enough on its own when baseline is missing", () => {
+		const rich: ClaudeRichContextUsage = {
+			modelId: CLAUDE_MODEL,
+			usedTokens: 60_000,
+			maxTokens: 200_000,
+			percentage: 30,
+			isAutoCompactEnabled: true,
+			categories: [{ name: "Messages", tokens: 60_000 }],
+		};
+		const res = resolveContextUsageDisplay(null, rich);
+		expect(res.kind).toBe("full");
+		if (res.kind !== "full") throw new Error("unreachable");
+		expect(res.percentage).toBe(30);
+	});
+
+	it("returns `empty` when baseline is null and rich is zeroed", () => {
+		const rich: ClaudeRichContextUsage = {
+			modelId: CLAUDE_MODEL,
+			usedTokens: 0,
+			maxTokens: 0,
+			percentage: 0,
+			isAutoCompactEnabled: false,
+			categories: [],
+		};
+		expect(resolveContextUsageDisplay(null, rich)).toEqual({ kind: "empty" });
+	});
+
 	it("computes ring tier from percentage", () => {
 		const near: StoredContextUsageMeta = {
 			...baselineClaude,
 			percentage: 85,
 		};
-		const res = resolveContextUsageDisplay(near, null, CLAUDE_MODEL);
+		const res = resolveContextUsageDisplay(near, null);
 		if (res.kind !== "full") throw new Error("unreachable");
 		expect(res.tier).toBe("danger");
 	});

--- a/src/features/composer/context-usage-ring/parse.ts
+++ b/src/features/composer/context-usage-ring/parse.ts
@@ -1,5 +1,6 @@
 // Display-ready parsing for context usage and per-provider rate limits.
-// Percentages are only trusted when the stored model matches the composer.
+// The ring shows whatever was recorded at the last turn end — switching the
+// composer model in-place does not invalidate it; the next turn refreshes it.
 
 /** Baseline: written at turn end by both Claude and Codex. */
 export type StoredContextUsageMeta = {
@@ -28,11 +29,6 @@ export function ringTier(percentage: number): RingTier {
 export type DisplayResolution =
 	| { readonly kind: "empty" }
 	| {
-			readonly kind: "tokensOnly";
-			readonly recordedModelId: string;
-			readonly usedTokens: number;
-	  }
-	| {
 			readonly kind: "full";
 			readonly modelId: string;
 			readonly usedTokens: number;
@@ -42,24 +38,17 @@ export type DisplayResolution =
 			readonly rich: ClaudeRichContextUsage | null;
 	  };
 
-/** Rich overrides baseline; model mismatches degrade to tokens-only. */
+/** Rich (hover-time live fetch) drives the ring when it carries
+ *  trustworthy numbers — that's the freshest read available. Otherwise
+ *  fall back to the baseline DB record. Zeroed rich payloads (e.g. a
+ *  resume against a stale provider session id right after a model
+ *  switch) are rejected so they can't blank the ring. */
 export function resolveContextUsageDisplay(
 	baseline: StoredContextUsageMeta | null,
 	rich: ClaudeRichContextUsage | null,
-	composerModelId: string | null,
 ): DisplayResolution {
-	const effective = rich ?? baseline;
+	const effective = isTrustedRich(rich) ? rich : baseline;
 	if (!effective) return { kind: "empty" };
-
-	const matches =
-		composerModelId === null || effective.modelId === composerModelId;
-	if (!matches) {
-		return {
-			kind: "tokensOnly",
-			recordedModelId: effective.modelId,
-			usedTokens: effective.usedTokens,
-		};
-	}
 
 	return {
 		kind: "full",
@@ -70,6 +59,14 @@ export function resolveContextUsageDisplay(
 		tier: ringTier(effective.percentage),
 		rich,
 	};
+}
+
+/** A rich payload is trusted when it has non-zero used/max — anything
+ *  else is treated as "the live fetch came back without real data". */
+export function isTrustedRich(
+	rich: ClaudeRichContextUsage | null,
+): rich is ClaudeRichContextUsage {
+	return rich !== null && rich.usedTokens > 0 && rich.maxTokens > 0;
 }
 
 // ── JSON parsers ───────────────────────────────────────────────────────

--- a/src/features/composer/context-usage-ring/popover-parts.tsx
+++ b/src/features/composer/context-usage-ring/popover-parts.tsx
@@ -36,18 +36,6 @@ export function UsageHeader({
 	);
 }
 
-/** Header for token counts without a trusted window size. */
-export function TokensOnlyHeader({ usedTokens }: { usedTokens: number }) {
-	return (
-		<div className="flex items-center justify-between">
-			<div className="text-[14px] font-semibold text-foreground">Context</div>
-			<div className="text-[12px] tabular-nums text-muted-foreground">
-				Used <span className="text-foreground">{formatTokens(usedTokens)}</span>
-			</div>
-		</div>
-	);
-}
-
 /** Compact percentage: 1 decimal under 10%, integer above. Strips ".0". */
 function formatPercentage(value: number): string {
 	if (!Number.isFinite(value) || value <= 0) return "0%";

--- a/src/features/composer/context-usage-ring/popover.tsx
+++ b/src/features/composer/context-usage-ring/popover.tsx
@@ -3,7 +3,6 @@ import type { DisplayResolution } from "./parse";
 import {
 	AutoCompactNote,
 	CategoryList,
-	TokensOnlyHeader,
 	UsageBar,
 	UsageHeader,
 } from "./popover-parts";
@@ -26,9 +25,7 @@ export function ContextUsagePopoverContent({
 
 	return (
 		<div className="flex flex-col gap-3 px-1 py-1">
-			{display.kind === "tokensOnly" ? (
-				<TokensOnlyHeader usedTokens={display.usedTokens} />
-			) : display.kind === "full" ? (
+			{display.kind === "full" ? (
 				<>
 					<UsageHeader
 						used={display.usedTokens}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2702,6 +2702,17 @@ export async function getSessionContextUsage(
 	});
 }
 
+/** Frontend-driven write of `context_usage_meta`. Used after a
+ *  trustworthy Claude hover-time live fetch so the persisted baseline
+ *  catches up without waiting for the next turn end. The backend
+ *  broadcasts `ContextUsageChanged`, so other observers refresh too. */
+export async function setSessionContextUsage(
+	sessionId: string,
+	meta: string,
+): Promise<void> {
+	await invoke<void>("set_session_context_usage", { sessionId, meta });
+}
+
 /** Active Codex `/goal` payload as JSON. Null when no goal is set. */
 export type CodexGoalState = {
 	threadId: string;


### PR DESCRIPTION
## Summary

- The composer's context-usage ring used to blank out (or fall back to a tokens-only label) the moment you switched the active model in-place — even though the previously recorded usage was still the most accurate reading we had. This PR removes that mismatch check so the ring keeps showing the last recorded percentage until the next turn refreshes it.
- Trustworthy hover-time live fetches (non-zero `usedTokens` / `maxTokens`) are now promoted back to the DB via a new `set_session_context_usage` Tauri command, which broadcasts `ContextUsageChanged` so other observers stay in sync. Zeroed rich payloads (e.g. a resume against a stale provider session id right after a model switch) are explicitly rejected so they can't visually blank the ring.
- Drops the now-unused `tokensOnly` display branch and the `TokensOnlyHeader` popover part; `resolveContextUsageDisplay` no longer takes `composerModelId`.

## Why

Switching models mid-session repeatedly triggered a "ring resets to 0%" flash, which made the indicator look broken to the user. The recorded percentage from the previous turn is still meaningful — the next turn end will update it anyway — so showing it is strictly better than blanking it.

## Notes

- Changeset added: `.changeset/steady-context-ring.md` (patch).
- Minor wording tweak to `.codex/skills/helmor-release/SKILL.md` (brevity bias for changeset entries).

## Test plan

- [ ] `bun run test:frontend` (parse + ring tests rewritten for the new behavior)
- [ ] `bun run test:rust`
- [ ] Manual: open a Claude session, switch model in composer, confirm the ring keeps the previous %; hover the ring and confirm a fresh fetch promotes back to the DB (verify by reloading and checking the cold-start value).