### PR TITLE
Remember workspace start mode per repository

### DIFF
--- a/.changeset/remember-workspace-start-mode.md
+++ b/.changeset/remember-workspace-start-mode.md
@@ -1,0 +1,4 @@
+"helmor": patch
+---
+
+Remember each repository's workspace-start mode so Helmor restores whether you last chose to work locally or create a new worktree.

--- a/src/App.create.test.tsx
+++ b/src/App.create.test.tsx
@@ -1,3 +1,4 @@
+import { invoke } from "@tauri-apps/api/core";
 import {
 	cleanup,
 	fireEvent,
@@ -20,6 +21,8 @@ const apiMocks = vi.hoisted(() => ({
 	createWorkspaceFromRepo: vi.fn(),
 	prepareWorkspaceFromRepo: vi.fn(),
 	finalizeWorkspaceFromRepo: vi.fn(),
+	getRepoCurrentBranch: vi.fn(),
+	listBranchesForLocalPicker: vi.fn(),
 	listSessionDrafts: vi.fn(),
 }));
 
@@ -80,6 +83,8 @@ vi.mock("./lib/api", async (importOriginal) => {
 		createWorkspaceFromRepo: apiMocks.createWorkspaceFromRepo,
 		prepareWorkspaceFromRepo: apiMocks.prepareWorkspaceFromRepo,
 		finalizeWorkspaceFromRepo: apiMocks.finalizeWorkspaceFromRepo,
+		getRepoCurrentBranch: apiMocks.getRepoCurrentBranch,
+		listBranchesForLocalPicker: apiMocks.listBranchesForLocalPicker,
 		listSessionDrafts: apiMocks.listSessionDrafts,
 	};
 });
@@ -290,6 +295,10 @@ describe("App create workspace flow", () => {
 		apiMocks.loadSessionThreadMessages.mockResolvedValue([]);
 		apiMocks.prepareWorkspaceFromRepo.mockReset();
 		apiMocks.finalizeWorkspaceFromRepo.mockReset();
+		apiMocks.getRepoCurrentBranch.mockReset();
+		apiMocks.getRepoCurrentBranch.mockResolvedValue("main");
+		apiMocks.listBranchesForLocalPicker.mockReset();
+		apiMocks.listBranchesForLocalPicker.mockResolvedValue(["main"]);
 		apiMocks.prepareWorkspaceFromRepo.mockImplementation(async () => {
 			// Backend generates the ids now. Mirror by generating once per
 			// call and stashing for subsequent finalize + detail mocks.
@@ -482,5 +491,64 @@ describe("App create workspace flow", () => {
 			).not.toBeInTheDocument();
 		});
 		expect(streamingMocks.handleComposerSubmit).toHaveBeenCalled();
+	});
+
+	it("initializes the start composer from the repository's remembered workspace mode", async () => {
+		const user = userEvent.setup({ pointerEventsCheck: 0 });
+		const invokeMock = vi.mocked(invoke);
+		const baseInvokeImpl = invokeMock.getMockImplementation();
+		invokeMock.mockImplementation(
+			async (command: string, args?: Parameters<typeof invoke>[1]) => {
+				if (command === "get_app_settings") {
+					return {
+						"app.onboarding_completed": "true",
+						"app.start_workspace_mode_by_repo_id": JSON.stringify({
+							"repo-1": "local",
+						}),
+					};
+				}
+				return baseInvokeImpl?.(command, args);
+			},
+		);
+		apiMocks.loadAgentModelSections.mockResolvedValue([
+			{
+				id: "claude",
+				label: "Claude",
+				options: [
+					{
+						id: "opus-1m",
+						provider: "claude",
+						label: "Opus 4.7 1M",
+						cliModel: "opus-1m",
+						effortLevels: ["low", "medium", "high"],
+					},
+				],
+			},
+		]);
+
+		try {
+			render(<App />);
+			await screen.findByRole("main", { name: "Application shell" });
+
+			await user.click(screen.getByRole("button", { name: "New workspace" }));
+			const createButton = await screen.findByRole("button", {
+				name: "New Workspace",
+			});
+			await waitFor(() => {
+				expect(createButton).toBeEnabled();
+			});
+
+			await user.click(createButton);
+
+			await waitFor(() => {
+				expect(apiMocks.prepareWorkspaceFromRepo).toHaveBeenCalledWith(
+					"repo-1",
+					"main",
+					"local",
+				);
+			});
+		} finally {
+			invokeMock.mockImplementation(baseInvokeImpl ?? (async () => undefined));
+		}
 	});
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2356,13 +2356,22 @@ function AppShell({
 	// repo switch — the picks were intent-bound to a specific repo.
 	const [startPendingLinkedDirectories, setStartPendingLinkedDirectories] =
 		useState<readonly string[]>(EMPTY_STRING_LIST);
-	const [startMode, setStartMode] = useState<WorkspaceMode>("worktree");
+	const rememberedStartMode =
+		startRepository?.id &&
+		appSettings.startWorkspaceModeByRepoId[startRepository.id]
+			? appSettings.startWorkspaceModeByRepoId[startRepository.id]
+			: "worktree";
+	const [startMode, setStartMode] =
+		useState<WorkspaceMode>(rememberedStartMode);
 	useEffect(() => {
 		setStartSourceBranchOverride(null);
 		setStartPendingNewBranch(null);
 		setStartPendingLinkedDirectories(EMPTY_STRING_LIST);
-		setStartMode("worktree");
 	}, [startRepositoryId]);
+	useEffect(() => {
+		if (!areSettingsLoaded) return;
+		setStartMode(rememberedStartMode);
+	}, [areSettingsLoaded, rememberedStartMode]);
 	// In local mode the picker should default to whatever branch the
 	// repo's HEAD currently points at — that's the branch the user
 	// will actually be working on. Worktree mode keeps the stored
@@ -2407,6 +2416,7 @@ function AppShell({
 			setWorkspacePreviewActive(false);
 			setStartSourceBranchOverride(null);
 			setStartPendingNewBranch(null);
+			setStartMode(rememberedStartMode);
 			setRightSidebarMode(
 				appSettings.startContextPanelOpen ? "context" : "inspector",
 			);
@@ -2418,7 +2428,7 @@ function AppShell({
 				void updateSettings({ lastSurface: "workspace-start" });
 			}
 		},
-		[appSettings.startContextPanelOpen, updateSettings],
+		[appSettings.startContextPanelOpen, rememberedStartMode, updateSettings],
 	);
 	useEffect(() => {
 		if (!areSettingsLoaded || appSettings.lastSurface !== "workspace-start") {
@@ -2943,6 +2953,14 @@ function AppShell({
 													mode={startMode}
 													onModeChange={(next) => {
 														setStartMode(next);
+														if (startRepository?.id) {
+															void updateSettings({
+																startWorkspaceModeByRepoId: {
+																	...appSettings.startWorkspaceModeByRepoId,
+																	[startRepository.id]: next,
+																},
+															});
+														}
 														setStartSourceBranchOverride(null);
 														setStartPendingNewBranch(null);
 													}}

--- a/src/features/settings/panels/repository-settings.test.tsx
+++ b/src/features/settings/panels/repository-settings.test.tsx
@@ -85,6 +85,7 @@ describe("RepositorySettingsPanel branch prefix", () => {
 			runFromProject: false,
 			archiveFromProject: false,
 			autoRunSetup: true,
+			runScriptMode: "concurrent",
 		});
 		apiMocks.prefetchRemoteRefs.mockResolvedValue({ fetched: false });
 		apiMocks.updateRepositoryBranchPrefix.mockResolvedValue(undefined);

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -91,6 +91,39 @@ describe("settings", () => {
 		);
 	});
 
+	it("hydrates and saves start workspace mode by repository", async () => {
+		invokeMock.mockResolvedValue({
+			"app.start_workspace_mode_by_repo_id": JSON.stringify({
+				"repo-1": "local",
+				"repo-2": "worktree",
+				"repo-3": "invalid",
+			}),
+		});
+
+		const settings = await loadSettings();
+
+		expect(settings.startWorkspaceModeByRepoId).toEqual({
+			"repo-1": "local",
+			"repo-2": "worktree",
+		});
+
+		invokeMock.mockResolvedValue(undefined);
+		await saveSettings({
+			startWorkspaceModeByRepoId: { "repo-1": "worktree" },
+		});
+
+		expect(invokeMock).toHaveBeenLastCalledWith(
+			"update_app_settings",
+			expect.objectContaining({
+				settingsMap: expect.objectContaining({
+					"app.start_workspace_mode_by_repo_id": JSON.stringify({
+						"repo-1": "worktree",
+					}),
+				}),
+			}),
+		);
+	});
+
 	it("hydrates and saves the last app surface", async () => {
 		invokeMock.mockResolvedValue({
 			"app.last_surface": "workspace-start",

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -19,6 +19,8 @@ export type FollowUpBehavior = "steer" | "queue";
 export type ClaudeThinkingDisplay = "summarized" | "omitted";
 export type AppSurface = "workspace" | "workspace-start";
 export type WorkspaceRightSidebarMode = "inspector" | "context";
+export type StartWorkspaceMode = "worktree" | "local";
+export type StartWorkspaceModeByRepoId = Record<string, StartWorkspaceMode>;
 
 export type ShortcutOverrides = Record<string, string | null>;
 
@@ -191,6 +193,7 @@ export type AppSettings = {
 	lastWorkspaceId: string | null;
 	lastSessionId: string | null;
 	lastSurface: AppSurface;
+	startWorkspaceModeByRepoId: StartWorkspaceModeByRepoId;
 	startContextPanelOpen: boolean;
 	workspaceRightSidebarMode: WorkspaceRightSidebarMode;
 	defaultModelId: string | null;
@@ -259,6 +262,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
 	lastWorkspaceId: null,
 	lastSessionId: null,
 	lastSurface: "workspace",
+	startWorkspaceModeByRepoId: {},
 	startContextPanelOpen: false,
 	workspaceRightSidebarMode: "inspector",
 	defaultModelId: null,
@@ -313,6 +317,7 @@ const SETTINGS_KEY_MAP: Record<
 	lastWorkspaceId: "app.last_workspace_id",
 	lastSessionId: "app.last_session_id",
 	lastSurface: "app.last_surface",
+	startWorkspaceModeByRepoId: "app.start_workspace_mode_by_repo_id",
 	startContextPanelOpen: "app.start_context_panel_open",
 	workspaceRightSidebarMode: "app.workspace_right_sidebar_mode",
 	defaultModelId: "app.default_model_id",
@@ -351,6 +356,25 @@ function parseShortcutOverrides(raw: string | undefined): ShortcutOverrides {
 		) as ShortcutOverrides;
 	} catch {
 		return DEFAULT_SETTINGS.shortcuts;
+	}
+}
+
+function parseStartWorkspaceModeByRepoId(
+	raw: string | undefined,
+): StartWorkspaceModeByRepoId {
+	if (!raw) return DEFAULT_SETTINGS.startWorkspaceModeByRepoId;
+	try {
+		const parsed = JSON.parse(raw) as unknown;
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+			return DEFAULT_SETTINGS.startWorkspaceModeByRepoId;
+		}
+		return Object.fromEntries(
+			Object.entries(parsed).filter(
+				([, value]) => value === "worktree" || value === "local",
+			),
+		) as StartWorkspaceModeByRepoId;
+	} catch {
+		return DEFAULT_SETTINGS.startWorkspaceModeByRepoId;
 	}
 }
 
@@ -739,6 +763,9 @@ export async function loadSettings(): Promise<AppSettings> {
 				raw[SETTINGS_KEY_MAP.lastSurface] === "workspace-start"
 					? "workspace-start"
 					: DEFAULT_SETTINGS.lastSurface,
+			startWorkspaceModeByRepoId: parseStartWorkspaceModeByRepoId(
+				raw[SETTINGS_KEY_MAP.startWorkspaceModeByRepoId],
+			),
 			startContextPanelOpen:
 				raw[SETTINGS_KEY_MAP.startContextPanelOpen] !== undefined
 					? raw[SETTINGS_KEY_MAP.startContextPanelOpen] === "true"
@@ -863,7 +890,8 @@ export async function saveSettings(patch: Partial<AppSettings>): Promise<void> {
 				key === "claudeCustomProviders" ||
 				key === "cursorProvider" ||
 				key === "inboxSourceConfig" ||
-				key === "kanbanViewState"
+				key === "kanbanViewState" ||
+				key === "startWorkspaceModeByRepoId"
 					? JSON.stringify(value)
 					: value === null
 						? ""


### PR DESCRIPTION
## What changed
- persist each repository's selected workspace-start mode in app settings
- initialize the workspace-start composer from the remembered mode when opening a repository
- update tests to cover settings hydration/saving and the remembered-mode create flow
- refresh the changeset summary to match the shipped behavior

## Why it changed
- users switch between local and worktree startup depending on the repository they're working in
- resetting that choice on every repository switch forces extra clicks and makes the workspace-start flow feel stateless
- remembering the last choice per repository restores the expected workflow without changing other startup behavior

Fixes #500.

## Follow-up / test notes
- committed as `07c9702d` after the pre-commit hook ran Biome on the staged frontend files
- I did not run the broader test suites in this turn
