### PR TITLE
fix: match fork PRs by bound owner

### DIFF
--- a/.changeset/fork-pr-workspace-lookup.md
+++ b/.changeset/fork-pr-workspace-lookup.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix workspace pull request status lookup for GitHub PRs opened from the bound account's fork.

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "helmor",

--- a/src-tauri/src/forge/github/actions.rs
+++ b/src-tauri/src/forge/github/actions.rs
@@ -19,6 +19,7 @@ use crate::forge::{
 use super::accounts as gh_accounts;
 use super::api::{run_graphql, GraphqlOutcome, GITHUB_HOST};
 use super::context::GithubContext;
+use super::pr_match::matches_workspace_pr;
 use super::types::{
     ActionCheckContextNode, ActionDeploymentNode, ActionGraphqlEnvelope, ActionPullRequestNode,
     GithubCheckRunDetail,
@@ -38,6 +39,7 @@ query($owner: String!, $name: String!, $head: String!) {
         reviewDecision
         mergeable
         isCrossRepository
+        headRepositoryOwner { login }
         commits(last: 1) {
           nodes {
             commit {
@@ -139,16 +141,24 @@ pub(super) fn query_workspace_pr_action_status(
             "GitHub repository was not returned",
         ));
     };
-    let Some(pr) = pick_in_repo_action_pr(repository.pull_requests.nodes) else {
+    let Some(pr) = pick_workspace_action_pr(repository.pull_requests.nodes, &context.login) else {
         return Ok(ForgeActionStatus::no_change_request());
     };
 
     Ok(build_action_status(pr))
 }
 
-/// Action-status counterpart to `pull_request::pick_in_repo_pr`.
-fn pick_in_repo_action_pr(nodes: Vec<ActionPullRequestNode>) -> Option<ActionPullRequestNode> {
-    nodes.into_iter().find(|node| !node.is_cross_repository)
+fn pick_workspace_action_pr(
+    nodes: Vec<ActionPullRequestNode>,
+    bound_login: &str,
+) -> Option<ActionPullRequestNode> {
+    nodes.into_iter().find(|node| {
+        matches_workspace_pr(
+            node.is_cross_repository,
+            node.head_repository_owner.as_ref(),
+            bound_login,
+        )
+    })
 }
 
 /// REST-side companion: fetch the human-readable detail blob for a
@@ -497,6 +507,7 @@ fn parse_github_datetime(value: &str) -> Option<DateTime<Utc>> {
 
 #[cfg(test)]
 mod tests {
+    use super::super::types::HeadRepositoryOwner;
     use super::*;
     use crate::forge::github::types::{
         ActionCheckApp, ActionCheckContextConnection, ActionCheckRunNode, ActionCheckSuite,
@@ -677,7 +688,7 @@ mod tests {
         assert_eq!(format_duration(None, Some("2026-04-10T00:00:00Z")), None);
     }
 
-    fn make_action_node(number: i64, cross: bool) -> ActionPullRequestNode {
+    fn make_action_node(number: i64, cross: bool, owner: Option<&str>) -> ActionPullRequestNode {
         ActionPullRequestNode {
             url: format!("https://github.com/octocat/hello-world/pull/{number}"),
             number,
@@ -687,21 +698,46 @@ mod tests {
             review_decision: None,
             mergeable: None,
             is_cross_repository: cross,
+            head_repository_owner: owner.map(|login| HeadRepositoryOwner {
+                login: login.to_string(),
+            }),
             commits: ActionCommitConnection { nodes: vec![] },
         }
     }
 
     #[test]
-    fn pick_in_repo_action_pr_skips_cross_repository_nodes() {
-        let nodes = vec![make_action_node(433, true), make_action_node(100, false)];
-        let picked = pick_in_repo_action_pr(nodes).expect("expected an in-repo PR");
+    fn pick_workspace_action_pr_skips_unrelated_cross_repository_nodes() {
+        let nodes = vec![
+            make_action_node(433, true, Some("other-user")),
+            make_action_node(100, false, None),
+        ];
+        let picked = pick_workspace_action_pr(nodes, "octocat").expect("expected an in-repo PR");
         assert_eq!(picked.number, 100);
     }
 
     #[test]
-    fn pick_in_repo_action_pr_returns_none_when_only_cross_repo_matches() {
-        let nodes = vec![make_action_node(433, true)];
-        assert!(pick_in_repo_action_pr(nodes).is_none());
+    fn pick_workspace_action_pr_matches_cross_repository_node_from_bound_login() {
+        let nodes = vec![make_action_node(473, true, Some("Aidxun"))];
+        let picked = pick_workspace_action_pr(nodes, "aidxun").expect("expected bound fork PR");
+        assert_eq!(picked.number, 473);
+    }
+
+    #[test]
+    fn pick_workspace_action_pr_does_not_match_cross_repository_node_for_different_login() {
+        let nodes = vec![make_action_node(473, true, Some("fork-owner"))];
+        assert!(pick_workspace_action_pr(nodes, "authorized-collaborator").is_none());
+    }
+
+    #[test]
+    fn pick_workspace_action_pr_returns_none_when_only_unrelated_cross_repo_matches() {
+        let nodes = vec![make_action_node(433, true, Some("other-user"))];
+        assert!(pick_workspace_action_pr(nodes, "octocat").is_none());
+    }
+
+    #[test]
+    fn pick_workspace_action_pr_returns_none_for_cross_repo_without_owner() {
+        let nodes = vec![make_action_node(433, true, None)];
+        assert!(pick_workspace_action_pr(nodes, "octocat").is_none());
     }
 
     #[test]
@@ -715,6 +751,7 @@ mod tests {
             review_decision: Some("CHANGES_REQUESTED".to_string()),
             mergeable: Some("CONFLICTING".to_string()),
             is_cross_repository: false,
+            head_repository_owner: None,
             commits: ActionCommitConnection {
                 nodes: vec![ActionPullRequestCommitNode {
                     commit: ActionCommitNode {
@@ -777,6 +814,7 @@ mod tests {
             review_decision: None,
             mergeable: Some("MERGEABLE".to_string()),
             is_cross_repository: false,
+            head_repository_owner: None,
             commits: ActionCommitConnection {
                 nodes: vec![ActionPullRequestCommitNode {
                     commit: ActionCommitNode {

--- a/src-tauri/src/forge/github/mod.rs
+++ b/src-tauri/src/forge/github/mod.rs
@@ -26,6 +26,7 @@ mod actions;
 mod api;
 mod context;
 pub mod inbox;
+mod pr_match;
 mod pull_request;
 mod types;
 

--- a/src-tauri/src/forge/github/pr_match.rs
+++ b/src-tauri/src/forge/github/pr_match.rs
@@ -1,0 +1,19 @@
+//! Shared GitHub PR selection rules. GitHub's `headRefName` filter is
+//! branch-name only, so cross-repository PRs must also match the repo's
+//! bound forge account to avoid unrelated fork PRs on common branch names.
+
+use super::types::HeadRepositoryOwner;
+
+pub(super) fn matches_workspace_pr(
+    is_cross_repository: bool,
+    head_repository_owner: Option<&HeadRepositoryOwner>,
+    bound_login: &str,
+) -> bool {
+    if !is_cross_repository {
+        return true;
+    }
+
+    head_repository_owner
+        .map(|owner| owner.login.eq_ignore_ascii_case(bound_login))
+        .unwrap_or(false)
+}

--- a/src-tauri/src/forge/github/pull_request.rs
+++ b/src-tauri/src/forge/github/pull_request.rs
@@ -9,6 +9,7 @@ use crate::forge::ChangeRequestInfo;
 
 use super::api::{run_graphql, run_graphql_raw, GraphqlOutcome};
 use super::context::GithubContext;
+use super::pr_match::matches_workspace_pr;
 use super::types::{GraphqlEnvelope, PullRequestNode};
 
 // `first: 10` leaves room for the cross-repo filter to find the in-repo match.
@@ -23,6 +24,7 @@ query($owner: String!, $name: String!, $head: String!) {
         title
         merged
         isCrossRepository
+        headRepositoryOwner { login }
       }
     }
   }
@@ -33,7 +35,7 @@ const PR_NODE_ID_QUERY: &str = r#"
 query($owner: String!, $name: String!, $head: String!) {
   repository(owner: $owner, name: $name) {
     pullRequests(headRefName: $head, states: [OPEN], first: 5) {
-      nodes { id, url, number, state, title, merged, isCrossRepository }
+      nodes { id, url, number, state, title, merged, isCrossRepository, headRepositoryOwner { login } }
     }
   }
 }
@@ -149,13 +151,18 @@ pub(super) fn find_workspace_pr(context: &GithubContext) -> Result<Option<Change
     Ok(parsed
         .data
         .and_then(|d| d.repository)
-        .and_then(|r| pick_in_repo_pr(r.pull_requests.nodes))
+        .and_then(|r| pick_workspace_pr(r.pull_requests.nodes, &context.login))
         .map(pr_info))
 }
 
-/// Drop fork PRs; `headRefName:` alone matches across forks.
-fn pick_in_repo_pr(nodes: Vec<PullRequestNode>) -> Option<PullRequestNode> {
-    nodes.into_iter().find(|node| !node.is_cross_repository)
+fn pick_workspace_pr(nodes: Vec<PullRequestNode>, bound_login: &str) -> Option<PullRequestNode> {
+    nodes.into_iter().find(|node| {
+        matches_workspace_pr(
+            node.is_cross_repository,
+            node.head_repository_owner.as_ref(),
+            bound_login,
+        )
+    })
 }
 
 /// Convert a GraphQL pull-request node into the public
@@ -189,7 +196,7 @@ pub(super) fn fetch_open_pr_node_id(context: &GithubContext) -> Result<Option<St
     Ok(parsed
         .data
         .and_then(|d| d.repository)
-        .and_then(|r| pick_in_repo_pr(r.pull_requests.nodes))
+        .and_then(|r| pick_workspace_pr(r.pull_requests.nodes, &context.login))
         .and_then(|n| n.id))
 }
 
@@ -286,6 +293,7 @@ fn run_pr_mutation(login: &str, mutation: &str, pr_node_id: &str) -> Result<()> 
 
 #[cfg(test)]
 mod tests {
+    use super::super::types::HeadRepositoryOwner;
     use super::*;
 
     fn make_node(state: &str, merged: bool) -> PullRequestNode {
@@ -297,10 +305,16 @@ mod tests {
             title: "Update".to_string(),
             merged,
             is_cross_repository: false,
+            head_repository_owner: None,
         }
     }
 
-    fn make_node_with_cross_repo(state: &str, number: i64, cross: bool) -> PullRequestNode {
+    fn make_node_with_cross_repo(
+        state: &str,
+        number: i64,
+        cross: bool,
+        owner: Option<&str>,
+    ) -> PullRequestNode {
         PullRequestNode {
             id: None,
             url: format!("https://github.com/octocat/hello-world/pull/{number}"),
@@ -309,6 +323,9 @@ mod tests {
             title: "Update".to_string(),
             merged: false,
             is_cross_repository: cross,
+            head_repository_owner: owner.map(|login| HeadRepositoryOwner {
+                login: login.to_string(),
+            }),
         }
     }
 
@@ -381,28 +398,57 @@ mod tests {
 
     // Regression: workspace on `main` got auto-canceled by a fork's closed `main` PR.
     #[test]
-    fn pick_in_repo_pr_skips_cross_repository_nodes() {
+    fn pick_workspace_pr_skips_unrelated_cross_repository_nodes() {
         let nodes = vec![
-            make_node_with_cross_repo("CLOSED", 433, true),
-            make_node_with_cross_repo("OPEN", 100, false),
+            make_node_with_cross_repo("CLOSED", 433, true, Some("other-user")),
+            make_node_with_cross_repo("OPEN", 100, false, None),
         ];
-        let picked = pick_in_repo_pr(nodes).expect("expected an in-repo PR");
+        let picked = pick_workspace_pr(nodes, "octocat").expect("expected an in-repo PR");
         assert_eq!(picked.number, 100);
     }
 
     #[test]
-    fn pick_in_repo_pr_returns_none_when_only_cross_repo_matches() {
-        let nodes = vec![make_node_with_cross_repo("CLOSED", 433, true)];
-        assert!(pick_in_repo_pr(nodes).is_none());
+    fn pick_workspace_pr_matches_cross_repository_node_from_bound_login() {
+        let nodes = vec![make_node_with_cross_repo("OPEN", 473, true, Some("Aidxun"))];
+        let picked = pick_workspace_pr(nodes, "aidxun").expect("expected bound fork PR");
+        assert_eq!(picked.number, 473);
     }
 
     #[test]
-    fn pick_in_repo_pr_preserves_order_when_first_node_is_in_repo() {
+    fn pick_workspace_pr_does_not_match_cross_repository_node_for_different_login() {
+        let nodes = vec![make_node_with_cross_repo(
+            "OPEN",
+            473,
+            true,
+            Some("fork-owner"),
+        )];
+        assert!(pick_workspace_pr(nodes, "authorized-collaborator").is_none());
+    }
+
+    #[test]
+    fn pick_workspace_pr_returns_none_when_only_unrelated_cross_repo_matches() {
+        let nodes = vec![make_node_with_cross_repo(
+            "CLOSED",
+            433,
+            true,
+            Some("other-user"),
+        )];
+        assert!(pick_workspace_pr(nodes, "octocat").is_none());
+    }
+
+    #[test]
+    fn pick_workspace_pr_returns_none_for_cross_repo_without_owner() {
+        let nodes = vec![make_node_with_cross_repo("CLOSED", 433, true, None)];
+        assert!(pick_workspace_pr(nodes, "octocat").is_none());
+    }
+
+    #[test]
+    fn pick_workspace_pr_preserves_order_when_first_node_is_in_repo() {
         let nodes = vec![
-            make_node_with_cross_repo("OPEN", 100, false),
-            make_node_with_cross_repo("CLOSED", 99, false),
+            make_node_with_cross_repo("OPEN", 100, false, None),
+            make_node_with_cross_repo("CLOSED", 99, false, None),
         ];
-        let picked = pick_in_repo_pr(nodes).expect("expected first in-repo PR");
+        let picked = pick_workspace_pr(nodes, "octocat").expect("expected first in-repo PR");
         assert_eq!(picked.number, 100);
     }
 

--- a/src-tauri/src/forge/github/types.rs
+++ b/src-tauri/src/forge/github/types.rs
@@ -41,8 +41,14 @@ pub(super) struct PullRequestNode {
     pub title: String,
     pub merged: bool,
     /// True when head is in a fork. `pullRequests(headRefName:)` matches
-    /// branch name only, so we drop these to avoid mis-association.
+    /// branch name only, so fork PRs need owner checks before matching.
     pub is_cross_repository: bool,
+    pub head_repository_owner: Option<HeadRepositoryOwner>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct HeadRepositoryOwner {
+    pub login: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -85,6 +91,7 @@ pub(super) struct ActionPullRequestNode {
     pub review_decision: Option<String>,
     pub mergeable: Option<String>,
     pub is_cross_repository: bool,
+    pub head_repository_owner: Option<HeadRepositoryOwner>,
     pub commits: ActionCommitConnection,
 }
 


### PR DESCRIPTION
What changed
- Updated GitHub PR lookup to keep cross-repository pull requests when the fork owner matches the workspace's bound GitHub account.
- Added a shared PR matching helper and extended the GraphQL selection types to include `headRepositoryOwner.login`.
- Added unit coverage for matching in-repo PRs, matching the bound fork owner, and rejecting unrelated fork PRs.

Why it changed
- `pullRequests(headRefName: ...)` matches by branch name only, so common branch names could be mis-associated with unrelated fork PRs.
- Helmor needs to keep the workspace attached to the correct PR when the user is working from their own fork.

Follow-up / test notes
- Verified with `cargo test pick_workspace_pr --manifest-path src-tauri/Cargo.toml`.
- The local worktree still has an unstaged `bun.lock` edit that is not part of this PR.

Fixes #495.
