### PR TITLE
fix(scripts): let fish users run scripts

### DIFF
--- a/.changeset/fair-suits-fry.md
+++ b/.changeset/fair-suits-fry.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Let fish users run scripts.

--- a/src-tauri/src/workspace/scripts.rs
+++ b/src-tauri/src/workspace/scripts.rs
@@ -309,6 +309,33 @@ fn shell_escape(s: &str) -> String {
     format!("'{}'", s.replace('\'', "'\\''"))
 }
 
+fn fish_shell_escape(s: &str) -> String {
+    format!(
+        "\"{}\"",
+        s.replace('\\', "\\\\")
+            .replace('$', "\\$")
+            .replace('"', "\\\"")
+    )
+}
+
+fn wrapped_script_for_shell(shell_path: &str, script: &str) -> String {
+    let shell_name = std::path::Path::new(shell_path)
+        .file_name()
+        .and_then(|name| name.to_str());
+
+    if shell_name == Some("fish") {
+        return format!(
+            "eval {}; set __helmor_ec $status; printf '\\r\\n\\033[2m[Completed with exit code %d]\\033[0m\\r\\n' $__helmor_ec; exit $__helmor_ec\n",
+            fish_shell_escape(script),
+        );
+    }
+
+    format!(
+        "eval {}; __helmor_ec=$?; printf '\\r\\n\\033[2m[Completed with exit code %d]\\033[0m\\r\\n' $__helmor_ec; exit $__helmor_ec\n",
+        shell_escape(script),
+    )
+}
+
 /// Spawn an interactive login shell on a PTY and feed it `script`.
 ///
 /// After the initial command is sent, the PTY stays open so the user can
@@ -551,10 +578,7 @@ pub(crate) fn run_script_with_shell(
     // the shell stays at its prompt and waits for input — the user typing
     // directly in the Terminal tab, or `boot_input` seeding it below.
     if let Some(script) = script {
-        let wrapped = format!(
-            "eval {}; __helmor_ec=$?; printf '\\r\\n\\033[2m[Completed with exit code %d]\\033[0m\\r\\n' $__helmor_ec; exit $__helmor_ec\n",
-            shell_escape(script),
-        );
+        let wrapped = wrapped_script_for_shell(shell_path, script);
         let mut file = stdin.lock().expect("stdin mutex poisoned");
         if let Err(e) = file.write_all(wrapped.as_bytes()) {
             tracing::warn!(error = %e, "initial PTY write failed");
@@ -612,6 +636,22 @@ mod tests {
     #[test]
     fn shell_escape_single_quotes() {
         assert_eq!(shell_escape("it's"), "'it'\\''s'");
+    }
+
+    #[test]
+    fn fish_shell_escape_handles_fish_expansion_chars() {
+        assert_eq!(
+            fish_shell_escape("printf \"%s\" '$value' \\ done"),
+            "\"printf \\\"%s\\\" '\\$value' \\\\ done\"",
+        );
+    }
+
+    #[test]
+    fn wrapped_script_uses_fish_status_for_fish_shell() {
+        assert_eq!(
+            wrapped_script_for_shell("/opt/homebrew/bin/fish", "echo \"it's\""),
+            "eval \"echo \\\"it's\\\"\"; set __helmor_ec $status; printf '\\r\\n\\033[2m[Completed with exit code %d]\\033[0m\\r\\n' $__helmor_ec; exit $__helmor_ec\n",
+        );
     }
 
     // ── Test helpers ───────────────────────────────────────────────────────
@@ -1053,7 +1093,7 @@ mod tests {
         })
     }
 
-    fn run_simple(script: &str) -> Option<i32> {
+    fn run_simple_with_shell(script: &str, shell_path: &str, shell_args: &[&str]) -> Option<i32> {
         let mgr = ScriptProcessManager::new();
         let dir = std::env::temp_dir();
         let ctx = ScriptContext {
@@ -1071,13 +1111,17 @@ mod tests {
             dir.to_str().unwrap(),
             &ctx,
             make_channel(),
-            // /bin/sh avoids the user's interactive zsh startup cost that
-            // makes tests flaky under `cargo test` parallelism.
-            "/bin/sh",
-            &[],
+            shell_path,
+            shell_args,
             None,
         )
         .unwrap()
+    }
+
+    fn run_simple(script: &str) -> Option<i32> {
+        // /bin/sh avoids the user's interactive zsh startup cost that
+        // makes tests flaky under `cargo test` parallelism.
+        run_simple_with_shell(script, "/bin/sh", &[])
     }
 
     #[test]
@@ -1088,6 +1132,28 @@ mod tests {
     #[test]
     fn run_script_failing_command_exits_nonzero() {
         assert_eq!(run_simple("exit 42"), Some(42));
+    }
+
+    #[test]
+    fn run_script_with_fish_shell_preserves_exit_status() {
+        let Ok(output) = StdCommand::new("fish")
+            .args(["-c", "command -s fish"])
+            .output()
+        else {
+            return;
+        };
+        if !output.status.success() {
+            return;
+        }
+        let fish_path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if fish_path.is_empty() {
+            return;
+        }
+
+        assert_eq!(
+            run_simple_with_shell("printf '%s\\n' \"it's\"; exit 42", &fish_path, &[]),
+            Some(42),
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add a fish-specific run script wrapper that uses `$status` instead of POSIX `$?` assignment
- keep the existing POSIX wrapper path for `sh`, `bash`, `zsh`, and `dash`
- cover fish quoting and live fish-shell exit status handling in script tests
- add a patch changeset

## Issue

- Closes #474

## Verification

- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `RUSTC_WRAPPER= cargo test workspace::scripts::tests -- --nocapture`
- `RUSTC_WRAPPER= cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- Manual: `bun run dev`, then confirmed run scripts no longer fail with fish's `Unsupported use of '='` error

<img width="686" height="401" alt="image" src="https://github.com/user-attachments/assets/68b42611-b708-4885-a72c-2f279313cdcf" />
<img width="676" height="250" alt="image" src="https://github.com/user-attachments/assets/c03b009b-317d-461a-b7da-94f1953b523b" />
