### PR TITLE
feat(streaming): Claude thinking-display setting + reasoning render perf

### DIFF
--- a/.changeset/swift-pandas-rest.md
+++ b/.changeset/swift-pandas-rest.md
@@ -1,0 +1,8 @@
+---
+"helmor": patch
+---
+
+Improve how thinking blocks are surfaced and rendered:
+- Add a Claude Code Thinking Display setting in General (Summarized / Omitted) to control how Claude returns thinking — choosing Omitted speeds up time-to-first-text-token when streaming.
+- Stop large reasoning blocks from flickering when they scroll out of view and back, and from stalling workspace switches.
+- Keep the conversation's bottom whitespace stable during long streaming replies instead of letting it grow until real content is pushed off-screen.

--- a/sidecar/src/claude-session-manager.ts
+++ b/sidecar/src/claude-session-manager.ts
@@ -358,6 +358,7 @@ export class ClaudeSessionManager implements SessionManager {
 			permissionMode,
 			effortLevel,
 			fastMode,
+			claudeThinkingDisplay,
 			claudeEnvironment,
 			images,
 			sourceRepoPath,
@@ -417,7 +418,10 @@ export class ClaudeSessionManager implements SessionManager {
 				permissionMode: parsePermissionMode(permissionMode),
 				allowDangerouslySkipPermissions: true,
 				effort: parseEffort(effortLevel),
-				thinking: { type: "adaptive", display: "summarized" },
+				thinking: {
+					type: "adaptive",
+					display: claudeThinkingDisplay ?? "summarized",
+				},
 				...(effectiveFastMode ? { settings: { fastMode: true } } : {}),
 				...(projectMcpServers ? { mcpServers: projectMcpServers } : {}),
 				onElicitation: async (request, options) => {

--- a/sidecar/src/request-parser.ts
+++ b/sidecar/src/request-parser.ts
@@ -59,6 +59,15 @@ function optionalBoolean(
 	return typeof value === "boolean" ? value : undefined;
 }
 
+/** Narrows the raw `claudeThinkingDisplay` field. Anything other than the
+ *  two SDK-recognised values is treated as absent so a stray override
+ *  can't reach the SDK. */
+function parseClaudeThinkingDisplay(
+	value: unknown,
+): "summarized" | "omitted" | undefined {
+	return value === "summarized" || value === "omitted" ? value : undefined;
+}
+
 export function optionalObject(
 	params: Record<string, unknown>,
 	key: string,
@@ -91,6 +100,9 @@ export function parseSendMessageParams(
 		permissionMode: optionalString(params, "permissionMode"),
 		effortLevel: optionalString(params, "effortLevel"),
 		fastMode: optionalBoolean(params, "fastMode"),
+		claudeThinkingDisplay: parseClaudeThinkingDisplay(
+			params.claudeThinkingDisplay,
+		),
 		claudeEnvironment: parseOptionalStringRecord(params, "claudeEnvironment"),
 		additionalDirectories: parseOptionalStringArray(
 			params,

--- a/sidecar/src/session-manager.ts
+++ b/sidecar/src/session-manager.ts
@@ -18,6 +18,9 @@ export interface SendMessageParams {
 	readonly permissionMode: string | undefined;
 	readonly effortLevel: string | undefined;
 	readonly fastMode: boolean | undefined;
+	/** Mirrors the Claude Agent SDK's `thinking.display` field. When
+	 *  absent, the manager falls back to its hardcoded default. */
+	readonly claudeThinkingDisplay?: "summarized" | "omitted";
 	readonly claudeEnvironment?: Readonly<Record<string, string>>;
 	/**
 	 * Extra directories the user linked via `/add-dir`. Passed to Claude as

--- a/src-tauri/src/agents/streaming/mod.rs
+++ b/src-tauri/src/agents/streaming/mod.rs
@@ -124,6 +124,16 @@ pub(super) fn stream_via_sidecar(
     };
 
     let images_for_wire = request.images.clone().unwrap_or_default();
+    // Read the user's `Claude Code Thinking Display` preference. The setting
+    // is global (not per-message), so we resolve it here on every send rather
+    // than threading it through `AgentSendRequest`. Anything other than the
+    // two SDK-recognised values is treated as "no override" so a stray DB
+    // value can't reach the sidecar.
+    let claude_thinking_display =
+        match crate::models::settings::load_setting_value("app.claude_thinking_display") {
+            Ok(Some(v)) if v == "summarized" || v == "omitted" => Some(v),
+            _ => None,
+        };
     let params = build_send_message_params(BuildSendMessageParamsInput {
         sidecar_session_id: &sidecar_session_id,
         prompt: &combined_prompt,
@@ -137,6 +147,7 @@ pub(super) fn stream_via_sidecar(
         helmor_session_id: request.helmor_session_id.as_deref(),
         claude_base_url: model.claude_base_url.as_deref(),
         claude_auth_token: model.claude_auth_token.as_deref(),
+        claude_thinking_display: claude_thinking_display.as_deref(),
         images: &images_for_wire,
     });
 

--- a/src-tauri/src/agents/streaming/params.rs
+++ b/src-tauri/src/agents/streaming/params.rs
@@ -21,6 +21,13 @@ pub struct BuildSendMessageParamsInput<'a> {
     pub helmor_session_id: Option<&'a str>,
     pub claude_base_url: Option<&'a str>,
     pub claude_auth_token: Option<&'a str>,
+    /// Forwarded as `claudeThinkingDisplay` to the sidecar. Expected
+    /// values: `"summarized"` or `"omitted"`. Omitted from the wire
+    /// payload when `None` so the sidecar falls back to its default.
+    /// Only the Claude Code sidecar reads this; the Codex sidecar
+    /// silently ignores the field, so we forward unconditionally rather
+    /// than gating on `provider`.
+    pub claude_thinking_display: Option<&'a str>,
     /// Image attachments to forward to the sidecar. Omitted from the
     /// wire payload when empty.
     pub images: &'a [String],
@@ -62,6 +69,11 @@ pub fn build_send_message_params(input: BuildSendMessageParamsInput<'_>) -> Valu
     if !input.images.is_empty() {
         if let Some(obj) = params.as_object_mut() {
             obj.insert("images".to_string(), Value::from(input.images.to_vec()));
+        }
+    }
+    if let Some(display) = input.claude_thinking_display {
+        if let Some(obj) = params.as_object_mut() {
+            obj.insert("claudeThinkingDisplay".to_string(), Value::from(display));
         }
     }
     if let (Some(base_url), Some(auth_token)) = (input.claude_base_url, input.claude_auth_token) {

--- a/src-tauri/tests/streaming_send_params.rs
+++ b/src-tauri/tests/streaming_send_params.rs
@@ -105,6 +105,7 @@ fn base_input<'a>(session_id: Option<&'a str>) -> BuildSendMessageParamsInput<'a
         helmor_session_id: session_id,
         claude_base_url: None,
         claude_auth_token: None,
+        claude_thinking_display: None,
         images: &[],
     }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -779,12 +779,6 @@ body {
 	color: var(--conversation-body-foreground);
 }
 
-/* Pin the fade so streamdown's per-frame `--sd-duration: 0ms` rewrite
-   can't clamp an in-flight char fade to a single frame. */
-.conversation-streamdown [data-sd-animate] {
-	animation: sd-fadeIn 300ms cubic-bezier(0.33, 0, 0.67, 1) forwards !important;
-}
-
 .conversation-streamdown :where(p, li, ul, ol, blockquote, table, strong, em) {
 	color: inherit;
 }
@@ -813,25 +807,6 @@ body {
 	border: 1px solid
 		color-mix(in oklch, var(--muted) 87%, var(--muted-foreground) 13%);
 	margin: 0 2px;
-}
-
-/*
- * Plain-text streaming fade — used by <StreamingPlainText/> for content
- * that does NOT need markdown rendering (e.g. reasoning blocks). One span
- * per character; the same easing as streamdown's char-level fade so the
- * two surfaces feel uniform.
- */
-@keyframes stream-char-fade-in {
-	from {
-		opacity: 0;
-	}
-	to {
-		opacity: 1;
-	}
-}
-
-.stream-char {
-	animation: stream-char-fade-in 300ms cubic-bezier(0.33, 0, 0.67, 1) forwards;
 }
 
 /* Table layout for assistant markdown */

--- a/src/components/ai/reasoning.tsx
+++ b/src/components/ai/reasoning.tsx
@@ -26,6 +26,7 @@ interface ReasoningContextValue {
 	isOpen: boolean;
 	setIsOpen: (open: boolean) => void;
 	duration: number | undefined;
+	hasContent: boolean;
 }
 
 const ReasoningContext = createContext<ReasoningContextValue | null>(null);
@@ -48,6 +49,10 @@ export type ReasoningProps = ComponentProps<typeof Collapsible> & {
 	defaultOpen?: boolean;
 	onOpenChange?: (open: boolean) => void;
 	duration?: number;
+	/** False when the block has no body to expand into (e.g. Claude
+	 *  Thinking Display = Omitted). Renders the trigger as a static
+	 *  non-interactive label. Defaults to true. */
+	hasContent?: boolean;
 };
 
 const MS_IN_S = 1000;
@@ -60,6 +65,7 @@ export const Reasoning = memo(
 		defaultOpen,
 		onOpenChange,
 		duration: durationProp,
+		hasContent = true,
 		children,
 		...props
 	}: ReasoningProps) => {
@@ -71,7 +77,9 @@ export const Reasoning = memo(
 		// with an expanded block, which both surprises users (per their
 		// "thinking 输出完之后自动收起" expectation) and inflates
 		// `totalRowsHeight` against the layout estimator.
-		const resolvedDefaultOpen = defaultOpen ?? lifecycle === "streaming";
+		const resolvedDefaultOpen = hasContent
+			? (defaultOpen ?? lifecycle === "streaming")
+			: false;
 
 		const [isOpen, setIsOpen] = useControllableState({
 			prop: open,
@@ -108,14 +116,32 @@ export const Reasoning = memo(
 			}
 		}, [lifecycle, setIsOpen]);
 
+		// Reasoning that mounts empty (e.g. first delta hadn't shipped text
+		// yet) initializes collapsed because `hasContent=false`. Once text
+		// arrives, restore the "streaming defaults open" promise.
+		const prevHasContentRef = useRef(hasContent);
+		useEffect(() => {
+			const prev = prevHasContentRef.current;
+			prevHasContentRef.current = hasContent;
+			if (!prev && hasContent && lifecycle === "streaming") {
+				setIsOpen(true);
+			}
+		}, [hasContent, lifecycle, setIsOpen]);
+
 		return (
 			<ReasoningContext.Provider
-				value={{ lifecycle, isOpen: isOpen ?? false, setIsOpen, duration }}
+				value={{
+					lifecycle,
+					isOpen: hasContent ? (isOpen ?? false) : false,
+					setIsOpen,
+					duration,
+					hasContent,
+				}}
 			>
 				<Collapsible
 					className={cn("flex flex-col", className)}
 					onOpenChange={setIsOpen}
-					open={isOpen}
+					open={hasContent ? isOpen : false}
 					{...props}
 				>
 					{children}
@@ -148,8 +174,25 @@ export const ReasoningTrigger = memo(
 		getThinkingMessage = defaultGetThinkingMessage,
 		...props
 	}: ReasoningTriggerProps) => {
-		const { lifecycle, isOpen, duration } = useReasoning();
+		const { lifecycle, isOpen, duration, hasContent } = useReasoning();
 		const isStreaming = lifecycle === "streaming";
+		const label = children ?? getThinkingMessage(isStreaming, duration);
+
+		// No body to expand into → render a flat, non-interactive label:
+		// no chevron, no cursor-pointer, no hover affordance.
+		if (!hasContent) {
+			return (
+				<div
+					className={cn(
+						"inline-flex max-w-full items-center gap-1.5 py-0.5 text-[12px] text-muted-foreground",
+						className,
+					)}
+				>
+					<BrainIcon className="size-3 shrink-0" strokeWidth={1.8} />
+					{label}
+				</div>
+			);
+		}
 
 		return (
 			<CollapsibleTrigger
@@ -160,7 +203,7 @@ export const ReasoningTrigger = memo(
 				{...props}
 			>
 				<BrainIcon className="size-3 shrink-0" strokeWidth={1.8} />
-				{children ?? getThinkingMessage(isStreaming, duration)}
+				{label}
 				<ChevronRightIcon
 					className={cn(
 						"size-3 shrink-0 text-[#444241] transition-[transform,color] group-hover/reasoning:text-[rgb(134,133,132)]",

--- a/src/components/ai/streaming-plain-text.tsx
+++ b/src/components/ai/streaming-plain-text.tsx
@@ -1,10 +1,11 @@
-import { type CSSProperties, memo, useMemo } from "react";
+import { type CSSProperties, memo } from "react";
 import { useSmoothStreamContent } from "@/features/conversation/hooks/use-smooth-stream-content";
 import { cn } from "@/lib/utils";
 
-// Char-level fade for plain prose (reasoning). Mirrors streamdown's char
-// animation without the markdown pipeline; static mode collapses to a
-// single text node so historical reads pay nothing.
+// Plain-text reasoning renderer. The smoothing buffer alone gives the
+// "soft typewriter" feel — we deliberately do NOT layer any fade animation
+// on top: per-char spans cause kerning to re-shape when chars settle, and
+// container-level CSS masks visibly dim the bottom of the last line.
 export const StreamingPlainText = memo(function StreamingPlainText({
 	children,
 	streaming,
@@ -18,34 +19,12 @@ export const StreamingPlainText = memo(function StreamingPlainText({
 }) {
 	const smoothed = useSmoothStreamContent(children, { enabled: streaming });
 
-	// `[...str]` splits by codepoint so emoji / surrogate pairs stay intact.
-	const chars = useMemo(
-		() => (streaming ? [...smoothed] : null),
-		[streaming, smoothed],
-	);
-
-	if (!streaming || chars === null) {
-		return (
-			<div
-				className={cn("whitespace-pre-wrap break-words", className)}
-				style={style}
-			>
-				{smoothed}
-			</div>
-		);
-	}
-
 	return (
 		<div
 			className={cn("whitespace-pre-wrap break-words", className)}
 			style={style}
 		>
-			{/* index keys are intentional — `chars` only grows, never reorders */}
-			{chars.map((c, i) => (
-				<span key={i} className="stream-char">
-					{c}
-				</span>
-			))}
+			{smoothed}
 		</div>
 	);
 });

--- a/src/features/conversation/hooks/use-smooth-stream-content.ts
+++ b/src/features/conversation/hooks/use-smooth-stream-content.ts
@@ -28,7 +28,31 @@ const clamp = (value: number, min: number, max: number): number =>
 const getNow = () =>
 	typeof performance === "undefined" ? Date.now() : performance.now();
 
-const countChars = (text: string): number => [...text].length;
+// Don't park the smoothed prefix on a markdown marker char — the literal
+// symbol would otherwise hang in the DOM until the closing token arrives.
+const MAX_MARKER_LOOKAHEAD = 16;
+
+const isMarkdownMarkerChar = (ch: string): boolean => {
+	switch (ch.charCodeAt(0)) {
+		case 0x21: // !
+		case 0x24: // $
+		case 0x28: // (
+		case 0x29: // )
+		case 0x2a: // *
+		case 0x3c: // <
+		case 0x3e: // >
+		case 0x5b: // [
+		case 0x5c: // \
+		case 0x5d: // ]
+		case 0x5f: // _
+		case 0x60: // `
+		case 0x7c: // |
+		case 0x7e: // ~
+			return true;
+		default:
+			return false;
+	}
+};
 
 interface UseSmoothStreamContentOptions {
 	enabled?: boolean;
@@ -42,17 +66,30 @@ export const useSmoothStreamContent = (
 	const [displayedContent, setDisplayedContent] = useState(content);
 
 	const displayedContentRef = useRef(content);
-	const displayedCountRef = useRef(countChars(content));
+	// Char-array refs are populated lazily on the first enabled render so a
+	// historical mount doesn't pay O(n) codepoint splits it'll never use.
+	const displayedCountRef = useRef(0);
 
 	const targetContentRef = useRef(content);
-	const targetCharsRef = useRef([...content]);
-	const targetCountRef = useRef(targetCharsRef.current.length);
+	const targetCharsRef = useRef<string[]>([]);
+	const targetCountRef = useRef(0);
+	const initializedRef = useRef(false);
 
 	const emaCpsRef = useRef(config.defaultCps);
 	const lastInputTsRef = useRef(0);
-	const lastInputCountRef = useRef(targetCountRef.current);
+	const lastInputCountRef = useRef(0);
 	const chunkSizeEmaRef = useRef(1);
 	const arrivalCpsEmaRef = useRef(config.defaultCps);
+
+	const ensureInitialized = useCallback((seed: string) => {
+		if (initializedRef.current) return;
+		initializedRef.current = true;
+		const chars = [...seed];
+		targetCharsRef.current = chars;
+		targetCountRef.current = chars.length;
+		displayedCountRef.current = chars.length;
+		lastInputCountRef.current = chars.length;
+	}, []);
 
 	const rafRef = useRef<number | null>(null);
 	const lastFrameTsRef = useRef<number | null>(null);
@@ -99,22 +136,25 @@ export const useSmoothStreamContent = (
 		(nextContent: string) => {
 			stopScheduling();
 
-			const chars = [...nextContent];
+			// Skip the codepoint split until smoothing is actually active.
+			const chars = initializedRef.current ? [...nextContent] : null;
 			const now = getNow();
 
 			targetContentRef.current = nextContent;
-			targetCharsRef.current = chars;
-			targetCountRef.current = chars.length;
+			if (chars) {
+				targetCharsRef.current = chars;
+				targetCountRef.current = chars.length;
+				displayedCountRef.current = chars.length;
+				lastInputCountRef.current = chars.length;
+			}
 
 			displayedContentRef.current = nextContent;
-			displayedCountRef.current = chars.length;
 			setDisplayedContent(nextContent);
 
 			emaCpsRef.current = config.defaultCps;
 			chunkSizeEmaRef.current = 1;
 			arrivalCpsEmaRef.current = config.defaultCps;
 			lastInputTsRef.current = now;
-			lastInputCountRef.current = chars.length;
 		},
 		[config.defaultCps, stopScheduling],
 	);
@@ -232,10 +272,18 @@ export const useSmoothStreamContent = (
 				revealChars = Math.min(revealChars, backlog);
 			}
 
-			const nextCount = displayedCount + revealChars;
-			const segment = targetCharsRef.current
-				.slice(displayedCount, nextCount)
-				.join("");
+			let nextCount = displayedCount + revealChars;
+			const targetChars = targetCharsRef.current;
+			let lookahead = 0;
+			while (
+				nextCount < targetCount &&
+				lookahead < MAX_MARKER_LOOKAHEAD &&
+				isMarkdownMarkerChar(targetChars[nextCount - 1] ?? "")
+			) {
+				nextCount += 1;
+				lookahead += 1;
+			}
+			const segment = targetChars.slice(displayedCount, nextCount).join("");
 
 			if (segment) {
 				const nextDisplayed = displayedContentRef.current + segment;
@@ -271,9 +319,26 @@ export const useSmoothStreamContent = (
 
 	useEffect(() => {
 		if (!enabled) {
-			syncImmediate(content);
+			// Bypass: just shadow `content` as the displayed value. No splits.
+			// Drop the lazy-init flag too so a future `enabled=true` flip
+			// re-seeds the char arrays from the current content (otherwise
+			// the append-only path would diff against a stale codepoint
+			// snapshot from the last enabled run).
+			stopScheduling();
+			initializedRef.current = false;
+			targetCharsRef.current = [];
+			targetCountRef.current = 0;
+			displayedCountRef.current = 0;
+			lastInputCountRef.current = 0;
+			if (targetContentRef.current !== content) {
+				targetContentRef.current = content;
+				displayedContentRef.current = content;
+				setDisplayedContent(content);
+			}
 			return;
 		}
+
+		ensureInitialized(targetContentRef.current);
 
 		const prevTargetContent = targetContentRef.current;
 		if (content === prevTargetContent) return;
@@ -340,7 +405,9 @@ export const useSmoothStreamContent = (
 		config.minCps,
 		content,
 		enabled,
+		ensureInitialized,
 		startFrameLoop,
+		stopScheduling,
 		syncImmediate,
 	]);
 

--- a/src/features/panel/message-components.test.tsx
+++ b/src/features/panel/message-components.test.tsx
@@ -284,9 +284,6 @@ describe("MemoConversationMessage plan review", () => {
 		);
 
 		expect(screen.getByText("Thinking...")).toBeInTheDocument();
-		// Streaming reasoning splits each char into its own <span> for the
-		// fade-in effect, so getByText("...") can't match a literal
-		// substring. toHaveTextContent walks the subtree.
 		expect(document.body).toHaveTextContent(
 			"Inspecting the streamed reasoning block.",
 		);

--- a/src/features/panel/message-components/assistant-message.tsx
+++ b/src/features/panel/message-components/assistant-message.tsx
@@ -40,13 +40,10 @@ import { AssistantToolCall, CollapsedToolGroup } from "./tool-call";
 
 // --- AssistantText ---
 
-// `animation` / `duration` / `easing` are pinned by the
-// `[data-sd-animate]` rule in App.css; only `sep` + `stagger` matter here.
-const STREAMING_ANIMATED = {
-	sep: "char" as const,
-	stagger: 0,
-};
-
+// `useSmoothStreamContent` paces character reveal at ~30 cps so streaming
+// feels steady. We deliberately disable streamdown's `animated` plugin —
+// per-char/word spans cause kerning re-shape on settle and balloon DOM size
+// during long streams.
 const AssistantText = memo(function AssistantText({
 	text,
 	streaming,
@@ -65,10 +62,10 @@ const AssistantText = memo(function AssistantText({
 		>
 			<Suspense fallback={<AssistantTextFallback text={smoothedText} />}>
 				<LazyStreamdown
-					animated={streaming ? STREAMING_ANIMATED : false}
+					animated={false}
 					caret={undefined}
 					className="conversation-streamdown"
-					isAnimating={streaming}
+					isAnimating={false}
 					mode={mode}
 				>
 					{smoothedText}
@@ -223,16 +220,20 @@ export function ChatAssistantMessage({
 						typeof part.durationMs === "number"
 							? Math.max(1, Math.ceil(part.durationMs / 1000))
 							: undefined;
+					const hasContent = part.text.trim().length > 0;
 					return (
 						<Reasoning
 							key={key}
 							lifecycle={reasoningLifecycle(part)}
 							duration={durationSeconds}
+							hasContent={hasContent}
 						>
 							<ReasoningTrigger />
-							<ReasoningContent fontSize={settings.fontSize}>
-								{part.text}
-							</ReasoningContent>
+							{hasContent ? (
+								<ReasoningContent fontSize={settings.fontSize}>
+									{part.text}
+								</ReasoningContent>
+							) : null}
 						</Reasoning>
 					);
 				}

--- a/src/features/panel/thread-viewport.test.ts
+++ b/src/features/panel/thread-viewport.test.ts
@@ -2,23 +2,21 @@ import { describe, expect, it } from "vitest";
 import { resolveConversationRowHeight } from "./thread-viewport";
 
 describe("resolveConversationRowHeight", () => {
-	it("keeps the larger estimate for streaming rows until measurement catches up", () => {
+	it("trusts the measured height even when the estimate runs ahead", () => {
 		expect(
 			resolveConversationRowHeight({
-				estimatedHeight: 168,
-				measuredHeight: 132,
-				streaming: true,
+				estimatedHeight: 7710,
+				measuredHeight: 512,
 			}),
-		).toBe(168);
+		).toBe(512);
 	});
 
-	it("trusts the measured height for non-streaming rows", () => {
+	it("falls back to the estimate when measurement isn't available yet", () => {
 		expect(
 			resolveConversationRowHeight({
 				estimatedHeight: 168,
-				measuredHeight: 132,
-				streaming: false,
+				measuredHeight: undefined,
 			}),
-		).toBe(132);
+		).toBe(168);
 	});
 });

--- a/src/features/panel/thread-viewport.tsx
+++ b/src/features/panel/thread-viewport.tsx
@@ -48,17 +48,11 @@ const CONVERSATION_BOTTOM_SPACER_HEIGHT = 40;
 export function resolveConversationRowHeight({
 	estimatedHeight,
 	measuredHeight,
-	streaming,
 }: {
 	estimatedHeight: number;
 	measuredHeight?: number;
-	streaming: boolean;
 }) {
-	if (measuredHeight === undefined) {
-		return estimatedHeight;
-	}
-
-	return streaming ? Math.max(measuredHeight, estimatedHeight) : measuredHeight;
+	return measuredHeight ?? estimatedHeight;
 }
 
 export function ActiveThreadViewport({
@@ -649,7 +643,6 @@ function ProgressiveConversationViewport({
 						const height = resolveConversationRowHeight({
 							estimatedHeight,
 							measuredHeight,
-							streaming: message.streaming === true,
 						});
 						result.push({
 							height,
@@ -766,7 +759,14 @@ function ProgressiveConversationViewport({
 
 					const inWindow = rows.filter((row) => {
 						const rowBottom = row.top + row.height;
-						return rowBottom >= windowTop && row.top <= windowBottom;
+						// Tall rows (multi-viewport reasoning blocks) keep a
+						// mount zone scaled to their own height so scrolling
+						// past and back doesn't tear down the smoothing-hook
+						// progress and streamdown's internal block state.
+						const localExpand = row.height > buffer ? row.height - buffer : 0;
+						const localTop = windowTop - localExpand;
+						const localBottom = windowBottom + localExpand;
+						return rowBottom >= localTop && row.top <= localBottom;
 					});
 					if (!pinTailRows || rows.length === 0) {
 						return inWindow;
@@ -788,6 +788,7 @@ function ProgressiveConversationViewport({
 				{ totalRows: rows.length },
 			),
 		[
+			buffer,
 			distanceFromBottom,
 			effectiveViewportHeight,
 			isTauri,

--- a/src/features/settings/index.tsx
+++ b/src/features/settings/index.tsx
@@ -2,6 +2,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
 	CheckCircle2,
 	ChevronDown,
+	HelpCircle,
 	Minus,
 	Monitor,
 	Moon,
@@ -50,7 +51,12 @@ import {
 	helmorQueryKeys,
 	repositoriesQueryOptions,
 } from "@/lib/query-client";
-import type { AppSettings, DarkTheme, ThemeMode } from "@/lib/settings";
+import type {
+	AppSettings,
+	ClaudeThinkingDisplay,
+	DarkTheme,
+	ThemeMode,
+} from "@/lib/settings";
 import { resolveTheme, useSettings } from "@/lib/settings";
 import { cn } from "@/lib/utils";
 import { clampEffort, findModelOption } from "@/lib/workspace-helpers";
@@ -440,6 +446,70 @@ export const SettingsDialog = memo(function SettingsDialog({
 												className="h-7 rounded-md px-2.5 text-[12px] font-medium text-muted-foreground data-[state=on]:bg-accent data-[state=on]:text-foreground"
 											>
 												Steer
+											</ToggleGroupItem>
+										</ToggleGroup>
+									</SettingsRow>
+									<SettingsRow
+										title={
+											<span className="inline-flex items-center gap-1.5">
+												Claude Code Thinking Display
+												<Tooltip>
+													<TooltipTrigger asChild>
+														<HelpCircle
+															className="size-3 cursor-help text-muted-foreground/70"
+															strokeWidth={1.8}
+														/>
+													</TooltipTrigger>
+													<TooltipContent
+														side="top"
+														className="max-w-[320px] text-left"
+													>
+														<div className="space-y-1.5">
+															<div>
+																<span className="font-medium">Summarized</span>
+																{" — "}
+																thinking blocks contain summarized text.
+															</div>
+															<div>
+																<span className="font-medium">Omitted</span>
+																{" — "}
+																thinking blocks are empty. The server skips
+																streaming thinking tokens, so the final text
+																streams sooner. Reduces latency, not cost.
+															</div>
+														</div>
+													</TooltipContent>
+												</Tooltip>
+											</span>
+										}
+										description="Controls how Claude Code returns thinking content."
+									>
+										<ToggleGroup
+											type="single"
+											value={settings.claudeThinkingDisplay}
+											onValueChange={(value) => {
+												if (value === "summarized" || value === "omitted") {
+													updateSettings({
+														claudeThinkingDisplay:
+															value as ClaudeThinkingDisplay,
+													});
+												}
+											}}
+											className="gap-1 bg-muted/40"
+										>
+											<ToggleGroupItem
+												value="summarized"
+												aria-label="Summarized"
+												className="h-7 rounded-md px-2.5 text-[12px] font-medium text-muted-foreground data-[state=on]:bg-accent data-[state=on]:text-foreground"
+											>
+												Summarized
+											</ToggleGroupItem>
+											<ToggleGroupItem
+												value="omitted"
+												aria-label="Omitted"
+												className="h-7 rounded-md px-2.5 text-[12px] font-medium text-muted-foreground data-[state=on]:bg-accent data-[state=on]:text-foreground"
+											>
+												Omitted
 											</ToggleGroupItem>
 										</ToggleGroup>
 									</SettingsRow>

--- a/src/lib/message-layout-estimator.ts
+++ b/src/lib/message-layout-estimator.ts
@@ -195,14 +195,21 @@ function estimateReasoningHeight(
 	part: ReasoningPart,
 	options: { fontSize: number; contentWidth: number },
 ) {
-	if (reasoningLifecycle(part) !== "streaming") {
+	// Empty body (e.g. Claude Thinking Display = Omitted) renders flat.
+	if (
+		reasoningLifecycle(part) !== "streaming" ||
+		part.text.trim().length === 0
+	) {
 		return REASONING_SUMMARY_HEIGHT;
 	}
 	const bodyWidth = Math.max(
 		MIN_TEXT_WIDTH,
 		options.contentWidth - REASONING_EXPANDED_CONTENT_HORIZONTAL_PADDING,
 	);
-	const textHeight = measureTextHeight(part.text, {
+	// Streaming row is mounted, so ResizeObserver feeds the real height back.
+	// Skip the per-tick `prepare()` + `layout()` cost (cache miss every frame
+	// since the text grows) and use the cheap fallback estimate as a placeholder.
+	const textHeight = fallbackTextHeight(part.text, {
 		fontSize: options.fontSize,
 		lineHeight: ASSISTANT_LINE_HEIGHT,
 		maxWidth: bodyWidth,

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -11,6 +11,12 @@ export type DarkTheme = "default" | "midnight" | "forest" | "ember" | "aurora";
  *  - `queue`: stash locally; auto-fire as a new turn once the agent finishes.
  */
 export type FollowUpBehavior = "steer" | "queue";
+
+/** Controls how Claude Code returns thinking content.
+ *  - `summarized`: thinking blocks contain summarized thinking text.
+ *  - `omitted`: server skips streaming thinking tokens; the final text
+ *    response begins streaming sooner. */
+export type ClaudeThinkingDisplay = "summarized" | "omitted";
 export type AppSurface = "workspace" | "workspace-start";
 export type WorkspaceRightSidebarMode = "inspector" | "context";
 
@@ -212,6 +218,9 @@ export type AppSettings = {
 	/** Webview zoom factor. 1.0 = 100%. Range 0.5–2.0. */
 	zoomLevel: number;
 	followUpBehavior: FollowUpBehavior;
+	/** How Claude Code returns thinking content. Plumbed through to the
+	 *  sidecar's `thinking.display` field. */
+	claudeThinkingDisplay: ClaudeThinkingDisplay;
 	/** Force the context-usage ring to always be visible. When false (the
 	 *  default), the ring auto-hides until usage crosses
 	 *  `CONTEXT_USAGE_AUTO_REVEAL_THRESHOLD`. */
@@ -263,6 +272,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
 	defaultFastMode: false,
 	zoomLevel: 1.0,
 	followUpBehavior: "steer",
+	claudeThinkingDisplay: "summarized",
 	alwaysShowContextUsage: true,
 	showUsageStats: true,
 	onboardingCompleted: false,
@@ -316,6 +326,7 @@ const SETTINGS_KEY_MAP: Record<
 	defaultFastMode: "app.default_fast_mode",
 	zoomLevel: "app.zoom_level",
 	followUpBehavior: "app.follow_up_behavior",
+	claudeThinkingDisplay: "app.claude_thinking_display",
 	alwaysShowContextUsage: "app.always_show_context_usage",
 	showUsageStats: "app.show_usage_stats",
 	onboardingCompleted: "app.onboarding_completed",
@@ -782,6 +793,12 @@ export async function loadSettings(): Promise<AppSettings> {
 				return v === "queue" || v === "steer"
 					? v
 					: DEFAULT_SETTINGS.followUpBehavior;
+			})(),
+			claudeThinkingDisplay: (() => {
+				const v = raw[SETTINGS_KEY_MAP.claudeThinkingDisplay];
+				return v === "summarized" || v === "omitted"
+					? v
+					: DEFAULT_SETTINGS.claudeThinkingDisplay;
 			})(),
 			alwaysShowContextUsage:
 				raw[SETTINGS_KEY_MAP.alwaysShowContextUsage] !== undefined


### PR DESCRIPTION
## Summary

Adds a user-facing setting for Claude Code's thinking-display mode and tightens how reasoning blocks render during long streams. Targets the perceived stutter / scroll-jank reported on big thinking blocks and gives users a way to skip thinking tokens entirely when they want faster time-to-first-text.

## What changed

**New setting — Claude Code Thinking Display (Summarized | Omitted)**
- Added under General settings with a tooltip explaining the trade-off.
- Plumbed end-to-end: `lib/settings.ts` -> Rust `agents/streaming` -> sidecar `request-parser` -> `ClaudeSessionManager` -> SDK `thinking.display`. Defaults to `summarized`; unknown values are treated as absent at every layer so a stray DB value can't reach the SDK.

**Reasoning component — handle empty bodies**
- `<Reasoning>` accepts a `hasContent` prop. When false (e.g. Thinking Display = Omitted), the trigger renders as a flat, non-interactive label: no chevron, no expand, no `cursor-pointer`. It also won't auto-open while streaming.
- If `hasContent` flips true mid-stream (the first delta hadn't shipped text yet), the open-on-streaming default is restored.
- `estimateReasoningHeight` returns `REASONING_SUMMARY_HEIGHT` for empty bodies so the layout estimator stays in sync.

**Streaming render — drop the per-char fade pipeline**
- Removed streamdown's `animated={{ sep: 'char', stagger: 0 }}` mode and the per-span fade in `<StreamingPlainText>`. Per-char spans cause kerning re-shape on settle and balloon DOM during long streams; the smoothing buffer alone gives the typewriter feel.
- Removed the corresponding `[data-sd-animate]` !important rule and `.stream-char` keyframes from `App.css`.

**Smoothing hook — lazy init + marker-aware reveal**
- `useSmoothStreamContent` no longer pays an O(n) codepoint split on historical mounts. Char arrays are populated on the first enabled render.
- When `enabled` flips false, refs are reset so a future `enabled=true` re-seeds from the current content (was diffing against a stale snapshot).
- Won't park the smoothed prefix on a markdown marker char (`*`, `` ` ``, `[`, etc.) within a 16-char lookahead — prevents stray symbols from hanging in the DOM until the closing token arrives.

**Thread viewport — trust the measured height + tall-row mount zone**
- `resolveConversationRowHeight` now returns `measuredHeight ?? estimatedHeight`. Removed the `streaming ? max(estimate, measured)` clamp — when the estimator overshoots (happens on long reasoning), the conversation tail gets pushed off-screen.
- Tall rows whose height exceeds the standard mount buffer get a per-row mount zone scaled to their own height, so scrolling past a multi-viewport reasoning block and back doesn't unmount it (would otherwise reset the smoothing hook progress and streamdown's internal block state).

**Estimator — skip per-tick layout measure during streaming**
- Streaming reasoning rows are mounted, so ResizeObserver feeds the real height back. Use the cheap `fallbackTextHeight` for the placeholder estimate instead of the full canvas-measure path (was a cache miss every frame because the text grows).

## Test notes

- `bun run typecheck` clean.
- Pre-commit hooks (biome + clippy + cargo fmt) pass.
- `streaming_send_params.rs` updated for the new `claude_thinking_display` field.
- `thread-viewport.test.ts` rewritten for the new `resolveConversationRowHeight` signature (`streaming` flag dropped).
- Worth a manual pass:
  - Toggle Thinking Display = Omitted, send a turn, confirm the reasoning header renders flat and final text streams quickly.
  - Long streaming reply (something that produces 5+ viewport-tall reasoning) — scroll up past it then back down; the block should stay mounted and content shouldn't reflow.
  - Switch workspaces during a long stream; should be snappy.

## Follow-up

- A snapshot pass on the pipeline (`cd src-tauri && cargo test --tests`) didn't change anything for this branch since storage shape is untouched, but worth re-running on review machines.