### PR TITLE
Fix title and branch generation reliability for Codex

### DIFF
--- a/.changeset/codex-title-rename.md
+++ b/.changeset/codex-title-rename.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix automatic workspace branch renaming failing on Codex by making title/branch generation more reliable.

--- a/sidecar/src/claude-session-manager.ts
+++ b/sidecar/src/claude-session-manager.ts
@@ -36,7 +36,7 @@ import type {
 } from "./session-manager.js";
 import {
 	buildTitlePrompt,
-	parseTitleAndBranch,
+	parseTitleAndBranchWithDiagnostics,
 	TITLE_GENERATION_TIMEOUT_MS,
 } from "./title.js";
 
@@ -815,12 +815,14 @@ export class ClaudeSessionManager implements SessionManager {
 				}
 			}
 
-			const { title, branchName } = parseTitleAndBranch(raw);
-			logger.info(`[${requestId}] titleGenerated`, {
-				title,
-				branchName: branchName ?? "(empty)",
-				rawPreview: raw.slice(0, 200),
-			});
+			const { title, branchName } = parseTitleAndBranchWithDiagnostics(
+				requestId,
+				raw,
+				{
+					generateBranch,
+					logError: (message, meta) => logger.error(message, meta),
+				},
+			);
 			emitter.titleGenerated(requestId, title, branchName);
 		} finally {
 			clearTimeout(timeout);

--- a/sidecar/src/codex-app-server-manager.ts
+++ b/sidecar/src/codex-app-server-manager.ts
@@ -40,7 +40,7 @@ import type {
 } from "./session-manager.js";
 import {
 	buildTitlePrompt,
-	parseTitleAndBranch,
+	parseTitleAndBranchWithDiagnostics,
 	TITLE_GENERATION_TIMEOUT_MS,
 } from "./title.js";
 
@@ -1063,6 +1063,7 @@ export class CodexAppServerManager implements SessionManager {
 			if (!threadId) throw new Error("thread/start did not return thread id");
 
 			let raw = "";
+			let failure: string | null = null;
 			const done = new Promise<void>((resolve) => {
 				server.setHandlers(
 					(n) => {
@@ -1070,7 +1071,26 @@ export class CodexAppServerManager implements SessionManager {
 							const delta = deepGet(n.params, "delta");
 							if (typeof delta === "string") raw += delta;
 						}
-						if (n.method === "turn/completed") resolve();
+						if (n.method === "error") {
+							const message = deepGet(n.params, "error", "message");
+							const asText =
+								typeof message === "string"
+									? message
+									: "Codex app-server error during title generation";
+							failure = asText;
+							return;
+						}
+						if (n.method === "turn/completed") {
+							const status = deepGet(n.params, "turn", "status");
+							if (status === "failed") {
+								const message = deepGet(n.params, "turn", "error", "message");
+								failure =
+									typeof message === "string"
+										? message
+										: "Codex turn failed during title generation";
+							}
+							resolve();
+						}
 					},
 					(req) => {
 						if (APPROVAL_METHODS.has(req.method)) {
@@ -1094,14 +1114,29 @@ export class CodexAppServerManager implements SessionManager {
 					},
 				],
 				model,
-				effort: "minimal",
+				effort: "low",
 				approvalPolicy: BYPASS_GRANULAR_POLICY,
 			};
 			if (fastMode) turnStartParams.serviceTier = "fast";
 			await server.sendRequest("turn/start", turnStartParams);
 
 			await done;
-			const { title, branchName } = parseTitleAndBranch(raw);
+			if (failure) {
+				logger.error(`[${requestId}] title generation failed`, {
+					model,
+					generateBranch,
+					message: failure,
+				});
+			}
+			const { title, branchName } = parseTitleAndBranchWithDiagnostics(
+				requestId,
+				raw,
+				{
+					model,
+					generateBranch,
+					logError: (message, meta) => logger.error(message, meta),
+				},
+			);
 			emitter.titleGenerated(requestId, title, branchName);
 		} finally {
 			clearTimeout(timeout);

--- a/sidecar/src/cursor-session-manager.ts
+++ b/sidecar/src/cursor-session-manager.ts
@@ -27,7 +27,7 @@ import type {
 } from "./session-manager.js";
 import {
 	buildTitlePrompt,
-	parseTitleAndBranch,
+	parseTitleAndBranchWithDiagnostics,
 	TITLE_GENERATION_TIMEOUT_MS,
 } from "./title.js";
 
@@ -256,7 +256,15 @@ export class CursorSessionManager implements SessionManager {
 			),
 		]);
 		const text = typeof result?.result === "string" ? result.result : "";
-		const { title, branchName } = parseTitleAndBranch(text);
+		const { title, branchName } = parseTitleAndBranchWithDiagnostics(
+			requestId,
+			text,
+			{
+				model: modelId,
+				generateBranch,
+				logError: (message, meta) => logger.error(message, meta),
+			},
+		);
 		emitter.titleGenerated(requestId, title, branchName);
 	}
 

--- a/sidecar/src/title.ts
+++ b/sidecar/src/title.ts
@@ -71,6 +71,18 @@ export interface ParsedTitle {
 	readonly branchName: string | undefined;
 }
 
+export type TitleGenerationErrorLogger = (
+	message: string,
+	meta: Record<string, unknown>,
+) => void;
+
+export interface TitleGenerationDiagnosticsOptions {
+	readonly generateBranch: boolean;
+	readonly model?: string;
+	readonly previewLimit?: number;
+	readonly logError: TitleGenerationErrorLogger;
+}
+
 export function parseTitleAndBranch(raw: string): ParsedTitle {
 	let title = "";
 	let branch = "";
@@ -96,4 +108,37 @@ export function parseTitleAndBranch(raw: string): ParsedTitle {
 	}
 
 	return { title, branchName: branch || undefined };
+}
+
+export function parseTitleAndBranchWithDiagnostics(
+	requestId: string,
+	raw: string,
+	options: TitleGenerationDiagnosticsOptions,
+): ParsedTitle {
+	const parsed = parseTitleAndBranch(raw);
+	const previewLimit = options.previewLimit ?? 200;
+	const rawPreview = raw.slice(0, previewLimit);
+	const model = options.model;
+	const generateBranch = options.generateBranch;
+
+	if (!parsed.title) {
+		options.logError(`[${requestId}] title generation returned empty title`, {
+			...(model ? { model } : {}),
+			generateBranch,
+			rawPreview,
+		});
+	}
+
+	if (generateBranch && !parsed.branchName) {
+		options.logError(
+			`[${requestId}] title generation returned empty branch name`,
+			{
+				...(model ? { model } : {}),
+				generateBranch,
+				rawPreview,
+			},
+		);
+	}
+
+	return parsed;
 }


### PR DESCRIPTION
Fixes #505 
## Summary
- Add `parseTitleAndBranchWithDiagnostics` for better error diagnostics when title/branch generation fails
- Handle Codex app-server errors (`error` method and `turn/completed` with failed status) during title generation
- Log warnings when title or branch name is empty to catch silent failures
- Change Codex effort from "minimal" to "low" for more reliable outputs
- Update all session managers (Claude, Codex, Cursor) to use the new diagnostics function

## Why
The automatic workspace branch renaming was failing silently on Codex sessions. This change adds proper error handling and diagnostics to identify and log failures, making the feature more reliable.

## Test plan
- [ ] Test title generation succeeds on Claude sessions
- [ ] Test title generation succeeds on Codex sessions
- [ ] Verify that empty titles/branch names are logged as errors
- [ ] Verify that Codex app-server errors are caught and logged