### PR TITLE
fix(workspace): wait for script child process groups

### DIFF
--- a/src-tauri/src/workspace/scripts.rs
+++ b/src-tauri/src/workspace/scripts.rs
@@ -211,10 +211,11 @@ impl ScriptProcessManager {
 }
 
 /// Send SIGTERM (and SIGKILL after a short grace period) to a process group
-/// and its leader. Polls `kill(pid, 0)` to detect when the process has been
+/// and its leader. Polls `kill(pid, 0)` to detect when the leader has been
 /// reaped by its parent — which is `run_script`'s `child.wait()` running on
-/// a separate thread. Zombies still report alive, so this effectively waits
-/// for the reap, which happens microseconds after the child actually dies.
+/// a separate thread. When the script owns a separate process group, also wait
+/// for that group to disappear so a fast leader exit cannot leave descendants
+/// running after Stop returns.
 fn escalating_kill(pid: libc::pid_t, pgid: libc::pid_t) {
     let current_pgrp = unsafe { libc::getpgrp() };
     let can_signal_group = pgid > 0 && pgid != current_pgrp;
@@ -226,7 +227,7 @@ fn escalating_kill(pid: libc::pid_t, pgid: libc::pid_t) {
         libc::kill(pid, libc::SIGTERM);
     }
 
-    if wait_for_pid_gone(pid, PROCESS_TERM_TIMEOUT) {
+    if wait_for_processes_gone(pid, pgid, can_signal_group, PROCESS_TERM_TIMEOUT) {
         return;
     }
 
@@ -237,26 +238,45 @@ fn escalating_kill(pid: libc::pid_t, pgid: libc::pid_t) {
         libc::kill(pid, libc::SIGKILL);
     }
 
-    let _ = wait_for_pid_gone(pid, PROCESS_KILL_TIMEOUT);
+    let _ = wait_for_processes_gone(pid, pgid, can_signal_group, PROCESS_KILL_TIMEOUT);
 }
 
-/// Poll `kill(pid, 0)` until it returns ESRCH or the deadline passes.
-/// ESRCH means the pid is gone AND has been reaped — zombies still return 0.
-fn wait_for_pid_gone(pid: libc::pid_t, timeout: Duration) -> bool {
+fn wait_for_processes_gone(
+    pid: libc::pid_t,
+    pgid: libc::pid_t,
+    can_signal_group: bool,
+    timeout: Duration,
+) -> bool {
     let deadline = Instant::now() + timeout;
     loop {
-        let ret = unsafe { libc::kill(pid, 0) };
-        if ret == -1 {
-            let err = std::io::Error::last_os_error();
-            if err.raw_os_error() == Some(libc::ESRCH) {
-                return true;
-            }
+        let pid_gone = is_pid_gone(pid);
+        let group_gone = !can_signal_group || is_process_group_gone(pgid);
+        if pid_gone && group_gone {
+            return true;
         }
         if Instant::now() >= deadline {
             return false;
         }
         std::thread::sleep(PTY_POLL_INTERVAL);
     }
+}
+
+fn is_pid_gone(pid: libc::pid_t) -> bool {
+    let ret = unsafe { libc::kill(pid, 0) };
+    if ret == -1 {
+        let err = std::io::Error::last_os_error();
+        return err.raw_os_error() == Some(libc::ESRCH);
+    }
+    false
+}
+
+fn is_process_group_gone(pgid: libc::pid_t) -> bool {
+    let ret = unsafe { libc::killpg(pgid, 0) };
+    if ret == -1 {
+        let err = std::io::Error::last_os_error();
+        return err.raw_os_error() == Some(libc::ESRCH);
+    }
+    false
 }
 
 /// Workspace context passed to scripts as environment variables.


### PR DESCRIPTION
## Summary
- Wait for the script process group to disappear before `escalating_kill` returns.
- Keep leader PID reaping checks while preventing background children from surviving a fast shell exit.

## Verification
- `cd src-tauri && cargo test workspace::scripts::tests::escalating_kill_terminates_child_tree -- --exact --nocapture`
- `cd src-tauri && cargo test workspace::scripts::tests -- --nocapture`
- `cd src-tauri && cargo clippy --all-targets -- -D warnings`
- `bun x biome check src scripts sidecar/src package.json tsconfig.json vite.config.ts components.json biome.json --config-path=./biome.json`
- `bun run typecheck`

The test was failing, so I've fixed it.
<img width="2168" height="1394" alt="CleanShot 2026-05-10 at 20 16 06@2x" src="https://github.com/user-attachments/assets/a97bc4fb-54c4-4cae-9d07-32442cdf52bf" />
https://github.com/dohooo/helmor/actions/runs/25621879423/job/75209948435