### PR TITLE
fix: prevent feedback textarea horizontal scroll

### DIFF
--- a/.changeset/fix-feedback-textarea-scroll.md
+++ b/.changeset/fix-feedback-textarea-scroll.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix a horizontal scrollbar appearing in the Send Feedback dialog textarea so the placeholder wraps within the dialog width.

--- a/src/features/feedback/step-input.tsx
+++ b/src/features/feedback/step-input.tsx
@@ -55,7 +55,7 @@ export function StepInput({
 				placeholder="Describe a bug, suggest an improvement, or ask a question."
 				aria-label="Feedback"
 				disabled={sending}
-				className="min-h-32"
+				className="field-sizing-fixed min-h-32"
 			/>
 			<div className="min-h-4 text-xs text-muted-foreground">
 				{!githubConnected ? (


### PR DESCRIPTION
## What changed
- Added fixed field sizing to the Send Feedback dialog textarea.
- Added a patch changeset describing the user-visible fix.

## Why
The feedback placeholder could force a horizontal scrollbar instead of wrapping within the dialog width.

## Test notes
- Commit hook ran Biome on staged frontend files.
- No full test suite run; change is a one-line styling fix.