### PR TITLE
fix: prevent tooltip re-open when dropdown/popover closes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "helmor",

--- a/src/components/branch-picker.tsx
+++ b/src/components/branch-picker.tsx
@@ -55,6 +55,7 @@ export function BranchPickerPopover({
 	align = "start",
 	children,
 	renderFooter,
+	onCloseAutoFocus,
 }: {
 	currentBranch: string;
 	/** Flat branch names. Used when `entries` is not provided. */
@@ -67,6 +68,9 @@ export function BranchPickerPopover({
 	align?: "start" | "center" | "end";
 	children: React.ReactNode;
 	renderFooter?: (helpers: { close: () => void }) => React.ReactNode;
+	/** Forwarded to the underlying popover content. Call `event.preventDefault()`
+	 *  when the trigger is wrapped in a Tooltip — otherwise focus return reopens it. */
+	onCloseAutoFocus?: (event: Event) => void;
 }) {
 	const [open, setOpen] = useState(false);
 	const close = () => setOpen(false);
@@ -84,7 +88,11 @@ export function BranchPickerPopover({
 			}}
 		>
 			<PopoverTrigger asChild>{children}</PopoverTrigger>
-			<CommandPopoverContent align={align} className="w-[260px]">
+			<CommandPopoverContent
+				align={align}
+				className="w-[260px]"
+				onCloseAutoFocus={onCloseAutoFocus}
+			>
 				<style>{scrollbarStyle}</style>
 				<div className="branch-picker">
 					<CommandInput placeholder="Search branches..." />

--- a/src/features/workspace-start/index.tsx
+++ b/src/features/workspace-start/index.tsx
@@ -351,7 +351,12 @@ export function WorkspaceStartPage({
 												/>
 											</TooltipContent>
 										</Tooltip>
-										<DropdownMenuContent align="center" className="min-w-56">
+										{/* Skip focus return so the wrapping Tooltip doesn't re-open via onFocus after selection. */}
+										<DropdownMenuContent
+											align="center"
+											className="min-w-56"
+											onCloseAutoFocus={(event) => event.preventDefault()}
+										>
 											{repositories.map((repository) => (
 												<DropdownMenuItem
 													key={repository.id}
@@ -500,7 +505,12 @@ export function WorkspaceStartPage({
 									Select where to run the task
 								</TooltipContent>
 							</Tooltip>
-							<DropdownMenuContent align="start" className="w-fit min-w-36">
+							{/* Skip focus return so the wrapping Tooltip doesn't re-open via onFocus after selection. */}
+							<DropdownMenuContent
+								align="start"
+								className="w-fit min-w-36"
+								onCloseAutoFocus={(event) => event.preventDefault()}
+							>
 								<DropdownMenuItem
 									onClick={() => onModeChange("local")}
 									className="gap-2 pr-3"
@@ -571,7 +581,12 @@ export function WorkspaceStartPage({
 											: "Fork a fresh branch off the picked base"}
 									</TooltipContent>
 								</Tooltip>
-								<DropdownMenuContent align="start" className="w-72">
+								{/* Skip focus return so the wrapping Tooltip doesn't re-open via onFocus after selection. */}
+								<DropdownMenuContent
+									align="start"
+									className="w-72"
+									onCloseAutoFocus={(event) => event.preventDefault()}
+								>
 									<DropdownMenuItem
 										onClick={() => onBranchIntentChange("from_branch")}
 										className="flex-col items-start gap-1 pr-3"
@@ -615,6 +630,8 @@ export function WorkspaceStartPage({
 										loading={branchesLoading}
 										onOpen={onOpenBranchPicker}
 										onSelect={onSelectBranch}
+										// Skip focus return so the wrapping Tooltip doesn't re-open via onFocus after selection.
+										onCloseAutoFocus={(event) => event.preventDefault()}
 										renderFooter={
 											mode === "local" && onCreateAndCheckoutBranch
 												? ({ close }) => (


### PR DESCRIPTION
## What changed

Fixed an interaction bug where dropdowns and popovers wrapped in tooltips would immediately re-open after a selection. This happened because the default focus-return behavior (`onCloseAutoFocus`) would return focus to the trigger element, which re-opened the tooltip.

## Why

When the user selected an option from a dropdown/popover, the tooltip would stubbornly reappear, creating a frustrating UX. The fix prevents focus return via `event.preventDefault()` in `onCloseAutoFocus` handlers.

## Changes

1. **BranchPickerPopover** (`src/components/branch-picker.tsx`): Added `onCloseAutoFocus` prop and forwarded it to the underlying `PopoverContent`.

2. **WorkspaceStartPage** (`src/features/workspace-start/index.tsx`): Applied `onCloseAutoFocus={(event) => event.preventDefault()}` to all `DropdownMenuContent` and `BranchPickerPopover` components wrapped in tooltips:
   - Repository picker dropdown
   - Mode selector ("local" / "remote") dropdown  
   - Branch intent selector dropdown
   - Branch picker popover

## Testing

Verified that:
- Selecting an option closes the dropdown/popover without re-opening the tooltip
- Tooltip still works normally when triggered independently
- All dropdown/popover selections remain functional