### PR TITLE
feat: add Cmd+Tab quick switch overlay for workspaces

### DIFF
--- a/.announcements/quick-switch-overlay.json
+++ b/.announcements/quick-switch-overlay.json
@@ -1,0 +1,11 @@
+{
+	"items": [
+		{
+			"text": "You can now hold Ctrl+Tab to cycle through recently used workspaces — release to switch, just like Cmd+Tab.",
+			"action": {
+				"label": "Customize Shortcut",
+				"value": { "type": "openSettings", "section": "shortcuts" }
+			}
+		}
+	]
+}

--- a/.changeset/brisk-tabs-pivot.md
+++ b/.changeset/brisk-tabs-pivot.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Add Ctrl+Tab quick switch for workspaces (Arc/Cmd+Tab style: hold to cycle, release to commit) and fix the workspace status dot rendering blank on rows with a legacy status spelling.

--- a/src-tauri/src/schema.rs
+++ b/src-tauri/src/schema.rs
@@ -538,6 +538,20 @@ fn run_migrations(connection: &Connection) -> Result<()> {
                 .execute_batch("ALTER TABLE workspaces DROP COLUMN derived_status")
                 .context("Failed to drop workspace derived_status column")?;
         }
+
+        // Normalize legacy status spellings on existing rows. Older builds
+        // wrote "in-review" / "cancelled"; the canonical form is
+        // "review" / "canceled". The SELECT-time COALESCE only handles
+        // NULL, so without this the legacy string survives and the
+        // frontend's status-dot dict lookup misses (rendering a
+        // transparent, visually grey-white dot).
+        connection
+            .execute_batch(
+                "UPDATE workspaces SET status = 'review' WHERE status = 'in-review';\
+                 UPDATE workspaces SET status = 'canceled' WHERE status = 'cancelled';\
+                 UPDATE workspaces SET status = 'in-progress' WHERE status NOT IN ('in-progress', 'done', 'review', 'backlog', 'canceled');",
+            )
+            .context("Failed to normalize workspace status values")?;
     }
 
     drop_dead_schema(connection)?;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client
 import { listen } from "@tauri-apps/api/event";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { CircleAlertIcon } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ForgeAccountsHealthSentinel } from "@/components/forge-accounts-health-sentinel";
 import { QuitConfirmDialog } from "@/components/quit-confirm-dialog";
@@ -30,6 +30,12 @@ import { regroupByRepo } from "@/features/navigation/sidebar-projection";
 import { AppOnboarding } from "@/features/onboarding";
 import { seedNewSessionInCache } from "@/features/panel/session-cache";
 import { useConfirmSessionClose } from "@/features/panel/use-confirm-session-close";
+import {
+	QuickSwitchOverlay,
+	type QuickSwitchSnapshot,
+	useQuickSwitch,
+	WorkspaceMruStack,
+} from "@/features/quick-switch";
 import { SettingsDialog, type SettingsSection } from "@/features/settings";
 import { getShortcut } from "@/features/shortcuts/registry";
 import {
@@ -47,6 +53,7 @@ import { useUiSyncBridge } from "@/shell/hooks/use-ui-sync-bridge";
 import {
 	findAdjacentSessionId,
 	findAdjacentWorkspaceId,
+	flattenWorkspaceRows,
 	PREFERRED_EDITOR_STORAGE_KEY,
 } from "@/shell/layout";
 import { clampZoom, useZoom, ZOOM_STEP } from "@/shell/use-zoom";
@@ -380,6 +387,9 @@ function AppShell({
 		() => (navigationArchivedQuery.data ?? []).map(summaryToArchivedRow),
 		[navigationArchivedQuery.data],
 	);
+	// MRU stack of workspace ids — drives Ctrl+Tab quick switch order.
+	// In-memory only; resets on app restart by design.
+	const workspaceMruRef = useRef<WorkspaceMruStack>(new WorkspaceMruStack());
 	const repositoriesQuery = useQuery(repositoriesQueryOptions());
 	const repositories = repositoriesQuery.data ?? [];
 	const { state: selection, actions: selectionActions } =
@@ -597,6 +607,27 @@ function AppShell({
 	}, []);
 	const handlePullLatest = usePullLatest({ queryClient, selectedWorkspaceId });
 
+	// Map workspace id -> live row (excluding archived). Used by the
+	// quick-switch overlay to render cards and by buildSnapshot to filter
+	// stale MRU ids.
+	const liveWorkspaceRowMap = useMemo(() => {
+		const map = new Map<
+			string,
+			(typeof workspaceGroups)[number]["rows"][number]
+		>();
+		for (const group of workspaceGroups) {
+			for (const row of group.rows) map.set(row.id, row);
+		}
+		return map;
+	}, [workspaceGroups]);
+
+	// Whenever the selection changes, mark the workspace as most-recently-used.
+	// All entry points (sidebar click, navigation hotkeys, quick-switch itself,
+	// session restore) flow through `selection.selectedWorkspaceId`, so a
+	// single effect here covers them all.
+	useEffect(() => {
+		if (selectedWorkspaceId) workspaceMruRef.current.touch(selectedWorkspaceId);
+	}, [selectedWorkspaceId]);
 	const selectedWorkspaceDetailQuery = useQuery({
 		...workspaceDetailQueryOptions(selectedWorkspaceId ?? "__none__"),
 		enabled: selectedWorkspaceId !== null,
@@ -990,6 +1021,45 @@ function AppShell({
 		[archivedRows, handleSelectWorkspace, selectionActions, workspaceGroups],
 	);
 
+	// MRU-ordered, archived-filtered, deduped list, capped at 4 cards
+	// (current + 3 most recent). Live workspaces never touched by MRU are
+	// appended in sidebar order so the overlay can still reach them on a
+	// cold MRU.
+	const buildQuickSwitchSnapshot = useCallback(
+		(direction: "next" | "previous"): QuickSwitchSnapshot | null => {
+			const QUICK_SWITCH_MAX_CARDS = 4;
+			const orderedLive = flattenWorkspaceRows(workspaceGroups, []).map(
+				(row) => row.id,
+			);
+			const liveSet = new Set(orderedLive);
+			const mruIds = workspaceMruRef.current
+				.list()
+				.filter((id) => liveSet.has(id));
+			const seen = new Set(mruIds);
+			const tailIds = orderedLive.filter((id) => !seen.has(id));
+			const ids = [...mruIds, ...tailIds].slice(0, QUICK_SWITCH_MAX_CARDS);
+			if (ids.length < 2) return null;
+			// MRU[0] is the current workspace (touched most recently); start
+			// at index 1 for "next" so a single Ctrl+Tab tap commits the
+			// previous workspace, exactly like Cmd+Tab.
+			const initialIndex = direction === "next" ? 1 : ids.length - 1;
+			return { ids, initialIndex };
+		},
+		[workspaceGroups],
+	);
+
+	const handleQuickSwitchCommit = useCallback(
+		(workspaceId: string) => {
+			handleSelectWorkspace(workspaceId);
+		},
+		[handleSelectWorkspace],
+	);
+
+	const quickSwitch = useQuickSwitch({
+		buildSnapshot: buildQuickSwitchSnapshot,
+		onCommit: handleQuickSwitchCommit,
+	});
+
 	const globalShortcutHandlers = useMemo<ShortcutHandler[]>(
 		() => [
 			{
@@ -1021,6 +1091,14 @@ function AppShell({
 			{
 				id: "workspace.next" as const,
 				callback: () => handleNavigateWorkspaces(1),
+			},
+			{
+				id: "workspace.quickSwitchNext" as const,
+				callback: () => quickSwitch.open("next"),
+			},
+			{
+				id: "workspace.quickSwitchPrevious" as const,
+				callback: () => quickSwitch.open("previous"),
 			},
 			{
 				id: "session.previous" as const,
@@ -1158,6 +1236,7 @@ function AppShell({
 			handleToggleZenMode,
 			preferredEditor,
 			pullRequestUrl,
+			quickSwitch,
 			selectedWorkspaceId,
 			setInspectorCollapsed,
 			setSidebarCollapsed,
@@ -1630,6 +1709,15 @@ function AppShell({
 							onOpenChangelog={handleOpenReleaseChangelog}
 							onOpenSettings={handleOpenAnnouncementSettings}
 							onSetRightSidebarMode={contextPanelActions.setMode}
+						/>
+						<QuickSwitchOverlay
+							state={quickSwitch.state}
+							getRow={(id) => liveWorkspaceRowMap.get(id) ?? null}
+							onSelectIndex={quickSwitch.selectIndex}
+							onCommitIndex={(index) => {
+								quickSwitch.selectIndex(index);
+								quickSwitch.commit();
+							}}
 						/>
 						{closeConfirmDialog}
 						{mergeConfirmDialogNode}

--- a/src/features/navigation/workspace-display.test.ts
+++ b/src/features/navigation/workspace-display.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import type { WorkspaceRow } from "@/lib/api";
+import { deriveWorkspaceDisplay } from "./workspace-display";
+
+function makeRow(extra?: Partial<WorkspaceRow>): WorkspaceRow {
+	return { id: "ws-1", title: "row-title", ...extra };
+}
+
+describe("deriveWorkspaceDisplay", () => {
+	it("uses PR title when present (whitespace trimmed)", () => {
+		const display = deriveWorkspaceDisplay(
+			makeRow({
+				prTitle: "  feat: Arc switcher  ",
+				primarySessionTitle: "session title",
+				branch: "feature/x",
+			}),
+		);
+		expect(display.title).toBe("feat: Arc switcher");
+		expect(display.prTitle).toBe("feat: Arc switcher");
+	});
+
+	it("falls back to primary session title when PR is missing", () => {
+		const display = deriveWorkspaceDisplay(
+			makeRow({
+				primarySessionTitle: "primary",
+				activeSessionTitle: "active",
+			}),
+		);
+		expect(display.title).toBe("primary");
+	});
+
+	it("falls back to active session title when primary is missing", () => {
+		const display = deriveWorkspaceDisplay(
+			makeRow({ activeSessionTitle: "active" }),
+		);
+		expect(display.title).toBe("active");
+	});
+
+	it("treats 'Untitled' session titles as missing", () => {
+		const display = deriveWorkspaceDisplay(
+			makeRow({
+				primarySessionTitle: "Untitled",
+				activeSessionTitle: "Untitled",
+				branch: "feature/x",
+			}),
+		);
+		expect(display.title).toBe("X");
+	});
+
+	it("falls back to humanized branch when no session/PR title", () => {
+		const display = deriveWorkspaceDisplay(
+			makeRow({ branch: "feature/cmd-tab-switcher" }),
+		);
+		expect(display.title).toBe("Cmd Tab Switcher");
+	});
+
+	it("falls back to raw row.title only as last resort", () => {
+		const display = deriveWorkspaceDisplay(makeRow({ title: "raw-row" }));
+		expect(display.title).toBe("raw-row");
+	});
+
+	it("subtitle = 'repo › branch' when both present", () => {
+		const display = deriveWorkspaceDisplay(
+			makeRow({ repoName: "helmor", branch: "feature/x" }),
+		);
+		expect(display.subtitle).toBe("helmor › feature/x");
+	});
+
+	it("subtitle falls back to directoryName when repoName missing", () => {
+		const display = deriveWorkspaceDisplay(
+			makeRow({ directoryName: "dir", branch: "feature/x" }),
+		);
+		expect(display.subtitle).toBe("dir › feature/x");
+	});
+
+	it("subtitle = repo only when branch missing", () => {
+		const display = deriveWorkspaceDisplay(makeRow({ repoName: "helmor" }));
+		expect(display.subtitle).toBe("helmor");
+	});
+
+	it("subtitle = branch only when repo missing", () => {
+		const display = deriveWorkspaceDisplay(makeRow({ branch: "feature/x" }));
+		expect(display.subtitle).toBe("feature/x");
+	});
+
+	it("subtitle is null when neither repo nor branch present", () => {
+		const display = deriveWorkspaceDisplay(makeRow());
+		expect(display.subtitle).toBeNull();
+	});
+});

--- a/src/features/navigation/workspace-display.ts
+++ b/src/features/navigation/workspace-display.ts
@@ -1,0 +1,38 @@
+import type { WorkspaceRow } from "@/lib/api";
+import { humanizeBranch } from "./shared";
+
+export type WorkspaceDisplay = {
+	title: string;
+	subtitle: string | null;
+	branch: string | null;
+	prTitle: string | null;
+};
+
+// Title priority: PR title > primary session > active session > humanized branch > row.title.
+export function deriveWorkspaceDisplay(row: WorkspaceRow): WorkspaceDisplay {
+	const branch = row.branch ?? null;
+	const repoLabel = row.repoName ?? row.directoryName ?? null;
+	const subtitle = repoLabel
+		? branch
+			? `${repoLabel} › ${branch}`
+			: repoLabel
+		: branch;
+
+	const trimmedPrTitle = row.prTitle?.trim() || null;
+	const primarySessionTitle =
+		row.primarySessionTitle && row.primarySessionTitle !== "Untitled"
+			? row.primarySessionTitle
+			: null;
+	const activeSessionTitle =
+		row.activeSessionTitle && row.activeSessionTitle !== "Untitled"
+			? row.activeSessionTitle
+			: null;
+
+	const title =
+		trimmedPrTitle ??
+		primarySessionTitle ??
+		activeSessionTitle ??
+		(branch ? humanizeBranch(branch) : row.title);
+
+	return { title, subtitle, branch, prTitle: trimmedPrTitle };
+}

--- a/src/features/navigation/workspace-hover-card.tsx
+++ b/src/features/navigation/workspace-hover-card.tsx
@@ -41,23 +41,8 @@ import {
 	WORKSPACE_DND_ACTIVE_ATTRIBUTE,
 	WORKSPACE_DND_ACTIVE_CHANGE_EVENT,
 } from "./dnd/shared";
-import { humanizeBranch } from "./shared";
-
-const STATUS_LABEL: Record<NonNullable<WorkspaceRow["status"]>, string> = {
-	"in-progress": "In progress",
-	review: "In review",
-	done: "Done",
-	backlog: "Backlog",
-	canceled: "Canceled",
-};
-
-const STATUS_DOT_CLASS: Record<NonNullable<WorkspaceRow["status"]>, string> = {
-	"in-progress": "bg-[var(--workspace-sidebar-status-progress)]",
-	review: "bg-[var(--workspace-sidebar-status-review)]",
-	done: "bg-[var(--workspace-sidebar-status-done)]",
-	backlog: "bg-[var(--workspace-sidebar-status-backlog)]",
-	canceled: "bg-[var(--workspace-sidebar-status-canceled)]",
-};
+import { deriveWorkspaceDisplay } from "./workspace-display";
+import { deriveWorkspaceStatusDot } from "./workspace-status-display";
 
 function relativeTime(iso?: string | null): string | null {
 	if (!iso) return null;
@@ -549,31 +534,17 @@ export function WorkspaceHoverCard({
 		[row.id],
 	);
 
-	const branch = row.branch ?? null;
-	const repoLabel = row.repoName ?? row.directoryName ?? null;
-	const subtitle = repoLabel
-		? branch
-			? `${repoLabel} › ${branch}`
-			: repoLabel
-		: branch;
+	// Shared derivation — keeps the sidebar hover card and the Ctrl+Tab
+	// quick-switch overlay showing the exact same human label for every
+	// workspace. `prTitle` is exposed separately so this card can still
+	// render the PR row when it differs from the resolved title.
+	const {
+		title,
+		subtitle,
+		prTitle: trimmedPrTitle,
+	} = deriveWorkspaceDisplay(row);
 
-	// Title fallback chain: PR title → primary session → active session → branch.
-	const trimmedPrTitle = row.prTitle?.trim() || null;
-	const primarySessionTitle =
-		row.primarySessionTitle && row.primarySessionTitle !== "Untitled"
-			? row.primarySessionTitle
-			: null;
-	const activeSessionTitleRaw =
-		row.activeSessionTitle && row.activeSessionTitle !== "Untitled"
-			? row.activeSessionTitle
-			: null;
-	const title =
-		trimmedPrTitle ??
-		primarySessionTitle ??
-		activeSessionTitleRaw ??
-		(branch ? humanizeBranch(branch) : row.title);
-
-	const status = row.status ?? "in-progress";
+	const statusDot = deriveWorkspaceStatusDot(row);
 
 	// "Last touched" prefers the most human-meaningful signal available.
 	const lastActivityIso =
@@ -621,11 +592,11 @@ export function WorkspaceHoverCard({
 						<div className="mt-0.5 flex shrink-0 items-center gap-2">
 							<GitStats workspaceId={row.id} />
 							<span
-								aria-label={STATUS_LABEL[status]}
-								title={STATUS_LABEL[status]}
+								aria-label={statusDot.label}
+								title={statusDot.label}
 								className={cn(
 									"size-2 shrink-0 rounded-full",
-									STATUS_DOT_CLASS[status],
+									statusDot.dotClass,
 								)}
 							/>
 						</div>

--- a/src/features/navigation/workspace-status-display.test.ts
+++ b/src/features/navigation/workspace-status-display.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import type { WorkspaceRow } from "@/lib/api";
+import { deriveWorkspaceStatusDot } from "./workspace-status-display";
+
+function makeRow(extra?: Partial<WorkspaceRow>): WorkspaceRow {
+	return { id: "ws-1", title: "Workspace", ...extra };
+}
+
+describe("deriveWorkspaceStatusDot", () => {
+	it("uses the workflow status when present", () => {
+		const dot = deriveWorkspaceStatusDot(makeRow({ status: "review" }));
+		expect(dot.label).toBe("In review");
+		expect(dot.dotClass).toContain("review");
+	});
+
+	it("falls back to in-progress when status is missing", () => {
+		const dot = deriveWorkspaceStatusDot(makeRow());
+		expect(dot.label).toBe("In progress");
+		expect(dot.dotClass).toContain("progress");
+	});
+
+	it("falls back to in-progress for legacy / unknown status strings", () => {
+		// Old DBs may carry "in-review" / "cancelled" — backend migration
+		// normalizes them, but the helper must stay safe in the meantime,
+		// otherwise the dot renders class-less and reads as transparent.
+		for (const legacy of ["in-review", "cancelled", "weird-value", ""]) {
+			const dot = deriveWorkspaceStatusDot(
+				makeRow({ status: legacy as WorkspaceRow["status"] }),
+			);
+			expect(dot.label).toBe("In progress");
+			expect(dot.dotClass).toContain("progress");
+		}
+	});
+
+	it("ignores pinned — pinned and un-pinned rows resolve to identical dots", () => {
+		// Pinned is a grouping signal on the sidebar, not a status. The
+		// hover card has always rendered the dot the same way on pinned
+		// and un-pinned rows; this helper must keep that invariant.
+		const unpinned = deriveWorkspaceStatusDot(makeRow({ status: "review" }));
+		const pinned = deriveWorkspaceStatusDot(
+			makeRow({ status: "review", pinnedAt: "2025-01-01T00:00:00Z" }),
+		);
+		expect(pinned).toEqual(unpinned);
+	});
+});

--- a/src/features/navigation/workspace-status-display.ts
+++ b/src/features/navigation/workspace-status-display.ts
@@ -1,0 +1,48 @@
+import type { WorkspaceRow } from "@/lib/api";
+
+export const WORKSPACE_STATUS_LABEL: Record<
+	NonNullable<WorkspaceRow["status"]>,
+	string
+> = {
+	"in-progress": "In progress",
+	review: "In review",
+	done: "Done",
+	backlog: "Backlog",
+	canceled: "Canceled",
+};
+
+export const WORKSPACE_STATUS_DOT_CLASS: Record<
+	NonNullable<WorkspaceRow["status"]>,
+	string
+> = {
+	"in-progress": "bg-[var(--workspace-sidebar-status-progress)]",
+	review: "bg-[var(--workspace-sidebar-status-review)]",
+	done: "bg-[var(--workspace-sidebar-status-done)]",
+	backlog: "bg-[var(--workspace-sidebar-status-backlog)]",
+	canceled: "bg-[var(--workspace-sidebar-status-canceled)]",
+};
+
+export type WorkspaceStatusValue = NonNullable<WorkspaceRow["status"]>;
+
+export type WorkspaceStatusDot = {
+	label: string;
+	dotClass: string;
+};
+
+export function deriveWorkspaceStatusDot(
+	row: WorkspaceRow,
+): WorkspaceStatusDot {
+	// Defensive lookup: legacy DBs may have rows with "in-review" /
+	// "cancelled" / etc. — a backend migration normalizes them on boot,
+	// but until that runs once we fall back to in-progress rather than
+	// rendering a class-less (transparent) dot.
+	const raw = row.status ?? "in-progress";
+	const status: WorkspaceStatusValue =
+		raw in WORKSPACE_STATUS_DOT_CLASS
+			? (raw as WorkspaceStatusValue)
+			: "in-progress";
+	return {
+		label: WORKSPACE_STATUS_LABEL[status],
+		dotClass: WORKSPACE_STATUS_DOT_CLASS[status],
+	};
+}

--- a/src/features/quick-switch/active-state.ts
+++ b/src/features/quick-switch/active-state.ts
@@ -1,0 +1,21 @@
+// Module-level flag mirroring `recording-state.ts`. While the quick-switch
+// overlay is open we want the global shortcut dispatcher to short-circuit so
+// raw Tab / Shift+Tab / Esc / typing keys belong to the overlay alone.
+let activeCount = 0;
+
+export function beginQuickSwitch() {
+	activeCount += 1;
+}
+
+export function endQuickSwitch() {
+	activeCount = Math.max(0, activeCount - 1);
+}
+
+export function isQuickSwitchActive() {
+	return activeCount > 0;
+}
+
+/** Test-only: reset between tests. */
+export function _resetQuickSwitchActiveForTesting() {
+	activeCount = 0;
+}

--- a/src/features/quick-switch/index.ts
+++ b/src/features/quick-switch/index.ts
@@ -1,0 +1,10 @@
+export { isQuickSwitchActive } from "./active-state";
+export { WorkspaceMruStack } from "./mru-stack";
+export { QuickSwitchOverlay } from "./quick-switch-overlay";
+export {
+	type QuickSwitchControls,
+	type QuickSwitchDirection,
+	type QuickSwitchSnapshot,
+	type QuickSwitchState,
+	useQuickSwitch,
+} from "./use-quick-switch";

--- a/src/features/quick-switch/mru-stack.test.ts
+++ b/src/features/quick-switch/mru-stack.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { WorkspaceMruStack } from "./mru-stack";
+
+describe("WorkspaceMruStack", () => {
+	it("starts empty", () => {
+		const mru = new WorkspaceMruStack();
+		expect(mru.list()).toEqual([]);
+		expect(mru.size()).toBe(0);
+	});
+
+	it("touch puts the id at index 0", () => {
+		const mru = new WorkspaceMruStack();
+		mru.touch("a");
+		mru.touch("b");
+		mru.touch("c");
+		expect(mru.list()).toEqual(["c", "b", "a"]);
+	});
+
+	it("touch dedupes: re-touching an id moves it to the front", () => {
+		const mru = new WorkspaceMruStack();
+		mru.touch("a");
+		mru.touch("b");
+		mru.touch("c");
+		mru.touch("a");
+		expect(mru.list()).toEqual(["a", "c", "b"]);
+		expect(mru.size()).toBe(3);
+	});
+
+	it("touch is a no-op when id is already at index 0", () => {
+		const mru = new WorkspaceMruStack();
+		mru.touch("a");
+		mru.touch("a");
+		mru.touch("a");
+		expect(mru.list()).toEqual(["a"]);
+	});
+
+	it("ignores empty ids", () => {
+		const mru = new WorkspaceMruStack();
+		mru.touch("");
+		expect(mru.list()).toEqual([]);
+	});
+
+	it("clamps to capacity, evicting oldest", () => {
+		const mru = new WorkspaceMruStack(3);
+		mru.touch("a");
+		mru.touch("b");
+		mru.touch("c");
+		mru.touch("d");
+		expect(mru.list()).toEqual(["d", "c", "b"]);
+	});
+
+	it("remove pulls an id from anywhere in the list", () => {
+		const mru = new WorkspaceMruStack();
+		mru.touch("a");
+		mru.touch("b");
+		mru.touch("c");
+		mru.remove("b");
+		expect(mru.list()).toEqual(["c", "a"]);
+		mru.remove("missing");
+		expect(mru.list()).toEqual(["c", "a"]);
+	});
+
+	it("clear empties the stack", () => {
+		const mru = new WorkspaceMruStack();
+		mru.touch("a");
+		mru.touch("b");
+		mru.clear();
+		expect(mru.list()).toEqual([]);
+	});
+});

--- a/src/features/quick-switch/mru-stack.ts
+++ b/src/features/quick-switch/mru-stack.ts
@@ -1,0 +1,41 @@
+// MRU stack of workspace ids — most-recently-used first. In-memory only;
+// resets on app restart by design (cold-start fallback uses sidebar order).
+const DEFAULT_CAPACITY = 50;
+
+export class WorkspaceMruStack {
+	private entries: string[] = [];
+	private readonly capacity: number;
+
+	constructor(capacity: number = DEFAULT_CAPACITY) {
+		this.capacity = Math.max(1, capacity);
+	}
+
+	/** Move id to position 0; dedupe; clamp to capacity. */
+	touch(id: string) {
+		if (!id) return;
+		const existing = this.entries.indexOf(id);
+		if (existing === 0) return;
+		if (existing > 0) this.entries.splice(existing, 1);
+		this.entries.unshift(id);
+		if (this.entries.length > this.capacity) {
+			this.entries.length = this.capacity;
+		}
+	}
+
+	remove(id: string) {
+		const idx = this.entries.indexOf(id);
+		if (idx >= 0) this.entries.splice(idx, 1);
+	}
+
+	clear() {
+		this.entries = [];
+	}
+
+	list(): readonly string[] {
+		return this.entries;
+	}
+
+	size(): number {
+		return this.entries.length;
+	}
+}

--- a/src/features/quick-switch/quick-switch-overlay.test.tsx
+++ b/src/features/quick-switch/quick-switch-overlay.test.tsx
@@ -1,0 +1,250 @@
+import { cleanup, fireEvent, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { WorkspaceRow } from "@/lib/api";
+import { renderWithProviders } from "@/test/render-with-providers";
+import { QuickSwitchOverlay } from "./quick-switch-overlay";
+
+function row(
+	id: string,
+	title: string,
+	extra?: Partial<WorkspaceRow>,
+): WorkspaceRow {
+	return { id, title, ...extra };
+}
+
+afterEach(() => {
+	cleanup();
+	document.body.innerHTML = "";
+});
+
+describe("QuickSwitchOverlay", () => {
+	it("renders nothing when phase is idle", () => {
+		renderWithProviders(
+			<QuickSwitchOverlay
+				state={{ phase: "idle" }}
+				getRow={() => null}
+				onSelectIndex={vi.fn()}
+				onCommitIndex={vi.fn()}
+			/>,
+		);
+		expect(screen.queryByTestId("quick-switch-overlay")).toBeNull();
+	});
+
+	it("renders one card per resolvable id and marks the active one", () => {
+		const rows = new Map([
+			["a", row("a", "Alpha")],
+			["b", row("b", "Beta")],
+			["c", row("c", "Gamma")],
+		]);
+		renderWithProviders(
+			<QuickSwitchOverlay
+				state={{ phase: "open", ids: ["a", "b", "c"], index: 1 }}
+				getRow={(id) => rows.get(id) ?? null}
+				onSelectIndex={vi.fn()}
+				onCommitIndex={vi.fn()}
+			/>,
+		);
+		const buttons = screen.getAllByRole("button");
+		expect(buttons).toHaveLength(3);
+		expect(buttons[0].getAttribute("data-active")).toBe("false");
+		expect(buttons[1].getAttribute("data-active")).toBe("true");
+		expect(buttons[2].getAttribute("data-active")).toBe("false");
+	});
+
+	it("hovering a card triggers onSelectIndex with that index", () => {
+		const onSelectIndex = vi.fn();
+		const rows = new Map([
+			["a", row("a", "Alpha")],
+			["b", row("b", "Beta")],
+		]);
+		renderWithProviders(
+			<QuickSwitchOverlay
+				state={{ phase: "open", ids: ["a", "b"], index: 0 }}
+				getRow={(id) => rows.get(id) ?? null}
+				onSelectIndex={onSelectIndex}
+				onCommitIndex={vi.fn()}
+			/>,
+		);
+		fireEvent.mouseEnter(screen.getAllByRole("button")[1]);
+		expect(onSelectIndex).toHaveBeenCalledWith(1);
+	});
+
+	it("clicking a card fires onCommitIndex with that index", () => {
+		const onCommitIndex = vi.fn();
+		const rows = new Map([
+			["a", row("a", "Alpha")],
+			["b", row("b", "Beta")],
+		]);
+		renderWithProviders(
+			<QuickSwitchOverlay
+				state={{ phase: "open", ids: ["a", "b"], index: 0 }}
+				getRow={(id) => rows.get(id) ?? null}
+				onSelectIndex={vi.fn()}
+				onCommitIndex={onCommitIndex}
+			/>,
+		);
+		fireEvent.click(screen.getAllByRole("button")[1]);
+		expect(onCommitIndex).toHaveBeenCalledWith(1);
+	});
+
+	it("filters out unresolvable ids without crashing", () => {
+		renderWithProviders(
+			<QuickSwitchOverlay
+				state={{ phase: "open", ids: ["missing-a", "b"], index: 1 }}
+				getRow={(id) => (id === "b" ? row("b", "Beta") : null)}
+				onSelectIndex={vi.fn()}
+				onCommitIndex={vi.fn()}
+			/>,
+		);
+		expect(screen.getAllByRole("button")).toHaveLength(1);
+		expect(screen.getByText("Beta")).toBeTruthy();
+	});
+
+	it("returns null when no ids resolve", () => {
+		renderWithProviders(
+			<QuickSwitchOverlay
+				state={{ phase: "open", ids: ["x", "y"], index: 0 }}
+				getRow={() => null}
+				onSelectIndex={vi.fn()}
+				onCommitIndex={vi.fn()}
+			/>,
+		);
+		expect(screen.queryByTestId("quick-switch-overlay")).toBeNull();
+	});
+
+	it("prefers session title over branch-derived row.title (no duplication)", () => {
+		// Mirrors a real Helmor row where `row.title` is itself derived from
+		// the branch — without the shared title chain we'd render
+		// "Cmd Tab Switcher" twice (once as title, once as subtitle).
+		const rows = new Map([
+			[
+				"a",
+				row("a", "Cmd Tab Switcher", {
+					repoName: "helmor",
+					branch: "feature/cmd-tab-switcher",
+					primarySessionTitle: "Designing the overlay",
+				}),
+			],
+			["b", row("b", "Beta")],
+		]);
+		renderWithProviders(
+			<QuickSwitchOverlay
+				state={{ phase: "open", ids: ["a", "b"], index: 0 }}
+				getRow={(id) => rows.get(id) ?? null}
+				onSelectIndex={vi.fn()}
+				onCommitIndex={vi.fn()}
+			/>,
+		);
+		// Title comes from the session, not the redundant row.title.
+		expect(screen.getByText("Designing the overlay")).toBeTruthy();
+		// Subtitle: repo › branch.
+		expect(screen.getByText("helmor › feature/cmd-tab-switcher")).toBeTruthy();
+	});
+
+	it("falls back to humanized branch when no PR / session title is available", () => {
+		const rows = new Map([
+			["a", row("a", "raw-title", { branch: "feature/cmd-tab-switcher" })],
+			["b", row("b", "Beta")],
+		]);
+		renderWithProviders(
+			<QuickSwitchOverlay
+				state={{ phase: "open", ids: ["a", "b"], index: 0 }}
+				getRow={(id) => rows.get(id) ?? null}
+				onSelectIndex={vi.fn()}
+				onCommitIndex={vi.fn()}
+			/>,
+		);
+		expect(screen.getByText("Cmd Tab Switcher")).toBeTruthy();
+		// Raw branch shows up only in the subtitle, not as a duplicate title.
+		expect(screen.queryByText("raw-title")).toBeNull();
+	});
+
+	it("prefers PR title over session and branch", () => {
+		const rows = new Map([
+			[
+				"a",
+				row("a", "raw-title", {
+					branch: "feature/cmd-tab-switcher",
+					primarySessionTitle: "Designing the overlay",
+					prTitle: "  feat: Arc-style quick switch  ",
+				}),
+			],
+			["b", row("b", "Beta")],
+		]);
+		renderWithProviders(
+			<QuickSwitchOverlay
+				state={{ phase: "open", ids: ["a", "b"], index: 0 }}
+				getRow={(id) => rows.get(id) ?? null}
+				onSelectIndex={vi.fn()}
+				onCommitIndex={vi.fn()}
+			/>,
+		);
+		// PR title wins; whitespace is trimmed.
+		expect(screen.getByText("feat: Arc-style quick switch")).toBeTruthy();
+		expect(screen.queryByText("Designing the overlay")).toBeNull();
+	});
+
+	it("shows a status dot in the top-right with the workspace status label", () => {
+		const rows = new Map([
+			["a", row("a", "Alpha", { status: "review" })],
+			["b", row("b", "Beta")],
+		]);
+		renderWithProviders(
+			<QuickSwitchOverlay
+				state={{ phase: "open", ids: ["a", "b"], index: 0 }}
+				getRow={(id) => rows.get(id) ?? null}
+				onSelectIndex={vi.fn()}
+				onCommitIndex={vi.fn()}
+			/>,
+		);
+		// Both cards render the dot (Beta falls back to in-progress).
+		expect(screen.getByLabelText("In review")).toBeTruthy();
+		expect(screen.getByLabelText("In progress")).toBeTruthy();
+	});
+
+	it("pinned and un-pinned rows render the same status dot", () => {
+		// The dot tracks `row.status` only — pinned is sidebar-grouping
+		// metadata, never a status color override. Matches the hover
+		// card's long-standing behavior.
+		const rows = new Map([
+			[
+				"a",
+				row("a", "Alpha", {
+					pinnedAt: "2025-01-01T00:00:00Z",
+					status: "review",
+				}),
+			],
+			["b", row("b", "Beta", { status: "review" })],
+		]);
+		renderWithProviders(
+			<QuickSwitchOverlay
+				state={{ phase: "open", ids: ["a", "b"], index: 0 }}
+				getRow={(id) => rows.get(id) ?? null}
+				onSelectIndex={vi.fn()}
+				onCommitIndex={vi.fn()}
+			/>,
+		);
+		const dots = screen.getAllByLabelText("In review");
+		expect(dots).toHaveLength(2);
+		expect(dots[0].className).toBe(dots[1].className);
+	});
+
+	it("skips 'Untitled' session titles in the title chain", () => {
+		// With no PR / valid session / branch, we fall all the way through
+		// to row.title — but 'Untitled' itself must never appear.
+		const rows = new Map([
+			["a", row("a", "Alpha", { primarySessionTitle: "Untitled" })],
+			["b", row("b", "Beta")],
+		]);
+		renderWithProviders(
+			<QuickSwitchOverlay
+				state={{ phase: "open", ids: ["a", "b"], index: 0 }}
+				getRow={(id) => rows.get(id) ?? null}
+				onSelectIndex={vi.fn()}
+				onCommitIndex={vi.fn()}
+			/>,
+		);
+		expect(screen.queryByText("Untitled")).toBeNull();
+		expect(screen.getByText("Alpha")).toBeTruthy();
+	});
+});

--- a/src/features/quick-switch/quick-switch-overlay.tsx
+++ b/src/features/quick-switch/quick-switch-overlay.tsx
@@ -1,0 +1,216 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { GitBranch } from "lucide-react";
+import { useEffect, useMemo } from "react";
+import { createPortal } from "react-dom";
+import { HelmorThinkingIndicator } from "@/components/helmor-thinking-indicator";
+import { WorkspaceAvatar } from "@/features/navigation/avatar";
+import { deriveWorkspaceDisplay } from "@/features/navigation/workspace-display";
+import { extractLiveActivity } from "@/features/navigation/workspace-hover-card";
+import { deriveWorkspaceStatusDot } from "@/features/navigation/workspace-status-display";
+import type { WorkspaceRow } from "@/lib/api";
+import { useBusySessionIds } from "@/lib/session-run-state-context";
+import {
+	readSessionThread,
+	sessionThreadCacheKey,
+} from "@/lib/session-thread-cache";
+import { cn } from "@/lib/utils";
+import type { QuickSwitchState } from "./use-quick-switch";
+
+type QuickSwitchOverlayProps = {
+	state: QuickSwitchState;
+	getRow: (id: string) => WorkspaceRow | null;
+	onSelectIndex: (index: number) => void;
+	onCommitIndex: (index: number) => void;
+};
+
+export function QuickSwitchOverlay({
+	state,
+	getRow,
+	onSelectIndex,
+	onCommitIndex,
+}: QuickSwitchOverlayProps) {
+	// Keep the highlighted card in view when cycling. Use a DOM query rather
+	// than a per-card ref so we don't have to thread refs through the loop.
+	useEffect(() => {
+		if (state.phase !== "open") return;
+		const active = document.querySelector<HTMLElement>(
+			'[data-testid="quick-switch-overlay"] [data-active="true"]',
+		);
+		active?.scrollIntoView({
+			behavior: "smooth",
+			block: "nearest",
+			inline: "center",
+		});
+	}, [state]);
+
+	if (state.phase !== "open") return null;
+	if (typeof document === "undefined") return null;
+
+	const items = state.ids
+		.map((id) => getRow(id))
+		.filter((row): row is WorkspaceRow => Boolean(row));
+	if (items.length === 0) return null;
+
+	return createPortal(
+		<div
+			className="fixed inset-0 z-[80] grid place-items-center bg-black/15 supports-backdrop-filter:backdrop-blur-sm"
+			data-testid="quick-switch-overlay"
+		>
+			<div
+				role="dialog"
+				aria-modal="true"
+				aria-label="Quick switch workspace"
+				className="rounded-2xl bg-popover/95 p-3 text-popover-foreground shadow-2xl ring-1 ring-foreground/10"
+			>
+				<div className="flex max-w-[80vw] gap-2 overflow-x-auto scroll-smooth py-1">
+					{items.map((row, idx) => (
+						<QuickSwitchCard
+							key={row.id}
+							row={row}
+							isActive={idx === state.index}
+							onSelect={() => onSelectIndex(idx)}
+							onCommit={() => onCommitIndex(idx)}
+						/>
+					))}
+				</div>
+			</div>
+		</div>,
+		document.body,
+	);
+}
+
+function QuickSwitchCard({
+	row,
+	isActive,
+	onSelect,
+	onCommit,
+}: {
+	row: WorkspaceRow;
+	isActive: boolean;
+	onSelect: () => void;
+	onCommit: () => void;
+}) {
+	const queryClient = useQueryClient();
+	const busySessionIds = useBusySessionIds();
+	const sessionId = row.activeSessionId ?? row.primarySessionId ?? null;
+	const isStreaming = sessionId ? busySessionIds.has(sessionId) : false;
+
+	// In-memory thread cache only — no IPC on render.
+	const { data: thread } = useQuery({
+		queryKey: sessionThreadCacheKey(sessionId ?? "__none__"),
+		queryFn: () =>
+			sessionId ? (readSessionThread(queryClient, sessionId) ?? []) : [],
+		enabled: Boolean(sessionId),
+		staleTime: Number.POSITIVE_INFINITY,
+		gcTime: 30_000,
+	});
+
+	const blocks = useMemo(() => extractLiveActivity(thread), [thread]);
+	const reversedBlocks = useMemo(() => [...blocks].reverse(), [blocks]);
+
+	const { title, subtitle, branch } = deriveWorkspaceDisplay(row);
+	const statusDot = deriveWorkspaceStatusDot(row);
+
+	const hasBlocks = reversedBlocks.length > 0;
+
+	return (
+		<button
+			type="button"
+			data-active={isActive ? "true" : "false"}
+			aria-selected={isActive}
+			onMouseEnter={onSelect}
+			onClick={onCommit}
+			className={cn(
+				"flex h-44 w-60 shrink-0 cursor-pointer flex-col gap-1.5 rounded-xl border p-3 text-left transition-colors",
+				isActive
+					? "border-foreground/20 bg-accent/80"
+					: "border-transparent hover:bg-accent/40",
+			)}
+		>
+			<div className="flex min-w-0 shrink-0 items-center gap-1.5">
+				<WorkspaceAvatar
+					title={title}
+					repoIconSrc={row.repoIconSrc}
+					repoInitials={row.repoInitials}
+					repoName={row.repoName}
+					className="size-4 rounded-[5px]"
+					fallbackClassName="text-[7px]"
+				/>
+				<span
+					className="min-w-0 flex-1 truncate text-[13px] font-semibold leading-tight text-foreground"
+					title={title}
+				>
+					{title}
+				</span>
+				{isStreaming ? (
+					<HelmorThinkingIndicator size={12} className="shrink-0" />
+				) : null}
+				<span
+					aria-label={statusDot.label}
+					title={statusDot.label}
+					className={cn("size-2 shrink-0 rounded-full", statusDot.dotClass)}
+				/>
+			</div>
+
+			{subtitle ? (
+				<div className="flex min-w-0 shrink-0 items-center gap-1 text-[10.5px] text-muted-foreground/90">
+					{branch ? (
+						<GitBranch className="size-2.5 shrink-0" strokeWidth={2.2} />
+					) : null}
+					<span className="truncate" title={subtitle}>
+						{subtitle}
+					</span>
+				</div>
+			) : null}
+
+			{/* Always mount: fixes card height regardless of preview content. */}
+			<div
+				data-testid="quick-switch-preview"
+				className="flex min-h-0 flex-1 flex-col-reverse gap-1 overflow-hidden text-[10.5px] leading-[1.4]"
+				style={
+					hasBlocks
+						? {
+								maskImage:
+									"linear-gradient(to top, black 78%, transparent 100%)",
+								WebkitMaskImage:
+									"linear-gradient(to top, black 78%, transparent 100%)",
+							}
+						: undefined
+				}
+			>
+				{hasBlocks
+					? reversedBlocks.map((block) => {
+							if (block.kind === "tool") {
+								return (
+									<div
+										key={block.key}
+										className="flex items-baseline gap-1 truncate font-mono text-[10px] text-muted-foreground/85"
+									>
+										<span className="text-muted-foreground/50">›</span>
+										<span className="truncate">{block.label}</span>
+									</div>
+								);
+							}
+							return (
+								<div
+									key={block.key}
+									className={cn(
+										"break-words whitespace-pre-wrap text-muted-foreground",
+										block.reasoning && "italic text-muted-foreground/70",
+									)}
+								>
+									{block.text}
+								</div>
+							);
+						})
+					: isStreaming
+						? [
+								<div key="thinking" className="italic text-muted-foreground/70">
+									Thinking…
+								</div>,
+							]
+						: null}
+			</div>
+		</button>
+	);
+}

--- a/src/features/quick-switch/use-quick-switch.test.tsx
+++ b/src/features/quick-switch/use-quick-switch.test.tsx
@@ -1,0 +1,365 @@
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { _resetActiveScopeForTesting } from "@/features/shortcuts/focus-scope";
+import { useAppShortcuts } from "@/features/shortcuts/use-app-shortcuts";
+import {
+	_resetQuickSwitchActiveForTesting,
+	isQuickSwitchActive,
+} from "./active-state";
+import {
+	QUICK_SWITCH_WARMING_MS,
+	type QuickSwitchControls,
+	type QuickSwitchSnapshot,
+	useQuickSwitch,
+} from "./use-quick-switch";
+
+type HarnessProps = {
+	snapshot: QuickSwitchSnapshot | null;
+	onCommit: (id: string) => void;
+	controlsRef: { current: QuickSwitchControls | null };
+};
+
+function Harness({ snapshot, onCommit, controlsRef }: HarnessProps) {
+	const controls = useQuickSwitch({
+		buildSnapshot: () => snapshot,
+		onCommit,
+	});
+	controlsRef.current = controls;
+	return null;
+}
+
+function makeControlsRef() {
+	return { current: null as QuickSwitchControls | null };
+}
+
+function dispatchKey(
+	type: "keydown" | "keyup",
+	init: KeyboardEventInit & { key: string },
+) {
+	window.dispatchEvent(new KeyboardEvent(type, init));
+}
+
+function advanceWarming() {
+	act(() => {
+		vi.advanceTimersByTime(QUICK_SWITCH_WARMING_MS);
+	});
+}
+
+describe("useQuickSwitch", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		_resetQuickSwitchActiveForTesting();
+	});
+	afterEach(() => {
+		// Unmount the rendered tree so the global keydown/keyup/blur listeners
+		// from previous tests don't leak forward and double-handle events.
+		cleanup();
+		document.body.innerHTML = "";
+		_resetQuickSwitchActiveForTesting();
+		vi.useRealTimers();
+	});
+
+	it("does not open when fewer than two ids are available", () => {
+		const ref = makeControlsRef();
+		render(
+			<Harness
+				snapshot={{ ids: ["a"], initialIndex: 0 }}
+				onCommit={vi.fn()}
+				controlsRef={ref}
+			/>,
+		);
+		act(() => ref.current?.open("next"));
+		expect(ref.current?.state.phase).toBe("idle");
+		expect(isQuickSwitchActive()).toBe(false);
+	});
+
+	it("a fast tap-and-release commits without ever entering the open phase", () => {
+		const onCommit = vi.fn();
+		const ref = makeControlsRef();
+		// Track every state.phase transition so we can assert the overlay
+		// (phase === "open") never appeared during the fast path.
+		const phaseHistory: string[] = [];
+		function HarnessWithHistory(props: HarnessProps) {
+			const { state, ...rest } = useQuickSwitch({
+				buildSnapshot: () => props.snapshot,
+				onCommit: props.onCommit,
+			});
+			phaseHistory.push(state.phase);
+			props.controlsRef.current = { state, ...rest };
+			return null;
+		}
+		render(
+			<HarnessWithHistory
+				snapshot={{ ids: ["current", "previous"], initialIndex: 1 }}
+				onCommit={onCommit}
+				controlsRef={ref}
+			/>,
+		);
+		// Tap.
+		act(() => ref.current?.open("next"));
+		expect(ref.current?.state).toMatchObject({ phase: "warming", index: 1 });
+		expect(isQuickSwitchActive()).toBe(true);
+		// Release before the warming threshold elapses — overlay never shows.
+		act(() => dispatchKey("keyup", { key: "Control" }));
+		expect(onCommit).toHaveBeenCalledWith("previous");
+		expect(ref.current?.state.phase).toBe("idle");
+		expect(isQuickSwitchActive()).toBe(false);
+		// Phase should have gone idle -> warming -> idle, never touching "open".
+		expect(phaseHistory).not.toContain("open");
+	});
+
+	it("holding past the warming threshold promotes to open (overlay appears)", () => {
+		const ref = makeControlsRef();
+		render(
+			<Harness
+				snapshot={{ ids: ["a", "b", "c"], initialIndex: 1 }}
+				onCommit={vi.fn()}
+				controlsRef={ref}
+			/>,
+		);
+		act(() => ref.current?.open("next"));
+		expect(ref.current?.state.phase).toBe("warming");
+		advanceWarming();
+		expect(ref.current?.state).toMatchObject({ phase: "open", index: 1 });
+	});
+
+	it("open(previous) starts at the last index", () => {
+		const onCommit = vi.fn();
+		const ref = makeControlsRef();
+		render(
+			<Harness
+				snapshot={{ ids: ["a", "b", "c"], initialIndex: 2 }}
+				onCommit={onCommit}
+				controlsRef={ref}
+			/>,
+		);
+		act(() => ref.current?.open("previous"));
+		expect(ref.current?.state).toMatchObject({ phase: "warming", index: 2 });
+
+		act(() => dispatchKey("keyup", { key: "Control" }));
+		expect(onCommit).toHaveBeenCalledWith("c");
+	});
+
+	it("Tab cycles forward, Shift+Tab cycles backward, with wrap-around", () => {
+		const onCommit = vi.fn();
+		const ref = makeControlsRef();
+		render(
+			<Harness
+				snapshot={{ ids: ["a", "b", "c"], initialIndex: 1 }}
+				onCommit={onCommit}
+				controlsRef={ref}
+			/>,
+		);
+		act(() => ref.current?.open("next"));
+		// Tab during warming: cycle AND promote to open.
+		act(() => dispatchKey("keydown", { key: "Tab" }));
+		expect(ref.current?.state).toMatchObject({ phase: "open", index: 2 });
+		// Tab: 2 -> 0 (wrap)
+		act(() => dispatchKey("keydown", { key: "Tab" }));
+		expect(ref.current?.state).toMatchObject({ phase: "open", index: 0 });
+		// Shift+Tab: 0 -> 2 (wrap)
+		act(() => dispatchKey("keydown", { key: "Tab", shiftKey: true }));
+		expect(ref.current?.state).toMatchObject({ phase: "open", index: 2 });
+		// commit
+		act(() => dispatchKey("keyup", { key: "Control" }));
+		expect(onCommit).toHaveBeenCalledWith("c");
+	});
+
+	it("ArrowLeft / ArrowRight cycle like Shift+Tab / Tab", () => {
+		const ref = makeControlsRef();
+		render(
+			<Harness
+				snapshot={{ ids: ["a", "b", "c"], initialIndex: 1 }}
+				onCommit={vi.fn()}
+				controlsRef={ref}
+			/>,
+		);
+		act(() => ref.current?.open("next"));
+		act(() => dispatchKey("keydown", { key: "ArrowRight" }));
+		expect(ref.current?.state).toMatchObject({ phase: "open", index: 2 });
+		act(() => dispatchKey("keydown", { key: "ArrowLeft" }));
+		expect(ref.current?.state).toMatchObject({ phase: "open", index: 1 });
+	});
+
+	it("Escape cancels without firing onCommit", () => {
+		const onCommit = vi.fn();
+		const ref = makeControlsRef();
+		render(
+			<Harness
+				snapshot={{ ids: ["a", "b"], initialIndex: 1 }}
+				onCommit={onCommit}
+				controlsRef={ref}
+			/>,
+		);
+		act(() => ref.current?.open("next"));
+		act(() => dispatchKey("keydown", { key: "Escape" }));
+		expect(onCommit).not.toHaveBeenCalled();
+		expect(ref.current?.state.phase).toBe("idle");
+		expect(isQuickSwitchActive()).toBe(false);
+	});
+
+	it("re-pressing open while engaged cycles instead of re-snapshotting", () => {
+		const ref = makeControlsRef();
+		render(
+			<Harness
+				snapshot={{ ids: ["a", "b", "c"], initialIndex: 1 }}
+				onCommit={vi.fn()}
+				controlsRef={ref}
+			/>,
+		);
+		act(() => ref.current?.open("next"));
+		act(() => ref.current?.open("next"));
+		act(() => ref.current?.open("next"));
+		// 1 -> 2 -> 0 (wrap); cycling promotes warming -> open.
+		expect(ref.current?.state).toMatchObject({ phase: "open", index: 0 });
+
+		act(() => ref.current?.open("previous"));
+		// 0 -> 2 (wrap)
+		expect(ref.current?.state).toMatchObject({ phase: "open", index: 2 });
+	});
+
+	it("window blur cancels and does not commit", () => {
+		const onCommit = vi.fn();
+		const ref = makeControlsRef();
+		render(
+			<Harness
+				snapshot={{ ids: ["a", "b"], initialIndex: 1 }}
+				onCommit={onCommit}
+				controlsRef={ref}
+			/>,
+		);
+		act(() => ref.current?.open("next"));
+		act(() => window.dispatchEvent(new Event("blur")));
+		expect(onCommit).not.toHaveBeenCalled();
+		expect(ref.current?.state.phase).toBe("idle");
+		expect(isQuickSwitchActive()).toBe(false);
+	});
+
+	it("clicking a card via selectIndex + commit fires onCommit with that id", () => {
+		const onCommit = vi.fn();
+		const ref = makeControlsRef();
+		render(
+			<Harness
+				snapshot={{ ids: ["a", "b", "c"], initialIndex: 1 }}
+				onCommit={onCommit}
+				controlsRef={ref}
+			/>,
+		);
+		act(() => ref.current?.open("next"));
+		// selectIndex only fires from the overlay, which only renders when
+		// the phase is "open" — wait past warming first.
+		advanceWarming();
+		act(() => ref.current?.selectIndex(2));
+		act(() => ref.current?.commit());
+		expect(onCommit).toHaveBeenCalledWith("c");
+	});
+
+	it("ignores keydown when isComposing (IME)", () => {
+		const ref = makeControlsRef();
+		render(
+			<Harness
+				snapshot={{ ids: ["a", "b", "c"], initialIndex: 1 }}
+				onCommit={vi.fn()}
+				controlsRef={ref}
+			/>,
+		);
+		act(() => ref.current?.open("next"));
+		act(() =>
+			window.dispatchEvent(
+				new KeyboardEvent("keydown", { key: "Tab", isComposing: true }),
+			),
+		);
+		// Still in warming with the original index — Tab was not consumed.
+		expect(ref.current?.state).toMatchObject({ phase: "warming", index: 1 });
+	});
+
+	it("repeating Ctrl+Tab with useAppShortcuts mounted alongside cycles by exactly 1", () => {
+		// Regression: useAppShortcuts and the overlay's own keydown listener
+		// both live on window in capture phase. Earlier, useAppShortcuts
+		// kept firing the quickSwitchNext callback while engaged, so each
+		// Tab cycled twice (once via the callback, once via the overlay
+		// listener) and the selection ricocheted between two workspaces.
+		_resetActiveScopeForTesting();
+		const onCommit = vi.fn();
+		const ref = makeControlsRef();
+		function CombinedHarness() {
+			const controls = useQuickSwitch({
+				buildSnapshot: () => ({ ids: ["a", "b", "c", "d"], initialIndex: 1 }),
+				onCommit,
+			});
+			ref.current = controls;
+			useAppShortcuts({
+				overrides: {},
+				handlers: [
+					{
+						id: "workspace.quickSwitchNext",
+						callback: () => controls.open("next"),
+					},
+					{
+						id: "workspace.quickSwitchPrevious",
+						callback: () => controls.open("previous"),
+					},
+				],
+			});
+			return null;
+		}
+		render(<CombinedHarness />);
+		// First press goes through useAppShortcuts → controls.open(),
+		// landing on MRU[1].
+		act(() =>
+			dispatchKey("keydown", {
+				key: "Tab",
+				code: "Tab",
+				ctrlKey: true,
+			}),
+		);
+		expect(ref.current?.state).toMatchObject({ index: 1 });
+		// Second press while engaged: useAppShortcuts must short-circuit;
+		// only the overlay's listener should advance the index.
+		act(() =>
+			dispatchKey("keydown", {
+				key: "Tab",
+				code: "Tab",
+				ctrlKey: true,
+			}),
+		);
+		expect(ref.current?.state).toMatchObject({ index: 2 });
+		// Third press — same expectation, no double-step.
+		act(() =>
+			dispatchKey("keydown", {
+				key: "Tab",
+				code: "Tab",
+				ctrlKey: true,
+			}),
+		);
+		expect(ref.current?.state).toMatchObject({ index: 3 });
+		// Ctrl+Shift+Tab walks back, again by exactly one.
+		act(() =>
+			dispatchKey("keydown", {
+				key: "Tab",
+				code: "Tab",
+				ctrlKey: true,
+				shiftKey: true,
+			}),
+		);
+		expect(ref.current?.state).toMatchObject({ index: 2 });
+		// Release commits MRU[2] = "c".
+		act(() => dispatchKey("keyup", { key: "Control" }));
+		expect(onCommit).toHaveBeenCalledWith("c");
+	});
+
+	it("releases the active flag if unmounted while engaged", () => {
+		const ref = makeControlsRef();
+		const { unmount } = render(
+			<Harness
+				snapshot={{ ids: ["a", "b"], initialIndex: 1 }}
+				onCommit={vi.fn()}
+				controlsRef={ref}
+			/>,
+		);
+		act(() => ref.current?.open("next"));
+		expect(isQuickSwitchActive()).toBe(true);
+		unmount();
+		expect(isQuickSwitchActive()).toBe(false);
+	});
+});

--- a/src/features/quick-switch/use-quick-switch.ts
+++ b/src/features/quick-switch/use-quick-switch.ts
@@ -1,0 +1,226 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { beginQuickSwitch, endQuickSwitch } from "./active-state";
+
+export type QuickSwitchDirection = "next" | "previous";
+
+export type QuickSwitchSnapshot = {
+	ids: string[];
+	initialIndex: number;
+};
+
+/**
+ * - `idle`: nothing happening.
+ * - `warming`: user pressed the hotkey but hasn't held long enough for the
+ *   overlay to appear. A quick tap-and-release in this phase commits without
+ *   the overlay ever flashing — same UX as macOS Cmd+Tab / Arc Ctrl+Tab.
+ * - `open`: overlay is visible. Reached by either holding past the threshold
+ *   or actively cycling (Tab / ArrowLeft / ArrowRight).
+ */
+export type QuickSwitchState =
+	| { phase: "idle" }
+	| { phase: "warming"; ids: string[]; index: number }
+	| { phase: "open"; ids: string[]; index: number };
+
+export type QuickSwitchControls = {
+	state: QuickSwitchState;
+	open: (direction: QuickSwitchDirection) => void;
+	cycle: (delta: 1 | -1) => void;
+	selectIndex: (index: number) => void;
+	commit: () => void;
+	cancel: () => void;
+};
+
+type UseQuickSwitchArgs = {
+	buildSnapshot: (
+		direction: QuickSwitchDirection,
+	) => QuickSwitchSnapshot | null;
+	onCommit: (id: string) => void;
+};
+
+const IDLE: QuickSwitchState = { phase: "idle" };
+
+/** How long the user has to hold the hotkey before the overlay appears. */
+export const QUICK_SWITCH_WARMING_MS = 200;
+
+export function useQuickSwitch({
+	buildSnapshot,
+	onCommit,
+}: UseQuickSwitchArgs): QuickSwitchControls {
+	const [state, setState] = useState<QuickSwitchState>(IDLE);
+	// stateRef mirrors `state` synchronously. Every write goes through
+	// `applyState`, which updates the ref before scheduling the React render —
+	// so even within React 18 batched updates, side-effect code reading the
+	// "current" state inside open/commit/cancel sees consistent values.
+	const stateRef = useRef<QuickSwitchState>(IDLE);
+	const buildSnapshotRef = useRef(buildSnapshot);
+	buildSnapshotRef.current = buildSnapshot;
+	const onCommitRef = useRef(onCommit);
+	onCommitRef.current = onCommit;
+	const warmingTimerRef = useRef<number | null>(null);
+
+	const applyState = useCallback((next: QuickSwitchState) => {
+		stateRef.current = next;
+		setState(next);
+	}, []);
+
+	const clearWarmingTimer = useCallback(() => {
+		if (warmingTimerRef.current !== null) {
+			window.clearTimeout(warmingTimerRef.current);
+			warmingTimerRef.current = null;
+		}
+	}, []);
+
+	const cycle = useCallback(
+		(delta: 1 | -1) => {
+			const cur = stateRef.current;
+			if (cur.phase !== "warming" && cur.phase !== "open") return;
+			const n = cur.ids.length;
+			if (n === 0) return;
+			const nextIndex = (((cur.index + delta) % n) + n) % n;
+			// Cycling is an explicit "I want to see the list" signal, so
+			// promote to `open` immediately even if we were still warming.
+			clearWarmingTimer();
+			applyState({ phase: "open", ids: cur.ids, index: nextIndex });
+		},
+		[applyState, clearWarmingTimer],
+	);
+
+	const selectIndex = useCallback(
+		(index: number) => {
+			const cur = stateRef.current;
+			// Hover/click target lives in the overlay, which only renders when
+			// phase === "open". Guard anyway to keep the function pure.
+			if (cur.phase !== "open") return;
+			if (index < 0 || index >= cur.ids.length) return;
+			applyState({ ...cur, index });
+		},
+		[applyState],
+	);
+
+	const cancel = useCallback(() => {
+		const cur = stateRef.current;
+		if (cur.phase === "idle") return;
+		clearWarmingTimer();
+		applyState(IDLE);
+		endQuickSwitch();
+	}, [applyState, clearWarmingTimer]);
+
+	const commit = useCallback(() => {
+		const cur = stateRef.current;
+		if (cur.phase === "idle") return;
+		const id = cur.ids[cur.index] ?? null;
+		clearWarmingTimer();
+		applyState(IDLE);
+		endQuickSwitch();
+		if (id) onCommitRef.current(id);
+	}, [applyState, clearWarmingTimer]);
+
+	const open = useCallback(
+		(direction: QuickSwitchDirection) => {
+			const cur = stateRef.current;
+			// Re-press while already engaged = cycle (and promote to open).
+			if (cur.phase !== "idle") {
+				cycle(direction === "next" ? 1 : -1);
+				return;
+			}
+			const snapshot = buildSnapshotRef.current(direction);
+			if (!snapshot || snapshot.ids.length < 2) return;
+			const safeIndex = Math.min(
+				Math.max(0, snapshot.initialIndex),
+				snapshot.ids.length - 1,
+			);
+			beginQuickSwitch();
+			applyState({ phase: "warming", ids: snapshot.ids, index: safeIndex });
+			// Promote to "open" (= overlay appears) only if the user is still
+			// holding the hotkey after the threshold. A fast tap-then-release
+			// commits inside this window with no overlay flash.
+			warmingTimerRef.current = window.setTimeout(() => {
+				warmingTimerRef.current = null;
+				const latest = stateRef.current;
+				if (latest.phase === "warming") {
+					applyState({
+						phase: "open",
+						ids: latest.ids,
+						index: latest.index,
+					});
+				}
+			}, QUICK_SWITCH_WARMING_MS);
+		},
+		[applyState, cycle],
+	);
+
+	useEffect(() => {
+		// Listeners attach for both warming and open: warming needs to see
+		// keyup-Control to commit a fast tap, and Tab/Esc during warming
+		// promote/cancel just like during open.
+		if (state.phase === "idle") return;
+
+		const onKeyDown = (event: KeyboardEvent) => {
+			// `event.isComposing` covers IME composition; never preempt input.
+			if (event.isComposing) return;
+			const key = event.key;
+			if (key === "Tab") {
+				event.preventDefault();
+				event.stopImmediatePropagation();
+				cycle(event.shiftKey ? -1 : 1);
+				return;
+			}
+			if (key === "ArrowRight") {
+				event.preventDefault();
+				event.stopImmediatePropagation();
+				cycle(1);
+				return;
+			}
+			if (key === "ArrowLeft") {
+				event.preventDefault();
+				event.stopImmediatePropagation();
+				cycle(-1);
+				return;
+			}
+			if (key === "Escape") {
+				event.preventDefault();
+				event.stopImmediatePropagation();
+				cancel();
+				return;
+			}
+			if (key === "Enter") {
+				event.preventDefault();
+				event.stopImmediatePropagation();
+				commit();
+				return;
+			}
+		};
+
+		const onKeyUp = (event: KeyboardEvent) => {
+			if (event.key === "Control") commit();
+		};
+
+		// Window blur: user Cmd+Tab'd away. Cancel rather than commit so
+		// returning to Helmor doesn't surprise-switch the workspace.
+		const onBlur = () => cancel();
+
+		window.addEventListener("keydown", onKeyDown, true);
+		window.addEventListener("keyup", onKeyUp, true);
+		window.addEventListener("blur", onBlur);
+		return () => {
+			window.removeEventListener("keydown", onKeyDown, true);
+			window.removeEventListener("keyup", onKeyUp, true);
+			window.removeEventListener("blur", onBlur);
+		};
+	}, [state.phase, cycle, cancel, commit]);
+
+	// Safety net: if the component using us unmounts while engaged, release
+	// the global active flag and any pending timer so the rest of the app
+	// isn't stuck short-circuiting.
+	useEffect(() => {
+		return () => {
+			if (warmingTimerRef.current !== null) {
+				window.clearTimeout(warmingTimerRef.current);
+				warmingTimerRef.current = null;
+			}
+			if (stateRef.current.phase !== "idle") endQuickSwitch();
+		};
+	}, []);
+
+	return { state, open, cycle, selectIndex, commit, cancel };
+}

--- a/src/features/shortcuts/registry.ts
+++ b/src/features/shortcuts/registry.ts
@@ -23,6 +23,22 @@ export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
 		editable: true,
 	},
 	{
+		id: "workspace.quickSwitchNext",
+		title: "Quick switch workspace",
+		group: "Navigation",
+		defaultHotkey: "Control+Tab",
+		scopes: ["app"],
+		editable: true,
+	},
+	{
+		id: "workspace.quickSwitchPrevious",
+		title: "Quick switch workspace (reverse)",
+		group: "Navigation",
+		defaultHotkey: "Control+Shift+Tab",
+		scopes: ["app"],
+		editable: true,
+	},
+	{
 		id: "session.previous",
 		title: "Previous session",
 		group: "Navigation",

--- a/src/features/shortcuts/types.ts
+++ b/src/features/shortcuts/types.ts
@@ -1,6 +1,8 @@
 export type ShortcutId =
 	| "workspace.previous"
 	| "workspace.next"
+	| "workspace.quickSwitchNext"
+	| "workspace.quickSwitchPrevious"
 	| "workspace.new"
 	| "workspace.addRepository"
 	| "workspace.copyPath"

--- a/src/features/shortcuts/use-app-shortcuts.test.tsx
+++ b/src/features/shortcuts/use-app-shortcuts.test.tsx
@@ -1,5 +1,10 @@
 import { render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	_resetQuickSwitchActiveForTesting,
+	beginQuickSwitch,
+	endQuickSwitch,
+} from "@/features/quick-switch/active-state";
 import { _resetActiveScopeForTesting } from "./focus-scope";
 import {
 	beginShortcutRecording,
@@ -28,6 +33,7 @@ function fireModT() {
 describe("useAppShortcuts", () => {
 	beforeEach(() => {
 		_resetActiveScopeForTesting();
+		_resetQuickSwitchActiveForTesting();
 	});
 	afterEach(() => {
 		endShortcutRecording();
@@ -179,6 +185,76 @@ describe("useAppShortcuts", () => {
 			new KeyboardEvent("keydown", { key: "Tab", code: "Tab", shiftKey: true }),
 		);
 		expect(togglePlanMode).not.toHaveBeenCalled();
+	});
+
+	it("mutes ALL global shortcuts while quick-switch is active", () => {
+		// Why "all" — even the quick-switch hotkey itself must not callback
+		// through `useAppShortcuts` while active. Otherwise a repeat
+		// Ctrl+Tab while holding Ctrl would cycle twice: once via this
+		// dispatcher and once via the overlay's own capture-phase listener
+		// (they're both registered on window, capture phase, and the
+		// dispatcher only does `stopPropagation`, not
+		// `stopImmediatePropagation`). The overlay's listener is the
+		// single source of truth while engaged.
+		const themeToggle = vi.fn();
+		const quickSwitchNext = vi.fn();
+
+		function Harness() {
+			useAppShortcuts({
+				overrides: {},
+				handlers: [
+					{ id: "theme.toggle", callback: themeToggle },
+					{ id: "workspace.quickSwitchNext", callback: quickSwitchNext },
+				],
+			});
+			return null;
+		}
+
+		render(<Harness />);
+		beginQuickSwitch();
+
+		// theme.toggle (Mod+Alt+T) muted.
+		window.dispatchEvent(
+			new KeyboardEvent("keydown", {
+				key: "t",
+				code: "KeyT",
+				metaKey: true,
+				altKey: true,
+			}),
+		);
+		expect(themeToggle).not.toHaveBeenCalled();
+
+		// quick-switch's own hotkey is ALSO muted at this layer — the
+		// overlay's capture-phase listener handles repeats directly.
+		window.dispatchEvent(
+			new KeyboardEvent("keydown", {
+				key: "Tab",
+				code: "Tab",
+				ctrlKey: true,
+			}),
+		);
+		expect(quickSwitchNext).not.toHaveBeenCalled();
+
+		endQuickSwitch();
+
+		// Once inactive, everything works again.
+		window.dispatchEvent(
+			new KeyboardEvent("keydown", {
+				key: "t",
+				code: "KeyT",
+				metaKey: true,
+				altKey: true,
+			}),
+		);
+		expect(themeToggle).toHaveBeenCalledTimes(1);
+		window.dispatchEvent(
+			new KeyboardEvent("keydown", {
+				key: "Tab",
+				code: "Tab",
+				ctrlKey: true,
+			}),
+		);
+		expect(quickSwitchNext).toHaveBeenCalledTimes(1);
 	});
 
 	it("fires app-scope shortcuts regardless of focus scope", () => {

--- a/src/features/shortcuts/use-app-shortcuts.ts
+++ b/src/features/shortcuts/use-app-shortcuts.ts
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef } from "react";
+import { isQuickSwitchActive } from "@/features/quick-switch/active-state";
 import { getActiveScopes } from "./focus-scope";
 import { normalizeShortcutEvent } from "./format";
 import { isShortcutRecordingActive } from "./recording-state";
@@ -66,6 +67,14 @@ export function useAppShortcuts({ overrides, handlers }: UseAppShortcutsArgs) {
 						registration.scopes.some((scope) => activeScopes.includes(scope))),
 			);
 			if (!match) return;
+			// Once quick-switch is engaged (warming or open), the overlay's
+			// own capture-phase listener owns every keystroke until it
+			// commits or cancels. We must NOT also fire `quickSwitch.open()`
+			// from here for repeat Ctrl+Tab presses — otherwise the same
+			// keydown cycles twice (once via this callback, once via the
+			// overlay listener), producing the "stuck between two tabs"
+			// bug. Hard short-circuit instead of carving exceptions.
+			if (isQuickSwitchActive()) return;
 			event.preventDefault();
 			event.stopPropagation();
 			match.callback();


### PR DESCRIPTION
## Summary

Add workspace quick-switch feature with Arc/Cmd+Tab-style interaction: hold to cycle through workspaces, release to commit selection. Also fix workspace status indicator rendering for legacy status spellings.

## Changes

- **Quick Switch Feature**: New `src/features/quick-switch/` module
  - `index.ts` — Main feature entry
  - `use-quick-switch.ts` — Hook driving overlay lifecycle (Cmd+Tab)
  - `quick-switch-overlay.tsx` — UI component with smooth cycling
  - `mru-stack.ts` — MRU (most-recently-used) tracking logic
  - `active-state.ts` — Active workspace state management
  - Comprehensive test coverage for all modules

- **Navigation Improvements**:
  - Extract `workspace-display.ts` and `workspace-status-display.ts` from hover-card for reuse
  - Fix workspace status dot rendering when status has legacy spellings
  - Update shortcuts registry to include Cmd+Tab binding

- **Release Announcement**: `.announcements/quick-switch-overlay.json` for in-app user notification

## Test Plan

- [x] All new test files pass (quick-switch feature, display modules)
- [x] Pre-commit hooks pass (biome, clippy, cargo fmt)
- [x] Feature tested manually with Cmd+Tab to cycle workspaces
- [x] Status indicator fixed and renders correctly for all status values