### PR TITLE
refactor(settings): widen "Get your API key" button and hide once a key is entered

### DIFF
--- a/.changeset/clever-keys-guide.md
+++ b/.changeset/clever-keys-guide.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Make the "Get your API key" button next to Cursor and Claude Code custom-provider key fields wider with a clearer label, and hide it once a key has been entered.

--- a/src/features/onboarding/components/cursor-api-key-action.tsx
+++ b/src/features/onboarding/components/cursor-api-key-action.tsx
@@ -4,12 +4,6 @@ import { ExternalLink, LoaderCircle } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipProvider,
-	TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { pickDefaultCursorModelIds } from "@/features/settings/panels/cursor-models";
 import { type CursorModelEntry, listCursorModels } from "@/lib/api";
 import {
@@ -116,34 +110,29 @@ export function CursorApiKeyAction({
 				disabled={isValidating}
 				className="h-8 w-[180px] border-border/50 bg-muted/20 text-[12px]"
 			/>
-			<TooltipProvider>
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<Button
-							type="button"
-							variant="outline"
-							size="icon-sm"
-							aria-label={
-								isValidating ? "Validating API key" : "Get Cursor API key"
-							}
-							disabled={isValidating}
-							onClick={() => {
-								if (isValidating) return;
-								void openUrl(CURSOR_DASHBOARD_URL);
-							}}
-						>
-							{isValidating ? (
-								<LoaderCircle className="size-3.5 animate-spin" />
-							) : (
-								<ExternalLink className="size-3.5" />
-							)}
-						</Button>
-					</TooltipTrigger>
-					<TooltipContent>
-						{isValidating ? "Validating…" : "Get API key"}
-					</TooltipContent>
-				</Tooltip>
-			</TooltipProvider>
+			{isValidating ? (
+				<Button
+					type="button"
+					variant="outline"
+					size="sm"
+					aria-label="Validating API key"
+					disabled
+				>
+					<LoaderCircle className="size-3.5 animate-spin" />
+					Validating…
+				</Button>
+			) : !draft ? (
+				<Button
+					type="button"
+					variant="outline"
+					size="sm"
+					aria-label="Get Cursor API key"
+					onClick={() => void openUrl(CURSOR_DASHBOARD_URL)}
+				>
+					<ExternalLink className="size-3.5" />
+					Get your API key
+				</Button>
+			) : null}
 		</div>
 	);
 }

--- a/src/features/settings/panels/cursor-provider.tsx
+++ b/src/features/settings/panels/cursor-provider.tsx
@@ -146,22 +146,18 @@ export function CursorProviderPanel() {
 						placeholder="Cursor API key"
 						className="h-8 min-w-0 flex-1 border-border/50 bg-muted/20 text-[13px]"
 					/>
-					<TooltipProvider>
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<Button
-									type="button"
-									variant="outline"
-									size="icon-sm"
-									aria-label="Get Cursor API key"
-									onClick={() => void openUrl(CURSOR_DASHBOARD_URL)}
-								>
-									<ExternalLink className="size-3.5" />
-								</Button>
-							</TooltipTrigger>
-							<TooltipContent>Get API key</TooltipContent>
-						</Tooltip>
-					</TooltipProvider>
+					{!keyDraft && (
+						<Button
+							type="button"
+							variant="outline"
+							size="sm"
+							aria-label="Get Cursor API key"
+							onClick={() => void openUrl(CURSOR_DASHBOARD_URL)}
+						>
+							<ExternalLink className="size-3.5" />
+							Get your API key
+						</Button>
+					)}
 				</div>
 			</SettingsRow>
 

--- a/src/features/settings/panels/model-providers.tsx
+++ b/src/features/settings/panels/model-providers.tsx
@@ -26,12 +26,6 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipProvider,
-	TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { helmorQueryKeys } from "@/lib/query-client";
 import type { ClaudeCustomProviderSettings } from "@/lib/settings";
 import { useSettings } from "@/lib/settings";
@@ -156,22 +150,18 @@ export function ClaudeCustomProvidersPanel() {
 								placeholder={`${builtinProvider.label} API key`}
 								className="h-8 min-w-0 flex-1 border-border/50 bg-muted/20 text-[13px]"
 							/>
-							<TooltipProvider>
-								<Tooltip>
-									<TooltipTrigger asChild>
-										<Button
-											type="button"
-											variant="outline"
-											size="icon-sm"
-											aria-label={`Get ${builtinProvider.label} API key`}
-											onClick={() => void openUrl(builtinProvider.apiKeyUrl)}
-										>
-											<ExternalLink className="size-3.5" />
-										</Button>
-									</TooltipTrigger>
-									<TooltipContent>Get API key</TooltipContent>
-								</Tooltip>
-							</TooltipProvider>
+							{!draft.apiKey && (
+								<Button
+									type="button"
+									variant="outline"
+									size="sm"
+									aria-label={`Get ${builtinProvider.label} API key`}
+									onClick={() => void openUrl(builtinProvider.apiKeyUrl)}
+								>
+									<ExternalLink className="size-3.5" />
+									Get your API key
+								</Button>
+							)}
 						</div>
 					) : (
 						<div className="grid gap-2">


### PR DESCRIPTION
## Summary
- Replaces the icon-only "Get API key" button (with tooltip) next to the Cursor and Claude Code custom-provider key inputs with a wider button labeled **"Get your API key"**, so the affordance is obvious without hover.
- Hides the button once a key has been entered/typed, so it stops competing with the input once it's no longer useful.
- Drops the now-unused `Tooltip*` imports in the touched files.

## Why
The icon-only entry point was easy to miss for first-time users setting up Cursor / Claude custom providers — the tooltip required hover, and on small key-row layouts the button blended in with surrounding controls. Giving it an explicit label and removing it from the layout once the user has supplied a key makes the onboarding step clearer and tidier.

## Test notes
- Manual: open Settings -> Model Providers (Cursor + Claude custom providers) and the onboarding Cursor step. Verify the button shows "Get your API key", clicking opens the dashboard URL, typing a key hides the button, and the validating state in onboarding shows a "Validating…" disabled button.
- No backend / pipeline changes; existing snapshots and unit tests should be unaffected.