### PR TITLE
Fix inspector section divider drag performance

### DIFF
--- a/.changeset/nimble-dividers-track.md
+++ b/.changeset/nimble-dividers-track.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix laggy dragging of the inspector sidebar's vertical section dividers, especially when resizing the Scripts section with terminal output.

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -187,14 +187,27 @@ describe("App", () => {
 			render(<App />);
 			await screen.findByRole("main", { name: "Application shell" });
 
+			// Section heights are driven by CSS variables on the inspector
+			// container so that mid-drag mousemove can update them without
+			// going through React. Verify the container has the right vars
+			// written via useLayoutEffect (synchronous, runs before first paint).
 			await waitFor(() => {
-				expect(screen.getByLabelText("Inspector section Git")).toHaveStyle({
-					height: "273px",
-				});
+				const container = screen.getByLabelText("Inspector section Git")
+					.parentElement as HTMLElement;
+				expect(
+					container.style.getPropertyValue("--inspector-changes-body-height"),
+				).toBe("240px");
 			});
-			expect(screen.getByLabelText("Inspector section Actions")).toHaveStyle({
-				height: "594px",
-			});
+			const container = screen.getByLabelText("Inspector section Git")
+				.parentElement as HTMLElement;
+			expect(
+				container.style.getPropertyValue("--inspector-actions-body-height"),
+			).toBe("561px");
+			expect(
+				container.style.getPropertyValue("--inspector-tabs-body-height"),
+			).toBe("0px");
+			// Tabs wrapper is collapsed (tabsOpen=false default) so its height
+			// is fixed at the section-header constant — not driven by the var.
 			const tabsWrapper = screen.getByLabelText("Inspector section Tabs")
 				.parentElement?.parentElement;
 			expect(tabsWrapper).toHaveStyle({

--- a/src/features/inspector/hooks/use-inspector.ts
+++ b/src/features/inspector/hooks/use-inspector.ts
@@ -8,6 +8,7 @@ import {
 	useRef,
 	useState,
 } from "react";
+import { suspendTerminalFit } from "@/components/terminal-output";
 import { loadRepoScripts, type RepoScripts } from "@/lib/api";
 import type { InspectorFileItem } from "@/lib/editor-session";
 import { workspaceChangesQueryOptions } from "@/lib/query-client";
@@ -17,10 +18,13 @@ import {
 	getInitialChangesHeight,
 	getInitialTabsHeight,
 	getInitialTabsOpen,
+	INSPECTOR_ACTIONS_BODY_VAR,
 	INSPECTOR_ACTIONS_OPEN_STORAGE_KEY,
 	INSPECTOR_ACTIVE_TAB_STORAGE_KEY,
+	INSPECTOR_CHANGES_BODY_VAR,
 	INSPECTOR_CHANGES_HEIGHT_STORAGE_KEY,
 	INSPECTOR_SECTION_HEADER_HEIGHT,
+	INSPECTOR_TABS_BODY_VAR,
 	INSPECTOR_TABS_HEIGHT_STORAGE_KEY,
 	INSPECTOR_TABS_OPEN_STORAGE_KEY,
 } from "../layout";
@@ -60,7 +64,21 @@ type ResizeState = {
 	bodyBudget: number;
 	tabsBody: number;
 	actionsOpen: boolean;
+	tabsOpen: boolean;
 };
+
+function writeBodyVars(container: HTMLElement | null, sizes: DerivedSizes) {
+	if (!container) return;
+	container.style.setProperty(
+		INSPECTOR_CHANGES_BODY_VAR,
+		`${sizes.changesBody}px`,
+	);
+	container.style.setProperty(
+		INSPECTOR_ACTIONS_BODY_VAR,
+		`${sizes.actionsBody}px`,
+	);
+	container.style.setProperty(INSPECTOR_TABS_BODY_VAR, `${sizes.tabsBody}px`);
+}
 
 type UseWorkspaceInspectorSidebarArgs = {
 	workspaceRootPath?: string | null;
@@ -210,6 +228,20 @@ export function useWorkspaceInspectorSidebar({
 			}),
 		[bodyBudget, actionsOpen, tabsOpen, storedChangesBody, storedTabsBody],
 	);
+
+	// 拖动期间 mousemove 直接写 CSS 变量,React state 是 stale 的;mouseup 才 commit
+	// 回来。这个 layout effect 负责非拖动场景(toggle、键盘步进、初始 mount)的
+	// React state → CSS 变量同步。拖动期间用 isResizingRef gate 掉,防止 stale
+	// state 在拖动中途被 effect 写回去把 mousemove 的实时值盖掉。
+	const isResizingRef = useRef(false);
+	useLayoutEffect(() => {
+		if (isResizingRef.current) return;
+		writeBodyVars(containerRef.current, {
+			changesBody,
+			actionsBody,
+			tabsBody,
+		});
+	}, [changesBody, actionsBody, tabsBody]);
 
 	useEffect(() => {
 		try {
@@ -387,40 +419,60 @@ export function useWorkspaceInspectorSidebar({
 			return;
 		}
 
+		isResizingRef.current = true;
+		// 拖动期间挂起所有已挂载 xterm 的 FitAddon —— 否则容器 ResizeObserver 会
+		// 每帧把 5000 行 scrollback 重新 reflow,在拖 scripts section 时尤其卡。
+		// 拖动结束 release,FitAddon 自己会做一次最终 fit。
+		const releaseFitSuspend = suspendTerminalFit();
+
+		const captured = resizeState;
+		const container = containerRef.current;
+
 		let pendingMove: globalThis.MouseEvent | null = null;
 		let animationFrameId: number | null = null;
+		let lastStoredChanges: number = captured.initialChangesBody;
+		let lastStoredTabs: number = captured.initialTabsBody;
+
 		const flush = () => {
 			animationFrameId = null;
 			const event = pendingMove;
 			pendingMove = null;
 			if (!event) return;
-			const deltaY = event.clientY - resizeState.pointerY;
+			const deltaY = event.clientY - captured.pointerY;
 
-			if (resizeState.target === RESIZE_TARGET_ACTIONS) {
+			if (captured.target === RESIZE_TARGET_ACTIONS) {
 				// Drag down → changes grows, actions auto-shrinks.
 				const max = Math.max(
 					MIN_CHANGES_BODY,
-					resizeState.bodyBudget - resizeState.tabsBody - MIN_ACTIONS_BODY,
+					captured.bodyBudget - captured.tabsBody - MIN_ACTIONS_BODY,
 				);
-				const next = clamp(
-					resizeState.initialChangesBody + deltaY,
+				lastStoredChanges = clamp(
+					captured.initialChangesBody + deltaY,
 					MIN_CHANGES_BODY,
 					max,
 				);
-				setStoredChangesBody(next);
-				return;
+			} else {
+				// Drag down → tabs shrinks, upper region (actions or changes) grows.
+				const upperMin =
+					MIN_CHANGES_BODY + (captured.actionsOpen ? MIN_ACTIONS_BODY : 0);
+				const max = Math.max(MIN_TABS_BODY, captured.bodyBudget - upperMin);
+				lastStoredTabs = clamp(
+					captured.initialTabsBody - deltaY,
+					MIN_TABS_BODY,
+					max,
+				);
 			}
 
-			// Drag down → tabs shrinks, upper region (actions or changes) grows.
-			const upperMin =
-				MIN_CHANGES_BODY + (resizeState.actionsOpen ? MIN_ACTIONS_BODY : 0);
-			const max = Math.max(MIN_TABS_BODY, resizeState.bodyBudget - upperMin);
-			const next = clamp(
-				resizeState.initialTabsBody - deltaY,
-				MIN_TABS_BODY,
-				max,
-			);
-			setStoredTabsBody(next);
+			// 直接算出 derived sizes 并写 CSS 变量 —— 不进 setState、不进 React
+			// 渲染路径。三个 section 通过 var(--inspector-X-body-height) 读取。
+			const sizes = deriveSizes({
+				bodyBudget: captured.bodyBudget,
+				actionsOpen: captured.actionsOpen,
+				tabsOpen: captured.tabsOpen,
+				storedChangesBody: lastStoredChanges,
+				storedTabsBody: lastStoredTabs,
+			});
+			writeBodyVars(container, sizes);
 		};
 
 		const handleMouseMove = (event: globalThis.MouseEvent) => {
@@ -436,6 +488,18 @@ export function useWorkspaceInspectorSidebar({
 				animationFrameId = null;
 			}
 			flush();
+			// Commit 最终值回 React state:触发 localStorage 持久化 + 让外部消费者
+			// (如设置面板里显示当前高度)拿到最新数值。同值 setState 是 no-op。
+			isResizingRef.current = false;
+			if (captured.target === RESIZE_TARGET_ACTIONS) {
+				if (lastStoredChanges !== captured.initialChangesBody) {
+					setStoredChangesBody(lastStoredChanges);
+				}
+			} else {
+				if (lastStoredTabs !== captured.initialTabsBody) {
+					setStoredTabsBody(lastStoredTabs);
+				}
+			}
 			setResizeState(null);
 		};
 
@@ -451,6 +515,8 @@ export function useWorkspaceInspectorSidebar({
 			if (animationFrameId !== null) {
 				window.cancelAnimationFrame(animationFrameId);
 			}
+			isResizingRef.current = false;
+			releaseFitSuspend();
 			document.body.style.cursor = previousCursor;
 			document.body.style.userSelect = previousUserSelect;
 			window.removeEventListener("mousemove", handleMouseMove);
@@ -470,9 +536,17 @@ export function useWorkspaceInspectorSidebar({
 				bodyBudget,
 				tabsBody,
 				actionsOpen,
+				tabsOpen,
 			});
 		},
-		[storedChangesBody, storedTabsBody, bodyBudget, tabsBody, actionsOpen],
+		[
+			storedChangesBody,
+			storedTabsBody,
+			bodyBudget,
+			tabsBody,
+			actionsOpen,
+			tabsOpen,
+		],
 	);
 
 	return {

--- a/src/features/inspector/layout.tsx
+++ b/src/features/inspector/layout.tsx
@@ -1,5 +1,4 @@
 import { ChevronDown, Plus, X, ZoomIn, ZoomOut } from "lucide-react";
-import { motion } from "motion/react";
 import { createContext, useCallback, useContext } from "react";
 import { Button } from "@/components/ui/button";
 import {
@@ -45,6 +44,13 @@ export const TABS_BLUR_HOLD_UNTIL_MS = TABS_HOVER_TRANSITION_MS - 50;
 /** 32px header (h-8) + 1px section border-b. */
 export const INSPECTOR_SECTION_HEADER_HEIGHT = 33;
 const TABS_WRAPPER_COLLAPSED_MIN_HEIGHT_PX = INSPECTOR_SECTION_HEADER_HEIGHT;
+
+// CSS variables written on the inspector container by `useWorkspaceInspectorSidebar`.
+// 拖动期间 mousemove 直接更新这些变量,不进 React 渲染路径 —— 和 shell/use-panels.ts
+// 里水平拖动的实现策略保持一致,把每帧 setState 的代价归零。
+export const INSPECTOR_CHANGES_BODY_VAR = "--inspector-changes-body-height";
+export const INSPECTOR_ACTIONS_BODY_VAR = "--inspector-actions-body-height";
+export const INSPECTOR_TABS_BODY_VAR = "--inspector-tabs-body-height";
 
 // Inspector layout persistence
 export const INSPECTOR_ACTIONS_OPEN_STORAGE_KEY =
@@ -282,22 +288,19 @@ export function InspectorTabsSection({
 	}, [open, onAddTerminal, onToggle]);
 
 	return (
-		<motion.div
+		<div
 			ref={wrapperRef}
 			className={cn(
 				"relative flex min-h-0 shrink-0 flex-col",
 				!isZoomPresented && "overflow-hidden",
 			)}
-			initial={false}
-			animate={{
-				height: TABS_WRAPPER_COLLAPSED_MIN_HEIGHT_PX + (open ? bodyHeight : 0),
-			}}
-			transition={{ duration: 0 }}
 			style={{
-				// The real content lives inside the absolutely-positioned child
-				// below, which contributes nothing to layout. Reserve header
-				// height when the panel is closed so the parent flex column
-				// keeps a stable footprint for us.
+				// 高度走 CSS 变量,拖动期间由 useWorkspaceInspectorSidebar 的 mousemove
+				// 直接 setProperty 更新,跳过 React 渲染。collapsed 状态固定 header 高,
+				// 确保父级 flex column 的占位稳定。
+				height: open
+					? `calc(${TABS_WRAPPER_COLLAPSED_MIN_HEIGHT_PX}px + var(${INSPECTOR_TABS_BODY_VAR}, ${bodyHeight}px))`
+					: `${TABS_WRAPPER_COLLAPSED_MIN_HEIGHT_PX}px`,
 				minHeight: `${TABS_WRAPPER_COLLAPSED_MIN_HEIGHT_PX}px`,
 			}}
 		>
@@ -641,7 +644,7 @@ export function InspectorTabsSection({
 					</div>
 				</section>
 			</div>
-		</motion.div>
+		</div>
 	);
 }
 

--- a/src/features/inspector/sections/actions.tsx
+++ b/src/features/inspector/sections/actions.tsx
@@ -8,7 +8,6 @@ import {
 	LoaderCircleIcon,
 	TriangleIcon,
 } from "lucide-react";
-import { motion } from "motion/react";
 import { useCallback, useState } from "react";
 import { toast } from "sonner";
 import {
@@ -49,6 +48,7 @@ import { resolveRepoPreferencePrompt } from "@/lib/repo-preferences-prompts";
 import { requestSidebarReconcile } from "@/lib/sidebar-mutation-gate";
 import { cn } from "@/lib/utils";
 import {
+	INSPECTOR_ACTIONS_BODY_VAR,
 	INSPECTOR_SECTION_HEADER_CLASS,
 	INSPECTOR_SECTION_HEADER_HEIGHT,
 	INSPECTOR_SECTION_TITLE_CLASS,
@@ -322,17 +322,19 @@ export function ActionsSection({
 		[workspaceId],
 	);
 	return (
-		<motion.section
+		<section
 			ref={sectionRef}
 			aria-label="Inspector section Actions"
 			className={cn(
 				"flex min-h-0 shrink-0 flex-col overflow-hidden border-b border-border/60 bg-sidebar transition-colors",
 			)}
-			initial={false}
-			animate={{
-				height: INSPECTOR_SECTION_HEADER_HEIGHT + (open ? bodyHeight : 0),
+			style={{
+				// 高度走 CSS 变量,拖动期间由 mousemove 直接更新。collapsed 时固定 header 高,
+				// 跳过 calc()。fallback 兜底 layout-effect 写 var 之前那一帧的 mount。
+				height: open
+					? `calc(${INSPECTOR_SECTION_HEADER_HEIGHT}px + var(${INSPECTOR_ACTIONS_BODY_VAR}, ${bodyHeight}px))`
+					: `${INSPECTOR_SECTION_HEADER_HEIGHT}px`,
 			}}
-			transition={{ duration: 0 }}
 		>
 			<div
 				className={cn(
@@ -366,7 +368,9 @@ export function ActionsSection({
 					<ScrollArea
 						aria-label="Actions panel body"
 						className="min-h-0 bg-muted/18 text-[11.5px]"
-						style={{ height: `${bodyHeight}px` }}
+						style={{
+							height: `var(${INSPECTOR_ACTIONS_BODY_VAR}, ${bodyHeight}px)`,
+						}}
 					>
 						{showHelpersGroup && (
 							<>
@@ -521,7 +525,7 @@ export function ActionsSection({
 					</ScrollArea>
 				</div>
 			)}
-		</motion.section>
+		</section>
 	);
 }
 

--- a/src/features/inspector/sections/changes.tsx
+++ b/src/features/inspector/sections/changes.tsx
@@ -19,7 +19,6 @@ import {
 	PlusIcon,
 	Undo2Icon,
 } from "lucide-react";
-import { motion } from "motion/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { AnimatedShinyText } from "@/components/ui/animated-shiny-text";
@@ -65,7 +64,10 @@ import {
 import { buildRemoteFileUrl } from "@/lib/remote-file-url";
 import { cn } from "@/lib/utils";
 import { useWorkspaceToast } from "@/lib/workspace-toast-context";
-import { INSPECTOR_SECTION_HEADER_HEIGHT } from "../layout";
+import {
+	INSPECTOR_CHANGES_BODY_VAR,
+	INSPECTOR_SECTION_HEADER_HEIGHT,
+} from "../layout";
 import { useChangesState } from "./changes/use-changes-state";
 import { useGitMutations } from "./changes/use-git-mutations";
 import { GitSectionHeader } from "./git-section-header";
@@ -273,12 +275,14 @@ export function ChangesSection({
 	const isForgeRefreshing = workspaceId !== null && forgeIsRefreshing;
 
 	return (
-		<motion.section
+		<section
 			aria-label="Inspector section Git"
 			className="flex min-h-0 shrink-0 flex-col overflow-hidden border-b border-border/60 bg-sidebar"
-			initial={false}
-			animate={{ height: INSPECTOR_SECTION_HEADER_HEIGHT + bodyHeight }}
-			transition={{ duration: 0 }}
+			style={{
+				// 拖动期间 var() 由 mousemove 直接更新,完全跳过 React。fallback 兜底
+				// 首次 mount 时 layout-effect 还没把 var 写到容器上的那一帧。
+				height: `calc(${INSPECTOR_SECTION_HEADER_HEIGHT}px + var(${INSPECTOR_CHANGES_BODY_VAR}, ${bodyHeight}px))`,
+			}}
 		>
 			<GitSectionHeader
 				commitButtonMode={commitButtonMode}
@@ -385,7 +389,7 @@ export function ChangesSection({
 					</div>
 				)}
 			</ScrollArea>
-		</motion.section>
+		</section>
 	);
 }
 


### PR DESCRIPTION
## What changed
- moved inspector vertical resize updates off the per-frame React render path and onto container CSS variables
- suspended terminal fit work while dragging so resizing the Scripts section no longer reflows xterm output every frame
- updated the inspector test and added a patch changeset for the drag-performance fix

## Why
- dragging the inspector section dividers, especially near terminal-backed scripts output, was visibly laggy because each mousemove triggered React work plus terminal reflow
- this keeps drag feedback on the DOM/CSS path and only commits the final sizes back to React state on mouseup

## Follow-up / test notes
- pre-commit hooks ran `biome check --write --error-on-warnings`
- no additional test suite was run manually beyond the updated automated hook checks