### PR TITLE
feat(workspace): create worktree workspace from an existing local branch

### DIFF
--- a/.changeset/workspace-existing-branch-mode.md
+++ b/.changeset/workspace-existing-branch-mode.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Add backend support for creating a worktree-mode workspace from an existing local branch via a new `branchIntent: "useExistingBranch"` parameter on `prepareWorkspaceFromRepo`, so the workspace reuses the branch as-is instead of always allocating a fresh auto-named branch.

--- a/src-tauri/src/commands/workspace_commands.rs
+++ b/src-tauri/src/commands/workspace_commands.rs
@@ -21,27 +21,57 @@ fn notify_workspace_changed_in_background(app: AppHandle) {
 /// frontend should follow up with `finalize_workspace_from_repo` to kick
 /// off the slow git worktree creation; UI remains visible during that
 /// phase with state=initializing.
+///
+/// `branch_intent` defaults to `NewBranch` (the historical "branch off
+/// `source_branch`" flow). `UseExistingBranch` reuses `source_branch` as
+/// the workspace branch — accepted only for worktree mode and requires
+/// the branch to already exist locally. The existing-branch path
+/// materialises the worktree inline (so `finalize_workspace_from_repo`
+/// short-circuits as a no-op).
 #[tauri::command]
 pub async fn prepare_workspace_from_repo(
     app: AppHandle,
     repo_id: String,
     source_branch: Option<String>,
     mode: Option<crate::workspace_state::WorkspaceMode>,
+    branch_intent: Option<crate::workspace_state::WorkspaceBranchIntent>,
     initial_status: Option<WorkspaceStatus>,
 ) -> CmdResult<workspaces::PrepareWorkspaceResponse> {
     let mode = mode.unwrap_or_default();
+    let branch_intent = branch_intent.unwrap_or_default();
     let initial_status = initial_status.unwrap_or_default();
     let result = {
         let _lock = db::WORKSPACE_FS_MUTATION_LOCK.lock().await;
-        run_blocking(move || match mode {
-            crate::workspace_state::WorkspaceMode::Worktree => {
+        run_blocking(move || match (mode, branch_intent) {
+            (
+                crate::workspace_state::WorkspaceMode::Worktree,
+                crate::workspace_state::WorkspaceBranchIntent::UseExistingBranch,
+            ) => {
+                let branch = source_branch
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|b| !b.is_empty())
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "UseExistingBranch requires `sourceBranch` to name an existing local branch"
+                        )
+                    })?;
+                workspaces::prepare_workspace_from_existing_branch_impl(
+                    &repo_id,
+                    branch,
+                    initial_status,
+                )
+            }
+            (crate::workspace_state::WorkspaceMode::Worktree, _) => {
                 workspaces::prepare_workspace_from_repo_impl(
                     &repo_id,
                     source_branch.as_deref(),
                     initial_status,
                 )
             }
-            crate::workspace_state::WorkspaceMode::Local => {
+            (crate::workspace_state::WorkspaceMode::Local, _) => {
+                // Local mode always checks out the picked branch
+                // in-place — UseExistingBranch is redundant there.
                 workspaces::prepare_local_workspace_impl(
                     &repo_id,
                     source_branch.as_deref(),

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -674,6 +674,61 @@ pub fn verify_branch_exists(repo_root: &Path, branch: &str) -> Result<()> {
     .with_context(|| format!("Branch does not exist: {branch}"))
 }
 
+/// Information about a single `git worktree list` entry that's relevant
+/// to the existing-branch workspace flow: the worktree path and which
+/// local branch (if any) it has checked out.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorktreeEntry {
+    pub path: String,
+    /// `None` for detached-HEAD worktrees and for the main worktree
+    /// when it's also detached.
+    pub branch: Option<String>,
+}
+
+/// Enumerate every worktree git tracks for this repo by parsing
+/// `git worktree list --porcelain`. The porcelain format pairs
+/// `worktree <path>` with either `branch refs/heads/<name>` or
+/// `detached`, separated by blank lines. We strip the `refs/heads/`
+/// prefix so callers can compare against short branch names directly.
+pub fn list_worktrees(repo_root: &Path) -> Result<Vec<WorktreeEntry>> {
+    let repo_root = repo_root.display().to_string();
+    let output = run_git(
+        ["-C", repo_root.as_str(), "worktree", "list", "--porcelain"],
+        None,
+    )
+    .context("Failed to list worktrees")?;
+
+    let mut entries = Vec::new();
+    let mut current_path: Option<String> = None;
+    let mut current_branch: Option<String> = None;
+    let flush =
+        |path: &mut Option<String>, branch: &mut Option<String>, sink: &mut Vec<WorktreeEntry>| {
+            if let Some(p) = path.take() {
+                sink.push(WorktreeEntry {
+                    path: p,
+                    branch: branch.take(),
+                });
+            } else {
+                *branch = None;
+            }
+        };
+    for line in output.lines() {
+        let line = line.trim_end();
+        if line.is_empty() {
+            flush(&mut current_path, &mut current_branch, &mut entries);
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("worktree ") {
+            flush(&mut current_path, &mut current_branch, &mut entries);
+            current_path = Some(rest.to_string());
+        } else if let Some(rest) = line.strip_prefix("branch ") {
+            current_branch = Some(rest.strip_prefix("refs/heads/").unwrap_or(rest).to_string());
+        }
+    }
+    flush(&mut current_path, &mut current_branch, &mut entries);
+    Ok(entries)
+}
+
 /// Verify a commit exists in the repo.
 pub fn verify_commit_exists(repo_root: &Path, commit: &str) -> Result<()> {
     let repo_root = repo_root.display().to_string();
@@ -1747,5 +1802,81 @@ mod tests {
         let parsed = parse_unmerged_paths(raw);
         assert_eq!(parsed.len(), 1);
         assert!(parsed.contains("valid.txt"));
+    }
+
+    #[test]
+    fn list_worktrees_returns_main_and_secondary_entries() {
+        let dir = init_repo();
+        // Add a secondary worktree on a new branch so the porcelain
+        // output has two entries to parse.
+        run(dir.path(), &["branch", "feature-x"]);
+        let secondary = tempfile::tempdir().unwrap();
+        run(
+            dir.path(),
+            &[
+                "worktree",
+                "add",
+                secondary.path().to_str().unwrap(),
+                "feature-x",
+            ],
+        );
+
+        let entries = list_worktrees(dir.path()).expect("list worktrees");
+        assert_eq!(entries.len(), 2);
+
+        let main = entries
+            .iter()
+            .find(|e| e.branch.as_deref() == Some("main"))
+            .expect("main worktree present with branch=main");
+        // Canonicalising both ends — tempdir on macOS surfaces as
+        // `/private/var/...` while git emits `/var/...`. Compare
+        // canonical forms instead of literal strings.
+        let main_canon = std::fs::canonicalize(&main.path).unwrap();
+        let main_expected = std::fs::canonicalize(dir.path()).unwrap();
+        assert_eq!(main_canon, main_expected);
+
+        let secondary_entry = entries
+            .iter()
+            .find(|e| e.branch.as_deref() == Some("feature-x"))
+            .expect("secondary worktree present with branch=feature-x");
+        let sec_canon = std::fs::canonicalize(&secondary_entry.path).unwrap();
+        let sec_expected = std::fs::canonicalize(secondary.path()).unwrap();
+        assert_eq!(sec_canon, sec_expected);
+    }
+
+    #[test]
+    fn list_worktrees_reports_detached_head_as_branchless() {
+        let dir = init_repo();
+        let head_sha = run_git(
+            ["-C", dir.path().to_str().unwrap(), "rev-parse", "HEAD"],
+            None,
+        )
+        .unwrap()
+        .trim()
+        .to_string();
+        let detached = tempfile::tempdir().unwrap();
+        run(
+            dir.path(),
+            &[
+                "worktree",
+                "add",
+                "--detach",
+                detached.path().to_str().unwrap(),
+                head_sha.as_str(),
+            ],
+        );
+
+        let entries = list_worktrees(dir.path()).expect("list worktrees");
+        assert_eq!(entries.len(), 2);
+        let detached_entry = entries
+            .iter()
+            .find(|e| {
+                std::fs::canonicalize(&e.path).ok() == std::fs::canonicalize(detached.path()).ok()
+            })
+            .expect("detached worktree present");
+        assert!(
+            detached_entry.branch.is_none(),
+            "detached worktree must report branch = None"
+        );
     }
 }

--- a/src-tauri/src/models/workspaces.rs
+++ b/src-tauri/src/models/workspaces.rs
@@ -259,6 +259,43 @@ pub(crate) fn insert_initializing_workspace_and_session_with_mode(
     status: WorkspaceStatus,
     timestamp: &str,
 ) -> Result<()> {
+    insert_initializing_workspace_with_branches(
+        repository,
+        workspace_id,
+        session_id,
+        directory_name,
+        branch,
+        default_branch,
+        default_branch,
+        mode,
+        status,
+        timestamp,
+    )
+}
+
+/// Insert an initializing workspace + initial session, recording the
+/// initialization parent and intended-target branches independently.
+///
+/// The existing `_with_mode` helper collapses both to a single
+/// `default_branch` argument, which is right for "new branch from X"
+/// (parent == target == X) and for local mode (parent == target ==
+/// the checked-out branch). The "use existing branch" worktree flow
+/// breaks that symmetry: parent is the user's picked branch (it IS
+/// the workspace branch), but the intended merge target is the
+/// repo's default branch.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn insert_initializing_workspace_with_branches(
+    repository: &repos::RepositoryRecord,
+    workspace_id: &str,
+    session_id: &str,
+    directory_name: &str,
+    branch: &str,
+    init_parent_branch: &str,
+    intended_target_branch: &str,
+    mode: WorkspaceMode,
+    status: WorkspaceStatus,
+    timestamp: &str,
+) -> Result<()> {
     let mut connection = db::write_conn()?;
     let transaction = connection
         .transaction()
@@ -304,8 +341,8 @@ pub(crate) fn insert_initializing_workspace_and_session_with_mode(
                 session_id,
                 branch,
                 WorkspaceState::Initializing,
-                default_branch,
-                default_branch,
+                init_parent_branch,
+                intended_target_branch,
                 mode,
                 next_order,
                 status,

--- a/src-tauri/src/workspace/lifecycle.rs
+++ b/src-tauri/src/workspace/lifecycle.rs
@@ -223,6 +223,165 @@ pub fn prepare_workspace_from_repo_impl(
     })
 }
 
+/// Create a worktree-mode workspace anchored to an existing local
+/// branch rather than to a fresh auto-generated branch off
+/// `source_branch`. The picked branch is reused as-is — no `-B` reset,
+/// no upstream coupling, no commits dropped.
+///
+/// Errors clearly when:
+/// - the branch name is empty;
+/// - the branch doesn't exist locally;
+/// - the branch is already checked out by another worktree (Git would
+///   refuse the `worktree add`; we catch it up front so the user gets
+///   the offending worktree path in the error).
+///
+/// On success the DB row is already in `Ready` / `SetupPending` and
+/// the worktree exists on disk, so the frontend's follow-up call to
+/// `finalize_workspace_from_repo` is a no-op (it short-circuits on
+/// non-`Initializing` state).
+///
+/// Remote-only branches (e.g. `origin/feature-x` without a local
+/// equivalent) are explicitly out of scope for this slice — that's
+/// Track B / PR B2.
+pub fn prepare_workspace_from_existing_branch_impl(
+    repo_id: &str,
+    branch: &str,
+    initial_status: WorkspaceStatus,
+) -> Result<PrepareWorkspaceResponse> {
+    let branch = branch.trim();
+    if branch.is_empty() {
+        bail!("Existing-branch workspace requires a branch name");
+    }
+
+    let repository = repos::load_repository_by_id(repo_id)?
+        .with_context(|| format!("Repository not found: {repo_id}"))?;
+    let repo_root = PathBuf::from(repository.root_path.trim());
+    git_ops::ensure_git_repository(&repo_root)?;
+
+    git_ops::verify_branch_exists(&repo_root, branch).with_context(|| {
+        format!(
+            "Branch `{branch}` does not exist locally in {}. Fetch or create it before reusing.",
+            repo_root.display()
+        )
+    })?;
+
+    let workspaces = git_ops::list_worktrees(&repo_root).with_context(|| {
+        format!(
+            "Failed to enumerate existing worktrees in {} while validating branch reuse",
+            repo_root.display()
+        )
+    })?;
+    if let Some(other) = workspaces
+        .iter()
+        .find(|w| w.branch.as_deref() == Some(branch))
+    {
+        bail!(
+            "Branch `{branch}` is already checked out in another worktree at `{}`. \
+             Switch that worktree away from `{branch}` or pick a different branch.",
+            other.path
+        );
+    }
+
+    let directory_name = helpers::allocate_directory_name_for_repo(repo_id)?;
+    // intended_target = repo default (typical PR target). init_parent
+    // = the picked branch itself, since the workspace WAS initialized
+    // from that branch — there's no separate `X` to record. This
+    // keeps realign logic intact (it will fast-forward against
+    // `origin/<branch>` when present).
+    let intended_target = repository
+        .default_branch
+        .clone()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "main".to_string());
+
+    let workspace_id = uuid::Uuid::new_v4().to_string();
+    let session_id = uuid::Uuid::new_v4().to_string();
+    let timestamp = db::current_timestamp()?;
+
+    workspace_models::insert_initializing_workspace_with_branches(
+        &repository,
+        &workspace_id,
+        &session_id,
+        &directory_name,
+        branch,
+        branch,
+        &intended_target,
+        WorkspaceMode::Worktree,
+        initial_status,
+        &timestamp,
+    )?;
+
+    let workspace_dir = crate::data_dir::workspace_dir(&repository.name, &directory_name)?;
+    if workspace_dir.exists() {
+        let _ = workspace_models::delete_workspace_and_session_rows(&workspace_id);
+        bail!(
+            "Workspace target already exists at {}",
+            workspace_dir.display()
+        );
+    }
+
+    if let Err(error) = git_ops::create_worktree(&repo_root, &workspace_dir, branch) {
+        let _ = workspace_models::delete_workspace_and_session_rows(&workspace_id);
+        return Err(error);
+    }
+
+    // Resolve setup script + auto-run intent the same way the
+    // newBranchFrom finalize step does so SetupPending/Ready semantics
+    // stay consistent between the two creation paths.
+    let has_setup = match resolve_setup_hook(&repository, &workspace_dir) {
+        Ok(Some(s)) if !s.trim().is_empty() => true,
+        Ok(_) => false,
+        Err(e) => {
+            tracing::warn!("Failed to resolve setup hook, skipping: {e:#}");
+            false
+        }
+    };
+    let final_state = if has_setup && repository.auto_run_setup {
+        WorkspaceState::SetupPending
+    } else {
+        WorkspaceState::Ready
+    };
+
+    if let Err(error) =
+        workspace_models::update_workspace_state(&workspace_id, final_state, &timestamp)
+    {
+        cleanup_failed_created_workspace(&workspace_id, &repo_root, &workspace_dir, branch, true);
+        return Err(error);
+    }
+
+    let repo_scripts =
+        repos::load_repo_scripts(repo_id, Some(&workspace_id)).unwrap_or_else(|_| {
+            repos::RepoScripts {
+                setup_script: None,
+                run_script: None,
+                archive_script: None,
+                setup_from_project: false,
+                run_from_project: false,
+                archive_from_project: false,
+                auto_run_setup: true,
+                run_script_mode: "concurrent".to_string(),
+            }
+        });
+
+    Ok(PrepareWorkspaceResponse {
+        workspace_id,
+        initial_session_id: session_id,
+        repo_id: repository.id,
+        repo_name: repository.name,
+        directory_name,
+        branch: branch.to_string(),
+        // Field name is legacy; for the existing-branch path the
+        // "base" is just the workspace branch itself.
+        default_branch: branch.to_string(),
+        state: final_state,
+        repo_scripts,
+        // Worktree is already on disk — finalize will short-circuit
+        // and the frontend's optimistic submit can use this path
+        // immediately.
+        working_directory: Some(workspace_dir.display().to_string()),
+    })
+}
+
 /// One-shot local workspace creation. Skips the prepare/finalize split
 /// since there's no worktree to create — the workspace operates
 /// directly on `repo.root_path`. If the user picked a `source_branch`
@@ -1404,5 +1563,137 @@ mod tests {
             ArchiveHookOutcome::ScriptError { code: Some(2) }
         );
         assert_ne!(ArchiveHookOutcome::Success, ArchiveHookOutcome::NoScript);
+    }
+
+    // ── existing-branch workspace mode ────────────────────────────────────
+
+    use crate::testkit::{GitTestRepo, TestEnv};
+
+    /// Seed a repo row in the DB pointing at the on-disk fixture so the
+    /// real prepare path can load it. Returns the repo id.
+    fn seed_repo_for_fixture(env: &TestEnv, name: &str, repo: &GitTestRepo) -> String {
+        let id = format!("repo-{name}");
+        env.db_connection()
+            .execute(
+                "INSERT INTO repos (id, name, default_branch, root_path, remote)
+                 VALUES (?1, ?2, 'main', ?3, 'origin')",
+                rusqlite::params![id, name, repo.path().display().to_string()],
+            )
+            .unwrap();
+        id
+    }
+
+    #[test]
+    fn existing_branch_happy_path_creates_worktree_and_persists_branches() {
+        let env = TestEnv::new("existing-branch-happy");
+        let (_origin, clone) = GitTestRepo::with_remote();
+        // Create a real local branch to reuse.
+        clone.git(&["branch", "feature-cool"]);
+        let repo_id = seed_repo_for_fixture(&env, "demo-happy", &clone);
+
+        let response = prepare_workspace_from_existing_branch_impl(
+            &repo_id,
+            "feature-cool",
+            WorkspaceStatus::default(),
+        )
+        .expect("existing-branch prepare succeeds");
+
+        assert_eq!(response.branch, "feature-cool");
+        // Worktree is already materialised inline, so the response
+        // state is Ready / SetupPending — no Initializing layover.
+        assert!(matches!(
+            response.state,
+            WorkspaceState::Ready | WorkspaceState::SetupPending
+        ));
+        let working_dir = response.working_directory.as_deref().expect("working dir");
+        assert!(std::path::Path::new(working_dir).is_dir());
+
+        // Persistence: init_parent = picked branch (provenance), but
+        // intended_target = repo default so PRs land where users expect.
+        let row: (String, String, String) = env
+            .db_connection()
+            .query_row(
+                "SELECT branch, initialization_parent_branch, intended_target_branch
+                 FROM workspaces WHERE id = ?1",
+                [&response.workspace_id],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(row.0, "feature-cool");
+        assert_eq!(row.1, "feature-cool");
+        assert_eq!(row.2, "main");
+    }
+
+    #[test]
+    fn existing_branch_errors_when_branch_missing_locally() {
+        let env = TestEnv::new("existing-branch-missing");
+        let (_origin, clone) = GitTestRepo::with_remote();
+        let repo_id = seed_repo_for_fixture(&env, "demo-missing", &clone);
+
+        let err = prepare_workspace_from_existing_branch_impl(
+            &repo_id,
+            "no-such-branch",
+            WorkspaceStatus::default(),
+        )
+        .expect_err("missing branch must error");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("no-such-branch") && msg.contains("does not exist locally"),
+            "expected missing-branch error; got: {msg}"
+        );
+
+        // Refuses BEFORE touching the DB — no orphan row left behind.
+        let count: i64 = env
+            .db_connection()
+            .query_row("SELECT COUNT(*) FROM workspaces", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn existing_branch_errors_when_branch_already_checked_out_elsewhere() {
+        let env = TestEnv::new("existing-branch-checked-out");
+        let (_origin, clone) = GitTestRepo::with_remote();
+        // The clone has `main` checked out at its own root. Reusing it
+        // for a new worktree must error with the conflicting path
+        // surfaced to the user.
+        let repo_id = seed_repo_for_fixture(&env, "demo-checked-out", &clone);
+
+        let err = prepare_workspace_from_existing_branch_impl(
+            &repo_id,
+            "main",
+            WorkspaceStatus::default(),
+        )
+        .expect_err("branch in another worktree must error");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("already checked out")
+                && msg.contains(&clone.path().display().to_string()),
+            "expected checked-out-elsewhere error with offending path; got: {msg}"
+        );
+        let count: i64 = env
+            .db_connection()
+            .query_row("SELECT COUNT(*) FROM workspaces", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn existing_branch_errors_on_empty_branch_name() {
+        let env = TestEnv::new("existing-branch-empty");
+        let (_origin, clone) = GitTestRepo::with_remote();
+        let repo_id = seed_repo_for_fixture(&env, "demo-empty", &clone);
+
+        let err = prepare_workspace_from_existing_branch_impl(
+            &repo_id,
+            "   ",
+            WorkspaceStatus::default(),
+        )
+        .expect_err("empty branch must error");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("requires a branch name"),
+            "expected empty-branch error; got: {msg}"
+        );
     }
 }

--- a/src-tauri/src/workspace/state.rs
+++ b/src-tauri/src/workspace/state.rs
@@ -154,6 +154,26 @@ impl ToSql for WorkspaceMode {
     }
 }
 
+/// How a worktree-mode workspace acquires its git branch. Lives in
+/// memory only (no `workspaces` column) — once the worktree is
+/// materialised the branch already exists, so the intent is purely a
+/// dispatch choice during `prepare`.
+///
+/// `NewBranch` — the historical default: allocate a fresh
+/// auto-generated branch name and create it off `source_branch`.
+///
+/// `UseExistingBranch` — attach the workspace to a branch the user
+/// already has locally. Disabled for the local workspace mode (which
+/// always checks out the picked branch in-place); accepted only for
+/// `WorkspaceMode::Worktree`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum WorkspaceBranchIntent {
+    #[default]
+    NewBranch,
+    UseExistingBranch,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/workspace/workspaces.rs
+++ b/src-tauri/src/workspace/workspaces.rs
@@ -31,11 +31,11 @@ pub use super::lifecycle::{
     archive_workspace_impl, cleanup_orphaned_initializing_workspaces,
     create_workspace_from_repo_impl, execute_archive_plan, finalize_workspace_from_repo_impl,
     move_local_workspace_to_worktree_impl, prepare_archive_plan, prepare_local_workspace_impl,
-    prepare_workspace_from_repo_impl, restore_workspace_impl, validate_archive_workspace,
-    validate_restore_workspace, ArchivePreparedPlan, ArchiveWorkspaceResponse, BranchRename,
-    CreateWorkspaceResponse, FinalizeWorkspaceResponse, MoveLocalToWorktreeResponse,
-    PrepareWorkspaceResponse, RestoreWorkspaceResponse, TargetBranchConflict,
-    ValidateRestoreResponse,
+    prepare_workspace_from_existing_branch_impl, prepare_workspace_from_repo_impl,
+    restore_workspace_impl, validate_archive_workspace, validate_restore_workspace,
+    ArchivePreparedPlan, ArchiveWorkspaceResponse, BranchRename, CreateWorkspaceResponse,
+    FinalizeWorkspaceResponse, MoveLocalToWorktreeResponse, PrepareWorkspaceResponse,
+    RestoreWorkspaceResponse, TargetBranchConflict, ValidateRestoreResponse,
 };
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1423,6 +1423,20 @@ export async function moveLocalWorkspaceToWorktree(
 /** How a workspace's filesystem is provisioned. */
 export type WorkspaceMode = "worktree" | "local";
 
+/**
+ * How a worktree-mode workspace acquires its git branch.
+ *
+ * - `newBranch` (default): allocate a fresh auto-named branch off
+ *   `sourceBranch` and create a worktree there.
+ * - `useExistingBranch`: attach the workspace to a branch that
+ *   already exists locally (named via `sourceBranch`). Reuses the
+ *   branch as-is — no `-B` reset, no upstream coupling.
+ *
+ * Local-mode workspaces ignore this flag — they always check out
+ * `sourceBranch` in place.
+ */
+export type WorkspaceBranchIntent = "newBranch" | "useExistingBranch";
+
 export type UpdateIntendedTargetBranchResponse = {
 	/** True if the workspace's local branch was hard-reset to origin/<target>. */
 	reset: boolean;
@@ -2276,11 +2290,13 @@ export async function prepareWorkspaceFromRepo(
 	sourceBranch?: string | null,
 	mode?: WorkspaceMode | null,
 	initialStatus?: WorkspaceStatus | null,
+	branchIntent?: WorkspaceBranchIntent | null,
 ): Promise<PrepareWorkspaceResponse> {
 	return invoke<PrepareWorkspaceResponse>("prepare_workspace_from_repo", {
 		repoId,
 		sourceBranch: sourceBranch ?? null,
 		mode: mode ?? null,
+		branchIntent: branchIntent ?? null,
 		initialStatus: initialStatus ?? null,
 	});
 }


### PR DESCRIPTION
## Summary

- Adds a backend `useExistingBranch` creation mode so a worktree-mode workspace can be anchored to a branch the user already has locally instead of always allocating a fresh auto-named branch off `sourceBranch`.
- Surfaced through `prepareWorkspaceFromRepo` as an optional `branchIntent` parameter (default: existing `newBranch` behavior, fully backwards-compatible).
- Reuses the picked branch as-is — no `-B` reset, no upstream coupling, no commits dropped. Materialises the worktree inline so `finalize_workspace_from_repo` short-circuits as a no-op.

## Why

Closes #508 — the maintainer specifically called out "feel free to open a PR" with first-class support for both "from a branch" (existing `newBranchFrom`) and "use a branch" (this PR).

## Scope boundary

Included:
- `WorkspaceBranchIntent` enum (`newBranch` | `useExistingBranch`) in `workspace::state` with serde + frontend type mirror in `src/lib/api.ts`.
- `prepare_workspace_from_existing_branch_impl` in `workspace::lifecycle`, dispatched from `prepare_workspace_from_repo` when `mode = worktree` and `branchIntent = useExistingBranch`.
- New `git_ops::list_worktrees(repo_root)` porcelain parser, used to detect "branch is already checked out elsewhere" up front.
- New `models::workspaces::insert_initializing_workspace_with_branches` that takes `init_parent_branch` and `intended_target_branch` as separate columns. The existing `_with_mode` helper now delegates with both fields set to the same value (no behavior change for existing call sites).
- Clear errors for:
  - empty branch name → "Existing-branch workspace requires a branch name";
  - branch missing locally → "Branch \`X\` does not exist locally in \`<repo>\`. Fetch or create it before reusing.";
  - branch already in another worktree → surfaces the conflicting worktree path so the user can recover.
- 4 lifecycle git-fixture tests + 2 `list_worktrees` parser tests.

Deferred (intentionally out of scope):
- Remote-only branches (no local tracking yet) → Track B / PR B2.
- PR/MR URL workspace creation → Track B / PR B4.
- Frontend UI surfacing the new mode (the command path is ready; UI lives in the existing branch picker plumbing, can be opted into in a follow-up).

## Test plan

- [x] `cd src-tauri && cargo nextest run` — 1139 / 1139 pass (4 new lifecycle tests + 2 new git-ops tests).
- [x] `cd src-tauri && cargo test --doc` — clean.
- [x] `cd src-tauri && cargo fmt --all -- --check` — clean.
- [x] `bun run lint` — biome + clippy `-D warnings` clean.
- [x] `bun run typecheck` — clean (TS type added for `WorkspaceBranchIntent`).
- [x] `bun run test:frontend` — 1092 / 1092 pass (existing call sites unchanged because the new parameter is optional + defaults to `null`).

## Design notes

- The existing-branch path stores `branch == initialization_parent_branch` (provenance: the workspace IS this branch — there's no separate `X` to record) and `intended_target_branch = repo.default_branch` (sane PR target by default; user can adjust later via the existing target-branch UI). This keeps the realign logic intact — it fast-forwards `branch` against `origin/<branch>` when present.
- Worktree is materialised inline because the branch already exists, so `git worktree add <dir> <branch>` is fast and there's nothing for `finalize` to do. The DB row is inserted in `Initializing`, then flipped to `Ready` / `SetupPending` after the on-disk worktree is in place. `finalize_workspace_from_repo` short-circuits on non-`Initializing` state (existing code path), so the frontend's two-phase flow keeps working without modification.

## Coverage added

New tests:
- `workspace::lifecycle::tests::existing_branch_happy_path_creates_worktree_and_persists_branches`
- `workspace::lifecycle::tests::existing_branch_errors_when_branch_missing_locally`
- `workspace::lifecycle::tests::existing_branch_errors_when_branch_already_checked_out_elsewhere`
- `workspace::lifecycle::tests::existing_branch_errors_on_empty_branch_name`
- `git::ops::tests::list_worktrees_returns_main_and_secondary_entries`
- `git::ops::tests::list_worktrees_reports_detached_head_as_branchless`

Changeset:
- `.changeset/workspace-existing-branch-mode.md`

## Follow-up

This is PR B1 in the branch-and-source-anchors track. The natural follow-up slices, in order:
- **B2**: remote-only branch reuse (fetch + create local tracking branch, then funnel into the same useExistingBranch path).
- **B3**: `session_links` table for issue / PR / MR metadata.
- **B4**: PR/MR-URL-driven workspace creation that composes B1 + B2 + B3.