### PR TITLE
Fix model settings for action helpers

### DIFF
--- a/.changeset/calm-action-models.md
+++ b/.changeset/calm-action-models.md
@@ -1,0 +1,7 @@
+---
+"helmor": patch
+---
+
+Fix model settings for action helpers:
+- Keep Opus 4.7 selections for Review and Action models after restarting Helmor.
+- Rename the PR/MR model setting to Action model and use it for create PR/MR, reopen PR/MR, and commit-and-push helpers.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,6 +57,7 @@ import {
 	type WorkspaceDetail,
 	type WorkspaceSessionSummary,
 } from "./lib/api";
+import { usesActionModelOverride } from "./lib/commit-button-prompts";
 import { ComposerInsertProvider } from "./lib/composer-insert-context";
 import {
 	activeStreamsQueryOptions,
@@ -798,12 +799,11 @@ function AppShell({
 		pushToast: pushWorkspaceToast,
 	});
 
-	// Wrapper that injects the configured PR/MR model overrides for the
-	// "create-pr" mode so the action runs on the user's preferred PR model
-	// (with effort + fast-mode falling back to defaults when null).
+	// Action model covers simple, bounded helper sessions. More involved
+	// fix/resolve flows keep following the default model.
 	const handleCommitAction = useCallback(
 		(mode: WorkspaceCommitButtonMode) => {
-			if (mode === "create-pr") {
+			if (usesActionModelOverride(mode)) {
 				return handleInspectorCommitAction(mode, {
 					modelId: appSettings.prModelId ?? appSettings.defaultModelId,
 					effort: appSettings.prEffort ?? appSettings.defaultEffort,
@@ -1080,7 +1080,7 @@ function AppShell({
 			},
 			{
 				id: "action.commitAndPush" as const,
-				callback: () => void handleInspectorCommitAction("commit-and-push"),
+				callback: () => void handleCommitAction("commit-and-push"),
 			},
 			{
 				id: "action.pullLatest" as const,

--- a/src/features/settings/index.tsx
+++ b/src/features/settings/index.tsx
@@ -532,7 +532,7 @@ export const SettingsDialog = memo(function SettingsDialog({
 									/>
 									<ModelSettingRow
 										title="Action model"
-										description="Model for creating or reopening PRs/MRs and commit-and-push"
+										description="Model for PRs/MRs and commit-and-push"
 										models={allModels}
 										modelSections={modelSections}
 										isLoadingModels={modelSectionsQuery.isPending}

--- a/src/features/settings/index.tsx
+++ b/src/features/settings/index.tsx
@@ -531,15 +531,15 @@ export const SettingsDialog = memo(function SettingsDialog({
 										}}
 									/>
 									<ModelSettingRow
-										title="PR / MR model"
-										description="Model for PRs and MRs"
+										title="Action model"
+										description="Model for creating or reopening PRs/MRs and commit-and-push"
 										models={allModels}
 										modelSections={modelSections}
 										isLoadingModels={modelSectionsQuery.isPending}
 										modelId={settings.prModelId ?? settings.defaultModelId}
 										effort={settings.prEffort ?? settings.defaultEffort}
 										fastMode={settings.prFastMode ?? settings.defaultFastMode}
-										ariaPrefix="PR / MR"
+										ariaPrefix="Action"
 										onChange={(p) => {
 											const patch: Partial<AppSettings> = {};
 											if (p.modelId !== undefined) patch.prModelId = p.modelId;

--- a/src/lib/commit-button-prompts.test.ts
+++ b/src/lib/commit-button-prompts.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { ForgeDetection } from "./api";
-import { buildCommitButtonPrompt } from "./commit-button-prompts";
+import {
+	buildCommitButtonPrompt,
+	usesActionModelOverride,
+} from "./commit-button-prompts";
 
 const GITLAB_FORGE: ForgeDetection = {
 	provider: "gitlab",
@@ -35,6 +38,15 @@ const GITHUB_FORGE: ForgeDetection = {
 };
 
 describe("buildCommitButtonPrompt", () => {
+	it("uses the action model only for simple bounded action sessions", () => {
+		expect(usesActionModelOverride("create-pr")).toBe(true);
+		expect(usesActionModelOverride("commit-and-push")).toBe(true);
+		expect(usesActionModelOverride("open-pr")).toBe(true);
+		expect(usesActionModelOverride("fix")).toBe(false);
+		expect(usesActionModelOverride("resolve-conflicts")).toBe(false);
+		expect(usesActionModelOverride("push")).toBe(false);
+	});
+
 	it("appends create-pr preferences after the built-in prompt", () => {
 		expect(
 			buildCommitButtonPrompt(

--- a/src/lib/commit-button-prompts.ts
+++ b/src/lib/commit-button-prompts.ts
@@ -87,6 +87,14 @@ export function isActionSessionMode(
 	);
 }
 
+export function usesActionModelOverride(
+	mode: WorkspaceCommitButtonMode,
+): mode is "create-pr" | "commit-and-push" | "open-pr" {
+	return (
+		mode === "create-pr" || mode === "commit-and-push" || mode === "open-pr"
+	);
+}
+
 /** Whether a session created with this `ActionKind` is eligible for the
  *  auto-hide flow (i.e. can be silently hidden once its post-stream verifier
  *  passes). Auto-created action sessions still get fixed titles, but only a

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -122,4 +122,18 @@ describe("settings", () => {
 			}),
 		);
 	});
+
+	it("keeps default as a valid model id", async () => {
+		invokeMock.mockResolvedValue({
+			"app.default_model_id": "gpt-5.5",
+			"app.review_model_id": "default",
+			"app.pr_model_id": "default",
+		});
+
+		const settings = await loadSettings();
+
+		expect(settings.defaultModelId).toBe("gpt-5.5");
+		expect(settings.reviewModelId).toBe("default");
+		expect(settings.prModelId).toBe("default");
+	});
 });

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -213,14 +213,13 @@ export type AppSettings = {
 	/** Fast-mode flag for the Review helper. When null, falls back to
 	 *  `defaultFastMode`. */
 	reviewFastMode: boolean | null;
-	/** Model used when the inspector "Create PR/MR" action starts a session.
-	 *  Applies to both GitHub PRs and GitLab MRs. When null, falls back to
-	 *  `defaultModelId`. */
+	/** Model used by simple action sessions: create/reopen PR/MR and
+	 *  commit-and-push. When null, falls back to `defaultModelId`. */
 	prModelId: string | null;
-	/** Effort level for the Create PR/MR helper. When null, falls back to
+	/** Effort level for simple action sessions. When null, falls back to
 	 *  `defaultEffort`. */
 	prEffort: string | null;
-	/** Fast-mode flag for the Create PR/MR helper. When null, falls back to
+	/** Fast-mode flag for simple action sessions. When null, falls back to
 	 *  `defaultFastMode`. */
 	prFastMode: boolean | null;
 	defaultEffort: string | null;
@@ -791,6 +790,10 @@ function readClampedInt(
 	return Math.min(max, Math.max(min, Math.round(n)));
 }
 
+function readModelId(value: string | undefined): string | null {
+	return value && value !== "" ? value : null;
+}
+
 export async function loadSettings(): Promise<AppSettings> {
 	try {
 		const raw = await invoke<Record<string, string>>("get_app_settings");
@@ -849,14 +852,8 @@ export async function loadSettings(): Promise<AppSettings> {
 				raw[SETTINGS_KEY_MAP.workspaceRightSidebarMode] === "context"
 					? "context"
 					: DEFAULT_SETTINGS.workspaceRightSidebarMode,
-			defaultModelId:
-				rawDefaultModelId && rawDefaultModelId !== "default"
-					? rawDefaultModelId
-					: DEFAULT_SETTINGS.defaultModelId,
-			reviewModelId:
-				rawReviewModelId && rawReviewModelId !== "default"
-					? rawReviewModelId
-					: DEFAULT_SETTINGS.reviewModelId,
+			defaultModelId: readModelId(rawDefaultModelId),
+			reviewModelId: readModelId(rawReviewModelId),
 			reviewEffort:
 				rawReviewEffort && rawReviewEffort !== ""
 					? rawReviewEffort
@@ -867,10 +864,7 @@ export async function loadSettings(): Promise<AppSettings> {
 					: rawReviewFastMode === "false"
 						? false
 						: DEFAULT_SETTINGS.reviewFastMode,
-			prModelId:
-				rawPrModelId && rawPrModelId !== "default"
-					? rawPrModelId
-					: DEFAULT_SETTINGS.prModelId,
+			prModelId: readModelId(rawPrModelId),
 			prEffort:
 				rawPrEffort && rawPrEffort !== ""
 					? rawPrEffort


### PR DESCRIPTION
## Summary
- Preserve the `default` model id so Opus 4.7 selections for Review and Action models survive app restarts.
- Rename the PR/MR model setting to Action model in the UI.
- Use the Action model for create PR/MR, reopen PR/MR, and commit-and-push helpers, while leaving fix/resolve flows on the default model.

Fixes #535

## Tests
- `bun x biome check src/App.tsx src/features/settings/index.tsx src/lib/settings.ts src/lib/settings.test.ts src/lib/commit-button-prompts.ts src/lib/commit-button-prompts.test.ts .changeset/calm-action-models.md`
- `bun x vitest run src/lib/settings.test.ts src/lib/commit-button-prompts.test.ts src/App.shortcuts.test.tsx src/features/commit/hooks/use-commit-lifecycle.test.tsx`
- `bun run typecheck`