### PR TITLE
Fix run controls when hover expansion is disabled

### DIFF
--- a/.changeset/pinned-run-controls.md
+++ b/.changeset/pinned-run-controls.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Keep the Stop and Rerun buttons reachable in the Setup and Run tabs when "Expand terminals on hover" is turned off.

--- a/src/features/inspector/sections/run.test.tsx
+++ b/src/features/inspector/sections/run.test.tsx
@@ -1,8 +1,13 @@
 import { cleanup, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { ReactNode } from "react";
+import type { ReactElement, ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Tabs } from "@/components/ui/tabs";
+import {
+	type AppSettings,
+	DEFAULT_SETTINGS,
+	SettingsContext,
+} from "@/lib/settings";
 import { renderWithProviders } from "@/test/render-with-providers";
 import { TabsZoomContext } from "../layout";
 import { _resetForTesting } from "../script-store";
@@ -58,19 +63,48 @@ function ZoomedProvider({ children }: { children: ReactNode }) {
 	);
 }
 
+function SettingsOverrideProvider({
+	children,
+	overrides,
+}: {
+	children: ReactNode;
+	overrides: Partial<AppSettings>;
+}) {
+	return (
+		<SettingsContext.Provider
+			value={{
+				settings: { ...DEFAULT_SETTINGS, ...overrides },
+				isLoaded: true,
+				updateSettings: async () => {},
+			}}
+		>
+			{children}
+		</SettingsContext.Provider>
+	);
+}
+
 function renderRun(
 	overrides: Partial<typeof defaults> = {},
-	{ zoomed = false }: { zoomed?: boolean } = {},
+	{
+		zoomed = false,
+		settings,
+	}: { zoomed?: boolean; settings?: Partial<AppSettings> } = {},
 ) {
 	const props = { ...defaults, ...overrides };
-	const tree = (
+	let tree: ReactElement = (
 		<Tabs defaultValue="run">
 			<RunTab {...props} />
 		</Tabs>
 	);
-	return renderWithProviders(
-		zoomed ? <ZoomedProvider>{tree}</ZoomedProvider> : tree,
-	);
+	if (zoomed) tree = <ZoomedProvider>{tree}</ZoomedProvider>;
+	if (settings) {
+		tree = (
+			<SettingsOverrideProvider overrides={settings}>
+				{tree}
+			</SettingsOverrideProvider>
+		);
+	}
+	return renderWithProviders(tree);
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -188,5 +222,37 @@ describe("RunTab", () => {
 		expect(
 			screen.queryByRole("button", { name: /stop/i }),
 		).not.toBeInTheDocument();
+	});
+
+	it("shows the Stop button without zoom when terminalHoverExpansion is off", async () => {
+		const user = userEvent.setup();
+		renderRun({}, { settings: { terminalHoverExpansion: false } });
+
+		await user.click(screen.getByRole("button", { name: /^run$/i }));
+
+		expect(screen.getByRole("button", { name: /stop/i })).toBeInTheDocument();
+	});
+
+	it("shows the Rerun button without zoom after exit when terminalHoverExpansion is off", async () => {
+		const user = userEvent.setup();
+
+		let onEvent: (e: unknown) => void = () => {};
+		apiMocks.executeRepoScript.mockImplementation(
+			(_r: string, _t: string, cb: (e: unknown) => void) => {
+				onEvent = cb;
+				return Promise.resolve();
+			},
+		);
+
+		renderRun({}, { settings: { terminalHoverExpansion: false } });
+		await user.click(screen.getByRole("button", { name: /^run$/i }));
+
+		onEvent({ type: "exited", code: 0 });
+
+		await waitFor(() => {
+			expect(
+				screen.getByRole("button", { name: /rerun/i }),
+			).toBeInTheDocument();
+		});
 	});
 });

--- a/src/features/inspector/sections/run.tsx
+++ b/src/features/inspector/sections/run.tsx
@@ -234,6 +234,11 @@ export function RunTab({
 	);
 
 	const hasScript = !!runScript?.trim();
+	const autoExpandEnabled = settings.terminalHoverExpansion;
+	// Auto-expand off → zoom never fires, so anchor the button unconditionally.
+	const showFloatingAction =
+		(status === "running" || status === "exited") &&
+		(autoExpandEnabled ? isZoomPresented : true);
 
 	return (
 		<div
@@ -257,14 +262,18 @@ export function RunTab({
 						/>
 					</div>
 
-					{isZoomPresented && (status === "running" || status === "exited") && (
+					{showFloatingAction && (
 						<div
 							className="absolute bottom-3 right-4"
-							style={{
-								opacity: isHoverExpanded ? 1 : 0,
-								pointerEvents: isHoverExpanded ? "auto" : "none",
-								transition: `opacity ${TABS_HOVER_TRANSITION_MS}ms ${TABS_EASING}`,
-							}}
+							style={
+								autoExpandEnabled
+									? {
+											opacity: isHoverExpanded ? 1 : 0,
+											pointerEvents: isHoverExpanded ? "auto" : "none",
+											transition: `opacity ${TABS_HOVER_TRANSITION_MS}ms ${TABS_EASING}`,
+										}
+									: undefined
+							}
 						>
 							<Button
 								variant={status === "running" ? "destructive" : "secondary"}

--- a/src/features/inspector/sections/setup.test.tsx
+++ b/src/features/inspector/sections/setup.test.tsx
@@ -1,8 +1,13 @@
 import { cleanup, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { ReactNode } from "react";
+import type { ReactElement, ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Tabs } from "@/components/ui/tabs";
+import {
+	type AppSettings,
+	DEFAULT_SETTINGS,
+	SettingsContext,
+} from "@/lib/settings";
 import { renderWithProviders } from "@/test/render-with-providers";
 import { TabsZoomContext } from "../layout";
 import { _resetForTesting } from "../script-store";
@@ -59,19 +64,48 @@ function ZoomedProvider({ children }: { children: ReactNode }) {
 	);
 }
 
+function SettingsOverrideProvider({
+	children,
+	overrides,
+}: {
+	children: ReactNode;
+	overrides: Partial<AppSettings>;
+}) {
+	return (
+		<SettingsContext.Provider
+			value={{
+				settings: { ...DEFAULT_SETTINGS, ...overrides },
+				isLoaded: true,
+				updateSettings: async () => {},
+			}}
+		>
+			{children}
+		</SettingsContext.Provider>
+	);
+}
+
 function renderSetup(
 	overrides: Partial<typeof defaults> = {},
-	{ zoomed = false }: { zoomed?: boolean } = {},
+	{
+		zoomed = false,
+		settings,
+	}: { zoomed?: boolean; settings?: Partial<AppSettings> } = {},
 ) {
 	const props = { ...defaults, ...overrides };
-	const tree = (
+	let tree: ReactElement = (
 		<Tabs defaultValue="setup">
 			<SetupTab {...props} />
 		</Tabs>
 	);
-	return renderWithProviders(
-		zoomed ? <ZoomedProvider>{tree}</ZoomedProvider> : tree,
-	);
+	if (zoomed) tree = <ZoomedProvider>{tree}</ZoomedProvider>;
+	if (settings) {
+		tree = (
+			<SettingsOverrideProvider overrides={settings}>
+				{tree}
+			</SettingsOverrideProvider>
+		);
+	}
+	return renderWithProviders(tree);
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -184,5 +218,37 @@ describe("SetupTab", () => {
 		expect(
 			screen.queryByRole("button", { name: /stop/i }),
 		).not.toBeInTheDocument();
+	});
+
+	it("shows the Stop button without zoom when terminalHoverExpansion is off", async () => {
+		const user = userEvent.setup();
+		renderSetup({}, { settings: { terminalHoverExpansion: false } });
+
+		await user.click(screen.getByRole("button", { name: /run setup/i }));
+
+		expect(screen.getByRole("button", { name: /stop/i })).toBeInTheDocument();
+	});
+
+	it("shows the Rerun button without zoom after exit when terminalHoverExpansion is off", async () => {
+		const user = userEvent.setup();
+
+		let onEvent: (e: unknown) => void = () => {};
+		apiMocks.executeRepoScript.mockImplementation(
+			(_r: string, _t: string, cb: (e: unknown) => void) => {
+				onEvent = cb;
+				return Promise.resolve();
+			},
+		);
+
+		renderSetup({}, { settings: { terminalHoverExpansion: false } });
+		await user.click(screen.getByRole("button", { name: /run setup/i }));
+
+		onEvent({ type: "exited", code: 0 });
+
+		await waitFor(() => {
+			expect(
+				screen.getByRole("button", { name: /rerun setup/i }),
+			).toBeInTheDocument();
+		});
 	});
 });

--- a/src/features/inspector/sections/setup.tsx
+++ b/src/features/inspector/sections/setup.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/components/terminal-output";
 import { Button } from "@/components/ui/button";
 import { helmorQueryKeys } from "@/lib/query-client";
+import { useSettings } from "@/lib/settings";
 import { cn } from "@/lib/utils";
 import { TABS_EASING, TABS_HOVER_TRANSITION_MS, useTabsZoom } from "../layout";
 import {
@@ -47,8 +48,14 @@ export function SetupTab({
 	const [hasRun, setHasRun] = useState(false);
 	const queryClient = useQueryClient();
 	const { isZoomPresented, isHoverExpanded } = useTabsZoom();
+	const { settings } = useSettings();
 
 	const hasScript = !!setupScript?.trim();
+	const autoExpandEnabled = settings.terminalHoverExpansion;
+	// Auto-expand off → zoom never fires, so anchor the button unconditionally.
+	const showFloatingAction =
+		(status === "running" || status === "exited") &&
+		(autoExpandEnabled ? isZoomPresented : true);
 
 	useEffect(() => {
 		if (!workspaceId) return;
@@ -162,14 +169,18 @@ export function SetupTab({
 						/>
 					</div>
 
-					{isZoomPresented && (status === "running" || status === "exited") && (
+					{showFloatingAction && (
 						<div
 							className="absolute bottom-3 right-4"
-							style={{
-								opacity: isHoverExpanded ? 1 : 0,
-								pointerEvents: isHoverExpanded ? "auto" : "none",
-								transition: `opacity ${TABS_HOVER_TRANSITION_MS}ms ${TABS_EASING}`,
-							}}
+							style={
+								autoExpandEnabled
+									? {
+											opacity: isHoverExpanded ? 1 : 0,
+											pointerEvents: isHoverExpanded ? "auto" : "none",
+											transition: `opacity ${TABS_HOVER_TRANSITION_MS}ms ${TABS_EASING}`,
+										}
+									: undefined
+							}
 						>
 							<Button
 								variant={status === "running" ? "destructive" : "secondary"}


### PR DESCRIPTION
## What changed
- keep the floating Stop and Rerun actions visible in the Setup and Run inspector tabs when terminal hover expansion is disabled
- gate the hover-only fade behavior behind the setting so the controls stay anchored when auto-expand is off
- add frontend tests covering the no-auto-expand cases and include a patch changeset

## Why
When "Expand terminals on hover" is turned off, the zoom state never activates, which left the Stop and Rerun actions inaccessible after running setup or run scripts. This keeps those controls reachable in that configuration.

## Follow-up / test notes
- Tests not run manually in this session
- Commit passed the repo's Biome pre-commit hook automatically