### PR TITLE
chore: update package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "helmor111",
+	"name": "helmor111222",
 	"description": "The local-first IDE for coding agent orchestration.",
 	"private": true,
 	"version": "0.12.2",


### PR DESCRIPTION
## What changed
- Updated the package name in package.json from `helmor111` to `helmor111222`.

## Why
- Keeps the package metadata aligned with the intended workspace/package identifier.

## Follow-up / tests
- Not run; metadata-only change.