### PR TITLE
fix(slash-commands): include project-level commands in start-page menu

### DIFF
--- a/.changeset/bright-otters-load.md
+++ b/.changeset/bright-otters-load.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix project-level slash commands missing from the start-page `/` menu for both Claude and Codex.

--- a/src-tauri/src/agents.rs
+++ b/src-tauri/src/agents.rs
@@ -61,6 +61,14 @@ pub async fn prewarm_slash_commands_for_workspace(
     Ok(())
 }
 
+/// Tauri command — called from the start page on repo switch. There's no
+/// workspace yet, so we prewarm using the repo's local `root_path`.
+#[tauri::command]
+pub async fn prewarm_slash_commands_for_repo(app: AppHandle, repo_id: String) -> CmdResult<()> {
+    queries::prewarm_slash_command_cache_for_repo(&app, &repo_id);
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Streaming event types
 // ---------------------------------------------------------------------------

--- a/src-tauri/src/agents/queries.rs
+++ b/src-tauri/src/agents/queries.rs
@@ -505,6 +505,10 @@ pub async fn list_slash_commands(
     cache: tauri::State<'_, super::slash_commands::SlashCommandCache>,
     request: ListSlashCommandsRequest,
 ) -> CmdResult<SlashCommandsResponse> {
+    // Start page has no workspace, so `working_directory` is empty. Fall
+    // back to the repo's `root_path` so Claude CLI can scan the project's
+    // `.claude/commands/` and the cache key aligns with the repo prewarm.
+    let request = resolve_repo_fallback_cwd(request);
     let cwd = request.working_directory.as_deref().unwrap_or("");
     let repo_id = request.repo_id.as_deref().unwrap_or("");
     let additional_directories =
@@ -584,6 +588,36 @@ pub async fn list_slash_commands(
     Ok(SlashCommandsResponse { commands })
 }
 
+/// When the caller (e.g. start page) has a `repo_id` but no `working_directory`,
+/// resolve it to the repo's local `root_path` so the sidecar can scan
+/// project-level `.claude/commands/`. Same key shape as `dispatch_prewarm_for_repo`,
+/// so cache hits line up.
+fn resolve_repo_fallback_cwd(mut request: ListSlashCommandsRequest) -> ListSlashCommandsRequest {
+    if request
+        .working_directory
+        .as_deref()
+        .map(str::trim)
+        .is_some_and(|s| !s.is_empty())
+    {
+        return request;
+    }
+    let Some(repo_id) = request.repo_id.as_deref().filter(|s| !s.is_empty()) else {
+        return request;
+    };
+    let Some(record) = crate::models::repos::load_repository_by_id(repo_id)
+        .ok()
+        .flatten()
+    else {
+        return request;
+    };
+    let root_path = record.root_path.trim();
+    if root_path.is_empty() || !std::path::Path::new(root_path).is_dir() {
+        return request;
+    }
+    request.working_directory = Some(root_path.to_string());
+    request
+}
+
 fn lookup_workspace_linked_directories_for_commands(workspace_id: Option<&str>) -> Vec<String> {
     let Some(workspace_id) = workspace_id else {
         return Vec::new();
@@ -645,7 +679,7 @@ pub fn prewarm_slash_command_cache_for_workspace(app: &AppHandle, workspace_id: 
                 );
                 return;
             };
-            dispatch_prewarm_for(&app, &workspace_id, root_path, &record.repo_id);
+            dispatch_prewarm(&app, Some(&workspace_id), root_path, &record.repo_id);
         });
 }
 
@@ -673,15 +707,51 @@ pub fn prewarm_slash_command_cache(app: &AppHandle) {
         });
 }
 
-fn dispatch_prewarm_for(app: &AppHandle, workspace_id: &str, root_path: &str, repo_id: &str) {
+/// Repo-level prewarm — for the start page where no workspace is selected.
+/// Uses the repo's `root_path` as cwd; cache key matches what
+/// `resolve_repo_fallback_cwd` produces, so the next `/` press hits warm.
+pub fn prewarm_slash_command_cache_for_repo(app: &AppHandle, repo_id: &str) {
+    let app = app.clone();
+    let repo_id = repo_id.to_string();
+    let _ = std::thread::Builder::new()
+        .name("slash-cmd-prewarm-repo".into())
+        .spawn(move || {
+            let record = match crate::models::repos::load_repository_by_id(&repo_id) {
+                Ok(Some(r)) => r,
+                Ok(None) => {
+                    tracing::debug!(repo_id, "Slash-command prewarm: repo not found");
+                    return;
+                }
+                Err(e) => {
+                    tracing::warn!(repo_id, error = %e, "Slash-command prewarm: load failed");
+                    return;
+                }
+            };
+            let root_path = record.root_path.trim();
+            if root_path.is_empty() || !std::path::Path::new(root_path).is_dir() {
+                tracing::debug!(
+                    repo_id,
+                    root_path,
+                    "Slash-command prewarm: repo root_path missing or not a directory"
+                );
+                return;
+            }
+            dispatch_prewarm(&app, None, root_path, &repo_id);
+        });
+}
+
+/// Schedule a background refresh per provider. Workspace-scoped callers pass
+/// `Some(workspace_id)` (which also pulls in any linked-directory commands);
+/// repo-scoped callers (start page) pass `None` and the key shape matches
+/// `resolve_repo_fallback_cwd` so the next `/` press hits warm cache.
+fn dispatch_prewarm(app: &AppHandle, workspace_id: Option<&str>, root_path: &str, repo_id: &str) {
     let cache: tauri::State<'_, super::slash_commands::SlashCommandCache> = app.state();
-    let additional_directories =
-        lookup_workspace_linked_directories_for_commands(Some(workspace_id));
+    let additional_directories = lookup_workspace_linked_directories_for_commands(workspace_id);
     for provider in ["claude", "codex"] {
         let request = ListSlashCommandsRequest {
             provider: provider.to_string(),
             working_directory: Some(root_path.to_string()),
-            workspace_id: Some(workspace_id.to_string()),
+            workspace_id: workspace_id.map(str::to_string),
             repo_id: Some(repo_id.to_string()),
         };
         let ws_key = super::slash_commands::workspace_key(
@@ -691,7 +761,7 @@ fn dispatch_prewarm_for(app: &AppHandle, workspace_id: &str, root_path: &str, re
         );
         tracing::debug!(
             provider,
-            workspace_id,
+            workspace_id = workspace_id.unwrap_or(""),
             cwd = root_path,
             repo_id,
             linked_dir_count = additional_directories.len(),
@@ -1129,4 +1199,113 @@ pub fn fetch_live_context_usage(
 
     sidecar.unsubscribe(&request_id);
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_request(cwd: Option<&str>, repo_id: Option<&str>) -> ListSlashCommandsRequest {
+        ListSlashCommandsRequest {
+            provider: "claude".to_string(),
+            working_directory: cwd.map(str::to_string),
+            workspace_id: None,
+            repo_id: repo_id.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn fallback_noop_when_working_directory_already_set() {
+        let req = make_request(Some("/some/path"), Some("r1"));
+        let resolved = resolve_repo_fallback_cwd(req);
+        assert_eq!(resolved.working_directory.as_deref(), Some("/some/path"));
+    }
+
+    #[test]
+    fn fallback_noop_when_repo_id_missing() {
+        let req = make_request(None, None);
+        let resolved = resolve_repo_fallback_cwd(req);
+        assert_eq!(resolved.working_directory, None);
+    }
+
+    #[test]
+    fn fallback_noop_when_repo_id_blank() {
+        let req = make_request(None, Some(""));
+        let resolved = resolve_repo_fallback_cwd(req);
+        assert_eq!(resolved.working_directory, None);
+    }
+
+    fn setup_test_db(dir: &std::path::Path) {
+        let db_path = dir.join("helmor.db");
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        crate::schema::ensure_schema(&conn).unwrap();
+        drop(conn);
+        crate::models::db::init_pools().expect("failed to init test DB pools");
+    }
+
+    fn insert_repo(repo_id: &str, root_path: &str) {
+        let db_path = crate::data_dir::data_dir().unwrap().join("helmor.db");
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute(
+            "INSERT INTO repos (id, name, root_path) VALUES (?1, 'test-repo', ?2)",
+            rusqlite::params![repo_id, root_path],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn fallback_resolves_to_repo_root_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let _guard = crate::data_dir::TEST_ENV_LOCK.lock().unwrap();
+        std::env::set_var("HELMOR_DATA_DIR", dir.path());
+
+        setup_test_db(dir.path());
+        let repo_root = dir.path().join("repo-root");
+        std::fs::create_dir(&repo_root).unwrap();
+        insert_repo("r1", repo_root.to_str().unwrap());
+
+        let req = make_request(None, Some("r1"));
+        let resolved = resolve_repo_fallback_cwd(req);
+        assert_eq!(
+            resolved.working_directory.as_deref(),
+            Some(repo_root.to_str().unwrap())
+        );
+
+        std::env::remove_var("HELMOR_DATA_DIR");
+    }
+
+    #[test]
+    fn fallback_noop_when_repo_root_path_does_not_exist() {
+        let dir = tempfile::tempdir().unwrap();
+        let _guard = crate::data_dir::TEST_ENV_LOCK.lock().unwrap();
+        std::env::set_var("HELMOR_DATA_DIR", dir.path());
+
+        setup_test_db(dir.path());
+        // Insert a repo whose root_path points at a directory that doesn't
+        // exist — guards the start-page case where the user deleted the
+        // working tree behind Helmor's back.
+        insert_repo("r1", "/nonexistent/path/for/test");
+
+        let req = make_request(None, Some("r1"));
+        let resolved = resolve_repo_fallback_cwd(req);
+        assert_eq!(resolved.working_directory, None);
+
+        std::env::remove_var("HELMOR_DATA_DIR");
+    }
+
+    #[test]
+    fn fallback_noop_when_repo_not_in_db() {
+        let dir = tempfile::tempdir().unwrap();
+        let _guard = crate::data_dir::TEST_ENV_LOCK.lock().unwrap();
+        std::env::set_var("HELMOR_DATA_DIR", dir.path());
+
+        setup_test_db(dir.path());
+        // No insert_repo — DB lookup returns Ok(None).
+
+        let req = make_request(None, Some("ghost-repo"));
+        let resolved = resolve_repo_fallback_cwd(req);
+        assert_eq!(resolved.working_directory, None);
+
+        std::env::remove_var("HELMOR_DATA_DIR");
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -234,6 +234,7 @@ pub fn run() {
             agents::generate_session_title,
             agents::list_slash_commands,
             agents::prewarm_slash_commands_for_workspace,
+            agents::prewarm_slash_commands_for_repo,
             commands::workspace_commands::prepare_archive_workspace,
             commands::workspace_commands::start_archive_workspace,
             commands::workspace_commands::validate_archive_workspace,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -95,6 +95,7 @@ import {
 	moveLocalWorkspaceToWorktree,
 	openWorkspaceInEditor,
 	openWorkspaceInFinder,
+	prewarmSlashCommandsForRepo,
 	prewarmSlashCommandsForWorkspace,
 	type RepositoryCreateOption,
 	syncWorkspaceWithTargetBranch,
@@ -2318,6 +2319,16 @@ function AppShell({
 		repositories.find((repository) => repository.id === startRepositoryId) ??
 		repositories[0] ??
 		null;
+	// Prewarm slash-commands for the start-page repo so the next `/` press
+	// hits warm cache (cold path otherwise has no cwd → misses project-level
+	// `.claude/commands/`). Gated on start view to avoid scheduling while the
+	// user is in workspace mode; deps key on `id` so a repositories refresh
+	// that doesn't change the selected repo doesn't re-fire.
+	useEffect(() => {
+		if (workspaceViewMode !== "start") return;
+		if (!startRepository) return;
+		void prewarmSlashCommandsForRepo(startRepository.id);
+	}, [workspaceViewMode, startRepository?.id]);
 	const selectedWorkspaceRepository =
 		repositories.find(
 			(repository) => repository.id === selectedWorkspaceDetail?.repoId,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1203,6 +1203,19 @@ export async function prewarmSlashCommandsForWorkspace(
 	}
 }
 
+/** Fire-and-forget: prewarm the slash-command cache for a repo (start page). */
+export async function prewarmSlashCommandsForRepo(
+	repoId: string,
+): Promise<void> {
+	try {
+		await invoke<void>("prewarm_slash_commands_for_repo", {
+			repoId,
+		});
+	} catch {
+		// Best-effort; cache will still be populated lazily on first /.
+	}
+}
+
 export async function loadWorkspaceDetail(
 	workspaceId: string,
 ): Promise<WorkspaceDetail | null> {


### PR DESCRIPTION
## Summary

On the start page (no workspace selected yet), pressing `/` only ever returned the user-level slash commands — project-level entries from `<repo>/.claude/commands/` were missing for both Claude and Codex.

Two fixes, both backend-side, plus a small frontend prewarm:

- **Backend resolver fallback**: `list_slash_commands` now falls back to the repo's `root_path` when the caller passes a `repo_id` but no `working_directory`. This is what the start page does. Without a cwd, the Claude/Codex CLI can't see project-level commands.
- **Repo-level prewarm**: New `prewarm_slash_commands_for_repo` Tauri command + `prewarm_slash_command_cache_for_repo` helper. Refactored the existing workspace prewarm to share `dispatch_prewarm` (with optional `workspace_id`), so the cache key shape matches between prewarm and live request — `/` press hits warm cache.
- **Frontend trigger**: New `useEffect` in `AppShell` fires `prewarmSlashCommandsForRepo(startRepository.id)` when the user is on the start view; deps key on `id` so a `repositories` refresh that doesn't change the selected repo doesn't re-fire.

## Why

Without the fallback, the start page calls `list_slash_commands` with empty cwd → CLI scans only `~/.claude/commands/` → project commands invisible. With the fallback, the cwd matches what the workspace flow uses, so the same commands surface in both contexts.

The prewarm matters because the start page is the first thing users see on launch; we want the `/` menu to feel instant rather than pay the CLI scan cost on first open.

## Test notes

- New unit tests in `src-tauri/src/agents/queries.rs` cover the fallback resolver: noop when cwd already set, noop when repo_id missing/blank, resolves to repo root, noop when root path doesn't exist on disk, noop when repo not in DB.
- Manual: launch the app, select a repo on the start page, press `/`, confirm project-level commands from `.claude/commands/` appear for both Claude and Codex.

## Test plan

- [ ] `bun run test:rust` passes (new fallback resolver tests)
- [ ] Cold start → start page → `/` shows project-level commands for Claude
- [ ] Cold start → start page → `/` shows project-level commands for Codex
- [ ] Switching repos on the start page repopulates the slash menu correctly
- [ ] Workspace flow still works (no regression in `dispatch_prewarm` refactor)