### PR TITLE
Add Just Chat workspaces

### DIFF
--- a/.announcements/editor-tabs-and-inline-edit.json
+++ b/.announcements/editor-tabs-and-inline-edit.json
@@ -1,7 +1,7 @@
 {
 	"items": [
 		{
-			"text": "Edit code right from the diff view, ⌘E flips between Diff and Edit."
+			"text": "You can now edit code right from the diff view."
 		}
 	]
 }

--- a/.announcements/just-chat-mode.json
+++ b/.announcements/just-chat-mode.json
@@ -1,0 +1,7 @@
+{
+	"items": [
+		{
+			"text": "Pick \"Just Chat\" on the start page to open a workspace without binding it to a repo."
+		}
+	]
+}

--- a/.changeset/just-chat-mode.md
+++ b/.changeset/just-chat-mode.md
@@ -1,0 +1,5 @@
+---
+"helmor": minor
+---
+
+Add a "Just Chat" mode on the start page for opening throwaway chat workspaces that aren't bound to any repository.

--- a/src-tauri/src/commands/workspace_commands.rs
+++ b/src-tauri/src/commands/workspace_commands.rs
@@ -52,8 +52,33 @@ pub async fn prepare_workspace_from_repo(
                     initial_status,
                 )
             }
+            crate::workspace_state::WorkspaceMode::Chat => {
+                // Chat workspaces don't bind to a repository; callers
+                // should use `prepare_chat_workspace` directly.
+                anyhow::bail!(
+                    "Chat workspaces must be created via prepare_chat_workspace, not prepare_workspace_from_repo"
+                )
+            }
         })
         .await?
+    };
+    notify_workspace_changed_in_background(app);
+    Ok(result)
+}
+
+/// One-shot creation of a Chat-mode workspace. Chat workspaces aren't
+/// bound to any repository — they're a scratch directory under
+/// `<data_dir>/chats/<YYYY-MM-DD>/new-chat[-N]` used as cwd for a plain
+/// AI chat session. No git, no branch, no finalize phase.
+#[tauri::command]
+pub async fn prepare_chat_workspace(
+    app: AppHandle,
+    initial_status: Option<WorkspaceStatus>,
+) -> CmdResult<workspaces::PrepareWorkspaceResponse> {
+    let initial_status = initial_status.unwrap_or_default();
+    let result = {
+        let _lock = db::WORKSPACE_FS_MUTATION_LOCK.lock().await;
+        run_blocking(move || workspaces::prepare_chat_workspace_impl(initial_status)).await?
     };
     notify_workspace_changed_in_background(app);
     Ok(result)

--- a/src-tauri/src/data_dir.rs
+++ b/src-tauri/src/data_dir.rs
@@ -52,6 +52,17 @@ pub fn workspaces_dir() -> Result<PathBuf> {
     Ok(dir)
 }
 
+/// Returns the chats directory inside the data dir. Houses Chat-mode
+/// workspaces — scratch dirs grouped by local date (`<chats>/YYYY-MM-DD/`)
+/// because chat workspaces aren't bound to any repository.
+pub fn chats_dir() -> Result<PathBuf> {
+    let dir = data_dir()?.join("chats");
+    if !dir.exists() {
+        fs::create_dir_all(&dir).context("Failed to create chats directory")?;
+    }
+    Ok(dir)
+}
+
 /// Returns the logs directory inside the data dir.
 pub fn logs_dir() -> Result<PathBuf> {
     let dir = data_dir()?.join("logs");
@@ -160,6 +171,7 @@ fn dirs_home() -> Option<PathBuf> {
 pub fn ensure_directory_structure() -> Result<()> {
     data_dir()?;
     workspaces_dir()?;
+    chats_dir()?;
     logs_dir()?;
     run_dir()?;
     generated_images_dir()?;

--- a/src-tauri/src/git/watcher.rs
+++ b/src-tauri/src/git/watcher.rs
@@ -98,6 +98,12 @@ impl WatchableWorkspace {
                 .as_deref()
                 .map(std::path::PathBuf::from)
                 .with_context(|| format!("Local workspace {} is missing repo root_path", self.id)),
+            // Chat workspaces have no git context; the watcher should
+            // skip them before this resolves (see `is_watchable`).
+            WorkspaceMode::Chat => anyhow::bail!(
+                "Chat workspace {} should never be watched (no git)",
+                self.id
+            ),
         }
     }
 }
@@ -661,6 +667,11 @@ fn lookup_fetch_target(workspace_id: &str) -> Result<(PathBuf, String, String, S
         WorkspaceMode::Local => root_path
             .map(PathBuf::from)
             .context("Local workspace is missing repo root_path")?,
+        // Chat workspaces have no remote, no branch — the watcher
+        // never registers them, so this branch shouldn't fire.
+        WorkspaceMode::Chat => {
+            anyhow::bail!("Chat workspace cannot fetch from remote (no git)")
+        }
     };
     Ok((workspace_dir, remote, branch, repo_id))
 }
@@ -770,12 +781,16 @@ fn update_branch_in_db(
 
 fn load_watchable_workspaces() -> Result<Vec<WatchableWorkspace>> {
     let connection = db::read_conn()?;
+    // Chat-mode workspaces have no git context — exclude them from the
+    // watcher entirely so we never try to fetch, diff, or read HEAD on
+    // a scratch dir that isn't a repo.
     let mut stmt = connection.prepare(
         "SELECT w.id, r.name, w.directory_name, w.branch, w.state,
                 r.remote, COALESCE(w.intended_target_branch, r.default_branch), r.id,
                 COALESCE(w.mode, 'worktree'), r.root_path
          FROM workspaces w
-         JOIN repos r ON r.id = w.repository_id",
+         JOIN repos r ON r.id = w.repository_id
+         WHERE COALESCE(w.mode, 'worktree') != 'chat'",
     )?;
     let rows = stmt.query_map([], |row| {
         Ok(WatchableWorkspace {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -96,6 +96,13 @@ pub fn run() {
             // Build read/write connection pools (must happen after schema).
             db::init_pools()?;
 
+            // Refresh the synthetic chat repo's display name in case the
+            // canonical value moved between releases. No-op for installs
+            // that have never created a chat workspace (no row to update).
+            if let Err(error) = models::repos::refresh_system_chat_repo_name_if_exists() {
+                tracing::warn!(%error, "Failed to refresh chat repo name");
+            }
+
             tracing::info!(
                 mode = data_dir::data_mode_label(),
                 data = %db_path.display(),
@@ -243,6 +250,7 @@ pub fn run() {
             commands::workspace_commands::complete_workspace_setup,
             commands::workspace_commands::create_workspace_from_repo,
             commands::workspace_commands::prepare_workspace_from_repo,
+            commands::workspace_commands::prepare_chat_workspace,
             commands::workspace_commands::finalize_workspace_from_repo,
             commands::repository_commands::get_add_repository_defaults,
             commands::settings_commands::get_app_settings,

--- a/src-tauri/src/models/repos.rs
+++ b/src-tauri/src/models/repos.rs
@@ -11,6 +11,19 @@ use crate::{git_ops, helpers, workspace::sidebar_order, workspace_state};
 
 use super::db;
 
+/// Synthetic repository ID owned by Chat-mode workspaces. They aren't
+/// bound to a real repo on disk, but the `workspaces.repository_id`
+/// column is filled in for every row, so we stash them under a hidden
+/// placeholder repo. The row is upserted on every startup
+/// (`ensure_chat_repo`) and excluded from the repo picker because it's
+/// flagged `hidden = 1`.
+pub const SYSTEM_CHAT_REPO_ID: &str = "__chat__";
+
+/// Display name for the synthetic chat repo. Surfaces as the sidebar
+/// group header label when chat workspaces are bucketed under their
+/// (hidden) repo — kept short and pluralized to read like "Chats".
+pub const SYSTEM_CHAT_REPO_NAME: &str = "Chats";
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RepositoryCreateOption {
@@ -149,6 +162,73 @@ pub fn list_repositories() -> Result<Vec<RepositoryCreateOption>> {
 
     rows.collect::<std::result::Result<Vec<_>, _>>()
         .context("Failed to deserialize repositories")
+}
+
+/// Refresh the synthetic `__chat__` repo's `name` (and other display
+/// fields) on existing rows, without creating one. Safe to call on
+/// every startup — touches no rows on installs that have never used
+/// chat-mode, and keeps the sidebar label current when the canonical
+/// `SYSTEM_CHAT_REPO_NAME` constant is bumped between releases.
+pub(crate) fn refresh_system_chat_repo_name_if_exists() -> Result<()> {
+    let connection = db::write_conn()?;
+    connection
+        .execute(
+            "UPDATE repos SET name = ?2 WHERE id = ?1",
+            rusqlite::params![SYSTEM_CHAT_REPO_ID, SYSTEM_CHAT_REPO_NAME],
+        )
+        .context("Failed to refresh synthetic chat repository name")?;
+    Ok(())
+}
+
+/// Lazily upsert the synthetic `__chat__` repository row, creating it
+/// on first use rather than at startup. Keeps existing test fixtures
+/// untouched (they don't expect this row in `repos`) and avoids a
+/// schema-level dependency on column availability.
+///
+/// Errors from `chats_dir()` propagate rather than fall back to a
+/// sentinel string: `repos.root_path` has a UNIQUE index, and a stray
+/// placeholder row would later block any legitimate repo whose root
+/// matched it.
+pub(crate) fn ensure_system_chat_repo() -> Result<()> {
+    let connection = db::write_conn()?;
+    let chats_dir_path = crate::data_dir::chats_dir()
+        .context("Failed to resolve chats directory while upserting synthetic chat repo")?
+        .display()
+        .to_string();
+    connection
+        .execute(
+            r#"
+            INSERT OR IGNORE INTO repos (
+              id, name, root_path, hidden, display_order
+            ) VALUES (?1, ?2, ?3, 1, ?4)
+            "#,
+            rusqlite::params![
+                SYSTEM_CHAT_REPO_ID,
+                SYSTEM_CHAT_REPO_NAME,
+                chats_dir_path,
+                i64::MIN,
+            ],
+        )
+        .context("Failed to upsert synthetic chat repository row")?;
+    connection
+        .execute(
+            r#"
+            UPDATE repos
+            SET name = ?2,
+                hidden = 1,
+                display_order = ?3,
+                root_path = ?4
+            WHERE id = ?1
+            "#,
+            rusqlite::params![
+                SYSTEM_CHAT_REPO_ID,
+                SYSTEM_CHAT_REPO_NAME,
+                i64::MIN,
+                chats_dir_path,
+            ],
+        )
+        .context("Failed to refresh synthetic chat repository row")?;
+    Ok(())
 }
 
 pub(crate) fn load_repository_by_id(repo_id: &str) -> Result<Option<RepositoryRecord>> {

--- a/src-tauri/src/models/workspaces.rs
+++ b/src-tauri/src/models/workspaces.rs
@@ -348,6 +348,102 @@ pub(crate) fn insert_initializing_workspace_and_session_with_mode(
         .context("Failed to commit create-workspace transaction")
 }
 
+/// Insert a Chat-mode workspace + its initial session in a single
+/// transaction. Chat workspaces have no branch and no parent/intended
+/// target branch — those columns stay NULL. `repository_id` points at
+/// the synthetic `SYSTEM_CHAT_REPO_ID` row.
+///
+/// `directory_name` stores the relative scratch path
+/// (`"YYYY-MM-DD/new-chat[-N]"`); `helpers::workspace_path` joins it
+/// under `chats_dir` to resolve the absolute cwd at read time.
+pub(crate) fn insert_chat_workspace_and_session(
+    repository: &repos::RepositoryRecord,
+    workspace_id: &str,
+    session_id: &str,
+    directory_name: &str,
+    status: WorkspaceStatus,
+    timestamp: &str,
+) -> Result<()> {
+    let mut connection = db::write_conn()?;
+    let transaction = connection
+        .transaction()
+        .context("Failed to start create-chat-workspace transaction")?;
+
+    let next_order = transaction
+        .query_row(
+            r#"
+                SELECT COALESCE(MAX(display_order), 0) + ?2
+                FROM workspaces
+                WHERE state <> ?1
+                  AND pinned_at IS NULL
+                  AND COALESCE(status, 'in-progress') = ?3
+                "#,
+            rusqlite::params![WorkspaceState::Archived, sidebar_order::ORDER_STEP, status],
+            |row| row.get::<_, i64>(0),
+        )
+        .context("Failed to compute next workspace display order")?;
+
+    transaction
+        .execute(
+            r#"
+            INSERT INTO workspaces (
+              id,
+              repository_id,
+              directory_name,
+              active_session_id,
+              branch,
+              state,
+              initialization_parent_branch,
+              intended_target_branch,
+              mode,
+              branch_intent,
+              display_order,
+              status,
+              unread,
+              created_at,
+              updated_at
+            ) VALUES (?1, ?2, ?3, ?4, NULL, ?5, NULL, NULL, ?6, ?7, ?8, ?9, 0, ?10, ?10)
+            "#,
+            (
+                workspace_id,
+                repository.id.as_str(),
+                directory_name,
+                session_id,
+                WorkspaceState::Initializing,
+                WorkspaceMode::Chat,
+                WorkspaceBranchIntent::UseBranch,
+                next_order,
+                status,
+                timestamp,
+            ),
+        )
+        .context("Failed to insert chat workspace")?;
+
+    transaction
+        .execute(
+            r#"
+            INSERT INTO sessions (
+              id,
+              workspace_id,
+              title,
+              status,
+              permission_mode,
+              unread_count,
+              fast_mode,
+              created_at,
+              updated_at,
+              is_hidden
+            ) VALUES (?1, ?2, 'Untitled', 'idle', 'default', 0, 0, ?3, ?3, 0)
+            "#,
+            (session_id, workspace_id, timestamp),
+        )
+        .context("Failed to insert initial chat session")?;
+
+    transaction
+        .commit()
+        .context("Failed to commit create-chat-workspace transaction")
+}
+
 /// Atomically convert a local-mode workspace into a worktree-mode one.
 /// Used by the move-local-to-worktree flow once the new worktree
 /// directory + branch have been created on disk.

--- a/src-tauri/src/workspace/helpers.rs
+++ b/src-tauri/src/workspace/helpers.rs
@@ -18,7 +18,9 @@ use crate::{
 
 /// Resolve the on-disk path a workspace operates against. Worktree
 /// workspaces live under the helmor data dir; Local workspaces operate
-/// directly on the source repo's root path.
+/// directly on the source repo's root path; Chat workspaces store
+/// their relative scratch path (`"YYYY-MM-DD/new-chat[-N]"`) in
+/// `directory_name` and resolve it under the `chats` data dir.
 pub fn workspace_path(record: &WorkspaceRecord) -> Result<PathBuf> {
     match record.mode {
         WorkspaceMode::Worktree => {
@@ -27,6 +29,13 @@ pub fn workspace_path(record: &WorkspaceRecord) -> Result<PathBuf> {
         WorkspaceMode::Local => non_empty(&record.root_path)
             .map(PathBuf::from)
             .with_context(|| format!("Workspace {} (local) is missing repo root_path", record.id)),
+        WorkspaceMode::Chat => {
+            let dir_name = record.directory_name.trim();
+            if dir_name.is_empty() {
+                bail!("Workspace {} (chat) is missing directory_name", record.id);
+            }
+            Ok(crate::data_dir::chats_dir()?.join(dir_name))
+        }
     }
 }
 
@@ -38,13 +47,12 @@ pub fn display_title(record: &WorkspaceRecord) -> String {
     }
 
     // Local workspaces don't own a `directory_name` (they share the
-    // user's repo root with potentially other local workspaces). Use
-    // the first conversation's title to differentiate them in the
-    // sidebar; primary_session_title is the most-message-count
-    // non-hidden session, which lines up with "the conversation" in
-    // practice. Fall back to "Untitled" / repo name when nothing is
-    // populated yet.
-    if record.mode == WorkspaceMode::Local {
+    // user's repo root with potentially other local workspaces). Chat
+    // workspaces own a synthetic directory name like
+    // `"YYYY-MM-DD/new-chat-N"` which doesn't humanize nicely. Both
+    // prefer the live session title when one is available, falling
+    // back to a generic placeholder rather than the directory name.
+    if matches!(record.mode, WorkspaceMode::Local | WorkspaceMode::Chat) {
         if let Some(title) = non_empty(&record.primary_session_title)
             .or_else(|| non_empty(&record.active_session_title))
         {
@@ -52,7 +60,11 @@ pub fn display_title(record: &WorkspaceRecord) -> String {
                 return title.to_string();
             }
         }
-        return record.repo_name.clone();
+        return if record.mode == WorkspaceMode::Chat {
+            "New chat".to_string()
+        } else {
+            record.repo_name.clone()
+        };
     }
 
     if let Some(session_title) = non_empty(&record.active_session_title) {
@@ -726,6 +738,74 @@ pub fn allocate_directory_name_for_repo(repo_id: &str) -> Result<String> {
     allocate_directory_name_with_conn(&connection, repo_id)
 }
 
+/// Allocate a fresh scratch directory for a Chat-mode workspace.
+///
+/// Layout: `<data_dir>/chats/<YYYY-MM-DD>/<name>` where `<name>` starts
+/// at `new-chat`, then `new-chat-1`, `new-chat-2`, ... — a slot is free
+/// only when BOTH the filesystem dir is absent AND no DB row already
+/// owns the same relative `directory_name`. Checking only the FS would
+/// re-issue a name to a new row whenever the user manually deletes a
+/// chat directory while the DB row still exists, causing two rows to
+/// resolve to the same `workspace_path`.
+///
+/// Creates the dir on disk before returning so the caller can immediately
+/// use it as a CLI `cwd`. Returns `(directory_name, absolute_path)`.
+pub fn allocate_chat_workspace_dir() -> Result<(String, PathBuf)> {
+    let today = chrono::Local::now().date_naive().to_string(); // "YYYY-MM-DD"
+    let date_dir = crate::data_dir::chats_dir()?.join(&today);
+    fs::create_dir_all(&date_dir).with_context(|| {
+        format!(
+            "Failed to create chat date directory {}",
+            date_dir.display()
+        )
+    })?;
+
+    // Snapshot every chat row's `directory_name` once up-front. The
+    // alternative — one COUNT query per candidate — is fine for 9999
+    // iterations but allocates a connection per loop tick.
+    let connection = crate::db::read_conn()?;
+    let mut used_names: std::collections::HashSet<String> = connection
+        .prepare(
+            "SELECT directory_name FROM workspaces \
+             WHERE COALESCE(mode, 'worktree') = 'chat' \
+               AND directory_name IS NOT NULL",
+        )?
+        .query_map([], |row| row.get::<_, String>(0))?
+        .collect::<std::result::Result<_, _>>()?;
+    drop(connection);
+
+    // Allocate first un-taken slot. Cap at 9999 to avoid pathological
+    // loops; the user would have to spin up a chat per minute for a
+    // week to hit it.
+    for index in 0..=9999 {
+        let candidate_name = if index == 0 {
+            "new-chat".to_string()
+        } else {
+            format!("new-chat-{index}")
+        };
+        let relative = format!("{today}/{candidate_name}");
+        if used_names.contains(&relative) {
+            continue;
+        }
+        let candidate_path = date_dir.join(&candidate_name);
+        if !candidate_path.exists() {
+            fs::create_dir(&candidate_path).with_context(|| {
+                format!(
+                    "Failed to create chat workspace directory {}",
+                    candidate_path.display()
+                )
+            })?;
+            // Reserve the name in-memory in case a future call inside
+            // the same process iterates here before the new row lands
+            // in the DB read snapshot.
+            used_names.insert(relative.clone());
+            return Ok((relative, candidate_path));
+        }
+    }
+
+    bail!("Unable to allocate a chat workspace directory under {date_dir:?}")
+}
+
 pub fn allocate_directory_name_with_conn(
     connection: &rusqlite::Connection,
     repo_id: &str,
@@ -857,6 +937,99 @@ mod tests {
         assert!(
             msg.contains("local") && msg.contains("root_path"),
             "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn workspace_path_for_chat_joins_chats_dir() {
+        let _guard = crate::data_dir::TEST_ENV_LOCK.lock();
+        let temp = tempfile::TempDir::new().unwrap();
+        std::env::set_var("HELMOR_DATA_DIR", temp.path());
+        let mut record = fixture_record(WorkspaceMode::Chat, None);
+        record.directory_name = "2026-05-19/new-chat".to_string();
+        let path = workspace_path(&record).unwrap();
+        assert_eq!(
+            path,
+            temp.path()
+                .join("chats")
+                .join("2026-05-19")
+                .join("new-chat")
+        );
+        std::env::remove_var("HELMOR_DATA_DIR");
+    }
+
+    #[test]
+    fn allocate_chat_workspace_dir_creates_unique_names() {
+        // `allocate_chat_workspace_dir` now consults the `workspaces`
+        // table to avoid handing out a name an orphaned DB row already
+        // owns, so the test needs a real schema-initialised env.
+        let _env = crate::testkit::TestEnv::new("alloc-chat-dir-unique");
+
+        let (name1, path1) = allocate_chat_workspace_dir().unwrap();
+        let (name2, path2) = allocate_chat_workspace_dir().unwrap();
+        let (name3, path3) = allocate_chat_workspace_dir().unwrap();
+
+        // First allocation gets the bare `new-chat`; subsequent ones
+        // append `-1`, `-2`. Date prefix is `YYYY-MM-DD/`.
+        assert!(
+            name1.ends_with("/new-chat"),
+            "expected first to end with /new-chat: {name1}"
+        );
+        assert!(
+            name2.ends_with("/new-chat-1"),
+            "expected second to end with /new-chat-1: {name2}"
+        );
+        assert!(
+            name3.ends_with("/new-chat-2"),
+            "expected third to end with /new-chat-2: {name3}"
+        );
+        assert!(path1.is_dir(), "first dir should exist: {path1:?}");
+        assert!(path2.is_dir(), "second dir should exist: {path2:?}");
+        assert!(path3.is_dir(), "third dir should exist: {path3:?}");
+    }
+
+    #[test]
+    fn allocate_chat_workspace_dir_skips_orphaned_db_name() {
+        // Simulate the failure mode from the review: a DB row still
+        // points at "new-chat" but the user wiped the dir. The allocator
+        // must NOT hand the same slot to a fresh chat — otherwise two
+        // rows resolve to the same workspace_path and one's delete
+        // would clobber the other's contents.
+        let env = crate::testkit::TestEnv::new("alloc-chat-skips-orphan");
+        let today = chrono::Local::now().date_naive().to_string();
+        let orphan_directory_name = format!("{today}/new-chat");
+
+        // Seed an orphan chat row with the slot we expect to be skipped.
+        let conn = env.db_connection();
+        conn.execute(
+            "INSERT OR IGNORE INTO repos (id, name, hidden, display_order) \
+             VALUES (?1, ?2, 1, ?3)",
+            rusqlite::params![
+                crate::models::repos::SYSTEM_CHAT_REPO_ID,
+                crate::models::repos::SYSTEM_CHAT_REPO_NAME,
+                i64::MIN,
+            ],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO workspaces (id, repository_id, directory_name, mode, state, status, display_order) \
+             VALUES ('orphan', ?1, ?2, 'chat', 'ready', 'in-progress', ?3)",
+            rusqlite::params![
+                crate::models::repos::SYSTEM_CHAT_REPO_ID,
+                &orphan_directory_name,
+                crate::workspace::sidebar_order::ORDER_STEP,
+            ],
+        )
+        .unwrap();
+
+        let (name, _path) = allocate_chat_workspace_dir().unwrap();
+        assert_ne!(
+            name, orphan_directory_name,
+            "must not reuse a slot owned by an existing chat row"
+        );
+        assert!(
+            name.ends_with("/new-chat-1"),
+            "should fall through to the next free slot, got {name}"
         );
     }
 

--- a/src-tauri/src/workspace/lifecycle.rs
+++ b/src-tauri/src/workspace/lifecycle.rs
@@ -398,6 +398,90 @@ pub fn prepare_local_workspace_impl(
     })
 }
 
+/// One-shot Chat workspace creation. Chat-mode workspaces aren't bound
+/// to any repository — they're a scratch directory under
+/// `<data_dir>/chats/<YYYY-MM-DD>/new-chat[-N]` used as cwd for an
+/// agent CLI session. No git init, no branch, no setup script — the
+/// row is inserted directly in `Ready` state and the caller can hand
+/// off to the agent immediately.
+///
+/// Returns a `PrepareWorkspaceResponse` shaped like the worktree/local
+/// equivalents so the frontend's optimistic-render code can reuse the
+/// same path. The companion `finalize_workspace_from_repo` is a no-op
+/// for chat workspaces (the row is already `Ready`).
+pub fn prepare_chat_workspace_impl(
+    initial_status: WorkspaceStatus,
+) -> Result<PrepareWorkspaceResponse> {
+    // Lazy-upsert the synthetic `__chat__` repo row on first chat
+    // creation. Doing it here (rather than at schema migration time)
+    // keeps `repos` empty for tests that don't touch the chat path and
+    // sidesteps schema-version juggling in legacy migration tests.
+    crate::repos::ensure_system_chat_repo()?;
+    let repository = repos::load_repository_by_id(crate::models::repos::SYSTEM_CHAT_REPO_ID)?
+        .with_context(|| {
+            format!(
+                "Synthetic chat repository row missing after upsert. id={}",
+                crate::models::repos::SYSTEM_CHAT_REPO_ID
+            )
+        })?;
+
+    let (directory_name, working_directory) = helpers::allocate_chat_workspace_dir()?;
+    let workspace_id = uuid::Uuid::new_v4().to_string();
+    let session_id = uuid::Uuid::new_v4().to_string();
+    let timestamp = db::current_timestamp()?;
+
+    // The scratch dir is already on disk; anything that fails from here
+    // on must clean it up before bubbling so retries don't accumulate
+    // empty `new-chat-N` directories.
+    if let Err(error) = workspace_models::insert_chat_workspace_and_session(
+        &repository,
+        &workspace_id,
+        &session_id,
+        &directory_name,
+        initial_status,
+        &timestamp,
+    ) {
+        let _ = fs::remove_dir_all(&working_directory);
+        return Err(error);
+    }
+
+    // Flip to Ready immediately — there's no worktree / setup phase.
+    if let Err(error) =
+        workspace_models::update_workspace_state(&workspace_id, WorkspaceState::Ready, &timestamp)
+    {
+        let _ = workspace_models::delete_workspace_and_session_rows(&workspace_id);
+        let _ = fs::remove_dir_all(&working_directory);
+        return Err(error);
+    }
+
+    Ok(PrepareWorkspaceResponse {
+        workspace_id,
+        initial_session_id: session_id,
+        repo_id: repository.id,
+        repo_name: repository.name,
+        directory_name,
+        // Chat workspaces have no branch — empty string keeps the type
+        // shape stable for the frontend. The header gates on
+        // `workspace.mode === "chat"` and doesn't read this field.
+        branch: String::new(),
+        default_branch: String::new(),
+        state: WorkspaceState::Ready,
+        // No setup/run scripts for chat mode — return the empty shape.
+        repo_scripts: repos::RepoScripts {
+            setup_script: None,
+            run_script: None,
+            archive_script: None,
+            setup_from_project: false,
+            run_from_project: false,
+            archive_from_project: false,
+            auto_run_setup: false,
+            run_script_mode: "concurrent".to_string(),
+        },
+        working_directory: Some(working_directory.display().to_string()),
+        branch_intent: WorkspaceBranchIntent::UseBranch,
+    })
+}
+
 /// Phase 2 of workspace creation: creates the git worktree, probes
 /// `helmor.json` for a setup script, and
 /// upgrades the workspace row from `Initializing` to `Ready` /
@@ -409,12 +493,13 @@ pub fn finalize_workspace_from_repo_impl(workspace_id: &str) -> Result<FinalizeW
         .ok_or_else(|| coded(ErrorCode::WorkspaceNotFound))
         .with_context(|| format!("Workspace not found: {workspace_id}"))?;
 
-    // Local workspaces never need worktree materialisation. Short-circuit
-    // unconditionally — even an orphaned `Initializing` local row (left by
-    // a partially-failed prepare) must not enter the worktree-creation
-    // path below, where a failure would route into
+    // Non-worktree workspaces never need worktree materialisation.
+    // Short-circuit unconditionally — even an orphaned `Initializing`
+    // row (left by a partially-failed prepare) must not enter the
+    // worktree-creation path below, where a failure would route into
     // `cleanup_failed_created_workspace(repo_root, root_path, ...)`.
-    if record.mode == WorkspaceMode::Local {
+    // Covers both Local (operates on user repo) and Chat (scratch dir).
+    if record.mode != WorkspaceMode::Worktree {
         let working_directory = helpers::workspace_path(&record)?.display().to_string();
         return Ok(FinalizeWorkspaceResponse {
             workspace_id: workspace_id.to_string(),
@@ -784,12 +869,16 @@ pub fn cleanup_orphaned_initializing_workspaces(max_age_seconds: i64) -> Result<
         let repo_root_value = record.root_path.as_deref().unwrap_or("").trim();
         let repo_root = PathBuf::from(repo_root_value);
         // Local-mode orphans: never touch the worktree path (it's the
-        // user's actual repo). Just remove the DB row.
-        if record.mode == crate::workspace_state::WorkspaceMode::Local {
+        // user's actual repo). Chat-mode orphans: the scratch dir is
+        // owned by helmor, but the cleanup logic below targets git
+        // worktrees only, so skip it too — the empty scratch dir is
+        // cheap to GC out-of-band.
+        if record.mode != crate::workspace_state::WorkspaceMode::Worktree {
             let _ = workspace_models::delete_workspace_and_session_rows(&record.id);
             tracing::info!(
                 workspace_id = %record.id,
-                "Cleaned up orphaned initializing local workspace (DB only)",
+                mode = %record.mode,
+                "Cleaned up orphaned initializing non-worktree workspace (DB only)",
             );
             continue;
         }
@@ -942,6 +1031,21 @@ pub fn prepare_archive_plan(workspace_id: &str) -> Result<ArchivePreparedPlan> {
         );
     }
 
+    // Chat workspaces have no repo / branch / git worktree — archive is
+    // a pure DB state flip. Return a placeholder plan so the manager's
+    // prepared/start handshake still works; `execute_archive_plan`
+    // short-circuits before touching any of these fields when
+    // `mode != Worktree`.
+    if record.mode != WorkspaceMode::Worktree {
+        let workspace_dir = helpers::workspace_path(&record).unwrap_or_default();
+        return Ok(ArchivePreparedPlan {
+            workspace_id: workspace_id.to_string(),
+            repo_root: PathBuf::new(),
+            branch: String::new(),
+            workspace_dir,
+        });
+    }
+
     let repo_root = helpers::non_empty(&record.root_path)
         .map(PathBuf::from)
         .with_context(|| format!("Workspace {workspace_id} is missing repo root_path"))?;
@@ -983,11 +1087,12 @@ pub fn validate_archive_workspace(workspace_id: &str) -> Result<()> {
 }
 
 pub fn archive_workspace_impl(workspace_id: &str) -> Result<ArchiveWorkspaceResponse> {
-    // Local workspaces: archive is purely a DB state flip. We MUST NOT
-    // touch the worktree (it's the user's repo) or delete the branch
-    // (the user / other local workspaces may still be using it).
+    // Non-worktree workspaces: archive is purely a DB state flip. We
+    // MUST NOT touch the worktree (Local: it's the user's repo; Chat:
+    // it's a scratch dir we'd rather keep around for diagnostic
+    // reasons) or delete branches.
     if let Some(record) = workspace_models::load_workspace_record_by_id(workspace_id)? {
-        if record.mode == WorkspaceMode::Local {
+        if record.mode != WorkspaceMode::Worktree {
             if !is_archive_eligible_state(record.state) {
                 bail!(
                     "Workspace is not archive-ready: {workspace_id} (state: {})",
@@ -1013,16 +1118,17 @@ pub fn execute_archive_plan(plan: &ArchivePreparedPlan) -> Result<ArchiveWorkspa
     let workspace_dir = &plan.workspace_dir;
     let workspace_id = &plan.workspace_id;
 
-    // CRITICAL safety check: for local-mode workspaces, `workspace_dir`
-    // IS the user's repo root. The downstream `remove_worktree` would
-    // rename + delete the user's repo. Short-circuit to a DB-only flip
-    // here BEFORE we touch anything on disk. The frontend's
+    // CRITICAL safety check: for non-worktree workspaces, `workspace_dir`
+    // points at something we must not blow away (Local: the user's repo;
+    // Chat: helmor's scratch dir). The downstream `remove_worktree`
+    // would rename + delete it. Short-circuit to a DB-only flip here
+    // BEFORE we touch anything on disk. The frontend's
     // `archive_workspace_impl` already does this; this is a second
     // line of defence for the archive path that goes through
     // `prepare_archive_plan` + this function.
     let record = workspace_models::load_workspace_record_by_id(workspace_id)?;
     if let Some(record) = record.as_ref() {
-        if record.mode == WorkspaceMode::Local {
+        if record.mode != WorkspaceMode::Worktree {
             workspace_models::update_archived_workspace_state(workspace_id, "")?;
             return Ok(ArchiveWorkspaceResponse {
                 archived_workspace_id: workspace_id.clone(),
@@ -1172,9 +1278,9 @@ pub fn validate_restore_workspace(workspace_id: &str) -> Result<ValidateRestoreR
     let record = workspace_models::load_workspace_record_by_id(workspace_id)?
         .ok_or_else(|| coded(ErrorCode::WorkspaceNotFound))
         .with_context(|| format!("Workspace not found: {workspace_id}"))?;
-    // Local restore is a pure DB state flip — no git involved, so no
-    // target-branch conflict is ever possible.
-    if record.mode == WorkspaceMode::Local {
+    // Non-worktree restore is a pure DB state flip — no git involved,
+    // so no target-branch conflict is ever possible.
+    if record.mode != WorkspaceMode::Worktree {
         return Ok(ValidateRestoreResponse {
             target_branch_conflict: None,
         });
@@ -1220,10 +1326,10 @@ pub fn restore_workspace_impl(
     workspace_id: &str,
     target_branch_override: Option<&str>,
 ) -> Result<RestoreWorkspaceResponse> {
-    // Local workspaces aren't materialised as a worktree — restoring
-    // one is purely a DB state flip. Skip every git operation (branch
-    // creation, worktree creation, archive_commit verification, …)
-    // that the worktree path performs.
+    // Non-worktree workspaces aren't materialised as a worktree —
+    // restoring one is purely a DB state flip. Skip every git
+    // operation (branch creation, worktree creation, archive_commit
+    // verification, …) that the worktree path performs.
     {
         let record = workspace_models::load_workspace_record_by_id(workspace_id)?
             .ok_or_else(|| coded(ErrorCode::WorkspaceNotFound))
@@ -1231,7 +1337,7 @@ pub fn restore_workspace_impl(
         if record.state != WorkspaceState::Archived {
             bail!("Workspace is not archived: {workspace_id}");
         }
-        if record.mode == WorkspaceMode::Local {
+        if record.mode != WorkspaceMode::Worktree {
             workspace_models::update_restored_workspace_state(
                 workspace_id,
                 target_branch_override,

--- a/src-tauri/src/workspace/state.rs
+++ b/src-tauri/src/workspace/state.rs
@@ -91,13 +91,16 @@ pub const OPERATIONAL_FILTER: &str = "NOT IN ('archived', 'initializing')";
 /// dedicated `git worktree` directory with its own auto-named branch
 /// (default + most-common). `Local` = operate directly on the source
 /// repo's root path; multiple Local workspaces can coexist as parallel
-/// conversations over the same disk.
+/// conversations over the same disk. `Chat` = a scratch directory with
+/// no git binding at all — used for "Just Chat" sessions that aren't
+/// tied to any repository.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum WorkspaceMode {
     #[default]
     Worktree,
     Local,
+    Chat,
 }
 
 impl WorkspaceMode {
@@ -105,7 +108,16 @@ impl WorkspaceMode {
         match self {
             Self::Worktree => "worktree",
             Self::Local => "local",
+            Self::Chat => "chat",
         }
+    }
+
+    /// True when the workspace has no git context (no repo, no branch,
+    /// no worktree). Chat-mode workspaces are the only such variant
+    /// today. Used by code paths that should early-return on chat
+    /// workspaces (git status watcher, branch ops, PR sync, etc.).
+    pub const fn is_chat(&self) -> bool {
+        matches!(self, Self::Chat)
     }
 }
 
@@ -133,6 +145,7 @@ impl FromStr for WorkspaceMode {
         match s {
             "worktree" => Ok(Self::Worktree),
             "local" => Ok(Self::Local),
+            "chat" => Ok(Self::Chat),
             other => Err(UnknownWorkspaceMode(other.to_string())),
         }
     }

--- a/src-tauri/src/workspace/workspaces.rs
+++ b/src-tauri/src/workspace/workspaces.rs
@@ -31,12 +31,12 @@ pub use super::branching::{
 pub use super::lifecycle::{
     archive_workspace_impl, cleanup_orphaned_initializing_workspaces,
     create_workspace_from_repo_impl, execute_archive_plan, finalize_workspace_from_repo_impl,
-    move_local_workspace_to_worktree_impl, prepare_archive_plan, prepare_local_workspace_impl,
-    prepare_workspace_from_repo_impl, restore_workspace_impl, validate_archive_workspace,
-    validate_restore_workspace, ArchivePreparedPlan, ArchiveWorkspaceResponse, BranchRename,
-    CreateWorkspaceResponse, FinalizeWorkspaceResponse, MoveLocalToWorktreeResponse,
-    PrepareWorkspaceResponse, RestoreWorkspaceResponse, TargetBranchConflict,
-    ValidateRestoreResponse,
+    move_local_workspace_to_worktree_impl, prepare_archive_plan, prepare_chat_workspace_impl,
+    prepare_local_workspace_impl, prepare_workspace_from_repo_impl, restore_workspace_impl,
+    validate_archive_workspace, validate_restore_workspace, ArchivePreparedPlan,
+    ArchiveWorkspaceResponse, BranchRename, CreateWorkspaceResponse, FinalizeWorkspaceResponse,
+    MoveLocalToWorktreeResponse, PrepareWorkspaceResponse, RestoreWorkspaceResponse,
+    TargetBranchConflict, ValidateRestoreResponse,
 };
 
 #[derive(Debug, Clone, Serialize)]
@@ -180,6 +180,7 @@ pub struct WorkspaceDetail {
 
 pub fn list_workspace_groups() -> Result<Vec<WorkspaceSidebarGroup>> {
     let mut pinned = Vec::new();
+    let mut chats = Vec::new();
     let mut done = Vec::new();
     let mut review = Vec::new();
     let mut progress = Vec::new();
@@ -190,13 +191,20 @@ pub fn list_workspace_groups() -> Result<Vec<WorkspaceSidebarGroup>> {
     // order. Iterating in that order and bucketing into status groups means
     // each group naturally inherits the same stable order, no per-group
     // re-sort needed.
+    //
+    // Chat workspaces live in their own bucket and don't participate in
+    // status/pinned buckets — their `status` column is meaningless
+    // (kept at the default `in-progress` for column compatibility).
     for record in workspace_models::load_workspace_records()? {
         if record.state == WorkspaceState::Archived {
             continue;
         }
+        let is_chat = record.mode == WorkspaceMode::Chat;
         let is_pinned = record.pinned_at.is_some();
         let row = record_to_sidebar_row(record);
-        if is_pinned {
+        if is_chat {
+            chats.push(row);
+        } else if is_pinned {
             pinned.push(row);
         } else {
             match row.status {
@@ -215,6 +223,12 @@ pub fn list_workspace_groups() -> Result<Vec<WorkspaceSidebarGroup>> {
             label: "Pinned".to_string(),
             tone: "pinned".to_string(),
             rows: pinned,
+        },
+        WorkspaceSidebarGroup {
+            id: "chats".to_string(),
+            label: "Chats".to_string(),
+            tone: "chats".to_string(),
+            rows: chats,
         },
         WorkspaceSidebarGroup {
             id: "done".to_string(),
@@ -310,11 +324,30 @@ pub fn mark_workspace_unread(workspace_id: &str) -> Result<()> {
         .context("Failed to commit workspace unread transaction")
 }
 
+/// Guard for status/pin operations: chat workspaces live in their own
+/// bucket and don't participate in the kanban (status / pinned). All
+/// three commands bail rather than silently no-op so the call site
+/// (frontend menu, automated PR-sync) can surface the rejection.
+fn assert_not_chat(transaction: &Transaction<'_>, workspace_id: &str) -> Result<()> {
+    let mode: String = transaction
+        .query_row(
+            "SELECT COALESCE(mode, 'worktree') FROM workspaces WHERE id = ?1",
+            [workspace_id],
+            |row| row.get(0),
+        )
+        .with_context(|| format!("Workspace not found: {workspace_id}"))?;
+    if mode == "chat" {
+        bail!("Chat workspaces don't participate in status/pinned buckets");
+    }
+    Ok(())
+}
+
 pub fn pin_workspace(workspace_id: &str) -> Result<()> {
     let mut connection = db::write_conn()?;
     let transaction = connection
         .transaction()
         .context("Failed to start pin-workspace transaction")?;
+    assert_not_chat(&transaction, workspace_id)?;
     let next_order = next_order_for_target(&transaction, &MoveTarget::Pinned)?;
     transaction
         .execute(
@@ -332,6 +365,7 @@ pub fn unpin_workspace(workspace_id: &str) -> Result<()> {
     let transaction = connection
         .transaction()
         .context("Failed to start unpin-workspace transaction")?;
+    assert_not_chat(&transaction, workspace_id)?;
     let status = load_workspace_status(&transaction, workspace_id)?;
     let next_order = next_order_for_target(&transaction, &MoveTarget::Status(status))?;
     transaction
@@ -350,6 +384,7 @@ pub fn set_workspace_status(workspace_id: &str, status: WorkspaceStatus) -> Resu
     let transaction = connection
         .transaction()
         .context("Failed to start set-status transaction")?;
+    assert_not_chat(&transaction, workspace_id)?;
     // Pinned rows stay pinned — keep their display_order, only flip status.
     let is_pinned: bool = transaction
         .query_row(
@@ -382,10 +417,12 @@ pub fn set_workspace_status(workspace_id: &str, status: WorkspaceStatus) -> Resu
 /// Where a workspace move is targeted. Mirrors the sidebar group ids the
 /// frontend sends across IPC:
 ///   - "pinned"
+///   - "chats"
 ///   - "done" / "review" / "progress" / "backlog" / "canceled"
 ///   - "repo:<repo_id>"
 pub enum MoveTarget {
     Pinned,
+    Chats,
     Status(WorkspaceStatus),
     Repo(String),
 }
@@ -394,6 +431,9 @@ impl MoveTarget {
     fn parse(transaction: &Transaction<'_>, target_group_id: &str) -> Result<Self> {
         if target_group_id == "pinned" {
             return Ok(Self::Pinned);
+        }
+        if target_group_id == "chats" {
+            return Ok(Self::Chats);
         }
         if let Some(repo_id) = target_group_id.strip_prefix("repo:") {
             let exists: bool = transaction
@@ -455,6 +495,28 @@ pub fn move_workspace_in_sidebar(
         }
     }
 
+    // Chat-mode workspaces only live in the Chats bucket; non-chat
+    // workspaces can never enter it. Both sides bail loudly so a stray
+    // drop on the wrong target surfaces during testing rather than
+    // silently corrupting the bucket layout.
+    let row_mode: String = transaction
+        .query_row(
+            "SELECT COALESCE(mode, 'worktree') FROM workspaces WHERE id = ?1",
+            [workspace_id],
+            |row| row.get(0),
+        )
+        .with_context(|| format!("Workspace not found: {workspace_id}"))?;
+    let row_is_chat = row_mode == "chat";
+    match (&target, row_is_chat) {
+        (MoveTarget::Chats, false) => {
+            bail!("Only chat workspaces can move into the Chats bucket")
+        }
+        (MoveTarget::Pinned | MoveTarget::Status(_) | MoveTarget::Repo(_), true) => {
+            bail!("Chat workspaces can only be reordered inside the Chats bucket")
+        }
+        _ => {}
+    }
+
     let neighbours = list_target_group_orders(&transaction, &target, workspace_id)?;
     let (prev, next) = resolve_neighbour_orders(&neighbours, workspace_id, before_workspace_id)?;
 
@@ -481,7 +543,23 @@ fn list_target_group_orders(
                 r#"
                 SELECT id, display_order
                 FROM workspaces
-                WHERE state <> ?1 AND pinned_at IS NOT NULL
+                WHERE state <> ?1
+                  AND pinned_at IS NOT NULL
+                  AND COALESCE(mode, 'worktree') != 'chat'
+                ORDER BY display_order ASC, datetime(created_at) DESC, id DESC
+                "#,
+            )?
+            .query_map([WorkspaceState::Archived], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+            })?
+            .collect::<std::result::Result<_, _>>()?,
+        MoveTarget::Chats => transaction
+            .prepare(
+                r#"
+                SELECT id, display_order
+                FROM workspaces
+                WHERE state <> ?1
+                  AND COALESCE(mode, 'worktree') = 'chat'
                 ORDER BY display_order ASC, datetime(created_at) DESC, id DESC
                 "#,
             )?
@@ -496,6 +574,7 @@ fn list_target_group_orders(
                 FROM workspaces
                 WHERE state <> ?1
                   AND pinned_at IS NULL
+                  AND COALESCE(mode, 'worktree') != 'chat'
                   AND COALESCE(status, 'in-progress') = ?2
                 ORDER BY display_order ASC, datetime(created_at) DESC, id DESC
                 "#,
@@ -607,6 +686,18 @@ fn apply_target_to_workspace(
             "#,
             rusqlite::params![workspace_id, new_order, WorkspaceState::Archived],
         )?,
+        // Chat target only changes display_order. status / pinned_at
+        // are meaningless for chat rows; leave them as-is so they
+        // never surface in status buckets even if a stale value lingers.
+        MoveTarget::Chats => transaction.execute(
+            r#"
+            UPDATE workspaces
+            SET display_order = ?2,
+                updated_at = datetime('now')
+            WHERE id = ?1 AND state <> ?3
+            "#,
+            rusqlite::params![workspace_id, new_order, WorkspaceState::Archived],
+        )?,
         MoveTarget::Status(status) => transaction.execute(
             r#"
             UPDATE workspaces
@@ -661,14 +752,21 @@ fn next_order_for_target(transaction: &Transaction<'_>, target: &MoveTarget) -> 
     let max: Option<i64> = match target {
         MoveTarget::Pinned => transaction
             .query_row(
-                "SELECT MAX(display_order) FROM workspaces WHERE state <> ?1 AND pinned_at IS NOT NULL",
+                "SELECT MAX(display_order) FROM workspaces WHERE state <> ?1 AND pinned_at IS NOT NULL AND COALESCE(mode, 'worktree') != 'chat'",
                 [WorkspaceState::Archived],
                 |row| row.get(0),
             )
             .context("Failed to compute next pinned workspace order")?,
+        MoveTarget::Chats => transaction
+            .query_row(
+                "SELECT MAX(display_order) FROM workspaces WHERE state <> ?1 AND COALESCE(mode, 'worktree') = 'chat'",
+                [WorkspaceState::Archived],
+                |row| row.get(0),
+            )
+            .context("Failed to compute next chat workspace order")?,
         MoveTarget::Status(status) => transaction
             .query_row(
-                "SELECT MAX(display_order) FROM workspaces WHERE state <> ?1 AND pinned_at IS NULL AND COALESCE(status, 'in-progress') = ?2",
+                "SELECT MAX(display_order) FROM workspaces WHERE state <> ?1 AND pinned_at IS NULL AND COALESCE(mode, 'worktree') != 'chat' AND COALESCE(status, 'in-progress') = ?2",
                 rusqlite::params![WorkspaceState::Archived, status],
                 |row| row.get(0),
             )
@@ -1442,14 +1540,30 @@ pub fn permanently_delete_workspace(workspace_id: &str) -> Result<()> {
     super::branching::clear_prefetch_rate_limit(workspace_id);
     db::remove_workspace_lock(workspace_id);
 
-    // Filesystem cleanup (best-effort). Local workspaces never own
-    // their directory — that's the user's repo, never delete it.
+    // Filesystem cleanup (best-effort).
+    //   Worktree: own dir under <data_dir>/workspaces — safe to wipe.
+    //   Local: it's the user's repo, never delete it.
+    //   Chat: own scratch dir under <data_dir>/chats/<date>/<name>,
+    //         safe to wipe.
     if let Some((repo_name, directory_name, _state, mode)) = record {
-        if mode == crate::workspace_state::WorkspaceMode::Worktree {
-            if let Ok(ws_dir) = crate::data_dir::workspace_dir(&repo_name, &directory_name) {
-                if ws_dir.is_dir() {
-                    std::fs::remove_dir_all(&ws_dir).ok();
+        match mode {
+            crate::workspace_state::WorkspaceMode::Worktree => {
+                if let Ok(ws_dir) = crate::data_dir::workspace_dir(&repo_name, &directory_name) {
+                    if ws_dir.is_dir() {
+                        std::fs::remove_dir_all(&ws_dir).ok();
+                    }
                 }
+            }
+            crate::workspace_state::WorkspaceMode::Chat => {
+                if let Ok(chats_root) = crate::data_dir::chats_dir() {
+                    let ws_dir = chats_root.join(&directory_name);
+                    if ws_dir.is_dir() {
+                        std::fs::remove_dir_all(&ws_dir).ok();
+                    }
+                }
+            }
+            crate::workspace_state::WorkspaceMode::Local => {
+                // User-owned dir — never touch.
             }
         }
     }
@@ -1982,5 +2096,238 @@ mod tests {
                 |row| Ok((row.get(0)?, row.get(1)?)),
             )
             .unwrap()
+    }
+
+    // ── Chat-mode workspace tests ────────────────────────────────────────
+    //
+    // Chat workspaces are a parallel universe to the kanban: own bucket,
+    // own scratch dir, no git. The tests below pin the contract that
+    // (a) prepare lays a row + dir down, (b) the drag-policy walls
+    // around the bucket hold both directions, (c) permanently_delete
+    // really wipes the scratch dir, and (d) archive is a pure DB flip.
+
+    fn insert_chat_repo(env: &TestEnv) {
+        let conn = env.db_connection();
+        conn.execute(
+            "INSERT OR IGNORE INTO repos (id, name, root_path, hidden, display_order) \
+             VALUES (?1, ?2, ?3, 1, ?4)",
+            rusqlite::params![
+                crate::models::repos::SYSTEM_CHAT_REPO_ID,
+                crate::models::repos::SYSTEM_CHAT_REPO_NAME,
+                crate::data_dir::chats_dir().unwrap().display().to_string(),
+                i64::MIN,
+            ],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn prepare_chat_workspace_writes_row_and_creates_dir() {
+        let env = TestEnv::new("prepare-chat-workspace");
+        insert_chat_repo(&env);
+
+        let response = super::super::lifecycle::prepare_chat_workspace_impl(
+            crate::workspace_status::WorkspaceStatus::InProgress,
+        )
+        .unwrap();
+
+        assert_eq!(response.state, WorkspaceState::Ready);
+        assert!(
+            response.directory_name.contains("/new-chat"),
+            "directory_name should be `<YYYY-MM-DD>/new-chat[-N]`: {}",
+            response.directory_name
+        );
+        let cwd = response.working_directory.expect("chat returns its cwd");
+        assert!(
+            std::path::Path::new(&cwd).is_dir(),
+            "scratch dir should exist on disk: {cwd}"
+        );
+
+        let conn = env.db_connection();
+        let (repo_id, mode, branch, status, state): (
+            String,
+            Option<String>,
+            Option<String>,
+            String,
+            String,
+        ) = conn
+            .query_row(
+                "SELECT repository_id, mode, branch, status, state \
+                 FROM workspaces WHERE id = ?1",
+                [&response.workspace_id],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                    ))
+                },
+            )
+            .unwrap();
+        assert_eq!(repo_id, crate::models::repos::SYSTEM_CHAT_REPO_ID);
+        assert_eq!(mode.as_deref(), Some("chat"));
+        assert!(branch.is_none(), "chat row must have NULL branch");
+        assert_eq!(status, "in-progress");
+        assert_eq!(state, "ready");
+    }
+
+    #[test]
+    fn move_workspace_rejects_chat_into_status_bucket() {
+        let env = TestEnv::new("move-rejects-chat-to-status");
+        insert_chat_repo(&env);
+        let response = super::super::lifecycle::prepare_chat_workspace_impl(
+            crate::workspace_status::WorkspaceStatus::InProgress,
+        )
+        .unwrap();
+
+        let result = move_workspace_in_sidebar(&response.workspace_id, "progress", None);
+        let err = result.expect_err("chat row must not move into a status bucket");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.to_lowercase().contains("chat"),
+            "error should mention chat: {msg}"
+        );
+    }
+
+    #[test]
+    fn move_workspace_rejects_non_chat_into_chats_bucket() {
+        let env = TestEnv::new("move-rejects-non-chat-to-chats");
+        let conn = env.db_connection();
+        insert_repo(&conn, "r1", "demo", None);
+        insert_workspace(
+            &conn,
+            &WorkspaceFixture {
+                id: "w1",
+                repo_id: "r1",
+                directory_name: "alpha",
+                state: WorkspaceState::Ready.as_str(),
+                branch: Some("feature/alpha"),
+                intended_target_branch: None,
+            },
+        );
+
+        let result = move_workspace_in_sidebar("w1", "chats", None);
+        let err = result.expect_err("non-chat row must not enter the chats bucket");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.to_lowercase().contains("chat"),
+            "error should mention chat: {msg}"
+        );
+    }
+
+    #[test]
+    fn move_workspace_allows_reorder_within_chats_bucket() {
+        let env = TestEnv::new("move-reorder-within-chats");
+        insert_chat_repo(&env);
+        let a = super::super::lifecycle::prepare_chat_workspace_impl(
+            crate::workspace_status::WorkspaceStatus::InProgress,
+        )
+        .unwrap();
+        let b = super::super::lifecycle::prepare_chat_workspace_impl(
+            crate::workspace_status::WorkspaceStatus::InProgress,
+        )
+        .unwrap();
+
+        // Move `b` before `a` inside the chats bucket.
+        move_workspace_in_sidebar(&b.workspace_id, "chats", Some(&a.workspace_id)).unwrap();
+
+        let conn = env.db_connection();
+        let order_a: i64 = conn
+            .query_row(
+                "SELECT display_order FROM workspaces WHERE id = ?1",
+                [&a.workspace_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let order_b: i64 = conn
+            .query_row(
+                "SELECT display_order FROM workspaces WHERE id = ?1",
+                [&b.workspace_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(
+            order_b < order_a,
+            "after moving b before a, display_order(b) ({order_b}) should precede display_order(a) ({order_a})"
+        );
+    }
+
+    #[test]
+    fn permanently_delete_chat_workspace_removes_scratch_dir() {
+        let env = TestEnv::new("delete-chat-removes-dir");
+        insert_chat_repo(&env);
+        let response = super::super::lifecycle::prepare_chat_workspace_impl(
+            crate::workspace_status::WorkspaceStatus::InProgress,
+        )
+        .unwrap();
+        let scratch_dir = response.working_directory.clone().unwrap();
+        assert!(std::path::Path::new(&scratch_dir).is_dir());
+
+        permanently_delete_workspace(&response.workspace_id).unwrap();
+
+        assert!(
+            !std::path::Path::new(&scratch_dir).exists(),
+            "permanently_delete must wipe the chat scratch dir: {scratch_dir}"
+        );
+        let remaining: i64 = env
+            .db_connection()
+            .query_row(
+                "SELECT COUNT(*) FROM workspaces WHERE id = ?1",
+                [&response.workspace_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(remaining, 0, "DB row must be gone too");
+    }
+
+    #[test]
+    fn archive_chat_workspace_is_pure_db_flip() {
+        let env = TestEnv::new("archive-chat-db-flip");
+        insert_chat_repo(&env);
+        let response = super::super::lifecycle::prepare_chat_workspace_impl(
+            crate::workspace_status::WorkspaceStatus::InProgress,
+        )
+        .unwrap();
+        let scratch_dir = response.working_directory.clone().unwrap();
+
+        let archive_response =
+            super::super::lifecycle::archive_workspace_impl(&response.workspace_id).unwrap();
+        assert_eq!(
+            archive_response.archived_state,
+            WorkspaceState::Archived,
+            "archive should flip state to archived"
+        );
+        assert!(
+            std::path::Path::new(&scratch_dir).is_dir(),
+            "archive must NOT touch the chat scratch dir (only permanently_delete does)"
+        );
+        assert_eq!(
+            workspace_state(&env, &response.workspace_id).as_deref(),
+            Some("archived"),
+            "DB row must be in `archived` state"
+        );
+    }
+
+    #[test]
+    fn set_workspace_status_rejects_chat_workspace() {
+        let env = TestEnv::new("set-status-rejects-chat");
+        insert_chat_repo(&env);
+        let response = super::super::lifecycle::prepare_chat_workspace_impl(
+            crate::workspace_status::WorkspaceStatus::InProgress,
+        )
+        .unwrap();
+
+        let err = set_workspace_status(
+            &response.workspace_id,
+            crate::workspace_status::WorkspaceStatus::Done,
+        )
+        .expect_err("chat rows don't participate in status buckets");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.to_lowercase().contains("chat"),
+            "error should mention chat: {msg}"
+        );
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1707,6 +1707,9 @@ function AppShell({
 																	rightSidebarToggleShortcut
 																}
 																inspectorCollapsed={inspectorCollapsed}
+																isChatMode={
+																	selectedWorkspaceDetail?.mode === "chat"
+																}
 																onOpenPreferredEditor={
 																	handleOpenPreferredEditor
 																}
@@ -1726,85 +1729,92 @@ function AppShell({
 									</div>
 								</section>
 
-								{rightSidebarAvailable && (
-									<>
-										<ShellResizeSeparator
-											side="inspector"
-											collapsed={inspectorCollapsed}
-											resizing={isInspectorResizing}
-											width={inspectorWidth}
-											onMouseDown={handleResizeStart("inspector")}
-											onKeyDown={handleResizeKeyDown("inspector")}
-										/>
-										<ShellInspectorPane
-											collapsed={inspectorCollapsed}
-											resizing={isInspectorResizing}
-											width={inspectorWidth}
-											rightSidebarMode={rightSidebarMode}
-											viewMode={workspaceViewMode}
-											startRepository={startRepository}
-											selectedWorkspaceRepository={selectedWorkspaceRepository}
-											startInboxProviderTab={startInboxProviderTab}
-											onStartInboxProviderTabChange={setStartInboxProviderTab}
-											startInboxProviderSourceTab={startInboxProviderSourceTab}
-											onStartInboxProviderSourceTabChange={
-												setStartInboxProviderSourceTab
-											}
-											startInboxStateFilterBySource={
-												startInboxStateFilterBySource
-											}
-											onStartInboxStateFilterBySourceChange={
-												setStartInboxStateFilterBySource
-											}
-											startComposerInsertTarget={startComposerInsertTarget}
-											startPreviewCardId={startPreviewCard?.id ?? null}
-											workspacePreviewCardId={workspacePreviewCard?.id ?? null}
-											onOpenStartContextCard={handleStartContextCardOpen}
-											onOpenWorkspaceContextCard={
-												handleWorkspaceContextCardOpen
-											}
-											selectedWorkspaceId={selectedWorkspaceId}
-											workspaceRootPath={workspaceRootPath}
-											selectedWorkspaceDetail={
-												selectedWorkspaceDetailQuery.data ?? null
-											}
-											displayedSessionId={displayedSessionId}
-											activeEditor={
-												editorSession
-													? {
-															path: editorSession.path,
-															originalRef: editorSession.originalRef,
-															modifiedRef: editorSession.modifiedRef,
-														}
-													: null
-											}
-											preferredEditor={preferredEditor}
-											onOpenEditorFile={handleOpenEditorFile}
-											onCommitAction={handleCommitAction}
-											onReviewAction={() =>
-												handleInspectorReviewAction({
-													modelId:
-														appSettings.reviewModelId ??
-														appSettings.defaultModelId,
-													effort:
-														appSettings.reviewEffort ??
-														appSettings.defaultEffort,
-													fastMode:
-														appSettings.reviewFastMode ??
-														appSettings.defaultFastMode,
-												})
-											}
-											onQueuePendingPromptForSession={
-												queuePendingPromptForSession
-											}
-											commitButtonMode={commitButtonMode}
-											commitButtonState={commitButtonState}
-											workspaceChangeRequest={workspaceChangeRequest}
-											workspaceForgeIsRefreshing={workspaceForgeIsRefreshing}
-											onOpenSettings={handleOpenSettings}
-										/>
-									</>
-								)}
+								{rightSidebarAvailable &&
+									selectedWorkspaceDetail?.mode !== "chat" && (
+										<>
+											<ShellResizeSeparator
+												side="inspector"
+												collapsed={inspectorCollapsed}
+												resizing={isInspectorResizing}
+												width={inspectorWidth}
+												onMouseDown={handleResizeStart("inspector")}
+												onKeyDown={handleResizeKeyDown("inspector")}
+											/>
+											<ShellInspectorPane
+												collapsed={inspectorCollapsed}
+												resizing={isInspectorResizing}
+												width={inspectorWidth}
+												rightSidebarMode={rightSidebarMode}
+												viewMode={workspaceViewMode}
+												startRepository={startRepository}
+												selectedWorkspaceRepository={
+													selectedWorkspaceRepository
+												}
+												startInboxProviderTab={startInboxProviderTab}
+												onStartInboxProviderTabChange={setStartInboxProviderTab}
+												startInboxProviderSourceTab={
+													startInboxProviderSourceTab
+												}
+												onStartInboxProviderSourceTabChange={
+													setStartInboxProviderSourceTab
+												}
+												startInboxStateFilterBySource={
+													startInboxStateFilterBySource
+												}
+												onStartInboxStateFilterBySourceChange={
+													setStartInboxStateFilterBySource
+												}
+												startComposerInsertTarget={startComposerInsertTarget}
+												startPreviewCardId={startPreviewCard?.id ?? null}
+												workspacePreviewCardId={
+													workspacePreviewCard?.id ?? null
+												}
+												onOpenStartContextCard={handleStartContextCardOpen}
+												onOpenWorkspaceContextCard={
+													handleWorkspaceContextCardOpen
+												}
+												selectedWorkspaceId={selectedWorkspaceId}
+												workspaceRootPath={workspaceRootPath}
+												selectedWorkspaceDetail={
+													selectedWorkspaceDetailQuery.data ?? null
+												}
+												displayedSessionId={displayedSessionId}
+												activeEditor={
+													editorSession
+														? {
+																path: editorSession.path,
+																originalRef: editorSession.originalRef,
+																modifiedRef: editorSession.modifiedRef,
+															}
+														: null
+												}
+												preferredEditor={preferredEditor}
+												onOpenEditorFile={handleOpenEditorFile}
+												onCommitAction={handleCommitAction}
+												onReviewAction={() =>
+													handleInspectorReviewAction({
+														modelId:
+															appSettings.reviewModelId ??
+															appSettings.defaultModelId,
+														effort:
+															appSettings.reviewEffort ??
+															appSettings.defaultEffort,
+														fastMode:
+															appSettings.reviewFastMode ??
+															appSettings.defaultFastMode,
+													})
+												}
+												onQueuePendingPromptForSession={
+													queuePendingPromptForSession
+												}
+												commitButtonMode={commitButtonMode}
+												commitButtonState={commitButtonState}
+												workspaceChangeRequest={workspaceChangeRequest}
+												workspaceForgeIsRefreshing={workspaceForgeIsRefreshing}
+												onOpenSettings={handleOpenSettings}
+											/>
+										</>
+									)}
 							</div>
 						</main>
 						<Toaster

--- a/src/features/editor/index.test.tsx
+++ b/src/features/editor/index.test.tsx
@@ -16,6 +16,7 @@ const apiMocks = vi.hoisted(() => ({
 	listWorkspaceChangesWithContent: vi.fn(),
 	listWorkspaceFiles: vi.fn(),
 	readEditorFile: vi.fn(),
+	readFileAtRef: vi.fn(),
 }));
 
 const runtimeMocks = vi.hoisted(() => {
@@ -24,6 +25,7 @@ const runtimeMocks = vi.hoisted(() => {
 
 	const fileController = {
 		dispose: vi.fn(),
+		focus: vi.fn(),
 		getValue: vi.fn(() => fileValue),
 		onDidChangeModelContent: vi.fn((callback: (value: string) => void) => {
 			changeHandler = callback;
@@ -45,6 +47,7 @@ const runtimeMocks = vi.hoisted(() => {
 
 	const diffController = {
 		dispose: vi.fn(),
+		focus: vi.fn(),
 		setTexts: vi.fn(),
 	};
 
@@ -68,8 +71,10 @@ const runtimeMocks = vi.hoisted(() => {
 			this.createDiffEditor.mockClear();
 			this.createFileEditor.mockClear();
 			this.diffController.dispose.mockClear();
+			this.diffController.focus.mockClear();
 			this.diffController.setTexts.mockClear();
 			this.fileController.dispose.mockClear();
+			this.fileController.focus.mockClear();
 			this.fileController.getValue.mockClear();
 			this.fileController.onDidChangeModelContent.mockClear();
 			this.fileController.revealPosition.mockClear();
@@ -89,6 +94,7 @@ vi.mock("@/lib/api", async (importOriginal) => {
 		listWorkspaceChangesWithContent: apiMocks.listWorkspaceChangesWithContent,
 		listWorkspaceFiles: apiMocks.listWorkspaceFiles,
 		readEditorFile: apiMocks.readEditorFile,
+		readFileAtRef: apiMocks.readFileAtRef,
 	};
 });
 
@@ -155,6 +161,7 @@ describe("WorkspaceEditorSurface", () => {
 		});
 		apiMocks.listWorkspaceFiles.mockReset();
 		apiMocks.readEditorFile.mockReset();
+		apiMocks.readFileAtRef.mockReset();
 	});
 
 	afterEach(() => {
@@ -580,6 +587,193 @@ describe("WorkspaceEditorSurface", () => {
 		await waitFor(() => {
 			expect(screen.queryByLabelText("Markdown preview")).toBeNull();
 		});
+	});
+
+	it("settles keyboard focus inside the editor surface after first render", async () => {
+		// Real invariant being protected: after the editor mounts, focus must
+		// be somewhere inside [data-focus-scope=editor] so Cmd+E/T/W resolve
+		// to the editor scope without a manual click. Whether the focus ends
+		// up on Monaco's textarea, the surface container, or an internal tab
+		// is an implementation detail — the only thing that matters is that
+		// it's NOT stranded outside the surface (e.g. on a changes-list row).
+		const onChangeSpy = vi.fn();
+
+		apiMocks.readEditorFile.mockResolvedValue({
+			path: "/tmp/helmor-workspace/src/App.tsx",
+			content: "const value = 1;\n",
+			mtimeMs: 10,
+		});
+
+		render(
+			<TooltipProvider delayDuration={0}>
+				<EditorSurfaceHarness
+					initialSession={{
+						kind: "file",
+						path: "/tmp/helmor-workspace/src/App.tsx",
+					}}
+					onChangeSpy={onChangeSpy}
+				/>
+			</TooltipProvider>,
+		);
+
+		await waitFor(() => {
+			expect(runtimeMocks.createFileEditor).toHaveBeenCalled();
+		});
+
+		const surface = screen.getByLabelText("Workspace editor surface");
+		expect(surface.contains(document.activeElement)).toBe(true);
+	});
+
+	it("reclaims focus after switching to another file via search", async () => {
+		const onChangeSpy = vi.fn();
+		const user = userEvent.setup();
+
+		apiMocks.listWorkspaceFiles.mockResolvedValue([
+			{
+				path: "src/utils.ts",
+				absolutePath: "/tmp/helmor-workspace/src/utils.ts",
+				name: "utils.ts",
+				status: "M",
+				stagedInsertions: 0,
+				stagedDeletions: 0,
+				unstagedInsertions: 0,
+				unstagedDeletions: 0,
+				committedInsertions: 0,
+				committedDeletions: 0,
+			},
+		]);
+		apiMocks.readEditorFile.mockResolvedValue({
+			path: "/tmp/helmor-workspace/src/utils.ts",
+			content: "export const value = 1;\n",
+			mtimeMs: 20,
+		});
+
+		render(
+			<TooltipProvider delayDuration={0}>
+				<EditorSurfaceHarness
+					initialSession={{
+						kind: "file",
+						path: "/tmp/helmor-workspace/src/App.tsx",
+						originalText: "const app = 1;\n",
+						modifiedText: "const app = 1;\n",
+					}}
+					onChangeSpy={onChangeSpy}
+				/>
+			</TooltipProvider>,
+		);
+
+		await waitFor(() => {
+			expect(runtimeMocks.createFileEditor).toHaveBeenCalled();
+		});
+
+		// First-mount focus already happened; we care about post-switch.
+		runtimeMocks.fileController.focus.mockClear();
+
+		await user.click(screen.getByRole("button", { name: "Open file" }));
+		await user.type(
+			screen.getByPlaceholderText("Search files"),
+			"utils{enter}",
+		);
+
+		await waitFor(() => {
+			expect(runtimeMocks.fileController.switchFile).toHaveBeenCalledWith(
+				"/tmp/helmor-workspace/src/utils.ts",
+				expect.anything(),
+				undefined,
+				undefined,
+			);
+			expect(runtimeMocks.fileController.focus).toHaveBeenCalled();
+		});
+	});
+
+	it("rebuilds the diff editor on file switch so the first frame is fully rendered", async () => {
+		// Why slow path (dispose + createDiffEditor) instead of model-reuse:
+		// Monaco computes diffs in a worker. setValue() on an existing diff
+		// model defers hunk decorations to a later frame — users see
+		// "incomplete first frame, complete second frame". createDiffEditor
+		// computes the diff synchronously during construction, so the first
+		// post-switch paint is the fully-decorated final result. The Monaco
+		// runtime is cached after first use, so the dispose+create round
+		// trip resolves inside the same microtask burst (no blank paint).
+		const onChangeSpy = vi.fn();
+		const user = userEvent.setup();
+
+		apiMocks.listWorkspaceFiles.mockResolvedValue([
+			{
+				path: "src/utils.ts",
+				absolutePath: "/tmp/helmor-workspace/src/utils.ts",
+				name: "utils.ts",
+				status: "M",
+				stagedInsertions: 0,
+				stagedDeletions: 0,
+				unstagedInsertions: 3,
+				unstagedDeletions: 1,
+				committedInsertions: 0,
+				committedDeletions: 0,
+			},
+		]);
+		apiMocks.listWorkspaceChangesWithContent.mockResolvedValue({
+			items: [
+				{
+					path: "src/utils.ts",
+					absolutePath: "/tmp/helmor-workspace/src/utils.ts",
+					name: "utils.ts",
+					status: "M",
+					stagedInsertions: 0,
+					stagedDeletions: 0,
+					unstagedInsertions: 3,
+					unstagedDeletions: 1,
+					committedInsertions: 0,
+					committedDeletions: 0,
+				},
+			],
+			prefetched: [],
+		});
+		apiMocks.readFileAtRef.mockResolvedValue("export const value = 0;\n");
+		apiMocks.readEditorFile.mockResolvedValue({
+			path: "/tmp/helmor-workspace/src/utils.ts",
+			content: "export const value = 1;\n",
+			mtimeMs: 20,
+		});
+
+		render(
+			<TooltipProvider delayDuration={0}>
+				<EditorSurfaceHarness
+					initialSession={{
+						kind: "diff",
+						path: "/tmp/helmor-workspace/src/App.tsx",
+						fileStatus: "M",
+						originalText: "const app = 1;\n",
+						modifiedText: "const app = 2;\n",
+					}}
+					onChangeSpy={onChangeSpy}
+				/>
+			</TooltipProvider>,
+		);
+
+		await waitFor(() => {
+			expect(runtimeMocks.createDiffEditor).toHaveBeenCalledTimes(1);
+		});
+
+		await user.click(screen.getByRole("button", { name: "Open file" }));
+		await user.type(
+			screen.getByPlaceholderText("Search files"),
+			"utils{enter}",
+		);
+
+		// New file → second createDiffEditor call with the new file's content.
+		await waitFor(() => {
+			expect(runtimeMocks.createDiffEditor).toHaveBeenCalledTimes(2);
+		});
+		expect(runtimeMocks.createDiffEditor).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				path: "/tmp/helmor-workspace/src/utils.ts",
+				originalText: "export const value = 0;\n",
+				modifiedText: "export const value = 1;\n",
+			}),
+		);
+		// The old diff controller was disposed as part of the rebuild.
+		expect(runtimeMocks.diffController.dispose).toHaveBeenCalled();
 	});
 
 	it("surfaces read failures without breaking the shell", async () => {

--- a/src/features/editor/index.tsx
+++ b/src/features/editor/index.tsx
@@ -628,12 +628,23 @@ export function WorkspaceEditorSurface({
 		};
 	}, [canRenderDiff, canRenderFile, editorSession, workspaceRootPath]);
 
+	// Reclaim focus on mount AND on every file/kind switch — without it, a click
+	// in the changes list (a tabIndex={0} row outside any focus-scope) leaves
+	// keyboard focus on that row and editor-scoped shortcuts (Cmd+E/T/W) stop
+	// firing. The `surface.contains(activeElement)` guard means we only step in
+	// when focus is currently outside the editor — typing inside Monaco isn't
+	// disturbed by tab switches.
 	useEffect(() => {
 		const surface = surfaceRef.current;
 		if (!surface) return;
 		if (surface.contains(document.activeElement)) return;
+		const controller = fileControllerRef.current ?? diffControllerRef.current;
+		if (controller) {
+			controller.focus();
+			return;
+		}
 		surface.focus({ preventScroll: true });
-	}, []);
+	}, [editorSession.path, editorSession.kind]);
 
 	// Dispose editors on unmount (separate from the switching effect so the
 	// fast-path can skip cleanup without leaking on unmount).
@@ -743,6 +754,18 @@ export function WorkspaceEditorSurface({
 			return;
 		}
 
+		// Note: there is intentionally no diff fast path. setValue() on an
+		// existing diff model defers diff computation to Monaco's worker, so
+		// the first paint after a path switch shows the new text without
+		// hunk decorations / line gutters — visually "incomplete first
+		// frame, complete second frame". createDiffEditor() computes the
+		// diff synchronously during construction, so the slow path (dispose
+		// + recreate) is what gives the "one-shot, fully-rendered first
+		// frame" behavior users expect. Since the Monaco runtime is cached
+		// after first use, the dispose+create round-trip resolves inside
+		// the same microtask burst (no blank paint), so we pay no visual
+		// cost for keeping diff on the slow path.
+
 		// ── Guard: need content for initial editor creation ──
 		if (!canRenderFile && !canRenderDiff) {
 			return;
@@ -800,6 +823,13 @@ export function WorkspaceEditorSurface({
 							});
 						},
 					);
+					// Slow path drops focus during the dispose→create cycle. If
+					// the user hasn't moved focus elsewhere while we were async,
+					// reclaim it so editor-scoped shortcuts work without a click.
+					const surface = surfaceRef.current;
+					if (surface && !surface.contains(document.activeElement)) {
+						controller.focus();
+					}
 					setSurfaceStatus({ kind: "ready" });
 				} catch (error) {
 					const message = describeUnknownError(
@@ -828,6 +858,10 @@ export function WorkspaceEditorSurface({
 					}
 
 					diffControllerRef.current = controller;
+					const surface = surfaceRef.current;
+					if (surface && !surface.contains(document.activeElement)) {
+						controller.focus();
+					}
 					setSurfaceStatus({ kind: "ready" });
 				} catch (error) {
 					const message = describeUnknownError(

--- a/src/features/navigation/avatar.tsx
+++ b/src/features/navigation/avatar.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useState } from "react";
+import { memo, type ReactNode, useEffect, useState } from "react";
 import { Avatar, AvatarBadge, AvatarImage } from "@/components/ui/avatar";
 import { ShineBorder } from "@/components/ui/shine-border";
 import { cn } from "@/lib/utils";
@@ -38,6 +38,7 @@ export const WorkspaceAvatar = memo(function WorkspaceAvatar({
 	title,
 	className,
 	fallbackClassName,
+	fallbackIcon,
 	badgeClassName,
 	badgeAriaLabel,
 	isRunning,
@@ -48,6 +49,10 @@ export const WorkspaceAvatar = memo(function WorkspaceAvatar({
 	title: string;
 	className?: string;
 	fallbackClassName?: string;
+	/** Optional node rendered in place of the initials fallback. Used by
+	 *  workspace flavors that have no real repo (e.g. chat-mode) where
+	 *  a lucide icon reads better than a synthetic 2-letter monogram. */
+	fallbackIcon?: ReactNode;
 	badgeClassName?: string | null;
 	badgeAriaLabel?: string;
 	isRunning?: boolean;
@@ -98,7 +103,7 @@ export const WorkspaceAvatar = memo(function WorkspaceAvatar({
 						"rounded-full",
 					)}
 				>
-					<span className="translate-y-px">{fallback}</span>
+					{fallbackIcon ?? <span className="translate-y-px">{fallback}</span>}
 				</span>
 			) : null}
 			{isRunning ? (

--- a/src/features/navigation/index.tsx
+++ b/src/features/navigation/index.tsx
@@ -6,6 +6,7 @@ import {
 	FolderPlus,
 	Globe,
 	LoaderCircle,
+	MessageCircle,
 	Plus,
 } from "lucide-react";
 import {
@@ -217,15 +218,23 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 						// Repo mode: same-bucket reorder + drag-to-pin /
 						// drag-to-backlog + the inverse (un-pin / un-backlog) back
 						// to the row's own repo bucket. No cross-repo moves.
+						// Chat rows are quarantined to the Chats bucket — they
+						// can only be reordered inside it.
 						canDragRow: (_row, sourceGroupId) =>
 							sourceGroupId === "pinned" ||
 							sourceGroupId === "backlog" ||
+							sourceGroupId === "chats" ||
 							repoIdFromGroupId(sourceGroupId) !== null,
 						canDropIntoGroup: (
 							sourceGroupId,
 							targetGroupId,
 							{ sourceRepoId },
 						) => {
+							// Chats is its own world: only chat-bucket rows
+							// drop in, and they can't leak elsewhere.
+							if (sourceGroupId === "chats" || targetGroupId === "chats") {
+								return sourceGroupId === "chats" && targetGroupId === "chats";
+							}
 							if (targetGroupId === "pinned") return true;
 							if (targetGroupId === "backlog") return true;
 							const targetRepoId = repoIdFromGroupId(targetGroupId);
@@ -242,12 +251,22 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 					}
 				: {
 						// Status mode: any lane + pinned (drag to pin / unpin).
+						// Chats sits alongside but isolated: chat rows can
+						// only reorder within "chats", and no other source
+						// can drop into it.
 						canDragRow: (_row, sourceGroupId) =>
 							sourceGroupId === "pinned" ||
+							sourceGroupId === "chats" ||
 							workspaceStatusFromGroupId(sourceGroupId) !== null,
-						canDropIntoGroup: (_sourceGroupId, targetGroupId) =>
-							targetGroupId === "pinned" ||
-							workspaceStatusFromGroupId(targetGroupId) !== null,
+						canDropIntoGroup: (sourceGroupId, targetGroupId) => {
+							if (sourceGroupId === "chats" || targetGroupId === "chats") {
+								return sourceGroupId === "chats" && targetGroupId === "chats";
+							}
+							return (
+								targetGroupId === "pinned" ||
+								workspaceStatusFromGroupId(targetGroupId) !== null
+							);
+						},
 					},
 		[sidebarGrouping],
 	);
@@ -433,6 +452,15 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 			// Skip the group being dragged entirely — its visual lives in
 			// the floating ghost.
 			if (group.id === draggingGroupId) {
+				continue;
+			}
+
+			// The Chats bucket has no kanban semantics — when no chat
+			// workspaces exist, drop the section entirely (header + gap)
+			// so the sidebar isn't littered with an always-empty bucket.
+			// Status / repo buckets keep their empty header because users
+			// rely on them as drop targets for the next drag.
+			if (group.id === "chats" && group.rows.length === 0) {
 				continue;
 			}
 
@@ -729,11 +757,20 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 					? item.group.rows[0]
 					: undefined;
 
+				// The dedicated "chats" bucket has no kanban semantics —
+				// surface it with a MessageCircle glyph that mirrors the
+				// chat-mode UI elsewhere (start-page picker, panel header).
+				const isChatGroup = item.group.id === "chats";
 				const headerLabel = (
 					<span className="flex items-center gap-2">
 						{isArchived ? (
 							<Archive
 								className="size-[14px] shrink-0 text-[var(--workspace-sidebar-status-backlog)]"
+								strokeWidth={1.9}
+							/>
+						) : isChatGroup ? (
+							<MessageCircle
+								className="size-[14px] shrink-0 text-muted-foreground"
 								strokeWidth={1.9}
 							/>
 						) : isRepoGroup ? (

--- a/src/features/navigation/row-item.tsx
+++ b/src/features/navigation/row-item.tsx
@@ -271,11 +271,11 @@ export const WorkspaceRowItem = memo(
 			? "bg-yellow-500"
 			: "bg-chart-2";
 		const showStatusDot = statusDotLabel !== null;
-		// Local workspaces don't carry a meaningful per-row branch label
-		// (multiple locals share the repo + a single HEAD), so always
-		// fall back to the auto-titled session title (`row.title`).
+		// Local & Chat workspaces don't carry a meaningful per-row branch
+		// label (locals share the repo's HEAD; chats have no branch at
+		// all), so always fall back to the auto-titled session title.
 		const displayTitle =
-			row.mode === "local"
+			row.mode === "local" || row.mode === "chat"
 				? row.title
 				: row.branch
 					? humanizeBranch(row.branch)
@@ -331,7 +331,14 @@ export const WorkspaceRowItem = memo(
 								)}
 								strokeWidth={1.9}
 							/>
-						) : (
+						) : row.mode ===
+							"chat" ? // Chat rows are bucketed under the dedicated
+						// "Chats" group header (which carries the
+						// MessageCircle glyph) — drawing the same icon on
+						// every row would just be noise. Keep the slot
+						// invisible so unread / status indicators still
+						// have a stable carrier.
+						null : (
 							<GitBranch
 								className={cn(
 									"size-[13px] shrink-0",
@@ -393,7 +400,12 @@ export const WorkspaceRowItem = memo(
 							<HyperText text={displayTitle} className="inline" />
 						</span>
 					);
-					if (hideRepoAvatar) {
+					// Chat workspaces have no real repo, so skip the avatar
+					// slot entirely — the branch icon (MessageCircle in
+					// chat mode) carries the leading visual identity. Falls
+					// through to the same layout used when an outer repo
+					// bucket already shows the avatar.
+					if (hideRepoAvatar || row.mode === "chat") {
 						return (
 							<div className="flex min-w-0 flex-1 items-center gap-2">
 								{branchSlot}

--- a/src/features/navigation/sidebar-projection.ts
+++ b/src/features/navigation/sidebar-projection.ts
@@ -233,10 +233,15 @@ function sortGroupsForView(
 	);
 	if (!hasRepoGroups) return sortedGroups;
 
-	const head = sortedGroups.filter((group) => group.id === "pinned");
+	// `chats` rides alongside `pinned` in the head — both buckets sit
+	// outside the sortable middle so sort changes don't shuffle them.
+	const head = sortedGroups.filter(
+		(group) => group.id === "pinned" || group.id === "chats",
+	);
 	const tail = sortedGroups.filter((group) => group.id === "backlog");
 	const middle = sortedGroups.filter(
-		(group) => group.id !== "pinned" && group.id !== "backlog",
+		(group) =>
+			group.id !== "pinned" && group.id !== "chats" && group.id !== "backlog",
 	);
 
 	middle.sort((left, right) =>
@@ -316,6 +321,9 @@ function compareStrings(left: string, right: string): number {
  *   orthogonal to repo (workspaces the user has elevated, and workspaces
  *   queued for later) and are worth preserving as their own buckets in
  *   either grouping mode.
+ * - "chats" also passes through (right after pinned). Chat workspaces
+ *   have no repo, so they can't be folded into a repo bucket — keeping
+ *   the bucket intact in either grouping mode is the only sane shape.
  * - Everything else (in-flight creates, in-progress, in review, done,
  *   canceled) flattens into per-repo buckets keyed by `repoId`. Each repo
  *   group's title is the repository name.
@@ -329,7 +337,7 @@ function compareStrings(left: string, right: string): number {
  *   sparse order shared with status grouping.
  */
 export function regroupByRepo(groups: WorkspaceGroup[]): WorkspaceGroup[] {
-	const head: WorkspaceGroup[] = []; // pinned
+	const head: WorkspaceGroup[] = []; // pinned, chats
 	const tail: WorkspaceGroup[] = []; // backlog
 	const firstSeen = new Map<string, number>();
 	const bucketOrder = new Map<string, number>();
@@ -340,7 +348,7 @@ export function regroupByRepo(groups: WorkspaceGroup[]): WorkspaceGroup[] {
 
 	let seen = 0;
 	for (const group of groups) {
-		if (group.id === "pinned") {
+		if (group.id === "pinned" || group.id === "chats") {
 			head.push(group);
 			continue;
 		}

--- a/src/features/navigation/workspace-hover-card.tsx
+++ b/src/features/navigation/workspace-hover-card.tsx
@@ -7,6 +7,7 @@ import {
 	GitBranch,
 	GitPullRequest,
 	type LucideIcon,
+	MessageCircle,
 } from "lucide-react";
 import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { HelmorThinkingIndicator } from "@/components/helmor-thinking-indicator";
@@ -582,6 +583,11 @@ export function WorkspaceHoverCard({
 								repoName={row.repoName}
 								title={title}
 								className="size-4 rounded-[4px]"
+								fallbackIcon={
+									row.mode === "chat" ? (
+										<MessageCircle className="size-[10px]" strokeWidth={1.9} />
+									) : undefined
+								}
 							/>
 							{subtitle ? (
 								<span className="truncate text-[11px] text-muted-foreground">
@@ -589,17 +595,22 @@ export function WorkspaceHoverCard({
 								</span>
 							) : null}
 						</div>
-						<div className="mt-0.5 flex shrink-0 items-center gap-2">
-							<GitStats workspaceId={row.id} />
-							<span
-								aria-label={statusDot.label}
-								title={statusDot.label}
-								className={cn(
-									"size-2 shrink-0 rounded-full",
-									statusDot.dotClass,
-								)}
-							/>
-						</div>
+						{/* Chat workspaces have no git context and no kanban
+						 *  status — the entire right-side cluster (branch +
+						 *  diff chips + status dot) is meaningless for them. */}
+						{row.mode !== "chat" ? (
+							<div className="mt-0.5 flex shrink-0 items-center gap-2">
+								<GitStats workspaceId={row.id} />
+								<span
+									aria-label={statusDot.label}
+									title={statusDot.label}
+									className={cn(
+										"size-2 shrink-0 rounded-full",
+										statusDot.dotClass,
+									)}
+								/>
+							</div>
+						) : null}
 					</div>
 
 					{/* Title row + Helmor logo + elapsed timer (when streaming). */}

--- a/src/features/panel/container.tsx
+++ b/src/features/panel/container.tsx
@@ -537,6 +537,12 @@ export const WorkspacePanelContainer = memo(function WorkspacePanelContainer({
 		sessions.find((session) => session.id === selectedSessionIdForPanel) ??
 		null;
 	const missingScriptTypes = useMemo<WorkspaceScriptType[]>(() => {
+		// Chat workspaces have no setup / run / archive concept — the
+		// empty state should show only the headline, not pitch scripts
+		// the user can never run from this surface.
+		if (workspace?.mode === "chat") {
+			return [];
+		}
 		if (!selectedSession) {
 			return [];
 		}
@@ -557,7 +563,7 @@ export const WorkspacePanelContainer = memo(function WorkspacePanelContainer({
 			missing.push("archive");
 		}
 		return missing;
-	}, [repoScriptsQuery.data, selectedSession]);
+	}, [repoScriptsQuery.data, selectedSession, workspace?.mode]);
 	const handleInitializeScript = useCallback(
 		(scriptType: WorkspaceScriptType) => {
 			if (!selectedSessionIdForPanel || !onQueuePendingPromptForSession) {

--- a/src/features/panel/header.tsx
+++ b/src/features/panel/header.tsx
@@ -10,6 +10,7 @@ import {
 	History,
 	Laptop,
 	Layers,
+	MessageCircle,
 	Pencil,
 	Plus,
 	RotateCcw,
@@ -222,177 +223,175 @@ export const WorkspacePanelHeader = memo(function WorkspacePanelHeader({
 					className="relative z-0 flex min-w-0 flex-1 items-center gap-2 overflow-hidden text-[12.5px]"
 				>
 					{headerLeading}
-					<span className="group/branch relative inline-flex items-center gap-1.5 overflow-hidden px-1 py-0.5 font-medium text-foreground">
-						{(() => {
-							// Avatar always wins when we have a URL AND the
-							// workspace's bound account is still valid (mirrors the
-							// right-side Connect CTA). Otherwise fall back to a
-							// mode-appropriate glyph: Laptop for local, GitBranch
-							// for worktree.
-							const FallbackIcon =
-								workspace?.mode === "local" ? Laptop : GitBranch;
-							const showAvatar =
-								accountProfile?.avatarUrl && !forgeNeedsConnect;
-							const hoverInfo = showAvatar
-								? accountInfoFromForgeAccount(accountProfile)
-								: null;
-							if (!showAvatar || !hoverInfo) {
-								return (
-									<FallbackIcon
-										className={cn(
-											"size-3.5 shrink-0",
-											getBranchToneClassName(branchTone),
-										)}
-										strokeWidth={1.9}
-									/>
-								);
-							}
-							return (
-								<HoverCard openDelay={120} closeDelay={80}>
-									<HoverCardTrigger asChild>
-										<span className="inline-flex">
-											<CachedAvatar
-												className="size-4 shrink-0 cursor-default"
-												src={accountProfile?.avatarUrl}
-												alt={accountLogin ?? ""}
-												fallback={initialsFor(accountDisplayName)}
-												fallbackClassName="bg-muted text-[8px] font-semibold uppercase text-muted-foreground"
-											/>
-										</span>
-									</HoverCardTrigger>
-									<HoverCardContent
-										side="bottom"
-										align="start"
-										sideOffset={8}
-										className="w-auto max-w-[260px] p-3"
-									>
-										<AccountHoverCardContent account={hoverInfo} />
-									</HoverCardContent>
-								</HoverCard>
-							);
-						})()}
-						{branchRename.editingBranch !== null ? (
-							<Input
-								autoFocus
-								value={branchRename.editingBranch}
-								onChange={(event) =>
-									branchRename.setEditingBranch(event.target.value)
-								}
-								onKeyDown={(event) => {
-									if (event.key === "Enter") {
-										event.preventDefault();
-										void branchRename.commitBranchRename();
-									} else if (event.key === "Escape") {
-										branchRename.cancelBranchRename();
-									}
-								}}
-								onBlur={() => void branchRename.commitBranchRename()}
-								onClick={(event) => event.stopPropagation()}
-								className="h-5 w-32 truncate rounded-md border-border bg-background px-1.5 py-0 text-[12.5px] font-medium text-foreground"
+					{workspace?.mode === "chat" ? (
+						<span className="inline-flex items-center gap-1.5 overflow-hidden px-1 py-0.5 font-medium text-foreground">
+							<MessageCircle
+								className="size-3.5 shrink-0 text-muted-foreground"
+								strokeWidth={1.9}
 							/>
-						) : (
-							<>
-								<HyperText
-									key={workspace?.id}
-									text={workspace?.branch ?? "No branch"}
-									className="truncate"
-								/>
-								{workspace?.branch && workspace.state !== "archived" ? (
-									<span className="pointer-events-none invisible absolute inset-y-0 right-0 flex items-center gap-0.5 bg-[linear-gradient(to_right,transparent_0%,var(--background)_35%,var(--background)_100%)] pl-5 pr-1 group-hover/branch:pointer-events-auto group-hover/branch:visible">
-										<span
-											role="button"
-											aria-label="Rename branch"
-											onClick={branchRename.startBranchRename}
-											className="flex cursor-interactive items-center justify-center rounded-sm p-0.5 text-muted-foreground hover:bg-accent/60 hover:text-foreground"
-										>
-											<Pencil className="size-3" strokeWidth={2} />
-										</span>
-										<span
-											role="button"
-											aria-label="Copy branch name"
-											onClick={branchRename.copyBranchName}
-											className="flex cursor-interactive items-center justify-center rounded-sm p-0.5 text-muted-foreground hover:bg-accent/60 hover:text-foreground"
-										>
-											{branchRename.branchCopied ? (
-												<Check
-													className="size-3 text-green-400"
-													strokeWidth={2}
-												/>
-											) : (
-												<Copy className="size-3" strokeWidth={2} />
-											)}
-										</span>
-									</span>
-								) : null}
-							</>
-						)}
-					</span>
-					{workspace?.intendedTargetBranch ? (
+							{/* `workspace.title` is computed server-side by
+							 *  `helpers::display_title`, the same source the
+							 *  sidebar row + hover card use. Keeps the three
+							 *  surfaces visually in sync without rebuilding
+							 *  the precedence rules in TS. */}
+							<span className="min-w-0 truncate">{workspace.title}</span>
+						</span>
+					) : (
 						<>
-							<ArrowRight
-								className="relative top-px size-3 shrink-0 self-center text-muted-foreground"
-								strokeWidth={1.8}
-							/>
-							{workspace.state === "archived" ? (
-								<span className="min-w-0 truncate px-1 py-0.5 font-medium text-muted-foreground">
-									{workspace.remote ?? "origin"}/
-									{workspace.intendedTargetBranch}
-								</span>
-							) : (
-								<BranchPicker
-									currentBranch={workspace.intendedTargetBranch ?? ""}
-									displayRemote={workspace.remote ?? "origin"}
-									branches={remoteBranches}
-									loading={loadingBranches}
-									onOpen={() => {
-										void branchesQuery.refetch();
-										void prefetchRemoteRefs({ workspaceId: workspace.id })
-											.then((result) => {
-												if (result.fetched) {
-													void branchesQuery.refetch();
-												}
-											})
-											.catch(() => {});
-									}}
-									onSelect={(branch: string) => {
-										if (branch === workspace.intendedTargetBranch) {
-											return;
-										}
-										const detailKey = helmorQueryKeys.workspaceDetail(
-											workspace.id,
+							<span className="group/branch relative inline-flex items-center gap-1.5 overflow-hidden px-1 py-0.5 font-medium text-foreground">
+								{(() => {
+									// Avatar always wins when we have a URL AND the
+									// workspace's bound account is still valid (mirrors the
+									// right-side Connect CTA). Otherwise fall back to a
+									// mode-appropriate glyph: Laptop for local, GitBranch
+									// for worktree.
+									const FallbackIcon =
+										workspace?.mode === "local" ? Laptop : GitBranch;
+									const showAvatar =
+										accountProfile?.avatarUrl && !forgeNeedsConnect;
+									const hoverInfo = showAvatar
+										? accountInfoFromForgeAccount(accountProfile)
+										: null;
+									if (!showAvatar || !hoverInfo) {
+										return (
+											<FallbackIcon
+												className={cn(
+													"size-3.5 shrink-0",
+													getBranchToneClassName(branchTone),
+												)}
+												strokeWidth={1.9}
+											/>
 										);
-										const previousDetail =
-											queryClient.getQueryData<WorkspaceDetail | null>(
-												detailKey,
-											);
-										if (previousDetail) {
-											queryClient.setQueryData<WorkspaceDetail | null>(
-												detailKey,
-												{
-													...previousDetail,
-													intendedTargetBranch: branch,
-												},
-											);
+									}
+									return (
+										<HoverCard openDelay={120} closeDelay={80}>
+											<HoverCardTrigger asChild>
+												<span className="inline-flex">
+													<CachedAvatar
+														className="size-4 shrink-0 cursor-default"
+														src={accountProfile?.avatarUrl}
+														alt={accountLogin ?? ""}
+														fallback={initialsFor(accountDisplayName)}
+														fallbackClassName="bg-muted text-[8px] font-semibold uppercase text-muted-foreground"
+													/>
+												</span>
+											</HoverCardTrigger>
+											<HoverCardContent
+												side="bottom"
+												align="start"
+												sideOffset={8}
+												className="w-auto max-w-[260px] p-3"
+											>
+												<AccountHoverCardContent account={hoverInfo} />
+											</HoverCardContent>
+										</HoverCard>
+									);
+								})()}
+								{branchRename.editingBranch !== null ? (
+									<Input
+										autoFocus
+										value={branchRename.editingBranch}
+										onChange={(event) =>
+											branchRename.setEditingBranch(event.target.value)
 										}
+										onKeyDown={(event) => {
+											if (event.key === "Enter") {
+												event.preventDefault();
+												void branchRename.commitBranchRename();
+											} else if (event.key === "Escape") {
+												branchRename.cancelBranchRename();
+											}
+										}}
+										onBlur={() => void branchRename.commitBranchRename()}
+										onClick={(event) => event.stopPropagation()}
+										className="h-5 w-32 truncate rounded-md border-border bg-background px-1.5 py-0 text-[12.5px] font-medium text-foreground"
+									/>
+								) : (
+									<>
+										<HyperText
+											key={workspace?.id}
+											text={workspace?.branch ?? "No branch"}
+											className="truncate"
+										/>
+										{workspace?.branch && workspace.state !== "archived" ? (
+											<span className="pointer-events-none invisible absolute inset-y-0 right-0 flex items-center gap-0.5 bg-[linear-gradient(to_right,transparent_0%,var(--background)_35%,var(--background)_100%)] pl-5 pr-1 group-hover/branch:pointer-events-auto group-hover/branch:visible">
+												<span
+													role="button"
+													aria-label="Rename branch"
+													onClick={branchRename.startBranchRename}
+													className="flex cursor-interactive items-center justify-center rounded-sm p-0.5 text-muted-foreground hover:bg-accent/60 hover:text-foreground"
+												>
+													<Pencil className="size-3" strokeWidth={2} />
+												</span>
+												<span
+													role="button"
+													aria-label="Copy branch name"
+													onClick={branchRename.copyBranchName}
+													className="flex cursor-interactive items-center justify-center rounded-sm p-0.5 text-muted-foreground hover:bg-accent/60 hover:text-foreground"
+												>
+													{branchRename.branchCopied ? (
+														<Check
+															className="size-3 text-green-400"
+															strokeWidth={2}
+														/>
+													) : (
+														<Copy className="size-3" strokeWidth={2} />
+													)}
+												</span>
+											</span>
+										) : null}
+									</>
+								)}
+							</span>
+							{workspace?.intendedTargetBranch ? (
+								<>
+									<ArrowRight
+										className="relative top-px size-3 shrink-0 self-center text-muted-foreground"
+										strokeWidth={1.8}
+									/>
+									{workspace.state === "archived" ? (
+										<span className="min-w-0 truncate px-1 py-0.5 font-medium text-muted-foreground">
+											{workspace.remote ?? "origin"}/
+											{workspace.intendedTargetBranch}
+										</span>
+									) : (
+										<BranchPicker
+											currentBranch={workspace.intendedTargetBranch ?? ""}
+											displayRemote={workspace.remote ?? "origin"}
+											branches={remoteBranches}
+											loading={loadingBranches}
+											onOpen={() => {
+												void branchesQuery.refetch();
+												void prefetchRemoteRefs({ workspaceId: workspace.id })
+													.then((result) => {
+														if (result.fetched) {
+															void branchesQuery.refetch();
+														}
+													})
+													.catch(() => {});
+											}}
+											onSelect={(branch: string) => {
+												if (branch === workspace.intendedTargetBranch) {
+													return;
+												}
+												const detailKey = helmorQueryKeys.workspaceDetail(
+													workspace.id,
+												);
+												const previousDetail =
+													queryClient.getQueryData<WorkspaceDetail | null>(
+														detailKey,
+													);
+												if (previousDetail) {
+													queryClient.setQueryData<WorkspaceDetail | null>(
+														detailKey,
+														{
+															...previousDetail,
+															intendedTargetBranch: branch,
+														},
+													);
+												}
 
-										// Invalidate changes so diff section shows loading.
-										if (workspace.rootPath) {
-											void queryClient.invalidateQueries({
-												queryKey: helmorQueryKeys.workspaceChanges(
-													workspace.rootPath,
-												),
-											});
-										}
-
-										void updateIntendedTargetBranch(workspace.id, branch)
-											.then(({ reset }) => {
-												onWorkspaceChanged?.();
-												// Recompute sync status vs. new target now; don't wait for 10s poll.
-												void queryClient.invalidateQueries({
-													queryKey: helmorQueryKeys.workspaceGitActionStatus(
-														workspace.id,
-													),
-												});
+												// Invalidate changes so diff section shows loading.
 												if (workspace.rootPath) {
 													void queryClient.invalidateQueries({
 														queryKey: helmorQueryKeys.workspaceChanges(
@@ -400,40 +399,60 @@ export const WorkspacePanelHeader = memo(function WorkspacePanelHeader({
 														),
 													});
 												}
-												if (reset) {
-													pushToast(
-														`Local branch reset to ${workspace.remote ?? "origin"}/${branch}`,
-														`Switched to ${branch}`,
-														"default",
-													);
-												} else {
-													pushToast(
-														"Target branch updated",
-														`Switched to ${branch}`,
-														"default",
-													);
-												}
-											})
-											.catch((error: unknown) => {
-												if (previousDetail) {
-													queryClient.setQueryData<WorkspaceDetail | null>(
-														detailKey,
-														previousDetail,
-													);
-												}
-												pushToast(
-													error instanceof Error
-														? error.message
-														: String(error),
-													"Branch switch failed",
-													"destructive",
-												);
-											});
-									}}
-								/>
-							)}
+
+												void updateIntendedTargetBranch(workspace.id, branch)
+													.then(({ reset }) => {
+														onWorkspaceChanged?.();
+														// Recompute sync status vs. new target now; don't wait for 10s poll.
+														void queryClient.invalidateQueries({
+															queryKey:
+																helmorQueryKeys.workspaceGitActionStatus(
+																	workspace.id,
+																),
+														});
+														if (workspace.rootPath) {
+															void queryClient.invalidateQueries({
+																queryKey: helmorQueryKeys.workspaceChanges(
+																	workspace.rootPath,
+																),
+															});
+														}
+														if (reset) {
+															pushToast(
+																`Local branch reset to ${workspace.remote ?? "origin"}/${branch}`,
+																`Switched to ${branch}`,
+																"default",
+															);
+														} else {
+															pushToast(
+																"Target branch updated",
+																`Switched to ${branch}`,
+																"default",
+															);
+														}
+													})
+													.catch((error: unknown) => {
+														if (previousDetail) {
+															queryClient.setQueryData<WorkspaceDetail | null>(
+																detailKey,
+																previousDetail,
+															);
+														}
+														pushToast(
+															error instanceof Error
+																? error.message
+																: String(error),
+															"Branch switch failed",
+															"destructive",
+														);
+													});
+											}}
+										/>
+									)}
+								</>
+							) : null}
 						</>
-					) : null}
+					)}
 				</div>
 				{headerActions ? (
 					<div className="relative z-10 flex shrink-0 items-center gap-1 bg-background pl-1">

--- a/src/features/quick-switch/quick-switch-overlay.tsx
+++ b/src/features/quick-switch/quick-switch-overlay.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { GitBranch } from "lucide-react";
+import { GitBranch, MessageCircle } from "lucide-react";
 import { useEffect, useMemo } from "react";
 import { createPortal } from "react-dom";
 import { HelmorThinkingIndicator } from "@/components/helmor-thinking-indicator";
@@ -135,6 +135,11 @@ function QuickSwitchCard({
 					repoName={row.repoName}
 					className="size-4 rounded-[5px]"
 					fallbackClassName="text-[7px]"
+					fallbackIcon={
+						row.mode === "chat" ? (
+							<MessageCircle className="size-[10px]" strokeWidth={1.9} />
+						) : undefined
+					}
 				/>
 				<span
 					className="min-w-0 flex-1 truncate text-[13px] font-semibold leading-tight text-foreground"

--- a/src/features/workspace-start/create-workspace.ts
+++ b/src/features/workspace-start/create-workspace.ts
@@ -5,6 +5,7 @@ import type { ComposerCreatePrepareOutcome } from "@/features/conversation";
 import {
 	type FinalizeWorkspaceResponse,
 	finalizeWorkspaceFromRepo,
+	prepareChatWorkspace,
 	prepareWorkspaceFromRepo,
 	setWorkspaceLinkedDirectories,
 	updateSessionSettings,
@@ -35,7 +36,9 @@ export async function createWorkspaceFromStartComposer({
 	composerConfig,
 	linkedDirectories,
 }: {
+	/** Ignored in `chat` mode. */
 	repoId: string;
+	/** Ignored in `chat` mode. */
 	sourceBranch: string;
 	mode: WorkspaceMode;
 	/** Defaults to `from_branch` when omitted. */
@@ -60,13 +63,17 @@ export async function createWorkspaceFromStartComposer({
 	// right group and the sidebar never flashes through "In progress"
 	// while finalize runs. Other submit modes default to in-progress.
 	const initialStatus = submitMode === "saveForLater" ? "backlog" : null;
-	const prepared = await prepareWorkspaceFromRepo(
-		repoId,
-		sourceBranch,
-		mode,
-		branchIntent ?? null,
-		initialStatus,
-	);
+	// Chat mode has no repo/branch — single-phase create.
+	const prepared =
+		mode === "chat"
+			? await prepareChatWorkspace(initialStatus)
+			: await prepareWorkspaceFromRepo(
+					repoId,
+					sourceBranch,
+					mode,
+					branchIntent ?? null,
+					initialStatus,
+				);
 
 	// Persist pending /add-dir picks before kicking off finalize. The DB
 	// write is fast and the column is just a property of the existing
@@ -77,9 +84,16 @@ export async function createWorkspaceFromStartComposer({
 		]);
 	}
 
+	// Chat workspaces are single-phase — prepare returns a `ready` row, no
+	// finalize needed. Worktree/local workspaces still need finalize.
+	const finalize =
+		mode === "chat"
+			? null
+			: () => finalizeWorkspaceFromRepo(prepared.workspaceId);
+
 	if (submitMode === "saveForLater") {
 		await Promise.all([
-			finalizeWorkspaceFromRepo(prepared.workspaceId),
+			finalize?.() ?? Promise.resolve(),
 			editorStateSnapshot
 				? persistSessionDraft(prepared.initialSessionId, editorStateSnapshot)
 				: Promise.resolve(),
@@ -101,7 +115,7 @@ export async function createWorkspaceFromStartComposer({
 	}
 
 	if (submitMode === "createOnly") {
-		await finalizeWorkspaceFromRepo(prepared.workspaceId);
+		if (finalize) await finalize();
 		return {
 			outcome: { shouldStream: false },
 			workspaceId: prepared.workspaceId,
@@ -111,7 +125,7 @@ export async function createWorkspaceFromStartComposer({
 	}
 
 	return {
-		finalizePromise: finalizeWorkspaceFromRepo(prepared.workspaceId),
+		finalizePromise: finalize?.(),
 		workspaceId: prepared.workspaceId,
 		sessionId: prepared.initialSessionId,
 		preparedWorkingDirectory: prepared.workingDirectory,

--- a/src/features/workspace-start/index.tsx
+++ b/src/features/workspace-start/index.tsx
@@ -4,6 +4,7 @@ import {
 	GitBranchPlus,
 	GitMerge,
 	Laptop,
+	MessageCircle,
 	Plus,
 	Split,
 	X,
@@ -260,115 +261,130 @@ export function WorkspaceStartPage({
 								"left-1/2 -translate-x-1/2 text-[24px]",
 							)}
 						>
-							<span
-								className={cn(
-									"inline-block overflow-hidden transition-[max-width,opacity,transform] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)]",
-									previewCard
-										? "max-w-0 -translate-y-1 opacity-0"
-										: "max-w-[22rem] translate-y-0 opacity-100",
-								)}
-							>
-								What should we build
-							</span>
-							<span
-								className={cn(
-									"inline-block overflow-hidden transition-[max-width,opacity,transform] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)]",
-									previewCard
-										? "max-w-0 -translate-y-1 opacity-0"
-										: "max-w-[2rem] translate-y-0 opacity-100",
-								)}
-							>
-								in
-							</span>
-							<DropdownMenu>
-								<Tooltip>
-									<TooltipTrigger asChild>
-										<DropdownMenuTrigger asChild>
-											<Button
-												type="button"
-												variant="ghost"
-												disabled={repositories.length === 0}
-												className={cn(
-													"font-semibold leading-none tracking-normal transition-[height,max-width,padding,font-size,gap] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)]",
-													"h-9 max-w-[18rem] gap-1.5 px-2 text-[24px]",
-												)}
-											>
-												{selectedRepository ? (
-													<>
-														<WorkspaceAvatar
-															repoIconSrc={selectedRepository.repoIconSrc}
-															repoInitials={selectedRepository.repoInitials}
-															repoName={selectedRepository.name}
-															title={selectedRepository.name}
-															className={cn(
-																"rounded-md transition-[width,height] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)]",
-																"size-6",
-															)}
-															fallbackClassName="text-[9px]"
-														/>
-														<span className="min-w-0 truncate">
-															{selectedRepository.name}
-														</span>
-														<ChevronDown
-															className={cn(
-																"shrink-0 text-muted-foreground transition-[width,height] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)]",
-																"size-4",
-															)}
-															strokeWidth={2}
-														/>
-													</>
-												) : (
-													<span className="text-muted-foreground">
-														a repository
-													</span>
-												)}
-											</Button>
-										</DropdownMenuTrigger>
-									</TooltipTrigger>
-									<TooltipContent
-										side="top"
-										sideOffset={4}
-										className="flex h-[24px] items-center gap-2 rounded-md px-2 text-[12px] leading-none"
+							{mode === "chat" ? (
+								<span
+									className={cn(
+										"inline-block overflow-hidden transition-[max-width,opacity,transform] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)]",
+										previewCard
+											? "max-w-0 -translate-y-1 opacity-0"
+											: "max-w-[32rem] translate-y-0 opacity-100",
+									)}
+								>
+									What should we work on?
+								</span>
+							) : (
+								<>
+									<span
+										className={cn(
+											"inline-block overflow-hidden transition-[max-width,opacity,transform] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)]",
+											previewCard
+												? "max-w-0 -translate-y-1 opacity-0"
+												: "max-w-[22rem] translate-y-0 opacity-100",
+										)}
 									>
-										<span>Switch repository</span>
-										<InlineShortcutDisplay
-											hotkey={SWITCH_REPOSITORY_SHORTCUT}
-											className="text-background/60"
-										/>
-									</TooltipContent>
-								</Tooltip>
-								<DropdownMenuContent align="center" className="min-w-56">
-									{repositories.map((repository) => (
-										<DropdownMenuItem
-											key={repository.id}
-											onClick={() => onSelectRepository(repository)}
-											className="gap-2"
-										>
-											<WorkspaceAvatar
-												repoIconSrc={repository.repoIconSrc}
-												repoInitials={repository.repoInitials}
-												repoName={repository.name}
-												title={repository.name}
-												className="size-5 rounded-md"
-												fallbackClassName="text-[8px]"
-											/>
-											<span className="min-w-0 flex-1 truncate">
-												{repository.name}
-											</span>
-										</DropdownMenuItem>
-									))}
-								</DropdownMenuContent>
-							</DropdownMenu>
-							<span
-								className={cn(
-									"inline-block overflow-hidden transition-[max-width,opacity,transform] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)]",
-									previewCard
-										? "max-w-0 -translate-y-1 opacity-0"
-										: "max-w-[2rem] translate-y-0 opacity-100",
-								)}
-							>
-								?
-							</span>
+										What should we build
+									</span>
+									<span
+										className={cn(
+											"inline-block overflow-hidden transition-[max-width,opacity,transform] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)]",
+											previewCard
+												? "max-w-0 -translate-y-1 opacity-0"
+												: "max-w-[2rem] translate-y-0 opacity-100",
+										)}
+									>
+										in
+									</span>
+									<DropdownMenu>
+										<Tooltip>
+											<TooltipTrigger asChild>
+												<DropdownMenuTrigger asChild>
+													<Button
+														type="button"
+														variant="ghost"
+														disabled={repositories.length === 0}
+														className={cn(
+															"font-semibold leading-none tracking-normal transition-[height,max-width,padding,font-size,gap] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)]",
+															"h-9 max-w-[18rem] gap-1.5 px-2 text-[24px]",
+														)}
+													>
+														{selectedRepository ? (
+															<>
+																<WorkspaceAvatar
+																	repoIconSrc={selectedRepository.repoIconSrc}
+																	repoInitials={selectedRepository.repoInitials}
+																	repoName={selectedRepository.name}
+																	title={selectedRepository.name}
+																	className={cn(
+																		"rounded-md transition-[width,height] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)]",
+																		"size-6",
+																	)}
+																	fallbackClassName="text-[9px]"
+																/>
+																<span className="min-w-0 truncate">
+																	{selectedRepository.name}
+																</span>
+																<ChevronDown
+																	className={cn(
+																		"shrink-0 text-muted-foreground transition-[width,height] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)]",
+																		"size-4",
+																	)}
+																	strokeWidth={2}
+																/>
+															</>
+														) : (
+															<span className="text-muted-foreground">
+																a repository
+															</span>
+														)}
+													</Button>
+												</DropdownMenuTrigger>
+											</TooltipTrigger>
+											<TooltipContent
+												side="top"
+												sideOffset={4}
+												className="flex h-[24px] items-center gap-2 rounded-md px-2 text-[12px] leading-none"
+											>
+												<span>Switch repository</span>
+												<InlineShortcutDisplay
+													hotkey={SWITCH_REPOSITORY_SHORTCUT}
+													className="text-background/60"
+												/>
+											</TooltipContent>
+										</Tooltip>
+										<DropdownMenuContent align="center" className="min-w-56">
+											{repositories.map((repository) => (
+												<DropdownMenuItem
+													key={repository.id}
+													onClick={() => onSelectRepository(repository)}
+													className="gap-2"
+												>
+													<WorkspaceAvatar
+														repoIconSrc={repository.repoIconSrc}
+														repoInitials={repository.repoInitials}
+														repoName={repository.name}
+														title={repository.name}
+														className="size-5 rounded-md"
+														fallbackClassName="text-[8px]"
+													/>
+													<span className="min-w-0 flex-1 truncate">
+														{repository.name}
+													</span>
+												</DropdownMenuItem>
+											))}
+										</DropdownMenuContent>
+									</DropdownMenu>
+									<span
+										className={cn(
+											"inline-block overflow-hidden transition-[max-width,opacity,transform] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)]",
+											previewCard
+												? "max-w-0 -translate-y-1 opacity-0"
+												: "max-w-[2rem] translate-y-0 opacity-100",
+										)}
+									>
+										?
+									</span>
+								</>
+							)}
 						</div>
 					</div>
 					<div className="w-full px-4">{children}</div>
@@ -380,7 +396,8 @@ export function WorkspaceStartPage({
 								: "-mt-5 h-7 translate-y-0 opacity-100",
 						)}
 					>
-						{previewCard ? (
+						{/* Preview-mode repo selector: hidden in chat mode (no repo). */}
+						{previewCard && mode !== "chat" ? (
 							<DropdownMenu>
 								<DropdownMenuTrigger asChild>
 									<button
@@ -440,11 +457,18 @@ export function WorkspaceStartPage({
 									<DropdownMenuTrigger asChild>
 										<button
 											type="button"
-											disabled={!selectedRepository}
+											// Chat mode is always enabled (no repo needed);
+											// other modes require a selected repository.
+											disabled={mode !== "chat" && !selectedRepository}
 											className="inline-flex h-7 cursor-interactive items-center gap-1 rounded-md px-1.5 text-[12px] font-medium text-muted-foreground outline-none transition-colors hover:bg-muted/45 hover:text-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
 										>
 											{mode === "local" ? (
 												<Laptop
+													className="size-3.5 shrink-0"
+													strokeWidth={1.8}
+												/>
+											) : mode === "chat" ? (
+												<MessageCircle
 													className="size-3.5 shrink-0"
 													strokeWidth={1.8}
 												/>
@@ -455,7 +479,11 @@ export function WorkspaceStartPage({
 												/>
 											)}
 											<span>
-												{mode === "local" ? "Work locally" : "New worktree"}
+												{mode === "local"
+													? "Work locally"
+													: mode === "chat"
+														? "Just chat"
+														: "New worktree"}
 											</span>
 											<ChevronDown
 												className="size-3 shrink-0 text-muted-foreground"
@@ -488,6 +516,14 @@ export function WorkspaceStartPage({
 								>
 									<Split className="size-3.5 rotate-90" strokeWidth={1.8} />
 									<span>New worktree</span>
+								</DropdownMenuItem>
+								<DropdownMenuItem
+									onClick={() => onModeChange("chat")}
+									className="gap-2 pr-3"
+									data-checked={mode === "chat" ? "true" : undefined}
+								>
+									<MessageCircle className="size-3.5" strokeWidth={1.8} />
+									<span>Just chat</span>
 								</DropdownMenuItem>
 							</DropdownMenuContent>
 						</DropdownMenu>
@@ -569,78 +605,83 @@ export function WorkspaceStartPage({
 								</DropdownMenuContent>
 							</DropdownMenu>
 						) : null}
-						<Tooltip>
-							<BranchPickerPopover
-								currentBranch={selectedBranch}
-								entries={branches}
-								loading={branchesLoading}
-								onOpen={onOpenBranchPicker}
-								onSelect={onSelectBranch}
-								renderFooter={
-									mode === "local" && onCreateAndCheckoutBranch
-										? ({ close }) => (
-												<button
-													type="button"
-													className="flex w-full cursor-interactive items-center gap-2 rounded-md px-2 py-1.5 text-left text-[12px] text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
-													onClick={() => {
-														close();
-														setCreateBranchOpen(true);
-													}}
-												>
-													<Plus className="size-3.5" strokeWidth={2} />
-													<span>Create and checkout new branch…</span>
-												</button>
-											)
-										: undefined
-								}
-							>
-								<TooltipTrigger asChild>
-									<button
-										type="button"
-										disabled={!selectedRepository}
-										className="inline-flex h-7 max-w-[13rem] cursor-interactive items-center gap-1 rounded-md px-1.5 text-[12px] font-medium text-muted-foreground outline-none transition-colors hover:bg-muted/45 hover:text-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+						{/* Branch picker: hidden in chat mode (no branches). */}
+						{mode !== "chat" ? (
+							<>
+								<Tooltip>
+									<BranchPickerPopover
+										currentBranch={selectedBranch}
+										entries={branches}
+										loading={branchesLoading}
+										onOpen={onOpenBranchPicker}
+										onSelect={onSelectBranch}
+										renderFooter={
+											mode === "local" && onCreateAndCheckoutBranch
+												? ({ close }) => (
+														<button
+															type="button"
+															className="flex w-full cursor-interactive items-center gap-2 rounded-md px-2 py-1.5 text-left text-[12px] text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+															onClick={() => {
+																close();
+																setCreateBranchOpen(true);
+															}}
+														>
+															<Plus className="size-3.5" strokeWidth={2} />
+															<span>Create and checkout new branch…</span>
+														</button>
+													)
+												: undefined
+										}
 									>
-										<GitBranch
-											className="size-3.5 shrink-0"
-											strokeWidth={1.8}
-										/>
-										<span className="min-w-0 truncate">
-											{/* Pill prefix follows the resolved source of the selected
-											 *  branch: `origin/<x>` when it'll come from remote,
-											 *  bare `<x>` when from local. */}
-											{selectedBranchSource === "remote"
-												? `${selectedRepository?.remote ?? "origin"}/${selectedBranch}`
-												: selectedBranch}
-										</span>
-										<ChevronDown
-											className="size-3 shrink-0 text-muted-foreground"
-											strokeWidth={2}
-										/>
-									</button>
-								</TooltipTrigger>
-							</BranchPickerPopover>
-							<TooltipContent
-								side="top"
-								sideOffset={4}
-								className="rounded-md px-2 text-[12px] leading-none"
-							>
-								{mode === "local"
-									? "Switch branch"
-									: branchIntent === "use_branch"
-										? "Branch to reuse"
-										: "Base to fork off"}
-							</TooltipContent>
-						</Tooltip>
-						<CreateBranchDialog
-							open={createBranchOpen}
-							onOpenChange={setCreateBranchOpen}
-							defaultPrefix={defaultBranchPrefix(selectedRepository)}
-							existingBranches={branches.map((b) => b.name)}
-							onSubmit={async (branch) => {
-								if (!onCreateAndCheckoutBranch) return;
-								await onCreateAndCheckoutBranch(branch);
-							}}
-						/>
+										<TooltipTrigger asChild>
+											<button
+												type="button"
+												disabled={!selectedRepository}
+												className="inline-flex h-7 max-w-[13rem] cursor-interactive items-center gap-1 rounded-md px-1.5 text-[12px] font-medium text-muted-foreground outline-none transition-colors hover:bg-muted/45 hover:text-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+											>
+												<GitBranch
+													className="size-3.5 shrink-0"
+													strokeWidth={1.8}
+												/>
+												<span className="min-w-0 truncate">
+													{/* Pill prefix follows the resolved source of the
+													 *  selected branch: `origin/<x>` when it'll come
+													 *  from remote, bare `<x>` when from local. */}
+													{selectedBranchSource === "remote"
+														? `${selectedRepository?.remote ?? "origin"}/${selectedBranch}`
+														: selectedBranch}
+												</span>
+												<ChevronDown
+													className="size-3 shrink-0 text-muted-foreground"
+													strokeWidth={2}
+												/>
+											</button>
+										</TooltipTrigger>
+									</BranchPickerPopover>
+									<TooltipContent
+										side="top"
+										sideOffset={4}
+										className="rounded-md px-2 text-[12px] leading-none"
+									>
+										{mode === "local"
+											? "Switch branch"
+											: branchIntent === "use_branch"
+												? "Branch to reuse"
+												: "Base to fork off"}
+									</TooltipContent>
+								</Tooltip>
+								<CreateBranchDialog
+									open={createBranchOpen}
+									onOpenChange={setCreateBranchOpen}
+									defaultPrefix={defaultBranchPrefix(selectedRepository)}
+									existingBranches={branches.map((b) => b.name)}
+									onSubmit={async (branch) => {
+										if (!onCreateAndCheckoutBranch) return;
+										await onCreateAndCheckoutBranch(branch);
+									}}
+								/>
+							</>
+						) : null}
 					</div>
 				</div>
 			</div>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1460,8 +1460,14 @@ export async function moveLocalWorkspaceToWorktree(
 	);
 }
 
-/** How a workspace's filesystem is provisioned. */
-export type WorkspaceMode = "worktree" | "local";
+/**
+ * How a workspace's filesystem is provisioned.
+ * - `worktree`: a dedicated git worktree with its own auto-named branch.
+ * - `local`: operates directly on the source repo's root path.
+ * - `chat`: a scratch dir under `<data_dir>/chats/<YYYY-MM-DD>/<name>`
+ *   with no git context. "Just Chat" mode from the start page.
+ */
+export type WorkspaceMode = "worktree" | "local" | "chat";
 
 /** `from_branch`: fork off the picked base. `use_branch`: attach to it. */
 export type WorkspaceBranchIntent = "from_branch" | "use_branch";
@@ -2347,6 +2353,21 @@ export async function finalizeWorkspaceFromRepo(
 ): Promise<FinalizeWorkspaceResponse> {
 	return invoke<FinalizeWorkspaceResponse>("finalize_workspace_from_repo", {
 		workspaceId,
+	});
+}
+
+/**
+ * One-shot creation of a Chat-mode workspace. Chat workspaces aren't
+ * bound to any repo — they're a scratch dir under
+ * `<data_dir>/chats/<YYYY-MM-DD>/new-chat[-N]` used as cwd for a plain
+ * AI chat session. No `finalize_*` follow-up — the row is `ready`
+ * immediately.
+ */
+export async function prepareChatWorkspace(
+	initialStatus?: WorkspaceStatus | null,
+): Promise<PrepareWorkspaceResponse> {
+	return invoke<PrepareWorkspaceResponse>("prepare_chat_workspace", {
+		initialStatus: initialStatus ?? null,
 	});
 }
 

--- a/src/lib/monaco-runtime.ts
+++ b/src/lib/monaco-runtime.ts
@@ -57,6 +57,8 @@ type FileEditorController = {
 	setValue(value: string): void;
 	setReadOnly(readOnly: boolean): void;
 	revealPosition(line?: number, column?: number): void;
+	/** Move keyboard focus into the editor's hidden textarea. */
+	focus(): void;
 	onDidChangeModelContent(callback: (value: string) => void): DisposableLike;
 	/** Swap the active model. Returns false if no cached model and no content provided. */
 	switchFile(
@@ -75,6 +77,8 @@ type DiffEditorController = {
 		modifiedText: string;
 		inline: boolean;
 	}): void;
+	/** Move keyboard focus into the modified-side textarea. */
+	focus(): void;
 };
 
 let runtimePromise: Promise<MonacoRuntime> | null = null;
@@ -180,6 +184,9 @@ export async function createFileEditor(options: {
 		},
 		revealPosition(line?: number, column?: number) {
 			revealEditorPosition(editor, line, column);
+		},
+		focus() {
+			editor.focus();
 		},
 		onDidChangeModelContent(callback) {
 			return currentModel.onDidChangeContent(() => {
@@ -305,6 +312,11 @@ export async function createDiffEditor(options: {
 				modifiedModel.setValue(modifiedText);
 			}
 			editor.updateOptions({ renderSideBySide: !inline });
+		},
+		focus() {
+			// Modified side carries the user's edits when they jump to Edit mode,
+			// so it's the more useful focus target than the read-only original.
+			editor.getModifiedEditor().focus();
 		},
 	};
 }

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -745,22 +745,43 @@ function parseStartSurfacePreferences(
 		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
 			return DEFAULT_START_SURFACE_PREFERENCES;
 		}
-		const o = parsed as Partial<StartSurfacePreferences>;
+		const o = parsed as Partial<StartSurfacePreferences> & {
+			mode?: unknown;
+			branchIntent?: unknown;
+		};
+		const repoId = typeof o.repoId === "string" && o.repoId ? o.repoId : null;
+		const modeByRepoId = parseEnumRecord(o.modeByRepoId, [
+			"worktree",
+			"local",
+			"chat",
+		] as const);
+		const branchIntentByRepoId = parseEnumRecord(o.branchIntentByRepoId, [
+			"from_branch",
+			"use_branch",
+		] as const);
+		if (repoId && !modeByRepoId[repoId]) {
+			const legacyMode =
+				o.mode === "worktree" || o.mode === "local" || o.mode === "chat"
+					? o.mode
+					: null;
+			if (legacyMode) modeByRepoId[repoId] = legacyMode;
+		}
+		if (repoId && !branchIntentByRepoId[repoId]) {
+			const legacyBranchIntent =
+				o.branchIntent === "from_branch" || o.branchIntent === "use_branch"
+					? o.branchIntent
+					: null;
+			if (legacyBranchIntent) branchIntentByRepoId[repoId] = legacyBranchIntent;
+		}
 		return {
 			createState:
 				o.createState === "backlog" || o.createState === "in-progress"
 					? o.createState
 					: DEFAULT_START_SURFACE_PREFERENCES.createState,
-			repoId: typeof o.repoId === "string" && o.repoId ? o.repoId : null,
+			repoId,
 			sourceBranchByRepoId: parseStringRecord(o.sourceBranchByRepoId),
-			modeByRepoId: parseEnumRecord(o.modeByRepoId, [
-				"worktree",
-				"local",
-			] as const),
-			branchIntentByRepoId: parseEnumRecord(o.branchIntentByRepoId, [
-				"from_branch",
-				"use_branch",
-			] as const),
+			modeByRepoId,
+			branchIntentByRepoId,
 		};
 	} catch {
 		return DEFAULT_START_SURFACE_PREFERENCES;

--- a/src/lib/workspace-helpers.ts
+++ b/src/lib/workspace-helpers.ts
@@ -349,10 +349,12 @@ export function reorderWorkspaceInSidebar(
 		pinnedAt: mutation.pinnedAt,
 	};
 
-	const homeGroupId = workspaceGroupIdFromStatus(
-		updatedRow.status,
-		updatedRow.pinnedAt,
-	);
+	// Chat workspaces have their own bucket — status/pinned don't apply.
+	// They reorder inside "chats" exclusively.
+	const homeGroupId =
+		sourceRow.mode === "chat"
+			? "chats"
+			: workspaceGroupIdFromStatus(updatedRow.status, updatedRow.pinnedAt);
 
 	// Neighbour scope must match the backend — for a repo target that's
 	// every row of the repo (cross-status), not just the row's own lane.
@@ -380,7 +382,7 @@ export function reorderWorkspaceInSidebar(
 	);
 }
 
-/** Mirrors the backend's three `MoveTarget` scopes. */
+/** Mirrors the backend's `MoveTarget` scopes (incl. the chats bucket). */
 function collectNeighboursForTarget(
 	targetGroupId: string,
 	row: WorkspaceRow,
@@ -389,6 +391,10 @@ function collectNeighboursForTarget(
 	if (targetGroupId === "pinned") {
 		const pinned = groups.find((g) => g.id === "pinned");
 		return [...(pinned?.rows ?? [])].sort(compareSidebarOrder);
+	}
+	if (targetGroupId === "chats") {
+		const chats = groups.find((g) => g.id === "chats");
+		return [...(chats?.rows ?? [])].sort(compareSidebarOrder);
 	}
 	if (targetGroupId.startsWith("repo:")) {
 		const repoId = targetGroupId.slice("repo:".length);
@@ -451,6 +457,12 @@ function resolveTargetGroup(
 			status: row.status ?? null,
 			pinnedAt: row.pinnedAt ?? new Date().toISOString(),
 		};
+	}
+	if (targetGroupId === "chats") {
+		// Chats bucket holds chat-mode rows only; status/pinned don't
+		// apply. Mutation is "no-op" — just signal acceptance so the
+		// outer reorder proceeds to recompute displayOrder.
+		return { status: null, pinnedAt: null };
 	}
 	if (targetGroupId.startsWith("repo:")) {
 		// A backlog row dragged into its repo bucket needs to leave the

--- a/src/shell/components/workspace-header-actions.tsx
+++ b/src/shell/components/workspace-header-actions.tsx
@@ -39,6 +39,9 @@ type Props = {
 	openPreferredEditorShortcut: string | null;
 	rightSidebarToggleShortcut: string | null;
 	inspectorCollapsed: boolean;
+	/** Chat-mode workspaces hide the editor/finder picker and the
+	 *  inspector toggle (the inspector is hidden entirely in chat). */
+	isChatMode?: boolean;
 	onOpenPreferredEditor: () => void;
 	onToggleInspector: () => void;
 	onPickEditor: (editorId: string) => void;
@@ -53,6 +56,7 @@ export function WorkspaceHeaderActions({
 	openPreferredEditorShortcut,
 	rightSidebarToggleShortcut,
 	inspectorCollapsed,
+	isChatMode = false,
 	onOpenPreferredEditor,
 	onToggleInspector,
 	onPickEditor,
@@ -60,7 +64,7 @@ export function WorkspaceHeaderActions({
 }: Props) {
 	return (
 		<div className="flex items-center gap-1">
-			{installedEditors.length > 0 && preferredEditor ? (
+			{!isChatMode && installedEditors.length > 0 && preferredEditor ? (
 				<div className="flex -translate-x-1 items-center gap-0">
 					<Tooltip>
 						<TooltipTrigger asChild>
@@ -151,43 +155,47 @@ export function WorkspaceHeaderActions({
 			) : null}
 			<div className="flex -translate-x-px items-center gap-1">
 				<ExportSessionImageButton sessionId={sessionId} />
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<Button
-							aria-label={
-								inspectorCollapsed
-									? "Expand right sidebar"
-									: "Collapse right sidebar"
-							}
-							onClick={onToggleInspector}
-							variant="ghost"
-							size="icon-xs"
-							className="text-muted-foreground hover:text-foreground"
+				{/* Inspector toggle hidden in chat mode — the inspector pane
+				 *  itself is hidden, so the button has nothing to toggle. */}
+				{!isChatMode ? (
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								aria-label={
+									inspectorCollapsed
+										? "Expand right sidebar"
+										: "Collapse right sidebar"
+								}
+								onClick={onToggleInspector}
+								variant="ghost"
+								size="icon-xs"
+								className="text-muted-foreground hover:text-foreground"
+							>
+								{inspectorCollapsed ? (
+									<PanelRightOpen className="size-4" strokeWidth={1.8} />
+								) : (
+									<PanelRightClose className="size-4" strokeWidth={1.8} />
+								)}
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent
+							side="bottom"
+							className="flex h-[24px] items-center gap-2 rounded-md px-2 text-[12px] leading-none"
 						>
-							{inspectorCollapsed ? (
-								<PanelRightOpen className="size-4" strokeWidth={1.8} />
-							) : (
-								<PanelRightClose className="size-4" strokeWidth={1.8} />
-							)}
-						</Button>
-					</TooltipTrigger>
-					<TooltipContent
-						side="bottom"
-						className="flex h-[24px] items-center gap-2 rounded-md px-2 text-[12px] leading-none"
-					>
-						<span>
-							{inspectorCollapsed
-								? "Expand right sidebar"
-								: "Collapse right sidebar"}
-						</span>
-						{rightSidebarToggleShortcut ? (
-							<InlineShortcutDisplay
-								hotkey={rightSidebarToggleShortcut}
-								className="text-background/60"
-							/>
-						) : null}
-					</TooltipContent>
-				</Tooltip>
+							<span>
+								{inspectorCollapsed
+									? "Expand right sidebar"
+									: "Collapse right sidebar"}
+							</span>
+							{rightSidebarToggleShortcut ? (
+								<InlineShortcutDisplay
+									hotkey={rightSidebarToggleShortcut}
+									className="text-background/60"
+								/>
+							) : null}
+						</TooltipContent>
+					</Tooltip>
+				) : null}
 			</div>
 		</div>
 	);

--- a/src/shell/controllers/use-start-surface-controller.ts
+++ b/src/shell/controllers/use-start-surface-controller.ts
@@ -21,6 +21,7 @@ import {
 	prewarmSlashCommandsForRepo,
 	type RepositoryCreateOption,
 	type WorkspaceBranchIntent,
+	type WorkspaceDetail,
 	type WorkspaceMode,
 } from "@/lib/api";
 import { extractError } from "@/lib/errors";
@@ -386,7 +387,9 @@ export function useStartSurfaceController(
 			payload: ComposerSubmitPayload,
 			options?: { startSubmitMode?: StartSubmitMode },
 		): Promise<ComposerCreatePrepareOutcome> => {
-			if (!startRepository?.id) {
+			// Chat mode doesn't require a repo selection — every other
+			// mode does.
+			if (startMode !== "chat" && !startRepository?.id) {
 				pushToastRef.current(
 					"Pick a repository before sending.",
 					"Can't create workspace",
@@ -395,7 +398,7 @@ export function useStartSurfaceController(
 			}
 
 			try {
-				if (startPendingNewBranch) {
+				if (startMode !== "chat" && startPendingNewBranch && startRepository) {
 					await createAndCheckoutBranch(
 						startRepository.id,
 						startPendingNewBranch,
@@ -409,10 +412,12 @@ export function useStartSurfaceController(
 					sessionId,
 					preparedWorkingDirectory,
 				} = await createWorkspaceFromStartComposer({
-					repoId: startRepository.id,
-					sourceBranch: startSourceBranch,
+					// Chat mode ignores repoId/sourceBranch — pass empty
+					// strings so the function signature stays the same.
+					repoId: startRepository?.id ?? "",
+					sourceBranch: startMode === "chat" ? "" : startSourceBranch,
 					mode: startMode,
-					// Local mode ignores `branchIntent`; only forward in worktree.
+					// Only worktree mode honors branchIntent.
 					branchIntent:
 						startMode === "worktree" ? startBranchIntent : undefined,
 					submitMode: options?.startSubmitMode ?? "startNow",
@@ -428,6 +433,38 @@ export function useStartSurfaceController(
 				// Picks belonged to the in-flight create; clear regardless of
 				// outcome so the next start-page session begins clean.
 				setStartPendingLinkedDirectories(EMPTY_STRING_LIST);
+
+				// Chat workspaces ship as `ready` from a single-phase prep,
+				// so a real WorkspaceDetail isn't materialised until the
+				// follow-up query roundtrips. Without something in the
+				// detail cache, the inspector pane reads `mode === undefined`
+				// → renders one frame → re-renders with `mode === "chat"`
+				// → vanishes. Seed a minimal synthetic detail with the
+				// fields the inspector gate checks; the real fetch
+				// overwrites it shortly after.
+				if (startMode === "chat") {
+					const synthetic: WorkspaceDetail = {
+						id: workspaceId,
+						title: "New chat",
+						repoId: "",
+						repoName: "Chats",
+						directoryName: "",
+						state: "ready",
+						hasUnread: false,
+						workspaceUnread: 0,
+						unreadSessionCount: 0,
+						status: "in-progress",
+						mode: "chat",
+						sessionCount: 1,
+						messageCount: 0,
+						rootPath: preparedWorkingDirectory ?? null,
+						activeSessionId: sessionId,
+					};
+					queryClient.setQueryData<WorkspaceDetail | null>(
+						helmorQueryKeys.workspaceDetail(workspaceId),
+						(existing) => existing ?? synthetic,
+					);
+				}
 
 				requestSidebarReconcile(queryClient);
 
@@ -530,9 +567,12 @@ export function useStartSurfaceController(
 		],
 	);
 
-	const startComposerContextKey = startRepository
-		? `start:repo:${startRepository.id}`
-		: "start:no-repo";
+	const startComposerContextKey =
+		startMode === "chat"
+			? "start:chat"
+			: startRepository
+				? `start:repo:${startRepository.id}`
+				: "start:no-repo";
 	const startComposerInsertTarget = useMemo(
 		() => ({ contextKey: startComposerContextKey }),
 		[startComposerContextKey],


### PR DESCRIPTION
## What changed
- add a "Just Chat" start-surface mode that creates scratch chat workspaces with no repository or git binding
- wire chat-mode workspace creation through the Rust backend, synthetic chat repo plumbing, sidebar grouping, and workspace lifecycle helpers
- update the workspace UI to hide repo/branch-only controls in chat mode and keep editor focus/edit affordances working cleanly
- add release artifacts for the new mode and adjust the inline-edit announcement copy

## Why
- this lets users open a throwaway AI chat workspace without picking a repository or creating git state
- the workspace model and settings layer now understand chat-mode as a first-class workspace type

## Test notes
- `bun x vitest run src/lib/settings.test.ts`
- commit hooks ran `biome check --write`, `cargo fmt`, and `cargo clippy -- -D warnings` successfully during commit