### PR TITLE
refactor: extract CSS color resolver to shared utility

### DIFF
--- a/src/components/terminal-output.tsx
+++ b/src/components/terminal-output.tsx
@@ -2,6 +2,7 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import { FitAddon } from "@xterm/addon-fit";
 import { type ILinkProvider, type ITheme, Terminal } from "@xterm/xterm";
 import { memo, useEffect, useRef } from "react";
+import { resolveCssColor } from "@/lib/css-color";
 import { useSettings } from "@/lib/settings";
 import "@xterm/xterm/css/xterm.css";
 
@@ -204,42 +205,14 @@ export function suspendTerminalWrites(): () => void {
 	};
 }
 
-/**
- * Read --terminal-* and --foreground CSS variables and build an xterm ITheme.
- *
- * CSS custom properties return raw token strings from getComputedStyle (e.g.
- * "oklch(0.145 0 0)"), but xterm.js only reliably parses #hex / rgb() / rgba().
- * We force the browser to resolve each value to rgb() by writing it into a real
- * CSS color property on a temporary element, then reading back the computed
- * result.
- */
 function resolveTerminalTheme(): ITheme {
-	const s = getComputedStyle(document.documentElement);
+	const v = (suffix: string) => resolveCssColor(`var(--terminal-${suffix})`);
+	const mix = (pct: number) =>
+		resolveCssColor(
+			`color-mix(in oklch, var(--foreground) ${pct}%, transparent)`,
+		);
 
-	// Probe element: setting its `color` property forces the browser to
-	// serialise any CSS color value (oklch, color-mix, etc.) as rgb()/rgba().
-	const probe = document.createElement("div");
-	probe.style.display = "none";
-	document.body.appendChild(probe);
-
-	const v = (suffix: string) => {
-		const raw = s.getPropertyValue(`--terminal-${suffix}`).trim();
-		// Reset before each assignment so an invalid/empty value doesn't
-		// silently carry over the previous successful color.
-		probe.style.color = "";
-		probe.style.color = raw;
-		return getComputedStyle(probe).color;
-	};
-
-	// Match the app's global scrollbar colors (foreground @ 18%/30%/40%).
-	// color-mix() is also not understood by xterm, so resolve it the same way.
-	const fg = s.getPropertyValue("--foreground").trim();
-	const mix = (pct: number) => {
-		probe.style.color = `color-mix(in oklch, ${fg} ${pct}%, transparent)`;
-		return getComputedStyle(probe).color;
-	};
-
-	const theme: ITheme = {
+	return {
 		background: v("background"),
 		foreground: v("foreground"),
 		cursor: v("cursor"),
@@ -264,9 +237,6 @@ function resolveTerminalTheme(): ITheme {
 		brightCyan: v("bright-cyan"),
 		brightWhite: v("bright-white"),
 	};
-
-	probe.remove();
-	return theme;
 }
 
 function resolveTerminalFontFamily(

--- a/src/lib/css-color.ts
+++ b/src/lib/css-color.ts
@@ -1,0 +1,65 @@
+let cssColorProbe: HTMLDivElement | null = null;
+let cssColorCanvas: CanvasRenderingContext2D | null = null;
+let unsupportedColorSentinel: CanvasGradient | null = null;
+
+function getCssColorProbe(): HTMLDivElement {
+	if (!cssColorProbe) {
+		cssColorProbe = document.createElement("div");
+		cssColorProbe.style.cssText =
+			"position:absolute;visibility:hidden;pointer-events:none;width:0;height:0;";
+		(document.body ?? document.documentElement).appendChild(cssColorProbe);
+	}
+	return cssColorProbe;
+}
+
+function getCssColorCanvas(): CanvasRenderingContext2D {
+	if (!cssColorCanvas) {
+		const canvas = document.createElement("canvas");
+		canvas.width = 1;
+		canvas.height = 1;
+		const ctx = canvas.getContext("2d", { willReadFrequently: true });
+		if (!ctx) {
+			throw new Error("Failed to get 2D context for color resolver");
+		}
+		ctx.globalCompositeOperation = "copy";
+		cssColorCanvas = ctx;
+		unsupportedColorSentinel = ctx.createLinearGradient(0, 0, 1, 1);
+	}
+	return cssColorCanvas;
+}
+
+function toHexByte(n: number): string {
+	return Math.max(0, Math.min(255, Math.round(n)))
+		.toString(16)
+		.padStart(2, "0");
+}
+
+export function resolveCssColor(value: string, alphaOverride?: number): string {
+	const probe = getCssColorProbe();
+	probe.style.backgroundColor = "";
+	probe.style.backgroundColor = value;
+	if (!probe.style.backgroundColor) {
+		throw new Error(`Unsupported CSS color: ${value}`);
+	}
+	const computed = getComputedStyle(probe).backgroundColor;
+
+	const ctx = getCssColorCanvas();
+	const sentinel = unsupportedColorSentinel;
+	if (!sentinel) {
+		throw new Error("Color resolver sentinel was not initialized");
+	}
+	ctx.fillStyle = sentinel;
+	ctx.fillStyle = computed;
+	if (typeof ctx.fillStyle !== "string") {
+		throw new Error(`Unsupported CSS color: ${value}`);
+	}
+
+	ctx.clearRect(0, 0, 1, 1);
+	ctx.fillRect(0, 0, 1, 1);
+	const [r, g, b, baseAlpha] = ctx.getImageData(0, 0, 1, 1).data;
+	const alpha =
+		alphaOverride === undefined ? baseAlpha : Math.round(alphaOverride * 255);
+	const alphaHex = alpha >= 255 ? "" : toHexByte(alpha);
+
+	return `#${toHexByte(r)}${toHexByte(g)}${toHexByte(b)}${alphaHex}`;
+}

--- a/src/lib/monaco-runtime.ts
+++ b/src/lib/monaco-runtime.ts
@@ -5,6 +5,7 @@ import cssWorker from "monaco-editor/esm/vs/language/css/css.worker?worker";
 import htmlWorker from "monaco-editor/esm/vs/language/html/html.worker?worker";
 import jsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
 import tsWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker";
+import { resolveCssColor } from "@/lib/css-color";
 
 type MonacoModule = typeof Monaco;
 type StandaloneEditor = Monaco.editor.IStandaloneCodeEditor;
@@ -519,111 +520,42 @@ const SYNTAX_RULES_LIGHT = [
 	{ token: "delimiter", foreground: "5a5857" },
 ];
 
-// Hidden div used to resolve `var(--x)` to a computed background-color
-// string. We can't put `var()` directly into a canvas fillStyle, so we ask
-// the engine to cascade the variable here first.
-let cssColorProbe: HTMLDivElement | null = null;
-function getCssColorProbe(): HTMLDivElement {
-	if (!cssColorProbe) {
-		cssColorProbe = document.createElement("div");
-		cssColorProbe.style.cssText =
-			"position:absolute;visibility:hidden;pointer-events:none;width:0;height:0;";
-		document.body.appendChild(cssColorProbe);
-	}
-	return cssColorProbe;
-}
-
-// 2D canvas used to normalize any CSS color (rgb / oklch / oklab / color()
-// / hex) to plain sRGB bytes. WebKit returns `oklch(...)` literals from
-// `getComputedStyle` instead of `rgb(...)`, so a regex on the computed
-// string isn't enough — canvas does the heavy lifting via the engine's
-// color pipeline.
-let cssColorCanvasCtx: CanvasRenderingContext2D | null = null;
-function getCssColorCanvas(): CanvasRenderingContext2D {
-	if (!cssColorCanvasCtx) {
-		const canvas = document.createElement("canvas");
-		canvas.width = 1;
-		canvas.height = 1;
-		const ctx = canvas.getContext("2d", { willReadFrequently: true });
-		if (!ctx) {
-			throw new Error("Failed to get 2D context for color resolver");
-		}
-		cssColorCanvasCtx = ctx;
-	}
-	return cssColorCanvasCtx;
-}
-
-function toHexByte(n: number): string {
-	return Math.max(0, Math.min(255, Math.round(n)))
-		.toString(16)
-		.padStart(2, "0");
-}
-
-/**
- * Resolve a CSS variable to a hex Monaco accepts.
- * `alphaOverride` (0–1) lets callers stamp a custom transparency without
- * defining a new --var (useful for soft overlays like inactive selection).
- */
-function resolveCssColor(varName: string, alphaOverride?: number): string {
-	const probe = getCssColorProbe();
-	probe.style.backgroundColor = `var(${varName})`;
-	const computed = window.getComputedStyle(probe).backgroundColor;
-
-	const ctx = getCssColorCanvas();
-	// Reset to a sentinel then assign — if the engine rejects `computed`
-	// (e.g. unknown function), fillStyle stays as the sentinel and we know
-	// resolution failed.
-	ctx.fillStyle = "rgba(0,0,0,0)";
-	ctx.fillStyle = computed;
-	ctx.clearRect(0, 0, 1, 1);
-	ctx.fillRect(0, 0, 1, 1);
-	const data = ctx.getImageData(0, 0, 1, 1).data;
-
-	const baseAlpha = data[3] / 255;
-	const alpha = alphaOverride !== undefined ? alphaOverride : baseAlpha;
-	const aHex = alpha >= 1 ? "" : toHexByte(alpha * 255);
-	return `#${toHexByte(data[0])}${toHexByte(data[1])}${toHexByte(data[2])}${aHex}`;
-}
+const cssVarColor = (name: string, alphaOverride?: number) =>
+	resolveCssColor(`var(${name})`, alphaOverride);
 
 function buildHelmorTheme(isDark: boolean) {
-	const editorBg = resolveCssColor("--editor-content-bg");
-	const editorFg = resolveCssColor("--editor-content-fg");
-	const lineActive = resolveCssColor("--editor-line-active-bg");
-	const selection = resolveCssColor("--editor-selection-bg");
-	const cursor = resolveCssColor("--editor-cursor");
-	const gutterBg = resolveCssColor("--editor-gutter-bg");
-	const gutterFg = resolveCssColor("--editor-gutter-fg");
-	const widgetBg = resolveCssColor("--bg-overlay");
-	const widgetBorder = resolveCssColor("--border-default");
-	const scrollbarBase = resolveCssColor("--fg-default", 0.15);
-	const scrollbarHover = resolveCssColor("--fg-default", 0.25);
-	const scrollbarActive = resolveCssColor("--fg-default", 0.35);
-	const indentGuide = resolveCssColor("--border-subtle");
-	const indentGuideActive = resolveCssColor("--border-strong");
+	const editorBg = cssVarColor("--editor-content-bg");
+	const editorFg = cssVarColor("--editor-content-fg");
+	const lineActive = cssVarColor("--editor-line-active-bg");
+	const selection = cssVarColor("--editor-selection-bg");
+	const cursor = cssVarColor("--editor-cursor");
+	const gutterBg = cssVarColor("--editor-gutter-bg");
+	const gutterFg = cssVarColor("--editor-gutter-fg");
+	const widgetBg = cssVarColor("--bg-overlay");
+	const widgetBorder = cssVarColor("--border-default");
+	const scrollbarBase = cssVarColor("--fg-default", 0.15);
+	const scrollbarHover = cssVarColor("--fg-default", 0.25);
+	const scrollbarActive = cssVarColor("--fg-default", 0.35);
+	const indentGuide = cssVarColor("--border-subtle");
+	const indentGuideActive = cssVarColor("--border-strong");
 	// Diff colors come from the workspace status palette — semantic and locked,
 	// so they match the sidebar PR badges across every theme. Alpha is layered
 	// on top to dim them into editor-overlay use.
-	const diffInsertLine = resolveCssColor("--workspace-pr-open-accent", 0.09);
-	const diffInsertText = resolveCssColor(
+	const diffInsertLine = cssVarColor("--workspace-pr-open-accent", 0.09);
+	const diffInsertText = cssVarColor(
 		"--workspace-pr-open-accent",
 		isDark ? 0.25 : 0.2,
 	);
-	const diffRemoveLine = resolveCssColor("--workspace-pr-closed-accent", 0.09);
-	const diffRemoveText = resolveCssColor(
+	const diffRemoveLine = cssVarColor("--workspace-pr-closed-accent", 0.09);
+	const diffRemoveText = cssVarColor(
 		"--workspace-pr-closed-accent",
 		isDark ? 0.25 : 0.2,
 	);
-	const diffGutterInsert = resolveCssColor("--workspace-pr-open-accent", 0.15);
-	const diffGutterRemove = resolveCssColor(
-		"--workspace-pr-closed-accent",
-		0.15,
-	);
-	const diffOverviewInsert = resolveCssColor("--workspace-pr-open-accent", 0.6);
-	const diffOverviewRemove = resolveCssColor(
-		"--workspace-pr-closed-accent",
-		0.6,
-	);
-	const diffDiagonal = resolveCssColor("--fg-default", isDark ? 0.03 : 0.04);
+	const diffGutterInsert = cssVarColor("--workspace-pr-open-accent", 0.15);
+	const diffGutterRemove = cssVarColor("--workspace-pr-closed-accent", 0.15);
+	const diffOverviewInsert = cssVarColor("--workspace-pr-open-accent", 0.6);
+	const diffOverviewRemove = cssVarColor("--workspace-pr-closed-accent", 0.6);
+	const diffDiagonal = cssVarColor("--fg-default", isDark ? 0.03 : 0.04);
 
 	return {
 		base: (isDark ? "vs-dark" : "vs") as "vs" | "vs-dark",
@@ -635,20 +567,20 @@ function buildHelmorTheme(isDark: boolean) {
 			"editor.lineHighlightBackground": lineActive,
 			"editor.lineHighlightBorder": "#00000000",
 			"editor.selectionBackground": selection,
-			"editor.inactiveSelectionBackground": resolveCssColor(
+			"editor.inactiveSelectionBackground": cssVarColor(
 				"--editor-selection-bg",
 				0.5,
 			),
-			"editor.wordHighlightBackground": resolveCssColor(
+			"editor.wordHighlightBackground": cssVarColor(
 				"--editor-selection-bg",
 				0.4,
 			),
-			"editor.wordHighlightStrongBackground": resolveCssColor(
+			"editor.wordHighlightStrongBackground": cssVarColor(
 				"--editor-selection-bg",
 				0.55,
 			),
 			"editorCursor.foreground": cursor,
-			"editorWhitespace.foreground": resolveCssColor("--fg-disabled"),
+			"editorWhitespace.foreground": cssVarColor("--fg-disabled"),
 			"editorIndentGuide.background1": indentGuide,
 			"editorIndentGuide.activeBackground1": indentGuideActive,
 			"editorLineNumber.foreground": gutterFg,

--- a/src/styles/color-theme.css
+++ b/src/styles/color-theme.css
@@ -264,7 +264,7 @@
 
 	/* Terminal ANSI palette (LOCKED) */
 	--terminal-background: var(--terminal-chrome-bg);
-	--terminal-foreground: var(--terminal-chrome-fg);
+	--terminal-foreground: var(--sidebar-fg);
 	--terminal-cursor: var(--fg-default);
 	--terminal-selection: oklch(0.87 0.03 250);
 	--terminal-black: oklch(0.26 0 0);

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -314,6 +314,10 @@ if (typeof window !== "undefined" && typeof window.matchMedia === "undefined") {
 if (typeof HTMLCanvasElement !== "undefined") {
 	Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
 		configurable: true,
+		// `src/lib/css-color.ts` resolves CSS values via canvas (gradient
+		// sentinel + getImageData). jsdom doesn't ship a canvas backend, so we
+		// stub the methods it touches with shapes that exercise the same code
+		// paths without crashing.
 		value: vi.fn(() => ({
 			measureText: (text: string) => ({
 				width: text.length * 8,
@@ -334,6 +338,14 @@ if (typeof HTMLCanvasElement !== "undefined") {
 			lineTo: () => {},
 			stroke: () => {},
 			fillText: () => {},
+			createLinearGradient: () => ({
+				addColorStop: () => {},
+			}),
+			getImageData: () => ({
+				data: new Uint8ClampedArray([0, 0, 0, 255]),
+			}),
+			fillStyle: "",
+			globalCompositeOperation: "source-over",
 			font: "",
 			textBaseline: "alphabetic",
 		})),


### PR DESCRIPTION
## Summary

This PR consolidates the CSS color resolution logic that was duplicated between `monaco-runtime.ts` and `terminal-output.tsx` into a new shared utility (`css-color.ts`). 

## Changes

- **New file**: `src/lib/css-color.ts` — centralized CSS color resolution with probe/canvas management
- **Monaco theme**: simplified to use the new `resolveCssColor` utility
- **Terminal theme**: simplified to use the new `resolveCssColor` utility
- **Terminal colors**: fixed foreground color to use `--sidebar-fg` instead of the undefined `--terminal-chrome-fg`

## Why

1. **Eliminate duplication** — CSS color probing logic is non-trivial (canvas + getComputedStyle for oklch/color-mix support) and was implemented separately in two places
2. **Fix terminal colors** — The terminal was using an undefined CSS variable, causing it to fall back to default text color. This now correctly respects the sidebar foreground color across theme changes
3. **Improve maintainability** — Future color resolution changes only need to happen in one place

## Testing

- Terminal theme colors now respond to appearance/theme changes
- Monaco editor still resolves colors correctly for editor surface, diff colors, and UI overlays
- Verified cross-theme (light/dark) and preset (Nova, etc.) color resolution still works