### PR TITLE
fix(feedback): prevent dialog focus from causing window jump

### DIFF
--- a/.changeset/calm-feedback-focus.md
+++ b/.changeset/calm-feedback-focus.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix the feedback dialog opening with a brief window jump on workspace pages.

--- a/src/features/feedback/feedback-dialog.tsx
+++ b/src/features/feedback/feedback-dialog.tsx
@@ -125,7 +125,15 @@ export function FeedbackDialog({
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
-			<DialogContent className="flex flex-col gap-5 p-4 sm:max-w-md">
+			<DialogContent
+				className="flex flex-col gap-5 p-4 sm:max-w-md"
+				onOpenAutoFocus={(event) => {
+					event.preventDefault();
+					document
+						.getElementById("feedback-input")
+						?.focus({ preventScroll: true });
+				}}
+			>
 				<DialogHeader>
 					<DialogTitle className="text-[13px] font-medium tracking-[-0.01em]">
 						{state.step.kind === "input"

--- a/src/features/feedback/step-input.tsx
+++ b/src/features/feedback/step-input.tsx
@@ -49,33 +49,32 @@ export function StepInput({
 	return (
 		<div className="flex flex-col gap-3">
 			<Textarea
+				id="feedback-input"
 				value={input}
 				onChange={(event) => onInputChange(event.target.value)}
 				placeholder="Describe a bug, suggest an improvement, or ask a question."
-				autoFocus
 				aria-label="Feedback"
 				disabled={sending}
 				className="min-h-32"
 			/>
-			{!githubConnected ? (
-				<p className="text-xs text-muted-foreground">
-					Connect GitHub in{" "}
-					<Button
-						variant="link"
-						size="xs"
-						className="h-auto p-0 text-xs"
-						onClick={onOpenSettings}
-					>
-						Settings
-					</Button>{" "}
-					to send feedback.
-				</p>
-			) : null}
-			{existing && githubConnected && !confirming ? (
-				<p className="text-xs text-muted-foreground">
-					Will reuse your local helmor repo.
-				</p>
-			) : null}
+			<div className="min-h-4 text-xs text-muted-foreground">
+				{!githubConnected ? (
+					<>
+						Connect GitHub in{" "}
+						<Button
+							variant="link"
+							size="xs"
+							className="h-auto p-0 text-xs"
+							onClick={onOpenSettings}
+						>
+							Settings
+						</Button>{" "}
+						to send feedback.
+					</>
+				) : existing && !confirming ? (
+					"Will reuse your local helmor repo."
+				) : null}
+			</div>
 			<div className="mt-1 flex items-center justify-between gap-3">
 				<p className="text-xs text-muted-foreground">
 					{confirming


### PR DESCRIPTION
## Summary
Fixes the feedback dialog briefly jumping the window when opened on workspace pages by preventing the default focus behavior and manually controlling focus with `preventScroll: true`.

## Changes
- Removed `autoFocus` attribute from the textarea input
- Added manual focus control via `onOpenAutoFocus` in the dialog
- Used `preventScroll: true` to prevent unwanted scroll jumps
- Refactored conditional message rendering for clarity

## Testing
- [ ] Verify feedback dialog opens smoothly without window jumping on workspace pages
- [ ] Confirm text input still receives focus when dialog opens
- [ ] Test on different page types (conversation, workspace, etc.)