### PR TITLE
Fix Codex reasoning effort not following UI setting

### DIFF
--- a/sidecar/src/codex-app-server-manager.ts
+++ b/sidecar/src/codex-app-server-manager.ts
@@ -591,7 +591,11 @@ export class CodexAppServerManager implements SessionManager {
 		if (model) turnStartParams.model = model;
 		if (effortLevel) turnStartParams.effort = effortLevel;
 		if (effectiveFastMode) turnStartParams.serviceTier = "fast";
-		const codexMode = toCodexCollaborationMode(permissionMode, model);
+		const codexMode = toCodexCollaborationMode(
+			permissionMode,
+			model,
+			effortLevel,
+		);
 		if (codexMode) turnStartParams.collaborationMode = codexMode;
 		const codexApproval = toCodexApprovalPolicy(permissionMode);
 		if (codexApproval) turnStartParams.approvalPolicy = codexApproval;
@@ -1924,12 +1928,14 @@ function parseSkillsResponse(
 function toCodexCollaborationMode(
 	permissionMode: string | undefined,
 	model: string | undefined,
+	effortLevel: string | undefined,
 ): Record<string, unknown> | undefined {
 	if (permissionMode === "plan") {
 		return {
 			mode: "plan",
 			settings: {
 				...(model ? { model } : {}),
+				...(effortLevel ? { reasoning_effort: effortLevel } : {}),
 			},
 		};
 	}
@@ -1943,6 +1949,7 @@ function toCodexCollaborationMode(
 			mode: "default",
 			settings: {
 				...(model ? { model } : {}),
+				...(effortLevel ? { reasoning_effort: effortLevel } : {}),
 			},
 		};
 	}

--- a/sidecar/test/codex-app-server-manager.test.ts
+++ b/sidecar/test/codex-app-server-manager.test.ts
@@ -246,6 +246,43 @@ describe("CodexAppServerManager", () => {
 		);
 	});
 
+	test("forwards effort through codex collaboration mode settings", async () => {
+		const manager = new CodexAppServerManager();
+
+		await manager.sendMessage(
+			"REQ-effort-collab-mode",
+			{
+				sessionId: "session-effort",
+				prompt: "hello",
+				model: "gpt-5.4",
+				cwd: "/tmp",
+				resume: undefined,
+				permissionMode: "bypassPermissions",
+				effortLevel: "high",
+				fastMode: false,
+				images: [],
+			},
+			emitter,
+		);
+
+		const turnStart = serverState.requests.find(
+			(request) => request.method === "turn/start",
+		);
+
+		expect(turnStart?.params).toEqual(
+			expect.objectContaining({
+				effort: "high",
+				collaborationMode: {
+					mode: "default",
+					settings: {
+						model: "gpt-5.4",
+						reasoning_effort: "high",
+					},
+				},
+			}),
+		);
+	});
+
 	test("plan mode with additionalDirectories sets sandboxPolicy writableRoots including cwd", async () => {
 		const manager = new CodexAppServerManager();
 		gitAccessState.directories = ["/git/worktree-meta", "/git/common"];
@@ -259,7 +296,7 @@ describe("CodexAppServerManager", () => {
 				cwd: "/tmp/workspace",
 				resume: undefined,
 				permissionMode: "plan",
-				effortLevel: "medium",
+				effortLevel: "xhigh",
 				fastMode: false,
 				images: [],
 				// Include cwd explicitly to verify dedupe, and a duplicate
@@ -275,6 +312,14 @@ describe("CodexAppServerManager", () => {
 
 		expect(turnStart?.params).toEqual(
 			expect.objectContaining({
+				effort: "xhigh",
+				collaborationMode: {
+					mode: "plan",
+					settings: {
+						model: "gpt-5.4",
+						reasoning_effort: "xhigh",
+					},
+				},
 				sandboxPolicy: {
 					type: "workspaceWrite",
 					writableRoots: [


### PR DESCRIPTION
## Summary

Fixes Codex/GPT reasoning effort not reliably following the effort selected in the Helmor UI.

Helmor was already sending `turn/start.effort`, but when `collaborationMode` was also sent, its `settings` only included the model. Codex collaboration mode settings also support `reasoning_effort`, so the selected UI effort could be lost and Codex could fall back to its default behavior.

Fixes #587.

## Changes

- Pass `effortLevel` into Codex collaboration mode construction.
- Include `reasoning_effort` in Codex collaboration mode settings.
- Add sidecar tests covering default and plan collaboration modes.

## Testing

- `cd sidecar && bun test test/codex-app-server-manager.test.ts`
- `bun run typecheck`
