### PR TITLE
fix(slash-commands): match omitted separators

### DIFF
--- a/.changeset/fresh-webs-walk.md
+++ b/.changeset/fresh-webs-walk.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Make slash command search match hyphenated commands when separators are omitted.

--- a/src/features/composer/editor/plugins/slash-command-plugin.test.ts
+++ b/src/features/composer/editor/plugins/slash-command-plugin.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import type { SlashCommandEntry } from "@/lib/api";
+import { filterCommands, rankCommand } from "./slash-command-plugin";
+
+function command(name: string): SlashCommandEntry {
+	return {
+		name,
+		description: `${name} command`,
+		source: "builtin",
+	};
+}
+
+describe("rankCommand", () => {
+	it("scores literal prefix matches highest", () => {
+		expect(rankCommand(command("add-dir"), "add")).toBe(5);
+	});
+
+	it("scores literal substring matches above normalized matches", () => {
+		expect(rankCommand(command("open-add-dir"), "add")).toBe(4);
+		expect(rankCommand(command("add-dir"), "addd")).toBe(3);
+	});
+
+	it("matches hyphenated names with separators omitted", () => {
+		expect(rankCommand(command("add-dir"), "adddir")).toBe(3);
+	});
+
+	it("matches obvious typos as ordered fuzzy matches", () => {
+		expect(rankCommand(command("add-dir"), "addir")).toBe(1);
+		expect(rankCommand(command("add-dir"), "adir")).toBe(1);
+	});
+
+	it("returns 0 when the query cannot match in order", () => {
+		expect(rankCommand(command("add-dir"), "zz")).toBe(0);
+	});
+});
+
+describe("filterCommands", () => {
+	const commands = [
+		command("open-add-dir"),
+		command("add-dir"),
+		command("compact"),
+		command("commit"),
+	];
+
+	it("keeps literal prefix and substring matches ahead of fuzzy matches", () => {
+		const result = filterCommands(commands, "add");
+		expect(result.map((entry) => entry.name)).toEqual([
+			"add-dir",
+			"open-add-dir",
+		]);
+	});
+
+	it("suggests add-dir when the user types addd", () => {
+		const result = filterCommands(commands, "addd");
+		expect(result.map((entry) => entry.name)).toContain("add-dir");
+	});
+
+	it("preserves upstream order within the same rank bucket", () => {
+		const result = filterCommands(commands, "co");
+		expect(result.map((entry) => entry.name)).toEqual(["compact", "commit"]);
+	});
+});

--- a/src/features/composer/editor/plugins/slash-command-plugin.tsx
+++ b/src/features/composer/editor/plugins/slash-command-plugin.tsx
@@ -72,26 +72,56 @@ function dedupeByName(
 	return out;
 }
 
-function filterCommands(
+function compactCommandSearchText(input: string): string {
+	return input.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function isOrderedSubsequence(query: string, value: string): boolean {
+	let queryIndex = 0;
+	for (const char of value) {
+		if (char === query[queryIndex]) {
+			queryIndex += 1;
+			if (queryIndex === query.length) return true;
+		}
+	}
+	return false;
+}
+
+/**
+ * Rank slash commands against a query. Higher score = better match.
+ * - 5: literal command name starts with query
+ * - 4: literal command name contains query
+ * - 3: separator-normalized command name starts with query
+ * - 2: separator-normalized command name contains query
+ * - 1: ordered fuzzy match on separator-normalized name
+ * - 0: no match
+ */
+export function rankCommand(command: SlashCommandEntry, query: string): number {
+	if (!query) return 1;
+	const q = query.toLowerCase();
+	const name = command.name.toLowerCase();
+	if (name.startsWith(q)) return 5;
+	if (name.includes(q)) return 4;
+
+	const compactQuery = compactCommandSearchText(q);
+	const compactName = compactCommandSearchText(name);
+	if (!compactQuery) return 1;
+	if (compactName.startsWith(compactQuery)) return 3;
+	if (compactName.includes(compactQuery)) return 2;
+	if (isOrderedSubsequence(compactQuery, compactName)) return 1;
+	return 0;
+}
+
+export function filterCommands(
 	commands: readonly SlashCommandEntry[],
 	query: string,
 ): readonly SlashCommandEntry[] {
 	if (!query) return commands;
-	const q = query.toLowerCase();
-	// Two-pass: prefix matches first (typing "co" surfaces /commit,
-	// /context, /compact in that order), then any remaining substring
-	// matches.
-	const prefix: SlashCommandEntry[] = [];
-	const substring: SlashCommandEntry[] = [];
-	for (const cmd of commands) {
-		const name = cmd.name.toLowerCase();
-		if (name.startsWith(q)) {
-			prefix.push(cmd);
-		} else if (name.includes(q)) {
-			substring.push(cmd);
-		}
-	}
-	return [...prefix, ...substring];
+	const ranked = commands
+		.map((command) => ({ command, score: rankCommand(command, query) }))
+		.filter((entry) => entry.score > 0);
+	ranked.sort((a, b) => b.score - a.score);
+	return ranked.map((entry) => entry.command);
 }
 
 export function SlashCommandPlugin({


### PR DESCRIPTION
## Summary

- Match slash-command queries against both literal command names and separator-normalized names.
- Keep literal prefix and substring matches ranked ahead of normalized and fuzzy matches.
- Add focused tests for ranking, separatorless queries, typo-style ordered matches, and stable same-rank ordering.

## Tests

- bun x vitest run src/features/composer/editor/plugins/slash-command-plugin.test.ts
- bun run typecheck
- bun run lint
