### PR TITLE
Require confirmation before archiving sidebar workspaces

### DIFF
--- a/.changeset/calm-keys-confirm.md
+++ b/.changeset/calm-keys-confirm.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Add a Confirm step to sidebar archive actions so workspaces are not archived from a single click.

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -417,6 +417,11 @@ describe("App", () => {
 		);
 
 		await user.click(screen.getByRole("button", { name: "Archive workspace" }));
+		expect(onArchiveWorkspace).not.toHaveBeenCalled();
+
+		await user.click(
+			screen.getByRole("button", { name: "Confirm archive workspace" }),
+		);
 
 		expect(onArchiveWorkspace).toHaveBeenCalledWith("ready-workspace");
 	});

--- a/src/features/navigation/index.test.tsx
+++ b/src/features/navigation/index.test.tsx
@@ -468,7 +468,46 @@ describe("WorkspacesSidebar", () => {
 		expect(archiveButtons[1]).toBeEnabled();
 
 		await user.click(archiveButtons[1]);
+		expect(onArchiveWorkspace).not.toHaveBeenCalled();
+
+		const confirmButton = screen.getByRole("button", {
+			name: "Confirm archive workspace",
+		});
+		expect(confirmButton).toBeEnabled();
+		expect(confirmButton).toHaveTextContent("Confirm");
+
+		await user.click(confirmButton);
 		expect(onArchiveWorkspace).toHaveBeenCalledWith("workspace-2");
+	});
+
+	it("resets the archive confirm button when the pointer leaves the workspace row", async () => {
+		const user = userEvent.setup();
+		const onArchiveWorkspace = vi.fn();
+
+		render(
+			<TooltipProvider delayDuration={0}>
+				<WorkspacesSidebar
+					groups={workspaceGroups}
+					archivedRows={[]}
+					onArchiveWorkspace={onArchiveWorkspace}
+				/>
+			</TooltipProvider>,
+		);
+
+		await user.click(screen.getByRole("button", { name: "Archive workspace" }));
+		expect(
+			screen.getByRole("button", { name: "Confirm archive workspace" }),
+		).toHaveTextContent("Confirm");
+
+		fireEvent.pointerLeave(screen.getByRole("button", { name: "Workspace 1" }));
+
+		expect(onArchiveWorkspace).not.toHaveBeenCalled();
+		expect(
+			screen.queryByRole("button", { name: "Confirm archive workspace" }),
+		).toBeNull();
+		expect(
+			screen.getByRole("button", { name: "Archive workspace" }),
+		).toBeInTheDocument();
 	});
 
 	it("keeps workspace actions enabled while a new workspace is being created", async () => {
@@ -492,6 +531,10 @@ describe("WorkspacesSidebar", () => {
 		expect(archiveButton).toBeEnabled();
 
 		await user.click(archiveButton);
+		expect(onArchiveWorkspace).not.toHaveBeenCalled();
+		await user.click(
+			screen.getByRole("button", { name: "Confirm archive workspace" }),
+		);
 		expect(onArchiveWorkspace).toHaveBeenCalledWith("workspace-1");
 	});
 

--- a/src/features/navigation/row-item.tsx
+++ b/src/features/navigation/row-item.tsx
@@ -194,13 +194,38 @@ export const WorkspaceRowItem = memo(
 		]);
 		useEffect(() => cancelPendingPrefetch, [cancelPendingPrefetch]);
 		const [moveDialogOpen, setMoveDialogOpen] = useState(false);
+		const [archiveConfirming, setArchiveConfirming] = useState(false);
+		const resetArchiveConfirm = useCallback(() => {
+			setArchiveConfirming(false);
+		}, []);
+		const startArchiveConfirm = useCallback(() => {
+			setArchiveConfirming(true);
+		}, []);
+		const handleRowPointerLeave = useCallback(() => {
+			cancelPendingPrefetch();
+			resetArchiveConfirm();
+		}, [cancelPendingPrefetch, resetArchiveConfirm]);
 		const actionLabel =
-			row.state === "archived" ? "Restore workspace" : "Archive workspace";
+			row.state === "archived"
+				? "Restore workspace"
+				: archiveConfirming
+					? "Confirm archive workspace"
+					: "Archive workspace";
 		const isArchiving = archivingWorkspaceIds?.has(row.id) ?? false;
 		const isMarkingUnread = markingUnreadWorkspaceId === row.id;
 		const isRestoring = restoringWorkspaceId === row.id;
 		const isRestoreAction = row.state === "archived";
 		const isBusy = isArchiving || isMarkingUnread || isRestoring;
+		useEffect(() => resetArchiveConfirm, [resetArchiveConfirm]);
+		useEffect(() => {
+			resetArchiveConfirm();
+		}, [
+			resetArchiveConfirm,
+			row.id,
+			isRestoreAction,
+			isBusy,
+			workspaceActionsDisabled,
+		]);
 		const hasActionHandler = isRestoreAction
 			? Boolean(onRestoreWorkspace)
 			: Boolean(onArchiveWorkspace);
@@ -211,12 +236,19 @@ export const WorkspaceRowItem = memo(
 		// instead of leaving a visible gap.
 		const hasTwoActions =
 			hasActionHandler && isRestoreAction && Boolean(onDeleteWorkspace);
-		const rowFadeStyle = hasTwoActions
+		const isArchiveConfirmVisible =
+			archiveConfirming && !isRestoreAction && !isBusy;
+		const rowFadeStyle = isArchiveConfirmVisible
 			? ({
-					"--row-fade-transparent": "2.6rem",
-					"--row-fade-solid": "3.4rem",
+					"--row-fade-transparent": "3.9rem",
+					"--row-fade-solid": "4.8rem",
 				} as React.CSSProperties)
-			: undefined;
+			: hasTwoActions
+				? ({
+						"--row-fade-transparent": "2.6rem",
+						"--row-fade-solid": "3.4rem",
+					} as React.CSSProperties)
+				: undefined;
 		const actionIcon = isBusy ? (
 			<LoaderCircle className="size-3.5 animate-spin" strokeWidth={2.1} />
 		) : isRestoreAction ? (
@@ -261,7 +293,7 @@ export const WorkspaceRowItem = memo(
 				data-busy={isBusy ? "true" : undefined}
 				style={rowFadeStyle}
 				onPointerEnter={handlePointerEnter}
-				onPointerLeave={cancelPendingPrefetch}
+				onPointerLeave={handleRowPointerLeave}
 				onPointerDown={(event) => {
 					cancelPendingPrefetch();
 					if (onDragPointerDown && groupId) {
@@ -410,26 +442,36 @@ export const WorkspaceRowItem = memo(
 										if (workspaceActionsDisabled || isBusy) return;
 										if (isRestoreAction) {
 											onRestoreWorkspace?.(row.id);
-										} else {
+										} else if (archiveConfirming) {
+											resetArchiveConfirm();
 											onArchiveWorkspace?.(row.id);
+										} else {
+											startArchiveConfirm();
 										}
 									}}
-									variant="ghost"
+									variant={isArchiveConfirmVisible ? "destructive" : "ghost"}
 									size="icon-xs"
 									className={cn(
-										"size-5 rounded-md p-0 text-muted-foreground",
+										"size-5 rounded-md p-0",
+										!isArchiveConfirmVisible && "text-muted-foreground",
+										isArchiveConfirmVisible &&
+											"h-5 w-auto min-w-11 px-1.5 text-[11px] font-medium leading-none transition-colors duration-100 hover:bg-destructive/10 hover:text-destructive active:not-aria-[haspopup]:translate-y-0 dark:hover:bg-destructive/20",
 										workspaceActionsDisabled
 											? "cursor-not-allowed opacity-60"
-											: "cursor-interactive hover:text-foreground",
+											: isArchiveConfirmVisible
+												? "cursor-interactive"
+												: "cursor-interactive hover:text-foreground",
 									)}
 								>
-									{actionIcon}
+									{isArchiveConfirmVisible ? "Confirm" : actionIcon}
 								</Button>
 							);
 							// Archived rows show restore + delete with no tooltips
 							// (the icons are already self-explanatory and the
 							// extra hover layer on a destructive control feels noisy).
 							return isRestoreAction ? (
+								actionButton
+							) : isArchiveConfirmVisible ? (
 								actionButton
 							) : (
 								<Tooltip>


### PR DESCRIPTION
## What changed
- add a two-step confirm state to the sidebar archive action before a workspace is archived
- reset the confirm state when the row loses hover or its state changes
- cover the confirm flow and reset behavior in the navigation sidebar tests
- add a patch changeset for the sidebar archive confirmation change

## Why
- archiving from a single click in the sidebar was easy to trigger accidentally
- the extra confirm step reduces destructive mistakes without changing the restore flow

## Follow-up / test notes
- Ran `bun x vitest run src/features/navigation/index.test.tsx`
- No additional follow-up is required unless we want to reuse the same confirm pattern for other destructive row actions later