### PR TITLE
fix(inspector): persist workspace setup completion across restarts

### DIFF
--- a/.changeset/bright-sparrows-remember.md
+++ b/.changeset/bright-sparrows-remember.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Persist when a workspace's setup script has finished so the Setup tab no longer treats it as never run after restarting Helmor.

--- a/src-tauri/src/commands/script_commands.rs
+++ b/src-tauri/src/commands/script_commands.rs
@@ -90,11 +90,7 @@ pub async fn execute_repo_script(
             Ok(Some(0)) if script_type == "setup" => {
                 if let Some(ws_id) = &workspace_id {
                     if let Ok(ts) = crate::models::db::current_timestamp() {
-                        let _ = crate::models::workspaces::update_workspace_state(
-                            ws_id,
-                            crate::workspace_state::WorkspaceState::Ready,
-                            &ts,
-                        );
+                        let _ = crate::models::workspaces::mark_setup_completed(ws_id, &ts);
                     }
                     crate::git::watcher::notify_workspace_changed(&app);
                 }

--- a/src-tauri/src/models/workspaces.rs
+++ b/src-tauri/src/models/workspaces.rs
@@ -57,6 +57,10 @@ pub struct WorkspaceRecord {
     /// Most recent `last_user_message_at` across all sessions in the
     /// workspace. `None` for workspaces with no user messages yet.
     pub last_user_message_at: Option<String>,
+    /// Timestamp of the last successful setup-script run for this
+    /// workspace. `None` means setup was never run (or was skipped
+    /// because the repo has no setup script).
+    pub setup_completed_at: Option<String>,
 }
 
 pub const WORKSPACE_RECORD_SQL: &str = r#"
@@ -160,7 +164,8 @@ pub const WORKSPACE_RECORD_SQL: &str = r#"
       r.forge_login,
       w.created_at,
       w.updated_at,
-      wss.last_user_message_at
+      wss.last_user_message_at,
+      w.setup_completed_at
     FROM workspaces w
     JOIN repos r ON r.id = w.repository_id
     LEFT JOIN sessions s ON s.id = w.active_session_id
@@ -371,6 +376,27 @@ pub(crate) fn update_workspace_state(
     Ok(())
 }
 
+/// Stamp the workspace as having successfully run its setup script and
+/// flip it to `ready`. Distinct from `update_workspace_state` so the
+/// "skipped setup (no script)" path can stay timestamp-less — that's
+/// what lets the inspector tell apart "ran in another session" vs
+/// "never ran" after a restart.
+pub(crate) fn mark_setup_completed(workspace_id: &str, timestamp: &str) -> Result<()> {
+    let connection = db::write_conn()?;
+    let updated_rows = connection
+        .execute(
+            "UPDATE workspaces SET state = ?2, setup_completed_at = ?3, updated_at = ?3 WHERE id = ?1",
+            (workspace_id, WorkspaceState::Ready, timestamp),
+        )
+        .context("Failed to mark workspace setup completed")?;
+
+    if updated_rows != 1 {
+        bail!("Setup-completion update affected {updated_rows} rows for {workspace_id}");
+    }
+
+    Ok(())
+}
+
 pub(crate) fn delete_workspace_and_session_rows(workspace_id: &str) -> Result<()> {
     let mut connection = db::write_conn()?;
     let transaction = connection
@@ -545,5 +571,6 @@ fn workspace_record_from_row(row: &Row<'_>) -> rusqlite::Result<WorkspaceRecord>
         created_at: row.get(33)?,
         updated_at: row.get(34)?,
         last_user_message_at: row.get(35)?,
+        setup_completed_at: row.get(36)?,
     })
 }

--- a/src-tauri/src/schema.rs
+++ b/src-tauri/src/schema.rs
@@ -563,6 +563,20 @@ fn run_migrations(connection: &Connection) -> Result<()> {
             .context("Failed to add workspaces.mode column")?;
     }
 
+    // Tracks the last successful run of the repo's setup script for this
+    // workspace. NULL means "never ran" (or the workspace was created
+    // before this column existed) — distinct from "ran but output got
+    // dropped at restart". The Setup inspector tab uses this to show a
+    // "ran in another session" notice instead of the default
+    // never-run placeholder.
+    if has_table(connection, "workspaces")
+        && !has_column(connection, "workspaces", "setup_completed_at")
+    {
+        connection
+            .execute_batch("ALTER TABLE workspaces ADD COLUMN setup_completed_at TEXT")
+            .context("Failed to add workspaces.setup_completed_at column")?;
+    }
+
     Ok(())
 }
 
@@ -630,6 +644,7 @@ CREATE TABLE IF NOT EXISTS workspaces (
     archive_commit TEXT,
     linked_directory_paths TEXT,
     mode TEXT DEFAULT 'worktree',
+    setup_completed_at TEXT,
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );

--- a/src-tauri/src/workspace/helpers.rs
+++ b/src-tauri/src/workspace/helpers.rs
@@ -819,6 +819,7 @@ mod tests {
             created_at: "2026-01-01T00:00:00Z".to_string(),
             updated_at: "2026-01-01T00:00:00Z".to_string(),
             last_user_message_at: None,
+            setup_completed_at: None,
         }
     }
 

--- a/src-tauri/src/workspace/workspaces.rs
+++ b/src-tauri/src/workspace/workspaces.rs
@@ -156,6 +156,11 @@ pub struct WorkspaceDetail {
     /// has been bound (auto-detect didn't find one); the UI shows the
     /// "Connect" prompt in that case.
     pub forge_login: Option<String>,
+    /// Timestamp of the most recent successful setup-script run for
+    /// this workspace. NULL if setup has never been run (or the
+    /// workspace was created before this column existed). Drives the
+    /// inspector's Setup tab "ran in another session" notice.
+    pub setup_completed_at: Option<String>,
 }
 
 // Workspace persistence lives in `crate::models::workspaces`.
@@ -847,6 +852,7 @@ pub fn record_to_detail(record: WorkspaceRecord) -> WorkspaceDetail {
         message_count: record.message_count,
         forge_provider: record.forge_provider,
         forge_login: record.forge_login,
+        setup_completed_at: record.setup_completed_at,
     }
 }
 

--- a/src-tauri/tests/schema_migrations.rs
+++ b/src-tauri/tests/schema_migrations.rs
@@ -31,6 +31,25 @@ fn repos_review_columns(connection: &rusqlite::Connection) -> Vec<(String, Strin
         .unwrap()
 }
 
+fn workspaces_setup_completed_at_columns(
+    connection: &rusqlite::Connection,
+) -> Vec<(String, String, i64, Option<String>)> {
+    let mut statement = connection
+        .prepare(
+            "SELECT name, type, \"notnull\", dflt_value
+             FROM pragma_table_info('workspaces')
+             WHERE name = 'setup_completed_at'",
+        )
+        .unwrap();
+    statement
+        .query_map([], |row| {
+            Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
+        })
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+}
+
 #[test]
 fn repos_branch_prefix_override_migration_is_idempotent() {
     let connection = rusqlite::Connection::open_in_memory().unwrap();
@@ -124,5 +143,48 @@ fn repos_review_migration_renames_legacy_column() {
     assert_yaml_snapshot!(
         "repos_review_migration_rename",
         repos_review_columns(&connection)
+    );
+}
+
+#[test]
+fn workspaces_setup_completed_at_migration_adds_column_when_missing() {
+    let connection = rusqlite::Connection::open_in_memory().unwrap();
+    // Pre-existing workspaces table from before the column existed.
+    connection
+        .execute_batch(
+            r#"
+            CREATE TABLE workspaces (
+                id TEXT PRIMARY KEY,
+                repository_id TEXT,
+                directory_name TEXT,
+                state TEXT DEFAULT 'active',
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+            INSERT INTO workspaces (id, repository_id, directory_name)
+            VALUES ('w1', 'r1', 'demo');
+            "#,
+        )
+        .unwrap();
+
+    schema::ensure_schema(&connection).unwrap();
+    // Idempotency: the guard MUST short-circuit on the second pass —
+    // ALTER TABLE ADD COLUMN twice would fail otherwise.
+    schema::ensure_schema(&connection).unwrap();
+
+    // Existing rows get NULL (not "" or 0) — that's the value the inspector
+    // uses to tell "ran in another session" apart from "never ran."
+    let preserved: Option<String> = connection
+        .query_row(
+            "SELECT setup_completed_at FROM workspaces WHERE id = 'w1'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(preserved.is_none());
+
+    assert_yaml_snapshot!(
+        "workspaces_setup_completed_at_migration",
+        workspaces_setup_completed_at_columns(&connection)
     );
 }

--- a/src-tauri/tests/snapshots/schema_migrations__workspaces_setup_completed_at_migration.snap
+++ b/src-tauri/tests/snapshots/schema_migrations__workspaces_setup_completed_at_migration.snap
@@ -1,0 +1,8 @@
+---
+source: tests/schema_migrations.rs
+expression: workspaces_setup_completed_at_columns(&connection)
+---
+- - setup_completed_at
+  - TEXT
+  - 0
+  - ~

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3370,6 +3370,10 @@ function AppShell({
 														workspaceState={
 															selectedWorkspaceDetailQuery.data?.state ?? null
 														}
+														workspaceSetupCompletedAt={
+															selectedWorkspaceDetailQuery.data
+																?.setupCompletedAt ?? null
+														}
 														repoId={
 															selectedWorkspaceDetailQuery.data?.repoId ?? null
 														}

--- a/src/features/inspector/hooks/use-inspector.ts
+++ b/src/features/inspector/hooks/use-inspector.ts
@@ -67,6 +67,10 @@ type UseWorkspaceInspectorSidebarArgs = {
 	workspaceRootPath?: string | null;
 	workspaceId: string | null;
 	repoId: string | null;
+	/** Drives the auto-relocate-to-Run-tab heuristic on workspace switch.
+	 * `null` until the workspace detail query resolves; nothing happens
+	 * while loading. */
+	workspaceState?: string | null;
 };
 
 type DerivedSizes = {
@@ -124,10 +128,31 @@ export function useWorkspaceInspectorSidebar({
 	workspaceRootPath,
 	workspaceId,
 	repoId,
+	workspaceState,
 }: UseWorkspaceInspectorSidebarArgs) {
 	const [actionsOpen, setActionsOpen] = useState(getInitialActionsOpen);
 	const [tabsOpen, setTabsOpen] = useState(getInitialTabsOpen);
 	const [activeTab, setActiveTab] = useState(getInitialActiveTab);
+
+	// On workspace switch, default the Setup/Run tab to whichever phase the
+	// workspace is currently in: `setup_pending` → "setup" so the user sees
+	// the script auto-running; anything else (`ready`, `archived`) → "run"
+	// because setup is already past. Only overrides when the active tab is
+	// already Setup/Run — leaves Terminal sub-tabs alone. Refs #460.
+	const lastWorkspaceIdRef = useRef<string | null>(null);
+	useEffect(() => {
+		if (!workspaceId) return;
+		if (lastWorkspaceIdRef.current === workspaceId) return;
+		// Wait until the parent has loaded workspaceState so we don't
+		// flip tabs based on a stale `null`.
+		if (workspaceState === null || workspaceState === undefined) return;
+		lastWorkspaceIdRef.current = workspaceId;
+		setActiveTab((current) => {
+			if (current !== "setup" && current !== "run") return current;
+			const target = workspaceState === "setup_pending" ? "setup" : "run";
+			return current === target ? current : target;
+		});
+	}, [workspaceId, workspaceState]);
 
 	const [containerHeight, setContainerHeight] = useState(0);
 	const [storedChangesBody, setStoredChangesBody] = useState(() =>

--- a/src/features/inspector/hooks/use-script-status.ts
+++ b/src/features/inspector/hooks/use-script-status.ts
@@ -37,11 +37,16 @@ function deriveState(
  * Subscribes to the shared script-store for live status of a script slot
  * (setup / run) in a given workspace. Returns a state label suitable for
  * driving the small status icon next to each tab label.
+ *
+ * `lastCompletedAt` lets the caller restore the success badge across app
+ * restarts: when there's no live in-memory entry but the workspace has a
+ * persisted completion timestamp, treat the slot as `success`.
  */
 export function useScriptStatus(
 	workspaceId: string | null,
 	scriptType: "setup" | "run",
 	hasScript: boolean,
+	lastCompletedAt: string | null = null,
 ): ScriptIconState {
 	const [status, setStatus] = useState<ScriptStatus>("idle");
 	const [exitCode, setExitCode] = useState<number | null>(null);
@@ -65,5 +70,9 @@ export function useScriptStatus(
 		});
 	}, [workspaceId, scriptType]);
 
-	return deriveState(hasScript, status, exitCode);
+	const state = deriveState(hasScript, status, exitCode);
+	// Restore the success badge after restart: in-memory entry is gone but
+	// the workspace row still has a completion timestamp.
+	if (state === "idle" && lastCompletedAt) return "success";
+	return state;
 }

--- a/src/features/inspector/index.tsx
+++ b/src/features/inspector/index.tsx
@@ -148,6 +148,7 @@ export function WorkspaceInspectorSidebar({
 		workspaceId ?? null,
 		"setup",
 		!!repoScripts?.setupScript?.trim(),
+		workspaceSetupCompletedAt ?? null,
 	);
 	const runScriptState = useScriptStatus(
 		workspaceId ?? null,

--- a/src/features/inspector/index.tsx
+++ b/src/features/inspector/index.tsx
@@ -39,6 +39,10 @@ type WorkspaceInspectorSidebarProps = {
 	workspaceRemote?: string | null;
 	workspaceRemoteUrl?: string | null;
 	workspaceState?: string | null;
+	/** Timestamp from `WorkspaceDetail.setupCompletedAt`. Null when setup
+	 * was never run (or skipped); drives the Setup tab placeholder copy
+	 * and the "default to Run tab" behaviour after restart. */
+	workspaceSetupCompletedAt?: string | null;
 	editorMode: boolean;
 	activeEditorPath?: string | null;
 	onOpenEditorFile(path: string, options?: DiffOpenOptions): void;
@@ -72,6 +76,7 @@ export function WorkspaceInspectorSidebar({
 	workspaceRemote,
 	workspaceRemoteUrl,
 	workspaceState,
+	workspaceSetupCompletedAt,
 	repoId,
 	editorMode,
 	activeEditorPath,
@@ -112,6 +117,7 @@ export function WorkspaceInspectorSidebar({
 		workspaceRootPath,
 		workspaceId: workspaceId ?? null,
 		repoId: repoId ?? null,
+		workspaceState: workspaceState ?? null,
 	});
 
 	// Fire setup auto-run / auto-complete at the sidebar level so it runs even
@@ -456,6 +462,7 @@ export function WorkspaceInspectorSidebar({
 					repoId={repoId ?? null}
 					workspaceId={workspaceId ?? null}
 					setupScript={repoScripts?.setupScript ?? null}
+					setupCompletedAt={workspaceSetupCompletedAt ?? null}
 					isActive={activeTab === "setup"}
 					onOpenSettings={handleOpenSettings}
 				/>

--- a/src/features/inspector/sections/setup.test.tsx
+++ b/src/features/inspector/sections/setup.test.tsx
@@ -40,6 +40,7 @@ const defaults = {
 	repoId: "repo-1",
 	workspaceId: "ws-1" as string | null,
 	setupScript: "echo hello" as string | null,
+	setupCompletedAt: null as string | null,
 	isActive: true,
 	onOpenSettings: vi.fn(),
 };

--- a/src/features/inspector/sections/setup.tsx
+++ b/src/features/inspector/sections/setup.tsx
@@ -1,5 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { Check, Play, RotateCcw, Settings2, Square } from "lucide-react";
+import { CircleCheck, Play, RotateCcw, Settings2, Square } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
 	type TerminalHandle,
@@ -207,12 +207,24 @@ export function SetupTab({
 					</Button>
 				</div>
 			) : setupCompletedAt ? (
-				<div className="flex h-full items-center justify-center">
-					<Check
+				<div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
+					<CircleCheck
 						aria-label="Setup completed"
-						className="size-12 text-muted-foreground/50"
-						strokeWidth={1.5}
+						className="size-8 text-[var(--workspace-pr-open-accent)]"
+						strokeWidth={1.75}
 					/>
+					<p className="text-[13px] font-medium text-muted-foreground">
+						Setup completed
+					</p>
+					<Button
+						variant="outline"
+						size="sm"
+						className="mt-1 gap-1.5 text-[12px]"
+						onClick={handleRun}
+					>
+						<RotateCcw className="size-3" strokeWidth={2} />
+						Rerun setup
+					</Button>
 				</div>
 			) : (
 				<div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">

--- a/src/features/inspector/sections/setup.tsx
+++ b/src/features/inspector/sections/setup.tsx
@@ -1,5 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { Play, RotateCcw, Settings2, Square } from "lucide-react";
+import { Check, Play, RotateCcw, Settings2, Square } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
 	type TerminalHandle,
@@ -25,6 +25,11 @@ type SetupTabProps = {
 	repoId: string | null;
 	workspaceId: string | null;
 	setupScript: string | null;
+	/** Persisted timestamp of the last successful setup-script run for
+	 * this workspace. Non-null + no live in-memory entry → setup ran in
+	 * a previous session whose terminal output didn't survive the
+	 * restart; show a notice instead of the never-run placeholder. */
+	setupCompletedAt: string | null;
 	isActive: boolean;
 	onOpenSettings: () => void;
 };
@@ -33,6 +38,7 @@ export function SetupTab({
 	repoId,
 	workspaceId,
 	setupScript,
+	setupCompletedAt,
 	isActive,
 	onOpenSettings,
 }: SetupTabProps) {
@@ -199,6 +205,14 @@ export function SetupTab({
 						<Settings2 className="size-3.5" strokeWidth={1.8} />
 						Open settings
 					</Button>
+				</div>
+			) : setupCompletedAt ? (
+				<div className="flex h-full items-center justify-center">
+					<Check
+						aria-label="Setup completed"
+						className="size-12 text-muted-foreground/50"
+						strokeWidth={1.5}
+					/>
 				</div>
 			) : (
 				<div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -312,6 +312,11 @@ export type WorkspaceDetail = {
 	/** gh/glab account login bound to the parent repo. NULL means no
 	 * account is bound — UI shows the "Connect" prompt. */
 	forgeLogin?: string | null;
+	/** Set when this workspace's setup script last finished with exit
+	 * code 0. NULL means never run (or skipped because the repo had no
+	 * setup script). Drives the inspector's Setup tab "ran in another
+	 * session" notice and the default-tab heuristic on workspace switch. */
+	setupCompletedAt?: string | null;
 };
 
 export type WorkspaceSessionSummary = {


### PR DESCRIPTION
## Summary

Closes #460.

When a workspace's setup script finished, the completion state lived only in the inspector's in-memory terminal buffer. After Helmor restarted, the Setup tab fell back to its never-run placeholder even for workspaces that were already provisioned, and the inspector kept defaulting to the Setup tab on every workspace switch.

This change persists setup completion in the workspaces table and uses it to drive the Setup tab UI and the default-tab heuristic.

### What changed

- **DB**: new `workspaces.setup_completed_at TEXT` column; idempotent migration adds it on existing DBs (NULL = never ran / pre-migration).
- **Backend**: `models::workspaces::mark_setup_completed` stamps the timestamp + flips state to `ready` in one update; `script_commands::execute_repo_script` calls it on a successful setup-script exit (replacing the prior `update_workspace_state(Ready)` call). The "skipped because no setup script" path stays timestamp-less, which is what lets the inspector tell "ran in another session" apart from "never ran."
- **API**: `WorkspaceDetail.setupCompletedAt` exposed through Tauri IPC.
- **Frontend**: Setup tab renders a centered check icon when `setupCompletedAt` is set but no live terminal entry exists; `use-inspector` now defaults the Setup/Run tab on workspace switch (`setup_pending` → Setup, otherwise → Run) so users land on the relevant tab after restart.

### Why

After a restart, the Setup tab UI was effectively lying about workspace state — telling the user setup had never run when in fact it had completed in a prior session. The fix makes the UI reflect persisted truth from the DB.

### Test notes

- New `schema_migrations` test (`workspaces_setup_completed_at_migration_adds_column_when_missing`) covers the migration on a pre-column DB, idempotency on a second `ensure_schema` pass, and that existing rows get NULL (not `""`/`0`).
- Snapshot added: `schema_migrations__workspaces_setup_completed_at_migration.snap`.
- `bun run lint` (biome + clippy) and `cargo fmt` pass via pre-commit hook.
- Manual: run setup script in a workspace, restart Helmor, confirm Setup tab shows the completed indicator and the inspector lands on the Run tab.