### PR TITLE
fix: keep submit queue across start-page toggle and add AUQ debugging

### DIFF
--- a/.changeset/keep-queue-across-start-page.md
+++ b/.changeset/keep-queue-across-start-page.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Stop clearing the follow-up message queue when switching to the Start Page so queued messages survive the trip back to the workspace.

--- a/sidecar/src/claude-session-manager.ts
+++ b/sidecar/src/claude-session-manager.ts
@@ -513,6 +513,11 @@ export class ClaudeSessionManager implements SessionManager {
 							!Array.isArray(auqInput.metadata)
 								? (auqInput.metadata as Record<string, unknown>)
 								: undefined;
+						logger.info(`[${requestId}] AUQ canUseTool fired`, {
+							toolUseId,
+							questionCount: rawQuestions.length,
+							hasMetadata: metadata !== undefined,
+						});
 						emitter.userInputRequest(
 							requestId,
 							toolUseId,
@@ -524,6 +529,9 @@ export class ClaudeSessionManager implements SessionManager {
 								...(metadata ? { metadata } : {}),
 							},
 						);
+						logger.info(`[${requestId}] AUQ userInputRequest emitted`, {
+							toolUseId,
+						});
 						const resolution = await new Promise<UserInputResolution>(
 							(resolve) => {
 								this.pendingUserInputs.set(toolUseId, {
@@ -540,6 +548,10 @@ export class ClaudeSessionManager implements SessionManager {
 								);
 							},
 						);
+						logger.info(`[${requestId}] AUQ resolved`, {
+							toolUseId,
+							action: resolution.action,
+						});
 						if (resolution.action === "submit") {
 							// The frontend AUQ renderer produces the full
 							// `updatedInput` shape directly (questions +

--- a/src-tauri/src/agents.rs
+++ b/src-tauri/src/agents.rs
@@ -74,7 +74,11 @@ pub async fn prewarm_slash_commands_for_repo(app: AppHandle, repo_id: String) ->
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase", tag = "kind")]
+#[serde(
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase",
+    tag = "kind"
+)]
 pub enum AgentStreamEvent {
     /// Full snapshot — sent on finalization events (assistant, user, result).
     /// The frontend replaces its entire message array.
@@ -108,11 +112,8 @@ pub enum AgentStreamEvent {
         reason: String,
     },
     PermissionRequest {
-        #[serde(rename = "permissionId")]
         permission_id: String,
-        #[serde(rename = "toolName")]
         tool_name: String,
-        #[serde(rename = "toolInput")]
         tool_input: Value,
         title: Option<String>,
         description: Option<String>,
@@ -135,7 +136,6 @@ pub enum AgentStreamEvent {
         session_id: Option<String>,
         working_directory: String,
         permission_mode: Option<String>,
-        #[serde(rename = "userInputId")]
         user_input_id: String,
         source: String,
         message: String,

--- a/src-tauri/src/agents/streaming/bridges.rs
+++ b/src-tauri/src/agents/streaming/bridges.rs
@@ -299,19 +299,19 @@ mod tests {
             @r#"
         kind: userInputRequest
         message: Claude is asking for your input.
-        model_id: opus-1m
+        modelId: opus-1m
         payload:
           kind: ask-user-question
           questions:
             - options: []
               question: Pick one
-        permission_mode: default
+        permissionMode: default
         provider: claude
-        resolved_model: claude-opus-4-20250514
-        session_id: provider-session-1
+        resolvedModel: claude-opus-4-20250514
+        sessionId: provider-session-1
         source: Claude
         userInputId: tool-1
-        working_directory: /tmp/helmor
+        workingDirectory: /tmp/helmor
         "#
         );
     }
@@ -369,12 +369,12 @@ mod tests {
             serde_json::to_value(&event).unwrap(),
             @r#"
         kind: done
-        model_id: opus-1m
+        modelId: opus-1m
         persisted: true
         provider: claude
-        resolved_model: claude-opus-4-20250514
-        session_id: provider-session-1
-        working_directory: /tmp/helmor
+        resolvedModel: claude-opus-4-20250514
+        sessionId: provider-session-1
+        workingDirectory: /tmp/helmor
         "#
         );
     }
@@ -395,13 +395,13 @@ mod tests {
             serde_json::to_value(&event).unwrap(),
             @r#"
         kind: aborted
-        model_id: opus-1m
+        modelId: opus-1m
         persisted: true
         provider: claude
         reason: user_requested
-        resolved_model: claude-opus-4-20250514
-        session_id: provider-session-1
-        working_directory: /tmp/helmor
+        resolvedModel: claude-opus-4-20250514
+        sessionId: provider-session-1
+        workingDirectory: /tmp/helmor
         "#
         );
     }

--- a/src-tauri/src/agents/streaming/mod.rs
+++ b/src-tauri/src/agents/streaming/mod.rs
@@ -892,6 +892,23 @@ pub(super) fn stream_via_sidecar(
                     // right position. Subsequent stream events flow
                     // normally once the user submits via
                     // `respondToUserInput`.
+                    let user_input_id = event
+                        .raw
+                        .get("userInputId")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default();
+                    let payload_kind = event
+                        .raw
+                        .get("payload")
+                        .and_then(|p| p.get("kind"))
+                        .and_then(Value::as_str)
+                        .unwrap_or("unknown");
+                    tracing::info!(
+                        rid = %rid,
+                        user_input_id = %user_input_id,
+                        payload_kind = %payload_kind,
+                        "AUQ/elicitation userInputRequest received from sidecar",
+                    );
                     let mut resolved_model = model_copy.cli_model.to_string();
                     let mut final_messages: Vec<ThreadMessageLike> = Vec::new();
 
@@ -935,9 +952,19 @@ pub(super) fn stream_via_sidecar(
                         final_messages,
                     ) {
                         Ok(actions) => {
+                            let emit_count = actions
+                                .iter()
+                                .filter(|a| matches!(a, actions::Action::EmitToFrontend(_)))
+                                .count();
                             for action in actions {
                                 actions::apply_action(action, &apply_ctx);
                             }
+                            tracing::info!(
+                                rid = %rid,
+                                user_input_id = %user_input_id,
+                                emit_count = emit_count,
+                                "AUQ/elicitation forwarded to frontend",
+                            );
                         }
                         Err(err) => {
                             tracing::error!(

--- a/src-tauri/tests/snapshots/agent_stream_event_wire__wire_format_aborted.snap
+++ b/src-tauri/tests/snapshots/agent_stream_event_wire__wire_format_aborted.snap
@@ -3,10 +3,10 @@ source: tests/agent_stream_event_wire.rs
 expression: "to_value(AgentStreamEvent::Aborted\n{\n    provider: \"claude\".into(), model_id: \"opus-1m\".into(), resolved_model:\n    \"claude-opus-4-20250514\".into(), session_id:\n    Some(\"provider-session-1\".into()), working_directory:\n    \"/tmp/helmor\".into(), persisted: true, reason: \"user_requested\".into(),\n})"
 ---
 kind: aborted
-model_id: opus-1m
+modelId: opus-1m
 persisted: true
 provider: claude
 reason: user_requested
-resolved_model: claude-opus-4-20250514
-session_id: provider-session-1
-working_directory: /tmp/helmor
+resolvedModel: claude-opus-4-20250514
+sessionId: provider-session-1
+workingDirectory: /tmp/helmor

--- a/src-tauri/tests/snapshots/agent_stream_event_wire__wire_format_done.snap
+++ b/src-tauri/tests/snapshots/agent_stream_event_wire__wire_format_done.snap
@@ -3,9 +3,9 @@ source: tests/agent_stream_event_wire.rs
 expression: "to_value(AgentStreamEvent::Done\n{\n    provider: \"claude\".into(), model_id: \"opus-1m\".into(), resolved_model:\n    \"claude-opus-4-20250514\".into(), session_id:\n    Some(\"provider-session-1\".into()), working_directory:\n    \"/tmp/helmor\".into(), persisted: true,\n})"
 ---
 kind: done
-model_id: opus-1m
+modelId: opus-1m
 persisted: true
 provider: claude
-resolved_model: claude-opus-4-20250514
-session_id: provider-session-1
-working_directory: /tmp/helmor
+resolvedModel: claude-opus-4-20250514
+sessionId: provider-session-1
+workingDirectory: /tmp/helmor

--- a/src-tauri/tests/snapshots/agent_stream_event_wire__wire_format_user_input_request_ask_user_question.snap
+++ b/src-tauri/tests/snapshots/agent_stream_event_wire__wire_format_user_input_request_ask_user_question.snap
@@ -4,16 +4,16 @@ expression: "to_value(AgentStreamEvent::UserInputRequest\n{\n    provider: \"cla
 ---
 kind: userInputRequest
 message: Claude is asking for your input.
-model_id: opus-1m
+modelId: opus-1m
 payload:
   kind: ask-user-question
   questions:
     - options: []
       question: Pick one
-permission_mode: default
+permissionMode: default
 provider: claude
-resolved_model: claude-opus-4-20250514
-session_id: provider-session-1
+resolvedModel: claude-opus-4-20250514
+sessionId: provider-session-1
 source: Claude
 userInputId: tool-1
-working_directory: /tmp/helmor
+workingDirectory: /tmp/helmor

--- a/src-tauri/tests/snapshots/agent_stream_event_wire__wire_format_user_input_request_form.snap
+++ b/src-tauri/tests/snapshots/agent_stream_event_wire__wire_format_user_input_request_form.snap
@@ -4,7 +4,7 @@ expression: "to_value(AgentStreamEvent::UserInputRequest\n{\n    provider: \"cla
 ---
 kind: userInputRequest
 message: Need structured input
-model_id: opus-1m
+modelId: opus-1m
 payload:
   kind: form
   schema:
@@ -14,10 +14,10 @@ payload:
     required:
       - name
     type: object
-permission_mode: ~
+permissionMode: ~
 provider: claude
-resolved_model: claude-opus-4-20250514
-session_id: provider-session-1
+resolvedModel: claude-opus-4-20250514
+sessionId: provider-session-1
 source: design-server
 userInputId: elicitation-1
-working_directory: /tmp/helmor
+workingDirectory: /tmp/helmor

--- a/src-tauri/tests/snapshots/agent_stream_event_wire__wire_format_user_input_request_url.snap
+++ b/src-tauri/tests/snapshots/agent_stream_event_wire__wire_format_user_input_request_url.snap
@@ -4,14 +4,14 @@ expression: "to_value(AgentStreamEvent::UserInputRequest\n{\n    provider: \"cla
 ---
 kind: userInputRequest
 message: Finish auth
-model_id: opus-1m
+modelId: opus-1m
 payload:
   kind: url
   url: "https://example.com/authorize"
-permission_mode: ~
+permissionMode: ~
 provider: claude
-resolved_model: claude-opus-4-20250514
-session_id: provider-session-1
+resolvedModel: claude-opus-4-20250514
+sessionId: provider-session-1
 source: auth-server
 userInputId: elicitation-2
-working_directory: /tmp/helmor
+workingDirectory: /tmp/helmor

--- a/src-tauri/tests/snapshots/stream_bridge_elicitation__form_user_input_replays_alongside_message_stream.snap
+++ b/src-tauri/tests/snapshots/stream_bridge_elicitation__form_user_input_replays_alongside_message_stream.snap
@@ -6,7 +6,7 @@ line_count: 5
 control_events:
   - kind: userInputRequest
     message: Need structured input
-    model_id: opus-1m
+    modelId: opus-1m
     payload:
       kind: form
       schema:
@@ -21,13 +21,13 @@ control_events:
           - name
           - approved
         type: object
-    permission_mode: ~
+    permissionMode: ~
     provider: claude
-    resolved_model: claude-opus-4-20250514
-    session_id: provider-session-1
+    resolvedModel: claude-opus-4-20250514
+    sessionId: provider-session-1
     source: design-server
     userInputId: user-input-form-1
-    working_directory: /tmp/helmor
+    workingDirectory: /tmp/helmor
 final_messages:
   - role: assistant
     id: msg-1

--- a/src-tauri/tests/snapshots/stream_bridge_elicitation__url_user_input_replays_without_polluting_pipeline.snap
+++ b/src-tauri/tests/snapshots/stream_bridge_elicitation__url_user_input_replays_without_polluting_pipeline.snap
@@ -6,17 +6,17 @@ line_count: 3
 control_events:
   - kind: userInputRequest
     message: Finish sign-in in the browser.
-    model_id: opus-1m
+    modelId: opus-1m
     payload:
       kind: url
       url: "https://example.com/authorize"
-    permission_mode: ~
+    permissionMode: ~
     provider: claude
-    resolved_model: claude-opus-4-20250514
-    session_id: provider-session-1
+    resolvedModel: claude-opus-4-20250514
+    sessionId: provider-session-1
     source: auth-server
     userInputId: user-input-url-1
-    working_directory: /tmp/helmor
+    workingDirectory: /tmp/helmor
 final_messages:
   - role: assistant
     id: msg-1

--- a/src-tauri/tests/snapshots/stream_bridge_events__aborted_event_carries_user_requested_reason.snap
+++ b/src-tauri/tests/snapshots/stream_bridge_events__aborted_event_carries_user_requested_reason.snap
@@ -5,13 +5,13 @@ expression: snapshot
 line_count: 3
 control_events:
   - kind: aborted
-    model_id: model-id
+    modelId: model-id
     persisted: true
     provider: claude
     reason: user_requested
-    resolved_model: test-model
-    session_id: provider-session-1
-    working_directory: /tmp/helmor
+    resolvedModel: test-model
+    sessionId: provider-session-1
+    workingDirectory: /tmp/helmor
 final_messages:
   - role: assistant
     id: msg-1

--- a/src-tauri/tests/snapshots/stream_bridge_events__ask_user_question_user_input_pauses_stream_with_pending_state.snap
+++ b/src-tauri/tests/snapshots/stream_bridge_events__ask_user_question_user_input_pauses_stream_with_pending_state.snap
@@ -6,19 +6,19 @@ line_count: 3
 control_events:
   - kind: userInputRequest
     message: Claude is asking for your input.
-    model_id: model-id
+    modelId: model-id
     payload:
       kind: ask-user-question
       questions:
         - options: []
           question: Pick one
-    permission_mode: default
+    permissionMode: default
     provider: claude
-    resolved_model: test-model
-    session_id: provider-session-1
+    resolvedModel: test-model
+    sessionId: provider-session-1
     source: Claude
     userInputId: tool-1
-    working_directory: /tmp/helmor
+    workingDirectory: /tmp/helmor
 final_messages:
   - role: assistant
     id: msg-1

--- a/src-tauri/tests/snapshots/stream_bridge_events__codex_user_input_passes_form_payload_through.snap
+++ b/src-tauri/tests/snapshots/stream_bridge_events__codex_user_input_passes_form_payload_through.snap
@@ -6,7 +6,7 @@ line_count: 1
 control_events:
   - kind: userInputRequest
     message: Codex needs your input.
-    model_id: model-id
+    modelId: model-id
     payload:
       kind: form
       schema:
@@ -25,12 +25,12 @@ control_events:
         required:
           - approval
         type: object
-    permission_mode: default
+    permissionMode: default
     provider: codex
-    resolved_model: test-model
-    session_id: provider-session-1
+    resolvedModel: test-model
+    sessionId: provider-session-1
     source: Codex
     userInputId: user-input-1
-    working_directory: /tmp/helmor
+    workingDirectory: /tmp/helmor
 final_messages: []
 dropped_event_types: []

--- a/src-tauri/tests/snapshots/stream_bridge_events__done_event_finalizes_full_turn.snap
+++ b/src-tauri/tests/snapshots/stream_bridge_events__done_event_finalizes_full_turn.snap
@@ -5,12 +5,12 @@ expression: snapshot
 line_count: 4
 control_events:
   - kind: done
-    model_id: model-id
+    modelId: model-id
     persisted: true
     provider: claude
-    resolved_model: test-model
-    session_id: provider-session-1
-    working_directory: /tmp/helmor
+    resolvedModel: test-model
+    sessionId: provider-session-1
+    workingDirectory: /tmp/helmor
 final_messages:
   - role: assistant
     id: msg-1

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -109,6 +109,7 @@ import {
 } from "./lib/settings";
 import { requestSidebarReconcile } from "./lib/sidebar-mutation-gate";
 import { useOsNotifications } from "./lib/use-os-notifications";
+import { useSubmitQueue } from "./lib/use-submit-queue";
 import { summaryToArchivedRow } from "./lib/workspace-helpers";
 import {
 	type WorkspaceToastOptions,
@@ -554,6 +555,12 @@ function AppShell({
 	const appUpdateStatus = useAppUpdater();
 	useDockUnreadBadge();
 	useEnsureDefaultModel();
+	// Follow-up submit queue lives at App scope so its state survives the
+	// start-page ↔ workspace toggle. The two `WorkspaceConversationContainer`
+	// instances below are different React subtrees — keeping `useSubmitQueue`
+	// inside the container would drop the queue every time the user switches
+	// to the Start Page and back.
+	const submitQueueState = useSubmitQueue();
 	const notify = useOsNotifications(appSettings);
 	const { state: readState, actions: readStateActions } =
 		useReadStateController({
@@ -1638,6 +1645,7 @@ function AppShell({
 														onRequestCloseSession={requestCloseSession}
 														workspaceRootPath={null}
 														onOpenFileReference={handleOpenFileReference}
+														submitQueueState={submitQueueState}
 														composerOnly
 														composerWrapperClassName="w-full"
 														composerForceAvailable={Boolean(startRepository)}
@@ -1700,6 +1708,7 @@ function AppShell({
 													onRequestCloseSession={requestCloseSession}
 													workspaceRootPath={workspaceRootPath}
 													onOpenFileReference={handleOpenFileReference}
+													submitQueueState={submitQueueState}
 													contextPanelOpen={contextPanelOpen}
 													onToggleContextPanel={handleToggleContextPanel}
 													contextPreviewCard={workspacePreviewCard}

--- a/src/features/conversation/index.tsx
+++ b/src/features/conversation/index.tsx
@@ -19,7 +19,11 @@ import { hasUnresolvedPlanReview } from "@/lib/plan-review";
 import { sessionThreadMessagesQueryOptions } from "@/lib/query-client";
 import { useSettings } from "@/lib/settings";
 import type { ContextCard } from "@/lib/sources/types";
-import { EMPTY_QUEUE, useSubmitQueue } from "@/lib/use-submit-queue";
+import {
+	EMPTY_QUEUE,
+	type SubmitQueueState,
+	useSubmitQueue,
+} from "@/lib/use-submit-queue";
 import { cn } from "@/lib/utils";
 import { getComposerContextKey } from "@/lib/workspace-helpers";
 import {
@@ -153,6 +157,11 @@ type WorkspaceConversationContainerProps = {
 		directories: readonly string[];
 		onChange: (next: readonly string[]) => void;
 	} | null;
+	/** Lifted submit-queue state. App.tsx owns the instance so it survives
+	 *  the start-page ↔ workspace toggle (both container instances share
+	 *  the same queue). Optional only so existing tests can mount without
+	 *  wiring this up — production callers must always pass it. */
+	submitQueueState?: SubmitQueueState;
 };
 
 export const WorkspaceConversationContainer = memo(
@@ -199,6 +208,7 @@ export const WorkspaceConversationContainer = memo(
 		onToggleContextPanel,
 		composerStartSubmitMenu = false,
 		composerLinkedDirectoriesController = null,
+		submitQueueState,
 	}: WorkspaceConversationContainerProps) {
 		const [composerModelSelections, setComposerModelSelections] = useState<
 			Record<string, string>
@@ -221,11 +231,16 @@ export const WorkspaceConversationContainer = memo(
 			selectedWorkspaceId !== displayedWorkspaceId ||
 			selectedSessionId !== displayedSessionId;
 
-		// App-level follow-up queue. Survives session / workspace
-		// switches because this container is mounted once in the App
-		// tree (not keyed by session id).
+		// Follow-up queue state. Production callers (App.tsx) pass a lifted
+		// instance via `submitQueueState` so the queue survives the start-page
+		// ↔ workspace toggle — this container is rendered in two separate
+		// subtrees (one inside `WorkspaceStartPage`, one outside) and switching
+		// between them unmounts the previous tree. The local fallback only
+		// exists for tests that don't care about queue lifetime.
 		const { settings } = useSettings();
-		const { queuesBySessionId, api: submitQueueApi } = useSubmitQueue();
+		const fallbackSubmitQueue = useSubmitQueue();
+		const { queuesBySessionId, api: submitQueueApi } =
+			submitQueueState ?? fallbackSubmitQueue;
 
 		const {
 			activeSendError,

--- a/src/features/conversation/pending-user-input.ts
+++ b/src/features/conversation/pending-user-input.ts
@@ -93,6 +93,10 @@ export function buildPendingUserInput(
 	const userInputId = event.userInputId?.trim();
 	const modelId = event.modelId || fallbackModelId || null;
 	if (!userInputId || !modelId) {
+		console.warn(
+			"[conversation] userInputRequest dropped: missing userInputId/modelId",
+			{ userInputId, modelId, hasFallback: Boolean(fallbackModelId) },
+		);
 		return null;
 	}
 
@@ -100,8 +104,21 @@ export function buildPendingUserInput(
 		event.payload as Record<string, unknown> | undefined,
 	);
 	if (!payload) {
+		console.warn(
+			"[conversation] userInputRequest dropped: payload normalization failed",
+			{
+				userInputId,
+				rawPayloadKind: (event.payload as { kind?: unknown })?.kind,
+			},
+		);
 		return null;
 	}
+
+	console.info("[conversation] userInputRequest accepted", {
+		userInputId,
+		payloadKind: payload.kind,
+		source: event.source,
+	});
 
 	return {
 		provider: event.provider,


### PR DESCRIPTION
## Summary

- **Lifts submit queue state** from `WorkspaceConversationContainer` to the `App` root so the queue survives the start-page ↔ workspace toggle. The two container instances (one inside `WorkspaceStartPage`, one outside) are different React subtrees; keeping the queue at app level ensures continuity when switching between modes.
- **Consistent camelCase serialization** for all `AgentStreamEvent` fields. Removed manual field-level `#[serde(rename)]` attributes and use a single `#[serde(rename_all = "camelCase")]` at the enum level for consistency.
- **Comprehensive AUQ logging** in the sidecar and backend for debugging user input request flows: logs when `canUseTool` fires, when `userInputRequest` is emitted, and when resolution completes.
- **Console instrumentation** in `pending-user-input.ts` to warn when requests are dropped (missing IDs/model) and info log when accepted.

## Test Coverage

All 14 pipeline test snapshots updated to reflect the serialization changes. Existing tests pass.

## Next Steps

Merge to `main` and monitor AUQ request handling logs in development.