### PR TITLE
fix: preserve restored workspace sidebar order

### DIFF
--- a/.changeset/swift-pandas-rest.md
+++ b/.changeset/swift-pandas-rest.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix the restored workspace briefly appearing in the wrong sidebar position before snapping into place once the refetch completes.

--- a/src/features/navigation/hooks/use-controller.ts
+++ b/src/features/navigation/hooks/use-controller.ts
@@ -52,7 +52,7 @@ import {
 	findInitialWorkspaceId,
 	findReplacementWorkspaceIdAfterRemoval,
 	hasWorkspaceId,
-	insertRowByCreatedAtDesc,
+	insertRowBySidebarOrder,
 	reorderWorkspaceInSidebar,
 	rowToWorkspaceSummary,
 	summaryToArchivedRow,
@@ -1590,16 +1590,18 @@ export function useWorkspacesSidebarController({
 				archivedSummary.status,
 				archivedSummary.pinnedAt,
 			);
-			// Sorted insert by createdAt DESC so the row lands where the server
-			// will place it on refetch — avoids the reorder flicker we'd get from
-			// unconditionally prepending.
+			// Sorted insert by `display_order ASC, created_at DESC` (same key the
+			// backend uses for live groups) so the row lands where the refetch
+			// will place it — avoids the reorder flicker we'd get from a naive
+			// prepend or a createdAt-only sort. The archived summary carries
+			// `displayOrder`, which restore_workspace_impl does NOT reset.
 			queryClient.setQueryData(helmorQueryKeys.workspaceGroups, (current) =>
 				Array.isArray(current)
 					? (current as typeof groups).map((group) =>
 							group.id === targetGroupId
 								? {
 										...group,
-										rows: insertRowByCreatedAtDesc(group.rows, placeholderRow),
+										rows: insertRowBySidebarOrder(group.rows, placeholderRow),
 									}
 								: group,
 						)

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -196,6 +196,10 @@ export type WorkspaceSummary = {
 	prSyncState?: PrSyncState;
 	prUrl?: string | null;
 	pinnedAt?: string | null;
+	/** Sparse sidebar order. Mirrors `WorkspaceRow.displayOrder`; carried
+	 * through the archived list so restore can predict the live-group
+	 * position without waiting for refetch. */
+	displayOrder?: number;
 	sessionCount?: number;
 	messageCount?: number;
 	createdAt: string;

--- a/src/lib/workspace-helpers.test.ts
+++ b/src/lib/workspace-helpers.test.ts
@@ -14,7 +14,7 @@ import {
 	findReplacementWorkspaceIdAfterRemoval,
 	getWorkspaceBranchTone,
 	inferDefaultModelId,
-	insertRowByCreatedAtDesc,
+	insertRowBySidebarOrder,
 	isNewSession,
 	moveWorkspaceToGroup,
 	reorderWorkspaceInSidebar,
@@ -166,57 +166,91 @@ describe("workspaceGroupIdFromStatus", () => {
 	});
 });
 
-describe("insertRowByCreatedAtDesc", () => {
-	const row = (id: string, createdAt?: string): WorkspaceRow => ({
+describe("insertRowBySidebarOrder", () => {
+	const row = (
+		id: string,
+		createdAt?: string,
+		displayOrder?: number,
+	): WorkspaceRow => ({
 		id,
 		title: id,
 		...(createdAt ? { createdAt } : {}),
+		...(displayOrder !== undefined ? { displayOrder } : {}),
 	});
 
-	it("inserts at the correct position to preserve DESC order", () => {
+	it("falls back to createdAt DESC when displayOrder ties (all zero)", () => {
 		const rows = [
 			row("a", "2024-03-01T00:00:00Z"),
 			row("b", "2024-02-01T00:00:00Z"),
 			row("c", "2024-01-01T00:00:00Z"),
 		];
-		const inserted = insertRowByCreatedAtDesc(
+		const inserted = insertRowBySidebarOrder(
 			rows,
 			row("new", "2024-02-15T00:00:00Z"),
 		);
 		expect(inserted.map((r) => r.id)).toEqual(["a", "new", "b", "c"]);
 	});
 
-	it("appends when new row is the oldest", () => {
+	it("appends when new row is the oldest under createdAt fallback", () => {
 		const rows = [
 			row("a", "2024-03-01T00:00:00Z"),
 			row("b", "2024-02-01T00:00:00Z"),
 		];
-		const inserted = insertRowByCreatedAtDesc(
+		const inserted = insertRowBySidebarOrder(
 			rows,
 			row("new", "2023-01-01T00:00:00Z"),
 		);
 		expect(inserted.map((r) => r.id)).toEqual(["a", "b", "new"]);
 	});
 
-	it("prepends when new row is the newest", () => {
+	it("prepends when new row is the newest under createdAt fallback", () => {
 		const rows = [
 			row("a", "2024-03-01T00:00:00Z"),
 			row("b", "2024-02-01T00:00:00Z"),
 		];
-		const inserted = insertRowByCreatedAtDesc(
+		const inserted = insertRowBySidebarOrder(
 			rows,
 			row("new", "2025-01-01T00:00:00Z"),
 		);
 		expect(inserted.map((r) => r.id)).toEqual(["new", "a", "b"]);
 	});
 
-	it("treats a missing createdAt as newest", () => {
+	it("treats a missing createdAt as oldest under createdAt fallback (mirrors backend NULL DESC)", () => {
 		const rows = [
 			row("a", "2024-03-01T00:00:00Z"),
 			row("b", "2024-02-01T00:00:00Z"),
 		];
-		const inserted = insertRowByCreatedAtDesc(rows, row("new"));
-		expect(inserted.map((r) => r.id)).toEqual(["new", "a", "b"]);
+		const inserted = insertRowBySidebarOrder(rows, row("new"));
+		expect(inserted.map((r) => r.id)).toEqual(["a", "b", "new"]);
+	});
+
+	it("respects displayOrder ASC over createdAt", () => {
+		// Backend order: display_order ASC, created_at DESC.
+		const rows = [
+			row("a", "2024-01-01T00:00:00Z", 1024),
+			row("b", "2024-02-01T00:00:00Z", 2048),
+			row("c", "2024-03-01T00:00:00Z", 3072),
+		];
+		// Restored row has an old createdAt but mid displayOrder — it must
+		// land between `a` and `b`, not at the top (createdAt would put it
+		// last) and not at the bottom.
+		const inserted = insertRowBySidebarOrder(
+			rows,
+			row("new", "2020-01-01T00:00:00Z", 1536),
+		);
+		expect(inserted.map((r) => r.id)).toEqual(["a", "new", "b", "c"]);
+	});
+
+	it("appends when displayOrder is higher than every existing row", () => {
+		const rows = [
+			row("a", "2024-01-01T00:00:00Z", 1024),
+			row("b", "2024-02-01T00:00:00Z", 2048),
+		];
+		const inserted = insertRowBySidebarOrder(
+			rows,
+			row("new", "2030-01-01T00:00:00Z", 5000),
+		);
+		expect(inserted.map((r) => r.id)).toEqual(["a", "b", "new"]);
 	});
 });
 

--- a/src/lib/workspace-helpers.ts
+++ b/src/lib/workspace-helpers.ts
@@ -184,21 +184,19 @@ export function workspaceStatusFromGroupId(
 }
 
 /**
- * Insert `row` into `rows` preserving `createdAt DESC` order (matching the
- * backend's `ORDER BY datetime(created_at) DESC` for non-archived groups).
- * Used for optimistic insertions — placing the row in its final spot avoids
- * the reorder flicker that happens when the refetch returns and re-sorts.
- *
- * Rows without a `createdAt` are treated as newest (sort to the front), so
- * freshly-created workspaces still land at the top as before.
+ * Insert `row` into `rows` preserving the backend's sidebar order for
+ * non-archived groups: `display_order ASC, created_at DESC`. Mirrors
+ * `load_workspace_records` so optimistic inserts land in their final spot
+ * and the refetch doesn't visibly reshuffle. Missing `displayOrder` is
+ * treated as 0; missing `createdAt` as newest.
  */
-export function insertRowByCreatedAtDesc(
+export function insertRowBySidebarOrder(
 	rows: WorkspaceRow[],
 	row: WorkspaceRow,
 ): WorkspaceRow[] {
-	const key = (r: WorkspaceRow): string => r.createdAt ?? "\uFFFF";
-	const incoming = key(row);
-	const index = rows.findIndex((existing) => key(existing) < incoming);
+	const index = rows.findIndex(
+		(existing) => compareSidebarOrder(existing, row) > 0,
+	);
 	if (index === -1) return [...rows, row];
 	return [...rows.slice(0, index), row, ...rows.slice(index)];
 }
@@ -206,7 +204,7 @@ export function insertRowByCreatedAtDesc(
 /**
  * Move a workspace row from its current sidebar group to the group implied by
  * `nextStatus`. Preserves the row's existing fields (createdAt, pinnedAt, …)
- * and uses `insertRowByCreatedAtDesc` so the optimistic position matches the
+ * and uses `insertRowBySidebarOrder` so the optimistic position matches the
  * spot the server will place the row on refetch — no reorder flicker.
  *
  * Returns `groups` unchanged when the workspace isn't in any live group
@@ -238,7 +236,7 @@ export function moveWorkspaceToGroup(
 
 	return stripped.map((group) =>
 		group.id === targetGroupId
-			? { ...group, rows: insertRowByCreatedAtDesc(group.rows, updatedRow) }
+			? { ...group, rows: insertRowBySidebarOrder(group.rows, updatedRow) }
 			: group,
 	);
 }
@@ -622,6 +620,7 @@ export function summaryToArchivedRow(summary: WorkspaceSummary): WorkspaceRow {
 		primarySessionAgentType: summary.primarySessionAgentType ?? null,
 		prTitle: summary.prTitle ?? null,
 		pinnedAt: summary.pinnedAt ?? null,
+		displayOrder: summary.displayOrder,
 		sessionCount: summary.sessionCount,
 		messageCount: summary.messageCount,
 		createdAt: summary.createdAt,
@@ -730,6 +729,7 @@ export function rowToWorkspaceSummary(
 		primarySessionAgentType: row.primarySessionAgentType ?? null,
 		prTitle: row.prTitle ?? null,
 		pinnedAt: row.pinnedAt ?? null,
+		displayOrder: row.displayOrder,
 		sessionCount: row.sessionCount,
 		messageCount: row.messageCount,
 		createdAt: row.createdAt ?? new Date().toISOString(),


### PR DESCRIPTION
## What changed
- Preserved `displayOrder` when converting workspace rows to archived summaries and back.
- Updated optimistic restore insertion to use the backend sidebar ordering key: `display_order ASC, created_at DESC`.
- Added focused helper tests and a patch changeset.

## Why
Restored workspaces could briefly appear in the wrong sidebar position before the refetch completed and snapped them into place. Matching the backend sort order locally removes that visual reorder.

## Follow-up / test notes
- Pre-commit ran `biome check --write` on staged frontend files.
- No full test suite was run during PR creation.