### PR TITLE
Add terminal font preference

### DIFF
--- a/.announcements/terminal-font-preference.json
+++ b/.announcements/terminal-font-preference.json
@@ -1,0 +1,11 @@
+{
+	"items": [
+		{
+			"text": "You can now choose a separate font for embedded terminals.",
+			"action": {
+				"label": "Open Appearance",
+				"value": { "type": "openSettings", "section": "appearance" }
+			}
+		}
+	]
+}

--- a/.changeset/terminal-font-preference.md
+++ b/.changeset/terminal-font-preference.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Add an Appearance setting for terminal fonts so embedded terminals can use a separate custom font without losing their buffer when it changes.

--- a/src/App.css
+++ b/src/App.css
@@ -12,12 +12,12 @@
 @custom-variant dark (&:is(.dark *));
 
 /*
- * Font stacks. `--font-sans-user` / `--font-mono-user` are written by
- * `useThemeApplication` when the user picks a custom family in
- * Appearance settings; absent, the cascade falls through to the bundled
- * Geist variable fonts. This is a single source of truth — every other
- * `--font-sans`/`--font-mono` declaration in this file chains through
- * the same var() to keep the override consistent.
+ * Font stacks. `--font-sans-user`, `--font-mono-user`, and
+ * `--font-terminal-user` are written by `useThemeApplication` when the user
+ * picks a custom family in Appearance settings; absent, the cascade falls
+ * through to the bundled Geist variable fonts. This is a single source of
+ * truth, every other `--font-sans`/`--font-mono` declaration in this file
+ * chains through the same var() to keep the override consistent.
  */
 @theme {
 	--font-sans:
@@ -26,6 +26,8 @@
 	--font-mono:
 		var(--font-mono-user, "Geist Mono Variable"), ui-monospace, "SF Mono",
 		SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+	--font-terminal:
+		var(--font-terminal-user, "GeistMono"), "SF Mono", Monaco, Menlo, monospace;
 }
 
 :root {
@@ -677,6 +679,8 @@ body {
 	--font-mono:
 		var(--font-mono-user, "Geist Mono Variable"), ui-monospace, "SF Mono",
 		SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+	--font-terminal:
+		var(--font-terminal-user, "GeistMono"), "SF Mono", Monaco, Menlo, monospace;
 	--color-sidebar-ring: var(--sidebar-ring);
 	--color-sidebar-border: var(--sidebar-border);
 	--color-sidebar-accent-foreground: var(--sidebar-accent-foreground);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -746,6 +746,7 @@ function AppShell({
 		darkTheme: appSettings.darkTheme,
 		uiFontFamily: appSettings.uiFontFamily,
 		codeFontFamily: appSettings.codeFontFamily,
+		terminalFontFamily: appSettings.terminalFontFamily,
 		chatFontSize: appSettings.chatFontSize,
 		usePointerCursors: appSettings.usePointerCursors,
 	});

--- a/src/components/terminal-output.tsx
+++ b/src/components/terminal-output.tsx
@@ -249,6 +249,7 @@ function TerminalOutputImpl({
 	const containerRef = useRef<HTMLDivElement>(null);
 	const xtermRef = useRef<Terminal | null>(null);
 	const fitRef = useRef<FitAddon | null>(null);
+	const runFitRef = useRef<(() => void) | null>(null);
 	// Refs so xterm effect doesn't recreate on parent rerender.
 	const onDataRef = useRef<typeof onData>(onData);
 	const onResizeRef = useRef<typeof onResize>(onResize);
@@ -352,6 +353,7 @@ function TerminalOutputImpl({
 				}, FIT_THROTTLE_MS - elapsed);
 			}
 		};
+		runFitRef.current = runFit;
 
 		runFit();
 
@@ -429,12 +431,23 @@ function TerminalOutputImpl({
 			terminal.dispose();
 			xtermRef.current = null;
 			fitRef.current = null;
+			runFitRef.current = null;
 			if (terminalRef) {
 				(terminalRef as React.MutableRefObject<TerminalHandle | null>).current =
 					null;
 			}
 		};
-	}, [detectLinks, fontSize, lineHeight, terminalFontFamily, terminalRef]);
+	}, [detectLinks, terminalRef]);
+
+	useEffect(() => {
+		const terminal = xtermRef.current;
+		if (!terminal) return;
+		terminal.options.fontSize = fontSize;
+		terminal.options.fontFamily = resolveTerminalFontFamily(terminalFontFamily);
+		terminal.options.lineHeight = lineHeight;
+		runFitRef.current?.();
+		terminal.refresh(0, terminal.rows - 1);
+	}, [fontSize, lineHeight, terminalFontFamily]);
 
 	return (
 		<div

--- a/src/components/terminal-output.tsx
+++ b/src/components/terminal-output.tsx
@@ -2,6 +2,7 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import { FitAddon } from "@xterm/addon-fit";
 import { type ILinkProvider, type ITheme, Terminal } from "@xterm/xterm";
 import { memo, useEffect, useRef } from "react";
+import { useSettings } from "@/lib/settings";
 import "@xterm/xterm/css/xterm.css";
 
 type TerminalOutputProps = {
@@ -9,6 +10,7 @@ type TerminalOutputProps = {
 	className?: string;
 	detectLinks?: boolean;
 	fontSize?: number;
+	fontFamily?: string;
 	lineHeight?: number;
 	padding?: string;
 	/**
@@ -219,6 +221,17 @@ function resolveTerminalTheme(): ITheme {
 	};
 }
 
+function resolveTerminalFontFamily(
+	fontFamily: string | null | undefined,
+): string {
+	if (fontFamily && fontFamily.length > 0) return fontFamily;
+	const root = getComputedStyle(document.documentElement);
+	return (
+		root.getPropertyValue("--font-terminal").trim() ||
+		"'GeistMono', 'SF Mono', Monaco, Menlo, monospace"
+	);
+}
+
 // Memoized so parent re-renders (e.g. inspector width drag) don't push a
 // fresh render through the heavy xterm wrapper.
 function TerminalOutputImpl({
@@ -226,11 +239,14 @@ function TerminalOutputImpl({
 	className,
 	detectLinks = false,
 	fontSize = 12,
+	fontFamily,
 	lineHeight = 1.3,
 	padding = "12px 2px 12px 12px",
 	onData,
 	onResize,
 }: TerminalOutputProps) {
+	const { settings } = useSettings();
+	const terminalFontFamily = fontFamily ?? settings.terminalFontFamily;
 	const containerRef = useRef<HTMLDivElement>(null);
 	const xtermRef = useRef<Terminal | null>(null);
 	const fitRef = useRef<FitAddon | null>(null);
@@ -251,7 +267,7 @@ function TerminalOutputImpl({
 			disableStdin: false,
 			scrollback: 5000,
 			fontSize,
-			fontFamily: "'GeistMono', 'SF Mono', Monaco, Menlo, monospace",
+			fontFamily: resolveTerminalFontFamily(terminalFontFamily),
 			lineHeight,
 			theme: resolveTerminalTheme(),
 			cursorBlink: false,
@@ -419,7 +435,7 @@ function TerminalOutputImpl({
 					null;
 			}
 		};
-	}, [detectLinks, fontSize, lineHeight, terminalRef]);
+	}, [detectLinks, fontSize, lineHeight, terminalFontFamily, terminalRef]);
 
 	return (
 		<div

--- a/src/components/terminal-output.tsx
+++ b/src/components/terminal-output.tsx
@@ -51,6 +51,8 @@ export type TerminalHandle = {
 
 const URL_PATTERN = /https?:\/\/[^\s<>"'`]+/gi;
 const TRAILING_URL_PUNCTUATION = /[),.;:!?]+$/;
+const DEFAULT_TERMINAL_FONT_FAMILY =
+	"'GeistMono', 'SF Mono', Monaco, Menlo, monospace";
 
 function sanitizeHttpUrl(value: string): string | null {
 	const trimmed = value.replace(TRAILING_URL_PUNCTUATION, "");
@@ -224,12 +226,9 @@ function resolveTerminalTheme(): ITheme {
 function resolveTerminalFontFamily(
 	fontFamily: string | null | undefined,
 ): string {
-	if (fontFamily && fontFamily.length > 0) return fontFamily;
-	const root = getComputedStyle(document.documentElement);
-	return (
-		root.getPropertyValue("--font-terminal").trim() ||
-		"'GeistMono', 'SF Mono', Monaco, Menlo, monospace"
-	);
+	return fontFamily && fontFamily.length > 0
+		? `${fontFamily}, ${DEFAULT_TERMINAL_FONT_FAMILY}`
+		: DEFAULT_TERMINAL_FONT_FAMILY;
 }
 
 // Memoized so parent re-renders (e.g. inspector width drag) don't push a

--- a/src/features/settings/panels/appearance.tsx
+++ b/src/features/settings/panels/appearance.tsx
@@ -71,16 +71,18 @@ const DARK_THEME_OPTIONS: readonly ColorThemeOption[] = [
 type EffectiveFonts = {
 	fontSans: string;
 	fontMono: string;
+	fontTerminal: string;
 };
 
 function sampleEffectiveFonts(): EffectiveFonts {
 	if (typeof document === "undefined") {
-		return { fontSans: "", fontMono: "" };
+		return { fontSans: "", fontMono: "", fontTerminal: "" };
 	}
 	const cs = getComputedStyle(document.documentElement);
 	return {
 		fontSans: cs.getPropertyValue("--font-sans").trim(),
 		fontMono: cs.getPropertyValue("--font-mono").trim(),
+		fontTerminal: cs.getPropertyValue("--font-terminal").trim(),
 	};
 }
 
@@ -106,7 +108,11 @@ export function AppearancePanel({
 			setEffective(sampleEffectiveFonts()),
 		);
 		return () => cancelAnimationFrame(id);
-	}, [settings.uiFontFamily, settings.codeFontFamily]);
+	}, [
+		settings.uiFontFamily,
+		settings.codeFontFamily,
+		settings.terminalFontFamily,
+	]);
 
 	return (
 		<SettingsGroup>
@@ -203,6 +209,15 @@ export function AppearancePanel({
 					onChange={(next) => updateSettings({ codeFontFamily: next })}
 					effectivePlaceholder={effective.fontMono}
 					ariaLabel="Code font family"
+				/>
+			</SettingsRow>
+
+			<SettingsRow title="Terminal font">
+				<FontPicker
+					value={settings.terminalFontFamily}
+					onChange={(next) => updateSettings({ terminalFontFamily: next })}
+					effectivePlaceholder={effective.fontTerminal}
+					ariaLabel="Terminal font family"
 				/>
 			</SettingsRow>
 

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -2,6 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	DEFAULT_KANBAN_VIEW_STATE,
+	getPreloadedSettings,
 	loadSettings,
 	saveSettings,
 } from "./settings";
@@ -110,6 +111,36 @@ describe("settings", () => {
 				}),
 			}),
 		);
+	});
+
+	it("preloads terminal font from localStorage", () => {
+		window.localStorage.setItem("helmor-terminal-font-family", "Berkeley Mono");
+
+		const settings = getPreloadedSettings();
+
+		expect(settings.terminalFontFamily).toBe("Berkeley Mono");
+	});
+
+	it("hydrates and saves terminal font from localStorage", async () => {
+		window.localStorage.setItem(
+			"helmor-terminal-font-family",
+			"JetBrains Mono",
+		);
+		invokeMock.mockResolvedValue({});
+
+		const settings = await loadSettings();
+
+		expect(settings.terminalFontFamily).toBe("JetBrains Mono");
+
+		await saveSettings({ terminalFontFamily: "Berkeley Mono" });
+		expect(window.localStorage.getItem("helmor-terminal-font-family")).toBe(
+			"Berkeley Mono",
+		);
+
+		await saveSettings({ terminalFontFamily: null });
+		expect(
+			window.localStorage.getItem("helmor-terminal-font-family"),
+		).toBeNull();
 	});
 
 	it("hydrates and saves the last app surface", async () => {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -192,6 +192,8 @@ export type AppSettings = {
 	uiFontFamily: string | null;
 	/** Override for the monospace code font stack. `null` = preset default. */
 	codeFontFamily: string | null;
+	/** Override for embedded terminal font stack. `null` = preset default. */
+	terminalFontFamily: string | null;
 	/** When true, all clickable elements show a pointer cursor on hover.
 	 *  When false, falls back to the default arrow. */
 	usePointerCursors: boolean;
@@ -270,6 +272,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
 	chatFontSize: 14,
 	uiFontFamily: null,
 	codeFontFamily: null,
+	terminalFontFamily: null,
 	usePointerCursors: true,
 	theme: "system",
 	darkTheme: "default",
@@ -317,6 +320,7 @@ export const DARK_THEME_STORAGE_KEY = "helmor-dark-theme";
 export const SIDEBAR_GROUPING_STORAGE_KEY = "helmor-sidebar-grouping";
 export const UI_FONT_FAMILY_STORAGE_KEY = "helmor-ui-font-family";
 export const CODE_FONT_FAMILY_STORAGE_KEY = "helmor-code-font-family";
+export const TERMINAL_FONT_FAMILY_STORAGE_KEY = "helmor-terminal-font-family";
 
 /** Keys mirrored to localStorage for flash-free synchronous boot reads.
  *  Anything visible in the first paint must live here so we don't wait
@@ -327,6 +331,7 @@ const LOCALSTORAGE_KEYS = {
 	sidebarGrouping: SIDEBAR_GROUPING_STORAGE_KEY,
 	uiFontFamily: UI_FONT_FAMILY_STORAGE_KEY,
 	codeFontFamily: CODE_FONT_FAMILY_STORAGE_KEY,
+	terminalFontFamily: TERMINAL_FONT_FAMILY_STORAGE_KEY,
 } as const;
 
 type LocalStorageKey = keyof typeof LOCALSTORAGE_KEYS;
@@ -372,6 +377,9 @@ export function getPreloadedSettings(): AppSettings {
 		darkTheme,
 		uiFontFamily: readLocalStorageString(UI_FONT_FAMILY_STORAGE_KEY),
 		codeFontFamily: readLocalStorageString(CODE_FONT_FAMILY_STORAGE_KEY),
+		terminalFontFamily: readLocalStorageString(
+			TERMINAL_FONT_FAMILY_STORAGE_KEY,
+		),
 	};
 }
 
@@ -819,6 +827,9 @@ export async function loadSettings(): Promise<AppSettings> {
 			),
 			uiFontFamily: readLocalStorageString(UI_FONT_FAMILY_STORAGE_KEY),
 			codeFontFamily: readLocalStorageString(CODE_FONT_FAMILY_STORAGE_KEY),
+			terminalFontFamily: readLocalStorageString(
+				TERMINAL_FONT_FAMILY_STORAGE_KEY,
+			),
 			usePointerCursors:
 				raw[SETTINGS_KEY_MAP.usePointerCursors] !== undefined
 					? raw[SETTINGS_KEY_MAP.usePointerCursors] === "true"

--- a/src/shell/hooks/use-theme-application.ts
+++ b/src/shell/hooks/use-theme-application.ts
@@ -17,6 +17,7 @@ export type ThemeApplicationOptions = {
 	darkTheme: DarkTheme;
 	uiFontFamily: string | null;
 	codeFontFamily: string | null;
+	terminalFontFamily: string | null;
 	chatFontSize: number;
 	usePointerCursors: boolean;
 };
@@ -39,6 +40,7 @@ export function useThemeApplication(opts: ThemeApplicationOptions): void {
 		darkTheme,
 		uiFontFamily,
 		codeFontFamily,
+		terminalFontFamily,
 		chatFontSize,
 		usePointerCursors,
 	} = opts;
@@ -89,6 +91,14 @@ export function useThemeApplication(opts: ThemeApplicationOptions): void {
 			codeFontFamily,
 		);
 	}, [codeFontFamily]);
+
+	useEffect(() => {
+		setOrRemoveProperty(
+			document.documentElement,
+			"--font-terminal-user",
+			terminalFontFamily,
+		);
+	}, [terminalFontFamily]);
 
 	// Chat font size mirrored to a CSS var so message components can pick
 	// it up without prop drilling. (They currently inline-style it from


### PR DESCRIPTION
Adds a Terminal font field next to the UI and Code font preferences.

The setting is saved like the other font overrides and used by the shared TerminalOutput component, so workspace terminals and auth terminals pick it up. Font changes update the existing xterm instance in place, so the terminal output stays visible while the font changes.

Manual testing:
- Changed the Terminal font from Settings while a workspace terminal had output.
- Confirmed the output stayed visible and the font updated.
- Tried a Nerd Font value and confirmed icons render.

Refs #468