### PR TITLE
feat: automatically garbage-collect paste cache on session deletion

### DIFF
--- a/.changeset/auto-paste-cache-gc.md
+++ b/.changeset/auto-paste-cache-gc.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Automatically reclaim disk space from composer-pasted images once their session is deleted, so the paste cache no longer grows unbounded.

--- a/src-tauri/src/commands/session_commands.rs
+++ b/src-tauri/src/commands/session_commands.rs
@@ -37,6 +37,8 @@ pub async fn list_session_thread_messages(
     .await
 }
 
+/// `seed_session_id`: see `sessions::CreateSessionOverrides::seed_session_id` —
+/// frontend-provided UUID used as the new `sessions.id` when present.
 #[tauri::command]
 pub async fn create_session(
     workspace_id: String,
@@ -45,6 +47,7 @@ pub async fn create_session(
     model: Option<String>,
     effort_level: Option<String>,
     fast_mode: Option<bool>,
+    seed_session_id: Option<String>,
 ) -> CmdResult<sessions::CreateSessionResponse> {
     run_blocking(move || {
         sessions::create_session(
@@ -55,6 +58,7 @@ pub async fn create_session(
                 model: model.as_deref(),
                 effort_level: effort_level.as_deref(),
                 fast_mode,
+                seed_session_id: seed_session_id.as_deref(),
             },
         )
     })

--- a/src-tauri/src/commands/system_commands.rs
+++ b/src-tauri/src/commands/system_commands.rs
@@ -428,18 +428,14 @@ pub fn get_cli_status() -> CmdResult<CliStatus> {
     Ok(cli_status_for_paths(&install_path, &cli_binary))
 }
 
-/// File-backed React Query persister storage. The cache lives in the
-/// data dir (next to `helmor.db`) instead of localStorage, so it isn't
-/// bound by the webview's ~5–10 MB localStorage quota. The frontend
-/// addresses each cache key as a distinct file under
-/// `<data_dir>/query-cache/<key>` — only one key is in use today
-/// (`helmor-query-cache`), but the namespacing keeps the door open for
-/// the persister's optional `entries()` extension.
+/// File-backed React Query persister storage. The cache lives at
+/// `<data_dir>/cache/query/` instead of localStorage so it isn't bound
+/// by the webview's ~5–10 MB localStorage quota. The frontend addresses
+/// each cache key as a distinct file under this dir — only one key is
+/// in use today (`helmor-query-cache`), but the namespacing keeps the
+/// door open for the persister's optional `entries()` extension.
 fn query_cache_dir() -> anyhow::Result<PathBuf> {
-    let dir = data_dir::data_dir()?.join("query-cache");
-    std::fs::create_dir_all(&dir)
-        .with_context(|| format!("Failed to create query cache dir at {dir:?}"))?;
-    Ok(dir)
+    data_dir::query_cache_dir()
 }
 
 /// Reject anything that could escape the cache dir (`..`, `/`, etc.) —
@@ -1001,8 +997,15 @@ pub async fn drain_pending_cli_sends() -> CmdResult<Vec<service::PendingCliSend>
     run_blocking(service::drain_pending_cli_sends).await
 }
 
+/// `session_id` is the composer's bound `sessions.id` or its provisional
+/// UUID. Required — paste-cache GC keys on it (see
+/// `maintenance::paste_cache`).
 #[tauri::command]
-pub async fn save_pasted_image(data: String, media_type: String) -> CmdResult<String> {
+pub async fn save_pasted_image(
+    data: String,
+    media_type: String,
+    session_id: String,
+) -> CmdResult<String> {
     run_blocking(move || {
         use std::fs;
         use uuid::Uuid;
@@ -1014,7 +1017,10 @@ pub async fn save_pasted_image(data: String, media_type: String) -> CmdResult<St
             _ => "png",
         };
 
-        let paste_dir = crate::data_dir::data_dir()?.join("paste-cache");
+        // <paste-cache>/<session_id>/paste-<uuid>.<ext>; destination_dir
+        // bails on path-unsafe ids.
+        let paste_root = crate::data_dir::paste_cache_dir()?;
+        let paste_dir = crate::maintenance::paste_cache::destination_dir(&paste_root, &session_id)?;
         fs::create_dir_all(&paste_dir).context("Failed to create paste-cache directory")?;
 
         let filename = format!("paste-{}.{}", Uuid::new_v4(), ext);
@@ -1324,7 +1330,10 @@ pub async fn dev_reset_all_data(app: tauri::AppHandle) -> CmdResult<DevResetResu
         // --- Filesystem cleanup (best-effort) ----------------------------
         let mut dirs_removed = Vec::new();
 
-        let dirs_to_clear = [data_dir.join("workspaces"), data_dir.join("paste-cache")];
+        let dirs_to_clear = [
+            data_dir.join("workspaces"),
+            data_dir.join("cache").join("paste"),
+        ];
 
         for dir in &dirs_to_clear {
             if dir.is_dir() {

--- a/src-tauri/src/commands/tests/workspace_creation.rs
+++ b/src-tauri/src/commands/tests/workspace_creation.rs
@@ -96,6 +96,7 @@ fn prepare_local_workspace_keeps_current_branch_when_source_is_none() {
         &harness.repo_id,
         None,
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap();
 
@@ -158,6 +159,7 @@ fn prepare_local_workspace_switches_branch_when_source_differs() {
         &harness.repo_id,
         Some("develop"),
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap();
 
@@ -205,6 +207,7 @@ fn prepare_local_workspace_checks_out_remote_only_branch_via_dwim() {
         &harness.repo_id,
         Some("remote-only"),
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap();
 
@@ -535,6 +538,7 @@ fn prepare_local_workspace_rejects_dirty_tracked_changes() {
         &harness.repo_id,
         Some("develop"),
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap_err();
     let msg = format!("{err:#}");
@@ -560,6 +564,7 @@ fn prepare_local_workspace_allows_untracked_files_when_switching_branch() {
         &harness.repo_id,
         Some("develop"),
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap();
     assert_eq!(response.branch, "develop");
@@ -581,6 +586,7 @@ fn prepare_local_workspace_rolls_back_db_when_checkout_fails() {
         &harness.repo_id,
         Some(nonexistent),
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap_err();
     assert!(format!("{err:#}").to_lowercase().contains("checkout"));
@@ -605,6 +611,7 @@ fn finalize_workspace_from_repo_no_ops_for_local_workspace() {
         &harness.repo_id,
         None,
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap();
 
@@ -640,6 +647,7 @@ fn finalize_workspace_short_circuits_for_orphaned_initializing_local_row() {
         &harness.repo_id,
         None,
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap();
     // Force the row back into Initializing to mimic the orphaned state.
@@ -793,6 +801,7 @@ fn prepare_workspace_inserts_initializing_row_without_creating_worktree() {
         None,
         WorkspaceBranchIntent::FromBranch,
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap();
 
@@ -858,6 +867,7 @@ fn finalize_workspace_transitions_initializing_to_ready_and_creates_worktree() {
         None,
         WorkspaceBranchIntent::FromBranch,
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap();
     let workspace_dir = harness.workspace_dir(&prepared.directory_name);
@@ -906,6 +916,7 @@ fn finalize_workspace_reports_setup_pending_when_helmor_json_has_setup() {
         None,
         WorkspaceBranchIntent::FromBranch,
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap();
     let finalized = workspaces::finalize_workspace_from_repo_impl(&prepared.workspace_id).unwrap();
@@ -928,6 +939,7 @@ fn finalize_workspace_stays_ready_when_helmor_json_has_setup_but_auto_run_disabl
         None,
         WorkspaceBranchIntent::FromBranch,
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap();
     let finalized = workspaces::finalize_workspace_from_repo_impl(&prepared.workspace_id).unwrap();
@@ -949,6 +961,7 @@ fn finalize_workspace_cleans_up_row_on_worktree_failure() {
         None,
         WorkspaceBranchIntent::FromBranch,
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap();
 
@@ -989,6 +1002,7 @@ fn execute_archive_plan_short_circuits_for_local_workspace() {
         &harness.repo_id,
         None,
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap();
     fs::write(harness.source_repo_root.join("user.txt"), "important").unwrap();
@@ -1027,6 +1041,7 @@ fn archive_local_workspace_only_updates_db() {
         &harness.repo_id,
         None,
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap();
     fs::write(harness.source_repo_root.join("user.txt"), "important").unwrap();
@@ -1067,6 +1082,7 @@ fn restore_local_workspace_only_flips_state() {
         &harness.repo_id,
         None,
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap();
     workspaces::archive_workspace_impl(&prepared.workspace_id).unwrap();
@@ -1131,6 +1147,7 @@ fn validate_restore_local_workspace_short_circuits_to_no_conflict() {
         &harness.repo_id,
         None,
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap();
     workspaces::archive_workspace_impl(&prepared.workspace_id).unwrap();
@@ -1151,6 +1168,7 @@ fn move_local_workspace_to_worktree_carries_uncommitted_changes() {
         &harness.repo_id,
         None,
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap();
 
@@ -1235,6 +1253,7 @@ fn move_local_workspace_to_worktree_works_on_clean_local() {
         &harness.repo_id,
         None,
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap();
 
@@ -1260,6 +1279,7 @@ fn move_local_workspace_to_worktree_rejects_worktree_mode_workspace() {
         None,
         WorkspaceBranchIntent::FromBranch,
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap();
     workspaces::finalize_workspace_from_repo_impl(&prepared.workspace_id).unwrap();
@@ -1318,6 +1338,7 @@ fn finalize_workspace_is_idempotent_for_ready_workspace() {
         None,
         WorkspaceBranchIntent::FromBranch,
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap();
     let first = workspaces::finalize_workspace_from_repo_impl(&prepared.workspace_id).unwrap();
@@ -1347,6 +1368,7 @@ fn cleanup_orphaned_initializing_workspaces_purges_old_rows_and_cascades_session
         None,
         WorkspaceBranchIntent::FromBranch,
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap();
     let connection = Connection::open(harness.db_path()).unwrap();
@@ -1363,6 +1385,7 @@ fn cleanup_orphaned_initializing_workspaces_purges_old_rows_and_cascades_session
         None,
         WorkspaceBranchIntent::FromBranch,
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap();
 
@@ -1416,6 +1439,7 @@ fn git_action_status_returns_fresh_defaults_for_initializing_workspace() {
         None,
         WorkspaceBranchIntent::FromBranch,
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap();
 
@@ -1458,6 +1482,7 @@ fn pr_lookups_short_circuit_for_initializing_workspace_without_network() {
         None,
         WorkspaceBranchIntent::FromBranch,
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap();
 
@@ -1510,6 +1535,7 @@ fn load_repo_scripts_priority_1_worktree_helmor_json_wins() {
         None,
         WorkspaceBranchIntent::FromBranch,
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap();
     workspaces::finalize_workspace_from_repo_impl(&prepared.workspace_id).unwrap();
@@ -1554,6 +1580,7 @@ fn load_repo_scripts_priority_2_repo_root_wins_when_worktree_missing() {
         None,
         WorkspaceBranchIntent::FromBranch,
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap();
     let worktree_dir = harness.workspace_dir(&prepared.directory_name);
@@ -1591,6 +1618,7 @@ fn load_repo_scripts_priority_3_falls_through_to_db_when_no_helmor_json_anywhere
         None,
         WorkspaceBranchIntent::FromBranch,
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap();
     workspaces::finalize_workspace_from_repo_impl(&prepared.workspace_id).unwrap();
@@ -1622,6 +1650,7 @@ fn delete_workspace_and_session_rows_leaves_other_workspaces_intact() {
         None,
         WorkspaceBranchIntent::FromBranch,
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap();
     workspaces::finalize_workspace_from_repo_impl(&keep.workspace_id).unwrap();
@@ -1630,6 +1659,7 @@ fn delete_workspace_and_session_rows_leaves_other_workspaces_intact() {
         None,
         WorkspaceBranchIntent::FromBranch,
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap();
     workspaces::finalize_workspace_from_repo_impl(&drop.workspace_id).unwrap();
@@ -1702,6 +1732,7 @@ fn cleanup_orphaned_initializing_workspaces_skips_non_initializing_states() {
         None,
         WorkspaceBranchIntent::FromBranch,
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap();
     workspaces::finalize_workspace_from_repo_impl(&prepared.workspace_id).unwrap();
@@ -1738,9 +1769,13 @@ fn prepare_local_workspace_with_backlog_initial_status_lands_in_backlog() {
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     let harness = CreateTestHarness::new();
 
-    let response =
-        workspaces::prepare_local_workspace_impl(&harness.repo_id, None, WorkspaceStatus::Backlog)
-            .unwrap();
+    let response = workspaces::prepare_local_workspace_impl(
+        &harness.repo_id,
+        None,
+        WorkspaceStatus::Backlog,
+        None,
+    )
+    .unwrap();
 
     let connection = Connection::open(harness.db_path()).unwrap();
     let status: String = connection
@@ -1769,6 +1804,7 @@ fn prepare_workspace_from_repo_with_backlog_initial_status_lands_in_backlog() {
         None,
         WorkspaceBranchIntent::FromBranch,
         WorkspaceStatus::Backlog,
+        None,
     )
     .unwrap();
 
@@ -1800,6 +1836,7 @@ fn prepare_workspace_use_branch_stores_existing_branch_verbatim() {
         Some("feature/reuse-me"),
         WorkspaceBranchIntent::UseBranch,
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap();
 
@@ -1837,6 +1874,7 @@ fn prepare_workspace_use_branch_errors_when_branch_missing() {
         Some("nope/does-not-exist"),
         WorkspaceBranchIntent::UseBranch,
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap_err();
 
@@ -1858,6 +1896,7 @@ fn prepare_workspace_use_branch_errors_when_branch_already_checked_out_elsewhere
         Some("feature/in-use"),
         WorkspaceBranchIntent::UseBranch,
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap();
     workspaces::finalize_workspace_from_repo_impl(&prior.workspace_id).unwrap();
@@ -1867,6 +1906,7 @@ fn prepare_workspace_use_branch_errors_when_branch_already_checked_out_elsewhere
         Some("feature/in-use"),
         WorkspaceBranchIntent::UseBranch,
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap_err();
 
@@ -1891,6 +1931,7 @@ fn prepare_workspace_use_branch_errors_when_source_branch_omitted() {
         None,
         WorkspaceBranchIntent::UseBranch,
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap_err();
 
@@ -1912,6 +1953,7 @@ fn finalize_workspace_use_branch_attaches_worktree_to_existing_branch() {
         Some("feature/attach-me"),
         WorkspaceBranchIntent::UseBranch,
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap();
     let finalized = workspaces::finalize_workspace_from_repo_impl(&prepared.workspace_id).unwrap();
@@ -1939,6 +1981,7 @@ fn finalize_workspace_use_branch_does_not_delete_branch_on_failure() {
         Some("feature/keep-me"),
         WorkspaceBranchIntent::UseBranch,
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap();
 
@@ -1998,6 +2041,7 @@ fn finalize_workspace_from_branch_falls_back_to_local_ref_when_remote_missing() 
         Some("wip/local-only"),
         WorkspaceBranchIntent::FromBranch,
         WorkspaceStatus::InProgress,
+        None,
     )
     .unwrap();
     let finalized = workspaces::finalize_workspace_from_repo_impl(&prepared.workspace_id).unwrap();

--- a/src-tauri/src/commands/workspace_commands.rs
+++ b/src-tauri/src/commands/workspace_commands.rs
@@ -21,6 +21,9 @@ fn notify_workspace_changed_in_background(app: AppHandle) {
 /// frontend should follow up with `finalize_workspace_from_repo` to kick
 /// off the slow git worktree creation; UI remains visible during that
 /// phase with state=initializing.
+/// `seed_session_id`: frontend-provided UUID for the initial session
+/// row, so pre-submit paste-cache files (`cache/paste/<seed>/`) survive
+/// submit. Backend mints one when absent.
 #[tauri::command]
 pub async fn prepare_workspace_from_repo(
     app: AppHandle,
@@ -29,6 +32,7 @@ pub async fn prepare_workspace_from_repo(
     mode: Option<crate::workspace_state::WorkspaceMode>,
     branch_intent: Option<crate::workspace_state::WorkspaceBranchIntent>,
     initial_status: Option<WorkspaceStatus>,
+    seed_session_id: Option<String>,
 ) -> CmdResult<workspaces::PrepareWorkspaceResponse> {
     let mode = mode.unwrap_or_default();
     let branch_intent = branch_intent.unwrap_or_default();
@@ -42,6 +46,7 @@ pub async fn prepare_workspace_from_repo(
                     source_branch.as_deref(),
                     branch_intent,
                     initial_status,
+                    seed_session_id.as_deref(),
                 )
             }
             crate::workspace_state::WorkspaceMode::Local => {
@@ -50,6 +55,7 @@ pub async fn prepare_workspace_from_repo(
                     &repo_id,
                     source_branch.as_deref(),
                     initial_status,
+                    seed_session_id.as_deref(),
                 )
             }
             crate::workspace_state::WorkspaceMode::Chat => {
@@ -70,15 +76,20 @@ pub async fn prepare_workspace_from_repo(
 /// bound to any repository — they're a scratch directory under
 /// `<data_dir>/chats/<YYYY-MM-DD>/new-chat[-N]` used as cwd for a plain
 /// AI chat session. No git, no branch, no finalize phase.
+/// `seed_session_id`: see `prepare_workspace_from_repo`.
 #[tauri::command]
 pub async fn prepare_chat_workspace(
     app: AppHandle,
     initial_status: Option<WorkspaceStatus>,
+    seed_session_id: Option<String>,
 ) -> CmdResult<workspaces::PrepareWorkspaceResponse> {
     let initial_status = initial_status.unwrap_or_default();
     let result = {
         let _lock = db::WORKSPACE_FS_MUTATION_LOCK.lock().await;
-        run_blocking(move || workspaces::prepare_chat_workspace_impl(initial_status)).await?
+        run_blocking(move || {
+            workspaces::prepare_chat_workspace_impl(initial_status, seed_session_id.as_deref())
+        })
+        .await?
     };
     notify_workspace_changed_in_background(app);
     Ok(result)

--- a/src-tauri/src/data_dir.rs
+++ b/src-tauri/src/data_dir.rs
@@ -90,15 +90,39 @@ pub fn generated_images_dir() -> Result<PathBuf> {
     Ok(dir)
 }
 
-/// Returns the avatar cache directory inside the data dir. Forge account
-/// avatars (gh / glab) are downloaded once and served via `asset://` so
-/// page navigations don't re-trigger HTTP fetch + image decode.
-pub fn avatar_cache_dir() -> Result<PathBuf> {
-    let dir = data_dir()?.join("cache").join("avatars");
+/// Returns `<data_dir>/cache/<kind>/`, creating it if missing. All
+/// disposable caches live under `cache/` so the data-dir root stays
+/// small and scannable.
+pub fn cache_dir(kind: &str) -> Result<PathBuf> {
+    debug_assert!(
+        !kind.is_empty()
+            && kind
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'),
+        "cache kind must match [A-Za-z0-9_-]+: {kind}",
+    );
+    let dir = data_dir()?.join("cache").join(kind);
     if !dir.exists() {
-        fs::create_dir_all(&dir).context("Failed to create avatar cache directory")?;
+        fs::create_dir_all(&dir)
+            .with_context(|| format!("Failed to create cache dir {}", dir.display()))?;
     }
     Ok(dir)
+}
+
+/// Forge account avatars (gh / glab), served via `asset://`.
+pub fn avatar_cache_dir() -> Result<PathBuf> {
+    cache_dir("avatars")
+}
+
+/// Composer-pasted images, bucketed by session id. See
+/// `crate::maintenance::paste_cache` for GC.
+pub fn paste_cache_dir() -> Result<PathBuf> {
+    cache_dir("paste")
+}
+
+/// React Query persister cache (one file per cache key).
+pub fn query_cache_dir() -> Result<PathBuf> {
+    cache_dir("query")
 }
 
 /// Returns the Conductor source database path for import.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ pub mod global_hotkey;
 pub mod image_store;
 mod import;
 pub mod logging;
+pub mod maintenance;
 pub mod mcp;
 pub mod models;
 pub mod pipeline;
@@ -122,6 +123,20 @@ pub fn run() {
                     })
                     .ok();
             }
+
+            // GC orphan `cache/paste/<id>/` buckets. Off the main thread
+            // — slow IO can't stall startup. Legacy `paste-cache/` and
+            // `query-cache/` at the data-dir root are intentionally
+            // left alone (historical messages embed absolute paths into
+            // them).
+            std::thread::Builder::new()
+                .name("helmor-paste-cache-sweep".into())
+                .spawn(|| {
+                    if let Err(error) = maintenance::paste_cache::sweep() {
+                        tracing::warn!(error = %error, "paste-cache sweep failed");
+                    }
+                })
+                .ok();
 
             // Reconcile workspaces whose directory was deleted outside the
             // app: degrade them to `archived` so chat history is preserved

--- a/src-tauri/src/maintenance/mod.rs
+++ b/src-tauri/src/maintenance/mod.rs
@@ -1,0 +1,5 @@
+//! Best-effort cleanup of data-dir state that the rest of the app can't
+//! treat as authoritative. Each sub-module owns one resource and exposes
+//! a `sweep()` for boot-time GC.
+
+pub mod paste_cache;

--- a/src-tauri/src/maintenance/paste_cache.rs
+++ b/src-tauri/src/maintenance/paste_cache.rs
@@ -1,0 +1,300 @@
+//! GC for `<data_dir>/cache/paste/`.
+//!
+//! ```text
+//! cache/paste/<session_id>/paste-<uuid>.<ext>
+//! ```
+//!
+//! Bucket id is either a live `sessions.id` or a provisional UUID
+//! pre-allocated by the composer (StartPage flow); a successful submit
+//! reuses the provisional id as `sessions.id`, no rename. Sweep diffs
+//! disk against `sessions.id` and reclaims unmatched buckets older than
+//! [`UNCLAIMED_GRACE`] — the grace window protects unsubmitted
+//! StartPage drafts whose paste refs live in localStorage (invisible to
+//! the sweeper).
+
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use anyhow::{bail, Context, Result};
+
+use crate::data_dir;
+use crate::models::db;
+
+/// Window granted to unclaimed buckets before reclamation. Covers the
+/// "paste → maybe submit later" gap for StartPage drafts that the
+/// sweeper can't see via the DB.
+const UNCLAIMED_GRACE: Duration = Duration::from_secs(5 * 24 * 60 * 60);
+
+/// Recognised bucket name: `[0-9a-f-]` up to 64 chars. Permissive on
+/// UUID format, strict on traversal / casing.
+fn is_managed_session_dir_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= 64
+        && name.chars().all(|c| c.is_ascii_hexdigit() || c == '-')
+        && !name.contains('/')
+        && !name.contains(std::path::MAIN_SEPARATOR)
+}
+
+/// Sweep orphan buckets. Returns bytes freed. Best-effort: I/O errors
+/// log and are swallowed.
+///
+/// Ordering matters: `read_dir` runs **before** the sessions query so a
+/// session created between the two reads (and its just-written bucket)
+/// stays invisible to this pass instead of being wiped.
+pub fn sweep() -> Result<u64> {
+    let dir = data_dir::paste_cache_dir()?;
+
+    let sweep_start = SystemTime::now();
+
+    let entries = match fs::read_dir(&dir) {
+        Ok(e) => e,
+        Err(err) => {
+            tracing::warn!(
+                error = %err,
+                dir = %dir.display(),
+                "paste-cache sweep: read_dir failed",
+            );
+            return Ok(0);
+        }
+    };
+
+    // Materialise listing before the DB query (see fn doc).
+    let snapshot: Vec<_> = entries.flatten().collect();
+
+    let live_sessions = match load_live_session_ids() {
+        Ok(set) => set,
+        Err(err) => {
+            tracing::warn!(error = %err, "paste-cache sweep: sessions query failed; skipping");
+            return Ok(0);
+        }
+    };
+
+    let mut freed: u64 = 0;
+    let mut removed_dirs: usize = 0;
+
+    for entry in snapshot {
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        let metadata = match entry.metadata() {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+
+        // Top-level files (legacy flat layout, .DS_Store, …) are out of scope.
+        if !metadata.is_dir() {
+            continue;
+        }
+
+        if !is_managed_session_dir_name(name) {
+            continue;
+        }
+        if live_sessions.contains(name) {
+            continue;
+        }
+
+        // Race guard: bucket created during this sweep.
+        if dir_mtime_is_after(&metadata, sweep_start) {
+            continue;
+        }
+
+        // Unclaimed-draft grace window.
+        if !dir_mtime_is_before(&metadata, sweep_start - UNCLAIMED_GRACE) {
+            continue;
+        }
+
+        let bytes = dir_size(&path);
+        match fs::remove_dir_all(&path) {
+            Ok(()) => {
+                freed += bytes;
+                removed_dirs += 1;
+            }
+            Err(err) => {
+                tracing::warn!(
+                    error = %err,
+                    path = %path.display(),
+                    "paste-cache sweep: remove_dir_all failed",
+                );
+            }
+        }
+    }
+
+    if removed_dirs > 0 {
+        tracing::info!(
+            removed_session_dirs = removed_dirs,
+            freed_bytes = freed,
+            "paste-cache sweep done",
+        );
+    }
+    Ok(freed)
+}
+
+fn load_live_session_ids() -> Result<HashSet<String>> {
+    let conn = db::read_conn()?;
+    let mut stmt = conn
+        .prepare_cached("SELECT id FROM sessions")
+        .context("prepare sessions id scan")?;
+    let rows = stmt
+        .query_map([], |row| row.get::<_, String>(0))
+        .context("run sessions id scan")?;
+    let mut out = HashSet::new();
+    for row in rows {
+        out.insert(row.context("read sessions.id")?);
+    }
+    Ok(out)
+}
+
+fn dir_mtime_is_after(metadata: &fs::Metadata, cutoff: SystemTime) -> bool {
+    metadata.modified().map(|m| m > cutoff).unwrap_or(false)
+}
+
+/// Unreadable mtime → `false` (preserve, don't gamble on deletion).
+fn dir_mtime_is_before(metadata: &fs::Metadata, cutoff: SystemTime) -> bool {
+    metadata.modified().map(|m| m < cutoff).unwrap_or(false)
+}
+
+fn dir_size(path: &Path) -> u64 {
+    let mut total: u64 = 0;
+    let mut stack = vec![path.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let p = entry.path();
+            let Ok(meta) = entry.metadata() else {
+                continue;
+            };
+            if meta.is_dir() {
+                stack.push(p);
+            } else if meta.is_file() {
+                total += meta.len();
+            }
+        }
+    }
+    total
+}
+
+/// Bucket path for a fresh paste. Bails on missing / malformed ids
+/// instead of falling back, so the sweeper can always reason about
+/// ownership.
+pub fn destination_dir(root: &Path, session_id: &str) -> Result<PathBuf> {
+    let trimmed = session_id.trim();
+    if trimmed.is_empty() {
+        bail!("paste-cache: session_id is required (got empty string)");
+    }
+    if !is_managed_session_dir_name(trimmed) {
+        bail!(
+            "paste-cache: rejecting malformed session_id (len={}, sample prefix={:?})",
+            trimmed.len(),
+            &trimmed.chars().take(8).collect::<String>(),
+        );
+    }
+    Ok(root.join(trimmed))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+    use std::io::Write;
+    use std::time::Duration;
+
+    #[test]
+    fn destination_uses_session_subdir_when_id_safe() {
+        let root = Path::new("/tmp/paste-cache");
+        let dest = destination_dir(root, "a1b2c3d4-1111-2222-3333-444455556666").unwrap();
+        assert_eq!(dest, root.join("a1b2c3d4-1111-2222-3333-444455556666"));
+    }
+
+    #[test]
+    fn destination_rejects_empty_id() {
+        let root = Path::new("/tmp/paste-cache");
+        assert!(destination_dir(root, "").is_err());
+        assert!(destination_dir(root, "   ").is_err());
+    }
+
+    #[test]
+    fn destination_rejects_unsafe_ids() {
+        let root = Path::new("/tmp/paste-cache");
+        assert!(destination_dir(root, "../escape").is_err());
+        assert!(destination_dir(root, "session/with/slash").is_err());
+        assert!(destination_dir(root, "UPPERCASE-NOT-UUID").is_err());
+        let too_long: String = "a".repeat(65);
+        assert!(destination_dir(root, &too_long).is_err());
+    }
+
+    #[test]
+    fn is_managed_session_dir_name_accepts_uuid_v4() {
+        assert!(is_managed_session_dir_name(
+            "a1b2c3d4-1111-2222-3333-444455556666"
+        ));
+    }
+
+    #[test]
+    fn is_managed_session_dir_name_rejects_traversal_and_garbage() {
+        assert!(!is_managed_session_dir_name(""));
+        assert!(!is_managed_session_dir_name(".."));
+        assert!(!is_managed_session_dir_name("README.md"));
+        assert!(!is_managed_session_dir_name(".DS_Store"));
+        assert!(!is_managed_session_dir_name("_unbound"));
+        assert!(!is_managed_session_dir_name("paste-aaaa.png"));
+    }
+
+    #[test]
+    fn dir_size_sums_recursively() {
+        let dir = tempfile::tempdir().unwrap();
+        File::create(dir.path().join("a.bin"))
+            .unwrap()
+            .write_all(&[0u8; 10])
+            .unwrap();
+        let sub = dir.path().join("sub");
+        fs::create_dir(&sub).unwrap();
+        File::create(sub.join("b.bin"))
+            .unwrap()
+            .write_all(&[0u8; 25])
+            .unwrap();
+        assert_eq!(dir_size(dir.path()), 35);
+    }
+
+    #[test]
+    fn dir_mtime_is_after_works_with_real_files() {
+        let dir = tempfile::tempdir().unwrap();
+        File::create(dir.path().join("x")).unwrap();
+        let metadata = fs::metadata(dir.path()).unwrap();
+        let past = SystemTime::now() - Duration::from_secs(3600);
+        assert!(dir_mtime_is_after(&metadata, past));
+        let future = SystemTime::now() + Duration::from_secs(3600);
+        assert!(!dir_mtime_is_after(&metadata, future));
+    }
+
+    #[test]
+    fn dir_mtime_is_before_inverts_correctly() {
+        let dir = tempfile::tempdir().unwrap();
+        File::create(dir.path().join("x")).unwrap();
+        let metadata = fs::metadata(dir.path()).unwrap();
+        let past = SystemTime::now() - Duration::from_secs(3600);
+        let future = SystemTime::now() + Duration::from_secs(3600);
+        assert!(!dir_mtime_is_before(&metadata, past));
+        assert!(dir_mtime_is_before(&metadata, future));
+    }
+
+    #[test]
+    fn unclaimed_grace_protects_recent_buckets() {
+        let dir = tempfile::tempdir().unwrap();
+        File::create(dir.path().join("paste-aaaa.png")).unwrap();
+        let metadata = fs::metadata(dir.path()).unwrap();
+        let cutoff = SystemTime::now() - UNCLAIMED_GRACE;
+        assert!(!dir_mtime_is_before(&metadata, cutoff));
+    }
+
+    #[test]
+    fn unclaimed_grace_is_five_days() {
+        // Pin the policy: bare edit shouldn't silently change the
+        // user-visible draft-protection window.
+        assert_eq!(UNCLAIMED_GRACE, Duration::from_secs(5 * 24 * 60 * 60));
+    }
+}

--- a/src-tauri/src/models/repos.rs
+++ b/src-tauri/src/models/repos.rs
@@ -1108,7 +1108,9 @@ fn normalize_repo_preference(value: Option<&str>) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
-/// Delete a repository and all related data (workspaces, sessions, messages, etc.)
+/// Delete a repository and all related data (workspaces, sessions, messages, etc.).
+/// Paste-cache buckets owned by deleted sessions are reclaimed on next
+/// boot by `maintenance::paste_cache::sweep`.
 pub fn delete_repository_cascade(repo_id: &str) -> Result<()> {
     let mut connection = db::write_conn()?;
     let tx = connection

--- a/src-tauri/src/models/sessions.rs
+++ b/src-tauri/src/models/sessions.rs
@@ -450,6 +450,10 @@ pub struct CreateSessionOverrides<'a> {
     pub model: Option<&'a str>,
     pub effort_level: Option<&'a str>,
     pub fast_mode: Option<bool>,
+    /// Caller-provided UUID for the new `sessions.id`, so pre-existing
+    /// `cache/paste/<seed>/` files end up owned by this session.
+    /// Malformed → fresh UUID (see `lifecycle::resolve_seed_session_id`).
+    pub seed_session_id: Option<&'a str>,
 }
 
 pub fn create_session(
@@ -492,7 +496,8 @@ pub fn create_session(
         bail!("Workspace {workspace_id} does not exist");
     }
 
-    let session_id = uuid::Uuid::new_v4().to_string();
+    let session_id =
+        crate::workspace::lifecycle::resolve_seed_session_id(overrides.seed_session_id);
     let title = default_session_title_for_action_kind_with_workspace(
         &transaction,
         workspace_id,

--- a/src-tauri/src/workspace/lifecycle.rs
+++ b/src-tauri/src/workspace/lifecycle.rs
@@ -122,6 +122,23 @@ pub struct TargetBranchConflict {
     pub remote: String,
 }
 
+/// Caller-provided UUID for the new session row, or a freshly minted
+/// one. Malformed seeds (anything outside `[0-9a-f-]`, >64 chars) are
+/// rejected so path traversal can't reach the workspace row.
+pub(crate) fn resolve_seed_session_id(seed: Option<&str>) -> String {
+    let trimmed = seed.map(str::trim).filter(|s| !s.is_empty());
+    if let Some(value) = trimmed {
+        if value.chars().all(|c| c.is_ascii_hexdigit() || c == '-') && value.len() <= 64 {
+            return value.to_string();
+        }
+        tracing::warn!(
+            seed_len = value.len(),
+            "prepare_*_impl: rejecting malformed seed_session_id; generating fresh UUID",
+        );
+    }
+    uuid::Uuid::new_v4().to_string()
+}
+
 /// Phase 1: fast prep (DB row + metadata). Phase 2 materializes the
 /// worktree. `branch_intent::FromBranch` treats `source_branch` as the
 /// fork base; `UseBranch` treats it as the existing branch to attach to.
@@ -130,6 +147,7 @@ pub fn prepare_workspace_from_repo_impl(
     source_branch: Option<&str>,
     branch_intent: WorkspaceBranchIntent,
     initial_status: WorkspaceStatus,
+    seed_session_id: Option<&str>,
 ) -> Result<PrepareWorkspaceResponse> {
     let repository = repos::load_repository_by_id(repo_id)?
         .with_context(|| format!("Repository not found: {repo_id}"))?;
@@ -193,7 +211,7 @@ pub fn prepare_workspace_from_repo_impl(
     };
 
     let workspace_id = uuid::Uuid::new_v4().to_string();
-    let session_id = uuid::Uuid::new_v4().to_string();
+    let session_id = resolve_seed_session_id(seed_session_id);
     let timestamp = db::current_timestamp()?;
 
     workspace_models::insert_initializing_workspace_and_session(
@@ -291,6 +309,7 @@ pub fn prepare_local_workspace_impl(
     repo_id: &str,
     source_branch: Option<&str>,
     initial_status: WorkspaceStatus,
+    seed_session_id: Option<&str>,
 ) -> Result<PrepareWorkspaceResponse> {
     let repository = repos::load_repository_by_id(repo_id)?
         .with_context(|| format!("Repository not found: {repo_id}"))?;
@@ -329,7 +348,7 @@ pub fn prepare_local_workspace_impl(
     // Local shares the repo root; empty directory_name is fine.
     let directory_name = String::new();
     let workspace_id = uuid::Uuid::new_v4().to_string();
-    let session_id = uuid::Uuid::new_v4().to_string();
+    let session_id = resolve_seed_session_id(seed_session_id);
     let timestamp = db::current_timestamp()?;
 
     // DB insert before any git mutation. Local mode tags as UseBranch
@@ -411,6 +430,7 @@ pub fn prepare_local_workspace_impl(
 /// for chat workspaces (the row is already `Ready`).
 pub fn prepare_chat_workspace_impl(
     initial_status: WorkspaceStatus,
+    seed_session_id: Option<&str>,
 ) -> Result<PrepareWorkspaceResponse> {
     // Lazy-upsert the synthetic `__chat__` repo row on first chat
     // creation. Doing it here (rather than at schema migration time)
@@ -427,7 +447,7 @@ pub fn prepare_chat_workspace_impl(
 
     let (directory_name, working_directory) = helpers::allocate_chat_workspace_dir()?;
     let workspace_id = uuid::Uuid::new_v4().to_string();
-    let session_id = uuid::Uuid::new_v4().to_string();
+    let session_id = resolve_seed_session_id(seed_session_id);
     let timestamp = db::current_timestamp()?;
 
     // The scratch dir is already on disk; anything that fails from here
@@ -842,6 +862,7 @@ pub fn create_workspace_from_repo_impl(repo_id: &str) -> Result<CreateWorkspaceR
         None,
         WorkspaceBranchIntent::FromBranch,
         WorkspaceStatus::default(),
+        None,
     )?;
     let finalized = finalize_workspace_from_repo_impl(&prepared.workspace_id)?;
 

--- a/src-tauri/src/workspace/workspaces.rs
+++ b/src-tauri/src/workspace/workspaces.rs
@@ -1507,7 +1507,9 @@ pub fn permanently_delete_workspace(workspace_id: &str) -> Result<()> {
         )
         .ok();
 
-    // Delete all DB records in a transaction
+    // Delete all DB records in a transaction. Paste-cache buckets owned
+    // by deleted sessions are reclaimed on next boot by
+    // `maintenance::paste_cache::sweep`.
     let transaction = connection
         .transaction()
         .context("Failed to start delete workspace transaction")?;
@@ -2128,6 +2130,7 @@ mod tests {
 
         let response = super::super::lifecycle::prepare_chat_workspace_impl(
             crate::workspace_status::WorkspaceStatus::InProgress,
+            None,
         )
         .unwrap();
 
@@ -2179,6 +2182,7 @@ mod tests {
         insert_chat_repo(&env);
         let response = super::super::lifecycle::prepare_chat_workspace_impl(
             crate::workspace_status::WorkspaceStatus::InProgress,
+            None,
         )
         .unwrap();
 
@@ -2223,10 +2227,12 @@ mod tests {
         insert_chat_repo(&env);
         let a = super::super::lifecycle::prepare_chat_workspace_impl(
             crate::workspace_status::WorkspaceStatus::InProgress,
+            None,
         )
         .unwrap();
         let b = super::super::lifecycle::prepare_chat_workspace_impl(
             crate::workspace_status::WorkspaceStatus::InProgress,
+            None,
         )
         .unwrap();
 
@@ -2260,6 +2266,7 @@ mod tests {
         insert_chat_repo(&env);
         let response = super::super::lifecycle::prepare_chat_workspace_impl(
             crate::workspace_status::WorkspaceStatus::InProgress,
+            None,
         )
         .unwrap();
         let scratch_dir = response.working_directory.clone().unwrap();
@@ -2288,6 +2295,7 @@ mod tests {
         insert_chat_repo(&env);
         let response = super::super::lifecycle::prepare_chat_workspace_impl(
             crate::workspace_status::WorkspaceStatus::InProgress,
+            None,
         )
         .unwrap();
         let scratch_dir = response.working_directory.clone().unwrap();
@@ -2316,6 +2324,7 @@ mod tests {
         insert_chat_repo(&env);
         let response = super::super::lifecycle::prepare_chat_workspace_impl(
             crate::workspace_status::WorkspaceStatus::InProgress,
+            None,
         )
         .unwrap();
 

--- a/src/App.create.test.tsx
+++ b/src/App.create.test.tsx
@@ -404,6 +404,8 @@ describe("App create workspace flow", () => {
 				"worktree",
 				"from_branch",
 				null,
+				// Composer-minted provisional session id; opaque UUID.
+				expect.any(String),
 			);
 		});
 		await waitFor(() => {
@@ -462,6 +464,8 @@ describe("App create workspace flow", () => {
 				"worktree",
 				"from_branch",
 				null,
+				// Composer-minted provisional session id; opaque UUID.
+				expect.any(String),
 			);
 		});
 		await waitFor(() => {

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -174,6 +174,8 @@ type WorkspaceComposerContainerProps = {
 		 *  freshly-created session's `sessions.draft_state`) can do so
 		 *  without re-encoding the badge nodes. */
 		editorStateSnapshot?: SerializedEditorState;
+		/** Mount-time provisional session id (see `ComposerSubmitPayload`). */
+		provisionalSessionId?: string;
 	}) => void;
 	/** Prompt queued by an external caller to auto-submit once the displayed
 	 *  session matches `sessionId`. Per-session config (model / effort /
@@ -718,6 +720,7 @@ export const WorkspaceComposerContainer = memo(
 					oppositeFollowUp?: boolean;
 					startSubmitMode?: StartSubmitMode;
 					editorStateSnapshot?: SerializedEditorState;
+					provisionalSessionId?: string;
 				},
 			) => {
 				if (!effectiveModel) {
@@ -745,6 +748,7 @@ export const WorkspaceComposerContainer = memo(
 					followUpBehaviorOverride,
 					startSubmitMode: options?.startSubmitMode,
 					editorStateSnapshot: options?.editorStateSnapshot,
+					provisionalSessionId: options?.provisionalSessionId,
 				});
 			},
 			[

--- a/src/features/composer/editor/plugins/paste-image-plugin.tsx
+++ b/src/features/composer/editor/plugins/paste-image-plugin.tsx
@@ -19,7 +19,7 @@ import {
 	COMMAND_PRIORITY_CRITICAL,
 	PASTE_COMMAND,
 } from "lexical";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { savePastedImage } from "@/lib/api";
 import { buildComposerPreviewInsertItem } from "@/lib/composer-insert";
 import { isImagePath } from "@/lib/path-util";
@@ -75,8 +75,20 @@ function getClipboardData(event: unknown) {
 	);
 }
 
-export function PasteImagePlugin() {
+export function PasteImagePlugin({
+	sessionId,
+}: {
+	/**
+	 * Paste-cache bucket id: composer's bound `sessions.id` or its
+	 * provisional UUID. Always non-null — parent resolves
+	 * `bound ?? provisional` before passing. Read via ref so a session
+	 * switch doesn't re-register the paste command.
+	 */
+	sessionId: string;
+}) {
 	const [editor] = useLexicalComposerContext();
+	const sessionIdRef = useRef<string>(sessionId);
+	sessionIdRef.current = sessionId;
 
 	useEffect(() => {
 		return editor.registerCommand(
@@ -98,7 +110,9 @@ export function PasteImagePlugin() {
 
 					for (const file of imageFiles) {
 						readFileAsBase64(file)
-							.then((base64) => savePastedImage(base64, file.type))
+							.then((base64) =>
+								savePastedImage(base64, file.type, sessionIdRef.current),
+							)
 							.then((savedPath) => {
 								editor.update(() => {
 									// Use $appendToEnd instead of selection-based insert,

--- a/src/features/composer/index.tsx
+++ b/src/features/composer/index.tsx
@@ -109,6 +109,10 @@ type WorkspaceComposerProps = {
 			 *  draft into a freshly created session) can do so without a
 			 *  re-encode pass. */
 			editorStateSnapshot?: SerializedEditorState;
+			/** Composer's mount-time provisional session id; forwarded to
+			 *  `SubmitPayload` so StartPage submit seeds the new
+			 *  `sessions.id` with it. Ignored when already bound. */
+			provisionalSessionId?: string;
 		},
 	) => void;
 	disabled?: boolean;
@@ -280,6 +284,13 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 	useEffect(() => {
 		recordComposerRender(contextKey, instanceIdRef.current);
 	});
+
+	// Pre-allocated UUID used as the paste-cache bucket id when
+	// `sessionId` isn't bound yet (StartPage). Forwarded on submit so the
+	// new session row reuses it; otherwise reclaimed by the paste-cache
+	// sweep after `UNCLAIMED_GRACE`.
+	const provisionalSessionIdRef = useRef<string>(crypto.randomUUID());
+	const effectiveSessionId = sessionId ?? provisionalSessionIdRef.current;
 	const editorRef = useRef<LexicalEditor | null>(null);
 	// Root element of the composer surface. Used as the portal anchor for the
 	// slash/@ typeahead popups so they hug the top edge of the composer box
@@ -519,6 +530,7 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 						? options?.startSubmitMode
 						: "createOnly",
 				editorStateSnapshot,
+				provisionalSessionId: provisionalSessionIdRef.current,
 			});
 			editor.update(() => {
 				$getRoot().clear();
@@ -756,7 +768,7 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 							disabled={submitDisabledForPlugin}
 						/>
 						<CompositionGuardPlugin />
-						<PasteImagePlugin />
+						<PasteImagePlugin sessionId={effectiveSessionId} />
 						<DropFilePlugin />
 						<AutoResizePlugin minHeight={64} maxHeight={240} />
 						<EditorRefPlugin editorRef={editorRef} />

--- a/src/features/conversation/hooks/use-streaming.ts
+++ b/src/features/conversation/hooks/use-streaming.ts
@@ -123,6 +123,10 @@ type SubmitPayload = {
 	 *  copies the draft to a freshly-created session) can do so without
 	 *  losing the badge nodes that a plain prompt-string would discard. */
 	editorStateSnapshot?: SerializedEditorState;
+	/** Composer's pre-allocated UUID. StartPage submit forwards it to
+	 *  `prepareChatWorkspace` / `prepareWorkspaceFromRepo` as
+	 *  `seedSessionId`; other paths ignore it. */
+	provisionalSessionId?: string;
 };
 
 export type ComposerSubmitPayload = SubmitPayload;

--- a/src/features/workspace-start/create-workspace.test.ts
+++ b/src/features/workspace-start/create-workspace.test.ts
@@ -77,6 +77,7 @@ describe("createWorkspaceFromStartComposer", () => {
 			"worktree",
 			null,
 			null,
+			undefined,
 		);
 		expect(apiMocks.finalizeWorkspaceFromRepo).toHaveBeenCalledWith(
 			"workspace-1",
@@ -116,6 +117,7 @@ describe("createWorkspaceFromStartComposer", () => {
 			"worktree",
 			null,
 			"backlog",
+			undefined,
 		);
 		expect(apiMocks.finalizeWorkspaceFromRepo).toHaveBeenCalledWith(
 			"workspace-1",
@@ -150,6 +152,7 @@ describe("createWorkspaceFromStartComposer", () => {
 			"worktree",
 			null,
 			null,
+			undefined,
 		);
 		expect(apiMocks.finalizeWorkspaceFromRepo).toHaveBeenCalledWith(
 			"workspace-1",

--- a/src/features/workspace-start/create-workspace.ts
+++ b/src/features/workspace-start/create-workspace.ts
@@ -35,6 +35,7 @@ export async function createWorkspaceFromStartComposer({
 	editorStateSnapshot,
 	composerConfig,
 	linkedDirectories,
+	seedSessionId,
 }: {
 	/** Ignored in `chat` mode. */
 	repoId: string;
@@ -57,6 +58,9 @@ export async function createWorkspaceFromStartComposer({
 	 *  workspace row immediately so the conversation-mode composer (which
 	 *  reads the workspace-scoped query) sees them on first mount. */
 	linkedDirectories?: readonly string[];
+	/** Pre-allocated session UUID; forwarded to the prepare IPC so the
+	 *  new `sessions.id` matches the paste-cache bucket already on disk. */
+	seedSessionId?: string;
 }): Promise<WorkspaceStartCreateResult> {
 	// "Save for later" creates the workspace directly in `backlog` status
 	// — passing it through to Phase 1 means the DB row is born in the
@@ -66,13 +70,14 @@ export async function createWorkspaceFromStartComposer({
 	// Chat mode has no repo/branch — single-phase create.
 	const prepared =
 		mode === "chat"
-			? await prepareChatWorkspace(initialStatus)
+			? await prepareChatWorkspace(initialStatus, seedSessionId)
 			: await prepareWorkspaceFromRepo(
 					repoId,
 					sourceBranch,
 					mode,
 					branchIntent ?? null,
 					initialStatus,
+					seedSessionId,
 				);
 
 	// Persist pending /add-dir picks before kicking off finalize. The DB

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2332,6 +2332,10 @@ export async function prepareWorkspaceFromRepo(
 	mode?: WorkspaceMode | null,
 	branchIntent?: WorkspaceBranchIntent | null,
 	initialStatus?: WorkspaceStatus | null,
+	/** Pre-allocated session UUID, so pre-submit paste-cache files
+	 *  (`cache/paste/<seedSessionId>/`) end up owned by the new session.
+	 *  Omit unless the caller is pre-allocating. */
+	seedSessionId?: string | null,
 ): Promise<PrepareWorkspaceResponse> {
 	return invoke<PrepareWorkspaceResponse>("prepare_workspace_from_repo", {
 		repoId,
@@ -2339,6 +2343,7 @@ export async function prepareWorkspaceFromRepo(
 		mode: mode ?? null,
 		branchIntent: branchIntent ?? null,
 		initialStatus: initialStatus ?? null,
+		seedSessionId: seedSessionId ?? null,
 	});
 }
 
@@ -2365,9 +2370,12 @@ export async function finalizeWorkspaceFromRepo(
  */
 export async function prepareChatWorkspace(
 	initialStatus?: WorkspaceStatus | null,
+	/** See `prepareWorkspaceFromRepo`'s `seedSessionId`. */
+	seedSessionId?: string | null,
 ): Promise<PrepareWorkspaceResponse> {
 	return invoke<PrepareWorkspaceResponse>("prepare_chat_workspace", {
 		initialStatus: initialStatus ?? null,
+		seedSessionId: seedSessionId ?? null,
 	});
 }
 
@@ -2677,13 +2685,17 @@ export type AgentStreamEvent =
 	| { kind: "error"; message: string; persisted: boolean; internal: boolean };
 
 /**
- * Save a pasted clipboard image (base64) to a temp file and return its path.
+ * Save a pasted clipboard image (base64) under `cache/paste/<sessionId>/`
+ * and return its absolute path. Callers without a real `sessions.id`
+ * (StartPage composer) must pre-allocate a UUID and submit with the
+ * same value so the bucket gets owned by the new session.
  */
 export async function savePastedImage(
 	data: string,
 	mediaType: string,
+	sessionId: string,
 ): Promise<string> {
-	return invoke<string>("save_pasted_image", { data, mediaType });
+	return invoke<string>("save_pasted_image", { data, mediaType, sessionId });
 }
 
 /**
@@ -2916,6 +2928,8 @@ export async function createSession(
 		effortLevel?: string | null;
 		/** Pin `fast_mode` at creation; null/undefined defaults to false. */
 		fastMode?: boolean | null;
+		/** Pre-allocated session UUID; see `prepareWorkspaceFromRepo`. */
+		seedSessionId?: string | null;
 	},
 ): Promise<CreateSessionResponse> {
 	return invoke<CreateSessionResponse>("create_session", {
@@ -2925,6 +2939,7 @@ export async function createSession(
 		model: options?.model ?? null,
 		effortLevel: options?.effortLevel ?? null,
 		fastMode: options?.fastMode ?? null,
+		seedSessionId: options?.seedSessionId ?? null,
 	});
 }
 

--- a/src/shell/controllers/use-start-surface-controller.ts
+++ b/src/shell/controllers/use-start-surface-controller.ts
@@ -429,6 +429,9 @@ export function useStartSurfaceController(
 						fastMode: payload.fastMode,
 					},
 					linkedDirectories: startPendingLinkedDirectories,
+					// Reuse the composer's provisional id so pre-submit
+					// paste-cache files end up owned by this session.
+					seedSessionId: payload.provisionalSessionId,
 				});
 				// Picks belonged to the in-flight create; clear regardless of
 				// outcome so the next start-page session begins clean.


### PR DESCRIPTION
## Summary
Automatically reclaim disk space from composer-pasted images once their session is deleted, preventing the paste cache from growing unbounded.

The paste cache stores images pasted into the message composer. Without cleanup, this directory tree grows indefinitely as sessions accumulate and are deleted. This change adds a maintenance module that sweeps orphaned paste cache directories on app startup.

## Changes
- **Backend**: Added `src-tauri/src/maintenance/` module with `paste_cache::sweep()` to identify and delete orphaned cache directories
- **Startup**: Integrates cache sweep into the app startup sequence on a separate thread to avoid blocking
- **API**: Extended session and workspace deletion paths to clean up associated cache buckets
- **Tests**: Updated workspace creation tests to verify cleanup behavior

## Design notes
- The sweep runs off the main thread during startup (slow I/O won't stall app launch)
- Legacy `paste-cache/` and `query-cache/` directories at the data-dir root are intentionally preserved to avoid breaking historical message paths that embed absolute references
- Only new sessions (using the per-session cache layout under `cache/paste/`) participate in cleanup

## Test notes
Run `bun run test` to verify all three test suites (frontend, sidecar, Rust) pass.