### PR TITLE
Fix Codex goal context permissions

### DIFF
--- a/.announcements/codex-goal-permissions.json
+++ b/.announcements/codex-goal-permissions.json
@@ -1,0 +1,7 @@
+{
+	"items": [
+		{
+			"text": "Codex /goal continuations no longer ask for approval."
+		}
+	]
+}

--- a/.changeset/codex-goal-permissions.md
+++ b/.changeset/codex-goal-permissions.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix Codex `/goal` continuations so they inherit the current workspace permission mode instead of reusing stale context permissions.

--- a/sidecar/src/codex-app-server-manager.ts
+++ b/sidecar/src/codex-app-server-manager.ts
@@ -553,6 +553,10 @@ export class CodexAppServerManager implements SessionManager {
 				sessionId,
 				effectiveResume,
 			);
+			effectiveResume = this.recycleIdleContextForGoal(
+				sessionId,
+				effectiveResume,
+			);
 		}
 
 		const ctx = await this.ensureContext(
@@ -1455,6 +1459,41 @@ export class CodexAppServerManager implements SessionManager {
 		this.pendingUserInputs.clear();
 	}
 
+	private clearPendingSessionState(sessionId: string): void {
+		for (const [id, p] of this.pendingApprovals) {
+			if (p.sessionId === sessionId) this.pendingApprovals.delete(id);
+		}
+		for (const [id, p] of this.pendingUserInputs) {
+			if (p.sessionId === sessionId) this.pendingUserInputs.delete(id);
+		}
+	}
+
+	private recycleIdleContextForGoal(
+		sessionId: string,
+		callerResume: string | undefined,
+	): string | undefined {
+		const stale = this.sessions.get(sessionId);
+		if (!stale || stale.server.killed) return callerResume;
+		if (stale.turnResolve || stale.turnReject || stale.activeTurnId) {
+			logger.info("Skipping /goal context recycle while turn is active", {
+				sessionId,
+				providerThreadId: stale.providerThreadId ?? "(none)",
+				activeTurnId: stale.activeTurnId ?? "(none)",
+			});
+			return callerResume;
+		}
+
+		const reuseThread = stale.providerThreadId ?? undefined;
+		logger.info("Recycling idle Codex context before /goal", {
+			sessionId,
+			providerThreadId: reuseThread ?? "(none)",
+		});
+		stale.server.kill();
+		this.sessions.delete(sessionId);
+		this.clearPendingSessionState(sessionId);
+		return callerResume ?? reuseThread;
+	}
+
 	// ── Private ──────────────────────────────────────────────────────────
 
 	private settleUnexpectedExit(
@@ -1559,9 +1598,21 @@ export class CodexAppServerManager implements SessionManager {
 		if (resume) {
 			try {
 				logger.info(`Attempting thread/resume`, { threadId: resume });
+				const resumeParams: Record<string, unknown> = {
+					threadId: resume,
+					cwd,
+					approvalPolicy:
+						toCodexApprovalPolicy(permissionMode) ?? BYPASS_GRANULAR_POLICY,
+					sandbox:
+						permissionMode === "plan"
+							? "workspace-write"
+							: "danger-full-access",
+				};
+				if (model) resumeParams.model = model;
+				if (fastMode) resumeParams.serviceTier = "fast";
 				const response = await server.sendRequest<Record<string, unknown>>(
 					"thread/resume",
-					{ threadId: resume },
+					resumeParams,
 				);
 				threadId = (deepGet(response, "thread", "id") as string) ?? resume;
 				logger.info(`Resumed Codex thread`, { threadId });

--- a/sidecar/test/codex-app-server-manager.test.ts
+++ b/sidecar/test/codex-app-server-manager.test.ts
@@ -795,6 +795,73 @@ describe("CodexAppServerManager goal pre-flight", () => {
 		});
 	});
 
+	test("/goal recycles idle context so continuation inherits full access", async () => {
+		const manager = new CodexAppServerManager();
+
+		await manager.sendMessage(
+			"REQ-seed-full-access",
+			{
+				sessionId: "s-goal-full-access",
+				prompt: "warm-up",
+				model: "gpt-5.4",
+				cwd: "/tmp",
+				resume: undefined,
+				permissionMode: "bypassPermissions",
+				effortLevel: "medium",
+				fastMode: false,
+				images: [],
+			},
+			emitter,
+		);
+		const stale = serverState.instances[0];
+		expect(stale?.killed).toBe(false);
+
+		serverState.requests = [];
+
+		await manager.sendMessage(
+			"REQ-goal-full-access",
+			{
+				sessionId: "s-goal-full-access",
+				prompt: "/goal finish the migration",
+				model: "gpt-5.4",
+				cwd: "/tmp",
+				resume: undefined,
+				permissionMode: "bypassPermissions",
+				effortLevel: "medium",
+				fastMode: false,
+				images: [],
+			},
+			emitter,
+		);
+
+		expect(stale?.killed).toBe(true);
+		expect(serverState.instances).toHaveLength(2);
+		const resume = serverState.requests.find(
+			(r) => r.method === "thread/resume",
+		);
+		expect(resume?.params).toMatchObject({
+			threadId: "thread-1",
+			cwd: "/tmp",
+			approvalPolicy: {
+				granular: {
+					sandbox_approval: false,
+					rules: false,
+					skill_approval: false,
+					request_permissions: false,
+					mcp_elicitations: true,
+				},
+			},
+			sandbox: "danger-full-access",
+		});
+		const goalSet = serverState.requests.find(
+			(r) => r.method === "thread/goal/set",
+		);
+		expect(goalSet?.params).toMatchObject({
+			threadId: "thread-1",
+			objective: "finish the migration",
+		});
+	});
+
 	test("/goal pre-flight: recycles stale codex and resumes its thread when toml had to be modified", async () => {
 		const manager = new CodexAppServerManager();
 


### PR DESCRIPTION
## Summary
- recycle idle Codex app-server contexts before `/goal` so resumed goal continuations pick up current permissions
- pass cwd, approval policy, sandbox, model, and fast tier through `thread/resume`
- add a patch changeset for the user-visible fix

## Tests
- `bun run test:sidecar`