### PR TITLE
chore: update package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "helmor111",
+	"name": "helmor111222",
 	"description": "The local-first IDE for coding agent orchestration.",
 	"private": true,
 	"version": "0.12.2",


### PR DESCRIPTION
## What changed
- Updated the package name in `package.json` from `helmor111` to `helmor111222`.

## Why
- Aligns the package metadata with the intended name for this branch.

## Follow-up / test notes
- Pre-commit formatting check ran successfully via the commit hook.
- No full test suite was run; this is a package metadata-only change.