### PR TITLE
fix: restore top drag regions in editor chrome

### DIFF
--- a/.changeset/restore-top-drag.md
+++ b/.changeset/restore-top-drag.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Restore window dragging on the Editor view and Start Page top bars.

--- a/src/App.create.test.tsx
+++ b/src/App.create.test.tsx
@@ -443,8 +443,8 @@ describe("App create workspace flow", () => {
 		await user.click(screen.getByRole("button", { name: "New workspace" }));
 		expect(await screen.findByLabelText("Workspace input")).toBeInTheDocument();
 		expect(
-			screen.queryByLabelText("Workspace panel drag region"),
-		).not.toBeInTheDocument();
+			screen.getByLabelText("Workspace panel drag region"),
+		).toBeInTheDocument();
 
 		commitComposerText(
 			screen.getByLabelText("Workspace input"),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1509,7 +1509,7 @@ function AppShell({
 									aria-label="Workspace panel"
 									className="relative flex min-h-0 flex-1 flex-col overflow-hidden bg-background"
 								>
-									{workspaceViewMode === "conversation" && (
+									{workspaceViewMode !== "editor" && (
 										<div
 											aria-label="Workspace panel drag region"
 											className="absolute inset-x-0 top-0 z-10 h-9 bg-transparent"

--- a/src/features/editor/index.tsx
+++ b/src/features/editor/index.tsx
@@ -210,7 +210,10 @@ function EditorFileTabs({
 	onOpenSearch: () => void;
 }) {
 	return (
-		<div className="flex h-full min-w-0 flex-1 items-stretch overflow-hidden">
+		<div
+			data-tauri-drag-region
+			className="flex h-full min-w-0 flex-1 items-stretch overflow-hidden"
+		>
 			<div className="scrollbar-none h-full min-w-0 overflow-x-auto">
 				<Tabs
 					value={activeTabId}
@@ -1062,11 +1065,15 @@ export function WorkspaceEditorSurface({
 		>
 			<div
 				className={cn("flex h-9 items-center", EDITOR_CHROME_BACKGROUND_CLASS)}
+				data-tauri-drag-region
 			>
 				{/* Traffic-light inset. macOS: left; Windows / Linux: right. */}
 				<TrafficLightSpacer side="left" width={86} />
 
-				<div className="flex min-w-0 flex-1 items-center">
+				<div
+					data-tauri-drag-region
+					className="flex min-w-0 flex-1 items-center"
+				>
 					<EditorFileTabs
 						tabs={fileTabs}
 						activeTabId={activeTabId}

--- a/src/features/workspace-start/index.tsx
+++ b/src/features/workspace-start/index.tsx
@@ -184,7 +184,10 @@ export function WorkspaceStartPage({
 				>
 					<div className="min-h-0 overflow-hidden">
 						<div className="relative flex h-full min-h-[320px] flex-col overflow-hidden bg-background">
-							<div className="flex h-8 shrink-0 items-center justify-between gap-3 border-border/60 border-b px-3">
+							<div
+								className="relative z-20 flex h-8 shrink-0 items-center justify-between gap-3 border-border/60 border-b px-3"
+								data-tauri-drag-region
+							>
 								{showWindowSafeTop ? (
 									<TrafficLightSpacer
 										side="left"
@@ -192,7 +195,10 @@ export function WorkspaceStartPage({
 									/>
 								) : null}
 								{previewCard ? (
-									<h2 className="flex h-full min-w-0 flex-1 translate-y-[2px] items-center text-[13px] font-medium leading-5 text-foreground">
+									<h2
+										data-tauri-drag-region
+										className="flex h-full min-w-0 flex-1 translate-y-[2px] items-center text-[13px] font-medium leading-5 text-foreground"
+									>
 										<span className="min-w-0 truncate">
 											{previewCard.title}
 										</span>
@@ -201,7 +207,7 @@ export function WorkspaceStartPage({
 										</span>
 									</h2>
 								) : (
-									<div className="min-w-0 flex-1" />
+									<div data-tauri-drag-region className="min-w-0 flex-1" />
 								)}
 								<Button
 									type="button"


### PR DESCRIPTION
## What changed
- restores the workspace top drag region for non-editor views instead of limiting it to conversation only
- marks the editor tab bar and top chrome as Tauri drag regions again
- marks the workspace start page header/title spacer as drag regions and adds a patch changeset

## Why
- window dragging was no longer available from the editor and start page top bars, which regressed desktop window chrome behavior

## Follow-up / test notes
- tests not run in this pass
- lint-staged/biome ran during commit and completed successfully