### PR TITLE
Fix per-repo start surface preference persistence

### DIFF
--- a/.changeset/start-picker-per-repo-memory.md
+++ b/.changeset/start-picker-per-repo-memory.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+- Remember the worktree/local mode and branch intent per repository so each project keeps its own defaults.

--- a/src-tauri/src/commands/tests/workspace_creation.rs
+++ b/src-tauri/src/commands/tests/workspace_creation.rs
@@ -973,10 +973,10 @@ fn finalize_workspace_cleans_up_row_on_worktree_failure() {
 
 #[test]
 fn execute_archive_plan_short_circuits_for_local_workspace() {
-    // CRITICAL regression test: `execute_archive_plan` is the path used
-    // by the queue / kanban-style archive flow. For local mode it MUST
-    // skip the worktree removal — `remove_worktree` would rename + delete
-    // the user's actual repo (since workspace_dir == repo_root).
+    // CRITICAL regression test: `execute_archive_plan` is the archive
+    // flow's path. For local mode it MUST skip worktree removal —
+    // `remove_worktree` would rename + delete the user's actual repo
+    // (since workspace_dir == repo_root).
     let _guard = TEST_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());

--- a/src-tauri/src/workspace/lifecycle.rs
+++ b/src-tauri/src/workspace/lifecycle.rs
@@ -1018,7 +1018,7 @@ pub fn execute_archive_plan(plan: &ArchivePreparedPlan) -> Result<ArchiveWorkspa
     // rename + delete the user's repo. Short-circuit to a DB-only flip
     // here BEFORE we touch anything on disk. The frontend's
     // `archive_workspace_impl` already does this; this is a second
-    // line of defence for the kanban / queue path that goes through
+    // line of defence for the archive path that goes through
     // `prepare_archive_plan` + this function.
     let record = workspace_models::load_workspace_record_by_id(workspace_id)?;
     if let Some(record) = record.as_ref() {

--- a/src-tauri/src/workspace/status.rs
+++ b/src-tauri/src/workspace/status.rs
@@ -1,5 +1,5 @@
-//! Workspace status enum — drives the kanban lanes (Done / In Review /
-//! In Progress / Backlog / Canceled) in the sidebar. Stored in
+//! Workspace status enum — drives the sidebar status lanes (Done /
+//! In Review / In Progress / Backlog / Canceled). Stored in
 //! `workspaces.status`.
 //!
 //! Historical data may carry `"in-review"` or `"cancelled"` (British) — the
@@ -34,7 +34,7 @@ impl WorkspaceStatus {
         }
     }
 
-    /// Sidebar kanban lane. Note: `InProgress` maps to `"progress"` — the
+    /// Sidebar status lane. Note: `InProgress` maps to `"progress"` — the
     /// stored value has a hyphen, the lane id does not.
     pub const fn group_id(&self) -> &'static str {
         match self {

--- a/src/features/composer/container.test.tsx
+++ b/src/features/composer/container.test.tsx
@@ -503,8 +503,8 @@ describe("WorkspaceComposerContainer", () => {
 				value={{
 					settings: {
 						...DEFAULT_SETTINGS,
-						kanbanViewState: {
-							...DEFAULT_SETTINGS.kanbanViewState,
+						startSurfacePreferences: {
+							...DEFAULT_SETTINGS.startSurfacePreferences,
 							createState: "backlog",
 						},
 					},
@@ -543,8 +543,8 @@ describe("WorkspaceComposerContainer", () => {
 		composerMockState.lastOnStartSubmitModeChange?.("startNow");
 
 		expect(updateSettings).toHaveBeenCalledWith({
-			kanbanViewState: {
-				...DEFAULT_SETTINGS.kanbanViewState,
+			startSurfacePreferences: {
+				...DEFAULT_SETTINGS.startSurfacePreferences,
 				createState: "in-progress",
 			},
 		});

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -116,15 +116,15 @@ type WorkspaceComposerContainerProps = {
 	repoId?: string | null;
 	disabled: boolean;
 	/** When true, treat the composer as available even if no workspace is
-	 *  selected — the bottom composer in kanban mode uses this so it can
-	 *  collect a prompt before any workspace exists. */
+	 *  selected — the start-surface composer uses this so it can collect
+	 *  a prompt before any workspace exists. */
 	forceAvailable?: boolean;
 	/** Custom placeholder text. When omitted, the composer falls back to
 	 *  the default "Ask to make changes…" copy. */
 	placeholder?: string;
 	/** Override the composer's context key. Without this the key falls
 	 *  back to `getComposerContextKey(displayedWorkspaceId, displayedSessionId)`.
-	 *  The kanban view supplies a per-repo key so each repo keeps its
+	 *  The start surface supplies a per-repo key so each repo keeps its
 	 *  own draft. */
 	contextKeyOverride?: string;
 	onStop?: () => void;
@@ -169,10 +169,10 @@ type WorkspaceComposerContainerProps = {
 		followUpBehaviorOverride?: "queue" | "steer";
 		startSubmitMode?: StartSubmitMode;
 		/** Snapshot of the editor's full Lexical state at submit time, so
-		 *  callers that need to round-trip chips/text/images (e.g. the kanban
-		 *  "backlog" handler that copies the draft into a freshly-created
-		 *  session's `sessions.draft_state`) can do so without re-encoding
-		 *  the badge nodes. */
+		 *  callers that need to round-trip chips/text/images (e.g. the
+		 *  start-composer "backlog" handler that copies the draft into a
+		 *  freshly-created session's `sessions.draft_state`) can do so
+		 *  without re-encoding the badge nodes. */
 		editorStateSnapshot?: SerializedEditorState;
 	}) => void;
 	/** Prompt queued by an external caller to auto-submit once the displayed
@@ -263,19 +263,19 @@ export const WorkspaceComposerContainer = memo(
 		const queryClient = useQueryClient();
 		const { settings, updateSettings } = useSettings();
 		const startSubmitMode: StartSubmitMode =
-			settings.kanbanViewState.createState === "backlog"
+			settings.startSurfacePreferences.createState === "backlog"
 				? "saveForLater"
 				: "startNow";
 		const handleStartSubmitModeChange = useCallback(
 			(mode: StartSubmitMode) => {
 				void updateSettings({
-					kanbanViewState: {
-						...settings.kanbanViewState,
+					startSurfacePreferences: {
+						...settings.startSurfacePreferences,
 						createState: mode === "saveForLater" ? "backlog" : "in-progress",
 					},
 				});
 			},
-			[settings.kanbanViewState, updateSettings],
+			[settings.startSurfacePreferences, updateSettings],
 		);
 		const modelSectionsQuery = useQuery(agentModelSectionsQueryOptions());
 		const workspaceDetailQuery = useQuery({

--- a/src/features/composer/index.tsx
+++ b/src/features/composer/index.tsx
@@ -104,9 +104,10 @@ type WorkspaceComposerProps = {
 			startSubmitMode?: StartSubmitMode;
 			/** Snapshot of the editor's full Lexical state at submit time.
 			 *  Captured synchronously before the editor clears so callers
-			 *  that need to round-trip chips/text/images (e.g. the kanban
-			 *  "backlog" submit handler that copies the draft into a freshly
-			 *  created session) can do so without a re-encode pass. */
+			 *  that need to round-trip chips/text/images (e.g. the
+			 *  start-composer "backlog" submit handler that copies the
+			 *  draft into a freshly created session) can do so without a
+			 *  re-encode pass. */
 			editorStateSnapshot?: SerializedEditorState;
 		},
 	) => void;
@@ -184,8 +185,9 @@ type WorkspaceComposerProps = {
 	contextPanelOpen?: boolean;
 	onToggleContextPanel?: () => void;
 	/** Custom placeholder string. When omitted, falls back to the default
-	 *  "Ask to make changes…" copy. The kanban view supplies a hint that
-	 *  nudges the user toward composing inbox sources for new workspaces. */
+	 *  "Ask to make changes…" copy. The start surface supplies a hint
+	 *  that nudges the user toward composing inbox sources for new
+	 *  workspaces. */
 	placeholder?: string;
 	startSubmitMenu?: boolean;
 	startSubmitMode?: StartSubmitMode;
@@ -500,9 +502,9 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 				if (!startSubmitMenu) return;
 			// Snapshot the editor's full Lexical state BEFORE the clear below
 			// wipes it. Synchronous capture is critical because callers that
-			// want to round-trip the draft (e.g. kanban "backlog" submit
-			// copying chips/text/images into a freshly-created session) read
-			// from this snapshot — by the time their async work runs, the
+			// want to round-trip the draft (e.g. the start-composer "backlog"
+			// submit copying chips/text/images into a freshly-created session)
+			// read from this snapshot — by the time their async work runs, the
 			// editor is already empty.
 			const editorStateSnapshot = editor
 				.getEditorState()

--- a/src/features/conversation/hooks/use-streaming.ts
+++ b/src/features/conversation/hooks/use-streaming.ts
@@ -119,9 +119,9 @@ type SubmitPayload = {
 	startSubmitMode?: StartSubmitMode;
 	/** Snapshot of the editor's full Lexical state at submit time. Captured
 	 *  synchronously inside the composer so callers that need to round-trip
-	 *  chips/text/images (e.g. the kanban "backlog" handler that copies the
-	 *  draft to a freshly-created session) can do so without losing the
-	 *  badge nodes that a plain prompt-string would discard. */
+	 *  chips/text/images (e.g. the start-composer "backlog" handler that
+	 *  copies the draft to a freshly-created session) can do so without
+	 *  losing the badge nodes that a plain prompt-string would discard. */
 	editorStateSnapshot?: SerializedEditorState;
 };
 

--- a/src/features/inbox/index.tsx
+++ b/src/features/inbox/index.tsx
@@ -222,7 +222,7 @@ export const InboxSidebar = memo(function InboxSidebar({
 	selectedCardId?: string | null;
 	appendContextTarget?: ComposerInsertTarget;
 	showWindowSafeTop?: boolean;
-	/** Repository the kanban is currently scoped to. Used to derive
+	/** Repository the inbox is currently scoped to. Used to derive
 	 *  which forge tab (GitHub vs GitLab) is shown — only the project's
 	 *  own forge appears, never both. */
 	repository?: RepositoryCreateOption | null;

--- a/src/features/inbox/use-inbox-items.ts
+++ b/src/features/inbox/use-inbox-items.ts
@@ -27,7 +27,7 @@ import { useWorkspaceToast } from "@/lib/workspace-toast-context";
 
 const PAGE_SIZE = 20;
 /** Stale window — keep cached pages fresh enough to feel live without
- * re-fetching on every kanban switch. Manual refetch path lives on the
+ * re-fetching on every tab switch. Manual refetch path lives on the
  * caller (e.g. a refresh button). */
 const STALE_MS = 60_000;
 
@@ -104,16 +104,16 @@ function scopeForKind(kind: InboxKind, toggles: ActiveInboxToggles) {
 	return null;
 }
 
-/** Drives the kanban-inbox list for ONE sub-tab at a time. The caller
- * passes the current forge provider plus sub-type tab; switching tabs
- * swaps to a different cached query (TanStack reuses prior pages on
+/** Drives the inbox list for ONE sub-tab at a time. The caller passes
+ * the current forge provider plus sub-type tab; switching tabs swaps
+ * to a different cached query (TanStack reuses prior pages on
  * switch-back).
  *
  * `repoFilter` is the `owner/name` (GitHub) or `group/sub/project`
- * (GitLab) for the kanban's currently-selected repo. When provided,
- * every kind is scoped to that single repo on the backend. Each repo
- * gets its own cache key so switching the repo picker doesn't trash
- * the previous repo's cached pages.
+ * (GitLab) for the currently-selected repo. When provided, every kind
+ * is scoped to that single repo on the backend. Each repo gets its own
+ * cache key so switching the repo picker doesn't trash the previous
+ * repo's cached pages.
  *
  * Single-account today — picks the first matching login. The hook is
  * shaped for future multi-account fan-out (run one infinite query per

--- a/src/features/navigation/dnd/use-workspace-dnd.ts
+++ b/src/features/navigation/dnd/use-workspace-dnd.ts
@@ -15,7 +15,7 @@ import {
 	useDndActiveOverlay,
 } from "./shared";
 
-// Status grouping: kanban lanes + pinned (drag-to-pin).
+// Status grouping: status lanes + pinned (drag-to-pin).
 function isStatusOrPinnedGroup(groupId: string) {
 	return groupId === "pinned" || workspaceStatusFromGroupId(groupId) !== null;
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -25,7 +25,7 @@ export type WorkspaceState =
 
 /**
  * Mirror of the Rust `WorkspaceStatus` enum
- * (`src-tauri/src/workspace/status.rs`). Drives the sidebar kanban
+ * (`src-tauri/src/workspace/status.rs`). Drives the sidebar status
  * lanes and PR-driven auto-status transitions.
  */
 export type WorkspaceStatus =
@@ -981,7 +981,7 @@ export async function listCursorModels(
 }
 
 // ---------------------------------------------------------------------------
-// Inbox (kanban-mode left sidebar)
+// Inbox (start-surface left sidebar)
 // ---------------------------------------------------------------------------
 
 export type InboxItemSource =

--- a/src/lib/forge-repo-filter.ts
+++ b/src/lib/forge-repo-filter.ts
@@ -3,8 +3,8 @@
 // Backend inbox queries scope to a single repo via a provider-specific
 // search qualifier — `repo:owner/name` for GitHub, project full path for
 // GitLab. The frontend computes the filter string from a repo's stored
-// remote URL + forge provider so the kanban repo picker drives the inbox
-// to the right slice.
+// remote URL + forge provider so the start-surface repo picker drives
+// the inbox to the right slice.
 
 import type { ForgeProvider, RepositoryCreateOption } from "./api";
 

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -1,10 +1,13 @@
 import { invoke } from "@tauri-apps/api/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-	DEFAULT_KANBAN_VIEW_STATE,
+	DEFAULT_START_SURFACE_PREFERENCES,
 	getPreloadedSettings,
+	LEGACY_SETTING_KEYS,
 	loadSettings,
+	readRepoPreference,
 	saveSettings,
+	writeRepoPreference,
 } from "./settings";
 
 const invokeMock = vi.mocked(invoke);
@@ -39,65 +42,120 @@ describe("settings", () => {
 		invokeMock.mockReset();
 	});
 
-	it("hydrates kanban view state with per-repo branches and inbox filters", async () => {
+	it("hydrates start-surface preferences from the current storage key", async () => {
 		invokeMock.mockResolvedValue({
-			"app.kanban_view_state": JSON.stringify({
+			"app.start_surface_preferences": JSON.stringify({
 				createState: "backlog",
 				repoId: "repo-1",
-				inboxProviderTab: "github",
-				inboxProviderSourceTab: "github_pr",
-				sourceBranchByRepoId: {
-					"repo-1": "release/next",
-				},
-				inboxStateFilterBySource: {
-					github_pr: "merged",
-				},
-				openInboxCards: [],
+				sourceBranchByRepoId: { "repo-1": "release/next" },
+				modeByRepoId: { "repo-1": "local" },
+				branchIntentByRepoId: { "repo-1": "use_branch" },
 			}),
 		});
 
 		const settings = await loadSettings();
 
-		expect(settings.kanbanViewState).toMatchObject({
+		expect(settings.startSurfacePreferences).toEqual({
 			createState: "backlog",
 			repoId: "repo-1",
-			inboxProviderSourceTab: "github_pr",
-			sourceBranchByRepoId: {
-				"repo-1": "release/next",
-			},
-			inboxStateFilterBySource: {
-				github_pr: "merged",
-			},
+			sourceBranchByRepoId: { "repo-1": "release/next" },
+			modeByRepoId: { "repo-1": "local" },
+			branchIntentByRepoId: { "repo-1": "use_branch" },
 		});
 	});
 
-	it("keeps old kanban view state blobs compatible", async () => {
+	it("hydrates per-repo mode and branch-intent and drops invalid entries", async () => {
 		invokeMock.mockResolvedValue({
-			"app.kanban_view_state": JSON.stringify({
-				createState: "in-progress",
-				repoId: "repo-1",
-				inboxProviderTab: "github",
-				inboxProviderSourceTab: "github_issue",
-				openInboxCards: [],
+			"app.start_surface_preferences": JSON.stringify({
+				modeByRepoId: {
+					"repo-1": "local",
+					"repo-2": "worktree",
+					"repo-3": "bogus",
+					"": "local",
+				},
+				branchIntentByRepoId: {
+					"repo-1": "use_branch",
+					"repo-2": "from_branch",
+					"repo-3": "nope",
+				},
 			}),
 		});
 
 		const settings = await loadSettings();
 
-		expect(settings.kanbanViewState).toMatchObject({
-			...DEFAULT_KANBAN_VIEW_STATE,
-			repoId: "repo-1",
+		expect(settings.startSurfacePreferences.modeByRepoId).toEqual({
+			"repo-1": "local",
+			"repo-2": "worktree",
+		});
+		expect(settings.startSurfacePreferences.branchIntentByRepoId).toEqual({
+			"repo-1": "use_branch",
+			"repo-2": "from_branch",
 		});
 	});
 
-	it("saves kanban view state as one JSON blob", async () => {
+	const LEGACY_KEY = LEGACY_SETTING_KEYS.startSurfacePreferences;
+	const CURRENT_KEY = "app.start_surface_preferences";
+
+	it("migrates legacy storage key and drops retired fields", async () => {
+		invokeMock.mockResolvedValue({
+			[LEGACY_KEY]: JSON.stringify({
+				createState: "backlog",
+				repoId: "repo-1",
+				mode: "local",
+				branchIntent: "use_branch",
+				inboxProviderTab: "github",
+				inboxProviderSourceTab: "github_pr",
+				inboxStateFilterBySource: { github_pr: "merged" },
+				openInboxCards: [{ id: "c" }],
+				sourceBranchByRepoId: { "repo-1": "main" },
+				modeByRepoId: { "repo-1": "local" },
+				branchIntentByRepoId: { "repo-1": "use_branch" },
+			}),
+		});
+
+		const settings = await loadSettings();
+
+		expect(settings.startSurfacePreferences).toEqual({
+			createState: "backlog",
+			repoId: "repo-1",
+			sourceBranchByRepoId: { "repo-1": "main" },
+			modeByRepoId: { "repo-1": "local" },
+			branchIntentByRepoId: { "repo-1": "use_branch" },
+		});
+
+		const writeCall = invokeMock.mock.calls.find(
+			([command]) => command === "update_app_settings",
+		);
+		expect(writeCall).toBeDefined();
+		const writtenMap = (
+			writeCall?.[1] as { settingsMap: Record<string, string> } | undefined
+		)?.settingsMap;
+		expect(writtenMap?.[CURRENT_KEY]).toEqual(expect.any(String));
+		expect(writtenMap?.[LEGACY_KEY]).toBe("");
+	});
+
+	it("prefers the current key when both legacy and current are present", async () => {
+		invokeMock.mockResolvedValue({
+			[CURRENT_KEY]: JSON.stringify({ repoId: "new" }),
+			[LEGACY_KEY]: JSON.stringify({ repoId: "old" }),
+		});
+
+		const settings = await loadSettings();
+		expect(settings.startSurfacePreferences.repoId).toBe("new");
+		const wroteAnything = invokeMock.mock.calls.some(
+			([command]) => command === "update_app_settings",
+		);
+		expect(wroteAnything).toBe(false);
+	});
+
+	it("saves start-surface preferences as one JSON blob under the new key", async () => {
 		invokeMock.mockResolvedValue(undefined);
 
 		await saveSettings({
-			kanbanViewState: {
-				...DEFAULT_KANBAN_VIEW_STATE,
+			startSurfacePreferences: {
+				...DEFAULT_START_SURFACE_PREFERENCES,
 				sourceBranchByRepoId: { "repo-1": "main" },
-				inboxStateFilterBySource: { github_issue: "closed" },
+				modeByRepoId: { "repo-1": "local" },
 			},
 		});
 
@@ -105,12 +163,29 @@ describe("settings", () => {
 			"update_app_settings",
 			expect.objectContaining({
 				settingsMap: expect.objectContaining({
-					"app.kanban_view_state": expect.stringContaining(
+					"app.start_surface_preferences": expect.stringContaining(
 						"sourceBranchByRepoId",
 					),
 				}),
 			}),
 		);
+	});
+
+	it("readRepoPreference returns record entry, falls back, and tolerates missing repoId", () => {
+		const record = { "repo-1": "local" as const };
+		expect(readRepoPreference(record, "repo-1", "worktree")).toBe("local");
+		expect(readRepoPreference(record, "repo-2", "worktree")).toBe("worktree");
+		expect(readRepoPreference(record, null, "worktree")).toBe("worktree");
+		expect(readRepoPreference(record, undefined, "worktree")).toBe("worktree");
+		expect(readRepoPreference({}, "repo-1", "worktree")).toBe("worktree");
+	});
+
+	it("writeRepoPreference returns a new record without mutating the input", () => {
+		const before = { "repo-1": "local" as const };
+		const after = writeRepoPreference(before, "repo-2", "worktree");
+		expect(after).toEqual({ "repo-1": "local", "repo-2": "worktree" });
+		expect(before).toEqual({ "repo-1": "local" });
+		expect(after).not.toBe(before);
 	});
 
 	it("preloads terminal font from localStorage", () => {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,7 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { createContext, useContext } from "react";
 import type { WorkspaceBranchIntent, WorkspaceMode } from "./api";
-import type { ContextCard } from "./sources/types";
 
 export type ThemeMode = "system" | "light" | "dark";
 
@@ -152,42 +151,15 @@ export const DEFAULT_INBOX_REPO_CONFIG: InboxRepoSourceConfig = {
 	prLabels: "",
 };
 
-/** Cap on how many inbox cards the kanban view will keep open as
- *  main-content tabs (and persist across restarts). Beyond this the
- *  user gets a toast nudging them to close some — keeps the tab strip
- *  legible and the persisted blob bounded. */
-export const KANBAN_OPEN_INBOX_CARDS_MAX = 10;
-
-/** Persisted UI state for the kanban view — the bits that should
- *  survive an app restart so the user lands back in the same place
- *  next time they open the kanban tab. Each field has a graceful
- *  fallback so a corrupt or partial blob still produces sane UI. */
-export type KanbanViewState = {
-	/** Whether new kanban workspaces land in "in progress" (immediate
-	 *  agent dispatch) or "backlog" (draft saved, no agent). */
+/** Persisted preferences for the workspace-start surface. */
+export type StartSurfacePreferences = {
+	/** Composer submit-mode: immediate dispatch or saved draft. */
 	createState: "in-progress" | "backlog";
-	/** Start-composer branch-intent picker default. Worktree mode only. */
-	branchIntent: WorkspaceBranchIntent;
-	/** Start-composer worktree-vs-local picker default. */
-	mode: WorkspaceMode;
-	/** Repository id last selected in the kanban header picker.
-	 *  Resolved against the current repo list on hydrate — falls back
-	 *  to the first repo when the saved id is no longer present. */
+	/** Last selected repository. */
 	repoId: string | null;
-	/** Inbox top-level provider tab id (e.g. "github", "linear"). Plain
-	 *  string here so settings.ts stays free of feature-module imports;
-	 *  consumers cast against their own narrower types. */
-	inboxProviderTab: string;
-	/** Inbox sub-tab id within the provider (e.g. "github_issue",
-	 *  "github_pr", "github_discussion"). */
-	inboxProviderSourceTab: string;
-	/** Branch selected in the kanban header, keyed by repository id. */
 	sourceBranchByRepoId: Record<string, string>;
-	/** GitHub inbox state filter keyed by source tab id. */
-	inboxStateFilterBySource: Record<string, string>;
-	/** Inbox cards open as main-content tabs at last app exit. Capped
-	 *  at `KANBAN_OPEN_INBOX_CARDS_MAX`. */
-	openInboxCards: ContextCard[];
+	modeByRepoId: Record<string, WorkspaceMode>;
+	branchIntentByRepoId: Record<string, WorkspaceBranchIntent>;
 };
 
 export type AppSettings = {
@@ -255,7 +227,7 @@ export type AppSettings = {
 	claudeCustomProviders: ClaudeCustomProviderSettings;
 	cursorProvider: CursorProviderSettings;
 	inboxSourceConfig: InboxSourceConfig;
-	kanbanViewState: KanbanViewState;
+	startSurfacePreferences: StartSurfacePreferences;
 	/** Sidebar grouping mode. Persisted to localStorage (sync read on boot
 	 *  to avoid the sidebar flashing the wrong grouping while SQLite-backed
 	 *  settings load asynchronously). */
@@ -267,17 +239,37 @@ export type AppSettings = {
 	sidebarSort: SidebarSort;
 };
 
-export const DEFAULT_KANBAN_VIEW_STATE: KanbanViewState = {
+export const DEFAULT_START_SURFACE_PREFERENCES: StartSurfacePreferences = {
 	createState: "in-progress",
-	branchIntent: "from_branch",
-	mode: "worktree",
 	repoId: null,
-	inboxProviderTab: "github",
-	inboxProviderSourceTab: "github_issue",
 	sourceBranchByRepoId: {},
-	inboxStateFilterBySource: {},
-	openInboxCards: [],
+	modeByRepoId: {},
+	branchIntentByRepoId: {},
 };
+
+/** Fallbacks for repos without a per-repo entry. */
+export const START_SURFACE_MODE_FALLBACK: WorkspaceMode = "worktree";
+export const START_SURFACE_BRANCH_INTENT_FALLBACK: WorkspaceBranchIntent =
+	"from_branch";
+
+/** Read a per-repo preference, falling back when missing. */
+export function readRepoPreference<V>(
+	record: Record<string, V>,
+	repoId: string | null | undefined,
+	fallback: V,
+): V {
+	if (!repoId) return fallback;
+	return record[repoId] ?? fallback;
+}
+
+/** Immutably set a per-repo entry. */
+export function writeRepoPreference<V>(
+	record: Record<string, V>,
+	repoId: string,
+	value: V,
+): Record<string, V> {
+	return { ...record, [repoId]: value };
+}
 
 /**
  * Percentage of the context window above which the ring auto-reveals
@@ -330,7 +322,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
 		cachedModels: null,
 	},
 	inboxSourceConfig: { accounts: {} },
-	kanbanViewState: DEFAULT_KANBAN_VIEW_STATE,
+	startSurfacePreferences: DEFAULT_START_SURFACE_PREFERENCES,
 	sidebarGrouping: "status",
 	sidebarRepoFilterIds: [],
 	sidebarSort: "custom",
@@ -466,8 +458,36 @@ const SETTINGS_KEY_MAP: Record<
 	claudeCustomProviders: "app.claude_custom_providers",
 	cursorProvider: "app.cursor_provider",
 	inboxSourceConfig: "app.inbox_source_config",
-	kanbanViewState: "app.kanban_view_state",
+	startSurfacePreferences: "app.start_surface_preferences",
 };
+
+/** Renamed storage keys. Append-only; never reuse a string as a current key. */
+export const LEGACY_SETTING_KEYS = {
+	startSurfacePreferences: "app.kanban_view_state",
+} as const;
+
+/** Shim legacy keys under their current names and clear them in the DB. */
+function migrateLegacySettings(
+	raw: Record<string, string>,
+): Record<string, string> {
+	const writes: Record<string, string> = {};
+	const shimmed = { ...raw };
+	for (const [currentKey, legacyKey] of Object.entries(LEGACY_SETTING_KEYS)) {
+		const currentValue =
+			raw[SETTINGS_KEY_MAP[currentKey as keyof typeof SETTINGS_KEY_MAP]];
+		const legacyValue = raw[legacyKey];
+		if (currentValue !== undefined || legacyValue === undefined) continue;
+		shimmed[SETTINGS_KEY_MAP[currentKey as keyof typeof SETTINGS_KEY_MAP]] =
+			legacyValue;
+		writes[SETTINGS_KEY_MAP[currentKey as keyof typeof SETTINGS_KEY_MAP]] =
+			legacyValue;
+		writes[legacyKey] = "";
+	}
+	if (Object.keys(writes).length > 0) {
+		void invoke("update_app_settings", { settingsMap: writes }).catch(() => {});
+	}
+	return shimmed;
+}
 
 function parseSidebarRepoFilterIds(raw: string | undefined): string[] {
 	if (!raw) return DEFAULT_SETTINGS.sidebarRepoFilterIds;
@@ -699,66 +719,51 @@ function parseStringRecord(value: unknown): Record<string, string> {
 	);
 }
 
-function parseKanbanViewState(raw: string | undefined): KanbanViewState {
-	if (!raw) return DEFAULT_KANBAN_VIEW_STATE;
+/** Like `parseStringRecord`, with each value constrained to `allowed`. */
+function parseEnumRecord<V extends string>(
+	value: unknown,
+	allowed: readonly V[],
+): Record<string, V> {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		return {};
+	}
+	const allowedSet = new Set<string>(allowed);
+	return Object.fromEntries(
+		Object.entries(value).filter(
+			([key, entry]) =>
+				key.length > 0 && typeof entry === "string" && allowedSet.has(entry),
+		),
+	) as Record<string, V>;
+}
+
+function parseStartSurfacePreferences(
+	raw: string | undefined,
+): StartSurfacePreferences {
+	if (!raw) return DEFAULT_START_SURFACE_PREFERENCES;
 	try {
 		const parsed = JSON.parse(raw) as unknown;
 		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-			return DEFAULT_KANBAN_VIEW_STATE;
+			return DEFAULT_START_SURFACE_PREFERENCES;
 		}
-		const o = parsed as Partial<KanbanViewState>;
-		const createState =
-			o.createState === "backlog" || o.createState === "in-progress"
-				? o.createState
-				: DEFAULT_KANBAN_VIEW_STATE.createState;
-		const branchIntent =
-			o.branchIntent === "use_branch" || o.branchIntent === "from_branch"
-				? o.branchIntent
-				: DEFAULT_KANBAN_VIEW_STATE.branchIntent;
-		const mode =
-			o.mode === "worktree" || o.mode === "local"
-				? o.mode
-				: DEFAULT_KANBAN_VIEW_STATE.mode;
-		const repoId = typeof o.repoId === "string" && o.repoId ? o.repoId : null;
-		const inboxProviderTab =
-			typeof o.inboxProviderTab === "string" && o.inboxProviderTab
-				? o.inboxProviderTab
-				: DEFAULT_KANBAN_VIEW_STATE.inboxProviderTab;
-		const inboxProviderSourceTab =
-			typeof o.inboxProviderSourceTab === "string" && o.inboxProviderSourceTab
-				? o.inboxProviderSourceTab
-				: DEFAULT_KANBAN_VIEW_STATE.inboxProviderSourceTab;
-		const sourceBranchByRepoId = parseStringRecord(o.sourceBranchByRepoId);
-		const inboxStateFilterBySource = parseStringRecord(
-			o.inboxStateFilterBySource,
-		);
-		// Trust the persisted ContextCard array as long as it's an array
-		// of objects — the cards are written by the same code that reads
-		// them, and a deep schema check here would couple settings.ts to
-		// every field we add to ContextCard. Cap at the bound so an old
-		// blob from before the cap doesn't blow up the UI.
-		const openInboxCardsRaw = Array.isArray(o.openInboxCards)
-			? o.openInboxCards
-			: [];
-		const openInboxCards = openInboxCardsRaw
-			.filter(
-				(card): card is ContextCard =>
-					Boolean(card) && typeof card === "object" && !Array.isArray(card),
-			)
-			.slice(0, KANBAN_OPEN_INBOX_CARDS_MAX);
+		const o = parsed as Partial<StartSurfacePreferences>;
 		return {
-			createState,
-			branchIntent,
-			mode,
-			repoId,
-			inboxProviderTab,
-			inboxProviderSourceTab,
-			sourceBranchByRepoId,
-			inboxStateFilterBySource,
-			openInboxCards,
+			createState:
+				o.createState === "backlog" || o.createState === "in-progress"
+					? o.createState
+					: DEFAULT_START_SURFACE_PREFERENCES.createState,
+			repoId: typeof o.repoId === "string" && o.repoId ? o.repoId : null,
+			sourceBranchByRepoId: parseStringRecord(o.sourceBranchByRepoId),
+			modeByRepoId: parseEnumRecord(o.modeByRepoId, [
+				"worktree",
+				"local",
+			] as const),
+			branchIntentByRepoId: parseEnumRecord(o.branchIntentByRepoId, [
+				"from_branch",
+				"use_branch",
+			] as const),
 		};
 	} catch {
-		return DEFAULT_KANBAN_VIEW_STATE;
+		return DEFAULT_START_SURFACE_PREFERENCES;
 	}
 }
 
@@ -885,7 +890,8 @@ function readModelId(value: string | undefined): string | null {
 
 export async function loadSettings(): Promise<AppSettings> {
 	try {
-		const raw = await invoke<Record<string, string>>("get_app_settings");
+		const rawFromDb = await invoke<Record<string, string>>("get_app_settings");
+		const raw = migrateLegacySettings(rawFromDb);
 		const rawDefaultModelId = raw[SETTINGS_KEY_MAP.defaultModelId];
 		const rawReviewModelId = raw[SETTINGS_KEY_MAP.reviewModelId];
 		const rawReviewEffort = raw[SETTINGS_KEY_MAP.reviewEffort];
@@ -1027,8 +1033,8 @@ export async function loadSettings(): Promise<AppSettings> {
 			inboxSourceConfig: parseInboxSourceConfig(
 				raw[SETTINGS_KEY_MAP.inboxSourceConfig],
 			),
-			kanbanViewState: parseKanbanViewState(
-				raw[SETTINGS_KEY_MAP.kanbanViewState],
+			startSurfacePreferences: parseStartSurfacePreferences(
+				raw[SETTINGS_KEY_MAP.startSurfacePreferences],
 			),
 		};
 	} catch {
@@ -1070,7 +1076,7 @@ export async function saveSettings(patch: Partial<AppSettings>): Promise<void> {
 				key === "claudeCustomProviders" ||
 				key === "cursorProvider" ||
 				key === "inboxSourceConfig" ||
-				key === "kanbanViewState"
+				key === "startSurfacePreferences"
 					? JSON.stringify(value)
 					: value === null
 						? ""

--- a/src/shell/controllers/use-start-surface-controller.ts
+++ b/src/shell/controllers/use-start-surface-controller.ts
@@ -25,7 +25,13 @@ import {
 } from "@/lib/api";
 import { extractError } from "@/lib/errors";
 import { helmorQueryKeys } from "@/lib/query-client";
-import type { AppSettings } from "@/lib/settings";
+import {
+	type AppSettings,
+	readRepoPreference,
+	START_SURFACE_BRANCH_INTENT_FALLBACK,
+	START_SURFACE_MODE_FALLBACK,
+	writeRepoPreference,
+} from "@/lib/settings";
 import { requestSidebarReconcile } from "@/lib/sidebar-mutation-gate";
 import { describeUnknownError } from "@/lib/workspace-helpers";
 import type { PushWorkspaceToast } from "@/lib/workspace-toast-context";
@@ -131,14 +137,23 @@ export function useStartSurfaceController(
 	const [startPendingLinkedDirectories, setStartPendingLinkedDirectories] =
 		useState<readonly string[]>(EMPTY_STRING_LIST);
 
-	// Pickers read straight from settings; writes go through `updateSettings`.
-	// Branch is per-repo, mode/intent are global.
-	const startMode = appSettings.kanbanViewState.mode;
-	const startBranchIntent = appSettings.kanbanViewState.branchIntent;
-	const startSourceBranchOverride = startRepositoryId
-		? (appSettings.kanbanViewState.sourceBranchByRepoId[startRepositoryId] ??
-			null)
-		: null;
+	// Pickers read from settings; writes go through `updateSettings`.
+	const prefs = appSettings.startSurfacePreferences;
+	const startMode = readRepoPreference(
+		prefs.modeByRepoId,
+		startRepositoryId,
+		START_SURFACE_MODE_FALLBACK,
+	);
+	const startBranchIntent = readRepoPreference(
+		prefs.branchIntentByRepoId,
+		startRepositoryId,
+		START_SURFACE_BRANCH_INTENT_FALLBACK,
+	);
+	const startSourceBranchOverride = readRepoPreference(
+		prefs.sourceBranchByRepoId,
+		startRepositoryId,
+		null,
+	);
 
 	// Latest cross-controller callbacks, kept in refs so AppShell can pass
 	// inline arrows without thrashing every downstream useCallback.
@@ -157,8 +172,9 @@ export function useStartSurfaceController(
 		repositories[0] ??
 		null;
 
-	// Default repo selection: prefer kanbanViewState.repoId, fall back to the
-	// first repo. Re-runs when the kanban repo persists or the list refreshes.
+	// Default repo selection: prefer the persisted `repoId`, fall back to
+	// the first repo. Re-runs when the persisted value resolves or the
+	// repository list refreshes.
 	useEffect(() => {
 		if (!areSettingsLoaded || repositories.length === 0) return;
 		if (
@@ -169,11 +185,12 @@ export function useStartSurfaceController(
 		}
 		const savedRepository =
 			repositories.find(
-				(repository) => repository.id === appSettings.kanbanViewState.repoId,
+				(repository) =>
+					repository.id === appSettings.startSurfacePreferences.repoId,
 			) ?? null;
 		setStartRepositoryId((savedRepository ?? repositories[0]).id);
 	}, [
-		appSettings.kanbanViewState.repoId,
+		appSettings.startSurfacePreferences.repoId,
 		areSettingsLoaded,
 		repositories,
 		startRepositoryId,
@@ -229,13 +246,13 @@ export function useStartSurfaceController(
 		(repository: RepositoryCreateOption) => {
 			setStartRepositoryId(repository.id);
 			void updateSettings({
-				kanbanViewState: {
-					...appSettings.kanbanViewState,
+				startSurfacePreferences: {
+					...appSettings.startSurfacePreferences,
 					repoId: repository.id,
 				},
 			});
 		},
-		[appSettings.kanbanViewState, updateSettings],
+		[appSettings.startSurfacePreferences, updateSettings],
 	);
 
 	const selectSourceBranch = useCallback(
@@ -244,43 +261,57 @@ export function useStartSurfaceController(
 			// Picking an existing branch drops any in-flight create-new stash.
 			setStartPendingNewBranch(null);
 			void updateSettings({
-				kanbanViewState: {
-					...appSettings.kanbanViewState,
-					sourceBranchByRepoId: {
-						...appSettings.kanbanViewState.sourceBranchByRepoId,
-						[startRepository.id]: branch,
-					},
+				startSurfacePreferences: {
+					...appSettings.startSurfacePreferences,
+					sourceBranchByRepoId: writeRepoPreference(
+						appSettings.startSurfacePreferences.sourceBranchByRepoId,
+						startRepository.id,
+						branch,
+					),
 				},
 			});
 		},
-		[appSettings.kanbanViewState, startRepository, updateSettings],
+		[appSettings.startSurfacePreferences, startRepository, updateSettings],
 	);
 
 	const selectMode = useCallback(
 		(mode: WorkspaceMode) => {
+			if (!startRepository) return;
 			// pendingNewBranch is local-mode-only; clear it on any mode flip.
 			setStartPendingNewBranch(null);
 			void updateSettings({
-				kanbanViewState: { ...appSettings.kanbanViewState, mode },
+				startSurfacePreferences: {
+					...appSettings.startSurfacePreferences,
+					modeByRepoId: writeRepoPreference(
+						appSettings.startSurfacePreferences.modeByRepoId,
+						startRepository.id,
+						mode,
+					),
+				},
 			});
 		},
-		[appSettings.kanbanViewState, updateSettings],
+		[appSettings.startSurfacePreferences, startRepository, updateSettings],
 	);
 
 	const selectBranchIntent = useCallback(
 		(intent: WorkspaceBranchIntent) => {
+			if (!startRepository) return;
 			// use_branch + pendingNewBranch is a logical conflict; drop the pending.
 			if (intent === "use_branch") {
 				setStartPendingNewBranch(null);
 			}
 			void updateSettings({
-				kanbanViewState: {
-					...appSettings.kanbanViewState,
-					branchIntent: intent,
+				startSurfacePreferences: {
+					...appSettings.startSurfacePreferences,
+					branchIntentByRepoId: writeRepoPreference(
+						appSettings.startSurfacePreferences.branchIntentByRepoId,
+						startRepository.id,
+						intent,
+					),
 				},
 			});
 		},
-		[appSettings.kanbanViewState, updateSettings],
+		[appSettings.startSurfacePreferences, startRepository, updateSettings],
 	);
 
 	const stashPendingNewBranch = useCallback(
@@ -288,16 +319,26 @@ export function useStartSurfaceController(
 			// Transient only — actual `git checkout -b` runs at submit time.
 			// Don't persist to `sourceBranchByRepoId` (branch doesn't exist yet).
 			setStartPendingNewBranch(branch);
-			if (appSettings.kanbanViewState.branchIntent !== "from_branch") {
+			if (!startRepository) return;
+			if (startBranchIntent !== "from_branch") {
 				void updateSettings({
-					kanbanViewState: {
-						...appSettings.kanbanViewState,
-						branchIntent: "from_branch",
+					startSurfacePreferences: {
+						...appSettings.startSurfacePreferences,
+						branchIntentByRepoId: writeRepoPreference(
+							appSettings.startSurfacePreferences.branchIntentByRepoId,
+							startRepository.id,
+							"from_branch",
+						),
 					},
 				});
 			}
 		},
-		[appSettings.kanbanViewState, updateSettings],
+		[
+			appSettings.startSurfacePreferences,
+			startBranchIntent,
+			startRepository,
+			updateSettings,
+		],
 	);
 
 	const refetchBranches = useCallback(() => {
@@ -330,14 +371,14 @@ export function useStartSurfaceController(
 		(repositoryId: string) => {
 			setStartRepositoryId(repositoryId);
 			void updateSettings({
-				kanbanViewState: {
-					...appSettings.kanbanViewState,
+				startSurfacePreferences: {
+					...appSettings.startSurfacePreferences,
 					repoId: repositoryId,
 				},
 			});
 			openWorkspaceStartRef.current();
 		},
-		[appSettings.kanbanViewState, updateSettings],
+		[appSettings.startSurfacePreferences, updateSettings],
 	);
 
 	const prepareComposer = useCallback(


### PR DESCRIPTION
## What changed
- rename the persisted start-surface settings blob from the old kanban key to `app.start_surface_preferences` and migrate legacy data on load
- store worktree/local mode and branch intent per repository instead of as one global preference
- update the start-surface controller and composer to read/write the new per-repo preference records
- refresh tests and related copy/comments, and add a changeset for the user-visible behavior change

## Why
The start surface was reusing kanban-era settings and leaked mode/branch-intent choices across repositories. This makes each repository keep its own defaults and preserves existing users' saved state through the key migration.

## Test notes
- pre-commit hook ran `biome check --write`, `cargo fmt`, and `cargo clippy -- -D warnings`
- no frontend or Rust test suites were run beyond the commit hook checks

## Follow-up
- none planned