### PR TITLE
Show dirty submodules in Git changes

### DIFF
--- a/.changeset/show-submodule-changes.md
+++ b/.changeset/show-submodule-changes.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Show dirty submodules in the Git changes panel even when repository config ignores submodule diffs.

--- a/src-tauri/src/workspace/files/changes.rs
+++ b/src-tauri/src/workspace/files/changes.rs
@@ -82,17 +82,35 @@ pub fn list_workspace_changes(workspace_root_path: &str) -> Result<Vec<EditorFil
     ) = std::thread::scope(|s| {
         let h_committed = s.spawn(|| {
             git_ops::run_git(
-                ["diff", "--name-status", target_ref.as_str(), "HEAD"],
+                [
+                    "diff",
+                    "--ignore-submodules=none",
+                    "--name-status",
+                    target_ref.as_str(),
+                    "HEAD",
+                ],
                 Some(workspace_root),
             )
             .unwrap_or_default()
         });
         let h_unstaged = s.spawn(|| {
-            git_ops::run_git(["diff", "--name-status"], Some(workspace_root)).unwrap_or_default()
+            git_ops::run_git(
+                ["diff", "--ignore-submodules=none", "--name-status"],
+                Some(workspace_root),
+            )
+            .unwrap_or_default()
         });
         let h_staged = s.spawn(|| {
-            git_ops::run_git(["diff", "--name-status", "--cached"], Some(workspace_root))
-                .unwrap_or_default()
+            git_ops::run_git(
+                [
+                    "diff",
+                    "--ignore-submodules=none",
+                    "--name-status",
+                    "--cached",
+                ],
+                Some(workspace_root),
+            )
+            .unwrap_or_default()
         });
         let h_untracked = s.spawn(|| {
             git_ops::run_git(
@@ -103,15 +121,25 @@ pub fn list_workspace_changes(workspace_root_path: &str) -> Result<Vec<EditorFil
         });
         let tr = target_ref.as_str();
         let h_cn = s.spawn(move || {
-            git_ops::run_git(["diff", "--numstat", tr, "HEAD"], Some(workspace_root))
-                .unwrap_or_default()
+            git_ops::run_git(
+                ["diff", "--ignore-submodules=none", "--numstat", tr, "HEAD"],
+                Some(workspace_root),
+            )
+            .unwrap_or_default()
         });
         let h_sn = s.spawn(|| {
-            git_ops::run_git(["diff", "--numstat", "--cached"], Some(workspace_root))
-                .unwrap_or_default()
+            git_ops::run_git(
+                ["diff", "--ignore-submodules=none", "--numstat", "--cached"],
+                Some(workspace_root),
+            )
+            .unwrap_or_default()
         });
         let h_un = s.spawn(|| {
-            git_ops::run_git(["diff", "--numstat"], Some(workspace_root)).unwrap_or_default()
+            git_ops::run_git(
+                ["diff", "--ignore-submodules=none", "--numstat"],
+                Some(workspace_root),
+            )
+            .unwrap_or_default()
         });
         (
             h_committed.join().unwrap_or_default(),

--- a/src-tauri/src/workspace/files/tests/support.rs
+++ b/src-tauri/src/workspace/files/tests/support.rs
@@ -110,6 +110,10 @@ impl GitRepoHarness {
         git_ops::run_git(args.iter().copied(), Some(&self.root)).unwrap_or_default()
     }
 
+    pub(super) fn git_in(&self, cwd: &std::path::Path, args: &[&str]) -> String {
+        git_ops::run_git(args.iter().copied(), Some(cwd)).unwrap_or_default()
+    }
+
     pub(super) fn changes(&self) -> Vec<EditorFileListItem> {
         list_workspace_changes(self.path_str()).unwrap()
     }

--- a/src-tauri/src/workspace/files/tests/workspace_changes.rs
+++ b/src-tauri/src/workspace/files/tests/workspace_changes.rs
@@ -180,6 +180,45 @@ fn classification_discard_removes_from_changes() {
     );
 }
 
+#[test]
+fn classification_dirty_submodule_ignores_repo_diff_ignore_setting() {
+    let repo = GitRepoHarness::new();
+    let submodule_source = std::path::Path::new(repo_root(&repo))
+        .parent()
+        .unwrap()
+        .join("submodule-source");
+    std::fs::create_dir_all(&submodule_source).unwrap();
+    repo.git_in(&submodule_source, &["init", "-b", "main"]);
+    repo.git_in(
+        &submodule_source,
+        &["config", "user.email", "test@helmor.test"],
+    );
+    repo.git_in(&submodule_source, &["config", "user.name", "Test"]);
+    std::fs::write(submodule_source.join("nested.txt"), "base\n").unwrap();
+    repo.git_in(&submodule_source, &["add", "."]);
+    repo.git_in(&submodule_source, &["commit", "-m", "init submodule"]);
+
+    let submodule_url = submodule_source.to_str().unwrap();
+    repo.git(&[
+        "-c",
+        "protocol.file.allow=always",
+        "submodule",
+        "add",
+        submodule_url,
+        "libs/sub",
+    ]);
+    repo.git(&["commit", "-am", "add submodule"]);
+    repo.git(&["config", "diff.ignoreSubmodules", "dirty"]);
+    repo.write_file("libs/sub/nested.txt", "dirty\n");
+
+    let item = repo.find("libs/sub").expect("submodule should appear");
+    assert_eq!(
+        item.unstaged_status.as_deref(),
+        Some("M"),
+        "dirty submodule should surface as an unstaged modification: {item:?}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Per-area line counts. Each area (committed / staged / unstaged) reports
 // its own insertions/deletions; numbers must NOT be summed across areas.


### PR DESCRIPTION
## What changed

- Force Git change-list diffs to use `--ignore-submodules=none` so dirty submodule worktrees appear as modified entries.
- Add a regression test covering repositories configured with `diff.ignoreSubmodules=dirty`.
- Add a patch changeset.

## Why

Git config can suppress dirty submodule diffs, which made Helmor's Git changes panel miss submodule-local modifications.

Fixes #513.

## Test notes

- `cd src-tauri && cargo test workspace::files::tests::workspace_changes::classification_dirty_submodule_ignores_repo_diff_ignore_setting`
- `cd src-tauri && cargo test workspace::files::tests::workspace_changes`
- pre-commit hook: `cargo fmt --manifest-path src-tauri/Cargo.toml --all`
- pre-commit hook: `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`