### PR TITLE
feat(inspector): make terminal hover expansion configurable

### DIFF
--- a/.announcements/terminal-hover-expansion.json
+++ b/.announcements/terminal-hover-expansion.json
@@ -1,0 +1,11 @@
+{
+	"items": [
+		{
+			"text": "You can now turn inspector terminal hover expansion on or off in Settings.",
+			"action": {
+				"label": "Open General",
+				"value": { "type": "openSettings", "section": "general" }
+			}
+		}
+	]
+}

--- a/.changeset/quiet-terminal-hover.md
+++ b/.changeset/quiet-terminal-hover.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Add a setting to disable inspector terminal expansion on hover while keeping it enabled by default.

--- a/src/features/inspector/index.tsx
+++ b/src/features/inspector/index.tsx
@@ -374,10 +374,12 @@ export function WorkspaceInspectorSidebar({
 		? terminalInstances.find((t) => t.id === activeTab)
 		: undefined;
 	const canHoverExpand = isTerminalTabActive
-		? !activeTerminalInstance?.hoverZoomDisabled
-		: scriptTabState === "running" ||
-			scriptTabState === "success" ||
-			scriptTabState === "failure";
+		? appSettings.terminalHoverExpansion &&
+			!activeTerminalInstance?.hoverZoomDisabled
+		: appSettings.terminalHoverExpansion &&
+			(scriptTabState === "running" ||
+				scriptTabState === "success" ||
+				scriptTabState === "failure");
 
 	const handleOpenSettings = onOpenSettings ?? (() => {});
 

--- a/src/features/settings/index.tsx
+++ b/src/features/settings/index.tsx
@@ -316,6 +316,7 @@ export const SettingsDialog = memo(function SettingsDialog({
 									</SettingsRow>
 									<SettingsRow
 										title="Expand terminals on hover"
+										releaseMarker={{ kind: "feature" }}
 										description="Enlarge inspector terminals when the cursor rests over them."
 									>
 										<Switch

--- a/src/features/settings/index.tsx
+++ b/src/features/settings/index.tsx
@@ -315,6 +315,17 @@ export const SettingsDialog = memo(function SettingsDialog({
 										/>
 									</SettingsRow>
 									<SettingsRow
+										title="Expand terminals on hover"
+										description="Enlarge inspector terminals when the cursor rests over them."
+									>
+										<Switch
+											checked={settings.terminalHoverExpansion}
+											onCheckedChange={(checked) =>
+												updateSettings({ terminalHoverExpansion: checked })
+											}
+										/>
+									</SettingsRow>
+									<SettingsRow
 										title="Always show context usage"
 										description="By default, context usage is only shown when more than 70% is used."
 									>

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -1,3 +1,4 @@
+import { invoke } from "@tauri-apps/api/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	DEFAULT_KANBAN_VIEW_STATE,
@@ -5,16 +6,36 @@ import {
 	saveSettings,
 } from "./settings";
 
-const invokeMock = vi.hoisted(() => vi.fn());
+const invokeMock = vi.mocked(invoke);
 
-vi.mock("@tauri-apps/api/core", () => ({
-	invoke: invokeMock,
-}));
+function installTestLocalStorage() {
+	const store = new Map<string, string>();
+	const storage = {
+		getItem: vi.fn((key: string) => store.get(key) ?? null),
+		setItem: vi.fn((key: string, value: string) => {
+			store.set(key, value);
+		}),
+		removeItem: vi.fn((key: string) => {
+			store.delete(key);
+		}),
+		clear: vi.fn(() => {
+			store.clear();
+		}),
+	};
+	Object.defineProperty(window, "localStorage", {
+		value: storage,
+		configurable: true,
+	});
+	Object.defineProperty(globalThis, "localStorage", {
+		value: storage,
+		configurable: true,
+	});
+}
 
 describe("settings", () => {
 	beforeEach(() => {
+		installTestLocalStorage();
 		invokeMock.mockReset();
-		window.localStorage.clear();
 	});
 
 	it("hydrates kanban view state with per-repo branches and inbox filters", async () => {
@@ -118,6 +139,28 @@ describe("settings", () => {
 					"app.last_surface": "workspace",
 					"app.start_context_panel_open": "false",
 					"app.workspace_right_sidebar_mode": "inspector",
+				}),
+			}),
+		);
+	});
+
+	it("hydrates and saves terminal hover expansion", async () => {
+		invokeMock.mockResolvedValue({
+			"app.terminal_hover_expansion": "false",
+		});
+
+		const settings = await loadSettings();
+
+		expect(settings.terminalHoverExpansion).toBe(false);
+
+		invokeMock.mockResolvedValue(undefined);
+		await saveSettings({ terminalHoverExpansion: true });
+
+		expect(invokeMock).toHaveBeenLastCalledWith(
+			"update_app_settings",
+			expect.objectContaining({
+				settingsMap: expect.objectContaining({
+					"app.terminal_hover_expansion": "true",
 				}),
 			}),
 		);

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -198,6 +198,8 @@ export type AppSettings = {
 	theme: ThemeMode;
 	darkTheme: DarkTheme;
 	notifications: boolean;
+	/** When true, hovering a terminal-like inspector tab body expands it. */
+	terminalHoverExpansion: boolean;
 	lastWorkspaceId: string | null;
 	lastSessionId: string | null;
 	lastSurface: AppSurface;
@@ -273,6 +275,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
 	theme: "system",
 	darkTheme: "default",
 	notifications: true,
+	terminalHoverExpansion: true,
 	lastWorkspaceId: null,
 	lastSessionId: null,
 	lastSurface: "workspace",
@@ -382,6 +385,7 @@ const SETTINGS_KEY_MAP: Record<
 	chatFontSize: "app.chat_font_size",
 	usePointerCursors: "app.use_pointer_cursors",
 	notifications: "app.notifications",
+	terminalHoverExpansion: "app.terminal_hover_expansion",
 	lastWorkspaceId: "app.last_workspace_id",
 	lastSessionId: "app.last_session_id",
 	lastSurface: "app.last_surface",
@@ -835,6 +839,10 @@ export async function loadSettings(): Promise<AppSettings> {
 				raw[SETTINGS_KEY_MAP.notifications] !== undefined
 					? raw[SETTINGS_KEY_MAP.notifications] === "true"
 					: DEFAULT_SETTINGS.notifications,
+			terminalHoverExpansion:
+				raw[SETTINGS_KEY_MAP.terminalHoverExpansion] !== undefined
+					? raw[SETTINGS_KEY_MAP.terminalHoverExpansion] === "true"
+					: DEFAULT_SETTINGS.terminalHoverExpansion,
 			lastWorkspaceId: raw[SETTINGS_KEY_MAP.lastWorkspaceId] || null,
 			lastSessionId: raw[SETTINGS_KEY_MAP.lastSessionId] || null,
 			lastSurface:


### PR DESCRIPTION
Adds a General setting to disable inspector terminal expansion on hover. It stays enabled by default, and the existing per-terminal right-click opt-out still works.

Closes #540.

Manual testing:
- Opened Settings and toggled "Expand terminals on hover" off.
- Confirmed inspector terminals no longer expand on hover.
- Turned it back on and confirmed hover expansion works again.

Also checked:
- bun run typecheck
- bun run test:frontend -- src/lib/settings.test.ts src/features/inspector/layout.test.tsx
- bunx biome check src/lib/settings.ts src/features/settings/index.tsx src/features/inspector/index.tsx src/lib/settings.test.ts .changeset/quiet-terminal-hover.md