### PR TITLE
Fix shell panel resize jank with long chat threads

### DIFF
--- a/.changeset/swift-panels-glide.md
+++ b/.changeset/swift-panels-glide.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Make dragging to resize the left sidebar and right inspector feel fluid, even with a long chat thread open.

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -21,6 +21,12 @@ vi.mock("@tauri-apps/plugin-dialog", () => ({
 
 const SIDEBAR_WIDTH_STORAGE_KEY = "helmor.workspaceSidebarWidth";
 const INSPECTOR_WIDTH_STORAGE_KEY = "helmor.workspaceInspectorWidth";
+const SIDEBAR_WIDTH_VAR = "--shell-sidebar-width";
+const INSPECTOR_WIDTH_VAR = "--shell-inspector-width";
+
+function getShellWidthVar(name: string): string {
+	return document.documentElement.style.getPropertyValue(name);
+}
 
 describe("App", () => {
 	beforeEach(() => {
@@ -75,10 +81,11 @@ describe("App", () => {
 		expect(shell).toHaveClass("overflow-hidden");
 		expect(sidebar).toHaveClass("bg-sidebar");
 		expect(sidebar).toHaveClass("overflow-hidden");
-		expect(sidebar).toHaveStyle({ width: "336px" });
 		expect(inspector).toHaveClass("bg-sidebar");
 		expect(inspector).toHaveClass("overflow-hidden");
-		expect(inspector).toHaveStyle({ width: "336px" });
+		// 宽度由 CSS variable 驱动,验证 documentElement 上的 variable 值。
+		expect(getShellWidthVar(SIDEBAR_WIDTH_VAR)).toBe("336px");
+		expect(getShellWidthVar(INSPECTOR_WIDTH_VAR)).toBe("336px");
 		expect(screen.getByLabelText("Inspector section Git")).toBeInTheDocument();
 		expect(
 			screen.getByLabelText("Inspector section Actions"),
@@ -104,10 +111,11 @@ describe("App", () => {
 		).toBeInTheDocument();
 		expect(resizeHandle).toHaveAttribute("aria-valuenow", "336");
 		expect(inspectorResizeHandle).toHaveAttribute("aria-valuenow", "336");
-		expect(inspectorResizeHandle).toHaveStyle({
-			right: "316px",
-			width: "20px",
-		});
+		// 位置由 CSS variable 驱动,inline style 表达成 calc(var(...) - X)。
+		expect(inspectorResizeHandle).toHaveStyle({ width: "20px" });
+		expect(inspectorResizeHandle.style.right).toBe(
+			`calc(var(--shell-inspector-width, 336px) - 20px)`,
+		);
 		expect(safeAreas).toHaveLength(1);
 		expect(groupsScrollRegion).toHaveClass("overflow-y-auto");
 		expect(groupsScrollRegion).toHaveClass("flex-1");
@@ -204,7 +212,6 @@ describe("App", () => {
 		render(<App />);
 		await screen.findByRole("main", { name: "Application shell" });
 
-		const sidebar = screen.getByLabelText("Workspace sidebar");
 		const resizeHandle = screen.getByRole("separator", {
 			name: "Resize sidebar",
 		});
@@ -217,15 +224,18 @@ describe("App", () => {
 
 		fireEvent.mouseMove(window, { clientX: 360 });
 
+		// 拖动期间宽度通过 CSS variable 实时驱动(避免 React 重渲染),
+		// 所以验证 documentElement 上的 variable 值,而不是元素 inline width。
+		// 注意:拖动期间 aria-valuenow 不会更新(separator 没重渲染),mouseup 才会同步。
 		await waitFor(() => {
-			expect(sidebar).toHaveStyle({ width: "360px" });
-			expect(resizeHandle).toHaveAttribute("aria-valuenow", "360");
+			expect(getShellWidthVar(SIDEBAR_WIDTH_VAR)).toBe("360px");
 		});
 
 		fireEvent.mouseUp(window);
 
 		await waitFor(() => {
 			expect(document.body.style.cursor).toBe("");
+			expect(resizeHandle).toHaveAttribute("aria-valuenow", "360");
 		});
 
 		expect(window.localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY)).toBe("360");
@@ -235,7 +245,6 @@ describe("App", () => {
 		render(<App />);
 		await screen.findByRole("main", { name: "Application shell" });
 
-		const inspector = screen.getByLabelText("Inspector sidebar");
 		const resizeHandle = screen.getByRole("separator", {
 			name: "Resize inspector sidebar",
 		});
@@ -249,14 +258,14 @@ describe("App", () => {
 		fireEvent.mouseMove(window, { clientX: 1172 });
 
 		await waitFor(() => {
-			expect(inspector).toHaveStyle({ width: "364px" });
-			expect(resizeHandle).toHaveAttribute("aria-valuenow", "364");
+			expect(getShellWidthVar(INSPECTOR_WIDTH_VAR)).toBe("364px");
 		});
 
 		fireEvent.mouseUp(window);
 
 		await waitFor(() => {
 			expect(document.body.style.cursor).toBe("");
+			expect(resizeHandle).toHaveAttribute("aria-valuenow", "364");
 		});
 
 		expect(window.localStorage.getItem(INSPECTOR_WIDTH_STORAGE_KEY)).toBe(
@@ -271,11 +280,10 @@ describe("App", () => {
 		render(<App />);
 		await screen.findByRole("main", { name: "Application shell" });
 
-		expect(screen.getByLabelText("Workspace sidebar")).toHaveStyle({
-			width: "404px",
-		});
-		expect(screen.getByLabelText("Inspector sidebar")).toHaveStyle({
-			width: "388px",
+		// 宽度通过 CSS variable 暴露;React state 同步在 mount 后立即把它写入。
+		await waitFor(() => {
+			expect(getShellWidthVar(SIDEBAR_WIDTH_VAR)).toBe("404px");
+			expect(getShellWidthVar(INSPECTOR_WIDTH_VAR)).toBe("388px");
 		});
 		expect(
 			screen.getByRole("separator", { name: "Resize sidebar" }),

--- a/src/features/panel/thread-viewport.tsx
+++ b/src/features/panel/thread-viewport.tsx
@@ -24,6 +24,7 @@ import { expandSessionThread } from "@/lib/query-client";
 import { useSessionThreadPagination } from "@/lib/session-thread-pagination";
 import { useSettings } from "@/lib/settings";
 import type { WorkspaceScriptType } from "@/lib/workspace-script-actions";
+import { isShellResizing, onShellResize } from "@/shell/hooks/use-panels";
 import { EmptyState, MemoConversationMessage } from "./message-components";
 import { useEscapeBottomLock } from "./thread-viewport/use-escape-bottom-lock";
 import { useStreamingIndicatorSync } from "./thread-viewport/use-streaming-indicator-sync";
@@ -43,7 +44,6 @@ type ThreadViewportSlot = ComponentType<Record<string, never>>;
 // (e.g. when switching sessions/workspaces and back).
 const streamingStartTimes = new Map<string, number>();
 
-const CHAT_LAYOUT_CACHE_VERSION = "chat-layout-v1";
 const NON_VIRTUALIZED_THREAD_MESSAGE_LIMIT = 12;
 const PROGRESSIVE_VIEWPORT_DEFAULT_HEIGHT = 900;
 const PROGRESSIVE_VIEWPORT_HEADER_HEIGHT = 24;
@@ -73,7 +73,9 @@ export function ActiveThreadViewport({
 }) {
 	const stackRef = useRef<HTMLDivElement | null>(null);
 	const [widthBucket, setWidthBucket] = useState(0);
-	const [paneWidth, setPaneWidth] = useState(0);
+	const pendingBucketRef = useRef<number | null>(null);
+	// 估算用 32px 粒度的宽度,拖动时只在跨越 bucket 边界才让 estimator/measureHeights 缓存失效。
+	const paneWidth = widthBucket * 32;
 
 	useLayoutEffect(() => {
 		if (
@@ -88,10 +90,21 @@ export function ActiveThreadViewport({
 			return;
 		}
 
+		const computeBucket = (width: number) =>
+			width > 0 ? Math.max(1, Math.round(width / 32)) : 0;
+
+		// 拖动期间 stack 的 clientWidth 通过 CSS variable 实时变化,RO 会按 60Hz fire,
+		// 但我们不希望每帧都进 React 渲染——视觉上文字换行已由浏览器 reflow 处理。
+		// 只记 pending,等 onShellResize(false) 触发再 flush。
 		const updateWidthBucket = () => {
 			const width = stack.clientWidth;
-			setPaneWidth(width);
-			setWidthBucket(width > 0 ? Math.max(1, Math.round(width / 32)) : 0);
+			const next = computeBucket(width);
+			if (isShellResizing()) {
+				pendingBucketRef.current = next;
+				return;
+			}
+			pendingBucketRef.current = null;
+			setWidthBucket((current) => (current === next ? current : next));
 		};
 
 		updateWidthBucket();
@@ -100,8 +113,17 @@ export function ActiveThreadViewport({
 		});
 		observer.observe(stack);
 
+		const unsubscribe = onShellResize((active) => {
+			if (active) return;
+			const pending = pendingBucketRef.current;
+			pendingBucketRef.current = null;
+			if (pending === null) return;
+			setWidthBucket((current) => (current === pending ? current : pending));
+		});
+
 		return () => {
 			observer.disconnect();
+			unsubscribe();
 		};
 	}, []);
 
@@ -113,7 +135,6 @@ export function ActiveThreadViewport({
 			<div className="relative z-10 flex min-h-0 min-w-0 flex-1">
 				<ChatThread
 					hasSession={hasSession}
-					layoutCacheKey={getSessionLayoutCacheKey(pane.sessionId, widthBucket)}
 					messages={pane.messages}
 					missingScriptTypes={missingScriptTypes}
 					onInitializeScript={onInitializeScript}
@@ -127,7 +148,6 @@ export function ActiveThreadViewport({
 }
 
 function ChatThread({
-	layoutCacheKey,
 	messages,
 	hasSession,
 	missingScriptTypes,
@@ -136,7 +156,6 @@ function ChatThread({
 	sessionId,
 	sending,
 }: {
-	layoutCacheKey: string;
 	messages: ThreadMessageLike[];
 	hasSession: boolean;
 	missingScriptTypes: WorkspaceScriptType[];
@@ -297,7 +316,6 @@ function ChatThread({
 				fontSize={settings.chatFontSize}
 				hasSession={hasSession}
 				itemContent={itemContent}
-				layoutCacheKey={layoutCacheKey}
 				missingScriptTypes={missingScriptTypes}
 				onInitializeScript={onInitializeScript}
 				paneWidth={paneWidth}
@@ -334,7 +352,6 @@ function ConversationViewport({
 	fontSize,
 	hasSession,
 	itemContent,
-	layoutCacheKey,
 	missingScriptTypes,
 	onInitializeScript,
 	paneWidth,
@@ -353,7 +370,6 @@ function ConversationViewport({
 	fontSize: number;
 	hasSession: boolean;
 	itemContent: (index: number, message: RenderedMessage) => ReactNode;
-	layoutCacheKey: string;
 	missingScriptTypes: WorkspaceScriptType[];
 	onInitializeScript?: (scriptType: WorkspaceScriptType) => void;
 	paneWidth: number;
@@ -426,7 +442,6 @@ function ConversationViewport({
 						fontSize={fontSize}
 						header={Header}
 						itemContent={itemContent}
-						layoutCacheKey={layoutCacheKey}
 						paneWidth={paneWidth}
 						pinTailRows={pinTailRows}
 						scrollParent={scrollParent}
@@ -479,7 +494,6 @@ function ProgressiveConversationViewport({
 	fontSize,
 	header: Header,
 	itemContent,
-	layoutCacheKey,
 	paneWidth,
 	pinTailRows,
 	scrollParent,
@@ -493,7 +507,6 @@ function ProgressiveConversationViewport({
 	fontSize: number;
 	header?: ThreadViewportSlot;
 	itemContent: (index: number, message: RenderedMessage) => ReactNode;
-	layoutCacheKey: string;
 	paneWidth: number;
 	pinTailRows: boolean;
 	scrollParent: HTMLDivElement | null;
@@ -526,9 +539,13 @@ function ProgressiveConversationViewport({
 		setStreamingRowEl(node);
 	}, []);
 
-	const [lastLayoutCacheKey, setLastLayoutCacheKey] = useState(layoutCacheKey);
-	if (lastLayoutCacheKey !== layoutCacheKey) {
-		setLastLayoutCacheKey(layoutCacheKey);
+	// Reset 只跟 sessionId 走。原来用 layoutCacheKey(含 widthBucket)做触发器会让
+	// 拖动结束跨越 32px 边界时清空 measuredHeights,造成可见行高度跳变 + 全量
+	// 重测量。同一 session 的 message 引用不变,DOM reflow 后 ResizeObserver 会
+	// 自然反馈新高度,无需手动 reset。
+	const [lastSessionId, setLastSessionId] = useState(sessionId);
+	if (lastSessionId !== sessionId) {
+		setLastSessionId(sessionId);
 		setCommittedScrollState({ scrollTop: 0, viewportHeight: 0 });
 		setMeasuredHeights({});
 		initialScrollAppliedRef.current = false;
@@ -1057,10 +1074,6 @@ function ConversationRowShell({ children }: { children: ReactNode }) {
 			{children}
 		</div>
 	);
-}
-
-function getSessionLayoutCacheKey(sessionId: string, widthBucket: number) {
-	return [CHAT_LAYOUT_CACHE_VERSION, sessionId, String(widthBucket)].join(":");
 }
 
 export function ConversationColdPlaceholder() {

--- a/src/shell/components/shell-inspector-pane.tsx
+++ b/src/shell/components/shell-inspector-pane.tsx
@@ -115,7 +115,11 @@ export function ShellInspectorPane({
 					: "transition-[width] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]",
 				collapsed ? "pointer-events-none" : "",
 			)}
-			style={{ width: collapsed ? 0 : `${width}px` }}
+			// 宽度由 CSS variable 驱动(use-panels.ts 拖动时直接 setProperty),
+			// 这样拖动期间 React 不需要重渲染就能更新视觉宽度。
+			style={{
+				width: collapsed ? 0 : `var(--shell-inspector-width, ${width}px)`,
+			}}
 		>
 			<div
 				className={cn(
@@ -124,7 +128,7 @@ export function ShellInspectorPane({
 						? "translate-x-full opacity-0"
 						: "translate-x-0 opacity-100",
 				)}
-				style={{ width: `${width}px` }}
+				style={{ width: `var(--shell-inspector-width, ${width}px)` }}
 			>
 				{rightSidebarMode === "context" ? (
 					<WorkspaceStartContextSidebar

--- a/src/shell/components/shell-resize-separator.tsx
+++ b/src/shell/components/shell-resize-separator.tsx
@@ -26,18 +26,19 @@ export function ShellResizeSeparator({
 	onMouseDown,
 	onKeyDown,
 }: Props) {
+	// 位置同样由 CSS variable 驱动,拖动时跟着面板宽度实时移动,无 React 重渲染。
 	const containerStyle: CSSProperties =
 		side === "sidebar"
 			? {
 					left: collapsed
 						? `${-SIDEBAR_RESIZE_HIT_AREA / 2}px`
-						: `${width - SIDEBAR_RESIZE_HIT_AREA / 2}px`,
+						: `calc(var(--shell-sidebar-width, ${width}px) - ${SIDEBAR_RESIZE_HIT_AREA / 2}px)`,
 					width: `${SIDEBAR_RESIZE_HIT_AREA}px`,
 				}
 			: {
 					right: collapsed
 						? `${-SIDEBAR_RESIZE_HIT_AREA}px`
-						: `${Math.max(0, width - SIDEBAR_RESIZE_HIT_AREA)}px`,
+						: `calc(var(--shell-inspector-width, ${width}px) - ${SIDEBAR_RESIZE_HIT_AREA}px)`,
 					width: `${SIDEBAR_RESIZE_HIT_AREA}px`,
 				};
 

--- a/src/shell/components/shell-sidebar-pane.tsx
+++ b/src/shell/components/shell-sidebar-pane.tsx
@@ -74,7 +74,11 @@ export function ShellSidebarPane({
 					: "transition-[width] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]",
 				collapsed ? "pointer-events-none" : "",
 			)}
-			style={{ width: collapsed ? 0 : `${width}px` }}
+			// 宽度由 CSS variable 驱动(use-panels.ts 拖动时直接 setProperty),
+			// 这样拖动期间 React 不需要重渲染就能更新视觉宽度。
+			style={{
+				width: collapsed ? 0 : `var(--shell-sidebar-width, ${width}px)`,
+			}}
 		>
 			<div
 				className={cn(
@@ -83,7 +87,7 @@ export function ShellSidebarPane({
 						? "-translate-x-full opacity-0"
 						: "translate-x-0 opacity-100",
 				)}
-				style={{ width: `${width}px` }}
+				style={{ width: `var(--shell-sidebar-width, ${width}px)` }}
 			>
 				<div className="min-h-0 flex-1">
 					<WorkspacesSidebarContainer

--- a/src/shell/hooks/use-panels.ts
+++ b/src/shell/hooks/use-panels.ts
@@ -3,6 +3,7 @@ import {
 	type MouseEvent,
 	useCallback,
 	useEffect,
+	useLayoutEffect,
 	useState,
 } from "react";
 import {
@@ -21,6 +22,51 @@ type ResizeState = {
 	target: ResizeTarget;
 };
 
+export const SIDEBAR_WIDTH_VAR = "--shell-sidebar-width";
+export const INSPECTOR_WIDTH_VAR = "--shell-inspector-width";
+
+// Module-level resize state store. 故意不放进 React state——订阅它的组件不应该
+// 因为拖动开始/结束而重渲染,只在拖动结束时通过 listener 主动 flush 一次。
+type ResizeListener = (active: boolean) => void;
+const resizeListeners = new Set<ResizeListener>();
+let resizingActive = false;
+
+export function isShellResizing(): boolean {
+	return resizingActive;
+}
+
+export function onShellResize(listener: ResizeListener): () => void {
+	resizeListeners.add(listener);
+	return () => {
+		resizeListeners.delete(listener);
+	};
+}
+
+function setResizingActive(active: boolean) {
+	if (resizingActive === active) return;
+	resizingActive = active;
+	for (const listener of resizeListeners) {
+		listener(active);
+	}
+}
+
+function writeWidthVar(target: ResizeTarget, width: number) {
+	if (typeof document === "undefined") return;
+	const varName =
+		target === "sidebar" ? SIDEBAR_WIDTH_VAR : INSPECTOR_WIDTH_VAR;
+	document.documentElement.style.setProperty(varName, `${width}px`);
+}
+
+// 模块加载时立刻把初始宽度写到 CSS variable,这样 React 首次 render 前 DOM 就有值,
+// 不会出现一帧的 0 宽度闪烁。
+if (typeof document !== "undefined") {
+	writeWidthVar("sidebar", getInitialSidebarWidth());
+	writeWidthVar(
+		"inspector",
+		getInitialSidebarWidth(INSPECTOR_WIDTH_STORAGE_KEY),
+	);
+}
+
 export function useShellPanels() {
 	const [sidebarWidth, setSidebarWidth] = useState(getInitialSidebarWidth);
 	const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
@@ -28,6 +74,17 @@ export function useShellPanels() {
 		getInitialSidebarWidth(INSPECTOR_WIDTH_STORAGE_KEY),
 	);
 	const [resizeState, setResizeState] = useState<ResizeState | null>(null);
+
+	// React state -> CSS variable 同步。仅在非拖动场景下生效(键盘步进、初始
+	// 载入、mouseup 后的 commit)。拖动期间 CSS variable 由 mousemove 直接写,
+	// React state 此时是 stale 的,但 setProperty(同值)是 no-op。
+	useLayoutEffect(() => {
+		writeWidthVar("sidebar", sidebarWidth);
+	}, [sidebarWidth]);
+
+	useLayoutEffect(() => {
+		writeWidthVar("inspector", inspectorWidth);
+	}, [inspectorWidth]);
 
 	useEffect(() => {
 		try {
@@ -62,18 +119,16 @@ export function useShellPanels() {
 			return;
 		}
 
+		setResizingActive(true);
+
 		let pendingWidth: number | null = null;
 		let rafId: number | null = null;
-		const flush = () => {
+
+		// 拖动期间只写 CSS variable, 完全不进 React 渲染路径。
+		const flushVar = () => {
 			rafId = null;
 			if (pendingWidth === null) return;
-			const nextWidth = pendingWidth;
-			pendingWidth = null;
-			if (resizeState.target === "sidebar") {
-				setSidebarWidth(nextWidth);
-			} else {
-				setInspectorWidth(nextWidth);
-			}
+			writeWidthVar(resizeState.target, pendingWidth);
 		};
 
 		const handleMouseMove = (event: globalThis.MouseEvent) => {
@@ -84,15 +139,27 @@ export function useShellPanels() {
 					: resizeState.sidebarWidth - deltaX;
 			pendingWidth = clampSidebarWidth(rawWidth);
 			if (rafId === null) {
-				rafId = window.requestAnimationFrame(flush);
+				rafId = window.requestAnimationFrame(flushVar);
 			}
 		};
+
 		const handleMouseUp = () => {
 			if (rafId !== null) {
 				window.cancelAnimationFrame(rafId);
 				rafId = null;
 			}
-			flush();
+			flushVar();
+			// 把 CSS variable 最终值 commit 回 React state,
+			// 用于持久化 + 触发依赖宽度的非拖动场景(比如设置面板里显示当前宽度)。
+			const finalWidth = pendingWidth;
+			if (finalWidth !== null) {
+				if (resizeState.target === "sidebar") {
+					setSidebarWidth(finalWidth);
+				} else {
+					setInspectorWidth(finalWidth);
+				}
+			}
+			setResizingActive(false);
 			setResizeState(null);
 		};
 		const previousCursor = document.body.style.cursor;
@@ -108,6 +175,7 @@ export function useShellPanels() {
 			if (rafId !== null) {
 				window.cancelAnimationFrame(rafId);
 			}
+			setResizingActive(false);
 			document.body.style.cursor = previousCursor;
 			document.body.style.userSelect = previousUserSelect;
 			window.removeEventListener("mousemove", handleMouseMove);


### PR DESCRIPTION
## What changed
- move sidebar and inspector drag updates onto CSS variables so the shell resizes without React rerendering every mousemove
- keep resize separators and pane widths driven by those CSS variables during drag, then commit the final width back into React state on mouseup
- stop resetting the thread viewport's measured layout on width-bucket changes and flush width-bucket updates after resizing ends
- update the app test coverage and add a patch changeset

## Why
Dragging the shell panes while a long chat thread was open caused avoidable rerenders and viewport remeasurement work, which made the resize interaction feel choppy.

## Follow-up / test notes
- Ran `bun x vitest run src/App.test.tsx`
- Broader frontend or Tauri manual verification was not run
