### PR TITLE
feat: add appearance customization and Codex skill discovery

### DIFF
--- a/.announcements/appearance-and-command-discovery.json
+++ b/.announcements/appearance-and-command-discovery.json
@@ -1,0 +1,14 @@
+{
+	"items": [
+		{
+			"text": "Appearance settings now let you customize chat size, UI and code fonts, and pointer cursors.",
+			"action": {
+				"label": "Open Appearance",
+				"value": { "type": "openSettings", "section": "appearance" }
+			}
+		},
+		{
+			"text": "Codex slash commands now include skills from linked directories and the repository root."
+		}
+	]
+}

--- a/.changeset/appearance-and-command-discovery.md
+++ b/.changeset/appearance-and-command-discovery.md
@@ -1,0 +1,8 @@
+---
+"helmor": patch
+---
+
+Add a round of appearance and command-discovery improvements:
+- Let users customize chat size, UI and code fonts, and pointer cursors from Appearance settings.
+- Make Codex slash commands discover skills from linked directories and the repository root.
+- Restore the main window mode reliably after onboarding completes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,7 +122,7 @@ When a snapshot drifts: look at the diff first. Only accept after confirming the
 - **Path alias**: `@/` maps to `src/`
 - **Styling**: Tailwind CSS v4 with oklch semantic color tokens (`bg-app-base`, `text-app-foreground`, etc.)
 - **UI**: shadcn/ui (base-nova), `lucide-react` icons. **No `@assistant-ui/react` or `react-virtuoso`** -- removed, do not re-introduce.
-- **Cursor**: Every clickable element MUST have `cursor-pointer`. This is already baked into base UI components (`Button`, `SidebarMenuButton`, `CommandItem`, `DropdownMenuItem`, `ContextMenuItem`, etc.). When adding custom clickable elements (e.g. `<div onClick>`), always include `cursor-pointer`.
+- **Cursor**: Clickable elements default to `cursor-pointer` (baked into base UI components; keep it on custom `<div onClick>` too). Users can flip the whole app back to the platform arrow via Appearance settings → "Use pointer cursors" (adds `.no-pointer-cursors` on `<html>`); don't bypass with inline `style={{ cursor }}`.
 - **Chat rendering**: `streamdown` + `use-stick-to-bottom`. Markdown overrides in `src/components/streamdown-components.tsx`.
 - **Rich text input**: Lexical in `src/features/composer/editor/`.
 - **File editor**: Monaco, lazy via `src/lib/monaco-runtime.ts`.

--- a/index.html
+++ b/index.html
@@ -7,12 +7,19 @@
     <title>Helmor</title>
     <script>
       ;(() => {
-        var t = localStorage.getItem('helmor-theme') || 'system'
+        var root = document.documentElement
+        var ls = localStorage
+        var t = ls.getItem('helmor-theme') || 'system'
         var dark = t === 'dark' || (t === 'system' && window.matchMedia('(prefers-color-scheme:dark)').matches)
-        if (dark) document.documentElement.classList.add('dark')
-        document.documentElement.style.colorScheme = dark ? 'dark' : 'light'
-        var ct = localStorage.getItem('helmor-dark-theme') || 'default'
-        if (ct !== 'default') document.documentElement.classList.add(`theme-${ct}`)
+        if (dark) root.classList.add('dark')
+        root.style.colorScheme = dark ? 'dark' : 'light'
+        var ct = ls.getItem('helmor-dark-theme') || 'default'
+        if (ct !== 'default') root.classList.add(`theme-${ct}`)
+        // User font overrides
+        var ui = ls.getItem('helmor-ui-font-family')
+        if (ui) root.style.setProperty('--font-sans-user', ui)
+        var mono = ls.getItem('helmor-code-font-family')
+        if (mono) root.style.setProperty('--font-mono-user', mono)
       })()
     </script>
     <style>

--- a/sidecar/src/codex-app-server-manager.ts
+++ b/sidecar/src/codex-app-server-manager.ts
@@ -1115,6 +1115,7 @@ export class CodexAppServerManager implements SessionManager {
 		params: ListSlashCommandsParams,
 	): Promise<readonly SlashCommandInfo[]> {
 		const cwd = params.cwd ?? process.cwd();
+		const cwds = collectSkillCwds(cwd, params.additionalDirectories);
 		const server = new CodexAppServer({
 			binaryPath: CODEX_BIN_PATH,
 			cwd,
@@ -1132,11 +1133,11 @@ export class CodexAppServerManager implements SessionManager {
 			// providers fail the same way when their CLI is missing/slow.
 			const result = await server.sendRequest<Record<string, unknown>>(
 				"skills/list",
-				{ cwds: [cwd] },
+				{ cwds },
 				20_000,
 			);
 
-			return parseSkillsResponse(result, cwd);
+			return parseSkillsResponse(result, cwds);
 		} finally {
 			server.kill();
 		}
@@ -1772,27 +1773,36 @@ function deepGet(obj: unknown, ...keys: string[]): unknown {
 	return current;
 }
 
-function parseSkillsResponse(result: unknown, cwd: string): SlashCommandInfo[] {
+function collectSkillCwds(
+	cwd: string,
+	additionalDirectories: readonly string[] | undefined,
+): string[] {
+	const cwds = [cwd, ...(additionalDirectories ?? [])].map((dir) => dir.trim());
+	return Array.from(new Set(cwds.filter(Boolean)));
+}
+
+function parseSkillsResponse(
+	result: unknown,
+	cwds: readonly string[],
+): SlashCommandInfo[] {
 	if (!result || typeof result !== "object") return [];
 	const r = result as Record<string, unknown>;
 
-	let skills: unknown[] = [];
+	const skills: unknown[] = [];
 	const dataBuckets = Array.isArray(r.data) ? r.data : [];
-	const bucket = dataBuckets.find(
-		(b: unknown) =>
-			typeof b === "object" &&
-			b !== null &&
-			(b as Record<string, unknown>).cwd === cwd,
-	);
-	if (bucket && typeof bucket === "object") {
-		const s = (bucket as Record<string, unknown>).skills;
-		if (Array.isArray(s)) skills = s;
+	const wantedCwds = new Set(cwds);
+	for (const bucket of dataBuckets) {
+		if (!bucket || typeof bucket !== "object") continue;
+		const record = bucket as Record<string, unknown>;
+		if (!wantedCwds.has(String(record.cwd ?? ""))) continue;
+		const bucketSkills = record.skills;
+		if (Array.isArray(bucketSkills)) skills.push(...bucketSkills);
 	}
 	if (skills.length === 0 && Array.isArray(r.skills)) {
-		skills = r.skills;
+		skills.push(...r.skills);
 	}
 
-	return skills.flatMap((s) => {
+	const commands = skills.flatMap((s) => {
 		if (!s || typeof s !== "object") return [];
 		const skill = s as Record<string, unknown>;
 		const name = typeof skill.name === "string" ? skill.name : null;
@@ -1814,6 +1824,11 @@ function parseSkillsResponse(result: unknown, cwd: string): SlashCommandInfo[] {
 			},
 		];
 	});
+	const byName = new Map<string, SlashCommandInfo>();
+	for (const command of commands) {
+		if (!byName.has(command.name)) byName.set(command.name, command);
+	}
+	return Array.from(byName.values());
 }
 
 /**

--- a/sidecar/test/codex-app-server-manager.test.ts
+++ b/sidecar/test/codex-app-server-manager.test.ts
@@ -69,6 +69,25 @@ class MockCodexAppServer {
 			});
 			return {};
 		}
+		if (method === "skills/list") {
+			return {
+				data: [
+					{
+						cwd: "/tmp/workspace",
+						skills: [
+							{ name: "workspace-skill", description: "from workspace" },
+						],
+					},
+					{
+						cwd: "/tmp/repo",
+						skills: [
+							{ name: "repo-skill", description: "from repo" },
+							{ name: "workspace-skill", description: "duplicate" },
+						],
+					},
+				],
+			};
+		}
 		if (method === "turn/start") {
 			queueMicrotask(() => {
 				serverState.onNotification?.({
@@ -146,6 +165,26 @@ describe("CodexAppServerManager", () => {
 		};
 		codexConfigState.calls = 0;
 		emitter = createSidecarEmitter(() => {});
+	});
+
+	test("listSlashCommands sends cwd plus additionalDirectories to skills/list", async () => {
+		const manager = new CodexAppServerManager();
+
+		const commands = await manager.listSlashCommands({
+			cwd: "/tmp/workspace",
+			additionalDirectories: ["/tmp/repo", "/tmp/repo", " "],
+		});
+
+		const skillsList = serverState.requests.find(
+			(request) => request.method === "skills/list",
+		);
+		expect(skillsList?.params).toEqual({
+			cwds: ["/tmp/workspace", "/tmp/repo"],
+		});
+		expect(commands.map((command) => command.name)).toEqual([
+			"workspace-skill",
+			"repo-skill",
+		]);
 	});
 
 	test("returns the hardcoded model list", async () => {

--- a/src-tauri/src/agents/queries.rs
+++ b/src-tauri/src/agents/queries.rs
@@ -511,8 +511,7 @@ pub async fn list_slash_commands(
     let request = resolve_repo_fallback_cwd(request);
     let cwd = request.working_directory.as_deref().unwrap_or("");
     let repo_id = request.repo_id.as_deref().unwrap_or("");
-    let additional_directories =
-        lookup_workspace_linked_directories_for_commands(request.workspace_id.as_deref());
+    let additional_directories = slash_command_scan_directories(&request);
     tracing::debug!(
         provider = %request.provider,
         cwd,
@@ -632,6 +631,37 @@ fn lookup_workspace_linked_directories_for_commands(workspace_id: Option<&str>) 
             );
             Vec::new()
         }
+    }
+}
+
+fn slash_command_scan_directories(request: &ListSlashCommandsRequest) -> Vec<String> {
+    let mut dirs =
+        lookup_workspace_linked_directories_for_commands(request.workspace_id.as_deref());
+    if request.provider == "codex" {
+        append_repo_root_scan_directory(request, &mut dirs);
+    }
+    dirs
+}
+
+fn append_repo_root_scan_directory(request: &ListSlashCommandsRequest, dirs: &mut Vec<String>) {
+    let Some(repo_id) = request.repo_id.as_deref().filter(|s| !s.is_empty()) else {
+        return;
+    };
+    let Some(record) = crate::models::repos::load_repository_by_id(repo_id)
+        .ok()
+        .flatten()
+    else {
+        return;
+    };
+    let root_path = record.root_path.trim();
+    if root_path.is_empty() || !std::path::Path::new(root_path).is_dir() {
+        return;
+    }
+    if request.working_directory.as_deref() == Some(root_path) {
+        return;
+    }
+    if !dirs.iter().any(|dir| dir == root_path) {
+        dirs.push(root_path.to_string());
     }
 }
 
@@ -915,8 +945,7 @@ fn spawn_background_refresh(
             let sidecar_state: tauri::State<'_, crate::sidecar::ManagedSidecar> = app.state();
             let cache_state: tauri::State<'_, super::slash_commands::SlashCommandCache> =
                 app.state();
-            let additional_directories =
-                lookup_workspace_linked_directories_for_commands(request.workspace_id.as_deref());
+            let additional_directories = slash_command_scan_directories(&request);
 
             match fetch_from_sidecar(&sidecar_state, &request, &additional_directories) {
                 Ok(commands) => {

--- a/src/App.css
+++ b/src/App.css
@@ -11,13 +11,21 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/*
+ * Font stacks. `--font-sans-user` / `--font-mono-user` are written by
+ * `useThemeApplication` when the user picks a custom family in
+ * Appearance settings; absent, the cascade falls through to the bundled
+ * Geist variable fonts. This is a single source of truth — every other
+ * `--font-sans`/`--font-mono` declaration in this file chains through
+ * the same var() to keep the override consistent.
+ */
 @theme {
 	--font-sans:
-		"Geist Variable", "SF Pro Display", -apple-system, BlinkMacSystemFont,
-		"Segoe UI", sans-serif;
+		var(--font-sans-user, "Geist Variable"), "SF Pro Display", -apple-system,
+		BlinkMacSystemFont, "Segoe UI", sans-serif;
 	--font-mono:
-		"Geist Mono Variable", ui-monospace, "SF Mono", SFMono-Regular, Menlo,
-		Monaco, Consolas, monospace;
+		var(--font-mono-user, "Geist Mono Variable"), ui-monospace, "SF Mono",
+		SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 }
 
 :root {
@@ -26,6 +34,18 @@
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	-webkit-text-size-adjust: 100%;
+}
+
+/*
+ * Pointer cursors. The whole app defaults to `cursor-pointer` on every
+ * interactive element (baked into base UI components — see CLAUDE.md).
+ * Users who prefer the platform default arrow can flip this off; the
+ * class below neutralises pointer cursors everywhere except text-input
+ * controls.
+ */
+html.no-pointer-cursors
+*:not(input):not(textarea):not([contenteditable="true"]) {
+	cursor: default !important;
 }
 
 html,
@@ -647,10 +667,10 @@ body {
 
 @theme inline {
 	--font-heading: var(--font-sans);
-	--font-sans: "Geist Variable", sans-serif;
+	--font-sans: var(--font-sans-user, "Geist Variable"), sans-serif;
 	--font-mono:
-		"Geist Mono Variable", ui-monospace, "SF Mono", SFMono-Regular, Menlo,
-		Monaco, Consolas, monospace;
+		var(--font-mono-user, "Geist Mono Variable"), ui-monospace, "SF Mono",
+		SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 	--color-sidebar-ring: var(--sidebar-ring);
 	--color-sidebar-border: var(--sidebar-border);
 	--color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -796,7 +816,7 @@ body {
  * Inline code font-size.
  *
  * Streamdown hard-codes `text-sm` (14px absolute) on inline `<code>` elements,
- * which ignores the user's settings.fontSize and visibly bulges when the
+ * which ignores the user's chatFontSize and visibly bulges when the
  * surrounding text is smaller (e.g. 13px). Force inline code (not the
  * pre-wrapped block code, which uses our CodeBlock) to inherit the parent
  * font-size so it always matches the surrounding text.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,6 +52,7 @@ import {
 import { clampZoom, useZoom, ZOOM_STEP } from "@/shell/use-zoom";
 import {
 	createSession,
+	exitOnboardingWindowMode,
 	openWorkspaceInEditor,
 	type WorkspaceDetail,
 	type WorkspaceSessionSummary,
@@ -204,6 +205,16 @@ function MainApp() {
 			setTimeout(() => setSplashMounted(false), SPLASH_FADE_MS);
 		});
 	}, []);
+
+	useEffect(() => {
+		if (appSettings?.onboardingCompleted !== true) {
+			return;
+		}
+
+		void exitOnboardingWindowMode().catch((error) => {
+			console.error("[app] failed to restore main window mode", error);
+		});
+	}, [appSettings?.onboardingCompleted]);
 
 	useShellEvent("reload-settings", () => {
 		void loadSettings().then(setAppSettings);
@@ -732,6 +743,10 @@ function AppShell({
 	useThemeApplication({
 		theme: appSettings.theme,
 		darkTheme: appSettings.darkTheme,
+		uiFontFamily: appSettings.uiFontFamily,
+		codeFontFamily: appSettings.codeFontFamily,
+		chatFontSize: appSettings.chatFontSize,
+		usePointerCursors: appSettings.usePointerCursors,
 	});
 
 	const handleSelectWorkspace = useCallback(

--- a/src/features/onboarding/index.tsx
+++ b/src/features/onboarding/index.tsx
@@ -75,9 +75,16 @@ export function AppOnboarding({ onComplete }: AppOnboardingProps) {
 	}, [refreshLoginItems]);
 
 	useEffect(() => {
-		void enterOnboardingWindowMode();
+		const entered = enterOnboardingWindowMode().catch((error) => {
+			console.error("[onboarding] failed to enter fixed window mode", error);
+		});
+
 		return () => {
-			void exitOnboardingWindowMode();
+			void entered.finally(() => {
+				void exitOnboardingWindowMode().catch((error) => {
+					console.error("[onboarding] failed to restore window mode", error);
+				});
+			});
 		};
 	}, []);
 

--- a/src/features/panel/message-components/assistant-message.tsx
+++ b/src/features/panel/message-components/assistant-message.tsx
@@ -58,7 +58,7 @@ const AssistantText = memo(function AssistantText({
 	return (
 		<div
 			className="conversation-markdown assistant-markdown-scale max-w-none break-words text-foreground"
-			style={{ fontSize: `${settings.fontSize}px` }}
+			style={{ fontSize: `${settings.chatFontSize}px` }}
 		>
 			<Suspense fallback={<AssistantTextFallback text={smoothedText} />}>
 				<LazyStreamdown
@@ -230,7 +230,7 @@ export function ChatAssistantMessage({
 						>
 							<ReasoningTrigger />
 							{hasContent ? (
-								<ReasoningContent fontSize={settings.fontSize}>
+								<ReasoningContent fontSize={settings.chatFontSize}>
 									{part.text}
 								</ReasoningContent>
 							) : null}

--- a/src/features/panel/message-components/user-message.tsx
+++ b/src/features/panel/message-components/user-message.tsx
@@ -23,7 +23,7 @@ export function ChatUserMessage({ message }: { message: RenderedMessage }) {
 			<div className="relative flex max-w-[75%] min-w-0 flex-col items-end pb-5">
 				<div
 					className="conversation-body-text w-full overflow-hidden rounded-md bg-accent/55 px-3 py-2 leading-7"
-					style={{ fontSize: `${settings.fontSize}px` }}
+					style={{ fontSize: `${settings.chatFontSize}px` }}
 				>
 					<p className="whitespace-pre-wrap break-words">
 						{parts.map((part, index) => {

--- a/src/features/panel/thread-viewport.tsx
+++ b/src/features/panel/thread-viewport.tsx
@@ -294,7 +294,7 @@ function ChatThread({
 			<ConversationViewport
 				contentRef={contentRef}
 				data={threadMessages}
-				fontSize={settings.fontSize}
+				fontSize={settings.chatFontSize}
 				hasSession={hasSession}
 				itemContent={itemContent}
 				layoutCacheKey={layoutCacheKey}

--- a/src/features/settings/components/font-picker.tsx
+++ b/src/features/settings/components/font-picker.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+/// Free-form font input. Codex-style: a single text field whose
+/// placeholder shows the currently rendered font stack so the user knows
+/// what they're overriding without us having to enumerate system fonts.
+/// Empty input on commit (blur / Enter) clears the override (= null).
+export type FontPickerProps = {
+	value: string | null;
+	onChange: (next: string | null) => void;
+	/** Effective CSS font-family used when value is null. */
+	effectivePlaceholder: string;
+	className?: string;
+	ariaLabel?: string;
+};
+
+export function FontPicker({
+	value,
+	onChange,
+	effectivePlaceholder,
+	className,
+	ariaLabel,
+}: FontPickerProps) {
+	const [local, setLocal] = useState(value ?? "");
+
+	useEffect(() => {
+		setLocal(value ?? "");
+	}, [value]);
+
+	function commit(next: string) {
+		const trimmed = next.trim();
+		onChange(trimmed.length === 0 ? null : trimmed);
+	}
+
+	return (
+		<Input
+			value={local}
+			onChange={(e) => setLocal(e.target.value)}
+			onBlur={() => commit(local)}
+			onKeyDown={(e) => {
+				if (e.key === "Enter") {
+					(e.target as HTMLInputElement).blur();
+				} else if (e.key === "Escape") {
+					setLocal(value ?? "");
+					(e.target as HTMLInputElement).blur();
+				}
+			}}
+			placeholder={effectivePlaceholder}
+			aria-label={ariaLabel}
+			className={cn(
+				"h-7 w-48 px-2 py-0 font-mono text-[10px] md:text-[10px]",
+				className,
+			)}
+			spellCheck={false}
+		/>
+	);
+}

--- a/src/features/settings/components/font-size-stepper.tsx
+++ b/src/features/settings/components/font-size-stepper.tsx
@@ -1,0 +1,52 @@
+import { Minus, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export type FontSizeStepperProps = {
+	value: number;
+	onChange: (next: number) => void;
+	min: number;
+	max: number;
+	step?: number;
+	unit?: string;
+	ariaLabel?: string;
+};
+
+/// Two-button +/- stepper with a centered numeric label. Used for all
+/// three appearance font sizes (chat, UI, code) so they stay visually
+/// identical and the bounds live with the caller.
+export function FontSizeStepper({
+	value,
+	onChange,
+	min,
+	max,
+	step = 1,
+	unit = "px",
+	ariaLabel,
+}: FontSizeStepperProps) {
+	return (
+		<div className="flex items-center gap-3" aria-label={ariaLabel}>
+			<Button
+				variant="outline"
+				size="icon-sm"
+				onClick={() => onChange(Math.max(min, value - step))}
+				disabled={value <= min}
+				aria-label="Decrease"
+			>
+				<Minus className="size-3.5" strokeWidth={2} />
+			</Button>
+			<span className="w-12 text-center text-[14px] font-semibold tabular-nums text-foreground">
+				{value}
+				{unit}
+			</span>
+			<Button
+				variant="outline"
+				size="icon-sm"
+				onClick={() => onChange(Math.min(max, value + step))}
+				disabled={value >= max}
+				aria-label="Increase"
+			>
+				<Plus className="size-3.5" strokeWidth={2} />
+			</Button>
+		</div>
+	);
+}

--- a/src/features/settings/index.tsx
+++ b/src/features/settings/index.tsx
@@ -1,15 +1,5 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import {
-	CheckCircle2,
-	ChevronDown,
-	HelpCircle,
-	Minus,
-	Monitor,
-	Moon,
-	Plus,
-	Settings,
-	Sun,
-} from "lucide-react";
+import { CheckCircle2, ChevronDown, HelpCircle, Settings } from "lucide-react";
 import { memo, useEffect, useRef, useState } from "react";
 import { ModelIcon } from "@/components/model-icon";
 import { Button } from "@/components/ui/button";
@@ -52,19 +42,15 @@ import {
 	helmorQueryKeys,
 	repositoriesQueryOptions,
 } from "@/lib/query-client";
-import type {
-	AppSettings,
-	ClaudeThinkingDisplay,
-	DarkTheme,
-	ThemeMode,
-} from "@/lib/settings";
-import { resolveTheme, useSettings } from "@/lib/settings";
+import type { AppSettings, ClaudeThinkingDisplay } from "@/lib/settings";
+import { useSettings } from "@/lib/settings";
 import { requestSidebarReconcile } from "@/lib/sidebar-mutation-gate";
 import { cn } from "@/lib/utils";
 import { clampEffort, findModelOption } from "@/lib/workspace-helpers";
 import { SettingsGroup, SettingsRow } from "./components/settings-row";
 import { AccountPanel } from "./panels/account";
 import { AppUpdatesPanel } from "./panels/app-updates";
+import { AppearancePanel } from "./panels/appearance";
 import { CliInstallPanel } from "./panels/cli-install";
 import { ConductorImportPanel } from "./panels/conductor-import";
 import { CursorProviderPanel } from "./panels/cursor-provider";
@@ -73,61 +59,7 @@ import { InboxSettingsPanel } from "./panels/inbox";
 import { ClaudeCustomProvidersPanel } from "./panels/model-providers";
 import { RepositorySettingsPanel } from "./panels/repository-settings";
 
-const MIN_FONT_SIZE = 12;
-const MAX_FONT_SIZE = 20;
 const FALLBACK_EFFORT_LEVELS = ["low", "medium", "high"];
-
-const DARK_THEME_OPTIONS: Array<{
-	id: DarkTheme;
-	label: string;
-	/** Gradient stop colors for dark-mode swatch (vivid, hue-family) */
-	bg: string;
-	accent: string;
-	/** Gradient stop colors for light-mode swatch (vivid, hue-family) */
-	lightBg: string;
-	lightAccent: string;
-}> = [
-	{
-		id: "default",
-		label: "Default",
-		bg: "oklch(0.38 0 0)",
-		accent: "oklch(0.18 0 0)",
-		lightBg: "oklch(0.88 0 0)",
-		lightAccent: "oklch(0.52 0 0)",
-	},
-	{
-		id: "midnight",
-		label: "Midnight",
-		bg: "oklch(0.62 0.14 258)",
-		accent: "oklch(0.30 0.10 260)",
-		lightBg: "oklch(0.82 0.09 258)",
-		lightAccent: "oklch(0.46 0.20 255)",
-	},
-	{
-		id: "forest",
-		label: "Forest",
-		bg: "oklch(0.58 0.13 150)",
-		accent: "oklch(0.28 0.08 155)",
-		lightBg: "oklch(0.80 0.09 152)",
-		lightAccent: "oklch(0.44 0.17 148)",
-	},
-	{
-		id: "ember",
-		label: "Ember",
-		bg: "oklch(0.66 0.15 55)",
-		accent: "oklch(0.32 0.09 48)",
-		lightBg: "oklch(0.84 0.11 60)",
-		lightAccent: "oklch(0.52 0.19 50)",
-	},
-	{
-		id: "aurora",
-		label: "Aurora",
-		bg: "oklch(0.60 0.15 286)",
-		accent: "oklch(0.28 0.09 292)",
-		lightBg: "oklch(0.80 0.10 289)",
-		lightAccent: "oklch(0.46 0.20 284)",
-	},
-];
 
 export type { SettingsSection } from "./types";
 
@@ -542,121 +474,10 @@ export const SettingsDialog = memo(function SettingsDialog({
 							)}
 
 							{activeSection === "appearance" && (
-								<SettingsGroup>
-									<SettingsRow
-										title="Theme"
-										description="Switch between light and dark appearance"
-									>
-										<ToggleGroup
-											type="single"
-											value={settings.theme}
-											className="gap-1.5"
-											onValueChange={(value: string) => {
-												if (value) {
-													updateSettings({ theme: value as ThemeMode });
-												}
-											}}
-										>
-											{(
-												[
-													{ value: "system", icon: Monitor, label: "System" },
-													{ value: "light", icon: Sun, label: "Light" },
-													{ value: "dark", icon: Moon, label: "Dark" },
-												] as const
-											).map(({ value, icon: Icon, label }) => (
-												<ToggleGroupItem
-													key={value}
-													value={value}
-													className="gap-1.5 rounded-lg px-3 py-1.5 text-[12px] font-medium text-muted-foreground data-[state=on]:bg-accent data-[state=on]:text-foreground"
-												>
-													<Icon className="size-3.5" strokeWidth={1.8} />
-													{label}
-												</ToggleGroupItem>
-											))}
-										</ToggleGroup>
-									</SettingsRow>
-									<SettingsRow
-										title="Color Theme"
-										description="Choose an accent palette"
-									>
-										{(() => {
-											const isLight = resolveTheme(settings.theme) === "light";
-											return (
-												<div className="flex gap-2">
-													{DARK_THEME_OPTIONS.map((opt) => {
-														const swatchBg = isLight ? opt.lightBg : opt.bg;
-														const swatchAccent = isLight
-															? opt.lightAccent
-															: opt.accent;
-														const isSelected = settings.darkTheme === opt.id;
-														return (
-															<button
-																key={opt.id}
-																type="button"
-																title={opt.label}
-																aria-label={opt.label}
-																aria-pressed={isSelected}
-																className={cn(
-																	"h-7 w-7 cursor-pointer rounded-full transition-transform duration-150",
-																	isSelected ? "scale-105" : "hover:scale-105",
-																)}
-																style={{
-																	background: `linear-gradient(135deg, ${swatchBg}, ${swatchAccent})`,
-																	boxShadow: isSelected
-																		? `0 0 0 2px var(--background), 0 0 0 3.5px ${swatchBg}`
-																		: undefined,
-																}}
-																onClick={() =>
-																	updateSettings({ darkTheme: opt.id })
-																}
-															/>
-														);
-													})}
-												</div>
-											);
-										})()}
-									</SettingsRow>
-									<SettingsRow
-										title="Font Size"
-										description="Adjust the text size for chat messages"
-									>
-										<div className="flex items-center gap-3">
-											<Button
-												variant="outline"
-												size="icon-sm"
-												onClick={() =>
-													updateSettings({
-														fontSize: Math.max(
-															MIN_FONT_SIZE,
-															settings.fontSize - 1,
-														),
-													})
-												}
-												disabled={settings.fontSize <= MIN_FONT_SIZE}
-											>
-												<Minus className="size-3.5" strokeWidth={2} />
-											</Button>
-											<span className="w-12 text-center text-[14px] font-semibold tabular-nums text-foreground">
-												{settings.fontSize}px
-											</span>
-											<Button
-												variant="outline"
-												size="icon-sm"
-												onClick={() =>
-													updateSettings({
-														fontSize: Math.min(
-															MAX_FONT_SIZE,
-															settings.fontSize + 1,
-														),
-													})
-												}
-												disabled={settings.fontSize >= MAX_FONT_SIZE}
-											>
-												<Plus className="size-3.5" strokeWidth={2} />
-											</Button>
-										</div>
-									</SettingsRow>
-								</SettingsGroup>
+								<AppearancePanel
+									settings={settings}
+									updateSettings={updateSettings}
+								/>
 							)}
 
 							{activeSection === "model" && (

--- a/src/features/settings/panels/appearance.tsx
+++ b/src/features/settings/panels/appearance.tsx
@@ -1,0 +1,223 @@
+import { Monitor, Moon, Sun } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Switch } from "@/components/ui/switch";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import {
+	type AppSettings,
+	type DarkTheme,
+	resolveTheme,
+	type ThemeMode,
+} from "@/lib/settings";
+import { cn } from "@/lib/utils";
+import { FontPicker } from "../components/font-picker";
+import { FontSizeStepper } from "../components/font-size-stepper";
+import { SettingsGroup, SettingsRow } from "../components/settings-row";
+
+type ColorThemeOption = {
+	id: DarkTheme;
+	label: string;
+	bg: string;
+	accent: string;
+	lightBg: string;
+	lightAccent: string;
+};
+
+/// Swatch tints for the Color Theme row. Two stops per side so each
+/// preset reads as a distinct gradient circle — vivid in dark mode,
+/// softer in light mode.
+const DARK_THEME_OPTIONS: readonly ColorThemeOption[] = [
+	{
+		id: "default",
+		label: "Default",
+		bg: "oklch(0.38 0 0)",
+		accent: "oklch(0.18 0 0)",
+		lightBg: "oklch(0.88 0 0)",
+		lightAccent: "oklch(0.52 0 0)",
+	},
+	{
+		id: "midnight",
+		label: "Midnight",
+		bg: "oklch(0.62 0.14 258)",
+		accent: "oklch(0.30 0.10 260)",
+		lightBg: "oklch(0.82 0.09 258)",
+		lightAccent: "oklch(0.46 0.20 255)",
+	},
+	{
+		id: "forest",
+		label: "Forest",
+		bg: "oklch(0.58 0.13 150)",
+		accent: "oklch(0.28 0.08 155)",
+		lightBg: "oklch(0.80 0.09 152)",
+		lightAccent: "oklch(0.44 0.17 148)",
+	},
+	{
+		id: "ember",
+		label: "Ember",
+		bg: "oklch(0.66 0.15 55)",
+		accent: "oklch(0.32 0.09 48)",
+		lightBg: "oklch(0.84 0.11 60)",
+		lightAccent: "oklch(0.52 0.19 50)",
+	},
+	{
+		id: "aurora",
+		label: "Aurora",
+		bg: "oklch(0.60 0.15 286)",
+		accent: "oklch(0.28 0.09 292)",
+		lightBg: "oklch(0.80 0.10 289)",
+		lightAccent: "oklch(0.46 0.20 284)",
+	},
+];
+
+type EffectiveFonts = {
+	fontSans: string;
+	fontMono: string;
+};
+
+function sampleEffectiveFonts(): EffectiveFonts {
+	if (typeof document === "undefined") {
+		return { fontSans: "", fontMono: "" };
+	}
+	const cs = getComputedStyle(document.documentElement);
+	return {
+		fontSans: cs.getPropertyValue("--font-sans").trim(),
+		fontMono: cs.getPropertyValue("--font-mono").trim(),
+	};
+}
+
+export type AppearancePanelProps = {
+	settings: AppSettings;
+	updateSettings: (patch: Partial<AppSettings>) => void;
+};
+
+export function AppearancePanel({
+	settings,
+	updateSettings,
+}: AppearancePanelProps) {
+	const isLight = resolveTheme(settings.theme) === "light";
+
+	// Re-sample the live font stacks each time the user changes a
+	// font-affecting setting so the placeholders show what's actually
+	// rendering. RAF defers one frame to let `useThemeApplication`
+	// commit its DOM mutations first.
+	const [effective, setEffective] =
+		useState<EffectiveFonts>(sampleEffectiveFonts);
+	useEffect(() => {
+		const id = requestAnimationFrame(() =>
+			setEffective(sampleEffectiveFonts()),
+		);
+		return () => cancelAnimationFrame(id);
+	}, [settings.uiFontFamily, settings.codeFontFamily]);
+
+	return (
+		<SettingsGroup>
+			{/* ── Mode ─────────────────────────────────────────────────────── */}
+			<SettingsRow
+				title="Theme"
+				description="Use light, dark, or match your system"
+			>
+				<ToggleGroup
+					type="single"
+					value={settings.theme}
+					className="gap-1.5"
+					onValueChange={(value: string) => {
+						if (value) updateSettings({ theme: value as ThemeMode });
+					}}
+				>
+					{(
+						[
+							{ value: "light", icon: Sun, label: "Light" },
+							{ value: "dark", icon: Moon, label: "Dark" },
+							{ value: "system", icon: Monitor, label: "System" },
+						] as const
+					).map(({ value, icon: Icon, label }) => (
+						<ToggleGroupItem
+							key={value}
+							value={value}
+							className="gap-1.5 rounded-lg px-3 py-1.5 text-[12px] font-medium text-muted-foreground data-[state=on]:bg-accent data-[state=on]:text-foreground"
+						>
+							<Icon className="size-3.5" strokeWidth={1.8} />
+							{label}
+						</ToggleGroupItem>
+					))}
+				</ToggleGroup>
+			</SettingsRow>
+
+			{/* ── Color theme ──────────────────────────────────────────────── */}
+			<SettingsRow title="Color Theme" description="Choose an accent palette">
+				<div className="flex gap-2">
+					{DARK_THEME_OPTIONS.map((opt) => {
+						const swatchBg = isLight ? opt.lightBg : opt.bg;
+						const swatchAccent = isLight ? opt.lightAccent : opt.accent;
+						const isSelected = settings.darkTheme === opt.id;
+						return (
+							<button
+								key={opt.id}
+								type="button"
+								title={opt.label}
+								aria-label={opt.label}
+								aria-pressed={isSelected}
+								className={cn(
+									"h-7 w-7 cursor-pointer rounded-full transition-transform duration-150",
+									isSelected ? "scale-105" : "hover:scale-105",
+								)}
+								style={{
+									background: `linear-gradient(135deg, ${swatchBg}, ${swatchAccent})`,
+									boxShadow: isSelected
+										? `0 0 0 2px var(--background), 0 0 0 3.5px ${swatchBg}`
+										: undefined,
+								}}
+								onClick={() => updateSettings({ darkTheme: opt.id })}
+							/>
+						);
+					})}
+				</div>
+			</SettingsRow>
+
+			{/* ── Chat font size ────────────────────────────────────────────── */}
+			<SettingsRow
+				title="Chat font size"
+				description="Size used for chat message bodies"
+			>
+				<FontSizeStepper
+					value={settings.chatFontSize}
+					onChange={(next) => updateSettings({ chatFontSize: next })}
+					min={12}
+					max={24}
+					ariaLabel="Chat font size"
+				/>
+			</SettingsRow>
+
+			{/* ── Fonts (free-form text inputs) ─────────────────────────────── */}
+			<SettingsRow title="UI font">
+				<FontPicker
+					value={settings.uiFontFamily}
+					onChange={(next) => updateSettings({ uiFontFamily: next })}
+					effectivePlaceholder={effective.fontSans}
+					ariaLabel="UI font family"
+				/>
+			</SettingsRow>
+
+			<SettingsRow title="Code font">
+				<FontPicker
+					value={settings.codeFontFamily}
+					onChange={(next) => updateSettings({ codeFontFamily: next })}
+					effectivePlaceholder={effective.fontMono}
+					ariaLabel="Code font family"
+				/>
+			</SettingsRow>
+
+			{/* ── Cursors ──────────────────────────────────────────────────── */}
+			<SettingsRow
+				title="Use pointer cursors"
+				description="Change the cursor to a pointer when hovering over interactive elements"
+			>
+				<Switch
+					checked={settings.usePointerCursors}
+					onCheckedChange={(checked) =>
+						updateSettings({ usePointerCursors: checked })
+					}
+				/>
+			</SettingsRow>
+		</SettingsGroup>
+	);
+}

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -185,7 +185,16 @@ export type KanbanViewState = {
 };
 
 export type AppSettings = {
-	fontSize: number;
+	/** Chat message body font size (px). Migrated from the legacy `fontSize`
+	 *  field, which only ever affected chat rendering. */
+	chatFontSize: number;
+	/** Override for the sans-serif UI font stack. `null` = preset default. */
+	uiFontFamily: string | null;
+	/** Override for the monospace code font stack. `null` = preset default. */
+	codeFontFamily: string | null;
+	/** When true, all clickable elements show a pointer cursor on hover.
+	 *  When false, falls back to the default arrow. */
+	usePointerCursors: boolean;
 	theme: ThemeMode;
 	darkTheme: DarkTheme;
 	notifications: boolean;
@@ -257,7 +266,10 @@ export const DEFAULT_KANBAN_VIEW_STATE: KanbanViewState = {
 export const CONTEXT_USAGE_AUTO_REVEAL_THRESHOLD = 70;
 
 export const DEFAULT_SETTINGS: AppSettings = {
-	fontSize: 14,
+	chatFontSize: 14,
+	uiFontFamily: null,
+	codeFontFamily: null,
+	usePointerCursors: true,
 	theme: "system",
 	darkTheme: "default",
 	notifications: true,
@@ -301,6 +313,21 @@ export const DEFAULT_SETTINGS: AppSettings = {
 export const THEME_STORAGE_KEY = "helmor-theme";
 export const DARK_THEME_STORAGE_KEY = "helmor-dark-theme";
 export const SIDEBAR_GROUPING_STORAGE_KEY = "helmor-sidebar-grouping";
+export const UI_FONT_FAMILY_STORAGE_KEY = "helmor-ui-font-family";
+export const CODE_FONT_FAMILY_STORAGE_KEY = "helmor-code-font-family";
+
+/** Keys mirrored to localStorage for flash-free synchronous boot reads.
+ *  Anything visible in the first paint must live here so we don't wait
+ *  on the async SQLite round-trip. */
+const LOCALSTORAGE_KEYS = {
+	theme: THEME_STORAGE_KEY,
+	darkTheme: DARK_THEME_STORAGE_KEY,
+	sidebarGrouping: SIDEBAR_GROUPING_STORAGE_KEY,
+	uiFontFamily: UI_FONT_FAMILY_STORAGE_KEY,
+	codeFontFamily: CODE_FONT_FAMILY_STORAGE_KEY,
+} as const;
+
+type LocalStorageKey = keyof typeof LOCALSTORAGE_KEYS;
 
 const VALID_SIDEBAR_GROUPINGS: readonly SidebarGrouping[] = ["status", "repo"];
 
@@ -324,17 +351,36 @@ export function getPreloadedTheme(): ThemeMode {
 	return (raw as ThemeMode | null) ?? DEFAULT_SETTINGS.theme;
 }
 
-export function getPreloadedSettings(): AppSettings {
-	return { ...DEFAULT_SETTINGS, theme: getPreloadedTheme() };
+function readLocalStorageString(key: string): string | null {
+	if (typeof localStorage === "undefined") return null;
+	const v = localStorage.getItem(key);
+	return v && v.length > 0 ? v : null;
 }
 
-// theme + darkTheme + sidebarGrouping are stored in localStorage
-// (sync read for flash-free boot), not SQLite
+export function getPreloadedSettings(): AppSettings {
+	const darkTheme = (() => {
+		const raw = readLocalStorageString(DARK_THEME_STORAGE_KEY);
+		return VALID_DARK_THEMES.includes(raw as DarkTheme)
+			? (raw as DarkTheme)
+			: DEFAULT_SETTINGS.darkTheme;
+	})();
+	return {
+		...DEFAULT_SETTINGS,
+		theme: getPreloadedTheme(),
+		darkTheme,
+		uiFontFamily: readLocalStorageString(UI_FONT_FAMILY_STORAGE_KEY),
+		codeFontFamily: readLocalStorageString(CODE_FONT_FAMILY_STORAGE_KEY),
+	};
+}
+
+// localStorage-backed fields (sync read for flash-free boot) live in
+// `LOCALSTORAGE_KEYS` above. Everything else goes through SQLite.
 const SETTINGS_KEY_MAP: Record<
-	Exclude<keyof AppSettings, "theme" | "darkTheme" | "sidebarGrouping">,
+	Exclude<keyof AppSettings, LocalStorageKey>,
 	string
 > = {
-	fontSize: "app.font_size",
+	chatFontSize: "app.chat_font_size",
+	usePointerCursors: "app.use_pointer_cursors",
 	notifications: "app.notifications",
 	lastWorkspaceId: "app.last_workspace_id",
 	lastSessionId: "app.last_session_id",
@@ -732,6 +778,19 @@ function parseClaudeCustomProviderSettings(
 	}
 }
 
+/** Read an integer setting bounded to [min, max] with a default fallback.
+ *  Used for font sizes so corrupted or out-of-range values can't render
+ *  the UI unreadable. */
+function readClampedInt(
+	value: string | undefined,
+	{ min, max, fallback }: { min: number; max: number; fallback: number },
+): number {
+	if (value === undefined) return fallback;
+	const n = Number(value);
+	if (!Number.isFinite(n)) return fallback;
+	return Math.min(max, Math.max(min, Math.round(n)));
+}
+
 export async function loadSettings(): Promise<AppSettings> {
 	try {
 		const raw = await invoke<Record<string, string>>("get_app_settings");
@@ -742,10 +801,21 @@ export async function loadSettings(): Promise<AppSettings> {
 		const rawPrModelId = raw[SETTINGS_KEY_MAP.prModelId];
 		const rawPrEffort = raw[SETTINGS_KEY_MAP.prEffort];
 		const rawPrFastMode = raw[SETTINGS_KEY_MAP.prFastMode];
+		// Migration: legacy `app.font_size` is the new chatFontSize. Read
+		// it as a fallback when the new key is absent; the old row stays
+		// in SQLite (unused) until the user next changes the chat font.
+		const legacyFontSize = raw["app.font_size"];
 		return {
-			fontSize: raw[SETTINGS_KEY_MAP.fontSize]
-				? Number(raw[SETTINGS_KEY_MAP.fontSize])
-				: DEFAULT_SETTINGS.fontSize,
+			chatFontSize: readClampedInt(
+				raw[SETTINGS_KEY_MAP.chatFontSize] ?? legacyFontSize,
+				{ min: 10, max: 24, fallback: DEFAULT_SETTINGS.chatFontSize },
+			),
+			uiFontFamily: readLocalStorageString(UI_FONT_FAMILY_STORAGE_KEY),
+			codeFontFamily: readLocalStorageString(CODE_FONT_FAMILY_STORAGE_KEY),
+			usePointerCursors:
+				raw[SETTINGS_KEY_MAP.usePointerCursors] !== undefined
+					? raw[SETTINGS_KEY_MAP.usePointerCursors] === "true"
+					: DEFAULT_SETTINGS.usePointerCursors,
 			theme:
 				(localStorage.getItem(THEME_STORAGE_KEY) as AppSettings["theme"]) ??
 				DEFAULT_SETTINGS.theme,
@@ -864,48 +934,27 @@ export async function loadSettings(): Promise<AppSettings> {
 }
 
 export async function saveSettings(patch: Partial<AppSettings>): Promise<void> {
-	if (patch.theme !== undefined) {
+	// localStorage-backed fields. `null` / "" clears the row so the next
+	// boot falls back to the preset default.
+	for (const [field, lsKey] of Object.entries(LOCALSTORAGE_KEYS) as Array<
+		[LocalStorageKey, string]
+	>) {
+		const value = patch[field];
+		if (value === undefined) continue;
 		try {
-			localStorage.setItem(THEME_STORAGE_KEY, patch.theme);
+			if (value === null || value === "") {
+				localStorage.removeItem(lsKey);
+			} else {
+				localStorage.setItem(lsKey, String(value));
+			}
 		} catch (error) {
-			console.error(
-				`[helmor] theme save failed for "${THEME_STORAGE_KEY}"`,
-				error,
-			);
-		}
-	}
-
-	if (patch.darkTheme !== undefined) {
-		try {
-			localStorage.setItem(DARK_THEME_STORAGE_KEY, patch.darkTheme);
-		} catch (error) {
-			console.error(
-				`[helmor] dark theme save failed for "${DARK_THEME_STORAGE_KEY}"`,
-				error,
-			);
-		}
-	}
-
-	if (patch.sidebarGrouping !== undefined) {
-		try {
-			localStorage.setItem(SIDEBAR_GROUPING_STORAGE_KEY, patch.sidebarGrouping);
-		} catch (error) {
-			console.error(
-				`[helmor] sidebar grouping save failed for "${SIDEBAR_GROUPING_STORAGE_KEY}"`,
-				error,
-			);
+			console.error(`[helmor] localStorage save failed for "${lsKey}"`, error);
 		}
 	}
 
 	const settings: Record<string, string> = {};
 	for (const [key, dbKey] of Object.entries(SETTINGS_KEY_MAP)) {
-		const value =
-			patch[
-				key as keyof Omit<
-					AppSettings,
-					"theme" | "darkTheme" | "sidebarGrouping"
-				>
-			];
+		const value = patch[key as keyof Omit<AppSettings, LocalStorageKey>];
 		if (value !== undefined) {
 			settings[dbKey] =
 				key === "shortcuts" ||

--- a/src/shell/hooks/use-theme-application.ts
+++ b/src/shell/hooks/use-theme-application.ts
@@ -1,6 +1,7 @@
-// Side-effect hook that mirrors the theme + dark-theme settings into
-// `<html>`'s class list and `colorScheme` so the rest of the app picks up
-// the right tokens without each component reaching into settings.
+// Side-effect hook that mirrors the theme + appearance settings into
+// `<html>`'s class list, data attributes, and inline CSS variables, so
+// the rest of the app picks up the right tokens without each component
+// reaching into settings.
 import { useEffect } from "react";
 import { type DarkTheme, resolveTheme, type ThemeMode } from "@/lib/settings";
 
@@ -11,11 +12,36 @@ const DARK_THEME_CLASSES: readonly DarkTheme[] = [
 	"aurora",
 ];
 
-export function useThemeApplication(opts: {
+export type ThemeApplicationOptions = {
 	theme: ThemeMode;
 	darkTheme: DarkTheme;
-}): void {
-	const { theme, darkTheme } = opts;
+	uiFontFamily: string | null;
+	codeFontFamily: string | null;
+	chatFontSize: number;
+	usePointerCursors: boolean;
+};
+
+function setOrRemoveProperty(
+	root: HTMLElement,
+	property: string,
+	value: string | null,
+): void {
+	if (value && value.length > 0) {
+		root.style.setProperty(property, value);
+	} else {
+		root.style.removeProperty(property);
+	}
+}
+
+export function useThemeApplication(opts: ThemeApplicationOptions): void {
+	const {
+		theme,
+		darkTheme,
+		uiFontFamily,
+		codeFontFamily,
+		chatFontSize,
+		usePointerCursors,
+	} = opts;
 
 	useEffect(() => {
 		const apply = () => {
@@ -45,4 +71,41 @@ export function useThemeApplication(opts: {
 			document.documentElement.classList.add(`theme-${darkTheme}`);
 		}
 	}, [darkTheme]);
+
+	// Font family overrides. `--font-sans` / `--font-mono` are also written by
+	// Tailwind's @theme block in `App.css`, but inline style on :root wins.
+	useEffect(() => {
+		setOrRemoveProperty(
+			document.documentElement,
+			"--font-sans-user",
+			uiFontFamily,
+		);
+	}, [uiFontFamily]);
+
+	useEffect(() => {
+		setOrRemoveProperty(
+			document.documentElement,
+			"--font-mono-user",
+			codeFontFamily,
+		);
+	}, [codeFontFamily]);
+
+	// Chat font size mirrored to a CSS var so message components can pick
+	// it up without prop drilling. (They currently inline-style it from
+	// settings; the var is here for future css-only consumers.)
+	useEffect(() => {
+		document.documentElement.style.setProperty(
+			"--chat-font-size",
+			`${chatFontSize}px`,
+		);
+	}, [chatFontSize]);
+
+	// Pointer-cursor toggle — class on <html> so CSS can flip the global
+	// cursor rule without a JS round-trip.
+	useEffect(() => {
+		document.documentElement.classList.toggle(
+			"no-pointer-cursors",
+			!usePointerCursors,
+		);
+	}, [usePointerCursors]);
 }


### PR DESCRIPTION
## Summary

This PR adds appearance customization options and improves Codex command discovery:

- **Appearance Settings**: Users can now customize chat size, UI/code fonts, and pointer cursor behavior from the Appearance settings panel
- **Codex Skill Discovery**: Codex slash commands now discover skills from linked directories and the repository root
- **Onboarding Stability**: Main window mode is restored reliably after onboarding completes

## Test Plan

- [ ] Verify appearance settings panel loads and persists font/size changes
- [ ] Test that Codex discovers skills from `.agents/` directories and repo root
- [ ] Confirm main window mode is restored properly after onboarding
- [ ] Run full test suite: `bun run test`

## Notes

This is a patch-level release (appearance UX improvements + skill discovery enhancement).