### PR TITLE
fix: flush final streamed assistant output

### DIFF
--- a/.changeset/bright-streams-finish.md
+++ b/.changeset/bright-streams-finish.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix streamed assistant replies sometimes leaving the final visible text incomplete after the turn finishes.

--- a/src/features/conversation/hooks/use-smooth-stream-content.test.tsx
+++ b/src/features/conversation/hooks/use-smooth-stream-content.test.tsx
@@ -1,0 +1,35 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useSmoothStreamContent } from "./use-smooth-stream-content";
+
+describe("useSmoothStreamContent", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("flushes the visible text when streaming turns off after the target already advanced", () => {
+		vi.spyOn(window, "requestAnimationFrame").mockImplementation(() => 1);
+		vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+
+		const fullText =
+			"明白。后续我会直接在本地原始仓库修改：\n\n`/Users/aidan/mi/mihome/miot-plugin-sdk/projects/com.xiaomi.robovac`\n\n不再先改 Helmor worktree 再复制。";
+
+		const { result, rerender } = renderHook(
+			({ content, enabled }: { content: string; enabled: boolean }) =>
+				useSmoothStreamContent(content, { enabled }),
+			{ initialProps: { content: "", enabled: true } },
+		);
+
+		act(() => {
+			rerender({ content: fullText, enabled: true });
+		});
+
+		expect(result.current).not.toBe(fullText);
+
+		act(() => {
+			rerender({ content: fullText, enabled: false });
+		});
+
+		expect(result.current).toBe(fullText);
+	});
+});

--- a/src/features/conversation/hooks/use-smooth-stream-content.ts
+++ b/src/features/conversation/hooks/use-smooth-stream-content.ts
@@ -330,7 +330,10 @@ export const useSmoothStreamContent = (
 			targetCountRef.current = 0;
 			displayedCountRef.current = 0;
 			lastInputCountRef.current = 0;
-			if (targetContentRef.current !== content) {
+			if (
+				targetContentRef.current !== content ||
+				displayedContentRef.current !== content
+			) {
 				targetContentRef.current = content;
 				displayedContentRef.current = content;
 				setDisplayedContent(content);


### PR DESCRIPTION
What changed
- Flush the displayed conversation text when streaming stops if the rendered content is still behind the final target content.
- Add a focused regression test for the case where the target text has advanced but the visible text has not fully caught up before the turn ends.
- Add a patch changeset for the user-visible reply rendering fix.

Why it changed
- Some streamed assistant replies could finish with the last visible text still incomplete because the hook only flushed on turn completion when the target content differed from the new content, not when the displayed content itself was lagging behind.

Follow-up / test notes
- Verified with `bun x vitest run src/features/conversation/hooks/use-smooth-stream-content.test.tsx`.
- Broader test suites were not run in this pass.