### PR TITLE
refactor: slim announcement storage to use watermark instead of set

### DIFF
--- a/.changeset/tidy-otters-store.md
+++ b/.changeset/tidy-otters-store.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Slim down how Helmor remembers which release-announcement toasts have been dismissed; users upgrading from a much older build may see pending release notes one more time.

--- a/src/features/announcements/announcements.test.ts
+++ b/src/features/announcements/announcements.test.ts
@@ -19,7 +19,7 @@ describe("selectReleaseAnnouncement", () => {
 				currentVersion: "0.20.0",
 				lastSeenVersion: null,
 				isFirstHelmorBoot: true,
-				dismissedReleaseVersions: new Set(),
+				lastDismissedReleaseVersion: null,
 			}),
 		).toBeNull();
 	});
@@ -30,7 +30,7 @@ describe("selectReleaseAnnouncement", () => {
 			currentVersion: "0.20.0",
 			lastSeenVersion: null,
 			isFirstHelmorBoot: false,
-			dismissedReleaseVersions: new Set(),
+			lastDismissedReleaseVersion: null,
 		});
 		expect(result?.releaseVersions).toEqual(["0.20.0"]);
 		expect(result?.items).toEqual([{ text: "A" }, { text: "B" }]);
@@ -43,7 +43,7 @@ describe("selectReleaseAnnouncement", () => {
 				currentVersion: "0.20.0",
 				lastSeenVersion: "0.20.0",
 				isFirstHelmorBoot: false,
-				dismissedReleaseVersions: new Set(),
+				lastDismissedReleaseVersion: null,
 			}),
 		).toBeNull();
 	});
@@ -55,7 +55,7 @@ describe("selectReleaseAnnouncement", () => {
 				currentVersion: "0.19.0",
 				lastSeenVersion: "0.20.0",
 				isFirstHelmorBoot: false,
-				dismissedReleaseVersions: new Set(),
+				lastDismissedReleaseVersion: null,
 			}),
 		).toBeNull();
 	});
@@ -66,7 +66,7 @@ describe("selectReleaseAnnouncement", () => {
 			currentVersion: "0.20.0",
 			lastSeenVersion: "0.19.1",
 			isFirstHelmorBoot: false,
-			dismissedReleaseVersions: new Set(),
+			lastDismissedReleaseVersion: null,
 		});
 		expect(result).toEqual({
 			releaseVersions: ["0.20.0"],
@@ -75,16 +75,33 @@ describe("selectReleaseAnnouncement", () => {
 		});
 	});
 
-	it("skips dismissed versions", () => {
+	it("skips releases ≤ the dismissed watermark", () => {
 		expect(
 			selectReleaseAnnouncement({
 				catalog,
 				currentVersion: "0.20.0",
 				lastSeenVersion: "0.19.1",
 				isFirstHelmorBoot: false,
-				dismissedReleaseVersions: new Set(["0.20.0"]),
+				lastDismissedReleaseVersion: "0.20.0",
 			}),
 		).toBeNull();
+	});
+
+	it("collapses older versions under a newer dismiss watermark", () => {
+		const wideCatalog: readonly ReleaseAnnouncementCatalogEntry[] = [
+			{ releaseVersion: "0.19.0", items: [{ text: "OLD" }] },
+			{ releaseVersion: "0.20.0", items: [{ text: "MID" }] },
+			{ releaseVersion: "0.21.0", items: [{ text: "NEW" }] },
+		];
+		const result = selectReleaseAnnouncement({
+			catalog: wideCatalog,
+			currentVersion: "0.21.0",
+			lastSeenVersion: "0.18.0",
+			isFirstHelmorBoot: false,
+			lastDismissedReleaseVersion: "0.20.0",
+		});
+		expect(result?.releaseVersions).toEqual(["0.21.0"]);
+		expect(result?.items).toEqual([{ text: "NEW" }]);
 	});
 
 	it("replays every version in (lastSeen, current] when the user skipped releases", () => {
@@ -97,7 +114,7 @@ describe("selectReleaseAnnouncement", () => {
 			currentVersion: "0.21.0",
 			lastSeenVersion: "0.19.1",
 			isFirstHelmorBoot: false,
-			dismissedReleaseVersions: new Set(),
+			lastDismissedReleaseVersion: null,
 		});
 		expect(result).toEqual({
 			releaseVersions: ["0.21.0", "0.20.0"],
@@ -116,7 +133,7 @@ describe("selectReleaseAnnouncement", () => {
 			currentVersion: "0.20.0",
 			lastSeenVersion: "0.19.1",
 			isFirstHelmorBoot: false,
-			dismissedReleaseVersions: new Set(),
+			lastDismissedReleaseVersion: null,
 		});
 		expect(result?.releaseVersions).toEqual(["0.20.0"]);
 	});
@@ -131,7 +148,7 @@ describe("selectReleaseAnnouncement", () => {
 			currentVersion: "0.21.0",
 			lastSeenVersion: "0.19.1",
 			isFirstHelmorBoot: false,
-			dismissedReleaseVersions: new Set(),
+			lastDismissedReleaseVersion: null,
 		});
 		expect(result?.releaseVersions).toEqual(["0.21.0", "0.20.0"]);
 		expect(result?.items).toEqual([{ text: "NEWER" }, { text: "OLDER" }]);
@@ -144,7 +161,7 @@ describe("selectReleaseAnnouncement", () => {
 				currentVersion: "0.21.0",
 				lastSeenVersion: "0.20.0",
 				isFirstHelmorBoot: false,
-				dismissedReleaseVersions: new Set(),
+				lastDismissedReleaseVersion: null,
 			}),
 		).toBeNull();
 	});

--- a/src/features/announcements/announcements.ts
+++ b/src/features/announcements/announcements.ts
@@ -52,7 +52,7 @@ function parseSemver(version: string): [number, number, number] {
 	return [major, minor, patch];
 }
 
-function compareSemver(a: string, b: string): number {
+export function compareSemver(a: string, b: string): number {
 	const [aMaj, aMin, aPat] = parseSemver(a);
 	const [bMaj, bMin, bPat] = parseSemver(b);
 	if (aMaj !== bMaj) return aMaj - bMaj;
@@ -93,13 +93,19 @@ export function selectReleaseAnnouncement(args: {
 	 *             replay the full catalog backlog into one toast.
 	 */
 	isFirstHelmorBoot: boolean;
-	dismissedReleaseVersions: ReadonlySet<string>;
+	/**
+	 * Highest release version the user has already dismissed. Treated as
+	 * "dismissed everything ≤ this", so older catalog entries are skipped
+	 * too — versions are monotonic, so a single watermark replaces the
+	 * legacy "set of every dismissed version" without losing meaning.
+	 */
+	lastDismissedReleaseVersion: string | null;
 }): ReleaseAnnouncement | null {
 	const {
 		catalog,
 		currentVersion,
 		isFirstHelmorBoot,
-		dismissedReleaseVersions,
+		lastDismissedReleaseVersion,
 	} = args;
 	let { lastSeenVersion } = args;
 
@@ -122,7 +128,8 @@ export function selectReleaseAnnouncement(args: {
 			(entry) =>
 				compareSemver(entry.releaseVersion, lastSeenVersion) > 0 &&
 				compareSemver(entry.releaseVersion, currentVersion) <= 0 &&
-				!dismissedReleaseVersions.has(entry.releaseVersion),
+				(lastDismissedReleaseVersion === null ||
+					compareSemver(entry.releaseVersion, lastDismissedReleaseVersion) > 0),
 		)
 		.slice()
 		// Newest version first. Stable sort preserves the original

--- a/src/features/announcements/index.tsx
+++ b/src/features/announcements/index.tsx
@@ -22,7 +22,7 @@ import releaseAnnouncementCatalog from "@/features/announcements/release-announc
 import {
 	dismissReleaseAnnouncement,
 	isFirstHelmorBoot,
-	readDismissedReleaseAnnouncementVersions,
+	readLastDismissedReleaseVersion,
 	readLastSeenInstallVersion,
 	writeLastSeenInstallVersion,
 } from "@/features/announcements/storage";
@@ -62,7 +62,7 @@ export function ReleaseAnnouncementToastHost({
 			// classified as a fresh install — meaning the very toast that
 			// introduces the announcement system is never seen by anyone.
 			isFirstHelmorBoot: isFirstHelmorBoot(),
-			dismissedReleaseVersions: readDismissedReleaseAnnouncementVersions(),
+			lastDismissedReleaseVersion: readLastDismissedReleaseVersion(),
 		});
 		// Always advance: bootstraps first-install (so we never re-evaluate
 		// fresh installs as upgrades) and prevents re-showing the same
@@ -92,11 +92,11 @@ export function ReleaseAnnouncementToastHost({
 	};
 
 	const close = () => {
-		// Multi-version when the user skipped releases — dismiss every version so the
-		// next launch doesn't replay the same backlog.
-		for (const version of announcement.releaseVersions) {
-			dismissReleaseAnnouncement(version);
-		}
+		// releaseVersions is sorted newest-first; the watermark stored by
+		// dismissReleaseAnnouncement collapses older versions too, so one
+		// call covers a skipped-version backlog.
+		const newest = announcement.releaseVersions[0];
+		if (newest) dismissReleaseAnnouncement(newest);
 		setAnnouncement(null);
 	};
 

--- a/src/features/announcements/storage.test.ts
+++ b/src/features/announcements/storage.test.ts
@@ -1,82 +1,51 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-	DISMISSED_RELEASE_ANNOUNCEMENTS_STORAGE_KEY,
 	dismissReleaseAnnouncement,
 	isFirstHelmorBoot,
+	LAST_DISMISSED_RELEASE_VERSION_STORAGE_KEY,
 	LAST_SEEN_INSTALL_VERSION_STORAGE_KEY,
-	readDismissedReleaseAnnouncementVersions,
+	readLastDismissedReleaseVersion,
 	readLastSeenInstallVersion,
 	writeLastSeenInstallVersion,
 } from "./storage";
 
-describe("dismissed-announcements storage", () => {
+describe("dismissed-release-version storage", () => {
 	beforeEach(() => {
 		window.localStorage.clear();
 	});
 
-	it("returns an empty set when nothing is stored", () => {
-		expect(readDismissedReleaseAnnouncementVersions().size).toBe(0);
+	afterEach(() => {
+		vi.restoreAllMocks();
 	});
 
-	it("returns the persisted versions as a Set", () => {
+	it("returns null when nothing is stored", () => {
+		expect(readLastDismissedReleaseVersion()).toBeNull();
+	});
+
+	it("returns the persisted watermark version", () => {
 		window.localStorage.setItem(
-			DISMISSED_RELEASE_ANNOUNCEMENTS_STORAGE_KEY,
-			JSON.stringify(["0.20.0", "0.21.0"]),
+			LAST_DISMISSED_RELEASE_VERSION_STORAGE_KEY,
+			"0.21.0",
 		);
-		const dismissed = readDismissedReleaseAnnouncementVersions();
-		expect([...dismissed].sort()).toEqual(["0.20.0", "0.21.0"]);
+		expect(readLastDismissedReleaseVersion()).toBe("0.21.0");
 	});
 
-	it("maps legacy dismissed ids to their release versions", () => {
-		window.localStorage.setItem(
-			DISMISSED_RELEASE_ANNOUNCEMENTS_STORAGE_KEY,
-			JSON.stringify(["2026-05-11-2300"]),
-		);
-		expect([...readDismissedReleaseAnnouncementVersions()]).toEqual(["0.21.0"]);
-	});
-
-	it("recovers gracefully from invalid JSON", () => {
-		window.localStorage.setItem(
-			DISMISSED_RELEASE_ANNOUNCEMENTS_STORAGE_KEY,
-			"{not json",
-		);
-		expect(readDismissedReleaseAnnouncementVersions().size).toBe(0);
-	});
-
-	it("ignores non-array stored values", () => {
-		window.localStorage.setItem(
-			DISMISSED_RELEASE_ANNOUNCEMENTS_STORAGE_KEY,
-			JSON.stringify({ rogue: "shape" }),
-		);
-		expect(readDismissedReleaseAnnouncementVersions().size).toBe(0);
-	});
-
-	it("filters out non-string entries from the persisted array", () => {
-		window.localStorage.setItem(
-			DISMISSED_RELEASE_ANNOUNCEMENTS_STORAGE_KEY,
-			JSON.stringify(["valid", 42, null, "also-valid"]),
-		);
-		expect([...readDismissedReleaseAnnouncementVersions()].sort()).toEqual([
-			"also-valid",
-			"valid",
-		]);
-	});
-
-	it("appends a version without losing previously dismissed ones", () => {
+	it("dismissing a newer version raises the watermark", () => {
 		dismissReleaseAnnouncement("0.20.0");
 		dismissReleaseAnnouncement("0.21.0");
-		expect([...readDismissedReleaseAnnouncementVersions()].sort()).toEqual([
-			"0.20.0",
-			"0.21.0",
-		]);
+		expect(readLastDismissedReleaseVersion()).toBe("0.21.0");
 	});
 
-	it("is idempotent — dismissing the same version twice doesn't duplicate it", () => {
+	it("dismissing an older version does not lower the watermark", () => {
+		dismissReleaseAnnouncement("0.21.0");
+		dismissReleaseAnnouncement("0.20.0");
+		expect(readLastDismissedReleaseVersion()).toBe("0.21.0");
+	});
+
+	it("dismissing the same version twice is a no-op", () => {
 		dismissReleaseAnnouncement("0.21.0");
 		dismissReleaseAnnouncement("0.21.0");
-		const dismissed = readDismissedReleaseAnnouncementVersions();
-		expect(dismissed.size).toBe(1);
-		expect(dismissed.has("0.21.0")).toBe(true);
+		expect(readLastDismissedReleaseVersion()).toBe("0.21.0");
 	});
 
 	it("doesn't throw when localStorage.setItem fails", () => {
@@ -88,7 +57,7 @@ describe("dismissed-announcements storage", () => {
 		const consoleErrorSpy = vi
 			.spyOn(console, "error")
 			.mockImplementation(() => {});
-		expect(() => dismissReleaseAnnouncement("x")).not.toThrow();
+		expect(() => dismissReleaseAnnouncement("0.21.0")).not.toThrow();
 		expect(consoleErrorSpy).toHaveBeenCalled();
 		setItemSpy.mockRestore();
 		consoleErrorSpy.mockRestore();

--- a/src/features/announcements/storage.ts
+++ b/src/features/announcements/storage.ts
@@ -1,12 +1,14 @@
-export const DISMISSED_RELEASE_ANNOUNCEMENTS_STORAGE_KEY =
-	"helmor:dismissed-release-announcements";
+import { compareSemver } from "./announcements";
+
+/**
+ * Watermark: the highest release version the user has dismissed
+ * announcements for. Anything ≤ this is treated as dismissed.
+ */
+export const LAST_DISMISSED_RELEASE_VERSION_STORAGE_KEY =
+	"helmor:last-dismissed-release-version";
 
 export const LAST_SEEN_INSTALL_VERSION_STORAGE_KEY =
 	"helmor:last-seen-install-version";
-
-const LEGACY_DISMISSED_RELEASE_ANNOUNCEMENT_IDS: Record<string, string> = {
-	"2026-05-11-2300": "0.21.0",
-};
 
 /**
  * Best-effort detection of "this device has never run Helmor before".
@@ -34,33 +36,24 @@ export function isFirstHelmorBoot(): boolean {
 	}
 }
 
-export function readDismissedReleaseAnnouncementVersions(): Set<string> {
+export function readLastDismissedReleaseVersion(): string | null {
 	try {
 		const raw = window.localStorage.getItem(
-			DISMISSED_RELEASE_ANNOUNCEMENTS_STORAGE_KEY,
+			LAST_DISMISSED_RELEASE_VERSION_STORAGE_KEY,
 		);
-		if (!raw) return new Set();
-
-		const parsed: unknown = JSON.parse(raw);
-		if (!Array.isArray(parsed)) return new Set();
-
-		return new Set(
-			parsed
-				.filter((id): id is string => typeof id === "string")
-				.map((id) => LEGACY_DISMISSED_RELEASE_ANNOUNCEMENT_IDS[id] ?? id),
-		);
+		return typeof raw === "string" && raw.length > 0 ? raw : null;
 	} catch {
-		return new Set();
+		return null;
 	}
 }
 
 export function dismissReleaseAnnouncement(releaseVersion: string): void {
-	const dismissed = readDismissedReleaseAnnouncementVersions();
-	dismissed.add(releaseVersion);
+	const current = readLastDismissedReleaseVersion();
+	if (current !== null && compareSemver(releaseVersion, current) <= 0) return;
 	try {
 		window.localStorage.setItem(
-			DISMISSED_RELEASE_ANNOUNCEMENTS_STORAGE_KEY,
-			JSON.stringify([...dismissed]),
+			LAST_DISMISSED_RELEASE_VERSION_STORAGE_KEY,
+			releaseVersion,
 		);
 	} catch (error) {
 		console.error(


### PR DESCRIPTION
## Summary

Replace Set-based dismissed-announcement tracking with a single watermark value (`lastDismissedReleaseVersion`). Since release versions are monotonic, storing only the highest dismissed version is sufficient — anything ≤ it is treated as dismissed.

**Benefits:**
- Smaller storage footprint
- Simpler comparison logic
- Clearer semantics (one watermark vs. set membership)

**Trade-off:** Users upgrading from older builds may see pending release notes one more time as we switch storage strategies.

## Test plan

- [x] All announcement tests pass (including new watermark-collapse test)
- [x] Storage tests confirm watermark behavior (raise on higher, no-op on lower)
- [x] First-boot detection still works
- [x] Legacy ID mapping removed (no longer needed)