### PR TITLE
perf(startup): defer file-mention scan and skip inspector diff during worktree init

### DIFF
--- a/.changeset/clever-pandas-rest.md
+++ b/.changeset/clever-pandas-rest.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix a multi-second UI freeze when starting a new worktree on a large repository, caused by the inspector running its file-diff panel against the worktree mid-checkout.

--- a/src/features/composer/editor/plugins/file-mention-plugin.tsx
+++ b/src/features/composer/editor/plugins/file-mention-plugin.tsx
@@ -22,7 +22,13 @@ import {
 import { useQuery } from "@tanstack/react-query";
 import { $createTextNode, type TextNode } from "lexical";
 import { FileText } from "lucide-react";
-import { type RefObject, useCallback, useMemo, useState } from "react";
+import {
+	type RefObject,
+	useCallback,
+	useEffect,
+	useMemo,
+	useState,
+} from "react";
 import { createPortal } from "react-dom";
 import {
 	Command,
@@ -104,11 +110,34 @@ export function FileMentionPlugin({
 	const [editor] = useLexicalComposerContext();
 	const [query, setQuery] = useState<string | null>(null);
 
-	// Cached per workspace root. The query is disabled until we have a root,
-	// so the popup simply never opens before the workspace finishes loading.
+	// Defer the recursive workspace walk to an idle frame so it doesn't
+	// compete with the view-switch reconciliation. By the time the user
+	// types `@`, the cache is usually warm.
+	const [hasIdledOnce, setHasIdledOnce] = useState(false);
+	useEffect(() => {
+		if (!workspaceRootPath || hasIdledOnce) return;
+		const win = typeof window === "undefined" ? null : window;
+		const ric =
+			win && "requestIdleCallback" in win
+				? win.requestIdleCallback.bind(win)
+				: null;
+		const cic =
+			win && "cancelIdleCallback" in win
+				? win.cancelIdleCallback.bind(win)
+				: null;
+		if (ric) {
+			const handle = ric(() => setHasIdledOnce(true), { timeout: 1500 });
+			return () => cic?.(handle);
+		}
+		const timer = setTimeout(() => setHasIdledOnce(true), 800);
+		return () => clearTimeout(timer);
+	}, [workspaceRootPath, hasIdledOnce]);
+
+	// Light up immediately if the picker opens before idle.
+	const pickerActive = query !== null;
 	const filesQuery = useQuery({
 		...workspaceFilesQueryOptions(workspaceRootPath ?? ""),
-		enabled: Boolean(workspaceRootPath),
+		enabled: Boolean(workspaceRootPath) && (hasIdledOnce || pickerActive),
 	});
 
 	const files = filesQuery.data ?? [];

--- a/src/features/inspector/hooks/use-inspector.ts
+++ b/src/features/inspector/hooks/use-inspector.ts
@@ -330,9 +330,18 @@ export function useWorkspaceInspectorSidebar({
 	const isActionsResizing = resizeState?.target === RESIZE_TARGET_ACTIONS;
 	const isTabsResizing = resizeState?.target === RESIZE_TARGET_TABS;
 
+	// Skip while the worktree isn't fully materialised. During
+	// `Initializing`, `git worktree add` is mid-checkout: `git diff`
+	// against the half-populated tree returns every tracked file as a
+	// phantom delete, and the inspector's auto-expanded tree stalls the
+	// JS thread for seconds. `Archived` has no worktree at all.
+	const changesQueryEnabled =
+		!!workspaceRootPath &&
+		workspaceState !== "initializing" &&
+		workspaceState !== "archived";
 	const changesQuery = useQuery({
 		...workspaceChangesQueryOptions(workspaceRootPath ?? ""),
-		enabled: !!workspaceRootPath,
+		enabled: changesQueryEnabled,
 	});
 	const changes: InspectorFileItem[] = changesQuery.data?.items ?? [];
 


### PR DESCRIPTION
## Summary

Two startup-lag fixes that compound on large repos when opening or switching to a workspace.

### What changed

- **`file-mention-plugin.tsx`** — defer the recursive workspace file walk powering the `@`-mention picker to `requestIdleCallback` (or an 800ms timeout fallback) so it no longer competes with the view-switch reconciliation. The query lights up immediately if the picker opens before idle, so there's no perceived delay for users typing `@`.
- **`use-inspector.ts`** — gate the inspector's changes query on a fully materialised worktree. During the `initializing` state `git worktree add` is mid-checkout, and a `git diff` against the half-populated tree returns every tracked file as a phantom delete; the inspector's auto-expanded file tree then stalls the JS thread for seconds. `archived` workspaces have no tree at all, so we skip them too.

### Why

On large repos, switching to a freshly-initialising workspace produced a multi-second UI freeze. Profiling pointed at two simultaneous offenders: the file-mention plugin eagerly walking the workspace tree on mount, and the inspector running a diff against a checkout that wasn't done yet. Each contributes to the lag independently — fixing both together restores a snappy switch.

### Test notes

- Manually verified on a large repo: switching into a new workspace no longer freezes; the `@` picker still opens instantly with file results.
- No new automated tests — both changes are timing/lifecycle gating with no new code paths to snapshot.
- Includes a `patch` changeset entry.