### PR TITLE
fix: snap chat to bottom when editor closes

### DIFF
--- a/.changeset/quick-editor-close-snap.md
+++ b/.changeset/quick-editor-close-snap.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix the chat visibly scrolling from the top down to the latest message every time the editor view closes.

--- a/src/features/panel/thread-viewport.tsx
+++ b/src/features/panel/thread-viewport.tsx
@@ -287,6 +287,51 @@ function ChatThread({
 		void scrollToBottom("instant");
 	}, [scrollToBottom, sessionId, usePlainThread]);
 
+	// Editor close path: when chat container's `hidden` class is removed,
+	// snap to bottom and pin for ~20 frames so the virtualized list's
+	// progressive content growth doesn't show as a long smooth scroll. A
+	// brief flash of top messages before the pin catches up is the accepted
+	// tradeoff for not breaking streaming animations.
+	useEffect(() => {
+		if (typeof MutationObserver === "undefined") {
+			return;
+		}
+		const scrollParent = scrollParentRef.current;
+		const chatContainer = scrollParent?.closest('[data-focus-scope="chat"]');
+		if (!chatContainer || !scrollParent) {
+			return;
+		}
+		let wasHidden = chatContainer.classList.contains("hidden");
+		let rafId: number | null = null;
+		const observer = new MutationObserver(() => {
+			const isHidden = chatContainer.classList.contains("hidden");
+			if (wasHidden && !isHidden) {
+				void scrollToBottom("instant");
+				let frames = 20;
+				const pin = () => {
+					scrollParent.scrollTop = scrollParent.scrollHeight;
+					if (frames-- > 0) {
+						rafId = requestAnimationFrame(pin);
+					} else {
+						rafId = null;
+					}
+				};
+				pin();
+			}
+			wasHidden = isHidden;
+		});
+		observer.observe(chatContainer, {
+			attributes: true,
+			attributeFilter: ["class"],
+		});
+		return () => {
+			observer.disconnect();
+			if (rafId !== null) {
+				cancelAnimationFrame(rafId);
+			}
+		};
+	}, [scrollToBottom]);
+
 	const itemContent = useCallback(
 		(index: number, message: RenderedMessage) => {
 			let previousAssistantMessage: RenderedMessage | null = null;


### PR DESCRIPTION
## Summary

Fixes the chat container visibly scrolling from top to bottom every time the editor pane closes.

## Changes

- Added a MutationObserver in thread-viewport.tsx to detect when the chat container exits the hidden state
- On unhiding, the viewport snaps to the bottom instantly and pins to that position for ~20 animation frames
- This prevents progressive content growth from appearing as a smooth scroll animation

## Notes

The brief flash of top messages before the pin catches up is an acceptable tradeoff for not breaking streaming animations. The pin duration (~20 frames) is short enough to be imperceptible in normal usage.