### PR TITLE
fix(terminal): white text on light mode — resolve oklch colors to rgb for xterm.js

### DIFF
--- a/src/components/terminal-output.tsx
+++ b/src/components/terminal-output.tsx
@@ -204,18 +204,42 @@ export function suspendTerminalWrites(): () => void {
 	};
 }
 
-/** Read --terminal-* and --foreground CSS variables and build an xterm ITheme. */
+/**
+ * Read --terminal-* and --foreground CSS variables and build an xterm ITheme.
+ *
+ * CSS custom properties return raw token strings from getComputedStyle (e.g.
+ * "oklch(0.145 0 0)"), but xterm.js only reliably parses #hex / rgb() / rgba().
+ * We force the browser to resolve each value to rgb() by writing it into a real
+ * CSS color property on a temporary element, then reading back the computed
+ * result.
+ */
 function resolveTerminalTheme(): ITheme {
 	const s = getComputedStyle(document.documentElement);
-	const v = (suffix: string) =>
-		s.getPropertyValue(`--terminal-${suffix}`).trim();
+
+	// Probe element: setting its `color` property forces the browser to
+	// serialise any CSS color value (oklch, color-mix, etc.) as rgb()/rgba().
+	const probe = document.createElement("div");
+	probe.style.display = "none";
+	document.body.appendChild(probe);
+
+	const v = (suffix: string) => {
+		const raw = s.getPropertyValue(`--terminal-${suffix}`).trim();
+		// Reset before each assignment so an invalid/empty value doesn't
+		// silently carry over the previous successful color.
+		probe.style.color = "";
+		probe.style.color = raw;
+		return getComputedStyle(probe).color;
+	};
 
 	// Match the app's global scrollbar colors (foreground @ 18%/30%/40%).
+	// color-mix() is also not understood by xterm, so resolve it the same way.
 	const fg = s.getPropertyValue("--foreground").trim();
-	const mix = (pct: number) =>
-		`color-mix(in oklch, ${fg} ${pct}%, transparent)`;
+	const mix = (pct: number) => {
+		probe.style.color = `color-mix(in oklch, ${fg} ${pct}%, transparent)`;
+		return getComputedStyle(probe).color;
+	};
 
-	return {
+	const theme: ITheme = {
 		background: v("background"),
 		foreground: v("foreground"),
 		cursor: v("cursor"),
@@ -240,6 +264,9 @@ function resolveTerminalTheme(): ITheme {
 		brightCyan: v("bright-cyan"),
 		brightWhite: v("bright-white"),
 	};
+
+	probe.remove();
+	return theme;
 }
 
 function resolveTerminalFontFamily(


### PR DESCRIPTION
xterm.js only parses #hex, rgb(), and rgba() color formats. CSS custom properties return raw token strings (e.g. "oklch(0.145 0 0)") from getComputedStyle, which xterm silently falls back to #ffffff (white) when it can't parse. This made terminal text invisible in light mode across all color schemes.

Use a temporary DOM element to force the browser to serialise each terminal color as rgb() before passing to xterm's theme API. Reset probe.style.color between assignments so invalid/empty values don't carry over from a previous read.