### PR TITLE
fix: chat sidebar unread indicator gaps

### DIFF
--- a/.changeset/chat-sidebar-unread-dot.md
+++ b/.changeset/chat-sidebar-unread-dot.md
@@ -1,0 +1,7 @@
+---
+"helmor": patch
+---
+
+Fix two sidebar unread-indicator gaps:
+- Chat rows now show the unread / interaction-required dot (hidden on hover so the archive icon can take its place); previously the dot had no carrier on chat entries and was silently dropped.
+- Background-completed sessions stay marked unread on every follow-up turn instead of only the first one — read-state was keying off the provider's resume token (non-null from the second turn onward), so subsequent completions no-op'd against the DB.

--- a/src/features/conversation/hooks/dispatch-stream-event.ts
+++ b/src/features/conversation/hooks/dispatch-stream-event.ts
@@ -206,15 +206,21 @@ export function createStreamEventDispatcher(
 			deps.clearFastPrelude(deps.contextKey);
 
 			if (event.kind === "done") {
-				const sid = event.sessionId ?? deps.targetSessionId;
-				if (sid && deps.targetWorkspaceId) {
-					deps.onSessionCompleted?.(sid, deps.targetWorkspaceId);
+				// `event.sessionId` is the *provider* session id (claude/codex
+				// resume token) — only non-null from the second turn onward,
+				// after the SDK has assigned a thread. Read-state tracking
+				// keys off the helmor session id, so feeding the provider id
+				// here would address a row that doesn't exist and
+				// `mark_session_*` would silently no-op (drops the unread dot
+				// on every follow-up turn).
+				if (deps.targetWorkspaceId) {
+					deps.onSessionCompleted?.(
+						deps.targetSessionId,
+						deps.targetWorkspaceId,
+					);
 				}
-			} else {
-				const sid = event.sessionId ?? deps.targetSessionId;
-				if (sid && deps.targetWorkspaceId) {
-					deps.onSessionAborted?.(sid, deps.targetWorkspaceId);
-				}
+			} else if (deps.targetWorkspaceId) {
+				deps.onSessionAborted?.(deps.targetSessionId, deps.targetWorkspaceId);
 			}
 
 			void deps.queryClient.invalidateQueries({

--- a/src/features/navigation/row-item.tsx
+++ b/src/features/navigation/row-item.tsx
@@ -435,6 +435,30 @@ export const WorkspaceRowItem = memo(
 					);
 				})()}
 
+				{/* Chat rows have no branch icon / avatar to carry the unread or
+				 * interaction-required dot, so park it absolute-positioned over
+				 * the archive icon slot. On hover/focus it fades out and the
+				 * actions cluster fades in, so the archive icon visually
+				 * replaces it without any layout shift. */}
+				{row.mode === "chat" && showStatusDot && !hideRepoAvatar ? (
+					<span
+						aria-hidden="false"
+						className={cn(
+							"pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2.5",
+							hasActionHandler &&
+								"group-hover/row:hidden group-focus-within/row:hidden",
+							isBusy && "hidden",
+						)}
+					>
+						<span className="flex size-5 items-center justify-center">
+							<span
+								aria-label={statusDotLabel ?? undefined}
+								className={cn("size-1.5 rounded-full", statusDotClassName)}
+							/>
+						</span>
+					</span>
+				) : null}
+
 				{hasActionHandler ? (
 					<span
 						data-workspace-row-actions="true"


### PR DESCRIPTION
## Summary

Fixes two gaps in the chat sidebar's unread/interaction-required indicators:

- **Chat rows now display the unread dot**: Previously the visual indicator had no carrier element on chat-mode rows and was silently dropped. The dot now appears in the archive icon slot and hides on hover to reveal the archive action.
- **Background-completed sessions stay marked unread**: Sessions that completed in the background were only marked unread on the first turn and then toggled back on every follow-up turn. This was because read-state tracking keyed off the provider's resume token (non-null from turn 2+), causing subsequent completions to no-op against the database. Now we key off the helmor session ID instead.

## Changes

- `src/features/conversation/hooks/use-streaming.ts`: Updated session completion/abort handlers to use `targetSessionId` (helmor session ID) instead of `event.sessionId` (provider resume token)
- `src/features/navigation/row-item.tsx`: Added unread dot indicator for chat rows with proper show/hide behavior on hover

## Testing

- Chat rows now display the unread indicator dot ✓
- Multi-turn conversations with background completions maintain unread state ✓
- Archive icon still shows on hover ✓