### PR TITLE
fix(commit-button): target repo default branch for local-mode workspaces

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -96,7 +96,10 @@ import {
 } from "./lib/settings";
 import { requestSidebarReconcile } from "./lib/sidebar-mutation-gate";
 import { useOsNotifications } from "./lib/use-os-notifications";
-import { summaryToArchivedRow } from "./lib/workspace-helpers";
+import {
+	pickWorkspaceTargetBranch,
+	summaryToArchivedRow,
+} from "./lib/workspace-helpers";
 import {
 	type WorkspaceToastOptions,
 	WorkspaceToastProvider,
@@ -782,10 +785,9 @@ function AppShell({
 		selectedWorkspaceId,
 		getSelectedWorkspaceId: () => selectionActions.getSnapshot().workspaceId,
 		selectedRepoId: selectedWorkspaceDetailQuery.data?.repoId ?? null,
-		selectedWorkspaceTargetBranch:
-			selectedWorkspaceDetailQuery.data?.intendedTargetBranch ??
-			selectedWorkspaceDetailQuery.data?.defaultBranch ??
-			null,
+		selectedWorkspaceTargetBranch: pickWorkspaceTargetBranch(
+			selectedWorkspaceDetailQuery.data ?? null,
+		),
 		selectedWorkspaceRemote: selectedWorkspaceDetailQuery.data?.remote ?? null,
 		changeRequest: workspaceChangeRequest,
 		forgeDetection: workspaceForge,

--- a/src/lib/workspace-helpers.test.ts
+++ b/src/lib/workspace-helpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type {
 	AgentModelSection,
+	WorkspaceDetail,
 	WorkspaceGroup,
 	WorkspaceRow,
 	WorkspaceSessionSummary,
@@ -17,6 +18,7 @@ import {
 	insertRowByCreatedAtDesc,
 	isNewSession,
 	moveWorkspaceToGroup,
+	pickWorkspaceTargetBranch,
 	reorderWorkspaceInSidebar,
 	resolveSessionDisplayProvider,
 	resolveSessionSelectedModelId,
@@ -960,5 +962,86 @@ describe("applyRepoReorder", () => {
 
 	it("returns undefined when groups is undefined", () => {
 		expect(applyRepoReorder(undefined, "repo-A", null)).toBeUndefined();
+	});
+});
+
+describe("pickWorkspaceTargetBranch", () => {
+	function detail(
+		overrides: Partial<
+			Pick<WorkspaceDetail, "mode" | "intendedTargetBranch" | "defaultBranch">
+		>,
+	): Pick<WorkspaceDetail, "mode" | "intendedTargetBranch" | "defaultBranch"> {
+		return {
+			mode: "worktree",
+			intendedTargetBranch: null,
+			defaultBranch: null,
+			...overrides,
+		};
+	}
+
+	it("returns null when detail is null", () => {
+		expect(pickWorkspaceTargetBranch(null)).toBeNull();
+	});
+
+	it("uses intendedTargetBranch for worktree workspaces", () => {
+		expect(
+			pickWorkspaceTargetBranch(
+				detail({
+					mode: "worktree",
+					intendedTargetBranch: "feat/parent",
+					defaultBranch: "main",
+				}),
+			),
+		).toBe("feat/parent");
+	});
+
+	it("falls back to defaultBranch for worktree workspaces with no parent", () => {
+		expect(
+			pickWorkspaceTargetBranch(
+				detail({
+					mode: "worktree",
+					intendedTargetBranch: null,
+					defaultBranch: "main",
+				}),
+			),
+		).toBe("main");
+	});
+
+	it("ignores intendedTargetBranch for local workspaces (would be the workspace branch itself)", () => {
+		// Local-mode persists `intended_target_branch = <current branch>` for
+		// symmetry with worktrees. Using it as a PR base would yield head==base.
+		expect(
+			pickWorkspaceTargetBranch(
+				detail({
+					mode: "local",
+					intendedTargetBranch: "feat/my-local-branch",
+					defaultBranch: "main",
+				}),
+			),
+		).toBe("main");
+	});
+
+	it("returns null for a local workspace with no repo default", () => {
+		expect(
+			pickWorkspaceTargetBranch(
+				detail({
+					mode: "local",
+					intendedTargetBranch: "feat/my-local-branch",
+					defaultBranch: null,
+				}),
+			),
+		).toBeNull();
+	});
+
+	it("returns null when neither field is set", () => {
+		expect(
+			pickWorkspaceTargetBranch(
+				detail({
+					mode: "worktree",
+					intendedTargetBranch: null,
+					defaultBranch: null,
+				}),
+			),
+		).toBeNull();
 	});
 });

--- a/src/lib/workspace-helpers.ts
+++ b/src/lib/workspace-helpers.ts
@@ -475,6 +475,36 @@ export type WorkspaceBranchTone =
 	| "closed"
 	| "inactive";
 
+/**
+ * Pick the branch a workspace's PR / review / resolve-conflicts prompts should
+ * target. Mirrors the data the inspector commit-button prompts need.
+ *
+ * - **Worktree mode**: the workspace was branched off a parent, so
+ *   `intendedTargetBranch` (the persisted parent) is the right PR base.
+ *   Falls back to the repo's `defaultBranch` when the parent isn't recorded.
+ * - **Local mode**: the workspace IS its own branch. The backend stores the
+ *   workspace branch in `intendedTargetBranch` for symmetry with worktrees,
+ *   so using it would set the change-request target to the current branch
+ *   (head == base, rejected by every forge). The repo's default branch is
+ *   the correct target instead.
+ *
+ * Returns `null` when neither is known — callers must handle that (the
+ * commit-button prompts throw with a clear message rather than emitting a
+ * literal `<target>` placeholder).
+ */
+export function pickWorkspaceTargetBranch(
+	detail: Pick<
+		WorkspaceDetail,
+		"mode" | "intendedTargetBranch" | "defaultBranch"
+	> | null,
+): string | null {
+	if (!detail) return null;
+	if (detail.mode === "local") {
+		return detail.defaultBranch ?? null;
+	}
+	return detail.intendedTargetBranch ?? detail.defaultBranch ?? null;
+}
+
 export function getWorkspaceBranchTone({
 	workspaceState,
 	status,


### PR DESCRIPTION
## Summary

Fixes #546.

For `WorkspaceMode::Local` workspaces, the inspector's Create-PR button asks the agent to run `gh pr create --base <target>` — but `<target>` is sourced from `intendedTargetBranch`, which the backend persists as the **workspace's own branch** for symmetry with worktrees. That produces `gh pr create --base <current-branch>` (head == base, rejected by every forge). Review and Resolve-Conflicts on local workspaces have the same bug (they end up diffing against / resolving against the current branch).

Introduce `pickWorkspaceTargetBranch` in `src/lib/workspace-helpers.ts`:

- **Worktree mode** (unchanged): `intendedTargetBranch ?? defaultBranch`.
- **Local mode** (new): `defaultBranch` — the repo's actual default branch, joined from `repos.default_branch` in `src-tauri/src/models/workspaces.rs` (line ~138).

Threaded through `App.tsx` at the single call site that builds `selectedWorkspaceTargetBranch`. Backend persistence is unchanged — no migration needed.

## Why a frontend fix

The backend overloads `intended_target_branch` for local workspaces (sets it to the current branch for symmetry with worktrees, see `src-tauri/src/workspace/lifecycle.rs` ~line 280). A backend fix would require a data migration for existing local workspaces. The prompt layer is the correct place to disambiguate — it's the only consumer that treats this value as a PR base.

## Follow-up

The backend overload is still worth cleaning up so future callers don't repeat this bug (set `intended_target_branch = NULL` for local mode and read `repos.default_branch` directly). I'll file a separate issue.

## Test plan

- [x] `vitest run src/lib/workspace-helpers.test.ts` — 6 new cases (worktree w/ parent, worktree fallback, local ignoring `intendedTargetBranch`, local with no default, null detail, both fields null). All 78 pass.
- [x] Full `vitest run` — 1102/1102 pass.
- [x] `tsc --noEmit` — clean.
- [x] `biome check` — clean.
- [ ] Manually verify in-app: on a local-mode workspace where the current branch is not the repo default, clicking Create PR should produce a prompt with `gh pr create --base <repo-default>`, not `<current-branch>`.