### PR TITLE
fix(navigation): keep sidebar scroll when deleting archived workspace

### DIFF
--- a/.changeset/archived-delete-keeps-scroll.md
+++ b/.changeset/archived-delete-keeps-scroll.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix the sidebar scrolling to the top when deleting an archived workspace.

--- a/src/features/navigation/hooks/use-controller.ts
+++ b/src/features/navigation/hooks/use-controller.ts
@@ -1135,18 +1135,21 @@ export function useWorkspacesSidebarController({
 			);
 
 			if (selectedWorkspaceId === workspaceId) {
+				// Pick the neighbour so virtualizer doesn't fling to the top.
 				const optimisticGroups =
 					(queryClient.getQueryData(
 						helmorQueryKeys.workspaceGroups,
 					) as typeof groups) ?? [];
-				const optimisticArchived =
-					(queryClient.getQueryData(
-						helmorQueryKeys.archivedWorkspaces,
-					) as typeof archivedSummaries) ?? [];
-				const nextWorkspaceId =
-					findInitialWorkspaceId(optimisticGroups) ??
-					optimisticArchived[0]?.id ??
-					null;
+				const nextArchivedRows = archivedRows.filter(
+					(row) => row.id !== workspaceId,
+				);
+				const nextWorkspaceId = findReplacementWorkspaceIdAfterRemoval({
+					currentGroups: groups,
+					currentArchivedRows: archivedRows,
+					nextGroups: optimisticGroups,
+					nextArchivedRows,
+					removedWorkspaceId: workspaceId,
+				});
 				if (nextWorkspaceId) {
 					prefetchWorkspace(nextWorkspaceId);
 				}
@@ -1176,8 +1179,10 @@ export function useWorkspacesSidebarController({
 				.finally(endSidebarMutation);
 		},
 		[
+			archivedRows,
 			beginSidebarMutation,
 			endSidebarMutation,
+			groups,
 			onSelectWorkspace,
 			prefetchWorkspace,
 			pushWorkspaceToast,


### PR DESCRIPTION
## Summary

- When deleting the currently selected archived workspace, the sidebar's virtualizer was flinging back to the top because the replacement-workspace lookup was reaching for the first item in the optimistic archived list rather than a neighbour of the row being removed.
- Replace the ad-hoc `findInitialWorkspaceId(...) ?? optimisticArchived[0]?.id` fallback with `findReplacementWorkspaceIdAfterRemoval`, passing both the current and next group/archived snapshots so the picker can choose the adjacent row and preserve scroll position.
- Add the now-referenced `groups` and `archivedRows` to the callback's dependency list so the optimistic computation stays in sync.

## Why

Deleting an archived workspace from far down the list jumped the sidebar back to the top, making bulk cleanup disorienting. The fix keeps the user's scroll position pinned near the deleted row.

## Test plan

- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] Manually delete an archived workspace partway down the list and confirm the sidebar stays scrolled near that position.