### PR TITLE
Add auto-archive on merge setting

### DIFF
--- a/.announcements/auto-archive-on-merge.json
+++ b/.announcements/auto-archive-on-merge.json
@@ -1,0 +1,11 @@
+{
+	"items": [
+		{
+			"text": "Workspaces can now archive themselves automatically once their linked PR/MR is merged.",
+			"action": {
+				"label": "Open General",
+				"value": { "type": "openSettings", "section": "general" }
+			}
+		}
+	]
+}

--- a/.changeset/auto-archive-on-merge.md
+++ b/.changeset/auto-archive-on-merge.md
@@ -1,0 +1,5 @@
+---
+"helmor": minor
+---
+
+Add an opt-in General setting to auto-archive a workspace when its linked PR/MR is merged.

--- a/src-tauri/src/agents/streaming/active_streams.rs
+++ b/src-tauri/src/agents/streaming/active_streams.rs
@@ -120,6 +120,20 @@ impl ActiveStreams {
         })
     }
 
+    /// True iff any registered handle targets `workspace_id`. Used by
+    /// auto-archive-after-merge to skip workspaces with an in-flight
+    /// agent turn — yanking the worktree under a running session would
+    /// crash it.
+    pub fn has_active_for_workspace(&self, workspace_id: &str) -> bool {
+        self.inner
+            .lock()
+            .map(|map| {
+                map.values()
+                    .any(|h| h.workspace_id.as_deref() == Some(workspace_id))
+            })
+            .unwrap_or(false)
+    }
+
     pub(crate) fn len(&self) -> usize {
         self.inner.lock().map(|map| map.len()).unwrap_or(0)
     }
@@ -222,5 +236,18 @@ mod tests {
         // Anonymous streams never collide.
         assert!(streams.try_register_for_session(handle("r3", None)));
         assert!(streams.try_register_for_session(handle("r4", None)));
+    }
+
+    #[test]
+    fn has_active_for_workspace_tracks_handles() {
+        let streams = ActiveStreams::new();
+        assert!(!streams.has_active_for_workspace("ws-s1"));
+
+        assert!(streams.try_register_for_session(handle("r1", Some("s1"))));
+        assert!(streams.has_active_for_workspace("ws-s1"));
+        assert!(!streams.has_active_for_workspace("ws-other"));
+
+        streams.unregister("r1");
+        assert!(!streams.has_active_for_workspace("ws-s1"));
     }
 }

--- a/src-tauri/src/commands/forge_commands.rs
+++ b/src-tauri/src/commands/forge_commands.rs
@@ -344,18 +344,23 @@ pub async fn refresh_workspace_change_request(
     app: tauri::AppHandle,
 ) -> CmdResult<Option<ChangeRequestInfo>> {
     let lookup_workspace_id = workspace_id.clone();
-    let (result, workspace_status_changed) = run_blocking(move || {
+    let (result, outcome) = run_blocking(move || {
         let result = forge::refresh_workspace_change_request(&lookup_workspace_id)?;
-        let changed =
+        let outcome =
             crate::workspaces::sync_workspace_pr_state(&lookup_workspace_id, result.as_ref())?;
-        Ok::<_, anyhow::Error>((result, changed))
+        Ok::<_, anyhow::Error>((result, outcome))
     })
     .await?;
-    if workspace_status_changed {
+    if outcome.changed {
         ui_sync::publish(
             &app,
-            UiMutationEvent::WorkspaceChangeRequestChanged { workspace_id },
+            UiMutationEvent::WorkspaceChangeRequestChanged {
+                workspace_id: workspace_id.clone(),
+            },
         );
+    }
+    if outcome.transitioned_to_merged {
+        crate::workspace::archive::try_auto_archive_after_merge(&app, &workspace_id);
     }
     Ok(result)
 }
@@ -410,18 +415,23 @@ async fn run_change_request_action(
     action: fn(&str) -> anyhow::Result<Option<ChangeRequestInfo>>,
 ) -> CmdResult<Option<ChangeRequestInfo>> {
     let sync_workspace_id = workspace_id.clone();
-    let (result, workspace_status_changed) = run_blocking(move || {
+    let (result, outcome) = run_blocking(move || {
         let result = action(&sync_workspace_id)?;
-        let changed =
+        let outcome =
             crate::workspaces::sync_workspace_pr_state(&sync_workspace_id, result.as_ref())?;
-        Ok::<_, anyhow::Error>((result, changed))
+        Ok::<_, anyhow::Error>((result, outcome))
     })
     .await?;
-    if workspace_status_changed {
+    if outcome.changed {
         ui_sync::publish(
             &app,
-            UiMutationEvent::WorkspaceChangeRequestChanged { workspace_id },
+            UiMutationEvent::WorkspaceChangeRequestChanged {
+                workspace_id: workspace_id.clone(),
+            },
         );
+    }
+    if outcome.transitioned_to_merged {
+        crate::workspace::archive::try_auto_archive_after_merge(&app, &workspace_id);
     }
     Ok(result)
 }

--- a/src-tauri/src/commands/tests/archive_restore.rs
+++ b/src-tauri/src/commands/tests/archive_restore.rs
@@ -482,7 +482,12 @@ fn start_archive_workspace_syncs_git_fetchers_after_success() {
 
     let archive_manager = app_handle.state::<workspaces::ArchiveJobManager>();
     archive_manager.prepare(&harness.workspace_id).unwrap();
-    workspaces::start_archive_workspace(&app_handle, &harness.workspace_id).unwrap();
+    workspaces::start_archive_workspace(
+        &app_handle,
+        &harness.workspace_id,
+        workspaces::ArchiveOrigin::Manual,
+    )
+    .unwrap();
 
     let deadline = Instant::now() + Duration::from_secs(3);
     loop {

--- a/src-tauri/src/commands/workspace_commands.rs
+++ b/src-tauri/src/commands/workspace_commands.rs
@@ -407,7 +407,7 @@ pub async fn prepare_archive_workspace(
 
 #[tauri::command]
 pub async fn start_archive_workspace(app: AppHandle, workspace_id: String) -> CmdResult<()> {
-    workspaces::start_archive_workspace(&app, &workspace_id)?;
+    workspaces::start_archive_workspace(&app, &workspace_id, workspaces::ArchiveOrigin::Manual)?;
     Ok(())
 }
 

--- a/src-tauri/src/models/settings.rs
+++ b/src-tauri/src/models/settings.rs
@@ -133,6 +133,19 @@ const AUTO_CLOSE_OPT_IN_ASKED_KEY: &str = "auto_close_opt_in_asked";
 pub const CODEX_RATE_LIMITS_KEY: &str = "app.codex_rate_limits";
 pub const CLAUDE_RATE_LIMITS_KEY: &str = "app.claude_rate_limits";
 
+/// Opt-in: when the workspace's linked PR/MR transitions to merged,
+/// attempt to archive the workspace automatically. Stored as the string
+/// `"true"` / `"false"` via the generic app-settings KV.
+pub const AUTO_ARCHIVE_ON_MERGE_KEY: &str = "app.auto_archive_on_merge";
+
+/// Read the opt-in toggle for archive-on-merge. Missing rows / parse
+/// failures default to `false` (off).
+pub fn load_auto_archive_on_merge_enabled() -> Result<bool> {
+    Ok(load_setting_value(AUTO_ARCHIVE_ON_MERGE_KEY)?
+        .map(|v| v == "true")
+        .unwrap_or(false))
+}
+
 /// Action kinds the user has opted-in to auto-close. Action sessions whose
 /// `action_kind` appears in this list are hidden automatically after their
 /// verifier reports `Success`.

--- a/src-tauri/src/workspace/archive.rs
+++ b/src-tauri/src/workspace/archive.rs
@@ -16,6 +16,18 @@ use super::lifecycle::{execute_archive_plan, prepare_archive_plan, ArchivePrepar
 pub const ARCHIVE_EXECUTION_FAILED_EVENT: &str = "archive-execution-failed";
 pub const ARCHIVE_EXECUTION_SUCCEEDED_EVENT: &str = "archive-execution-succeeded";
 
+/// What kicked off this archive run. Plumbed through to the success /
+/// failure events so the frontend can branch on it — manual flow drives
+/// the sidebar via the existing `archiveGate` + `pendingArchives`
+/// machinery; auto flow has no such state and needs its own sidebar
+/// reconcile + a calmer failure toast.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ArchiveOrigin {
+    Manual,
+    AutoAfterMerge,
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PrepareArchiveWorkspaceResponse {
@@ -28,12 +40,14 @@ pub struct ArchiveExecutionFailedPayload {
     pub workspace_id: String,
     pub code: ErrorCode,
     pub message: String,
+    pub origin: ArchiveOrigin,
 }
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ArchiveExecutionSucceededPayload {
     pub workspace_id: String,
+    pub origin: ArchiveOrigin,
 }
 
 #[derive(Default)]
@@ -155,7 +169,7 @@ pub fn try_auto_archive_after_merge<R: Runtime>(app: &AppHandle<R>, workspace_id
 
     // Hand off to the existing async path so success / failure events,
     // git unwatch, and the toast pipeline are all reused.
-    if let Err(error) = start_archive_workspace(app, workspace_id) {
+    if let Err(error) = start_archive_workspace(app, workspace_id, ArchiveOrigin::AutoAfterMerge) {
         tracing::warn!(
             workspace_id,
             error = %error,
@@ -166,7 +180,11 @@ pub fn try_auto_archive_after_merge<R: Runtime>(app: &AppHandle<R>, workspace_id
     }
 }
 
-pub fn start_archive_workspace<R: Runtime>(app: &AppHandle<R>, workspace_id: &str) -> Result<()> {
+pub fn start_archive_workspace<R: Runtime>(
+    app: &AppHandle<R>,
+    workspace_id: &str,
+    origin: ArchiveOrigin,
+) -> Result<()> {
     let manager = app.state::<ArchiveJobManager>();
     let plan = manager.start_prepared(workspace_id)?;
     let app_handle = app.clone();
@@ -206,6 +224,7 @@ pub fn start_archive_workspace<R: Runtime>(app: &AppHandle<R>, workspace_id: &st
                     ARCHIVE_EXECUTION_SUCCEEDED_EVENT,
                     ArchiveExecutionSucceededPayload {
                         workspace_id: workspace_id.clone(),
+                        origin,
                     },
                 );
             }
@@ -223,6 +242,7 @@ pub fn start_archive_workspace<R: Runtime>(app: &AppHandle<R>, workspace_id: &st
                         workspace_id: workspace_id.clone(),
                         code: extract_code(&error),
                         message: outermost_message(&error),
+                        origin,
                     },
                 );
             }
@@ -235,6 +255,7 @@ pub fn start_archive_workspace<R: Runtime>(app: &AppHandle<R>, workspace_id: &st
                         workspace_id: workspace_id.clone(),
                         code: ErrorCode::Unknown,
                         message: format!("Archive task failed: {error}"),
+                        origin,
                     },
                 );
             }

--- a/src-tauri/src/workspace/archive.rs
+++ b/src-tauri/src/workspace/archive.rs
@@ -6,8 +6,9 @@ use serde::Serialize;
 use tauri::{AppHandle, Emitter, Manager, Runtime};
 
 use crate::{
+    agents::ActiveStreams,
     error::{extract_code, outermost_message, ErrorCode},
-    git_watcher,
+    git_watcher, settings,
 };
 
 use super::lifecycle::{execute_archive_plan, prepare_archive_plan, ArchivePreparedPlan};
@@ -98,6 +99,70 @@ impl ArchiveJobManager {
         if let Ok(mut state) = self.state.lock() {
             state.running.remove(workspace_id);
         }
+    }
+}
+
+/// Opt-in auto-archive triggered when a workspace's PR transitions to
+/// merged. Fires once at the edge — callers gate on
+/// `state_changed && next_state == Merged` (see `forge_commands`), and
+/// `PrSyncState::Merged` is an absorbing state in
+/// `stabilize_pr_sync_state`, so this can't re-fire on subsequent polls.
+///
+/// Best-effort: every skip path logs and returns. Failures are routed
+/// through the existing `ARCHIVE_EXECUTION_FAILED_EVENT` so the UI toast
+/// still surfaces them.
+pub fn try_auto_archive_after_merge<R: Runtime>(app: &AppHandle<R>, workspace_id: &str) {
+    let enabled = match settings::load_auto_archive_on_merge_enabled() {
+        Ok(v) => v,
+        Err(error) => {
+            tracing::warn!(
+                workspace_id,
+                error = %error,
+                "Auto-archive: failed to read setting, skipping"
+            );
+            return;
+        }
+    };
+    if !enabled {
+        return;
+    }
+
+    // Active agent turn → skip. Yanking the worktree out from under a
+    // running session would crash it.
+    if app
+        .state::<ActiveStreams>()
+        .has_active_for_workspace(workspace_id)
+    {
+        tracing::info!(
+            workspace_id,
+            "Auto-archive skipped: workspace has an active session"
+        );
+        return;
+    }
+
+    // `prepare` covers eligibility + missing repo/worktree + already-
+    // running archive in one shot. A failure here is the right outcome
+    // for "conditions not met" — log and bail without retry.
+    let manager = app.state::<ArchiveJobManager>();
+    if let Err(error) = manager.prepare(workspace_id) {
+        tracing::info!(
+            workspace_id,
+            error = %error,
+            "Auto-archive skipped: prepare failed"
+        );
+        return;
+    }
+
+    // Hand off to the existing async path so success / failure events,
+    // git unwatch, and the toast pipeline are all reused.
+    if let Err(error) = start_archive_workspace(app, workspace_id) {
+        tracing::warn!(
+            workspace_id,
+            error = %error,
+            "Auto-archive: failed to start archive task"
+        );
+    } else {
+        tracing::info!(workspace_id, "Auto-archive started after merge");
     }
 }
 

--- a/src-tauri/src/workspace/workspaces.rs
+++ b/src-tauri/src/workspace/workspaces.rs
@@ -17,7 +17,7 @@ use crate::{
 
 pub use super::archive::{
     start_archive_workspace, ArchiveExecutionFailedPayload, ArchiveExecutionSucceededPayload,
-    ArchiveJobManager, PrepareArchiveWorkspaceResponse,
+    ArchiveJobManager, ArchiveOrigin, PrepareArchiveWorkspaceResponse,
 };
 pub use super::branching::{
     _reset_prefetch_rate_limit, continue_workspace_from_target_branch, list_remote_branches,

--- a/src-tauri/src/workspace/workspaces.rs
+++ b/src-tauri/src/workspace/workspaces.rs
@@ -683,15 +683,37 @@ fn next_order_for_target(transaction: &Transaction<'_>, target: &MoveTarget) -> 
     Ok(max.unwrap_or(0) + sidebar_order::ORDER_STEP)
 }
 
+/// Outcome of a `sync_workspace_pr_state` call. `changed` drives the
+/// `WorkspaceChangeRequestChanged` UI-sync publish; `transitioned_to_merged`
+/// drives one-shot side effects like auto-archive-after-merge. The latter
+/// is true iff `pr_sync_state` flipped from a non-Merged value to
+/// `Merged` in this call — combined with the absorbing-state guarantee
+/// in `stabilize_pr_sync_state`, this means it fires at most once per
+/// workspace per merge.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PrSyncOutcome {
+    pub changed: bool,
+    pub transitioned_to_merged: bool,
+}
+
+impl PrSyncOutcome {
+    fn unchanged() -> Self {
+        Self {
+            changed: false,
+            transitioned_to_merged: false,
+        }
+    }
+}
+
 pub fn sync_workspace_pr_state(
     workspace_id: &str,
     change_request: Option<&ChangeRequestInfo>,
-) -> Result<bool> {
+) -> Result<PrSyncOutcome> {
     let record = workspace_models::load_workspace_record_by_id(workspace_id)?
         .ok_or_else(|| coded(ErrorCode::WorkspaceNotFound))
         .with_context(|| format!("Workspace not found: {workspace_id}"))?;
     if !record.state.is_operational() {
-        return Ok(false);
+        return Ok(PrSyncOutcome::unchanged());
     }
 
     let next_state = stabilize_pr_sync_state(
@@ -711,8 +733,12 @@ pub fn sync_workspace_pr_state(
     let title_changed = record.pr_title != next_title;
     let url_changed = record.pr_url != next_url;
     if !state_changed && !title_changed && !url_changed {
-        return Ok(false);
+        return Ok(PrSyncOutcome::unchanged());
     }
+
+    let transitioned_to_merged = state_changed
+        && next_state == PrSyncState::Merged
+        && record.pr_sync_state != PrSyncState::Merged;
 
     let target_status = if state_changed {
         match next_state {
@@ -790,7 +816,10 @@ pub fn sync_workspace_pr_state(
             )
             .context("Failed to record workspace PR sync state")?;
     }
-    Ok(true)
+    Ok(PrSyncOutcome {
+        changed: true,
+        transitioned_to_merged,
+    })
 }
 
 fn pr_sync_state_from_change_request(change_request: Option<&ChangeRequestInfo>) -> PrSyncState {
@@ -1617,7 +1646,9 @@ mod tests {
             title: "PR".to_string(),
             is_merged: false,
         };
-        assert!(sync_workspace_pr_state("w-pr", Some(&open)).unwrap());
+        let outcome = sync_workspace_pr_state("w-pr", Some(&open)).unwrap();
+        assert!(outcome.changed);
+        assert!(!outcome.transitioned_to_merged);
         assert_eq!(
             workspace_statuses(&env, "w-pr"),
             ("review".to_string(), "open".to_string())
@@ -1628,7 +1659,11 @@ mod tests {
             [],
         )
         .unwrap();
-        assert!(!sync_workspace_pr_state("w-pr", Some(&open)).unwrap());
+        assert!(
+            !sync_workspace_pr_state("w-pr", Some(&open))
+                .unwrap()
+                .changed
+        );
         assert_eq!(
             workspace_statuses(&env, "w-pr"),
             ("in-progress".to_string(), "open".to_string())
@@ -1639,11 +1674,19 @@ mod tests {
             is_merged: true,
             ..open
         };
-        assert!(sync_workspace_pr_state("w-pr", Some(&merged)).unwrap());
+        let outcome = sync_workspace_pr_state("w-pr", Some(&merged)).unwrap();
+        assert!(outcome.changed);
+        assert!(outcome.transitioned_to_merged);
         assert_eq!(
             workspace_statuses(&env, "w-pr"),
             ("done".to_string(), "merged".to_string())
         );
+
+        // Re-running with the same merged state must NOT re-fire the
+        // transition edge — auto-archive depends on this for try-once.
+        let outcome = sync_workspace_pr_state("w-pr", Some(&merged)).unwrap();
+        assert!(!outcome.changed);
+        assert!(!outcome.transitioned_to_merged);
     }
 
     #[test]
@@ -1678,7 +1721,11 @@ mod tests {
             is_merged: false,
         };
 
-        assert!(!sync_workspace_pr_state("w-pr", Some(&stale_open)).unwrap());
+        assert!(
+            !sync_workspace_pr_state("w-pr", Some(&stale_open))
+                .unwrap()
+                .changed
+        );
         assert_eq!(
             workspace_statuses(&env, "w-pr"),
             ("done".to_string(), "merged".to_string())
@@ -1707,7 +1754,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(sync_workspace_pr_state("w-pr", None).unwrap());
+        assert!(sync_workspace_pr_state("w-pr", None).unwrap().changed);
         assert_eq!(
             workspace_statuses(&env, "w-pr"),
             ("done".to_string(), "none".to_string())
@@ -1738,7 +1785,11 @@ mod tests {
             title: "Add cool feature".to_string(),
             is_merged: false,
         };
-        assert!(sync_workspace_pr_state("w-pr", Some(&open)).unwrap());
+        assert!(
+            sync_workspace_pr_state("w-pr", Some(&open))
+                .unwrap()
+                .changed
+        );
         assert_eq!(
             workspace_pr_metadata(&env, "w-pr"),
             (
@@ -1753,14 +1804,22 @@ mod tests {
             title: "Renamed PR".to_string(),
             ..open
         };
-        assert!(sync_workspace_pr_state("w-pr", Some(&renamed)).unwrap());
+        assert!(
+            sync_workspace_pr_state("w-pr", Some(&renamed))
+                .unwrap()
+                .changed
+        );
         assert_eq!(
             workspace_pr_metadata(&env, "w-pr").0,
             Some("Renamed PR".to_string())
         );
 
         // Calling again with identical data is a no-op.
-        assert!(!sync_workspace_pr_state("w-pr", Some(&renamed)).unwrap());
+        assert!(
+            !sync_workspace_pr_state("w-pr", Some(&renamed))
+                .unwrap()
+                .changed
+        );
     }
 
     #[test]
@@ -1785,7 +1844,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(sync_workspace_pr_state("w-pr", None).unwrap());
+        assert!(sync_workspace_pr_state("w-pr", None).unwrap().changed);
         assert_eq!(workspace_pr_metadata(&env, "w-pr"), (None, None));
     }
 
@@ -1882,7 +1941,11 @@ mod tests {
             title: "PR".to_string(),
             is_merged: true,
         };
-        assert!(sync_workspace_pr_state("w-pin", Some(&merged)).unwrap());
+        assert!(
+            sync_workspace_pr_state("w-pin", Some(&merged))
+                .unwrap()
+                .changed
+        );
 
         let (status, pinned_at, display_order) = pinned_status_and_order(&env, "w-pin");
         assert_eq!(status, "done");

--- a/src/features/navigation/hooks/use-controller.test.tsx
+++ b/src/features/navigation/hooks/use-controller.test.tsx
@@ -1030,6 +1030,7 @@ describe("useWorkspacesSidebarController archive flow", () => {
 				workspaceId: "ws-1",
 				code: "Unknown",
 				message: "archive failed later",
+				origin: "manual",
 			});
 		});
 
@@ -1096,7 +1097,7 @@ describe("useWorkspacesSidebarController archive flow", () => {
 				{ ...workspaceGroups[0], rows: [workspaceGroups[0].rows[1]] },
 			];
 			archivedFromServer = [makeArchivedSummary("ws-1")];
-			apiMocks.emitArchiveSucceeded({ workspaceId: "ws-1" });
+			apiMocks.emitArchiveSucceeded({ workspaceId: "ws-1", origin: "manual" });
 		});
 
 		await waitFor(() => {
@@ -1156,7 +1157,7 @@ describe("useWorkspacesSidebarController archive flow", () => {
 		});
 
 		act(() => {
-			apiMocks.emitArchiveSucceeded({ workspaceId: "ws-1" });
+			apiMocks.emitArchiveSucceeded({ workspaceId: "ws-1", origin: "manual" });
 		});
 
 		await waitFor(() => {
@@ -1368,7 +1369,7 @@ describe("useWorkspacesSidebarController × sidebar-mutation-gate", () => {
 		// next test (and `resetSidebarMutationGate` papers over it).
 		act(() => {
 			resolveStart?.();
-			apiMocks.emitArchiveSucceeded({ workspaceId: "ws-1" });
+			apiMocks.emitArchiveSucceeded({ workspaceId: "ws-1", origin: "manual" });
 		});
 	});
 
@@ -1619,6 +1620,109 @@ describe("useWorkspacesSidebarController × sidebar-mutation-gate", () => {
 		expect(isSidebarMutationInFlight()).toBe(false);
 	});
 
+	it("auto-archive success reconciles the sidebar without a pendingArchive", async () => {
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false } },
+		});
+		let archivedFromServer: WorkspaceSummary[] = [];
+		let groupsFromServer = workspaceGroups;
+		apiMocks.loadWorkspaceGroups.mockImplementation(
+			async () => groupsFromServer,
+		);
+		apiMocks.loadArchivedWorkspaces.mockImplementation(
+			async () => archivedFromServer,
+		);
+
+		const { result } = renderHook(
+			() =>
+				useWorkspacesSidebarController({
+					selectedWorkspaceId: null,
+					onSelectWorkspace: vi.fn(),
+					pushWorkspaceToast: vi.fn(),
+				}),
+			{ wrapper: createWrapper(queryClient) },
+		);
+
+		await waitFor(() => {
+			expect(result.current.groups[0]?.rows).toHaveLength(2);
+		});
+		const groupsCallsBefore = apiMocks.loadWorkspaceGroups.mock.calls.length;
+		const archivedCallsBefore =
+			apiMocks.loadArchivedWorkspaces.mock.calls.length;
+
+		// Auto-archive fires without ever going through handleArchiveWorkspace,
+		// so no pendingArchive / gate exists. The success listener must drive
+		// the sidebar reconcile itself.
+		act(() => {
+			groupsFromServer = [
+				{ ...workspaceGroups[0], rows: [workspaceGroups[0].rows[1]] },
+			];
+			archivedFromServer = [makeArchivedSummary("ws-1")];
+			apiMocks.emitArchiveSucceeded({
+				workspaceId: "ws-1",
+				origin: "autoAfterMerge",
+			});
+		});
+
+		await waitFor(() => {
+			expect(result.current.groups[0]?.rows.map((row) => row.id)).toEqual([
+				"ws-2",
+			]);
+		});
+		expect(result.current.archivedRows.map((row) => row.id)).toEqual(["ws-1"]);
+		expect(apiMocks.loadWorkspaceGroups.mock.calls.length).toBeGreaterThan(
+			groupsCallsBefore,
+		);
+		expect(apiMocks.loadArchivedWorkspaces.mock.calls.length).toBeGreaterThan(
+			archivedCallsBefore,
+		);
+	});
+
+	it("auto-archive failure pushes a plain toast (no permanent-delete recovery)", async () => {
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false } },
+		});
+		const pushWorkspaceToast = vi.fn();
+		const { result } = renderHook(
+			() =>
+				useWorkspacesSidebarController({
+					selectedWorkspaceId: "ws-1",
+					onSelectWorkspace: vi.fn(),
+					pushWorkspaceToast,
+				}),
+			{ wrapper: createWrapper(queryClient) },
+		);
+		await waitFor(() => expect(result.current.groups[0]?.rows).toHaveLength(2));
+
+		act(() => {
+			apiMocks.emitArchiveFailed({
+				workspaceId: "ws-1",
+				code: "Unknown",
+				message: "merge race lost",
+				origin: "autoAfterMerge",
+			});
+		});
+
+		await waitFor(() => expect(pushWorkspaceToast).toHaveBeenCalled());
+		// Plain variant + no destructive action — the user didn't ask for this
+		// archive, so the "Permanently Delete" recovery toast is wrong here.
+		const [, title, variant, opts] = pushWorkspaceToast.mock.calls[0] as [
+			string,
+			string,
+			string | undefined,
+			{ action?: unknown } | undefined,
+		];
+		expect(title).toMatch(/auto-archive failed/i);
+		expect(variant ?? "default").toBe("default");
+		expect(opts?.action).toBeUndefined();
+		// Row must NOT be moved or rolled back — it was never optimistically
+		// archived in the first place.
+		expect(result.current.groups[0]?.rows.map((row) => row.id)).toEqual([
+			"ws-1",
+			"ws-2",
+		]);
+	});
+
 	it("archive failure listener releases the gate (no leak)", async () => {
 		const queryClient = new QueryClient({
 			defaultOptions: { queries: { retry: false } },
@@ -1645,6 +1749,7 @@ describe("useWorkspacesSidebarController × sidebar-mutation-gate", () => {
 				workspaceId: "ws-1",
 				code: "Unknown",
 				message: "archive worker exited",
+				origin: "manual",
 			});
 		});
 		await waitFor(() => expect(isSidebarMutationInFlight()).toBe(false));
@@ -1745,14 +1850,14 @@ describe("useWorkspacesSidebarController × sidebar-mutation-gate", () => {
 
 		// Releasing only one of the archives must NOT drop the gate yet.
 		act(() => {
-			apiMocks.emitArchiveSucceeded({ workspaceId: "ws-a" });
+			apiMocks.emitArchiveSucceeded({ workspaceId: "ws-a", origin: "manual" });
 		});
 		await new Promise((r) => setTimeout(r, 20));
 		expect(isSidebarMutationInFlight()).toBe(true);
 
 		// Releasing the second one finally drops the gate.
 		act(() => {
-			apiMocks.emitArchiveSucceeded({ workspaceId: "ws-b" });
+			apiMocks.emitArchiveSucceeded({ workspaceId: "ws-b", origin: "manual" });
 		});
 		await waitFor(() => expect(isSidebarMutationInFlight()).toBe(false));
 	});

--- a/src/features/navigation/hooks/use-controller.ts
+++ b/src/features/navigation/hooks/use-controller.ts
@@ -326,6 +326,17 @@ export function useWorkspacesSidebarController({
 			if (disposed) {
 				return;
 			}
+			// Auto-archive has no pendingArchives / gate to roll back, and the
+			// destructive "Permanently Delete" recovery toast is wrong for a
+			// failure the user didn't initiate. Surface a calm notice instead.
+			if (payload.origin === "autoAfterMerge") {
+				const { message } = extractError(
+					payload,
+					"Unable to auto-archive workspace.",
+				);
+				pushWorkspaceToast(message, "Auto-archive failed", "default");
+				return;
+			}
 			rollbackArchivedWorkspace(
 				payload.workspaceId,
 				payload,
@@ -341,6 +352,17 @@ export function useWorkspacesSidebarController({
 
 		void listenArchiveExecutionSucceeded((payload) => {
 			if (disposed) {
+				return;
+			}
+			// Auto-archive bypasses the optimistic pendingArchives flow, so the
+			// regular gate.end -> reconcile path is a no-op for it. Trigger the
+			// sidebar reconcile ourselves; otherwise the row stays in its
+			// pre-archive group until something else refetches.
+			if (payload.origin === "autoAfterMerge") {
+				requestSidebarReconcile(queryClient);
+				void queryClient.invalidateQueries({
+					queryKey: helmorQueryKeys.archivedWorkspaces,
+				});
 				return;
 			}
 			setPendingArchives((current) => {
@@ -373,7 +395,7 @@ export function useWorkspacesSidebarController({
 			unlistenFailure?.();
 			unlistenSuccess?.();
 		};
-	}, [archiveGate, queryClient, rollbackArchivedWorkspace]);
+	}, [archiveGate, pushWorkspaceToast, queryClient, rollbackArchivedWorkspace]);
 
 	useEffect(() => {
 		if (pendingArchives.size === 0) {

--- a/src/features/settings/index.tsx
+++ b/src/features/settings/index.tsx
@@ -336,7 +336,7 @@ export const SettingsDialog = memo(function SettingsDialog({
 									<SettingsRow
 										title="Auto-archive on merge"
 										releaseMarker={{ kind: "feature" }}
-										description="When a workspace's linked PR/MR is merged, archive the workspace automatically. Skipped if the workspace has an active session or fails archive validation."
+										description="When a workspace's linked PR/MR is merged, archive the workspace automatically."
 									>
 										<Switch
 											checked={settings.autoArchiveOnMerge}

--- a/src/features/settings/index.tsx
+++ b/src/features/settings/index.tsx
@@ -302,7 +302,6 @@ export const SettingsDialog = memo(function SettingsDialog({
 									</SettingsRow>
 									<SettingsRow
 										title="Expand terminals on hover"
-										releaseMarker={{ kind: "feature" }}
 										description="Enlarge inspector terminals when the cursor rests over them."
 									>
 										<Switch
@@ -336,6 +335,7 @@ export const SettingsDialog = memo(function SettingsDialog({
 									</SettingsRow>
 									<SettingsRow
 										title="Auto-archive on merge"
+										releaseMarker={{ kind: "feature" }}
 										description="When a workspace's linked PR/MR is merged, archive the workspace automatically. Skipped if the workspace has an active session or fails archive validation."
 									>
 										<Switch
@@ -439,7 +439,6 @@ export const SettingsDialog = memo(function SettingsDialog({
 												</TooltipProvider>
 											</span>
 										}
-										releaseMarker={{ kind: "feature" }}
 										description="Controls how Claude Code returns thinking content."
 									>
 										<ToggleGroup

--- a/src/features/settings/index.tsx
+++ b/src/features/settings/index.tsx
@@ -335,6 +335,17 @@ export const SettingsDialog = memo(function SettingsDialog({
 										/>
 									</SettingsRow>
 									<SettingsRow
+										title="Auto-archive on merge"
+										description="When a workspace's linked PR/MR is merged, archive the workspace automatically. Skipped if the workspace has an active session or fails archive validation."
+									>
+										<Switch
+											checked={settings.autoArchiveOnMerge}
+											onCheckedChange={(checked) =>
+												updateSettings({ autoArchiveOnMerge: checked })
+											}
+										/>
+									</SettingsRow>
+									<SettingsRow
 										title="Follow-up behavior"
 										description={
 											<>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -376,14 +376,22 @@ export type PrepareArchiveWorkspaceResponse = {
 	workspaceId: string;
 };
 
+/** Mirrors `workspace::archive::ArchiveOrigin`. `manual` drives the existing
+ *  `pendingArchives` + `archiveGate` UI flow; `autoAfterMerge` has no
+ *  optimistic state and needs the controller to reconcile + use a calmer
+ *  failure toast on its own. */
+export type ArchiveOrigin = "manual" | "autoAfterMerge";
+
 export type ArchiveExecutionFailedPayload = {
 	workspaceId: string;
 	code: ErrorCode;
 	message: string;
+	origin: ArchiveOrigin;
 };
 
 export type ArchiveExecutionSucceededPayload = {
 	workspaceId: string;
+	origin: ArchiveOrigin;
 };
 
 export type CreateWorkspaceResponse = {

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -197,6 +197,31 @@ describe("settings", () => {
 		);
 	});
 
+	it("hydrates and saves auto-archive-on-merge toggle", async () => {
+		invokeMock.mockResolvedValue({
+			"app.auto_archive_on_merge": "true",
+		});
+
+		const enabled = await loadSettings();
+		expect(enabled.autoArchiveOnMerge).toBe(true);
+
+		invokeMock.mockResolvedValue({});
+		const defaulted = await loadSettings();
+		expect(defaulted.autoArchiveOnMerge).toBe(false);
+
+		invokeMock.mockResolvedValue(undefined);
+		await saveSettings({ autoArchiveOnMerge: true });
+
+		expect(invokeMock).toHaveBeenLastCalledWith(
+			"update_app_settings",
+			expect.objectContaining({
+				settingsMap: expect.objectContaining({
+					"app.auto_archive_on_merge": "true",
+				}),
+			}),
+		);
+	});
+
 	it("keeps default as a valid model id", async () => {
 		invokeMock.mockResolvedValue({
 			"app.default_model_id": "gpt-5.5",

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -240,6 +240,11 @@ export type AppSettings = {
 	 *  `CONTEXT_USAGE_AUTO_REVEAL_THRESHOLD`. */
 	alwaysShowContextUsage: boolean;
 	showUsageStats: boolean;
+	/** Opt-in: when the workspace's linked PR/MR transitions to merged,
+	 *  attempt to archive the workspace automatically. One-shot — runs
+	 *  exactly once at the merged-edge; skipped if the workspace has an
+	 *  active agent session or fails archive validation. */
+	autoArchiveOnMerge: boolean;
 	onboardingCompleted: boolean;
 	shortcuts: ShortcutOverrides;
 	claudeCustomProviders: ClaudeCustomProviderSettings;
@@ -303,6 +308,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
 	claudeThinkingDisplay: "summarized",
 	alwaysShowContextUsage: true,
 	showUsageStats: true,
+	autoArchiveOnMerge: false,
 	onboardingCompleted: false,
 	shortcuts: {},
 	claudeCustomProviders: {
@@ -447,6 +453,7 @@ const SETTINGS_KEY_MAP: Record<
 	claudeThinkingDisplay: "app.claude_thinking_display",
 	alwaysShowContextUsage: "app.always_show_context_usage",
 	showUsageStats: "app.show_usage_stats",
+	autoArchiveOnMerge: "app.auto_archive_on_merge",
 	onboardingCompleted: "app.onboarding_completed",
 	shortcuts: "app.shortcuts",
 	claudeCustomProviders: "app.claude_custom_providers",
@@ -985,6 +992,10 @@ export async function loadSettings(): Promise<AppSettings> {
 				raw[SETTINGS_KEY_MAP.showUsageStats] !== undefined
 					? raw[SETTINGS_KEY_MAP.showUsageStats] === "true"
 					: DEFAULT_SETTINGS.showUsageStats,
+			autoArchiveOnMerge:
+				raw[SETTINGS_KEY_MAP.autoArchiveOnMerge] !== undefined
+					? raw[SETTINGS_KEY_MAP.autoArchiveOnMerge] === "true"
+					: DEFAULT_SETTINGS.autoArchiveOnMerge,
 			onboardingCompleted:
 				raw[SETTINGS_KEY_MAP.onboardingCompleted] !== undefined
 					? raw[SETTINGS_KEY_MAP.onboardingCompleted] === "true"


### PR DESCRIPTION
Closes #478 
## What changed
- added a General setting to auto-archive a workspace when its linked PR/MR transitions to merged
- wired PR sync to detect the merged edge once and trigger archive startup through the existing archive flow
- skip auto-archive when the workspace still has an active agent session or fails archive preparation
- added the release announcement and changeset for the new opt-in behavior

## Why
Users who want merged workspaces cleaned up automatically can now opt in without changing the default archive behavior for everyone else. The merged-edge guard keeps the side effect one-shot and avoids tearing down an active worktree mid-session.

## Test notes
- `bun run typecheck`
- `cargo test has_active_for_workspace_tracks_handles --lib`
- pre-commit hooks passed: Biome, `cargo fmt`, `cargo clippy -- -D warnings`