### PR TITLE
feat(workspace): backend dashboard read model

### DIFF
--- a/.changeset/dashboard-read-model.md
+++ b/.changeset/dashboard-read-model.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Add a backend `load_dashboard_snapshot` command that groups workspaces into kanban lanes (in-progress / review / done / backlog / canceled / archived) with a live `isStreaming` overlay, so the upcoming dashboard view (#482) can render cards without rewriting the sidebar's aggregate queries.

--- a/src-tauri/src/commands/workspace_commands.rs
+++ b/src-tauri/src/commands/workspace_commands.rs
@@ -195,6 +195,19 @@ pub async fn list_archived_workspaces() -> CmdResult<Vec<workspaces::WorkspaceSu
     run_blocking(workspaces::list_archived_workspaces).await
 }
 
+/// Typed kanban projection for the dashboard view (#482). Reuses the
+/// same workspace + session aggregates as the sidebar, adds an
+/// `Archived` lane that pulls in archived rows, and overlays each
+/// card with an `isStreaming` bit so the dashboard can render busy
+/// indicators without a separate `list_active_streams` query.
+#[tauri::command]
+pub async fn load_dashboard_snapshot(
+    active_streams: tauri::State<'_, crate::agents::ActiveStreams>,
+) -> CmdResult<crate::workspace::dashboard::DashboardSnapshot> {
+    let streams = active_streams.snapshot_for_ui();
+    run_blocking(move || crate::workspace::dashboard::build_dashboard_snapshot(&streams)).await
+}
+
 #[tauri::command]
 pub async fn get_workspace(workspace_id: String) -> CmdResult<workspaces::WorkspaceDetail> {
     run_blocking(move || workspaces::get_workspace(&workspace_id)).await

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -288,6 +288,7 @@ pub fn run() {
             commands::repository_commands::add_repository_from_local_path,
             commands::repository_commands::clone_repository_from_url,
             commands::workspace_commands::list_archived_workspaces,
+            commands::workspace_commands::load_dashboard_snapshot,
             commands::repository_commands::list_repositories,
             commands::repository_commands::update_repository_default_branch,
             commands::repository_commands::update_repository_branch_prefix,

--- a/src-tauri/src/workspace/dashboard.rs
+++ b/src-tauri/src/workspace/dashboard.rs
@@ -1,0 +1,391 @@
+//! Dashboard read model — a typed kanban projection over the same
+//! workspace + session aggregates the sidebar uses.
+//!
+//! The dashboard view (#482) wants the same data the sidebar already
+//! renders, just reshuffled into wider lanes. Rather than push that
+//! re-shape into React, we expose it as a backend command so the
+//! grouping rules + active-stream overlay live in one place and the
+//! frontend can render dumb cards.
+//!
+//! Scope is deliberately narrow:
+//! - one read-only command, no mutation;
+//! - reuses `load_workspace_records` + `load_archived_workspace_records`
+//!   so the dashboard never disagrees with the sidebar about a row's
+//!   status / pr metadata / message counts;
+//! - no expensive per-workspace git work (change line counts come from
+//!   `workspace_action_status`, which is heavy and per-workspace —
+//!   leave that to follow-up hover/lazy fetches).
+
+use std::collections::HashSet;
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use crate::agents::streaming::ActiveStreamSummary;
+use crate::models::workspaces as workspace_models;
+use crate::workspace_state::WorkspaceState;
+use crate::workspace_status::WorkspaceStatus;
+
+use super::workspaces::{record_to_summary, WorkspaceSummary};
+
+/// Dashboard lane discriminator. The five status values mirror
+/// [`WorkspaceStatus`] one-for-one (so the dashboard never drifts from
+/// the sidebar's grouping); the additional `Archived` lane surfaces
+/// workspaces that have transitioned to `WorkspaceState::Archived`.
+///
+/// Wire format is kebab-case to match the existing
+/// `WorkspaceStatus` serialization, so the frontend can branch on the
+/// same string literals it already knows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum DashboardLaneId {
+    InProgress,
+    Review,
+    Done,
+    Backlog,
+    Canceled,
+    Archived,
+}
+
+impl DashboardLaneId {
+    pub const fn label(&self) -> &'static str {
+        match self {
+            Self::InProgress => "In progress",
+            Self::Review => "In review",
+            Self::Done => "Done",
+            Self::Backlog => "Backlog",
+            Self::Canceled => "Canceled",
+            Self::Archived => "Archived",
+        }
+    }
+
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::InProgress => "in-progress",
+            Self::Review => "review",
+            Self::Done => "done",
+            Self::Backlog => "backlog",
+            Self::Canceled => "canceled",
+            Self::Archived => "archived",
+        }
+    }
+
+    const fn from_status(status: WorkspaceStatus) -> Self {
+        match status {
+            WorkspaceStatus::InProgress => Self::InProgress,
+            WorkspaceStatus::Review => Self::Review,
+            WorkspaceStatus::Done => Self::Done,
+            WorkspaceStatus::Backlog => Self::Backlog,
+            WorkspaceStatus::Canceled => Self::Canceled,
+        }
+    }
+}
+
+/// One workspace card on the dashboard. Carries the full
+/// [`WorkspaceSummary`] (so the frontend can render the same metadata
+/// it already uses for sidebar hover-cards) plus a single live
+/// overlay: whether any Helmor session in this workspace currently
+/// has an active stream.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DashboardCard {
+    #[serde(flatten)]
+    pub workspace: WorkspaceSummary,
+    /// True when an `ActiveStreams` handle reports this workspace as
+    /// the target of an in-flight stream. Drives the per-card "busy"
+    /// indicator without forcing the frontend to cross-reference
+    /// `list_active_streams` itself.
+    pub is_streaming: bool,
+}
+
+/// A single column on the kanban board.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DashboardLane {
+    pub id: DashboardLaneId,
+    pub label: String,
+    pub cards: Vec<DashboardCard>,
+}
+
+/// Snapshot of the entire dashboard. Lanes are returned in a fixed
+/// display order; the frontend renders columns in iteration order
+/// and never needs to sort.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DashboardSnapshot {
+    pub lanes: Vec<DashboardLane>,
+}
+
+/// Build the dashboard snapshot from current DB state plus an
+/// `ActiveStreams` snapshot. Pure modulo the two DB reads — accepts
+/// the streams as an injected slice so unit tests don't need to spin
+/// up the `ActiveStreams` registry.
+pub fn build_dashboard_snapshot(
+    active_streams: &[ActiveStreamSummary],
+) -> Result<DashboardSnapshot> {
+    let active = workspace_models::load_workspace_records()?;
+    let archived = workspace_models::load_archived_workspace_records()?;
+    Ok(assemble_snapshot(active, archived, active_streams))
+}
+
+/// Pure shaping function — given the loaded workspace records and
+/// the active-stream snapshot, produce the lane projection. Split
+/// from `build_dashboard_snapshot` so tests can feed synthetic
+/// records without touching the DB pool.
+pub fn assemble_snapshot(
+    active_records: Vec<workspace_models::WorkspaceRecord>,
+    archived_records: Vec<workspace_models::WorkspaceRecord>,
+    active_streams: &[ActiveStreamSummary],
+) -> DashboardSnapshot {
+    let streaming_workspaces: HashSet<String> = active_streams
+        .iter()
+        .filter_map(|s| s.workspace_id.clone())
+        .collect();
+
+    let mut lanes: [(DashboardLaneId, Vec<DashboardCard>); 6] = [
+        (DashboardLaneId::InProgress, Vec::new()),
+        (DashboardLaneId::Review, Vec::new()),
+        (DashboardLaneId::Done, Vec::new()),
+        (DashboardLaneId::Backlog, Vec::new()),
+        (DashboardLaneId::Canceled, Vec::new()),
+        (DashboardLaneId::Archived, Vec::new()),
+    ];
+
+    for record in active_records {
+        // `load_workspace_records` returns every row regardless of
+        // state. Archived rows are handled by the dedicated pass
+        // below — skip them here so they don't double-count under
+        // their old `status` value.
+        if record.state == WorkspaceState::Archived {
+            continue;
+        }
+        let lane_id = DashboardLaneId::from_status(record.status);
+        let card = card_from_record(record, &streaming_workspaces);
+        push_into_lane(&mut lanes, lane_id, card);
+    }
+    for record in archived_records {
+        let card = card_from_record(record, &streaming_workspaces);
+        push_into_lane(&mut lanes, DashboardLaneId::Archived, card);
+    }
+
+    DashboardSnapshot {
+        lanes: lanes
+            .into_iter()
+            .map(|(id, cards)| DashboardLane {
+                id,
+                label: id.label().to_string(),
+                cards,
+            })
+            .collect(),
+    }
+}
+
+fn push_into_lane(
+    lanes: &mut [(DashboardLaneId, Vec<DashboardCard>); 6],
+    target: DashboardLaneId,
+    card: DashboardCard,
+) {
+    if let Some((_, cards)) = lanes.iter_mut().find(|(id, _)| *id == target) {
+        cards.push(card);
+    }
+}
+
+fn card_from_record(
+    record: workspace_models::WorkspaceRecord,
+    streaming_workspaces: &HashSet<String>,
+) -> DashboardCard {
+    let workspace_id = record.id.clone();
+    let workspace = record_to_summary(record);
+    DashboardCard {
+        is_streaming: streaming_workspaces.contains(&workspace_id),
+        workspace,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testkit::{insert_repo, insert_workspace, TestEnv, WorkspaceFixture};
+
+    /// Update a workspace's status column post-insert. The `testkit`
+    /// fixture inserts every row as `in-progress` (the production
+    /// default); the dashboard test cases need a way to set an
+    /// alternative status without duplicating that helper.
+    fn set_status(env: &TestEnv, workspace_id: &str, status: &str) {
+        env.db_connection()
+            .execute(
+                "UPDATE workspaces SET status = ?2 WHERE id = ?1",
+                rusqlite::params![workspace_id, status],
+            )
+            .unwrap();
+    }
+
+    fn set_state(env: &TestEnv, workspace_id: &str, state: &str) {
+        env.db_connection()
+            .execute(
+                "UPDATE workspaces SET state = ?2 WHERE id = ?1",
+                rusqlite::params![workspace_id, state],
+            )
+            .unwrap();
+    }
+
+    fn cards_in(snapshot: &DashboardSnapshot, lane: DashboardLaneId) -> Vec<String> {
+        snapshot
+            .lanes
+            .iter()
+            .find(|l| l.id == lane)
+            .map(|l| l.cards.iter().map(|c| c.workspace.id.clone()).collect())
+            .unwrap_or_default()
+    }
+
+    #[test]
+    fn snapshot_always_returns_all_six_lanes_in_stable_order() {
+        let _env = TestEnv::new("dashboard-empty");
+        let snapshot = build_dashboard_snapshot(&[]).unwrap();
+        assert_eq!(snapshot.lanes.len(), 6);
+        let ids: Vec<DashboardLaneId> = snapshot.lanes.iter().map(|l| l.id).collect();
+        assert_eq!(
+            ids,
+            vec![
+                DashboardLaneId::InProgress,
+                DashboardLaneId::Review,
+                DashboardLaneId::Done,
+                DashboardLaneId::Backlog,
+                DashboardLaneId::Canceled,
+                DashboardLaneId::Archived,
+            ]
+        );
+        // Empty dashboard — every lane has zero cards. The frontend
+        // renders empty-state placeholders, so it relies on lanes
+        // showing up even when nothing matches.
+        assert!(snapshot.lanes.iter().all(|l| l.cards.is_empty()));
+    }
+
+    #[test]
+    fn workspaces_are_grouped_by_status_and_archived_split_into_own_lane() {
+        let env = TestEnv::new("dashboard-grouping");
+        insert_repo(&env.db_connection(), "r1", "demo", None);
+        for (id, status, state) in [
+            ("w-progress", "in-progress", "ready"),
+            ("w-review", "review", "ready"),
+            ("w-done", "done", "ready"),
+            ("w-backlog", "backlog", "ready"),
+            ("w-canceled", "canceled", "ready"),
+            ("w-archived-1", "in-progress", "archived"),
+            ("w-archived-2", "done", "archived"),
+        ] {
+            insert_workspace(
+                &env.db_connection(),
+                &WorkspaceFixture {
+                    id,
+                    repo_id: "r1",
+                    directory_name: id,
+                    state: "ready",
+                    branch: Some("main"),
+                    intended_target_branch: Some("main"),
+                },
+            );
+            set_status(&env, id, status);
+            set_state(&env, id, state);
+        }
+
+        let snapshot = build_dashboard_snapshot(&[]).unwrap();
+
+        assert_eq!(
+            cards_in(&snapshot, DashboardLaneId::InProgress),
+            vec!["w-progress"]
+        );
+        assert_eq!(
+            cards_in(&snapshot, DashboardLaneId::Review),
+            vec!["w-review"]
+        );
+        assert_eq!(cards_in(&snapshot, DashboardLaneId::Done), vec!["w-done"]);
+        assert_eq!(
+            cards_in(&snapshot, DashboardLaneId::Backlog),
+            vec!["w-backlog"]
+        );
+        assert_eq!(
+            cards_in(&snapshot, DashboardLaneId::Canceled),
+            vec!["w-canceled"]
+        );
+
+        // Archived lane should include BOTH archived rows regardless
+        // of the status column they had before archival — the lane
+        // is keyed off `state`, not `status`.
+        let archived = cards_in(&snapshot, DashboardLaneId::Archived);
+        assert_eq!(archived.len(), 2);
+        assert!(archived.contains(&"w-archived-1".to_string()));
+        assert!(archived.contains(&"w-archived-2".to_string()));
+    }
+
+    #[test]
+    fn is_streaming_overlays_active_workspaces_only() {
+        let env = TestEnv::new("dashboard-streaming");
+        insert_repo(&env.db_connection(), "r1", "demo", None);
+        for id in ["w-a", "w-b", "w-c"] {
+            insert_workspace(
+                &env.db_connection(),
+                &WorkspaceFixture {
+                    id,
+                    repo_id: "r1",
+                    directory_name: id,
+                    state: "ready",
+                    branch: Some("main"),
+                    intended_target_branch: Some("main"),
+                },
+            );
+        }
+        // Two streams: one targets `w-a`, one has no `workspace_id`
+        // (the bootstrap race the snapshot guards against). `w-b` and
+        // `w-c` should both report `is_streaming: false`.
+        let streams = vec![
+            ActiveStreamSummary {
+                session_id: "s-a".into(),
+                workspace_id: Some("w-a".into()),
+                provider: "claude".into(),
+            },
+            ActiveStreamSummary {
+                session_id: "s-orphan".into(),
+                workspace_id: None,
+                provider: "codex".into(),
+            },
+        ];
+
+        let snapshot = build_dashboard_snapshot(&streams).unwrap();
+        let cards: Vec<(String, bool)> = snapshot
+            .lanes
+            .iter()
+            .find(|l| l.id == DashboardLaneId::InProgress)
+            .unwrap()
+            .cards
+            .iter()
+            .map(|c| (c.workspace.id.clone(), c.is_streaming))
+            .collect();
+
+        let by_id: std::collections::HashMap<_, _> = cards.into_iter().collect();
+        assert_eq!(by_id.get("w-a"), Some(&true));
+        assert_eq!(by_id.get("w-b"), Some(&false));
+        assert_eq!(by_id.get("w-c"), Some(&false));
+    }
+
+    #[test]
+    fn lane_id_kebab_case_serialization_matches_workspace_status() {
+        // The frontend's `WorkspaceStatus` type already uses kebab-case
+        // strings ("in-progress", "review", …). Locking down the same
+        // wire format on `DashboardLaneId` means the dashboard view
+        // can reuse the existing status-color / status-label helpers
+        // without a separate translation layer.
+        for (lane, wire) in [
+            (DashboardLaneId::InProgress, "in-progress"),
+            (DashboardLaneId::Review, "review"),
+            (DashboardLaneId::Done, "done"),
+            (DashboardLaneId::Backlog, "backlog"),
+            (DashboardLaneId::Canceled, "canceled"),
+            (DashboardLaneId::Archived, "archived"),
+        ] {
+            assert_eq!(lane.as_str(), wire);
+            let json = serde_json::to_string(&lane).unwrap();
+            assert_eq!(json, format!("\"{wire}\""));
+        }
+    }
+}

--- a/src-tauri/src/workspace/mod.rs
+++ b/src-tauri/src/workspace/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod archive;
 pub(crate) mod branching;
+pub mod dashboard;
 pub mod files;
 pub mod helpers;
 pub(crate) mod lifecycle;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -203,6 +203,35 @@ export type WorkspaceSummary = {
 	lastUserMessageAt?: string | null;
 };
 
+/** Dashboard kanban lane discriminator. Mirrors `WorkspaceStatus` for
+ *  the five live lanes and adds an `archived` lane for workspaces in
+ *  `WorkspaceState.Archived`. */
+export type DashboardLaneId =
+	| "in-progress"
+	| "review"
+	| "done"
+	| "backlog"
+	| "canceled"
+	| "archived";
+
+/** One dashboard card. The flattened `WorkspaceSummary` carries every
+ *  field the sidebar hover-card already exposes; `isStreaming` is the
+ *  one live overlay (true when any session in the workspace has an
+ *  in-flight agent stream). */
+export type DashboardCard = WorkspaceSummary & {
+	isStreaming: boolean;
+};
+
+export type DashboardLane = {
+	id: DashboardLaneId;
+	label: string;
+	cards: DashboardCard[];
+};
+
+export type DashboardSnapshot = {
+	lanes: DashboardLane[];
+};
+
 export type BranchPrefixType = "username" | "custom" | "none";
 
 export type RepositoryCreateOption = {
@@ -856,6 +885,22 @@ export async function loadArchivedWorkspaces(): Promise<WorkspaceSummary[]> {
 	} catch (error) {
 		throw new Error(
 			describeInvokeError(error, "Unable to load archived workspaces."),
+		);
+	}
+}
+
+/** Kanban projection for the dashboard view. Same workspace +
+ *  session aggregates as the sidebar, regrouped into status lanes,
+ *  with an `Archived` lane that pulls from `WorkspaceState.Archived`
+ *  rows. Each card carries an `isStreaming` overlay computed from
+ *  `ActiveStreams` so the frontend never has to cross-reference
+ *  `listActiveStreams` itself. */
+export async function loadDashboardSnapshot(): Promise<DashboardSnapshot> {
+	try {
+		return await invoke<DashboardSnapshot>("load_dashboard_snapshot");
+	} catch (error) {
+		throw new Error(
+			describeInvokeError(error, "Unable to load dashboard snapshot."),
 		);
 	}
 }

--- a/src/lib/query-client.ts
+++ b/src/lib/query-client.ts
@@ -35,6 +35,7 @@ import {
 	loadArchivedWorkspaces,
 	loadAutoCloseActionKinds,
 	loadAutoCloseOptInAsked,
+	loadDashboardSnapshot,
 	loadSessionThreadMessages,
 	loadWorkspaceDetail,
 	loadWorkspaceForgeActionStatus,
@@ -61,6 +62,7 @@ const PERSIST_GC_TIME = 24 * 60 * 60_000; // 24h — persisted entries live this
 export const helmorQueryKeys = {
 	workspaceGroups: ["workspaceGroups"] as const,
 	archivedWorkspaces: ["archivedWorkspaces"] as const,
+	dashboardSnapshot: ["dashboardSnapshot"] as const,
 	repositories: ["repositories"] as const,
 	agentModelSections: ["agentModelSections"] as const,
 	workspaceDetail: (workspaceId: string) =>
@@ -317,6 +319,22 @@ export function archivedWorkspacesQueryOptions() {
 		initialDataUpdatedAt: 0,
 		staleTime: 0,
 		meta: PERSIST_META,
+	});
+}
+
+/** Dashboard kanban projection. Event-driven via the existing
+ *  workspace / active-stream `UiMutationEvent`s — the bridge handler
+ *  invalidates this query alongside the sidebar queries so the
+ *  dashboard stays in lockstep with the rest of the app. */
+export function dashboardSnapshotQueryOptions() {
+	return queryOptions({
+		queryKey: helmorQueryKeys.dashboardSnapshot,
+		queryFn: loadDashboardSnapshot,
+		// `staleTime: 0` mirrors the sidebar groups query — the
+		// dashboard view should always re-validate on mount because
+		// workspace state can flip while the user is elsewhere in
+		// the app.
+		staleTime: 0,
 	});
 }
 

--- a/src/shell/hooks/use-ui-sync-bridge.ts
+++ b/src/shell/hooks/use-ui-sync-bridge.ts
@@ -35,6 +35,9 @@ function handleUiMutation(
 				predicate: (query) =>
 					query.queryKey[0] === "workspaceCandidateDirectories",
 			});
+			void queryClient.invalidateQueries({
+				queryKey: helmorQueryKeys.dashboardSnapshot,
+			});
 			return;
 		case "workspaceChanged":
 			requestSidebarReconcile(queryClient);
@@ -43,6 +46,9 @@ function handleUiMutation(
 			});
 			void queryClient.invalidateQueries({
 				queryKey: helmorQueryKeys.workspaceLinkedDirectories(event.workspaceId),
+			});
+			void queryClient.invalidateQueries({
+				queryKey: helmorQueryKeys.dashboardSnapshot,
 			});
 			return;
 		case "sessionListChanged":
@@ -185,6 +191,13 @@ function handleUiMutation(
 		case "activeStreamsChanged":
 			void queryClient.invalidateQueries({
 				queryKey: helmorQueryKeys.activeStreams,
+			});
+			// Dashboard cards carry an `isStreaming` overlay that's
+			// recomputed every time the active-streams set changes,
+			// so the dashboard projection needs the same invalidation
+			// the busy-badge fan-out gets.
+			void queryClient.invalidateQueries({
+				queryKey: helmorQueryKeys.dashboardSnapshot,
 			});
 			return;
 	}


### PR DESCRIPTION
## Summary

- Adds a typed `load_dashboard_snapshot` command that groups workspaces into kanban lanes (in-progress / review / done / backlog / canceled / archived) with a live `isStreaming` overlay per card.
- Reuses the same `load_workspace_records` + `load_archived_workspace_records` queries the sidebar already runs, so the dashboard never disagrees with the sidebar about a row's status / PR metadata / message counts.
- New `workspace::dashboard` module + `DashboardSnapshot` / `DashboardLane` / `DashboardCard` / `DashboardLaneId` types, mirrored on the frontend in `src/lib/api.ts`.
- Bridge handler invalidates the `dashboardSnapshot` query on `WorkspaceListChanged` / `WorkspaceChanged` / `ActiveStreamsChanged` so the dashboard stays in lockstep with the sidebar.

## Why

Closes #482 (backend slice — UI is the next PR in this track). The issue asks for a kanban view that groups existing workspaces by status; the data already exists on the workspace row, this PR just exposes it in the shape a dashboard card grid wants.

## Scope boundary

Included:
- `workspace::dashboard` module + `build_dashboard_snapshot` / `assemble_snapshot` (the second is a pure shaping helper so tests don't need to spin up the DB pool).
- `DashboardLaneId` kebab-case enum mirroring `WorkspaceStatus` plus an `Archived` lane; six lanes always returned in stable display order so the frontend renders columns in iteration order.
- `DashboardCard` flattens `WorkspaceSummary` and adds `isStreaming: bool` from `ActiveStreams::snapshot_for_ui`. Frontend never has to cross-reference `listActiveStreams` for the busy badge.
- `load_dashboard_snapshot` Tauri command + `loadDashboardSnapshot` TS wrapper + `dashboardSnapshotQueryOptions` factory.
- UI sync bridge: dashboard invalidates on the same events the sidebar listens for, plus on `ActiveStreamsChanged` so the streaming overlay stays live.

Deferred (intentionally out of scope):
- Dashboard UI rendering — that's the next PR in track E.
- Git change-line counts per workspace — those come from the heavy `workspace_action_status` path (one git subprocess per workspace). Better to fetch lazily per card on hover or per visible card.
- Project filtering server-side — every card already carries `repoId`, so the filter is a one-liner on the frontend.
- Drag-and-drop / status mutation / new task-management state — explicitly called out in the plan's review boundary.

## Test plan

- [x] `cd src-tauri && cargo nextest run` — 1158 / 1158 pass (4 new dashboard tests).
- [x] `cd src-tauri && cargo test --doc` — clean.
- [x] `cd src-tauri && cargo fmt --all -- --check` — clean.
- [x] `bun run lint` — biome + clippy `-D warnings` clean.
- [x] `bun run typecheck` — clean (new `DashboardSnapshot` / `DashboardLane` / `DashboardCard` / `DashboardLaneId` TS types).
- [x] `bun run test:frontend` — 1113 / 1113 pass (existing tests unchanged; new query options + bridge handler additions are tree-shaken from non-dashboard surfaces).

## Coverage added

New tests:
- `workspace::dashboard::tests::snapshot_always_returns_all_six_lanes_in_stable_order`
- `workspace::dashboard::tests::workspaces_are_grouped_by_status_and_archived_split_into_own_lane`
- `workspace::dashboard::tests::is_streaming_overlays_active_workspaces_only`
- `workspace::dashboard::tests::lane_id_kebab_case_serialization_matches_workspace_status`

The streaming test deliberately includes a defensive case for the rare boot race where an `ActiveStreamSummary` has `workspace_id: None` — the snapshot should treat those entries as unmatched rather than panic on `.unwrap()`.

## Follow-up

This is PR E1 in the dashboard track. E2 wires the actual UI: a route, a card grid using `dashboardSnapshotQueryOptions`, and a project filter chip set powered by `repoId` on each card.