### PR TITLE
fix(slash-commands): refetch start-page menu when switching repo

### DIFF
--- a/src/lib/query-client.ts
+++ b/src/lib/query-client.ts
@@ -119,12 +119,14 @@ export const helmorQueryKeys = {
 		provider: AgentProvider,
 		workingDirectory: string | null,
 		workspaceId: string | null,
+		repoId: string | null,
 	) =>
 		[
 			"slashCommands",
 			provider,
 			workingDirectory ?? "",
 			workspaceId ?? "",
+			repoId ?? "",
 		] as const,
 	workspaceLinkedDirectories: (workspaceId: string) =>
 		["workspaceLinkedDirectories", workspaceId] as const,
@@ -580,6 +582,7 @@ export function slashCommandsQueryOptions(
 			provider,
 			workingDirectory,
 			workspaceId,
+			repoId,
 		),
 		queryFn: () =>
 			listSlashCommands({


### PR DESCRIPTION
## Summary

Follow-up to #469. The earlier fix made the backend resolve `repo_id` → `root_path` so cold-path requests had a cwd, but the frontend still missed the case where the user switches repos *within the start page*.

The slash-commands React Query key was `(provider, workingDirectory, workspaceId)` — both `workingDirectory` and `workspaceId` are `null` on the start page, so every repo collapsed onto the same cache entry. Switching repo didn't change the key, so React Query never refetched and the user saw the previous repo's commands (or nothing on cold start). Going to a workspace and back "fixed" it because composer container remounted and `gcTime: 0` evicted the stale entry.

Added `repoId` to the query key. One-line fix; everything else (backend fallback resolver, repo prewarm, useEffect gate) already in place from #469.

## Test plan

- [ ] Open Helmor on the start page; pick a repo with `.claude/commands/`; press `/` → project commands appear immediately
- [ ] Switch to a different repo on the start page; press `/` → that repo's project commands appear (not the previous repo's, not empty)
- [ ] Repeat with Codex selected as provider
- [ ] No regression on workspace composer `/` menu (workspaceId & workingDirectory still distinguish keys per workspace)