### PR TITLE
Fix staged and unstaged diff bases

### DIFF
--- a/.changeset/brisk-pumas-divide.md
+++ b/.changeset/brisk-pumas-divide.md
@@ -1,0 +1,8 @@
+---
+"helmor": patch
+---
+
+Fix the inspector's Staged Changes / Changes diff when the same file appears in both areas:
+- Each area now shows its own diff (HEAD ↔ index for Staged, index ↔ working tree for Unstaged) instead of a combined HEAD ↔ working-tree view that mixed both.
+- Clicking the same file across the two areas now actually switches the diff, and the selection highlight only marks the row whose diff is open.
+- Opening a file from a chat link no longer inherits stale bytes from a diff view, closing a path where saving could overwrite unstaged edits.

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -94,6 +94,32 @@ where
     handle_git_output(output)
 }
 
+/// Like `run_git`, but returns stdout **verbatim** (no trimming). Use this
+/// when stdout *is* the payload — e.g. `git show <ref>:<path>` reading a
+/// file's bytes — where a trailing newline is part of the file, not shell
+/// noise. The standard `run_git` trims, which is right for status/rev-parse
+/// lines but wrong for file content (a trimmed file content makes every
+/// diff editor show a spurious "trailing newline" delta against the
+/// working-tree side).
+pub fn run_git_capture<I, S>(args: I, current_dir: Option<&Path>) -> Result<String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let mut command = Command::new("git");
+
+    for arg in args {
+        command.arg(arg.as_ref());
+    }
+
+    if let Some(current_dir) = current_dir {
+        command.current_dir(current_dir);
+    }
+
+    let output = command.output().context("Failed to run git")?;
+    handle_git_output_raw(output)
+}
+
 /// Run `git` with a hard wall-clock timeout and an environment that locks
 /// down every interactive prompt path. Use this for any command that may
 /// contact a remote (`fetch`, `pull`, `push`, `ls-remote`, …) — without it,
@@ -204,7 +230,20 @@ fn handle_git_output(output: Output) -> Result<String> {
     if output.status.success() {
         return Ok(String::from_utf8_lossy(&output.stdout).trim().to_string());
     }
+    handle_git_failure(output)
+}
 
+/// Same failure handling as `handle_git_output`, but on success returns
+/// stdout **without** trimming. Pair with `run_git_capture` for callers
+/// that need byte-faithful output (e.g. file content from `git show`).
+fn handle_git_output_raw(output: Output) -> Result<String> {
+    if output.status.success() {
+        return Ok(String::from_utf8_lossy(&output.stdout).into_owned());
+    }
+    handle_git_failure(output)
+}
+
+fn handle_git_failure(output: Output) -> Result<String> {
     let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
     let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
     let detail = if !stderr.is_empty() {

--- a/src-tauri/src/workspace/files/editor.rs
+++ b/src-tauri/src/workspace/files/editor.rs
@@ -49,7 +49,10 @@ pub fn read_file_at_ref(
     let relative_str = relative.to_string_lossy().replace('\\', "/");
 
     let object = format!("{git_ref}:{relative_str}");
-    match crate::git_ops::run_git(["show", &object], Some(workspace_root)) {
+    // Use `run_git_capture` (NOT `run_git`) so the file's trailing newline is
+    // preserved — `run_git` trims, which would make every diff against the
+    // working-tree side show a phantom "trailing newline" delta.
+    match crate::git_ops::run_git_capture(["show", &object], Some(workspace_root)) {
         Ok(content) => Ok(Some(content)),
         Err(_) => Ok(None),
     }

--- a/src-tauri/src/workspace/files/tests/mod.rs
+++ b/src-tauri/src/workspace/files/tests/mod.rs
@@ -1,4 +1,5 @@
 mod editor_files;
+mod read_file_at_ref;
 mod support;
 mod workspace_changes;
 mod workspace_targets;
@@ -7,5 +8,5 @@ pub(super) use super::changes::{parse_workspace_path, query_workspace_target, re
 pub(super) use super::support::canonicalize_missing_path;
 pub(super) use super::{
     list_editor_files, list_workspace_changes, list_workspace_files, read_editor_file,
-    stat_editor_file, write_editor_file, EditorFileListItem,
+    read_file_at_ref, stat_editor_file, write_editor_file, EditorFileListItem,
 };

--- a/src-tauri/src/workspace/files/tests/read_file_at_ref.rs
+++ b/src-tauri/src/workspace/files/tests/read_file_at_ref.rs
@@ -1,0 +1,104 @@
+//! Tests for `read_file_at_ref` — specifically the three diff bases used by
+//! the inspector:
+//!   - "HEAD" → HEAD ref (staged area's original side, committed-diff base)
+//!   - ":0" → git stage 0 (index), used as the modified side of the staged
+//!     area AND the original side of the unstaged area
+//!   - working-tree reads are NOT covered here (they go through
+//!     `read_editor_file`, not `read_file_at_ref`)
+//!
+//! Regression cover for issue #544: same file in both Staged and Unstaged
+//! produced a `HEAD ↔ working-tree` diff because the unstaged side never
+//! asked for the index version. With `:0` plumbed through, each area now
+//! reads its own base ref.
+
+use super::{read_file_at_ref, support::GitRepoHarness};
+
+#[test]
+fn reads_file_at_head_ref() {
+    let repo = GitRepoHarness::new();
+    repo.write_file("src/app.ts", "const v1 = true;\n");
+    repo.git(&["add", "src/app.ts"]);
+    repo.git(&["commit", "-m", "add app"]);
+    // Subsequent edits must not leak into HEAD.
+    repo.write_file("src/app.ts", "const v2 = true;\n");
+    repo.git(&["add", "src/app.ts"]);
+    repo.write_file("src/app.ts", "const v3 = true;\n");
+
+    let absolute = format!("{}/src/app.ts", repo.path_str());
+    let content = read_file_at_ref(repo.path_str(), &absolute, "HEAD")
+        .unwrap()
+        .expect("file must exist at HEAD");
+    assert_eq!(content, "const v1 = true;\n");
+}
+
+#[test]
+fn reads_file_at_index_ref() {
+    let repo = GitRepoHarness::new();
+    repo.write_file("src/app.ts", "const v1 = true;\n");
+    repo.git(&["add", "src/app.ts"]);
+    repo.git(&["commit", "-m", "add app"]);
+    // Stage a modification, then make an unstaged change on top. The index
+    // must hold the staged version (v2), distinct from HEAD (v1) and from
+    // the working tree (v3).
+    repo.write_file("src/app.ts", "const v2 = true;\n");
+    repo.git(&["add", "src/app.ts"]);
+    repo.write_file("src/app.ts", "const v3 = true;\n");
+
+    let absolute = format!("{}/src/app.ts", repo.path_str());
+    let content = read_file_at_ref(repo.path_str(), &absolute, ":0")
+        .unwrap()
+        .expect("file must exist in the index");
+    assert_eq!(content, "const v2 = true;\n");
+}
+
+#[test]
+fn head_index_and_worktree_yield_distinct_content() {
+    // The whole point of the fix: the three areas must read different bytes
+    // when a file lives in all three "stages" with different content.
+    let repo = GitRepoHarness::new();
+    repo.write_file("foo.txt", "head\n");
+    repo.git(&["add", "foo.txt"]);
+    repo.git(&["commit", "-m", "init foo"]);
+    repo.write_file("foo.txt", "index\n");
+    repo.git(&["add", "foo.txt"]);
+    repo.write_file("foo.txt", "worktree\n");
+
+    let absolute = format!("{}/foo.txt", repo.path_str());
+    let head = read_file_at_ref(repo.path_str(), &absolute, "HEAD")
+        .unwrap()
+        .unwrap();
+    let index = read_file_at_ref(repo.path_str(), &absolute, ":0")
+        .unwrap()
+        .unwrap();
+    assert_eq!(head, "head\n");
+    assert_eq!(index, "index\n");
+    // The working-tree side is the editor's job — we just confirm git did
+    // not bleed working-tree bytes into either ref view.
+    assert_ne!(head, index);
+}
+
+#[test]
+fn returns_none_when_path_not_in_index() {
+    // Untracked file → `git show :0:path` fails → caller gets None. The
+    // unstaged area relies on this when status=="A" (we skip reading the
+    // original side anyway, but defense in depth).
+    let repo = GitRepoHarness::new();
+    repo.write_file("untracked.txt", "fresh\n");
+
+    let absolute = format!("{}/untracked.txt", repo.path_str());
+    let result = read_file_at_ref(repo.path_str(), &absolute, ":0").unwrap();
+    assert!(result.is_none());
+}
+
+#[test]
+fn returns_none_when_path_not_in_head() {
+    // Staged-but-not-committed file → `git show HEAD:path` fails. The staged
+    // area relies on this when stagedStatus=="A".
+    let repo = GitRepoHarness::new();
+    repo.write_file("new.txt", "added\n");
+    repo.git(&["add", "new.txt"]);
+
+    let absolute = format!("{}/new.txt", repo.path_str());
+    let result = read_file_at_ref(repo.path_str(), &absolute, "HEAD").unwrap();
+    assert!(result.is_none());
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1592,7 +1592,15 @@ function AppShell({
 												selectedWorkspaceDetailQuery.data ?? null
 											}
 											displayedSessionId={displayedSessionId}
-											editorSessionPath={editorSession?.path ?? null}
+											activeEditor={
+												editorSession
+													? {
+															path: editorSession.path,
+															originalRef: editorSession.originalRef,
+															modifiedRef: editorSession.modifiedRef,
+														}
+													: null
+											}
 											onOpenEditorFile={handleOpenEditorFile}
 											onCommitAction={handleCommitAction}
 											onReviewAction={() =>

--- a/src/features/inspector/index.tsx
+++ b/src/features/inspector/index.tsx
@@ -8,7 +8,7 @@ import {
 	useAppShortcuts,
 } from "@/features/shortcuts/use-app-shortcuts";
 import type { ChangeRequestInfo } from "@/lib/api";
-import type { DiffOpenOptions } from "@/lib/editor-session";
+import type { ActiveEditorTarget, DiffOpenOptions } from "@/lib/editor-session";
 import { useSettings } from "@/lib/settings";
 import { cn } from "@/lib/utils";
 import { useWorkspaceInspectorSidebar } from "./hooks/use-inspector";
@@ -44,7 +44,7 @@ type WorkspaceInspectorSidebarProps = {
 	 * and the "default to Run tab" behaviour after restart. */
 	workspaceSetupCompletedAt?: string | null;
 	editorMode: boolean;
-	activeEditorPath?: string | null;
+	activeEditor?: ActiveEditorTarget | null;
 	onOpenEditorFile(path: string, options?: DiffOpenOptions): void;
 	onOpenMockReview?: (path: string) => void;
 	onCommitAction?: (mode: WorkspaceCommitButtonMode) => Promise<void>;
@@ -79,7 +79,7 @@ export function WorkspaceInspectorSidebar({
 	workspaceSetupCompletedAt,
 	repoId,
 	editorMode,
-	activeEditorPath,
+	activeEditor,
 	onOpenEditorFile,
 	onCommitAction,
 	onReviewAction,
@@ -399,7 +399,7 @@ export function WorkspaceInspectorSidebar({
 				workspaceTargetBranch={workspaceTargetBranch ?? null}
 				changes={changes}
 				editorMode={editorMode}
-				activeEditorPath={activeEditorPath}
+				activeEditor={activeEditor}
 				onOpenEditorFile={onOpenEditorFile}
 				flashingPaths={flashingPaths}
 				onCommitAction={onCommitAction}

--- a/src/features/inspector/sections/changes.tsx
+++ b/src/features/inspector/sections/changes.tsx
@@ -42,7 +42,13 @@ import {
 	type ForgeDetection,
 	revealPathInFinder,
 } from "@/lib/api";
-import type { DiffOpenOptions, InspectorFileItem } from "@/lib/editor-session";
+import {
+	type ActiveEditorTarget,
+	type DiffOpenOptions,
+	INDEX_REF,
+	type InspectorFileItem,
+	isActiveEditorTarget,
+} from "@/lib/editor-session";
 import {
 	helmorQueryKeys,
 	workspaceForgeActionStatusQueryOptions,
@@ -82,7 +88,7 @@ type ChangesSectionProps = {
 	workspaceTargetBranch: string | null;
 	changes: InspectorFileItem[];
 	editorMode: boolean;
-	activeEditorPath?: string | null;
+	activeEditor?: ActiveEditorTarget | null;
 	onOpenEditorFile: (path: string, options?: DiffOpenOptions) => void;
 	flashingPaths: Set<string>;
 	onCommitAction?: (mode: WorkspaceCommitButtonMode) => Promise<void>;
@@ -107,7 +113,7 @@ export function ChangesSection({
 	workspaceTargetBranch,
 	changes,
 	editorMode,
-	activeEditorPath,
+	activeEditor,
 	onOpenEditorFile,
 	flashingPaths,
 	onCommitAction,
@@ -304,11 +310,13 @@ export function ChangesSection({
 								onStageAction={unstageFile}
 								onBatchAction={unstageAll}
 								editorMode={editorMode}
-								activeEditorPath={activeEditorPath}
+								activeEditor={activeEditor}
 								onOpenEditorFile={onOpenEditorFile}
 								flashingPaths={flashingPaths}
 								workspaceBranch={workspaceBranch}
 								workspaceRemoteUrl={workspaceRemoteUrl}
+								originalRef="HEAD"
+								modifiedRef={INDEX_REF}
 							/>
 						)}
 						{unstagedChanges.length > 0 && (
@@ -331,11 +339,12 @@ export function ChangesSection({
 								onBatchAction={stageAll}
 								onDiscard={discardFile}
 								editorMode={editorMode}
-								activeEditorPath={activeEditorPath}
+								activeEditor={activeEditor}
 								onOpenEditorFile={onOpenEditorFile}
 								flashingPaths={flashingPaths}
 								workspaceBranch={workspaceBranch}
 								workspaceRemoteUrl={workspaceRemoteUrl}
+								originalRef={INDEX_REF}
 							/>
 						)}
 					</>
@@ -352,7 +361,7 @@ export function ChangesSection({
 						treeView={branchDiffTreeView}
 						onToggleTreeView={() => toggleBranchDiffTreeView()}
 						editorMode={editorMode}
-						activeEditorPath={activeEditorPath}
+						activeEditor={activeEditor}
 						onOpenEditorFile={onOpenEditorFile}
 						flashingPaths={flashingPaths}
 						workspaceBranch={workspaceBranch}
@@ -386,11 +395,13 @@ function ChangesGroup({
 	onBatchAction,
 	onDiscard,
 	editorMode,
-	activeEditorPath,
+	activeEditor,
 	onOpenEditorFile,
 	flashingPaths,
 	workspaceBranch,
 	workspaceRemoteUrl,
+	originalRef,
+	modifiedRef,
 }: {
 	label: string;
 	icon?: React.ReactNode;
@@ -405,12 +416,37 @@ function ChangesGroup({
 	onBatchAction?: () => void;
 	onDiscard?: (path: string) => void;
 	editorMode: boolean;
-	activeEditorPath?: string | null;
+	activeEditor?: ActiveEditorTarget | null;
 	onOpenEditorFile: (path: string, options?: DiffOpenOptions) => void;
 	flashingPaths: Set<string>;
 	workspaceBranch: string | null;
 	workspaceRemoteUrl: string | null;
+	/** Git ref for the original (left) side. Staged → "HEAD"; Unstaged → INDEX_REF. */
+	originalRef?: string;
+	/** Git ref for the modified (right) side. Staged → INDEX_REF; Unstaged → undefined
+	 * (so the editor reads the working tree from disk). */
+	modifiedRef?: string;
 }) {
+	const handleOpenFile = useCallback(
+		(path: string, options?: DiffOpenOptions) => {
+			onOpenEditorFile(path, {
+				fileStatus: options?.fileStatus ?? "M",
+				originalRef,
+				modifiedRef,
+			});
+		},
+		[onOpenEditorFile, originalRef, modifiedRef],
+	);
+	// Same file can appear in Staged AND Unstaged. The selection highlight
+	// belongs to whichever area's bases match the open editor — comparing
+	// path alone lights up both rows simultaneously.
+	const activeEditorPath = isActiveEditorTarget(
+		activeEditor,
+		originalRef,
+		modifiedRef,
+	)
+		? activeEditor.path
+		: null;
 	return (
 		<div>
 			<div className="group/header flex w-full items-center gap-1 py-1 pl-1 pr-2 text-[11.5px] font-semibold tracking-[-0.01em] text-muted-foreground">
@@ -463,7 +499,7 @@ function ChangesGroup({
 							changes={changes}
 							editorMode={editorMode}
 							activeEditorPath={activeEditorPath}
-							onOpenEditorFile={onOpenEditorFile}
+							onOpenEditorFile={handleOpenFile}
 							flashingPaths={flashingPaths}
 							action={action}
 							onStageAction={onStageAction}
@@ -476,7 +512,7 @@ function ChangesGroup({
 							changes={changes}
 							editorMode={editorMode}
 							activeEditorPath={activeEditorPath}
-							onOpenEditorFile={onOpenEditorFile}
+							onOpenEditorFile={handleOpenFile}
 							flashingPaths={flashingPaths}
 							action={action}
 							onStageAction={onStageAction}
@@ -501,7 +537,7 @@ function BranchDiffSection({
 	treeView,
 	onToggleTreeView,
 	editorMode,
-	activeEditorPath,
+	activeEditor,
 	onOpenEditorFile,
 	flashingPaths,
 	workspaceBranch,
@@ -516,22 +552,31 @@ function BranchDiffSection({
 	treeView: boolean;
 	onToggleTreeView: () => void;
 	editorMode: boolean;
-	activeEditorPath?: string | null;
+	activeEditor?: ActiveEditorTarget | null;
 	onOpenEditorFile: (path: string, options?: DiffOpenOptions) => void;
 	flashingPaths: Set<string>;
 	workspaceBranch: string | null;
 	workspaceRemoteUrl: string | null;
 }) {
+	const remoteOriginalRef = targetBranch ?? undefined;
+	const remoteModifiedRef = "HEAD";
 	const handleOpenFile = useCallback(
 		(path: string, options?: DiffOpenOptions) => {
 			onOpenEditorFile(path, {
 				fileStatus: options?.fileStatus ?? "M",
-				originalRef: targetBranch ?? undefined,
-				modifiedRef: "HEAD",
+				originalRef: remoteOriginalRef,
+				modifiedRef: remoteModifiedRef,
 			});
 		},
-		[onOpenEditorFile, targetBranch],
+		[onOpenEditorFile, remoteOriginalRef, remoteModifiedRef],
 	);
+	const activeEditorPath = isActiveEditorTarget(
+		activeEditor,
+		remoteOriginalRef,
+		remoteModifiedRef,
+	)
+		? activeEditor.path
+		: null;
 
 	return (
 		<div>

--- a/src/lib/editor-session.test.ts
+++ b/src/lib/editor-session.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { isMarkdownPath } from "./editor-session";
+import {
+	INDEX_REF,
+	isActiveEditorTarget,
+	isMarkdownPath,
+} from "./editor-session";
 
 describe("isMarkdownPath", () => {
 	it("matches common markdown extensions", () => {
@@ -23,5 +27,49 @@ describe("isMarkdownPath", () => {
 	it("does not match files that merely contain '.md' in the name", () => {
 		expect(isMarkdownPath("md-utils.ts")).toBe(false);
 		expect(isMarkdownPath("foo.md.bak")).toBe(false);
+	});
+});
+
+describe("isActiveEditorTarget", () => {
+	// Regression cover for issue #544 follow-up: same file in both Staged
+	// and Unstaged must light up exactly one row, not both. The selection
+	// test is "does the open editor's diff base match THIS area's refs?".
+	it("returns false when target is null/undefined", () => {
+		expect(isActiveEditorTarget(null, "HEAD", INDEX_REF)).toBe(false);
+		expect(isActiveEditorTarget(undefined, "HEAD", INDEX_REF)).toBe(false);
+	});
+
+	it("matches staged area's bases (HEAD ↔ INDEX) only", () => {
+		const target = {
+			path: "/ws/foo.txt",
+			originalRef: "HEAD",
+			modifiedRef: INDEX_REF,
+		};
+		// Same path opened from Staged → matches Staged refs.
+		expect(isActiveEditorTarget(target, "HEAD", INDEX_REF)).toBe(true);
+		// Same path, but Unstaged refs → must NOT match.
+		expect(isActiveEditorTarget(target, INDEX_REF, undefined)).toBe(false);
+	});
+
+	it("matches unstaged area's bases (INDEX ↔ worktree) only", () => {
+		const target = {
+			path: "/ws/foo.txt",
+			originalRef: INDEX_REF,
+			modifiedRef: undefined,
+		};
+		expect(isActiveEditorTarget(target, INDEX_REF, undefined)).toBe(true);
+		expect(isActiveEditorTarget(target, "HEAD", INDEX_REF)).toBe(false);
+	});
+
+	it("treats undefined modifiedRef as a real value (strict equality)", () => {
+		// The unstaged area passes modifiedRef=undefined ("read from disk").
+		// We rely on `===`, NOT loose truthiness, so an open editor with a
+		// real modifiedRef of "" or null does NOT collide with undefined.
+		const target = {
+			path: "/ws/foo.txt",
+			originalRef: INDEX_REF,
+			modifiedRef: undefined,
+		};
+		expect(isActiveEditorTarget(target, INDEX_REF, "")).toBe(false);
 	});
 });

--- a/src/lib/editor-session.ts
+++ b/src/lib/editor-session.ts
@@ -1,10 +1,45 @@
 export type DiffFileStatus = "M" | "A" | "D";
 
+/** Git stage-0 (clean index) syntax. `read_file_at_ref` concatenates
+ * `<ref>:<path>`, so passing `":0"` yields `:0:<path>` — the canonical
+ * way to read a file's staged content. Used by the unstaged area as its
+ * diff base, and by the staged area as its modified side. */
+export const INDEX_REF = ":0";
+
 export type DiffOpenOptions = {
 	fileStatus: DiffFileStatus;
 	originalRef?: string;
 	modifiedRef?: string;
 };
+
+/** What the inspector knows about the open editor target. We carry the
+ * diff bases (not just the path) so that "same file opened from Staged"
+ * vs "same file opened from Unstaged" can render as distinct selections —
+ * comparing path alone highlights both rows at once. Null when no file is
+ * open. */
+export type ActiveEditorTarget = {
+	path: string;
+	originalRef?: string;
+	modifiedRef?: string;
+};
+
+/** Returns true when the open editor's diff bases match the supplied
+ * area refs. Used by inspector groups to decide whether *their* row for
+ * a given path should render selected — comparing path alone breaks down
+ * when the same file lives in multiple areas (Staged + Unstaged) with
+ * different bases. Refs are compared strictly so `undefined`
+ * ("read modified side from disk") matches itself. */
+export function isActiveEditorTarget(
+	target: ActiveEditorTarget | null | undefined,
+	originalRef: string | undefined,
+	modifiedRef: string | undefined,
+): target is ActiveEditorTarget {
+	return (
+		!!target &&
+		target.originalRef === originalRef &&
+		target.modifiedRef === modifiedRef
+	);
+}
 
 /** "source" = Monaco editor; "preview" = rendered streamdown view. Only meaningful for markdown paths. */
 export type EditorViewMode = "source" | "preview";

--- a/src/shell/components/shell-inspector-pane.tsx
+++ b/src/shell/components/shell-inspector-pane.tsx
@@ -13,7 +13,7 @@ import type {
 	RepositoryCreateOption,
 	WorkspaceDetail,
 } from "@/lib/api";
-import type { DiffOpenOptions } from "@/lib/editor-session";
+import type { ActiveEditorTarget, DiffOpenOptions } from "@/lib/editor-session";
 import type { WorkspaceRightSidebarMode } from "@/lib/settings";
 import type { ContextCard } from "@/lib/sources/types";
 import { cn } from "@/lib/utils";
@@ -48,7 +48,7 @@ type Props = {
 	workspaceRootPath: string | null;
 	selectedWorkspaceDetail: WorkspaceDetail | null;
 	displayedSessionId: string | null;
-	editorSessionPath: string | null;
+	activeEditor: ActiveEditorTarget | null;
 	onOpenEditorFile: (path: string, options?: DiffOpenOptions) => void;
 	onCommitAction: (mode: WorkspaceCommitButtonMode) => Promise<void>;
 	onReviewAction: () => Promise<void>;
@@ -83,7 +83,7 @@ export function ShellInspectorPane({
 	workspaceRootPath,
 	selectedWorkspaceDetail,
 	displayedSessionId,
-	editorSessionPath,
+	activeEditor,
 	onOpenEditorFile,
 	onCommitAction,
 	onReviewAction,
@@ -167,7 +167,7 @@ export function ShellInspectorPane({
 						workspaceRemoteUrl={selectedWorkspaceDetail?.remoteUrl ?? null}
 						workspaceTargetBranch={targetBranch}
 						editorMode={editorMode}
-						activeEditorPath={editorSessionPath}
+						activeEditor={activeEditor}
 						onOpenEditorFile={onOpenEditorFile}
 						onCommitAction={onCommitAction}
 						onReviewAction={onReviewAction}

--- a/src/shell/controllers/use-editor-session-controller.test.tsx
+++ b/src/shell/controllers/use-editor-session-controller.test.tsx
@@ -1,0 +1,185 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { INDEX_REF } from "@/lib/editor-session";
+import { useEditorSessionController } from "./use-editor-session-controller";
+
+vi.mock("@/lib/api", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/lib/api")>();
+	return {
+		...actual,
+		triggerWorkspaceFetch: vi.fn(),
+	};
+});
+
+const workspaceRoot = "/tmp/ws-1";
+const filePath = `${workspaceRoot}/foo.txt`;
+
+function setup() {
+	const enterEditorMode = vi.fn();
+	const exitEditorMode = vi.fn();
+	const pushToast = vi.fn();
+	const hook = renderHook(() =>
+		useEditorSessionController({
+			pushToast,
+			workspaceRootPath: workspaceRoot,
+			selectedWorkspaceId: "ws-1",
+			enterEditorMode,
+			exitEditorMode,
+		}),
+	);
+	return { hook, enterEditorMode, exitEditorMode, pushToast };
+}
+
+describe("useEditorSessionController.openFile", () => {
+	it("reopens the diff with new refs when the same path is clicked in a different area", () => {
+		// Regression for issue #544 follow-up: same file in both Staged and
+		// Unstaged. Clicking across areas must swap the diff bases, not freeze
+		// on the first area's view.
+		const { hook } = setup();
+
+		act(() => {
+			hook.result.current.actions.openFile(filePath, {
+				fileStatus: "M",
+				originalRef: "HEAD",
+				modifiedRef: INDEX_REF,
+			});
+		});
+		expect(hook.result.current.state.editorSession).toMatchObject({
+			kind: "diff",
+			path: filePath,
+			originalRef: "HEAD",
+			modifiedRef: INDEX_REF,
+		});
+
+		act(() => {
+			hook.result.current.actions.openFile(filePath, {
+				fileStatus: "M",
+				originalRef: INDEX_REF,
+				modifiedRef: undefined,
+			});
+		});
+		// Same path, different bases → session updates, not stuck on HEAD↔INDEX.
+		expect(hook.result.current.state.editorSession).toMatchObject({
+			kind: "diff",
+			path: filePath,
+			originalRef: INDEX_REF,
+			modifiedRef: undefined,
+		});
+		// originalText/modifiedText must be cleared so the editor effect
+		// re-fetches against the new refs; otherwise we'd render stale bytes.
+		expect(
+			hook.result.current.state.editorSession?.originalText,
+		).toBeUndefined();
+		expect(
+			hook.result.current.state.editorSession?.modifiedText,
+		).toBeUndefined();
+	});
+
+	it("is a no-op when path AND both refs match the current session", () => {
+		// Clicking the same row twice should not thrash — keep refs as-is and
+		// avoid a re-fetch storm.
+		const { hook } = setup();
+
+		act(() => {
+			hook.result.current.actions.openFile(filePath, {
+				fileStatus: "M",
+				originalRef: "HEAD",
+				modifiedRef: INDEX_REF,
+			});
+		});
+		const firstSession = hook.result.current.state.editorSession;
+		act(() => {
+			hook.result.current.actions.openFile(filePath, {
+				fileStatus: "M",
+				originalRef: "HEAD",
+				modifiedRef: INDEX_REF,
+			});
+		});
+		// Identity check: short-circuit must skip setEditorSession entirely.
+		expect(hook.result.current.state.editorSession).toBe(firstSession);
+	});
+
+	it("opens a fresh diff when switching to a different path", () => {
+		const { hook } = setup();
+		act(() => {
+			hook.result.current.actions.openFile(filePath, { fileStatus: "M" });
+		});
+		const otherPath = `${workspaceRoot}/bar.txt`;
+		act(() => {
+			hook.result.current.actions.openFile(otherPath, { fileStatus: "A" });
+		});
+		expect(hook.result.current.state.editorSession).toMatchObject({
+			kind: "diff",
+			path: otherPath,
+			fileStatus: "A",
+			inline: true,
+		});
+	});
+});
+
+describe("useEditorSessionController.openFileReference", () => {
+	// Regression cover: clicking a chat link to a file whose diff was just
+	// open in the inspector must NOT inherit the diff's `originalText`
+	// (which is HEAD/INDEX content, not the working-tree). If it did,
+	// dirty-tracking would compare editor bytes against a git-ref baseline
+	// and a Save would clobber unstaged work.
+	it("does not reuse diff-session texts when transitioning to file mode", () => {
+		const { hook } = setup();
+		// Stage 1: simulate a fully-loaded diff session for the same path.
+		act(() => {
+			hook.result.current.actions.openFile(filePath, {
+				fileStatus: "M",
+				originalRef: "HEAD",
+				modifiedRef: INDEX_REF,
+			});
+		});
+		act(() => {
+			hook.result.current.actions.changeSession({
+				...hook.result.current.state.editorSession!,
+				originalText: "HEAD bytes",
+				modifiedText: "INDEX bytes",
+			});
+		});
+		// Stage 2: chat-link click → openFileReference for the SAME path.
+		act(() => {
+			hook.result.current.actions.openFileReference(filePath, 10, 0);
+		});
+		// File session must be a clean slate — texts cleared, dirty reset.
+		// Otherwise canRenderFile=true would skip the disk fetch and the
+		// editor would render INDEX bytes as if they were the working tree.
+		const session = hook.result.current.state.editorSession;
+		expect(session?.kind).toBe("file");
+		expect(session?.path).toBe(filePath);
+		expect(session?.originalText).toBeUndefined();
+		expect(session?.modifiedText).toBeUndefined();
+		expect(session?.dirty).toBe(false);
+	});
+
+	it("reuses texts when re-opening the same file (file → file)", () => {
+		// Counter-example: same-file re-open from chat must NOT throw away
+		// the user's dirty edits — that's why the kind guard is "diff →
+		// file only", not blanket "always clear".
+		const { hook } = setup();
+		act(() => {
+			hook.result.current.actions.openFileReference(filePath, 1, 1);
+		});
+		act(() => {
+			hook.result.current.actions.changeSession({
+				...hook.result.current.state.editorSession!,
+				originalText: "disk",
+				modifiedText: "user edits",
+				dirty: true,
+			});
+		});
+		act(() => {
+			hook.result.current.actions.openFileReference(filePath, 20, 5);
+		});
+		const session = hook.result.current.state.editorSession;
+		expect(session?.kind).toBe("file");
+		expect(session?.originalText).toBe("disk");
+		expect(session?.modifiedText).toBe("user edits");
+		expect(session?.dirty).toBe(true);
+		expect(session?.line).toBe(20);
+		expect(session?.column).toBe(5);
+	});
+});

--- a/src/shell/controllers/use-editor-session-controller.ts
+++ b/src/shell/controllers/use-editor-session-controller.ts
@@ -93,7 +93,20 @@ export function useEditorSessionController(
 				);
 				return;
 			}
-			if (editorSession?.path === path) return;
+			const nextOriginalRef = options?.originalRef;
+			const nextModifiedRef = options?.modifiedRef;
+			// Same path can appear in multiple inspector areas (Staged / Unstaged /
+			// Remote) with different diff bases — short-circuit only when the
+			// destination matches the current view byte-for-byte. Comparing path
+			// alone would freeze the editor on the first-opened area's bases.
+			if (
+				editorSession?.kind === "diff" &&
+				editorSession.path === path &&
+				editorSession.originalRef === nextOriginalRef &&
+				editorSession.modifiedRef === nextModifiedRef
+			) {
+				return;
+			}
 			if (!confirmDiscardEditorChanges("open another file")) return;
 
 			const status = options?.fileStatus ?? "M";
@@ -108,15 +121,18 @@ export function useEditorSessionController(
 				inline: status !== "M",
 				dirty: false,
 				fileStatus: status,
-				originalRef: options?.originalRef,
-				modifiedRef: options?.modifiedRef,
+				originalRef: nextOriginalRef,
+				modifiedRef: nextModifiedRef,
 				// Diff click is "see what changed" — default to source even for `.md`.
 				viewMode: isMarkdownPath(path) ? "source" : undefined,
 			});
 		},
 		[
 			confirmDiscardEditorChanges,
+			editorSession?.kind,
 			editorSession?.path,
+			editorSession?.originalRef,
+			editorSession?.modifiedRef,
 			selectedWorkspaceId,
 			workspaceRootPath,
 		],
@@ -151,9 +167,16 @@ export function useEditorSessionController(
 			enterEditorModeRef.current();
 			setEditorSession((current) => {
 				const samePath = current?.path === path;
+				// `originalText` carries area-specific bytes when `current` is a
+				// diff session (HEAD/INDEX content) — reusing those for a file
+				// session would make dirty-tracking compare against a git ref,
+				// not the working-tree, and a Save could clobber unstaged work.
+				// Only reuse texts when we're staying inside a `file` session.
+				const sameFile = samePath && current?.kind === "file";
 				// Chat-link open of markdown defaults to preview; preserve a user
-				// toggle if the same file is reopened. Non-markdown paths leave
-				// viewMode unset.
+				// toggle if the same file is reopened. The view-mode preference
+				// is presentation-only, so the loose samePath check is safe even
+				// across kind transitions.
 				const viewMode = isMarkdownPath(path)
 					? samePath && current?.viewMode
 						? current.viewMode
@@ -164,10 +187,10 @@ export function useEditorSessionController(
 					path,
 					line,
 					column,
-					dirty: samePath ? current.dirty : false,
-					originalText: samePath ? current.originalText : undefined,
-					modifiedText: samePath ? current.modifiedText : undefined,
-					mtimeMs: samePath ? current.mtimeMs : undefined,
+					dirty: sameFile ? current.dirty : false,
+					originalText: sameFile ? current.originalText : undefined,
+					modifiedText: sameFile ? current.modifiedText : undefined,
+					mtimeMs: sameFile ? current.mtimeMs : undefined,
 					viewMode,
 				};
 			});


### PR DESCRIPTION
Closes #544
## What changed
- Read staged file contents from the git index without trimming file bytes.
- Pass distinct diff refs for staged, unstaged, and branch-diff inspector rows.
- Track the active editor by path plus diff refs so the same file highlights only in the matching area.
- Reset stale diff text when opening a normal file reference from chat.
- Added regression coverage for git ref reads and editor-session transitions.

## Why
When the same file appeared in both Staged Changes and Changes, the inspector could show a combined HEAD-to-working-tree diff instead of the area-specific diff. It could also leave both rows highlighted or keep stale editor bytes when switching contexts.

## Follow-up / tests
Pre-commit hook passed: biome check/write, cargo fmt, and cargo clippy with -D warnings.