### PR TITLE
fix: skip git status polling for chat workspaces

### DIFF
--- a/.changeset/fix-chat-workspace-git-status-poll.md
+++ b/.changeset/fix-chat-workspace-git-status-poll.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix a `WorkspaceBroken` error logged on every git-status poll for chat workspaces, which have no git binding.

--- a/src-tauri/src/commands/editor_commands.rs
+++ b/src-tauri/src/commands/editor_commands.rs
@@ -112,6 +112,11 @@ pub async fn get_workspace_git_action_status(
         if !record.state.is_operational() {
             return Ok(quiet_status());
         }
+        // Chat workspaces are scratch dirs with no git binding at all. Polling
+        // `git status` would just spam `WorkspaceBroken` on every tick.
+        if record.mode.is_chat() {
+            return Ok(quiet_status());
+        }
         let workspace_dir = crate::workspace::helpers::workspace_path(&record)?;
         // Defensive: if the worktree directory was removed externally (e.g.
         // user `rm -rf`ed it while the row is still `ready`), return quiet

--- a/src-tauri/src/commands/tests/workspace_creation.rs
+++ b/src-tauri/src/commands/tests/workspace_creation.rs
@@ -1471,6 +1471,38 @@ fn git_action_status_returns_fresh_defaults_for_initializing_workspace() {
 }
 
 #[test]
+fn git_action_status_returns_quiet_status_for_chat_workspace() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _harness = CreateTestHarness::new();
+
+    // Chat workspaces are scratch dirs with no git binding. A naive
+    // `git status` call would emit `WorkspaceBroken` on every poll;
+    // the short-circuit must catch chat mode before running git.
+    let prepared =
+        crate::workspace::lifecycle::prepare_chat_workspace_impl(WorkspaceStatus::InProgress, None)
+            .unwrap();
+
+    let status = tauri::async_runtime::block_on(
+        crate::commands::editor_commands::get_workspace_git_action_status(
+            prepared.workspace_id.clone(),
+        ),
+    )
+    .expect("get_workspace_git_action_status should succeed for chat workspace");
+
+    assert_eq!(status.uncommitted_count, 0);
+    assert_eq!(status.conflict_count, 0);
+    assert_eq!(status.behind_target_count, 0);
+    assert_eq!(status.ahead_of_remote_count, 0);
+    assert_eq!(status.sync_status, git_ops::WorkspaceSyncStatus::UpToDate);
+    assert_eq!(
+        status.push_status,
+        git_ops::WorkspacePushStatus::Unpublished,
+    );
+}
+
+#[test]
 fn pr_lookups_short_circuit_for_initializing_workspace_without_network() {
     let _guard = TEST_LOCK
         .lock()


### PR DESCRIPTION
## Summary
Chat workspaces are scratch directories with no git binding. Polling git status on every tick was logging spurious `WorkspaceBroken` errors. This fix short-circuits the git status check early if the workspace mode is chat, returning a quiet status instead.

## Changes
- **editor_commands.rs**: Added `is_chat()` mode check to return quiet status early for chat workspaces
- **workspace_creation.rs**: Added test case to verify the chat workspace git status short-circuit works correctly
- **.changeset**: Documented patch-level fix

## Testing
- Added unit test `git_action_status_returns_quiet_status_for_chat_workspace()` to verify the fix
- Existing tests pass
- Pre-commit hooks (cargo fmt, cargo clippy) passed successfully

## Why
Chat workspaces don't have a git binding by design. They're scratch directories. Attempting to poll git status on them repeatedly would generate error logs that clutter the logs and provide no useful information to users.