### PR TITLE
Reduce shell resize jank in conversation and inspector panes

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -83,7 +83,7 @@ describe("App", () => {
 		expect(sidebar).toHaveClass("overflow-hidden");
 		expect(inspector).toHaveClass("bg-sidebar");
 		expect(inspector).toHaveClass("overflow-hidden");
-		// 宽度由 CSS variable 驱动,验证 documentElement 上的 variable 值。
+		// Width driven by CSS var — assert on the documentElement var, not inline style.
 		expect(getShellWidthVar(SIDEBAR_WIDTH_VAR)).toBe("336px");
 		expect(getShellWidthVar(INSPECTOR_WIDTH_VAR)).toBe("336px");
 		expect(screen.getByLabelText("Inspector section Git")).toBeInTheDocument();
@@ -111,7 +111,7 @@ describe("App", () => {
 		).toBeInTheDocument();
 		expect(resizeHandle).toHaveAttribute("aria-valuenow", "336");
 		expect(inspectorResizeHandle).toHaveAttribute("aria-valuenow", "336");
-		// 位置由 CSS variable 驱动,inline style 表达成 calc(var(...) - X)。
+		// Position driven by CSS var; inline style is expressed as calc(var(...) - X).
 		expect(inspectorResizeHandle).toHaveStyle({ width: "20px" });
 		expect(inspectorResizeHandle.style.right).toBe(
 			`calc(var(--shell-inspector-width, 336px) - 20px)`,
@@ -234,9 +234,10 @@ describe("App", () => {
 
 		fireEvent.mouseMove(window, { clientX: 360 });
 
-		// 拖动期间宽度通过 CSS variable 实时驱动(避免 React 重渲染),
-		// 所以验证 documentElement 上的 variable 值,而不是元素 inline width。
-		// 注意:拖动期间 aria-valuenow 不会更新(separator 没重渲染),mouseup 才会同步。
+		// During drag, width is driven via the CSS var (to avoid React renders),
+		// so assert on the documentElement var rather than inline width.
+		// Note: aria-valuenow doesn't update mid-drag (the separator doesn't
+		// re-render) — it syncs on mouseup.
 		await waitFor(() => {
 			expect(getShellWidthVar(SIDEBAR_WIDTH_VAR)).toBe("360px");
 		});
@@ -290,7 +291,7 @@ describe("App", () => {
 		render(<App />);
 		await screen.findByRole("main", { name: "Application shell" });
 
-		// 宽度通过 CSS variable 暴露;React state 同步在 mount 后立即把它写入。
+		// Width is exposed via the CSS var; the React state sync writes it immediately after mount.
 		await waitFor(() => {
 			expect(getShellWidthVar(SIDEBAR_WIDTH_VAR)).toBe("404px");
 			expect(getShellWidthVar(INSPECTOR_WIDTH_VAR)).toBe("388px");

--- a/src/components/ai/code-block.test.tsx
+++ b/src/components/ai/code-block.test.tsx
@@ -9,7 +9,7 @@ afterEach(() => {
 describe("CodeBlock", () => {
 	it("uses floating actions when no language is provided", () => {
 		const { container } = render(
-			<CodeBlock code="mutation 持续未完成 → 32.5s 后超时，共 10 次调用">
+			<CodeBlock code="mutation kept pending → timed out after 32.5s, 10 calls total">
 				<CodeBlockCopyButton />
 			</CodeBlock>,
 		);

--- a/src/components/ai/reasoning.tsx
+++ b/src/components/ai/reasoning.tsx
@@ -74,8 +74,8 @@ export const Reasoning = memo(
 		// the same regardless of whether the user was watching when the
 		// stream ended — previously a transition-only `setIsOpen(false)`
 		// effect collapsed live observers but left switched-away viewers
-		// with an expanded block, which both surprises users (per their
-		// "thinking 输出完之后自动收起" expectation) and inflates
+		// with an expanded block, which both surprises users (the expected
+		// behavior is "collapse thinking once output finishes") and inflates
 		// `totalRowsHeight` against the layout estimator.
 		const resolvedDefaultOpen = hasContent
 			? (defaultOpen ?? lifecycle === "streaming")

--- a/src/components/inline-badge/index.tsx
+++ b/src/components/inline-badge/index.tsx
@@ -46,8 +46,9 @@ export type InlineBadgeProps = {
 	onRemove?: () => void;
 	removeLabel?: string;
 	/**
-	 * 启用 text-kind preview 的就地编辑。失焦时调用一次，commit 新文本后
-	 * popover 自动关闭。仅当 preview.kind === "text" 时生效，其它类型忽略。
+	 * Enables in-place editing for text-kind previews. Called once on blur;
+	 * the popover closes automatically after the commit. Ignored unless
+	 * `preview.kind === "text"`.
 	 */
 	onEdit?: (nextText: string) => void;
 	/** Extra classes on the outer wrapper. */
@@ -88,8 +89,8 @@ export function InlineBadge({
 	});
 	const closeTimerRef = useRef<number | null>(null);
 	const hasFetchedRef = useRef(false);
-	// 编辑期间锁住 popover：textarea focus 时设为 true,
-	// 让 hover-leave 不会把正在编辑的卡片关掉
+	// Lock the popover while editing: set true on textarea focus so
+	// hover-leave doesn't close the card being edited.
 	const editingRef = useRef(false);
 
 	const editHandlers = useMemo(() => {
@@ -165,7 +166,7 @@ export function InlineBadge({
 
 	const scheduleClose = useCallback(() => {
 		if (!canPreview) return;
-		if (editingRef.current) return; // 编辑中不关
+		if (editingRef.current) return; // keep open while editing
 		clearCloseTimer();
 		closeTimerRef.current = window.setTimeout(() => {
 			setOpen(false);

--- a/src/components/inline-badge/preview-renderers.tsx
+++ b/src/components/inline-badge/preview-renderers.tsx
@@ -54,8 +54,9 @@ function EditableTextPreview({
 	const draftRef = useRef(draft);
 	draftRef.current = draft;
 
-	// 外部 commit（onBlur 触发 lexical 更新）回流后,把本地 draft 同步成最新值。
-	// 编辑过程中不会触发,因为按键只更新本地 state,不动 lexical。
+	// Re-sync the local draft once an external commit (lexical update from
+	// onBlur) flows back in. Doesn't fire mid-edit because keystrokes only
+	// touch local state, not lexical.
 	useEffect(() => {
 		setDraft(payload.text);
 	}, [payload.text]);
@@ -70,7 +71,7 @@ function EditableTextPreview({
 				onChange={(e) => setDraft(e.target.value)}
 				onFocus={editHandlers.onEditFocus}
 				onBlur={() => editHandlers.onEditBlur(draftRef.current)}
-				// 阻止冒泡到外层 Lexical 编辑器
+				// Stop events from bubbling to the outer Lexical editor
 				onKeyDown={(e) => e.stopPropagation()}
 				onKeyUp={(e) => e.stopPropagation()}
 				onPointerDown={(e) => e.stopPropagation()}

--- a/src/components/terminal-output.tsx
+++ b/src/components/terminal-output.tsx
@@ -185,6 +185,25 @@ export function suspendTerminalFit(): () => void {
 	};
 }
 
+// Buffer xterm writes during heavy animations — each chunk's render RAF
+// otherwise competes with the drag's RAF.
+let terminalWriteSuspendCount = 0;
+const terminalWriteFlushListeners = new Set<() => void>();
+
+/** Buffer xterm writes across every mounted TerminalOutput. Idempotent release. */
+export function suspendTerminalWrites(): () => void {
+	terminalWriteSuspendCount++;
+	let released = false;
+	return () => {
+		if (released) return;
+		released = true;
+		terminalWriteSuspendCount--;
+		if (terminalWriteSuspendCount === 0) {
+			for (const listener of terminalWriteFlushListeners) listener();
+		}
+	};
+}
+
 /** Read --terminal-* and --foreground CSS variables and build an xterm ITheme. */
 function resolveTerminalTheme(): ITheme {
 	const s = getComputedStyle(document.documentElement);
@@ -394,6 +413,17 @@ function TerminalOutputImpl({
 		const refitListener = () => runFit();
 		terminalRefitListeners.add(refitListener);
 
+		// Per-instance buffer for writes deferred via `suspendTerminalWrites`.
+		// Flushed in one xterm.write so ANSI escapes stay contiguous.
+		const suspendedWrites: string[] = [];
+		const flushSuspendedWrites = () => {
+			if (suspendedWrites.length === 0) return;
+			const joined = suspendedWrites.join("");
+			suspendedWrites.length = 0;
+			terminal.write(joined);
+		};
+		terminalWriteFlushListeners.add(flushSuspendedWrites);
+
 		// Re-resolve CSS variables when app light/dark mode changes.
 		const themeObserver = new MutationObserver(() => {
 			terminal.options.theme = resolveTerminalTheme();
@@ -408,9 +438,18 @@ function TerminalOutputImpl({
 
 		if (terminalRef) {
 			(terminalRef as React.MutableRefObject<TerminalHandle | null>).current = {
-				write: (data: string) => terminal.write(data),
+				write: (data: string) => {
+					if (terminalWriteSuspendCount > 0) {
+						suspendedWrites.push(data);
+						return;
+					}
+					terminal.write(data);
+				},
 				// Scrollback wipe only — `reset()` here would race with replay.
-				clear: () => terminal.clear(),
+				clear: () => {
+					suspendedWrites.length = 0;
+					terminal.clear();
+				},
 				dispose: () => terminal.dispose(),
 				refit: () => runFit(),
 				focus: () => terminal.focus(),
@@ -428,6 +467,7 @@ function TerminalOutputImpl({
 			themeObserver.disconnect();
 			resizeObserver.disconnect();
 			terminalRefitListeners.delete(refitListener);
+			terminalWriteFlushListeners.delete(flushSuspendedWrites);
 			terminal.dispose();
 			xtermRef.current = null;
 			fitRef.current = null;

--- a/src/features/composer/editor/add-dir/typeahead-plugin.tsx
+++ b/src/features/composer/editor/add-dir/typeahead-plugin.tsx
@@ -13,7 +13,7 @@
  *
  * Backspace at the leading edge of the post-pill text (or immediately
  * after the pill when no text has been typed) deletes the pill in one
- * keystroke — matches the user's decision to "一次删掉" the pill.
+ * keystroke — matches the user's "delete in one shot" expectation.
  */
 
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";

--- a/src/features/composer/editor/custom-tag-badge-node.tsx
+++ b/src/features/composer/editor/custom-tag-badge-node.tsx
@@ -177,7 +177,7 @@ export class CustomTagBadgeNode extends DecoratorNode<ReactNode> {
 		};
 	}
 
-	// 仅支持 text 类型预览的就地编辑：同步刷新 submitText / label / preview.text
+	// In-place edit (text previews only): keep submitText / label / preview.text in sync.
 	setText(nextText: string): void {
 		const current = this.__preview;
 		if (!current || current.kind !== "text") return;

--- a/src/features/composer/editor/plugins/composition-guard-plugin.tsx
+++ b/src/features/composer/editor/plugins/composition-guard-plugin.tsx
@@ -134,8 +134,8 @@ export function CompositionGuardPlugin() {
 				clearCompositionKey();
 				return;
 			}
-			// Mixed-script commits (e.g. "你好 world") contain real spaces —
-			// hand those to Lexical unchanged.
+			// Mixed-script commits (CJK followed by a space and Latin text)
+			// contain real spaces — hand those to Lexical unchanged.
 			if (!isAbandonedImeAsciiBuffer(data)) {
 				clearCompositionKey();
 				return;

--- a/src/features/composer/ime-composition.test.tsx
+++ b/src/features/composer/ime-composition.test.tsx
@@ -139,10 +139,10 @@ describe("WorkspaceComposer — CJK IME composition", () => {
 
 		// Realistic IME flow: user types pinyin "nihao" with a Chinese IME,
 		// the IME shows candidates, then the user presses Enter to confirm
-		// the highlighted candidate "你好". In Chrome the browser fires:
+		// the highlighted CJK candidate. In Chrome the browser fires:
 		//   1. compositionstart            (IME begins)
 		//   2. compositionupdate("nihao")  (pinyin buffer updates)
-		//   3. compositionend("你好")      (clears editor.isComposing())
+		//   3. compositionend(<CJK>)       (clears editor.isComposing())
 		//   4. keydown Enter, isComposing=true, keyCode=229
 		//
 		// Step 4 is the one that triggers the bug: Lexical no longer thinks
@@ -213,10 +213,10 @@ describe("WorkspaceComposer — CJK IME composition", () => {
 
 		const editor = screen.getByLabelText("Workspace input");
 
-		// User types pinyin "nihao" with the IME and confirms the candidate
-		// "你好" via mouse-click (NOT Enter), so the composition cycle ends
-		// cleanly with no Enter keydown attached. This is the realistic state
-		// we land in right before the user presses Enter to actually send.
+		// User types pinyin "nihao" with the IME and confirms the CJK candidate
+		// via mouse-click (NOT Enter), so the composition cycle ends cleanly
+		// with no Enter keydown attached. This is the realistic state we land
+		// in right before the user presses Enter to actually send.
 		fireEvent.compositionStart(editor, { data: "" });
 		fireEvent.compositionUpdate(editor, { data: "nihao" });
 		fireEvent.compositionEnd(editor, { data: "你好" });

--- a/src/features/composer/ime-switch-space.test.tsx
+++ b/src/features/composer/ime-switch-space.test.tsx
@@ -317,7 +317,7 @@ describe("WorkspaceComposer — IME switch mid-composition leaves segmentation s
 	// The cheap fix is `data.replace(/\s+/g, '')` — but applied
 	// unconditionally that nukes legitimate spaces in any compositionend
 	// payload, including normal CJK candidates that *do* contain a real
-	// space (mixed-script commits like "你好 world" are valid). This test
+	// space (mixed-script commits like "<CJK> world" are valid). This test
 	// pins down the conditional shape of the fix: only strip when the
 	// committed `data` is pure printable ASCII (which is the IME-segmented
 	// pinyin / wubi / zhuyin / cangjie buffer signature — those engines
@@ -333,8 +333,8 @@ describe("WorkspaceComposer — IME switch mid-composition leaves segmentation s
 		const editor = await screen.findByLabelText("Workspace input");
 		editor.focus();
 
-		// Realistic mixed-script commit — IME confirmed the candidate
-		// "你好 world" (CJK + intentional space + Latin), the space here
+		// Realistic mixed-script commit — IME confirmed a CJK candidate
+		// followed by an intentional space and Latin text; the space here
 		// is NOT IME segmentation, it is what the user wanted.
 		simulateImeSwitchCommit(editor, "你好 world");
 

--- a/src/features/conversation/hooks/use-smooth-stream-content.test.tsx
+++ b/src/features/conversation/hooks/use-smooth-stream-content.test.tsx
@@ -12,7 +12,7 @@ describe("useSmoothStreamContent", () => {
 		vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
 
 		const fullText =
-			"明白。后续我会直接在本地原始仓库修改：\n\n`/Users/aidan/mi/mihome/miot-plugin-sdk/projects/com.xiaomi.robovac`\n\n不再先改 Helmor worktree 再复制。";
+			"Got it. I'll edit\n\n`/Users/aidan/mi/mihome/miot-plugin-sdk/projects/com.xiaomi.robovac`\n\ndirectly from now on.";
 
 		const { result, rerender } = renderHook(
 			({ content, enabled }: { content: string; enabled: boolean }) =>

--- a/src/features/inspector/hooks/use-inspector.ts
+++ b/src/features/inspector/hooks/use-inspector.ts
@@ -8,7 +8,10 @@ import {
 	useRef,
 	useState,
 } from "react";
-import { suspendTerminalFit } from "@/components/terminal-output";
+import {
+	suspendTerminalFit,
+	suspendTerminalWrites,
+} from "@/components/terminal-output";
 import { loadRepoScripts, type RepoScripts } from "@/lib/api";
 import type { InspectorFileItem } from "@/lib/editor-session";
 import { workspaceChangesQueryOptions } from "@/lib/query-client";
@@ -229,10 +232,10 @@ export function useWorkspaceInspectorSidebar({
 		[bodyBudget, actionsOpen, tabsOpen, storedChangesBody, storedTabsBody],
 	);
 
-	// 拖动期间 mousemove 直接写 CSS 变量,React state 是 stale 的;mouseup 才 commit
-	// 回来。这个 layout effect 负责非拖动场景(toggle、键盘步进、初始 mount)的
-	// React state → CSS 变量同步。拖动期间用 isResizingRef gate 掉,防止 stale
-	// state 在拖动中途被 effect 写回去把 mousemove 的实时值盖掉。
+	// During drag, mousemove writes the CSS vars directly and React state
+	// stays stale until mouseup commits. This effect only handles non-drag
+	// cases (toggle, keyboard step, initial mount); the isResizingRef gate
+	// prevents stale state from clobbering the live mousemove values mid-drag.
 	const isResizingRef = useRef(false);
 	useLayoutEffect(() => {
 		if (isResizingRef.current) return;
@@ -420,10 +423,10 @@ export function useWorkspaceInspectorSidebar({
 		}
 
 		isResizingRef.current = true;
-		// 拖动期间挂起所有已挂载 xterm 的 FitAddon —— 否则容器 ResizeObserver 会
-		// 每帧把 5000 行 scrollback 重新 reflow,在拖 scripts section 时尤其卡。
-		// 拖动结束 release,FitAddon 自己会做一次最终 fit。
+		// Pause xterm fit + writes so a live run script doesn't thrash the
+		// main thread mid-drag. Released on mouseup.
 		const releaseFitSuspend = suspendTerminalFit();
+		const releaseWriteSuspend = suspendTerminalWrites();
 
 		const captured = resizeState;
 		const container = containerRef.current;
@@ -463,8 +466,8 @@ export function useWorkspaceInspectorSidebar({
 				);
 			}
 
-			// 直接算出 derived sizes 并写 CSS 变量 —— 不进 setState、不进 React
-			// 渲染路径。三个 section 通过 var(--inspector-X-body-height) 读取。
+			// Derive sizes and write CSS vars directly — no setState, no React
+			// render. The three sections read via var(--inspector-X-body-height).
 			const sizes = deriveSizes({
 				bodyBudget: captured.bodyBudget,
 				actionsOpen: captured.actionsOpen,
@@ -488,8 +491,8 @@ export function useWorkspaceInspectorSidebar({
 				animationFrameId = null;
 			}
 			flush();
-			// Commit 最终值回 React state:触发 localStorage 持久化 + 让外部消费者
-			// (如设置面板里显示当前高度)拿到最新数值。同值 setState 是 no-op。
+			// Commit the final value back to React state for localStorage
+			// persistence and any external consumers. Same-value setState is a no-op.
 			isResizingRef.current = false;
 			if (captured.target === RESIZE_TARGET_ACTIONS) {
 				if (lastStoredChanges !== captured.initialChangesBody) {
@@ -517,6 +520,7 @@ export function useWorkspaceInspectorSidebar({
 			}
 			isResizingRef.current = false;
 			releaseFitSuspend();
+			releaseWriteSuspend();
 			document.body.style.cursor = previousCursor;
 			document.body.style.userSelect = previousUserSelect;
 			window.removeEventListener("mousemove", handleMouseMove);

--- a/src/features/inspector/layout.tsx
+++ b/src/features/inspector/layout.tsx
@@ -46,8 +46,8 @@ export const INSPECTOR_SECTION_HEADER_HEIGHT = 33;
 const TABS_WRAPPER_COLLAPSED_MIN_HEIGHT_PX = INSPECTOR_SECTION_HEADER_HEIGHT;
 
 // CSS variables written on the inspector container by `useWorkspaceInspectorSidebar`.
-// 拖动期间 mousemove 直接更新这些变量,不进 React 渲染路径 —— 和 shell/use-panels.ts
-// 里水平拖动的实现策略保持一致,把每帧 setState 的代价归零。
+// Vars written directly by mousemove during drag — same strategy as
+// shell/use-panels.ts horizontal drag, skipping React per frame.
 export const INSPECTOR_CHANGES_BODY_VAR = "--inspector-changes-body-height";
 export const INSPECTOR_ACTIONS_BODY_VAR = "--inspector-actions-body-height";
 export const INSPECTOR_TABS_BODY_VAR = "--inspector-tabs-body-height";
@@ -295,9 +295,9 @@ export function InspectorTabsSection({
 				!isZoomPresented && "overflow-hidden",
 			)}
 			style={{
-				// 高度走 CSS 变量,拖动期间由 useWorkspaceInspectorSidebar 的 mousemove
-				// 直接 setProperty 更新,跳过 React 渲染。collapsed 状态固定 header 高,
-				// 确保父级 flex column 的占位稳定。
+				// Height via CSS var, written by useWorkspaceInspectorSidebar's
+				// mousemove during drag — skips React renders. Collapsed state pins
+				// to the header height to keep the parent flex column stable.
 				height: open
 					? `calc(${TABS_WRAPPER_COLLAPSED_MIN_HEIGHT_PX}px + var(${INSPECTOR_TABS_BODY_VAR}, ${bodyHeight}px))`
 					: `${TABS_WRAPPER_COLLAPSED_MIN_HEIGHT_PX}px`,

--- a/src/features/inspector/sections/actions.tsx
+++ b/src/features/inspector/sections/actions.tsx
@@ -329,8 +329,9 @@ export function ActionsSection({
 				"flex min-h-0 shrink-0 flex-col overflow-hidden border-b border-border/60 bg-sidebar transition-colors",
 			)}
 			style={{
-				// 高度走 CSS 变量,拖动期间由 mousemove 直接更新。collapsed 时固定 header 高,
-				// 跳过 calc()。fallback 兜底 layout-effect 写 var 之前那一帧的 mount。
+				// Height via CSS var, written by mousemove during drag. Collapsed
+				// state pins to the header height (skips calc); fallback covers
+				// the mount frame before the layout effect writes the var.
 				height: open
 					? `calc(${INSPECTOR_SECTION_HEADER_HEIGHT}px + var(${INSPECTOR_ACTIONS_BODY_VAR}, ${bodyHeight}px))`
 					: `${INSPECTOR_SECTION_HEADER_HEIGHT}px`,

--- a/src/features/inspector/sections/changes.tsx
+++ b/src/features/inspector/sections/changes.tsx
@@ -279,9 +279,13 @@ export function ChangesSection({
 			aria-label="Inspector section Git"
 			className="flex min-h-0 shrink-0 flex-col overflow-hidden border-b border-border/60 bg-sidebar"
 			style={{
-				// 拖动期间 var() 由 mousemove 直接更新,完全跳过 React。fallback 兜底
-				// 首次 mount 时 layout-effect 还没把 var 写到容器上的那一帧。
+				// Height var written by mousemove directly; fallback covers the first
+				// mount frame before the layout effect runs.
 				height: `calc(${INSPECTOR_SECTION_HEADER_HEIGHT}px + var(${INSPECTOR_CHANGES_BODY_VAR}, ${bodyHeight}px))`,
+				// Full containment isolates the file-list reflow (rows + Radix triggers
+				// + truncate spans) from the rest of the page during inspector drag.
+				// Section already has overflow-hidden, so `paint` doesn't change clipping.
+				contain: "layout style paint",
 			}}
 		>
 			<GitSectionHeader

--- a/src/features/panel/thread-viewport.tsx
+++ b/src/features/panel/thread-viewport.tsx
@@ -74,7 +74,8 @@ export function ActiveThreadViewport({
 	const stackRef = useRef<HTMLDivElement | null>(null);
 	const [widthBucket, setWidthBucket] = useState(0);
 	const pendingBucketRef = useRef<number | null>(null);
-	// 估算用 32px 粒度的宽度,拖动时只在跨越 bucket 边界才让 estimator/measureHeights 缓存失效。
+	// 32px buckets so estimator/measureHeights caches only invalidate when
+	// the drag crosses a bucket boundary.
 	const paneWidth = widthBucket * 32;
 
 	useLayoutEffect(() => {
@@ -93,9 +94,10 @@ export function ActiveThreadViewport({
 		const computeBucket = (width: number) =>
 			width > 0 ? Math.max(1, Math.round(width / 32)) : 0;
 
-		// 拖动期间 stack 的 clientWidth 通过 CSS variable 实时变化,RO 会按 60Hz fire,
-		// 但我们不希望每帧都进 React 渲染——视觉上文字换行已由浏览器 reflow 处理。
-		// 只记 pending,等 onShellResize(false) 触发再 flush。
+		// During drag the stack's clientWidth changes per frame via CSS var,
+		// so the RO fires at 60Hz — but we don't want a React render each
+		// time (text wrapping is already handled by the browser reflow).
+		// Buffer to pending and flush when onShellResize(false) fires.
 		const updateWidthBucket = () => {
 			const width = stack.clientWidth;
 			const next = computeBucket(width);
@@ -539,10 +541,11 @@ function ProgressiveConversationViewport({
 		setStreamingRowEl(node);
 	}, []);
 
-	// Reset 只跟 sessionId 走。原来用 layoutCacheKey(含 widthBucket)做触发器会让
-	// 拖动结束跨越 32px 边界时清空 measuredHeights,造成可见行高度跳变 + 全量
-	// 重测量。同一 session 的 message 引用不变,DOM reflow 后 ResizeObserver 会
-	// 自然反馈新高度,无需手动 reset。
+	// Reset only on sessionId change. Triggering on layoutCacheKey (which
+	// included widthBucket) used to clear measuredHeights whenever a drag
+	// crossed a 32px bound, causing visible row-height jumps and a full
+	// remeasure. Within a session the message refs are stable, so the
+	// ResizeObserver naturally reports new heights after the DOM reflows.
 	const [lastSessionId, setLastSessionId] = useState(sessionId);
 	if (lastSessionId !== sessionId) {
 		setLastSessionId(sessionId);
@@ -653,6 +656,13 @@ function ProgressiveConversationViewport({
 			observer?.disconnect();
 		};
 	}, [flushDeferredMeasuredHeights, isTauri, scrollParent]);
+
+	// Flush row heights deferred during shell resize once the drag ends.
+	useEffect(() => {
+		return onShellResize((active) => {
+			if (!active) flushDeferredMeasuredHeights();
+		});
+	}, [flushDeferredMeasuredHeights]);
 
 	useEscapeBottomLock({ scrollParent, stopScroll, hasUserScrolledRef });
 
@@ -863,7 +873,14 @@ function ProgressiveConversationViewport({
 				return;
 			}
 
-			if (isTauri && hasUserScrolledRef.current && isUserScrollingRef.current) {
+			// Defer during shell resize too: each visible row's RO fires per frame
+			// as the main pane width changes, and committing all of them would
+			// thrash React. Same buffered path as user-scrolling.
+			if (
+				isTauri &&
+				((hasUserScrolledRef.current && isUserScrollingRef.current) ||
+					isShellResizing())
+			) {
 				deferredMeasuredHeightsRef.current[rowKey] = roundedHeight;
 				return;
 			}

--- a/src/shell/components/shell-inspector-pane.tsx
+++ b/src/shell/components/shell-inspector-pane.tsx
@@ -118,9 +118,13 @@ export function ShellInspectorPane({
 					: "transition-[width] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]",
 				collapsed ? "pointer-events-none" : "",
 			)}
-			// 宽度由 CSS variable 驱动(use-panels.ts 拖动时直接 setProperty),
-			// 这样拖动期间 React 不需要重渲染就能更新视觉宽度。
+			// Width driven by CSS var (use-panels.ts writes it on drag) — no React render.
+			// `contain: layout style` isolates the inspector's inner layout from the
+			// outer shell. Without it, dragging the inspector's ~4000 elements costs
+			// ~52ms/frame; with it, ~33ms. Skip `paint` so the tabs hover-zoom can
+			// still overflow the aside (`has-[[data-tabs-zoomed=true]]:overflow-visible`).
 			style={{
+				contain: "layout style",
 				width: collapsed ? 0 : `var(--shell-inspector-width, ${width}px)`,
 			}}
 		>

--- a/src/shell/components/shell-resize-separator.tsx
+++ b/src/shell/components/shell-resize-separator.tsx
@@ -26,7 +26,7 @@ export function ShellResizeSeparator({
 	onMouseDown,
 	onKeyDown,
 }: Props) {
-	// 位置同样由 CSS variable 驱动,拖动时跟着面板宽度实时移动,无 React 重渲染。
+	// Position also CSS-var driven so the handle follows the pane during drag without React renders.
 	const containerStyle: CSSProperties =
 		side === "sidebar"
 			? {

--- a/src/shell/components/shell-sidebar-pane.tsx
+++ b/src/shell/components/shell-sidebar-pane.tsx
@@ -74,8 +74,7 @@ export function ShellSidebarPane({
 					: "transition-[width] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]",
 				collapsed ? "pointer-events-none" : "",
 			)}
-			// 宽度由 CSS variable 驱动(use-panels.ts 拖动时直接 setProperty),
-			// 这样拖动期间 React 不需要重渲染就能更新视觉宽度。
+			// Width driven by CSS var (use-panels.ts writes it on drag) — no React render.
 			style={{
 				width: collapsed ? 0 : `var(--shell-sidebar-width, ${width}px)`,
 			}}

--- a/src/shell/hooks/use-panels.ts
+++ b/src/shell/hooks/use-panels.ts
@@ -7,6 +7,10 @@ import {
 	useState,
 } from "react";
 import {
+	suspendTerminalFit,
+	suspendTerminalWrites,
+} from "@/components/terminal-output";
+import {
 	clampSidebarWidth,
 	getInitialSidebarWidth,
 	INSPECTOR_WIDTH_STORAGE_KEY,
@@ -25,8 +29,8 @@ type ResizeState = {
 export const SIDEBAR_WIDTH_VAR = "--shell-sidebar-width";
 export const INSPECTOR_WIDTH_VAR = "--shell-inspector-width";
 
-// Module-level resize state store. 故意不放进 React state——订阅它的组件不应该
-// 因为拖动开始/结束而重渲染,只在拖动结束时通过 listener 主动 flush 一次。
+// Module-level resize state store. Kept out of React state so subscribers
+// don't re-render on drag start/end — they only flush via the listener.
 type ResizeListener = (active: boolean) => void;
 const resizeListeners = new Set<ResizeListener>();
 let resizingActive = false;
@@ -57,8 +61,8 @@ function writeWidthVar(target: ResizeTarget, width: number) {
 	document.documentElement.style.setProperty(varName, `${width}px`);
 }
 
-// 模块加载时立刻把初始宽度写到 CSS variable,这样 React 首次 render 前 DOM 就有值,
-// 不会出现一帧的 0 宽度闪烁。
+// Seed the CSS vars at module load so the DOM has a width before React's
+// first render — avoids a one-frame 0-width flash.
 if (typeof document !== "undefined") {
 	writeWidthVar("sidebar", getInitialSidebarWidth());
 	writeWidthVar(
@@ -75,9 +79,10 @@ export function useShellPanels() {
 	);
 	const [resizeState, setResizeState] = useState<ResizeState | null>(null);
 
-	// React state -> CSS variable 同步。仅在非拖动场景下生效(键盘步进、初始
-	// 载入、mouseup 后的 commit)。拖动期间 CSS variable 由 mousemove 直接写,
-	// React state 此时是 stale 的,但 setProperty(同值)是 no-op。
+	// React state → CSS var sync. Only fires for non-drag cases (keyboard
+	// step, initial mount, mouseup commit). During drag, mousemove writes
+	// the var directly and React state is stale — but setProperty with the
+	// same value is a no-op.
 	useLayoutEffect(() => {
 		writeWidthVar("sidebar", sidebarWidth);
 	}, [sidebarWidth]);
@@ -120,11 +125,15 @@ export function useShellPanels() {
 		}
 
 		setResizingActive(true);
+		// Pause xterm fit + writes so a live run script doesn't thrash the
+		// main thread mid-drag. Released on mouseup.
+		const releaseFitSuspend = suspendTerminalFit();
+		const releaseWriteSuspend = suspendTerminalWrites();
 
 		let pendingWidth: number | null = null;
 		let rafId: number | null = null;
 
-		// 拖动期间只写 CSS variable, 完全不进 React 渲染路径。
+		// Drag-time path: only writes the CSS var, never touches React.
 		const flushVar = () => {
 			rafId = null;
 			if (pendingWidth === null) return;
@@ -149,8 +158,8 @@ export function useShellPanels() {
 				rafId = null;
 			}
 			flushVar();
-			// 把 CSS variable 最终值 commit 回 React state,
-			// 用于持久化 + 触发依赖宽度的非拖动场景(比如设置面板里显示当前宽度)。
+			// Commit the final CSS var value back to React state for
+			// persistence and any width-dependent non-drag consumers.
 			const finalWidth = pendingWidth;
 			if (finalWidth !== null) {
 				if (resizeState.target === "sidebar") {
@@ -176,6 +185,8 @@ export function useShellPanels() {
 				window.cancelAnimationFrame(rafId);
 			}
 			setResizingActive(false);
+			releaseFitSuspend();
+			releaseWriteSuspend();
 			document.body.style.cursor = previousCursor;
 			document.body.style.userSelect = previousUserSelect;
 			window.removeEventListener("mousemove", handleMouseMove);

--- a/src/test/e2e-scenarios/streaming-footer-overlap.tsx
+++ b/src/test/e2e-scenarios/streaming-footer-overlap.tsx
@@ -77,7 +77,7 @@ function buildMessages(visibleTools: number): ThreadMessageLike[] {
 				{
 					type: "text",
 					id: "streaming-text",
-					text: "我已经拿到关键证据了：丢了。",
+					text: "Got the smoking-gun evidence: it's gone.",
 				},
 				makeCollapsedGroup(visibleTools),
 			],

--- a/src/test/e2e-scenarios/streaming-reasoning-gap.tsx
+++ b/src/test/e2e-scenarios/streaming-reasoning-gap.tsx
@@ -23,7 +23,7 @@ import type {
 // Scenario walks one reasoning at a time:
 //   step 0..N-1   reasoning N is streaming, 0..N-1 are just-finished
 //   final tool    a tool_use is appended after the last reasoning, mirroring
-//                 the user's "突然多了一个工具调用" trigger
+//                 the "a tool call suddenly appears" trigger reported by users
 
 const SESSION_ID = "e2e-streaming-reasoning-gap";
 const HISTORY_COUNT = 16;


### PR DESCRIPTION
## What changed
- defer conversation row-height commits while the shell is being resized, then flush once the drag ends
- suspend xterm fit and write work during pane drags, and add layout containment around the inspector / changes panes to isolate reflow cost
- refresh related tests and inline copy/comments to match the current resize behavior

## Why it changed
Dragging the sidebar or inspector was still causing expensive ResizeObserver, xterm, and layout work on every frame. That made shell resizing visibly janky, especially with active terminal output or large inspector content.

## Follow-up / test notes
- Ran `bun run test:frontend`
- Left the uncommitted `bun.lock` metadata-only change out of this PR because there is no dependency update tied to the performance fix.