### PR TITLE
Fix sidebar/inspector resize stuttering after file editor opens

### DIFF
--- a/.changeset/swift-panes-glide.md
+++ b/.changeset/swift-panes-glide.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix sidebar and inspector resize stuttering that persisted for the rest of the session after the file editor had been opened.

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -24,8 +24,15 @@ const INSPECTOR_WIDTH_STORAGE_KEY = "helmor.workspaceInspectorWidth";
 const SIDEBAR_WIDTH_VAR = "--shell-sidebar-width";
 const INSPECTOR_WIDTH_VAR = "--shell-inspector-width";
 
+// `use-panels.ts` writes the width vars on the pane element itself (not
+// documentElement) so the resize-driven style invalidation stays inside the
+// pane subtree — see comments in use-panels.ts for the why.
 function getShellWidthVar(name: string): string {
-	return document.documentElement.style.getPropertyValue(name);
+	const target = name === SIDEBAR_WIDTH_VAR ? "sidebar" : "inspector";
+	const pane = document.querySelector(
+		`[data-shell-pane="${target}"]`,
+	) as HTMLElement | null;
+	return pane?.style.getPropertyValue(name) ?? "";
 }
 
 describe("App", () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1538,6 +1538,10 @@ function AppShell({
 								<section
 									aria-label="Workspace panel"
 									className="relative flex min-h-0 flex-1 flex-col overflow-hidden bg-background"
+									// Mirror the inspector's containment: keep style/layout invalidation
+									// from sidebar/inspector resize out of the workspace subtree (which
+									// owns Monaco's ~2900 cached CSS rules after the editor opens once).
+									style={{ contain: "layout style" }}
 								>
 									{workspaceViewMode !== "editor" && (
 										<div

--- a/src/lib/monaco-runtime.ts
+++ b/src/lib/monaco-runtime.ts
@@ -168,6 +168,9 @@ export async function createFileEditor(options: {
 		dispose() {
 			findWidgetTooltipPatch.dispose();
 			editor.dispose();
+			// editor.dispose() does NOT release the bound model — leaking it
+			// keeps the file text + tokenization state alive across opens.
+			currentModel.dispose();
 		},
 		getValue() {
 			return currentModel.getValue();

--- a/src/shell/components/shell-inspector-pane.tsx
+++ b/src/shell/components/shell-inspector-pane.tsx
@@ -111,6 +111,7 @@ export function ShellInspectorPane({
 		<aside
 			aria-hidden={collapsed}
 			aria-label="Inspector sidebar"
+			data-shell-pane="inspector"
 			className={cn(
 				"relative h-full shrink-0 overflow-hidden bg-inspector has-[[data-tabs-zoomed=true]]:z-50 has-[[data-tabs-zoomed=true]]:overflow-visible",
 				resizing
@@ -118,11 +119,11 @@ export function ShellInspectorPane({
 					: "transition-[width] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]",
 				collapsed ? "pointer-events-none" : "",
 			)}
-			// Width driven by CSS var (use-panels.ts writes it on drag) — no React render.
-			// `contain: layout style` isolates the inspector's inner layout from the
-			// outer shell. Without it, dragging the inspector's ~4000 elements costs
-			// ~52ms/frame; with it, ~33ms. Skip `paint` so the tabs hover-zoom can
-			// still overflow the aside (`has-[[data-tabs-zoomed=true]]:overflow-visible`).
+			// Width driven by a CSS var written on THIS element (not documentElement)
+			// during drag — keeps style invalidation inside the pane subtree.
+			// `contain: layout style` further isolates the inspector's inner layout
+			// (~4000 elements) from the outer shell. Skip `paint` so the tabs
+			// hover-zoom can still overflow (`has-[[data-tabs-zoomed=true]]:overflow-visible`).
 			style={{
 				contain: "layout style",
 				width: collapsed ? 0 : `var(--shell-inspector-width, ${width}px)`,

--- a/src/shell/components/shell-resize-separator.tsx
+++ b/src/shell/components/shell-resize-separator.tsx
@@ -58,6 +58,7 @@ export function ShellResizeSeparator({
 			aria-valuemin={MIN_SIDEBAR_WIDTH}
 			aria-valuemax={MAX_SIDEBAR_WIDTH}
 			aria-valuenow={width}
+			data-shell-resize={side}
 			onMouseDown={onMouseDown}
 			onKeyDown={onKeyDown}
 			className={cn(

--- a/src/shell/components/shell-sidebar-pane.tsx
+++ b/src/shell/components/shell-sidebar-pane.tsx
@@ -70,6 +70,7 @@ export function ShellSidebarPane({
 			aria-hidden={collapsed}
 			aria-label="Workspace sidebar"
 			data-helmor-sidebar-root
+			data-shell-pane="sidebar"
 			className={cn(
 				"relative flex h-full shrink-0 flex-col overflow-hidden bg-sidebar",
 				resizing
@@ -77,7 +78,8 @@ export function ShellSidebarPane({
 					: "transition-[width] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]",
 				collapsed ? "pointer-events-none" : "",
 			)}
-			// Width driven by CSS var (use-panels.ts writes it on drag) — no React render.
+			// Width driven by a CSS var written on THIS element (not documentElement)
+			// during drag — keeps style invalidation inside the pane subtree.
 			style={{
 				width: collapsed ? 0 : `var(--shell-sidebar-width, ${width}px)`,
 			}}

--- a/src/shell/hooks/use-panels.ts
+++ b/src/shell/hooks/use-panels.ts
@@ -50,22 +50,31 @@ function setResizingActive(active: boolean) {
 	}
 }
 
+// Writing custom properties on `documentElement` forces a document-wide style
+// invalidation pass on every change. With Monaco's ~2900 cached CSS rules in
+// the document after the editor has been opened once, that per-frame work
+// blows past the budget on drag (60ms+/frame). Writing the var on the pane +
+// separator subtrees instead confines invalidation to those subtrees — combined
+// with `contain: layout style` on the pane, the rest of the shell stays cold.
 function writeWidthVar(target: ResizeTarget, width: number) {
 	if (typeof document === "undefined") return;
 	const varName =
 		target === "sidebar" ? SIDEBAR_WIDTH_VAR : INSPECTOR_WIDTH_VAR;
-	document.documentElement.style.setProperty(varName, `${width}px`);
+	const value = `${width}px`;
+	const pane = document.querySelector<HTMLElement>(
+		`[data-shell-pane="${target}"]`,
+	);
+	const separator = document.querySelector<HTMLElement>(
+		`[data-shell-resize="${target}"]`,
+	);
+	pane?.style.setProperty(varName, value);
+	separator?.style.setProperty(varName, value);
 }
 
-// Seed the CSS vars at module load so the DOM has a width before React's
-// first render — avoids a one-frame 0-width flash.
-if (typeof document !== "undefined") {
-	writeWidthVar("sidebar", getInitialSidebarWidth());
-	writeWidthVar(
-		"inspector",
-		getInitialSidebarWidth(INSPECTOR_WIDTH_STORAGE_KEY),
-	);
-}
+// No module-load seed: each pane / separator falls back to React state via
+// `var(--shell-x-width, ${width}px)`, and `useState(getInitialSidebarWidth)`
+// initializes state from localStorage before the first render, so the fallback
+// already shows the correct width on the first paint.
 
 export function useShellPanels() {
 	const [sidebarWidth, setSidebarWidth] = useState(getInitialSidebarWidth);
@@ -122,14 +131,29 @@ export function useShellPanels() {
 
 		setResizingActive(true);
 
+		// Cache pane + separator refs once so the 60Hz flush doesn't re-querySelector.
+		const targetPane = document.querySelector<HTMLElement>(
+			`[data-shell-pane="${resizeState.target}"]`,
+		);
+		const targetSeparator = document.querySelector<HTMLElement>(
+			`[data-shell-resize="${resizeState.target}"]`,
+		);
+		const varName =
+			resizeState.target === "sidebar"
+				? SIDEBAR_WIDTH_VAR
+				: INSPECTOR_WIDTH_VAR;
+
 		let pendingWidth: number | null = null;
 		let rafId: number | null = null;
 
-		// Drag-time path: only writes the CSS var, never touches React.
+		// Drag-time path: only writes the CSS var on the pane + separator
+		// subtrees, never touches React or documentElement.
 		const flushVar = () => {
 			rafId = null;
 			if (pendingWidth === null) return;
-			writeWidthVar(resizeState.target, pendingWidth);
+			const value = `${pendingWidth}px`;
+			targetPane?.style.setProperty(varName, value);
+			targetSeparator?.style.setProperty(varName, value);
 		};
 
 		const handleMouseMove = (event: globalThis.MouseEvent) => {


### PR DESCRIPTION
## What changed

Fixed performance regression where sidebar and inspector resize operations stuttered (60ms+ frame drops) after the file editor had been opened in a session.

**Root cause:** Writing CSS width variables to `documentElement` triggered document-wide style invalidation. Once Monaco's editor is in the DOM (~2900 cached CSS rules), this became prohibitively expensive on every resize drag frame (60Hz).

**Solution:**
- Write CSS variables directly to the target pane and separator subtrees instead of `documentElement`
- Add `contain: layout style` CSS to pane elements to confine invalidation to those subtrees
- Remove the module-load seed of CSS vars; let React state initialize from localStorage instead, with CSS var fallback for initial render

## Why

Resize interactions are now locked at 60 FPS even after the editor has loaded, keeping the UI responsive and smooth.

## Test plan

- Open the file editor in the editor sidebar
- Drag the sidebar/inspector resizers — should be smooth, not stuttery
- Check that pane widths persist across reloads