### PR TITLE
fix: route follow-up sends via backend active streams to survive remount

### DIFF
--- a/.changeset/quiet-otters-resume.md
+++ b/.changeset/quiet-otters-resume.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix Queue and Steer follow-up sends failing with a "previous send is still running" error after toggling away from a streaming session (e.g. opening the start page) and coming back.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -83,6 +83,7 @@ import {
 } from "@/shell/layout";
 import { clampZoom, useZoom, ZOOM_STEP } from "@/shell/use-zoom";
 import {
+	type ActiveStreamSummary,
 	createAndCheckoutBranch,
 	createSession,
 	drainPendingCliSends,
@@ -174,6 +175,7 @@ const OPEN_SETTINGS_EVENT = "helmor:open-settings";
 type WorkspaceViewMode = "conversation" | "editor" | "start";
 const EMPTY_SESSION_RUN_STATES = new Map<string, SessionRunState>();
 const EMPTY_STRING_LIST: readonly string[] = [];
+const EMPTY_ACTIVE_STREAMS: ActiveStreamSummary[] = [];
 
 function App() {
 	const e2eScenario =
@@ -492,12 +494,15 @@ function AppShell({
 	// StartPage's optimistic "creating workspace" marker on top so the
 	// panel can show a busy spinner before the real stream registers.
 	const activeStreamsQuery = useQuery(activeStreamsQueryOptions());
+	// Stable empty fallback so referential-equality consumers don't churn
+	// on undefined-data ticks.
+	const activeStreams = activeStreamsQuery.data ?? EMPTY_ACTIVE_STREAMS;
 	const effectiveSessionRunStates = useMemo<
 		ReadonlyMap<string, SessionRunState>
 	>(
 		() =>
 			buildSessionRunStates(
-				activeStreamsQuery.data ?? [],
+				activeStreams,
 				pendingCreatedWorkspaceSubmit
 					? {
 							sessionId: pendingCreatedWorkspaceSubmit.sessionId,
@@ -505,7 +510,7 @@ function AppShell({
 						}
 					: null,
 			),
-		[activeStreamsQuery.data, pendingCreatedWorkspaceSubmit],
+		[activeStreams, pendingCreatedWorkspaceSubmit],
 	);
 	const effectiveBusySessionIds = useMemo(
 		() => deriveBusySessionIds(effectiveSessionRunStates),
@@ -2952,6 +2957,7 @@ function AppShell({
 														onInteractionSessionsChange={
 															handleInteractionSessionsChange
 														}
+														activeStreams={activeStreams}
 														busySessionIds={effectiveBusySessionIds}
 														stoppableSessionIds={effectiveStoppableSessionIds}
 														interactionRequiredSessionIds={
@@ -3011,6 +3017,7 @@ function AppShell({
 													onInteractionSessionsChange={
 														handleInteractionSessionsChange
 													}
+													activeStreams={activeStreams}
 													busySessionIds={effectiveBusySessionIds}
 													stoppableSessionIds={effectiveStoppableSessionIds}
 													interactionRequiredSessionIds={

--- a/src/features/conversation/hooks/use-streaming.test.tsx
+++ b/src/features/conversation/hooks/use-streaming.test.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PendingUserInput } from "@/features/conversation/pending-user-input";
 import type {
+	ActiveStreamSummary,
 	AgentModelOption,
 	ThreadMessageLike,
 	ToolCallPart,
@@ -28,6 +29,14 @@ const noopSubmitQueue: SubmitQueueApi = {
 	clear: () => {},
 };
 
+const NO_ACTIVE_STREAMS: ActiveStreamSummary[] = [];
+
+// Drain replay runs on `setTimeout(0)`; `Promise.resolve()` only flushes
+// microtasks, so tests need this to yield through one macrotask tick.
+async function flushDrainTimer() {
+	await new Promise<void>((resolve) => setTimeout(resolve, 0));
+}
+
 const apiMocks = vi.hoisted(() => ({
 	generateSessionTitle: vi.fn(),
 	loadRepoPreferences: vi.fn(),
@@ -40,16 +49,6 @@ const apiMocks = vi.hoisted(() => ({
 	stopAgentStream: vi.fn(),
 }));
 
-// `listActiveStreams` is intentionally NOT mocked here. The hook reads it
-// via React Query, where `activeStreamsQueryOptions` provides
-// `initialData: []`, and `src/test/setup.ts`'s default invoke mock
-// returns `undefined` for unhandled commands — both paths produce an
-// empty array, which matches "no backend-tracked streams" for these
-// unit tests. If a future test wants to assert the backend-truth abort
-// path (e.g. that `handleStopStream` picks up a `provider` published by
-// the Rust registry rather than the local optimistic fallback), mock
-// `listActiveStreams` explicitly here so the default doesn't silently
-// swallow the assertion.
 vi.mock("@/lib/api", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("@/lib/api")>();
 
@@ -223,6 +222,7 @@ describe("useConversationStreaming", () => {
 					selectionPending: false,
 					followUpBehavior: "steer",
 					submitQueue: noopSubmitQueue,
+					activeStreams: NO_ACTIVE_STREAMS,
 				}),
 			{
 				initialProps: {
@@ -315,6 +315,7 @@ describe("useConversationStreaming", () => {
 					selectionPending: false,
 					followUpBehavior: "steer",
 					submitQueue: noopSubmitQueue,
+					activeStreams: NO_ACTIVE_STREAMS,
 				}),
 			{ wrapper: Wrapper },
 		);
@@ -353,6 +354,7 @@ describe("useConversationStreaming", () => {
 					selectionPending: false,
 					followUpBehavior: "steer",
 					submitQueue: noopSubmitQueue,
+					activeStreams: NO_ACTIVE_STREAMS,
 				}),
 			{ wrapper: Wrapper },
 		);
@@ -392,6 +394,7 @@ describe("useConversationStreaming", () => {
 					selectionPending: false,
 					followUpBehavior: "steer",
 					submitQueue: noopSubmitQueue,
+					activeStreams: NO_ACTIVE_STREAMS,
 				}),
 			{ wrapper: Wrapper },
 		);
@@ -456,6 +459,7 @@ describe("useConversationStreaming", () => {
 					selectionPending: false,
 					followUpBehavior: "steer",
 					submitQueue: noopSubmitQueue,
+					activeStreams: NO_ACTIVE_STREAMS,
 				}),
 			{ wrapper: Wrapper },
 		);
@@ -520,6 +524,7 @@ describe("useConversationStreaming", () => {
 					selectionPending: false,
 					followUpBehavior: "steer",
 					submitQueue: noopSubmitQueue,
+					activeStreams: NO_ACTIVE_STREAMS,
 				}),
 				emptySibling: useConversationStreaming({
 					composerContextKey: "start:repo:repo-1",
@@ -529,6 +534,7 @@ describe("useConversationStreaming", () => {
 					selectionPending: false,
 					followUpBehavior: "steer",
 					submitQueue: noopSubmitQueue,
+					activeStreams: NO_ACTIVE_STREAMS,
 				}),
 			}),
 			{ wrapper: Wrapper },
@@ -595,6 +601,7 @@ describe("useConversationStreaming", () => {
 					selectionPending: false,
 					followUpBehavior: "steer",
 					submitQueue: noopSubmitQueue,
+					activeStreams: NO_ACTIVE_STREAMS,
 				}),
 			{ wrapper: Wrapper },
 		);
@@ -648,6 +655,7 @@ describe("useConversationStreaming", () => {
 					selectionPending: false,
 					followUpBehavior: "steer",
 					submitQueue: noopSubmitQueue,
+					activeStreams: NO_ACTIVE_STREAMS,
 				}),
 			{ wrapper: Wrapper },
 		);
@@ -789,6 +797,7 @@ describe("useConversationStreaming", () => {
 					selectionPending: false,
 					followUpBehavior: "steer",
 					submitQueue: noopSubmitQueue,
+					activeStreams: NO_ACTIVE_STREAMS,
 				}),
 			{ wrapper: Wrapper },
 		);
@@ -851,6 +860,7 @@ describe("useConversationStreaming", () => {
 					selectionPending: false,
 					followUpBehavior: "steer",
 					submitQueue: noopSubmitQueue,
+					activeStreams: NO_ACTIVE_STREAMS,
 				}),
 			{ wrapper: Wrapper },
 		);
@@ -939,6 +949,7 @@ describe("useConversationStreaming", () => {
 					selectionPending: false,
 					followUpBehavior: "steer",
 					submitQueue: noopSubmitQueue,
+					activeStreams: NO_ACTIVE_STREAMS,
 				}),
 			{ wrapper: Wrapper },
 		);
@@ -1038,6 +1049,7 @@ describe("useConversationStreaming", () => {
 					selectionPending: false,
 					followUpBehavior: "steer",
 					submitQueue: noopSubmitQueue,
+					activeStreams: NO_ACTIVE_STREAMS,
 				}),
 			{ wrapper: Wrapper },
 		);
@@ -1092,6 +1104,7 @@ describe("useConversationStreaming", () => {
 					selectionPending: false,
 					followUpBehavior: "steer",
 					submitQueue: noopSubmitQueue,
+					activeStreams: NO_ACTIVE_STREAMS,
 				}),
 			{ wrapper: Wrapper },
 		);
@@ -1143,6 +1156,7 @@ describe("useConversationStreaming", () => {
 					selectionPending: false,
 					followUpBehavior: "steer",
 					submitQueue: noopSubmitQueue,
+					activeStreams: NO_ACTIVE_STREAMS,
 				}),
 			{ wrapper: Wrapper },
 		);
@@ -1177,6 +1191,7 @@ describe("useConversationStreaming", () => {
 					selectionPending: false,
 					followUpBehavior: "steer",
 					submitQueue: noopSubmitQueue,
+					activeStreams: NO_ACTIVE_STREAMS,
 				}),
 			{ wrapper: Wrapper },
 		);
@@ -1246,6 +1261,7 @@ describe("useConversationStreaming", () => {
 					selectionPending: false,
 					followUpBehavior: "steer",
 					submitQueue: noopSubmitQueue,
+					activeStreams: NO_ACTIVE_STREAMS,
 				}),
 			{ wrapper: Wrapper },
 		);
@@ -1297,6 +1313,7 @@ describe("useConversationStreaming", () => {
 					selectionPending: false,
 					followUpBehavior: "steer",
 					submitQueue: noopSubmitQueue,
+					activeStreams: NO_ACTIVE_STREAMS,
 				}),
 			{
 				initialProps: {
@@ -1399,6 +1416,7 @@ describe("useConversationStreaming", () => {
 					selectionPending: false,
 					followUpBehavior: "steer",
 					submitQueue: noopSubmitQueue,
+					activeStreams: NO_ACTIVE_STREAMS,
 				}),
 			{ wrapper: Wrapper },
 		);
@@ -1448,6 +1466,7 @@ describe("useConversationStreaming", () => {
 					selectionPending: false,
 					followUpBehavior: "steer",
 					submitQueue: noopSubmitQueue,
+					activeStreams: NO_ACTIVE_STREAMS,
 				}),
 			{ wrapper: Wrapper },
 		);
@@ -1581,6 +1600,7 @@ describe("useConversationStreaming", () => {
 						selectionPending: false,
 						followUpBehavior: "queue",
 						submitQueue: queue,
+						activeStreams: NO_ACTIVE_STREAMS,
 					}),
 				{ wrapper: Wrapper },
 			);
@@ -1639,10 +1659,17 @@ describe("useConversationStreaming", () => {
 				},
 			);
 			const queue = createFakeQueue();
+			const session1Active: ActiveStreamSummary[] = [
+				{
+					sessionId: "session-1",
+					workspaceId: "workspace-1",
+					provider: "codex",
+				},
+			];
 
 			const { Wrapper } = createWrapper();
-			const { result } = renderHook(
-				() =>
+			const { result, rerender } = renderHook(
+				({ activeStreams }: { activeStreams: ActiveStreamSummary[] }) =>
 					useConversationStreaming({
 						composerContextKey: "session:session-1",
 						displayedSelectedModelId: MODEL.id,
@@ -1651,11 +1678,15 @@ describe("useConversationStreaming", () => {
 						selectionPending: false,
 						followUpBehavior: "queue",
 						submitQueue: queue,
+						activeStreams,
 					}),
-				{ wrapper: Wrapper },
+				{
+					wrapper: Wrapper,
+					initialProps: { activeStreams: NO_ACTIVE_STREAMS },
+				},
 			);
 
-			// Kick off the primary turn.
+			// Kick off the primary turn, then mirror the backend register.
 			await act(async () => {
 				await result.current.handleComposerSubmit({
 					prompt: "Primary",
@@ -1669,8 +1700,9 @@ describe("useConversationStreaming", () => {
 					fastMode: false,
 				});
 			});
+			rerender({ activeStreams: session1Active });
 
-			// Enqueue a follow-up.
+			// Enqueue a follow-up while the stream is active.
 			await act(async () => {
 				await result.current.handleComposerSubmit({
 					prompt: "Queued",
@@ -1686,7 +1718,8 @@ describe("useConversationStreaming", () => {
 			});
 			expect(queue.snapshot().get("session-1")).toHaveLength(1);
 
-			// Finish the first turn — drain effect should pop + replay.
+			// Done → drain pops + replays.
+			rerender({ activeStreams: NO_ACTIVE_STREAMS });
 			await act(async () => {
 				streamCallbacks[0]({
 					kind: "done",
@@ -1698,13 +1731,11 @@ describe("useConversationStreaming", () => {
 					persisted: false,
 				});
 			});
-			// Drain is scheduled via `queueMicrotask`; let it run.
 			await act(async () => {
-				await Promise.resolve();
+				await flushDrainTimer();
 			});
 
 			expect(queue.snapshot().has("session-1")).toBe(false);
-			// Second `startAgentMessageStream` call carries the queued prompt.
 			expect(apiMocks.startAgentMessageStream).toHaveBeenCalledTimes(2);
 			const secondCallPayload = apiMocks.startAgentMessageStream.mock
 				.calls[1][0] as { prompt: string };
@@ -1743,6 +1774,7 @@ describe("useConversationStreaming", () => {
 						selectionPending: false,
 						followUpBehavior: "queue",
 						submitQueue: queue,
+						activeStreams: NO_ACTIVE_STREAMS,
 					}),
 				{ wrapper: Wrapper },
 			);
@@ -1776,6 +1808,7 @@ describe("useConversationStreaming", () => {
 						selectionPending: false,
 						followUpBehavior: "queue",
 						submitQueue: queue,
+						activeStreams: NO_ACTIVE_STREAMS,
 					}),
 				{ wrapper: Wrapper },
 			);
@@ -1829,11 +1862,28 @@ describe("useConversationStreaming", () => {
 				},
 			);
 			const queue = createFakeQueue();
+			const sessionAActive: ActiveStreamSummary[] = [
+				{
+					sessionId: "session-A",
+					workspaceId: "workspace-1",
+					provider: "codex",
+				},
+			];
 
 			const { Wrapper } = createWrapper();
 			// Start displayed on session A.
 			const { result, rerender } = renderHook(
-				({ sessionId, workspaceId, contextKey }) =>
+				({
+					sessionId,
+					workspaceId,
+					contextKey,
+					activeStreams,
+				}: {
+					sessionId: string;
+					workspaceId: string;
+					contextKey: string;
+					activeStreams: ActiveStreamSummary[];
+				}) =>
 					useConversationStreaming({
 						composerContextKey: contextKey,
 						displayedSelectedModelId: MODEL.id,
@@ -1842,12 +1892,14 @@ describe("useConversationStreaming", () => {
 						selectionPending: false,
 						followUpBehavior: "queue",
 						submitQueue: queue,
+						activeStreams,
 					}),
 				{
 					initialProps: {
 						sessionId: "session-A",
 						workspaceId: "workspace-1",
 						contextKey: "session:session-A",
+						activeStreams: NO_ACTIVE_STREAMS,
 					},
 					wrapper: Wrapper,
 				},
@@ -1867,6 +1919,12 @@ describe("useConversationStreaming", () => {
 					fastMode: false,
 				});
 			});
+			rerender({
+				sessionId: "session-A",
+				workspaceId: "workspace-1",
+				contextKey: "session:session-A",
+				activeStreams: sessionAActive,
+			});
 			// Queue a follow-up in session A.
 			await act(async () => {
 				await result.current.handleComposerSubmit({
@@ -1883,14 +1941,21 @@ describe("useConversationStreaming", () => {
 			});
 			expect(queue.snapshot().get("session-A")).toHaveLength(1);
 
-			// User navigates to session B BEFORE A's turn finishes.
+			// User navigates to session B; A's stream is still alive.
 			rerender({
 				sessionId: "session-B",
 				workspaceId: "workspace-1",
 				contextKey: "session:session-B",
+				activeStreams: sessionAActive,
 			});
 
 			// A's turn finishes → drain fires.
+			rerender({
+				sessionId: "session-B",
+				workspaceId: "workspace-1",
+				contextKey: "session:session-B",
+				activeStreams: NO_ACTIVE_STREAMS,
+			});
 			await act(async () => {
 				streamCallbacks[0]({
 					kind: "done",
@@ -1903,15 +1968,12 @@ describe("useConversationStreaming", () => {
 				});
 			});
 			await act(async () => {
-				await Promise.resolve();
+				await flushDrainTimer();
 			});
 
-			// Queue for A is empty, queue for B untouched.
+			// Drained submit targets A (not the displayed B).
 			expect(queue.snapshot().has("session-A")).toBe(false);
 			expect(queue.snapshot().has("session-B")).toBe(false);
-			// The drained submit targeted session A (NOT B, which is
-			// currently displayed) — verified via the helmorSessionId
-			// passed to the second `startAgentMessageStream` call.
 			expect(apiMocks.startAgentMessageStream).toHaveBeenCalledTimes(2);
 			const drainedPayload = apiMocks.startAgentMessageStream.mock
 				.calls[1][0] as { prompt: string; helmorSessionId: string };
@@ -1941,6 +2003,7 @@ describe("useConversationStreaming", () => {
 						// submit would steer. `forceQueue: true` must override.
 						followUpBehavior: "steer",
 						submitQueue: queue,
+						activeStreams: NO_ACTIVE_STREAMS,
 					}),
 				{ wrapper: Wrapper },
 			);
@@ -2006,6 +2069,7 @@ describe("useConversationStreaming", () => {
 						// submit would steer mid-turn.
 						followUpBehavior: "steer",
 						submitQueue: queue,
+						activeStreams: NO_ACTIVE_STREAMS,
 					}),
 				{ wrapper: Wrapper },
 			);
@@ -2066,6 +2130,7 @@ describe("useConversationStreaming", () => {
 						selectionPending: false,
 						followUpBehavior: "queue",
 						submitQueue: queue,
+						activeStreams: NO_ACTIVE_STREAMS,
 					}),
 				{ wrapper: Wrapper },
 			);
@@ -2122,6 +2187,7 @@ describe("useConversationStreaming", () => {
 						selectionPending: false,
 						followUpBehavior: "queue",
 						submitQueue: queue,
+						activeStreams: NO_ACTIVE_STREAMS,
 					}),
 				{ wrapper: Wrapper },
 			);
@@ -2189,6 +2255,7 @@ describe("useConversationStreaming", () => {
 						selectionPending: false,
 						followUpBehavior: "queue",
 						submitQueue: queue,
+						activeStreams: NO_ACTIVE_STREAMS,
 					}),
 				{ wrapper: Wrapper },
 			);
@@ -2255,6 +2322,7 @@ describe("useConversationStreaming", () => {
 						selectionPending: false,
 						followUpBehavior: "queue",
 						submitQueue: queue,
+						activeStreams: NO_ACTIVE_STREAMS,
 					}),
 				{ wrapper: Wrapper },
 			);
@@ -2309,10 +2377,17 @@ describe("useConversationStreaming", () => {
 				},
 			);
 			const queue = createFakeQueue();
+			const session1Active: ActiveStreamSummary[] = [
+				{
+					sessionId: "session-1",
+					workspaceId: "workspace-1",
+					provider: "codex",
+				},
+			];
 
 			const { Wrapper } = createWrapper();
-			const { result } = renderHook(
-				() =>
+			const { result, rerender } = renderHook(
+				({ activeStreams }: { activeStreams: ActiveStreamSummary[] }) =>
 					useConversationStreaming({
 						composerContextKey: "session:session-1",
 						displayedSelectedModelId: MODEL.id,
@@ -2321,8 +2396,12 @@ describe("useConversationStreaming", () => {
 						selectionPending: false,
 						followUpBehavior: "queue",
 						submitQueue: queue,
+						activeStreams,
 					}),
-				{ wrapper: Wrapper },
+				{
+					wrapper: Wrapper,
+					initialProps: { activeStreams: NO_ACTIVE_STREAMS },
+				},
 			);
 
 			// Start primary.
@@ -2339,6 +2418,7 @@ describe("useConversationStreaming", () => {
 					fastMode: false,
 				});
 			});
+			rerender({ activeStreams: session1Active });
 			// Queue two follow-ups.
 			for (const prompt of ["One", "Two"]) {
 				await act(async () => {
@@ -2357,7 +2437,8 @@ describe("useConversationStreaming", () => {
 			}
 			expect(queue.snapshot().get("session-1")).toHaveLength(2);
 
-			// Finish primary → drain pops "One".
+			// Finish primary → drain pops "One"; backend re-registers.
+			rerender({ activeStreams: NO_ACTIVE_STREAMS });
 			await act(async () => {
 				streamCallbacks[0]({
 					kind: "done",
@@ -2370,12 +2451,14 @@ describe("useConversationStreaming", () => {
 				});
 			});
 			await act(async () => {
-				await Promise.resolve();
+				await flushDrainTimer();
 			});
+			rerender({ activeStreams: session1Active });
 			expect(apiMocks.startAgentMessageStream).toHaveBeenCalledTimes(2);
 			expect(queue.snapshot().get("session-1")).toHaveLength(1);
 
 			// Finish second → drain pops "Two".
+			rerender({ activeStreams: NO_ACTIVE_STREAMS });
 			await act(async () => {
 				streamCallbacks[1]({
 					kind: "done",
@@ -2388,13 +2471,17 @@ describe("useConversationStreaming", () => {
 				});
 			});
 			await act(async () => {
-				await Promise.resolve();
+				await flushDrainTimer();
 			});
 			expect(apiMocks.startAgentMessageStream).toHaveBeenCalledTimes(3);
 			expect(queue.snapshot().has("session-1")).toBe(false);
-			const thirdPayload = apiMocks.startAgentMessageStream.mock
+			// FIFO: "One" drained first, "Two" second.
+			const firstDrainPayload = apiMocks.startAgentMessageStream.mock
+				.calls[1][0] as { prompt: string };
+			const secondDrainPayload = apiMocks.startAgentMessageStream.mock
 				.calls[2][0] as { prompt: string };
-			expect(thirdPayload.prompt).toBe("Two");
+			expect(firstDrainPayload.prompt).toBe("One");
+			expect(secondDrainPayload.prompt).toBe("Two");
 		});
 
 		it("drains queued items when the prior turn errors instead of done", async () => {
@@ -2405,10 +2492,17 @@ describe("useConversationStreaming", () => {
 				},
 			);
 			const queue = createFakeQueue();
+			const session1Active: ActiveStreamSummary[] = [
+				{
+					sessionId: "session-1",
+					workspaceId: "workspace-1",
+					provider: "codex",
+				},
+			];
 
 			const { Wrapper } = createWrapper();
-			const { result } = renderHook(
-				() =>
+			const { result, rerender } = renderHook(
+				({ activeStreams }: { activeStreams: ActiveStreamSummary[] }) =>
 					useConversationStreaming({
 						composerContextKey: "session:session-1",
 						displayedSelectedModelId: MODEL.id,
@@ -2417,8 +2511,12 @@ describe("useConversationStreaming", () => {
 						selectionPending: false,
 						followUpBehavior: "queue",
 						submitQueue: queue,
+						activeStreams,
 					}),
-				{ wrapper: Wrapper },
+				{
+					wrapper: Wrapper,
+					initialProps: { activeStreams: NO_ACTIVE_STREAMS },
+				},
 			);
 
 			await act(async () => {
@@ -2434,6 +2532,7 @@ describe("useConversationStreaming", () => {
 					fastMode: false,
 				});
 			});
+			rerender({ activeStreams: session1Active });
 			await act(async () => {
 				await result.current.handleComposerSubmit({
 					prompt: "Queued after error",
@@ -2448,6 +2547,7 @@ describe("useConversationStreaming", () => {
 				});
 			});
 
+			rerender({ activeStreams: NO_ACTIVE_STREAMS });
 			await act(async () => {
 				streamCallbacks[0]({
 					kind: "error",
@@ -2459,12 +2559,114 @@ describe("useConversationStreaming", () => {
 				});
 			});
 			await act(async () => {
-				await Promise.resolve();
+				await flushDrainTimer();
 			});
 
 			// error-path also drains — queued prompt doesn't get stuck.
 			expect(apiMocks.startAgentMessageStream).toHaveBeenCalledTimes(2);
 			expect(queue.snapshot().has("session-1")).toBe(false);
+		});
+
+		// Regression — start-page-toggle bug: hook remounts with empty
+		// local state but backend stream still registered. Routing must
+		// see this through `activeStreams` and route to steer/queue.
+		it("routes to steer after hook remount when backend stream is still active", async () => {
+			apiMocks.startAgentMessageStream.mockImplementation(async () => {});
+			apiMocks.steerAgentStream.mockResolvedValue({ accepted: true });
+			const queue = createFakeQueue();
+			const session1Active: ActiveStreamSummary[] = [
+				{
+					sessionId: "session-1",
+					workspaceId: "workspace-1",
+					provider: "codex",
+				},
+			];
+			const { Wrapper } = createWrapper();
+
+			const { result } = renderHook(
+				() =>
+					useConversationStreaming({
+						composerContextKey: "session:session-1",
+						displayedSelectedModelId: MODEL.id,
+						displayedSessionId: "session-1",
+						displayedWorkspaceId: "workspace-1",
+						selectionPending: false,
+						followUpBehavior: "steer",
+						submitQueue: queue,
+						activeStreams: session1Active,
+					}),
+				{ wrapper: Wrapper },
+			);
+
+			await act(async () => {
+				await result.current.handleComposerSubmit({
+					prompt: "Follow up after remount",
+					imagePaths: [],
+					filePaths: [],
+					customTags: [],
+					model: MODEL,
+					workingDirectory: "/tmp/helmor",
+					effortLevel: "medium",
+					permissionMode: "default",
+					fastMode: false,
+				});
+			});
+
+			// Must not collide with the still-held backend lock.
+			expect(apiMocks.startAgentMessageStream).not.toHaveBeenCalled();
+			expect(apiMocks.steerAgentStream).toHaveBeenCalledWith(
+				expect.objectContaining({
+					sessionId: "session-1",
+					provider: "codex",
+					prompt: "Follow up after remount",
+				}),
+			);
+		});
+
+		it("routes to queue after hook remount when backend stream is still active", async () => {
+			apiMocks.startAgentMessageStream.mockImplementation(async () => {});
+			const queue = createFakeQueue();
+			const session1Active: ActiveStreamSummary[] = [
+				{
+					sessionId: "session-1",
+					workspaceId: "workspace-1",
+					provider: "codex",
+				},
+			];
+			const { Wrapper } = createWrapper();
+
+			const { result } = renderHook(
+				() =>
+					useConversationStreaming({
+						composerContextKey: "session:session-1",
+						displayedSelectedModelId: MODEL.id,
+						displayedSessionId: "session-1",
+						displayedWorkspaceId: "workspace-1",
+						selectionPending: false,
+						followUpBehavior: "queue",
+						submitQueue: queue,
+						activeStreams: session1Active,
+					}),
+				{ wrapper: Wrapper },
+			);
+
+			await act(async () => {
+				await result.current.handleComposerSubmit({
+					prompt: "Queued after remount",
+					imagePaths: [],
+					filePaths: [],
+					customTags: [],
+					model: MODEL,
+					workingDirectory: "/tmp/helmor",
+					effortLevel: "medium",
+					permissionMode: "default",
+					fastMode: false,
+				});
+			});
+
+			expect(apiMocks.startAgentMessageStream).not.toHaveBeenCalled();
+			expect(apiMocks.steerAgentStream).not.toHaveBeenCalled();
+			expect(queue.snapshot().get("session-1")).toHaveLength(1);
 		});
 	});
 });

--- a/src/features/conversation/hooks/use-streaming.ts
+++ b/src/features/conversation/hooks/use-streaming.ts
@@ -15,6 +15,7 @@ import {
 } from "@/features/conversation/pending-user-input";
 import { stabilizeStreamingMessages } from "@/features/conversation/streaming-tail-collapse";
 import type {
+	ActiveStreamSummary,
 	AgentModelOption,
 	CodexGoalState,
 	ThreadMessageLike,
@@ -33,7 +34,6 @@ import {
 import type { ComposerCustomTag } from "@/lib/composer-insert";
 import { extractError, isRecoverableByPurge } from "@/lib/errors";
 import {
-	activeStreamsQueryOptions,
 	agentModelSectionsQueryOptions,
 	helmorQueryKeys,
 	sessionThreadMessagesQueryOptions,
@@ -140,6 +140,10 @@ type UseConversationStreamingArgs = {
 	/** App-level queue handle (read + mutate). Shared across session /
 	 *  workspace switches so the queue survives navigation. */
 	submitQueue: SubmitQueueApi;
+	/** Backend-truth active-streams snapshot, owned by App. Drives
+	 *  follow-up routing and the queue-drain trigger; survives this
+	 *  hook's unmount/remount. */
+	activeStreams: readonly ActiveStreamSummary[];
 	onInteractionSessionsChange?: (
 		sessionWorkspaceMap: Map<string, string>,
 		interactionCounts: Map<string, number>,
@@ -157,6 +161,7 @@ export function useConversationStreaming({
 	selectionPending,
 	followUpBehavior,
 	submitQueue,
+	activeStreams,
 	onInteractionSessionsChange,
 	onSessionCompleted,
 	onSessionAborted,
@@ -252,13 +257,16 @@ export function useConversationStreaming({
 	);
 
 	const modelSectionsQuery = useQuery(agentModelSectionsQueryOptions());
-	// Backend-truth list of in-flight streams. Used by `handleStopStream`
-	// so abort works even after the conversation container unmount/remount
-	// race that would clear `activeSessionByContext`. Stays in sync via
-	// `UiMutationEvent::ActiveStreamsChanged` → `helmorQueryKeys.activeStreams`
-	// invalidation in the ui-sync bridge.
-	const activeStreamsQuery = useQuery(activeStreamsQueryOptions());
-	const activeStreams = activeStreamsQuery.data ?? [];
+	// Value-stable fingerprint for effects that only care about the set
+	// of active session ids, not the array's reference.
+	const activeSessionIdsKey = useMemo(
+		() =>
+			activeStreams
+				.map((stream) => stream.sessionId)
+				.sort()
+				.join("\n"),
+		[activeStreams],
+	);
 	const selectedProvider = useMemo(() => {
 		if (!displayedSelectedModelId) return null;
 		const sections = modelSectionsQuery.data ?? [];
@@ -779,20 +787,24 @@ export function useConversationStreaming({
 
 			const contextKey = targetContextKey;
 
-			// Follow-up branch: if a stream is already running for this
-			// context, either inject mid-turn (`steer`) or stash locally
-			// to fire as a fresh turn when the agent finishes (`queue`).
-			// The choice is user-controlled via the Follow-up behavior
-			// setting. Plan-review takes precedence over both: submitting
-			// a free-form message while a plan is pending means "abandon
-			// the plan and start fresh," so fall through to normal send.
-			const liveStream = activeSessionByContext[contextKey];
+			// Follow-up branch: stream still alive → steer or queue.
+			// `activeStreams` is the source of truth (survives remount);
+			// `activeSessionByContext` is the optimistic fast-path for the
+			// in-flight register window. Plan-review = abandon plan.
+			const localLiveStream = activeSessionByContext[contextKey];
+			const backendLiveStream = activeStreams.find(
+				(stream) => stream.sessionId === targetSessionId,
+			);
+			const liveStream =
+				localLiveStream ??
+				(backendLiveStream
+					? {
+							stopSessionId: targetSessionId,
+							provider: backendLiveStream.provider,
+						}
+					: null);
 			const hasPlanReviewForContext = planReviewByContext[contextKey] ?? false;
-			if (
-				sendingContextKeys.has(contextKey) &&
-				liveStream &&
-				!hasPlanReviewForContext
-			) {
+			if (liveStream && !hasPlanReviewForContext) {
 				// `forceQueue` is a caller-supplied override that pins
 				// the routing to the queue regardless of the user's
 				// `followUpBehavior` setting — used for host-triggered
@@ -1285,41 +1297,43 @@ export function useConversationStreaming({
 			refreshSessionThreadFromDb,
 			setFastPreludeActive,
 			activeSessionByContext,
-			sendingContextKeys,
+			activeStreams,
 			planReviewByContext,
 			followUpBehavior,
 			submitQueue,
 		],
 	);
 
-	// Queue drain — pops the first queued entry for any session whose
-	// stream just terminated and replays it through `handleComposerSubmit`
-	// using the queued item's stored context (not the currently displayed
-	// one). Ref indirection keeps the effect dep list to sending-state
-	// only; `queueMicrotask` defers the replay so it doesn't call
-	// `setSendingContextKeys` inside a React commit phase.
+	// Queue drain — replay queued entries when a session's backend
+	// stream ends. Keys on `activeStreams` (not `sendingContextKeys`,
+	// which `userInputRequest` also clears) so pause doesn't trip it.
+	// Replay on `setTimeout(0)` so the Done-callback setStates commit
+	// first; otherwise the replayed submit reads a stale
+	// `activeSessionByContext` and routes back into steer/queue.
 	const handleComposerSubmitRef = useRef(handleComposerSubmit);
 	handleComposerSubmitRef.current = handleComposerSubmit;
-	const previousSendingRef = useRef<Set<string>>(new Set());
+	const activeStreamsRef = useRef(activeStreams);
+	activeStreamsRef.current = activeStreams;
+	const previousActiveSessionIdsRef = useRef<Set<string>>(new Set());
 	useEffect(() => {
-		const previous = previousSendingRef.current;
-		const current = sendingContextKeys;
-		const justFinished: string[] = [];
-		for (const key of previous) {
-			if (!current.has(key)) justFinished.push(key);
+		const previous = previousActiveSessionIdsRef.current;
+		const current = new Set(
+			activeStreamsRef.current.map((stream) => stream.sessionId),
+		);
+		const justEnded: string[] = [];
+		for (const sid of previous) {
+			if (!current.has(sid)) justEnded.push(sid);
 		}
-		previousSendingRef.current = new Set(current);
+		previousActiveSessionIdsRef.current = current;
 
-		for (const key of justFinished) {
-			if (!key.startsWith("session:")) continue;
-			const sessionId = key.slice("session:".length);
+		for (const sessionId of justEnded) {
 			const next = submitQueue.popNext(sessionId);
 			if (!next) continue;
-			queueMicrotask(() => {
+			setTimeout(() => {
 				handleComposerSubmitRef.current(next.payload, next.context);
-			});
+			}, 0);
 		}
-	}, [sendingContextKeys, submitQueue]);
+	}, [activeSessionIdsKey, submitQueue]);
 
 	// Row actions: Steer now / Remove. Both key off the item's stored
 	// context (NOT the currently displayed session) so row clicks from

--- a/src/features/conversation/index.test.tsx
+++ b/src/features/conversation/index.test.tsx
@@ -81,6 +81,7 @@ function renderContainer(
 				selectedSessionId="session-1"
 				displayedSessionId="session-1"
 				repoId="repo-1"
+				activeStreams={[]}
 				onSelectSession={vi.fn()}
 				onResolveDisplayedSession={vi.fn()}
 				pendingCreatedWorkspaceSubmit={{

--- a/src/features/conversation/index.tsx
+++ b/src/features/conversation/index.tsx
@@ -12,7 +12,7 @@ import type { UserInputResponseHandler } from "@/features/composer/user-input";
 import { WorkspacePanelContainer } from "@/features/panel/container";
 import { FileLinkProvider } from "@/features/panel/message-components/file-link-context";
 import type { SessionCloseRequest } from "@/features/panel/use-confirm-session-close";
-import type { ChangeRequestInfo } from "@/lib/api";
+import type { ActiveStreamSummary, ChangeRequestInfo } from "@/lib/api";
 import type { ResolvedComposerInsertRequest } from "@/lib/composer-insert";
 import { insertRequestMatchesComposer } from "@/lib/composer-insert";
 import { hasUnresolvedPlanReview } from "@/lib/plan-review";
@@ -78,6 +78,10 @@ type WorkspaceConversationContainerProps = {
 		sessionWorkspaceMap: Map<string, string>,
 		interactionCounts: Map<string, number>,
 	) => void;
+	/** Backend-truth active-streams snapshot from App's
+	 *  `activeStreamsQuery`. Survives this container's unmount/remount,
+	 *  so follow-up routing/drain stays correct across start ↔ chat. */
+	activeStreams: readonly ActiveStreamSummary[];
 	busySessionIds?: Set<string>;
 	stoppableSessionIds?: Set<string>;
 	interactionRequiredSessionIds?: Set<string>;
@@ -162,6 +166,7 @@ export const WorkspaceConversationContainer = memo(
 		onSelectSession,
 		onResolveDisplayedSession,
 		onInteractionSessionsChange,
+		activeStreams,
 		busySessionIds,
 		stoppableSessionIds,
 		interactionRequiredSessionIds,
@@ -250,6 +255,7 @@ export const WorkspaceConversationContainer = memo(
 			selectionPending,
 			followUpBehavior: settings.followUpBehavior,
 			submitQueue: submitQueueApi,
+			activeStreams,
 			onInteractionSessionsChange,
 			onSessionCompleted,
 			onSessionAborted,


### PR DESCRIPTION
## Summary

- Fix Queue and Steer follow-up sends failing with `"previous send is still running"` after toggling away from a streaming session (e.g. opening the start page) and returning. The local `activeSessionByContext` / `sendingContextKeys` state was being wiped by the conversation container's unmount/remount, so the next submit didn't recognize the still-running stream and tried to start a fresh one.
- Promote `activeStreams` (backend-truth, owned by `App` via `activeStreamsQuery`) to the canonical signal for follow-up routing. `useConversationStreaming` now accepts it as a prop, falls back to it when the optimistic local map is empty, and uses it as the trigger for the queue-drain effect.
- Adjust the queue-drain replay to fire on `setTimeout(0)` (instead of `queueMicrotask`) so Done-callback `setState`s commit before the replay reads `activeSessionByContext`, preventing the replay from re-routing back into steer/queue.
- Add two regression tests covering the start-page-toggle bug (steer + queue paths after hook remount), update the existing queue/drain tests to mirror the backend register/unregister via `activeStreams` rerenders, and replace `Promise.resolve()` waits with a macrotask flush helper.

## Why

After the user opened the start page and came back to a session that was still streaming, the conversation container remounted with empty local state. The follow-up routing only consulted that local state, so submitting Queue/Steer would attempt `startAgentMessageStream` — and the Rust side, which still held the per-session lock, rejected it with `"previous send is still running"`. Routing through the React-Query-backed `activeStreams` survives the remount and matches what the backend actually thinks is in flight.

## Test plan

- [ ] `bun run test:frontend` — confirm new regression tests + existing drain tests pass
- [ ] Manual: start a long stream → open the start page → return to the session → submit Queue → verify it queues without error
- [ ] Manual: same flow with Steer → verify the prompt is steered into the live turn
- [ ] Manual: queue two follow-ups, finish primary, confirm FIFO replay still works