### PR TITLE
fix: sync local workspace branch state

### DIFF
--- a/.changeset/clean-local-branches.md
+++ b/.changeset/clean-local-branches.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix local workspaces so PR targets stay separate from the current branch and checkout changes update Helmor's branch state.

--- a/src-tauri/src/commands/tests/workspace_creation.rs
+++ b/src-tauri/src/commands/tests/workspace_creation.rs
@@ -101,6 +101,7 @@ fn prepare_local_workspace_keeps_current_branch_when_source_is_none() {
 
     assert_eq!(response.state, WorkspaceState::Ready);
     assert_eq!(response.branch, "main");
+    assert_eq!(response.default_branch, "main");
     assert_eq!(response.directory_name, "");
     // Local mode: prepare returns the cwd immediately so the start-page
     // submit flow can pin it onto the pending payload without waiting for
@@ -162,10 +163,27 @@ fn prepare_local_workspace_switches_branch_when_source_differs() {
 
     assert_eq!(response.state, WorkspaceState::Ready);
     assert_eq!(response.branch, "develop");
+    assert_eq!(response.default_branch, "main");
 
     // Verify the source repo's HEAD actually moved.
     let head = crate::git_ops::current_branch_name(&harness.source_repo_root).unwrap();
     assert_eq!(head, "develop");
+
+    let connection = Connection::open(harness.db_path()).unwrap();
+    let (branch, init_parent, target_branch): (String, String, String) = connection
+        .query_row(
+            r#"
+            SELECT branch, initialization_parent_branch, intended_target_branch
+            FROM workspaces WHERE id = ?1
+            "#,
+            [&response.workspace_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
+
+    assert_eq!(branch, "develop");
+    assert_eq!(init_parent, "main");
+    assert_eq!(target_branch, "main");
 }
 
 #[test]
@@ -191,6 +209,7 @@ fn prepare_local_workspace_checks_out_remote_only_branch_via_dwim() {
     .unwrap();
 
     assert_eq!(response.branch, "remote-only");
+    assert_eq!(response.default_branch, "main");
     let head = crate::git_ops::current_branch_name(&harness.source_repo_root).unwrap();
     assert_eq!(head, "remote-only");
     // DWIM should have created a local tracking branch.

--- a/src-tauri/src/git/watcher.rs
+++ b/src-tauri/src/git/watcher.rs
@@ -356,14 +356,9 @@ fn start_watcher<R: Runtime>(
     let db_branch = ws.branch.clone();
     let app_handle = app.clone();
     let gitdir_for_callback = gitdir.clone();
-    // Local workspaces treat `branch` as a fixed label (set at creation
-    // and never auto-updated). Skip the head-change → DB-write side
-    // effect for them; we still emit refs-changed events for UI
-    // invalidation.
-    let track_branch_changes = ws.mode != WorkspaceMode::Local;
 
     // Shared state for the callback: last-known branch
-    let last_branch = std::sync::Arc::new(Mutex::new(db_branch));
+    let last_branch = std::sync::Arc::new(Mutex::new(db_branch.clone()));
     let last_branch_clone = last_branch.clone();
 
     let mut debouncer = new_debouncer(
@@ -408,7 +403,7 @@ fn start_watcher<R: Runtime>(
                 }
             }
 
-            if head_changed && track_branch_changes {
+            if head_changed {
                 handle_head_change(
                     &app_handle,
                     &workspace_id,
@@ -465,11 +460,12 @@ fn start_watcher<R: Runtime>(
         .watch(&common_dir, RecursiveMode::NonRecursive)
         .with_context(|| format!("Failed to watch {}", common_dir.display()))?;
 
-    // Seed last_branch with the actual current HEAD
+    // Seed last_branch with the actual current HEAD and reconcile stale DB.
     if let Some(current) = read_head_branch(&gitdir) {
         if let Ok(mut lb) = last_branch.lock() {
             *lb = Some(current);
         }
+        reconcile_initial_head_branch(app, &ws.id, db_branch.as_deref(), &gitdir, last_branch);
     }
 
     Ok(WorkspaceWatcher {
@@ -477,6 +473,48 @@ fn start_watcher<R: Runtime>(
         remote: ws.remote.clone(),
         target_branch: ws.target_branch.clone(),
     })
+}
+
+fn reconcile_initial_head_branch<R: Runtime>(
+    app: &AppHandle<R>,
+    workspace_id: &str,
+    db_branch: Option<&str>,
+    gitdir: &Path,
+    last_branch: Arc<Mutex<Option<String>>>,
+) {
+    let current = read_head_branch(gitdir);
+    if current.as_deref() == db_branch {
+        return;
+    }
+    let Some(ref branch) = current else {
+        return;
+    };
+    if let Err(e) = update_branch_in_db(workspace_id, db_branch, branch) {
+        tracing::error!(
+            workspace_id,
+            "Failed to reconcile initial branch in DB: {e:#}"
+        );
+        return;
+    }
+    if let Ok(mut lb) = last_branch.lock() {
+        *lb = current.clone();
+    }
+    ui_sync::publish(
+        app,
+        ui_sync::UiMutationEvent::WorkspaceGitStateChanged {
+            workspace_id: workspace_id.to_string(),
+        },
+    );
+    if let Err(e) = app.emit(
+        GIT_BRANCH_CHANGED_EVENT,
+        GitBranchChangedPayload {
+            workspace_id: workspace_id.to_string(),
+            old_branch: db_branch.map(ToOwned::to_owned),
+            new_branch: current,
+        },
+    ) {
+        tracing::warn!("Failed to emit git-branch-changed: {e}");
+    }
 }
 
 // -- Auto-fetch (one thread per unique target) --
@@ -973,6 +1011,37 @@ mod tests {
         let json = serde_json::to_value(&payload).unwrap();
         assert!(json["oldBranch"].is_null());
         assert!(json["newBranch"].is_null());
+    }
+
+    #[test]
+    fn update_branch_in_db_syncs_checkout_branch() {
+        let env = crate::testkit::TestEnv::new("git-watcher-checkout-branch");
+        let conn = env.db_connection();
+        crate::testkit::insert_repo(&conn, "repo-1", "Repo", Some("origin"));
+        crate::testkit::insert_workspace(
+            &conn,
+            &crate::testkit::WorkspaceFixture {
+                id: "ws-1",
+                repo_id: "repo-1",
+                directory_name: "alpha",
+                state: WorkspaceState::Ready.as_str(),
+                branch: Some("feature/old"),
+                intended_target_branch: Some("main"),
+            },
+        );
+        drop(conn);
+
+        update_branch_in_db("ws-1", Some("feature/old"), "feature/new").unwrap();
+
+        let branch: String = env
+            .db_connection()
+            .query_row(
+                "SELECT branch FROM workspaces WHERE id = 'ws-1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(branch, "feature/new");
     }
 
     // -- FetchKey identity --

--- a/src-tauri/src/workspace/lifecycle.rs
+++ b/src-tauri/src/workspace/lifecycle.rs
@@ -255,6 +255,13 @@ pub fn prepare_local_workspace_impl(
         .filter(|value| !value.is_empty())
         .map(ToOwned::to_owned)
         .unwrap_or_else(|| current_branch.clone());
+    let base_branch = repository
+        .default_branch
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| "main".to_string());
 
     // Tracked-only check — `git checkout` is fine with untracked files.
     if target_branch != current_branch
@@ -279,7 +286,7 @@ pub fn prepare_local_workspace_impl(
         &session_id,
         &directory_name,
         &target_branch,
-        &target_branch,
+        &base_branch,
         crate::workspace_state::WorkspaceMode::Local,
         initial_status,
         &timestamp,
@@ -324,7 +331,8 @@ pub fn prepare_local_workspace_impl(
         repo_name: repository.name,
         directory_name,
         branch: target_branch.clone(),
-        default_branch: target_branch,
+        // Field name is legacy; value is the initial PR/review base.
+        default_branch: base_branch,
         state: WorkspaceState::Ready,
         repo_scripts,
         // Local mode operates directly on the repo root — already on disk,


### PR DESCRIPTION
Closes #546 
## What changed
- Keep local workspace checkout branch state in sync when HEAD changes, including initial watcher reconciliation.
- Preserve the repository default branch as the local workspace PR/review base instead of replacing it with the checkout branch.
- Add coverage for local workspace preparation and watcher branch DB updates.
- Add a patch changeset.

## Why
Local workspaces need to distinguish the current checkout branch from the intended target/base branch, otherwise PR targeting and branch state can drift after switching branches.

## Tests
- `cd src-tauri && cargo test prepare_local_workspace`
- `cd src-tauri && cargo test update_branch_in_db_syncs_checkout_branch`