### PR TITLE
fix: persist composer picks immediately in all workspace-start submit modes

### DIFF
--- a/.changeset/steady-otters-persist.md
+++ b/.changeset/steady-otters-persist.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix composer effort/model/permission/fast-mode picks reverting to defaults when switching back to a workspace whose first turn hasn't finished.

--- a/src/features/conversation/index.tsx
+++ b/src/features/conversation/index.tsx
@@ -12,7 +12,11 @@ import type { UserInputResponseHandler } from "@/features/composer/user-input";
 import { WorkspacePanelContainer } from "@/features/panel/container";
 import { FileLinkProvider } from "@/features/panel/message-components/file-link-context";
 import type { SessionCloseRequest } from "@/features/panel/use-confirm-session-close";
-import type { ActiveStreamSummary, ChangeRequestInfo } from "@/lib/api";
+import {
+	type ActiveStreamSummary,
+	type ChangeRequestInfo,
+	updateSessionSettings,
+} from "@/lib/api";
 import type { ResolvedComposerInsertRequest } from "@/lib/composer-insert";
 import { insertRequestMatchesComposer } from "@/lib/composer-insert";
 import { hasUnresolvedPlanReview } from "@/lib/plan-review";
@@ -21,7 +25,10 @@ import { useSettings } from "@/lib/settings";
 import type { ContextCard } from "@/lib/sources/types";
 import { EMPTY_QUEUE, useSubmitQueue } from "@/lib/use-submit-queue";
 import { cn } from "@/lib/utils";
-import { getComposerContextKey } from "@/lib/workspace-helpers";
+import {
+	getComposerContextKey,
+	parseSessionIdFromContextKey,
+} from "@/lib/workspace-helpers";
 import {
 	type ComposerSubmitPayload,
 	useConversationStreaming,
@@ -341,14 +348,38 @@ export const WorkspaceConversationContainer = memo(
 			);
 		}, [pendingCreatedWorkspaceSubmit]);
 
+		// Composer picks are persisted to `sessions` immediately so they
+		// survive a conversation-container unmount (e.g. switching to start
+		// page and back). Memory cache is kept for optimistic UI. Only
+		// `session:*` contextKeys map to a session row — start-page /
+		// workspace / global keys are memory-only.
+		const persistSessionSetting = useCallback(
+			(
+				contextKey: string,
+				patch: Parameters<typeof updateSessionSettings>[1],
+			) => {
+				const sessionId = parseSessionIdFromContextKey(contextKey);
+				if (!sessionId) return;
+				void updateSessionSettings(sessionId, patch).catch((error) => {
+					console.error(
+						"Failed to persist composer setting",
+						{ sessionId, patch },
+						error,
+					);
+				});
+			},
+			[],
+		);
+
 		const handleSelectModel = useCallback(
 			(contextKey: string, modelId: string) => {
 				setComposerModelSelections((current) => ({
 					...current,
 					[contextKey]: modelId,
 				}));
+				persistSessionSetting(contextKey, { model: modelId });
 			},
-			[],
+			[persistSessionSetting],
 		);
 
 		const handleSelectEffort = useCallback(
@@ -357,8 +388,9 @@ export const WorkspaceConversationContainer = memo(
 					...current,
 					[contextKey]: level,
 				}));
+				persistSessionSetting(contextKey, { effortLevel: level });
 			},
-			[],
+			[persistSessionSetting],
 		);
 
 		const handleChangePermissionMode = useCallback(
@@ -367,8 +399,9 @@ export const WorkspaceConversationContainer = memo(
 					...current,
 					[contextKey]: mode,
 				}));
+				persistSessionSetting(contextKey, { permissionMode: mode });
 			},
-			[],
+			[persistSessionSetting],
 		);
 
 		const handleChangeFastMode = useCallback(
@@ -377,8 +410,9 @@ export const WorkspaceConversationContainer = memo(
 					...current,
 					[contextKey]: enabled,
 				}));
+				persistSessionSetting(contextKey, { fastMode: enabled });
 			},
-			[],
+			[persistSessionSetting],
 		);
 
 		const handleComposerSubmitWrapper = useCallback(

--- a/src/features/workspace-start/create-workspace.test.ts
+++ b/src/features/workspace-start/create-workspace.test.ts
@@ -5,6 +5,7 @@ const apiMocks = vi.hoisted(() => ({
 	prepareWorkspaceFromRepo: vi.fn(),
 	finalizeWorkspaceFromRepo: vi.fn(),
 	setWorkspaceStatus: vi.fn(),
+	updateSessionSettings: vi.fn(),
 }));
 
 const draftMocks = vi.hoisted(() => ({
@@ -15,6 +16,7 @@ vi.mock("@/lib/api", () => ({
 	prepareWorkspaceFromRepo: apiMocks.prepareWorkspaceFromRepo,
 	finalizeWorkspaceFromRepo: apiMocks.finalizeWorkspaceFromRepo,
 	setWorkspaceStatus: apiMocks.setWorkspaceStatus,
+	updateSessionSettings: apiMocks.updateSessionSettings,
 }));
 
 vi.mock("@/features/composer/draft-storage", () => ({
@@ -44,6 +46,7 @@ describe("createWorkspaceFromStartComposer", () => {
 		apiMocks.prepareWorkspaceFromRepo.mockReset();
 		apiMocks.finalizeWorkspaceFromRepo.mockReset();
 		apiMocks.setWorkspaceStatus.mockReset();
+		apiMocks.updateSessionSettings.mockReset();
 		draftMocks.persistSessionDraft.mockReset();
 
 		apiMocks.prepareWorkspaceFromRepo.mockResolvedValue({
@@ -57,8 +60,16 @@ describe("createWorkspaceFromStartComposer", () => {
 			workingDirectory: finalizedWorkingDirectory,
 		});
 		apiMocks.setWorkspaceStatus.mockResolvedValue(undefined);
+		apiMocks.updateSessionSettings.mockResolvedValue(undefined);
 		draftMocks.persistSessionDraft.mockResolvedValue(undefined);
 	}
+
+	const composerConfig = {
+		modelId: "claude-sonnet-4-5",
+		effortLevel: "max",
+		permissionMode: "bypassPermissions",
+		fastMode: false,
+	};
 
 	it("creates an in-progress workspace and returns a streaming target", async () => {
 		resetMocks();
@@ -84,6 +95,8 @@ describe("createWorkspaceFromStartComposer", () => {
 		);
 		expect(apiMocks.setWorkspaceStatus).not.toHaveBeenCalled();
 		expect(draftMocks.persistSessionDraft).not.toHaveBeenCalled();
+		// No composerConfig → no persist call.
+		expect(apiMocks.updateSessionSettings).not.toHaveBeenCalled();
 		expect(result.outcome).toEqual({
 			shouldStream: true,
 			workspaceId: "workspace-1",
@@ -97,6 +110,30 @@ describe("createWorkspaceFromStartComposer", () => {
 		expect(result.preparedWorkingDirectory).toBeNull();
 	});
 
+	it("persists composer picks immediately on startNow so they survive a container unmount", async () => {
+		// Regression: previously only `saveForLater` wrote the session row.
+		// `startNow` left effort/permission/model/fastMode in memory only,
+		// so visiting start-page and back snapped chips to defaults until
+		// the first turn's finalize ran.
+		resetMocks();
+
+		await createWorkspaceFromStartComposer({
+			repoId: "repo-1",
+			sourceBranch: "origin/main",
+			mode: "worktree",
+			submitMode: "startNow",
+			editorStateSnapshot,
+			composerConfig,
+		});
+
+		expect(apiMocks.updateSessionSettings).toHaveBeenCalledWith("session-1", {
+			model: "claude-sonnet-4-5",
+			effortLevel: "max",
+			permissionMode: "bypassPermissions",
+			fastMode: false,
+		});
+	});
+
 	it("saves the new workspace to backlog with the composer draft", async () => {
 		resetMocks();
 
@@ -106,6 +143,7 @@ describe("createWorkspaceFromStartComposer", () => {
 			mode: "worktree",
 			submitMode: "saveForLater",
 			editorStateSnapshot,
+			composerConfig,
 		});
 
 		// "Save for later" passes initialStatus=backlog directly into Phase 1
@@ -126,6 +164,12 @@ describe("createWorkspaceFromStartComposer", () => {
 			"session-1",
 			editorStateSnapshot,
 		);
+		expect(apiMocks.updateSessionSettings).toHaveBeenCalledWith("session-1", {
+			model: "claude-sonnet-4-5",
+			effortLevel: "max",
+			permissionMode: "bypassPermissions",
+			fastMode: false,
+		});
 		expect(apiMocks.setWorkspaceStatus).not.toHaveBeenCalled();
 		expect(result).toEqual({
 			outcome: { shouldStream: false },
@@ -144,6 +188,7 @@ describe("createWorkspaceFromStartComposer", () => {
 			mode: "worktree",
 			submitMode: "createOnly",
 			editorStateSnapshot,
+			composerConfig,
 		});
 
 		expect(apiMocks.prepareWorkspaceFromRepo).toHaveBeenCalledWith(
@@ -158,6 +203,12 @@ describe("createWorkspaceFromStartComposer", () => {
 			"workspace-1",
 		);
 		expect(draftMocks.persistSessionDraft).not.toHaveBeenCalled();
+		expect(apiMocks.updateSessionSettings).toHaveBeenCalledWith("session-1", {
+			model: "claude-sonnet-4-5",
+			effortLevel: "max",
+			permissionMode: "bypassPermissions",
+			fastMode: false,
+		});
 		expect(apiMocks.setWorkspaceStatus).not.toHaveBeenCalled();
 		expect(result).toEqual({
 			outcome: { shouldStream: false },

--- a/src/features/workspace-start/create-workspace.ts
+++ b/src/features/workspace-start/create-workspace.ts
@@ -46,8 +46,13 @@ export async function createWorkspaceFromStartComposer({
 	branchIntent?: WorkspaceBranchIntent;
 	submitMode: StartSubmitMode;
 	editorStateSnapshot?: SerializedEditorState;
-	/** StartPage composer picks. Only persisted to the session row on
-	 *  saveForLater; startNow consumes them via the submit payload. */
+	/** StartPage composer picks. Persisted to the session row in all submit
+	 *  modes so the row reflects the user's choice from the moment the
+	 *  workspace exists — independent of whether/when the first turn runs.
+	 *  Without this, switching away to start-page (which unmounts the
+	 *  conversation container and drops its in-memory composer caches) and
+	 *  coming back snaps the chips back to settings defaults on any session
+	 *  whose first turn hasn't yet finalised. */
 	composerConfig?: {
 		modelId?: string;
 		effortLevel?: string;
@@ -96,20 +101,26 @@ export async function createWorkspaceFromStartComposer({
 			? null
 			: () => finalizeWorkspaceFromRepo(prepared.workspaceId);
 
+	// Single source of truth for the composer-pick persist. Awaited in every
+	// submit mode — the write is one UPDATE and finishes long before the
+	// user can switch surfaces, so it's not worth the complexity of racing
+	// it against finalize.
+	const persistComposerConfig = composerConfig
+		? updateSessionSettings(prepared.initialSessionId, {
+				model: composerConfig.modelId,
+				effortLevel: composerConfig.effortLevel,
+				permissionMode: composerConfig.permissionMode,
+				fastMode: composerConfig.fastMode,
+			})
+		: Promise.resolve();
+
 	if (submitMode === "saveForLater") {
 		await Promise.all([
 			finalize?.() ?? Promise.resolve(),
 			editorStateSnapshot
 				? persistSessionDraft(prepared.initialSessionId, editorStateSnapshot)
 				: Promise.resolve(),
-			composerConfig
-				? updateSessionSettings(prepared.initialSessionId, {
-						model: composerConfig.modelId,
-						effortLevel: composerConfig.effortLevel,
-						permissionMode: composerConfig.permissionMode,
-						fastMode: composerConfig.fastMode,
-					})
-				: Promise.resolve(),
+			persistComposerConfig,
 		]);
 		return {
 			outcome: { shouldStream: false },
@@ -120,7 +131,10 @@ export async function createWorkspaceFromStartComposer({
 	}
 
 	if (submitMode === "createOnly") {
-		if (finalize) await finalize();
+		await Promise.all([
+			finalize?.() ?? Promise.resolve(),
+			persistComposerConfig,
+		]);
 		return {
 			outcome: { shouldStream: false },
 			workspaceId: prepared.workspaceId,
@@ -129,6 +143,11 @@ export async function createWorkspaceFromStartComposer({
 		};
 	}
 
+	// startNow: don't block the surface swap on finalize, but do await the
+	// (very fast) settings write so by the time conversation mounts and
+	// reads `sessions.effort_level / model / permission_mode / fast_mode`
+	// the row already reflects the user's pick.
+	await persistComposerConfig;
 	return {
 		finalizePromise: finalize?.(),
 		workspaceId: prepared.workspaceId,

--- a/src/lib/workspace-helpers.ts
+++ b/src/lib/workspace-helpers.ts
@@ -777,6 +777,16 @@ export function getComposerContextKey(
 	return "global";
 }
 
+/** Reverse of `getComposerContextKey` for the `session:*` form. Returns null
+ *  for `workspace:*` / `start:*` / `global` — those have no session row to
+ *  persist composer picks against. */
+export function parseSessionIdFromContextKey(
+	contextKey: string,
+): string | null {
+	const prefix = "session:";
+	return contextKey.startsWith(prefix) ? contextKey.slice(prefix.length) : null;
+}
+
 export function inferDefaultModelId(
 	session: Pick<
 		WorkspaceSessionSummary,


### PR DESCRIPTION
## Summary

Fixes a regression where composer effort/model/permission/fast-mode picks would revert to settings defaults when switching back to a workspace whose first turn hadn't yet completed.

**Root cause:** These picks were only persisted to the session row on `saveForLater`, leaving them in memory-only for `startNow` and `createOnly`. When the conversation container unmounted (switching to start-page) and remounted, the in-memory cache was lost, snapping the chips back to defaults.

**Solution:** Persist composer config to the session row in all submit modes (`startNow`, `createOnly`, `saveForLater`) so the row reflects the user's choice from the moment the workspace is created — independent of when/whether the first turn finalizes.

## Changes

- `src/features/workspace-start/create-workspace.ts`: Extract composer-config persist into a shared promise awaited in all submit modes
- `src/features/conversation/index.tsx`: Add `persistSessionSetting()` callback to persist composer picks during interaction (model/effort/permission/fastMode)
- `src/lib/workspace-helpers.ts`: Add `parseSessionIdFromContextKey()` helper to reverse context key mapping
- Tests: Add regression coverage and update mocks

## Test plan

- [ ] Start a workspace with non-default composer picks and switch to start-page without finishing the first turn — verify chips retain their values on return
- [ ] Verify all three submit modes (`startNow`, `saveForLater`, `createOnly`) persist picks to the session row
- [ ] Verify the conversation container still updates picks on interaction (e.g., changing model mid-conversation)