### PR TITLE
docs: point terminal contributors to AGENTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Open Helmor, Import Helmor, Ask Helmor:
 > _"How do I contribute to Helmor?"_
 
 That's the guide.
+If you're contributing from the terminal, the repo workflow lives in [AGENTS.md](./AGENTS.md).
 
 ## License
 


### PR DESCRIPTION
What changed
Added a short README note pointing terminal contributors to `AGENTS.md`.

Why it changed
The repo workflow for terminal-based contribution lives in `AGENTS.md`, so this makes that entry point easier to find.

Follow-up / test notes
Docs-only change. No tests run.