### PR TITLE
feat(streaming): smooth char-level fade for assistant text and reasoning

### DIFF
--- a/.changeset/silky-otters-glow.md
+++ b/.changeset/silky-otters-glow.md
@@ -1,0 +1,7 @@
+---
+"helmor": patch
+---
+
+Polish the streaming response visuals:
+- Reveal assistant text and reasoning character-by-character with a steady fade-in, even when the underlying SDK output arrives in bursts.
+- Restyle the reasoning block as inline text without a separate background or container.

--- a/package.json
+++ b/package.json
@@ -111,9 +111,9 @@
 		"use-stick-to-bottom": "^1.1.3"
 	},
 	"devDependencies": {
+		"@biomejs/biome": "^2.4.10",
 		"@changesets/changelog-github": "^0.5.1",
 		"@changesets/cli": "^2.29.7",
-		"@biomejs/biome": "^2.4.10",
 		"@chromatic-com/storybook": "^5.1.2",
 		"@playwright/test": "^1.59.1",
 		"@rolldown/plugin-babel": "^0.2.2",

--- a/src/App.css
+++ b/src/App.css
@@ -779,10 +779,6 @@ body {
 	color: var(--conversation-body-foreground);
 }
 
-.conversation-streamdown [data-sd-animate] {
-	animation: none;
-}
-
 .conversation-streamdown :where(p, li, ul, ol, blockquote, table, strong, em) {
 	color: inherit;
 }
@@ -811,6 +807,26 @@ body {
 	border: 1px solid
 		color-mix(in oklch, var(--muted) 87%, var(--muted-foreground) 13%);
 	margin: 0 2px;
+}
+
+/*
+ * Plain-text streaming fade — used by <StreamingPlainText/> for content
+ * that does NOT need markdown rendering (e.g. reasoning blocks). One span
+ * per character; the same easing as streamdown's char-level fade so the
+ * two surfaces feel uniform.
+ */
+@keyframes stream-char-fade-in {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}
+
+.stream-char {
+	animation: stream-char-fade-in var(--stream-fade-ms, 300ms)
+		cubic-bezier(0.33, 0, 0.67, 1) forwards;
 }
 
 /* Table layout for assistant markdown */

--- a/src/components/ai/reasoning.tsx
+++ b/src/components/ai/reasoning.tsx
@@ -9,6 +9,7 @@ import {
 	useRef,
 	useState,
 } from "react";
+import { StreamingPlainText } from "@/components/ai/streaming-plain-text";
 import {
 	Collapsible,
 	CollapsibleContent,
@@ -181,14 +182,22 @@ export type ReasoningContentProps = ComponentProps<
 
 export const ReasoningContent = memo(
 	({ className, children, fontSize, ...props }: ReasoningContentProps) => {
+		const { lifecycle } = useReasoning();
+		const streaming = lifecycle === "streaming";
+		// SDK reasoning text often starts with a stray space; under
+		// `whitespace-pre-wrap` that renders as a leading <span> and shifts
+		// the first line right by one char while wrapped lines sit flush.
+		const trimmed = children.replace(/^\s+/, "");
+
 		return (
-			<CollapsibleContent className={cn("pt-1.5", className)} {...props}>
-				<pre
-					className="whitespace-pre-wrap break-words rounded-lg bg-muted/40 px-3 py-2.5 font-sans leading-relaxed text-muted-foreground/80"
+			<CollapsibleContent className={cn("pt-0.5", className)} {...props}>
+				<StreamingPlainText
+					streaming={streaming}
+					className="px-3 py-1 font-sans leading-relaxed text-muted-foreground/80"
 					style={fontSize ? { fontSize: `${fontSize}px` } : undefined}
 				>
-					{children}
-				</pre>
+					{trimmed}
+				</StreamingPlainText>
 			</CollapsibleContent>
 		);
 	},

--- a/src/components/ai/streaming-animated.ts
+++ b/src/components/ai/streaming-animated.ts
@@ -1,12 +1,5 @@
-/**
- * Shared `animated` config passed to `<LazyStreamdown>` for live streams.
- *
- * `sep: "char"` reveals one character at a time (vs. "word"), giving the
- * smoother typewriter feel; `stagger` is the per-unit fade offset in ms.
- * Tune `duration` to match `.stream-char` in App.css so the markdown
- * surface (AssistantText) and the plain-text surface (ReasoningContent)
- * feel uniform.
- */
+// Streamdown char-level fade config; keep `duration` in sync with
+// `.stream-char` in App.css so markdown and plain-text surfaces match.
 export const STREAMING_ANIMATED = {
 	animation: "fadeIn" as const,
 	duration: 300,
@@ -15,9 +8,5 @@ export const STREAMING_ANIMATED = {
 	stagger: 0,
 };
 
-/**
- * Shared smoothing preset for both AssistantText and StreamingPlainText.
- * `silky` defaults to ~28 cps (vs. balanced's 38) and a longer settling
- * window — slower, more deliberate typewriter cadence.
- */
+// Smoothing preset shared by AssistantText and StreamingPlainText.
 export const STREAMING_SMOOTHING_PRESET = "silky" as const;

--- a/src/components/ai/streaming-animated.ts
+++ b/src/components/ai/streaming-animated.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared `animated` config passed to `<LazyStreamdown>` for live streams.
+ *
+ * `sep: "char"` reveals one character at a time (vs. "word"), giving the
+ * smoother typewriter feel; `stagger` is the per-unit fade offset in ms.
+ * Tune `duration` to match `.stream-char` in App.css so the markdown
+ * surface (AssistantText) and the plain-text surface (ReasoningContent)
+ * feel uniform.
+ */
+export const STREAMING_ANIMATED = {
+	animation: "fadeIn" as const,
+	duration: 300,
+	easing: "linear" as const,
+	sep: "char" as const,
+	stagger: 0,
+};
+
+/**
+ * Shared smoothing preset for both AssistantText and StreamingPlainText.
+ * `silky` defaults to ~28 cps (vs. balanced's 38) and a longer settling
+ * window — slower, more deliberate typewriter cadence.
+ */
+export const STREAMING_SMOOTHING_PRESET = "silky" as const;

--- a/src/components/ai/streaming-plain-text.tsx
+++ b/src/components/ai/streaming-plain-text.tsx
@@ -3,16 +3,9 @@ import { STREAMING_SMOOTHING_PRESET } from "@/components/ai/streaming-animated";
 import { useSmoothStreamContent } from "@/features/conversation/hooks/use-smooth-stream-content";
 import { cn } from "@/lib/utils";
 
-/**
- * Streamed plain-text renderer with character-level fade-in.
- *
- * Mirrors the typewriter look of <LazyStreamdown animated.sep="char"/> but
- * without the markdown pipeline — used for content that the model emits as
- * pure prose (reasoning blocks). Each character mounts inside its own
- * `<span class="stream-char">`, which CSS fades in. When `streaming` is
- * false we collapse to a single text node, so historical / static reads
- * pay nothing.
- */
+// Char-level fade for plain prose (reasoning). Mirrors streamdown's char
+// animation without the markdown pipeline; static mode collapses to a
+// single text node so historical reads pay nothing.
 export const StreamingPlainText = memo(function StreamingPlainText({
 	children,
 	streaming,

--- a/src/components/ai/streaming-plain-text.tsx
+++ b/src/components/ai/streaming-plain-text.tsx
@@ -1,0 +1,64 @@
+import { type CSSProperties, memo, useMemo } from "react";
+import { STREAMING_SMOOTHING_PRESET } from "@/components/ai/streaming-animated";
+import { useSmoothStreamContent } from "@/features/conversation/hooks/use-smooth-stream-content";
+import { cn } from "@/lib/utils";
+
+/**
+ * Streamed plain-text renderer with character-level fade-in.
+ *
+ * Mirrors the typewriter look of <LazyStreamdown animated.sep="char"/> but
+ * without the markdown pipeline — used for content that the model emits as
+ * pure prose (reasoning blocks). Each character mounts inside its own
+ * `<span class="stream-char">`, which CSS fades in. When `streaming` is
+ * false we collapse to a single text node, so historical / static reads
+ * pay nothing.
+ */
+export const StreamingPlainText = memo(function StreamingPlainText({
+	children,
+	streaming,
+	className,
+	style,
+}: {
+	children: string;
+	streaming: boolean;
+	className?: string;
+	style?: CSSProperties;
+}) {
+	const smoothed = useSmoothStreamContent(children, {
+		enabled: streaming,
+		preset: STREAMING_SMOOTHING_PRESET,
+	});
+
+	// `[...str]` splits by codepoint so emoji / surrogate pairs stay intact.
+	const chars = useMemo(
+		() => (streaming ? [...smoothed] : null),
+		[streaming, smoothed],
+	);
+
+	if (!streaming || chars === null) {
+		return (
+			<div
+				className={cn("whitespace-pre-wrap break-words", className)}
+				style={style}
+			>
+				{smoothed}
+			</div>
+		);
+	}
+
+	return (
+		<div
+			className={cn("whitespace-pre-wrap break-words", className)}
+			style={style}
+		>
+			{/* index keys are intentional — `chars` only grows, never reorders */}
+			{chars.map((c, i) => (
+				<span key={i} className="stream-char">
+					{c}
+				</span>
+			))}
+		</div>
+	);
+});
+
+StreamingPlainText.displayName = "StreamingPlainText";

--- a/src/features/conversation/hooks/use-smooth-stream-content.ts
+++ b/src/features/conversation/hooks/use-smooth-stream-content.ts
@@ -1,0 +1,415 @@
+/**
+ * Smooths a continuously-growing string into a steady character-per-frame reveal.
+ *
+ * Vendored from `lobe-ui` (`src/Markdown/SyntaxMarkdown/useSmoothStreamContent.ts`,
+ * MIT). Profiler hooks removed; behaviour otherwise identical.
+ *
+ * Why: agent SDK deltas arrive bursty (a paragraph at once, then a long pause).
+ * Feeding bursts straight to the renderer causes the typewriter animation to
+ * jitter or skip ahead. This hook keeps an internal target buffer + EMA on the
+ * arrival rate, then drains characters out at a frame-paced rate matching the
+ * sender. End result: smooth, paced output regardless of network jitter.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type StreamSmoothingPreset = "realtime" | "balanced" | "silky";
+
+interface StreamSmoothingPresetConfig {
+	activeInputWindowMs: number;
+	defaultCps: number;
+	emaAlpha: number;
+	flushCps: number;
+	largeAppendChars: number;
+	maxActiveCps: number;
+	maxCps: number;
+	maxFlushCps: number;
+	minCps: number;
+	settleAfterMs: number;
+	settleDrainMaxMs: number;
+	settleDrainMinMs: number;
+	targetBufferMs: number;
+}
+
+const PRESET_CONFIG: Record<
+	StreamSmoothingPreset,
+	StreamSmoothingPresetConfig
+> = {
+	balanced: {
+		activeInputWindowMs: 220,
+		defaultCps: 38,
+		emaAlpha: 0.2,
+		flushCps: 120,
+		largeAppendChars: 120,
+		maxActiveCps: 132,
+		maxCps: 72,
+		maxFlushCps: 280,
+		minCps: 18,
+		settleAfterMs: 360,
+		settleDrainMaxMs: 520,
+		settleDrainMinMs: 180,
+		targetBufferMs: 120,
+	},
+	realtime: {
+		activeInputWindowMs: 140,
+		defaultCps: 50,
+		emaAlpha: 0.3,
+		flushCps: 170,
+		largeAppendChars: 180,
+		maxActiveCps: 180,
+		maxCps: 96,
+		maxFlushCps: 360,
+		minCps: 24,
+		settleAfterMs: 260,
+		settleDrainMaxMs: 360,
+		settleDrainMinMs: 140,
+		targetBufferMs: 40,
+	},
+	silky: {
+		activeInputWindowMs: 320,
+		defaultCps: 28,
+		emaAlpha: 0.14,
+		flushCps: 96,
+		largeAppendChars: 100,
+		maxActiveCps: 102,
+		maxCps: 56,
+		maxFlushCps: 220,
+		minCps: 14,
+		settleAfterMs: 460,
+		settleDrainMaxMs: 680,
+		settleDrainMinMs: 240,
+		targetBufferMs: 170,
+	},
+};
+
+const clamp = (value: number, min: number, max: number): number =>
+	Math.min(max, Math.max(min, value));
+
+const getNow = () =>
+	typeof performance === "undefined" ? Date.now() : performance.now();
+
+const countChars = (text: string): number => [...text].length;
+
+interface UseSmoothStreamContentOptions {
+	enabled?: boolean;
+	preset?: StreamSmoothingPreset;
+}
+
+export const useSmoothStreamContent = (
+	content: string,
+	{ enabled = true, preset = "balanced" }: UseSmoothStreamContentOptions = {},
+): string => {
+	const config = PRESET_CONFIG[preset];
+	const [displayedContent, setDisplayedContent] = useState(content);
+
+	const displayedContentRef = useRef(content);
+	const displayedCountRef = useRef(countChars(content));
+
+	const targetContentRef = useRef(content);
+	const targetCharsRef = useRef([...content]);
+	const targetCountRef = useRef(targetCharsRef.current.length);
+
+	const emaCpsRef = useRef(config.defaultCps);
+	const lastInputTsRef = useRef(0);
+	const lastInputCountRef = useRef(targetCountRef.current);
+	const chunkSizeEmaRef = useRef(1);
+	const arrivalCpsEmaRef = useRef(config.defaultCps);
+
+	const rafRef = useRef<number | null>(null);
+	const lastFrameTsRef = useRef<number | null>(null);
+	const wakeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	const clearWakeTimer = useCallback(() => {
+		if (wakeTimerRef.current !== null) {
+			clearTimeout(wakeTimerRef.current);
+			wakeTimerRef.current = null;
+		}
+	}, []);
+
+	const stopFrameLoop = useCallback(() => {
+		if (rafRef.current !== null) {
+			cancelAnimationFrame(rafRef.current);
+			rafRef.current = null;
+		}
+		lastFrameTsRef.current = null;
+	}, []);
+
+	const stopScheduling = useCallback(() => {
+		stopFrameLoop();
+		clearWakeTimer();
+	}, [clearWakeTimer, stopFrameLoop]);
+
+	const startFrameLoopRef = useRef<() => void>(() => {});
+
+	const scheduleFrameWake = useCallback(
+		(delayMs: number) => {
+			clearWakeTimer();
+
+			wakeTimerRef.current = setTimeout(
+				() => {
+					wakeTimerRef.current = null;
+					startFrameLoopRef.current();
+				},
+				Math.max(1, Math.ceil(delayMs)),
+			);
+		},
+		[clearWakeTimer],
+	);
+
+	const syncImmediate = useCallback(
+		(nextContent: string) => {
+			stopScheduling();
+
+			const chars = [...nextContent];
+			const now = getNow();
+
+			targetContentRef.current = nextContent;
+			targetCharsRef.current = chars;
+			targetCountRef.current = chars.length;
+
+			displayedContentRef.current = nextContent;
+			displayedCountRef.current = chars.length;
+			setDisplayedContent(nextContent);
+
+			emaCpsRef.current = config.defaultCps;
+			chunkSizeEmaRef.current = 1;
+			arrivalCpsEmaRef.current = config.defaultCps;
+			lastInputTsRef.current = now;
+			lastInputCountRef.current = chars.length;
+		},
+		[config.defaultCps, stopScheduling],
+	);
+
+	const startFrameLoop = useCallback(() => {
+		clearWakeTimer();
+		if (rafRef.current !== null) return;
+
+		const tick = (ts: number) => {
+			if (lastFrameTsRef.current === null) {
+				lastFrameTsRef.current = ts;
+				rafRef.current = requestAnimationFrame(tick);
+				return;
+			}
+
+			const frameIntervalMs = Math.max(0, ts - lastFrameTsRef.current);
+			const dtSeconds = Math.max(0.001, Math.min(frameIntervalMs / 1000, 0.05));
+			lastFrameTsRef.current = ts;
+
+			const targetCount = targetCountRef.current;
+			const displayedCount = displayedCountRef.current;
+			const backlog = targetCount - displayedCount;
+
+			if (backlog <= 0) {
+				stopFrameLoop();
+				return;
+			}
+
+			const now = getNow();
+			const idleMs = now - lastInputTsRef.current;
+			const inputActive = idleMs <= config.activeInputWindowMs;
+			const settling = !inputActive && idleMs >= config.settleAfterMs;
+
+			const baseCps = clamp(emaCpsRef.current, config.minCps, config.maxCps);
+			const baseLagChars = Math.max(
+				1,
+				Math.round((baseCps * config.targetBufferMs) / 1000),
+			);
+			const lagUpperBound = Math.max(baseLagChars + 2, baseLagChars * 3);
+			const targetLagChars = inputActive
+				? Math.round(
+						clamp(
+							baseLagChars + chunkSizeEmaRef.current * 0.35,
+							baseLagChars,
+							lagUpperBound,
+						),
+					)
+				: 0;
+			const desiredDisplayed = Math.max(0, targetCount - targetLagChars);
+
+			let currentCps: number;
+			if (inputActive) {
+				const backlogPressure =
+					targetLagChars > 0 ? backlog / targetLagChars : 1;
+				const chunkPressure =
+					targetLagChars > 0 ? chunkSizeEmaRef.current / targetLagChars : 1;
+				const arrivalPressure = arrivalCpsEmaRef.current / Math.max(baseCps, 1);
+				const combinedPressure = clamp(
+					backlogPressure * 0.6 + chunkPressure * 0.25 + arrivalPressure * 0.15,
+					1,
+					4.5,
+				);
+				const activeCap = clamp(
+					config.maxActiveCps + chunkSizeEmaRef.current * 6,
+					config.maxActiveCps,
+					config.maxFlushCps,
+				);
+				currentCps = clamp(
+					baseCps * combinedPressure,
+					config.minCps,
+					activeCap,
+				);
+			} else if (settling) {
+				// If upstream likely ended, cap the remaining tail duration so we
+				// don't keep replaying old backlog for seconds.
+				const drainTargetMs = clamp(
+					backlog * 8,
+					config.settleDrainMinMs,
+					config.settleDrainMaxMs,
+				);
+				const settleCps = (backlog * 1000) / drainTargetMs;
+				currentCps = clamp(settleCps, config.flushCps, config.maxFlushCps);
+			} else {
+				const idleFlushCps = Math.max(
+					config.flushCps,
+					baseCps * 1.8,
+					arrivalCpsEmaRef.current * 0.8,
+				);
+				currentCps = clamp(idleFlushCps, config.flushCps, config.maxFlushCps);
+			}
+
+			const urgentBacklog =
+				inputActive && targetLagChars > 0 && backlog > targetLagChars * 2.2;
+			const burstyInput =
+				inputActive && chunkSizeEmaRef.current >= targetLagChars * 0.9;
+			const minRevealChars = inputActive
+				? urgentBacklog || burstyInput
+					? 2
+					: 1
+				: 2;
+			let revealChars = Math.max(
+				minRevealChars,
+				Math.round(currentCps * dtSeconds),
+			);
+
+			if (inputActive) {
+				const shortfall = desiredDisplayed - displayedCount;
+				if (shortfall <= 0) {
+					stopFrameLoop();
+					scheduleFrameWake(config.activeInputWindowMs - idleMs);
+					return;
+				}
+				revealChars = Math.min(revealChars, shortfall, backlog);
+			} else {
+				revealChars = Math.min(revealChars, backlog);
+			}
+
+			const nextCount = displayedCount + revealChars;
+			const segment = targetCharsRef.current
+				.slice(displayedCount, nextCount)
+				.join("");
+
+			if (segment) {
+				const nextDisplayed = displayedContentRef.current + segment;
+				displayedContentRef.current = nextDisplayed;
+				displayedCountRef.current = nextCount;
+				setDisplayedContent(nextDisplayed);
+			} else {
+				displayedContentRef.current = targetContentRef.current;
+				displayedCountRef.current = targetCount;
+				setDisplayedContent(targetContentRef.current);
+			}
+
+			rafRef.current = requestAnimationFrame(tick);
+		};
+
+		rafRef.current = requestAnimationFrame(tick);
+	}, [
+		clearWakeTimer,
+		config.activeInputWindowMs,
+		config.flushCps,
+		config.maxActiveCps,
+		config.maxCps,
+		config.maxFlushCps,
+		config.minCps,
+		config.settleAfterMs,
+		config.settleDrainMaxMs,
+		config.settleDrainMinMs,
+		config.targetBufferMs,
+		scheduleFrameWake,
+		stopFrameLoop,
+	]);
+	startFrameLoopRef.current = startFrameLoop;
+
+	useEffect(() => {
+		if (!enabled) {
+			syncImmediate(content);
+			return;
+		}
+
+		const prevTargetContent = targetContentRef.current;
+		if (content === prevTargetContent) return;
+
+		const now = getNow();
+		const appendOnly = content.startsWith(prevTargetContent);
+
+		if (!appendOnly) {
+			// Non-monotonic update (rewrite, truncation, restart): jump to the
+			// new content without animating diff.
+			syncImmediate(content);
+			return;
+		}
+
+		const appended = content.slice(prevTargetContent.length);
+		const appendedChars = [...appended];
+		const appendedCount = appendedChars.length;
+
+		if (appendedCount > config.largeAppendChars) {
+			// Single delta too big to smooth (paste / large flush) — skip
+			// animation to avoid seconds of unnecessary backlog.
+			syncImmediate(content);
+			return;
+		}
+
+		targetContentRef.current = content;
+		targetCharsRef.current = [...targetCharsRef.current, ...appendedChars];
+		targetCountRef.current += appendedCount;
+
+		const deltaChars = targetCountRef.current - lastInputCountRef.current;
+		const deltaMs = Math.max(1, now - lastInputTsRef.current);
+
+		if (deltaChars > 0) {
+			const instantCps = (deltaChars * 1000) / deltaMs;
+			const normalizedInstantCps = clamp(
+				instantCps,
+				config.minCps,
+				config.maxFlushCps * 2,
+			);
+			const chunkEmaAlpha = 0.35;
+			chunkSizeEmaRef.current =
+				chunkSizeEmaRef.current * (1 - chunkEmaAlpha) +
+				appendedCount * chunkEmaAlpha;
+			arrivalCpsEmaRef.current =
+				arrivalCpsEmaRef.current * (1 - chunkEmaAlpha) +
+				normalizedInstantCps * chunkEmaAlpha;
+
+			const clampedCps = clamp(instantCps, config.minCps, config.maxActiveCps);
+			emaCpsRef.current =
+				emaCpsRef.current * (1 - config.emaAlpha) +
+				clampedCps * config.emaAlpha;
+		}
+
+		lastInputTsRef.current = now;
+		lastInputCountRef.current = targetCountRef.current;
+
+		startFrameLoop();
+	}, [
+		config.emaAlpha,
+		config.largeAppendChars,
+		config.maxActiveCps,
+		config.maxCps,
+		config.maxFlushCps,
+		config.minCps,
+		content,
+		enabled,
+		startFrameLoop,
+		syncImmediate,
+	]);
+
+	useEffect(() => {
+		return () => {
+			stopScheduling();
+		};
+	}, [stopScheduling]);
+
+	return displayedContent;
+};

--- a/src/features/conversation/hooks/use-smooth-stream-content.ts
+++ b/src/features/conversation/hooks/use-smooth-stream-content.ts
@@ -1,15 +1,6 @@
-/**
- * Smooths a continuously-growing string into a steady character-per-frame reveal.
- *
- * Vendored from `lobe-ui` (`src/Markdown/SyntaxMarkdown/useSmoothStreamContent.ts`,
- * MIT). Profiler hooks removed; behaviour otherwise identical.
- *
- * Why: agent SDK deltas arrive bursty (a paragraph at once, then a long pause).
- * Feeding bursts straight to the renderer causes the typewriter animation to
- * jitter or skip ahead. This hook keeps an internal target buffer + EMA on the
- * arrival rate, then drains characters out at a frame-paced rate matching the
- * sender. End result: smooth, paced output regardless of network jitter.
- */
+// Smooths bursty agent SDK deltas into a steady character-per-frame reveal.
+// Vendored from lobe-ui (src/Markdown/SyntaxMarkdown/useSmoothStreamContent.ts,
+// MIT); profiler hooks removed, behaviour otherwise identical.
 
 import { useCallback, useEffect, useRef, useState } from "react";
 

--- a/src/features/panel/message-components.test.tsx
+++ b/src/features/panel/message-components.test.tsx
@@ -284,9 +284,12 @@ describe("MemoConversationMessage plan review", () => {
 		);
 
 		expect(screen.getByText("Thinking...")).toBeInTheDocument();
-		expect(
-			screen.getByText("Inspecting the streamed reasoning block."),
-		).toBeInTheDocument();
+		// Streaming reasoning splits each char into its own <span> for the
+		// fade-in effect, so getByText("...") can't match a literal
+		// substring. toHaveTextContent walks the subtree.
+		expect(document.body).toHaveTextContent(
+			"Inspecting the streamed reasoning block.",
+		);
 
 		act(() => {
 			vi.advanceTimersByTime(2_000);
@@ -319,10 +322,11 @@ describe("MemoConversationMessage plan review", () => {
 		);
 
 		expect(screen.getByText("Thought for 2s")).toBeInTheDocument();
-		// Content is hidden because reasoning auto-collapses on completion.
-		expect(
-			screen.queryByText("Inspecting the streamed reasoning block."),
-		).not.toBeInTheDocument();
+		// Content is hidden because reasoning auto-collapses on completion
+		// (CollapsibleContent unmounts via Radix Presence).
+		expect(document.body).not.toHaveTextContent(
+			"Inspecting the streamed reasoning block.",
+		);
 		expect(screen.getByText("Done.")).toBeInTheDocument();
 	});
 

--- a/src/features/panel/message-components/assistant-message.tsx
+++ b/src/features/panel/message-components/assistant-message.tsx
@@ -5,7 +5,12 @@ import {
 	ReasoningContent,
 	ReasoningTrigger,
 } from "@/components/ai/reasoning";
+import {
+	STREAMING_ANIMATED,
+	STREAMING_SMOOTHING_PRESET,
+} from "@/components/ai/streaming-animated";
 import { LazyStreamdown } from "@/components/streamdown-loader";
+import { useSmoothStreamContent } from "@/features/conversation/hooks/use-smooth-stream-content";
 import {
 	type ExtendedMessagePart,
 	partKey,
@@ -39,14 +44,6 @@ import { AssistantToolCall, CollapsedToolGroup } from "./tool-call";
 
 // --- AssistantText ---
 
-const STREAMING_ANIMATED = {
-	animation: "blurIn" as const,
-	duration: 150,
-	easing: "linear" as const,
-	sep: "word" as const,
-	stagger: 30,
-};
-
 const AssistantText = memo(function AssistantText({
 	text,
 	streaming,
@@ -56,13 +53,19 @@ const AssistantText = memo(function AssistantText({
 }) {
 	const mode: StreamdownMode = streaming ? "streaming" : "static";
 	const { settings } = useSettings();
+	// Smooth out bursty SDK deltas so the typewriter cadence stays even
+	// regardless of how chunky the upstream stream happens to be.
+	const smoothedText = useSmoothStreamContent(text, {
+		enabled: streaming,
+		preset: STREAMING_SMOOTHING_PRESET,
+	});
 
 	return (
 		<div
 			className="conversation-markdown assistant-markdown-scale max-w-none break-words text-foreground"
 			style={{ fontSize: `${settings.fontSize}px` }}
 		>
-			<Suspense fallback={<AssistantTextFallback text={text} />}>
+			<Suspense fallback={<AssistantTextFallback text={smoothedText} />}>
 				<LazyStreamdown
 					animated={streaming ? STREAMING_ANIMATED : false}
 					caret={undefined}
@@ -70,7 +73,7 @@ const AssistantText = memo(function AssistantText({
 					isAnimating={streaming}
 					mode={mode}
 				>
-					{text}
+					{smoothedText}
 				</LazyStreamdown>
 			</Suspense>
 		</div>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,4 @@
+import "streamdown/styles.css";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,3 @@
-import "streamdown/styles.css";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";


### PR DESCRIPTION
## Summary

Polish how live agent output is revealed:

- **Smooth burst-tolerant typewriter.** New `useSmoothStreamContent` hook (vendored from `lobe-ui`, MIT) buffers SDK deltas and drains them at a frame-paced cadence based on an EMA of arrival rate, so the typewriter no longer stutters when the SDK flushes a paragraph at once and then idles. Shared `silky` preset (~28 cps default) tuned for both surfaces.
- **Char-level fade for assistant markdown.** `STREAMING_ANIMATED` switched from `word`/`blurIn`/150ms to `char`/`fadeIn`/300ms in `assistant-message.tsx`. Pulled the config into `streaming-animated.ts` so AssistantText and the new plain-text surface stay in sync.
- **New `<StreamingPlainText/>` for reasoning blocks.** Same char-level fade but without the markdown pipeline — one `<span class="stream-char">` per codepoint, fading via the `stream-char-fade-in` keyframe in `App.css`. Static / historical reads collapse to a single text node so they pay nothing.
- **Reasoning visual restyle.** Dropped the muted box around reasoning content; render as inline prose (`px-3 py-1`, no background). Trim a stray leading space from SDK reasoning text so the first line aligns with subsequent wrapped lines.
- **Misc.** Imported `streamdown/styles.css` from `main.tsx` (animated fade requires it). Removed the old `[data-sd-animate]` override that disabled streamdown's animation.

## Why

Two things were off:

1. The previous word-level `blurIn` looked snappy in isolation but felt jittery when the SDK delivered a whole paragraph in one chunk.
2. Reasoning was rendered in a `<pre>` with a muted background — visually disconnected from the rest of the assistant turn and noisier than necessary.

## Test plan

- [ ] Send a long assistant response and verify text fades in character-by-character at a steady cadence even when the upstream SDK is bursty.
- [ ] Trigger a reasoning block and verify it renders as inline prose with the same char-fade animation; auto-collapses on completion.
- [ ] Reload an existing session — historical messages should render instantly, no animation.
- [ ] `bun run test:frontend` passes (updated `message-components.test.tsx` to use `toHaveTextContent`, since each char is now its own span).