### PR TITLE
Fix start-page Shift+Tab conflict by splitting composer scopes

### DIFF
--- a/.changeset/fix-startpage-shift-tab-just-chat.md
+++ b/.changeset/fix-startpage-shift-tab-just-chat.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix Shift+Tab on the workspace-start page so cycling repositories no longer also toggles Just Chat or plan mode.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1656,6 +1656,7 @@ function AppShell({
 														composerContextKeyOverride={startComposerContextKey}
 														composerPlaceholder="Describe what you want to build"
 														composerCreateContext={startCreateContext}
+														composerFocusScope="start-composer"
 														contextPanelOpen={contextPanelOpen}
 														onToggleContextPanel={handleToggleContextPanel}
 														composerStartSubmitMenu

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -209,6 +209,11 @@ type WorkspaceComposerContainerProps = {
 		directories: readonly string[];
 		onChange: (next: readonly string[]) => void;
 	} | null;
+	/** Surface-specific focus scope. `start-composer` on the workspace-start
+	 *  page, `workspace-composer` everywhere else. Drives the composer's
+	 *  `data-focus-scope` and gates surface-only hotkeys (plan-mode toggle
+	 *  vs cycle-repository). */
+	focusScope?: "start-composer" | "workspace-composer";
 };
 
 const noopUserInputResponse: UserInputResponseHandler = () => {};
@@ -261,6 +266,7 @@ export const WorkspaceComposerContainer = memo(
 		onToggleContextPanel,
 		startSubmitMenu = false,
 		linkedDirectoriesController = null,
+		focusScope = "workspace-composer",
 	}: WorkspaceComposerContainerProps) {
 		const queryClient = useQueryClient();
 		const { settings, updateSettings } = useSettings();
@@ -1093,6 +1099,7 @@ export const WorkspaceComposerContainer = memo(
 						startSubmitMenu={startSubmitMenu}
 						startSubmitMode={startSubmitMode}
 						onStartSubmitModeChange={handleStartSubmitModeChange}
+						focusScope={focusScope}
 					/>
 				</div>
 			</div>

--- a/src/features/composer/index.tsx
+++ b/src/features/composer/index.tsx
@@ -196,6 +196,10 @@ type WorkspaceComposerProps = {
 	startSubmitMenu?: boolean;
 	startSubmitMode?: StartSubmitMode;
 	onStartSubmitModeChange?: (mode: StartSubmitMode) => void;
+	/** Surface-specific focus scope. Drives `data-focus-scope` on the
+	 *  composer root and gates surface-only hotkeys (e.g. plan-mode toggle
+	 *  fires only inside `workspace-composer`, never on the start surface). */
+	focusScope?: "start-composer" | "workspace-composer";
 };
 
 const EMPTY_SLASH_COMMANDS: readonly SlashCommandEntry[] = [];
@@ -277,6 +281,7 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 	startSubmitMenu = false,
 	startSubmitMode = "startNow",
 	onStartSubmitModeChange,
+	focusScope = "workspace-composer",
 }: WorkspaceComposerProps) {
 	const instanceIdRef = useRef(
 		`composer-${Math.random().toString(36).slice(2, 10)}`,
@@ -595,10 +600,16 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 				return;
 			}
 
+			// Plan mode is a workspace-only concept — the start composer has
+			// no session to flip yet. Gating on `focusScope` here keeps the
+			// hotkey from double-firing alongside the start surface's
+			// `Shift+Tab` (cycle repository) without forcing the shortcuts
+			// registry to thread surface awareness through every binding.
 			if (
 				togglePlanShortcut &&
 				hotkey === togglePlanShortcut &&
-				supportsPlanMode
+				supportsPlanMode &&
+				focusScope === "workspace-composer"
 			) {
 				event.preventDefault();
 				event.stopPropagation();
@@ -607,6 +618,7 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 		},
 		[
 			inputDisabled,
+			focusScope,
 			onChangePermissionMode,
 			permissionMode,
 			supportsPlanMode,
@@ -621,7 +633,7 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 		<div
 			ref={composerRootRef}
 			aria-label="Workspace composer"
-			data-focus-scope="composer"
+			data-focus-scope={focusScope}
 			onKeyDownCapture={handleComposerKeyDownCapture}
 			className={cn(
 				"relative flex flex-col rounded-2xl border border-border/40 bg-sidebar shadow-[0_-1px_8px_rgba(0,0,0,0.05),0_0_0_1px_rgba(255,255,255,0.02)]",

--- a/src/features/conversation/index.tsx
+++ b/src/features/conversation/index.tsx
@@ -156,6 +156,10 @@ type WorkspaceConversationContainerProps = {
 	contextPanelOpen?: boolean;
 	onToggleContextPanel?: () => void;
 	composerStartSubmitMenu?: boolean;
+	/** Surface-specific focus scope forwarded to the composer. `start-composer`
+	 *  on the workspace-start page, `workspace-composer` everywhere else.
+	 *  See `WorkspaceComposerContainerProps.focusScope`. */
+	composerFocusScope?: "start-composer" | "workspace-composer";
 	/** Pre-workspace linked-directories controller. Forwarded to the
 	 *  composer; see `WorkspaceComposerContainerProps.linkedDirectoriesController`.
 	 *  Used by the start-page composer to collect /add-dir picks before any
@@ -214,6 +218,7 @@ export const WorkspaceConversationContainer = memo(
 		contextPanelOpen = false,
 		onToggleContextPanel,
 		composerStartSubmitMenu = false,
+		composerFocusScope = "workspace-composer",
 		composerLinkedDirectoriesController = null,
 		submitQueueState,
 	}: WorkspaceConversationContainerProps) {
@@ -620,6 +625,7 @@ export const WorkspaceConversationContainer = memo(
 						contextPanelOpen={contextPanelOpen}
 						onToggleContextPanel={onToggleContextPanel}
 						startSubmitMenu={composerStartSubmitMenu}
+						focusScope={composerFocusScope}
 						linkedDirectoriesController={composerLinkedDirectoriesController}
 					/>
 				</div>

--- a/src/features/shortcuts/focus-scope.ts
+++ b/src/features/shortcuts/focus-scope.ts
@@ -13,15 +13,23 @@ const KNOWN_SCOPES: ReadonlySet<ShortcutScope> = new Set([
 	"composer",
 	"terminal",
 	"editor",
+	"start-composer",
+	"workspace-composer",
 ]);
 
 // Scope inheritance: when a leaf scope is active, every parent scope is also
 // considered active. The composer is a sibling of the chat panel in the DOM
 // (not a descendant), but semantically it IS chat — so chat-bound shortcuts
 // (Cmd+T, Cmd+W, session navigation) must keep firing while typing.
+//
+// `start-composer` / `workspace-composer` are the surface-specific siblings of
+// `composer`; both inherit composer (so model picker / follow-up keep working
+// in both places) but stay distinct so surface-only shortcuts can opt in.
 const SCOPE_PARENTS: Partial<Record<ShortcutScope, readonly ShortcutScope[]>> =
 	{
 		composer: ["chat"],
+		"start-composer": ["composer"],
+		"workspace-composer": ["composer"],
 	};
 
 export const DEFAULT_FOCUS_SCOPE: ShortcutScope = "chat";

--- a/src/features/shortcuts/registry.test.ts
+++ b/src/features/shortcuts/registry.test.ts
@@ -115,4 +115,30 @@ describe("shortcut registry", () => {
 		const ids = SHORTCUT_DEFINITIONS.map((definition) => definition.id);
 		expect(new Set<ShortcutId>(ids).size).toBe(ids.length);
 	});
+
+	it("lets Shift+Tab dual-bind across start-composer and workspace-composer", () => {
+		// `composer.togglePlanMode` lives on workspace-composer and
+		// `startSurface.cycleRepository` lives on start-composer. They share
+		// Shift+Tab on purpose — sibling leaf scopes mustn't be flagged as
+		// overlapping or both would be auto-disabled at boot.
+		const planMode = SHORTCUT_DEFINITIONS.find(
+			(definition) => definition.id === "composer.togglePlanMode",
+		);
+		const cycleRepo = SHORTCUT_DEFINITIONS.find(
+			(definition) => definition.id === "startSurface.cycleRepository",
+		);
+		expect(planMode?.defaultHotkey).toBe("Shift+Tab");
+		expect(cycleRepo?.defaultHotkey).toBe("Shift+Tab");
+		expect(planMode?.scopes).toEqual(["workspace-composer"]);
+		expect(cycleRepo?.scopes).toEqual(["start-composer"]);
+		expect(scopesOverlap(planMode?.scopes ?? [], cycleRepo?.scopes ?? [])).toBe(
+			false,
+		);
+
+		const conflicts = getShortcutConflicts({});
+		expect(conflicts.disabledIds.has("composer.togglePlanMode")).toBe(false);
+		expect(conflicts.disabledIds.has("startSurface.cycleRepository")).toBe(
+			false,
+		);
+	});
 });

--- a/src/features/shortcuts/registry.ts
+++ b/src/features/shortcuts/registry.ts
@@ -263,9 +263,22 @@ export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
 		title: "Toggle plan mode",
 		group: "Composer",
 		defaultHotkey: "Shift+Tab",
-		// composer-only: don't let Shift+Tab steal default a11y focus traversal
-		// from the inspector / message list.
-		scopes: ["composer"],
+		// workspace-composer only: plan mode is a per-session concept with
+		// no UI on the start surface. Bound to the narrower sibling scope so
+		// the start surface can reclaim Shift+Tab for cycling repositories
+		// without scope-overlap forcing both to disable each other.
+		scopes: ["workspace-composer"],
+		editable: true,
+	},
+	{
+		id: "startSurface.cycleRepository",
+		title: "Switch repository",
+		group: "Start surface",
+		defaultHotkey: "Shift+Tab",
+		// start-composer only: cycles through repositories in the start
+		// composer. Sibling scope to workspace-composer, so the two
+		// Shift+Tab bindings don't scope-overlap and stay both enabled.
+		scopes: ["start-composer"],
 		editable: true,
 	},
 	{

--- a/src/features/shortcuts/settings-panel.tsx
+++ b/src/features/shortcuts/settings-panel.tsx
@@ -36,6 +36,7 @@ const GROUPS: ShortcutGroup[] = [
 	"Actions",
 	"System",
 	"Composer",
+	"Start surface",
 	"Editor",
 	"Terminal",
 ];

--- a/src/features/shortcuts/types.ts
+++ b/src/features/shortcuts/types.ts
@@ -34,6 +34,7 @@ export type ShortcutId =
 	| "composer.toggleContextPanel"
 	| "composer.openModelPicker"
 	| "composer.toggleFollowUpBehavior"
+	| "startSurface.cycleRepository"
 	| "editor.edit"
 	| "editor.new"
 	| "editor.close"
@@ -51,6 +52,7 @@ export type ShortcutGroup =
 	| "Actions"
 	| "System"
 	| "Composer"
+	| "Start surface"
 	| "Editor"
 	| "Terminal";
 
@@ -60,7 +62,20 @@ export type ShortcutGroup =
 // "composer" and "chat"), so a shortcut bound to "chat" still fires while
 // typing — and a "composer"-only shortcut stays off when chat focus lives
 // elsewhere (inspector, message list).
-export type ShortcutScope = "app" | "chat" | "composer" | "terminal" | "editor";
+//
+// `start-composer` and `workspace-composer` are sibling leaf scopes that split
+// the composer namespace by surface. They both inherit from `composer` (and
+// transitively from `chat`) so generic composer shortcuts keep firing, but
+// surface-specific shortcuts (Shift+Tab → cycle repo on start, toggle plan
+// mode on workspace) can target one and not the other.
+export type ShortcutScope =
+	| "app"
+	| "chat"
+	| "composer"
+	| "terminal"
+	| "editor"
+	| "start-composer"
+	| "workspace-composer";
 
 export type ShortcutDefinition = {
 	id: ShortcutId;

--- a/src/features/shortcuts/use-app-shortcuts.test.tsx
+++ b/src/features/shortcuts/use-app-shortcuts.test.tsx
@@ -137,9 +137,12 @@ describe("useAppShortcuts", () => {
 					{ id: "composer.togglePlanMode", callback: togglePlanMode },
 				],
 			});
+			// Plan-mode toggle now lives on the narrower `workspace-composer`
+			// leaf; it inherits `composer` (and transitively `chat`) so generic
+			// chat shortcuts keep working alongside it.
 			return (
 				<div data-focus-scope="chat">
-					<div data-focus-scope="composer">
+					<div data-focus-scope="workspace-composer">
 						<input data-testid="composer-input" />
 					</div>
 				</div>
@@ -160,6 +163,51 @@ describe("useAppShortcuts", () => {
 		expect(togglePlanMode).toHaveBeenCalledTimes(1);
 	});
 
+	it("isolates start-composer and workspace-composer Shift+Tab bindings", () => {
+		const togglePlanMode = vi.fn();
+		const cycleRepository = vi.fn();
+
+		function Harness() {
+			useAppShortcuts({
+				overrides: {},
+				handlers: [
+					{ id: "composer.togglePlanMode", callback: togglePlanMode },
+					{
+						id: "startSurface.cycleRepository",
+						callback: cycleRepository,
+					},
+				],
+			});
+			return (
+				<div data-focus-scope="chat">
+					<div data-focus-scope="start-composer">
+						<input data-testid="start-input" />
+					</div>
+					<div data-focus-scope="workspace-composer">
+						<input data-testid="workspace-input" />
+					</div>
+				</div>
+			);
+		}
+
+		const { getByTestId } = render(<Harness />);
+
+		(getByTestId("start-input") as HTMLInputElement).focus();
+		window.dispatchEvent(
+			new KeyboardEvent("keydown", { key: "Tab", code: "Tab", shiftKey: true }),
+		);
+		expect(cycleRepository).toHaveBeenCalledTimes(1);
+		expect(togglePlanMode).not.toHaveBeenCalled();
+
+		(getByTestId("workspace-input") as HTMLInputElement).focus();
+		window.dispatchEvent(
+			new KeyboardEvent("keydown", { key: "Tab", code: "Tab", shiftKey: true }),
+		);
+		expect(togglePlanMode).toHaveBeenCalledTimes(1);
+		// Cycling stays put — the workspace surface doesn't claim its hotkey.
+		expect(cycleRepository).toHaveBeenCalledTimes(1);
+	});
+
 	it("does not fire composer-only shortcuts when chat focus is outside composer", () => {
 		const togglePlanMode = vi.fn();
 
@@ -171,7 +219,7 @@ describe("useAppShortcuts", () => {
 			return (
 				<div data-focus-scope="chat">
 					<input data-testid="inspector-input" />
-					<div data-focus-scope="composer">
+					<div data-focus-scope="workspace-composer">
 						<input data-testid="composer-input" />
 					</div>
 				</div>

--- a/src/features/workspace-start/index.tsx
+++ b/src/features/workspace-start/index.tsx
@@ -28,10 +28,12 @@ import {
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { WorkspaceAvatar } from "@/features/navigation/avatar";
+import { getShortcut } from "@/features/shortcuts/registry";
 import {
 	InlineShortcutDisplay,
 	ShortcutDisplay,
 } from "@/features/shortcuts/shortcut-display";
+import { useAppShortcuts } from "@/features/shortcuts/use-app-shortcuts";
 import { SourceDetailView } from "@/features/source-detail";
 import type {
 	BranchPickerEntry,
@@ -40,12 +42,12 @@ import type {
 	WorkspaceMode,
 } from "@/lib/api";
 import type { ComposerInsertTarget } from "@/lib/composer-insert";
+import { useSettings } from "@/lib/settings";
 import type { ContextCard } from "@/lib/sources/types";
 import { cn } from "@/lib/utils";
 import { CreateBranchDialog } from "./create-branch-dialog";
 
 const PREVIEW_TRAFFIC_LIGHT_SPACER_WIDTH = 52;
-const SWITCH_REPOSITORY_SHORTCUT = "Shift+Tab";
 
 function defaultBranchPrefix(repo: RepositoryCreateOption | null): string {
 	if (!repo) return "";
@@ -118,6 +120,12 @@ export function WorkspaceStartPage({
 			// footer) — treat as local: no `origin/` prefix in the pill.
 			"local";
 
+	const { settings } = useSettings();
+	const cycleRepositoryShortcut = getShortcut(
+		settings.shortcuts,
+		"startSurface.cycleRepository",
+	);
+
 	const selectNextRepository = useCallback(() => {
 		if (repositories.length === 0) {
 			return;
@@ -132,28 +140,21 @@ export function WorkspaceStartPage({
 		onSelectRepository(repositories[nextIndex]);
 	}, [onSelectRepository, repositories, selectedRepository]);
 
-	useEffect(() => {
-		const handleKeyDown = (event: KeyboardEvent) => {
-			if (event.key !== "Tab" || !event.shiftKey || event.defaultPrevented) {
-				return;
-			}
-
-			const activeElement = document.activeElement;
-			if (!(activeElement instanceof HTMLElement)) {
-				return;
-			}
-
-			if (!activeElement.closest('[aria-label="Workspace composer"]')) {
-				return;
-			}
-
-			event.preventDefault();
-			selectNextRepository();
-		};
-
-		window.addEventListener("keydown", handleKeyDown, true);
-		return () => window.removeEventListener("keydown", handleKeyDown, true);
-	}, [selectNextRepository]);
+	// Cycle-repository goes through the central shortcuts registry. Its
+	// `start-composer` scope is a sibling of `workspace-composer`, so the
+	// Shift+Tab plan-mode toggle that lives on the workspace composer does
+	// NOT fire on the start surface (the start surface composer carries
+	// `data-focus-scope="start-composer"`).
+	useAppShortcuts({
+		overrides: settings.shortcuts,
+		handlers: [
+			{
+				id: "startSurface.cycleRepository",
+				callback: selectNextRepository,
+				enabled: repositories.length > 1,
+			},
+		],
+	});
 
 	useEffect(() => {
 		if (!previewCard || !onClosePreview) {
@@ -346,7 +347,7 @@ export function WorkspaceStartPage({
 											>
 												<span>Switch repository</span>
 												<InlineShortcutDisplay
-													hotkey={SWITCH_REPOSITORY_SHORTCUT}
+													hotkey={cycleRepositoryShortcut}
 													className="text-background/60"
 												/>
 											</TooltipContent>

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -61,6 +61,45 @@ describe("settings", () => {
 			sourceBranchByRepoId: { "repo-1": "release/next" },
 			modeByRepoId: { "repo-1": "local" },
 			branchIntentByRepoId: { "repo-1": "use_branch" },
+			chatModeActive: false,
+		});
+	});
+
+	it("migrates legacy chat entries in modeByRepoId into chatModeActive", async () => {
+		invokeMock.mockResolvedValue({
+			"app.start_surface_preferences": JSON.stringify({
+				repoId: "repo-1",
+				modeByRepoId: {
+					"repo-1": "chat",
+					"repo-2": "worktree",
+				},
+			}),
+		});
+
+		const settings = await loadSettings();
+
+		// chat must be stripped from the repo record (it's no longer
+		// repo-bound), and the top-level toggle must capture the user's
+		// last intent so re-entering the start surface is unsurprising.
+		expect(settings.startSurfacePreferences.modeByRepoId).toEqual({
+			"repo-2": "worktree",
+		});
+		expect(settings.startSurfacePreferences.chatModeActive).toBe(true);
+	});
+
+	it("respects an explicit chatModeActive when present", async () => {
+		invokeMock.mockResolvedValue({
+			"app.start_surface_preferences": JSON.stringify({
+				repoId: "repo-1",
+				modeByRepoId: { "repo-1": "worktree" },
+				chatModeActive: true,
+			}),
+		});
+
+		const settings = await loadSettings();
+		expect(settings.startSurfacePreferences.chatModeActive).toBe(true);
+		expect(settings.startSurfacePreferences.modeByRepoId).toEqual({
+			"repo-1": "worktree",
 		});
 	});
 
@@ -121,6 +160,7 @@ describe("settings", () => {
 			sourceBranchByRepoId: { "repo-1": "main" },
 			modeByRepoId: { "repo-1": "local" },
 			branchIntentByRepoId: { "repo-1": "use_branch" },
+			chatModeActive: false,
 		});
 
 		const writeCall = invokeMock.mock.calls.find(

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,6 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { createContext, useContext } from "react";
-import type { WorkspaceBranchIntent, WorkspaceMode } from "./api";
+import type { WorkspaceBranchIntent } from "./api";
 
 export type ThemeMode = "system" | "light" | "dark";
 
@@ -160,6 +160,10 @@ export const DEFAULT_INBOX_REPO_CONFIG: InboxRepoSourceConfig = {
 	prLabels: "",
 };
 
+/** Per-repo work mode on the start surface. `chat` is a top-level toggle
+ *  (`chatModeActive`) because it doesn't belong to any repo. */
+export type StartSurfaceWorkMode = "worktree" | "local";
+
 /** Persisted preferences for the workspace-start surface. */
 export type StartSurfacePreferences = {
 	/** Composer submit-mode: immediate dispatch or saved draft. */
@@ -167,8 +171,10 @@ export type StartSurfacePreferences = {
 	/** Last selected repository. */
 	repoId: string | null;
 	sourceBranchByRepoId: Record<string, string>;
-	modeByRepoId: Record<string, WorkspaceMode>;
+	modeByRepoId: Record<string, StartSurfaceWorkMode>;
 	branchIntentByRepoId: Record<string, WorkspaceBranchIntent>;
+	/** Top-level "Just chat" toggle. Independent of the selected repo. */
+	chatModeActive: boolean;
 };
 
 export type AppSettings = {
@@ -254,10 +260,11 @@ export const DEFAULT_START_SURFACE_PREFERENCES: StartSurfacePreferences = {
 	sourceBranchByRepoId: {},
 	modeByRepoId: {},
 	branchIntentByRepoId: {},
+	chatModeActive: false,
 };
 
 /** Fallbacks for repos without a per-repo entry. */
-export const START_SURFACE_MODE_FALLBACK: WorkspaceMode = "worktree";
+export const START_SURFACE_MODE_FALLBACK: StartSurfaceWorkMode = "worktree";
 export const START_SURFACE_BRANCH_INTENT_FALLBACK: WorkspaceBranchIntent =
 	"from_branch";
 
@@ -761,23 +768,36 @@ function parseStartSurfacePreferences(
 		const o = parsed as Partial<StartSurfacePreferences> & {
 			mode?: unknown;
 			branchIntent?: unknown;
+			chatModeActive?: unknown;
 		};
 		const repoId = typeof o.repoId === "string" && o.repoId ? o.repoId : null;
-		const modeByRepoId = parseEnumRecord(o.modeByRepoId, [
+		// Legacy `modeByRepoId` may still contain "chat" entries from before
+		// chat was promoted to a top-level toggle. Capture them so the user
+		// doesn't lose the "I was in Just Chat last session" state, then
+		// strip them out — modeByRepoId now only carries repo-bound modes.
+		const rawModeByRepoId = parseEnumRecord(o.modeByRepoId, [
 			"worktree",
 			"local",
 			"chat",
 		] as const);
+		const modeByRepoId: Record<string, StartSurfaceWorkMode> = {};
+		let migratedFromLegacyChat = false;
+		for (const [key, value] of Object.entries(rawModeByRepoId)) {
+			if (value === "chat") {
+				migratedFromLegacyChat = true;
+				continue;
+			}
+			modeByRepoId[key] = value;
+		}
 		const branchIntentByRepoId = parseEnumRecord(o.branchIntentByRepoId, [
 			"from_branch",
 			"use_branch",
 		] as const);
 		if (repoId && !modeByRepoId[repoId]) {
 			const legacyMode =
-				o.mode === "worktree" || o.mode === "local" || o.mode === "chat"
-					? o.mode
-					: null;
+				o.mode === "worktree" || o.mode === "local" ? o.mode : null;
 			if (legacyMode) modeByRepoId[repoId] = legacyMode;
+			if (o.mode === "chat") migratedFromLegacyChat = true;
 		}
 		if (repoId && !branchIntentByRepoId[repoId]) {
 			const legacyBranchIntent =
@@ -786,6 +806,10 @@ function parseStartSurfacePreferences(
 					: null;
 			if (legacyBranchIntent) branchIntentByRepoId[repoId] = legacyBranchIntent;
 		}
+		const chatModeActive =
+			typeof o.chatModeActive === "boolean"
+				? o.chatModeActive
+				: migratedFromLegacyChat;
 		return {
 			createState:
 				o.createState === "backlog" || o.createState === "in-progress"
@@ -795,6 +819,7 @@ function parseStartSurfacePreferences(
 			sourceBranchByRepoId: parseStringRecord(o.sourceBranchByRepoId),
 			modeByRepoId,
 			branchIntentByRepoId,
+			chatModeActive,
 		};
 	} catch {
 		return DEFAULT_START_SURFACE_PREFERENCES;

--- a/src/shell/controllers/use-start-surface-controller.ts
+++ b/src/shell/controllers/use-start-surface-controller.ts
@@ -140,11 +140,14 @@ export function useStartSurfaceController(
 
 	// Pickers read from settings; writes go through `updateSettings`.
 	const prefs = appSettings.startSurfacePreferences;
-	const startMode = readRepoPreference(
+	// Chat is a top-level toggle (independent of repo). When off, the start
+	// surface falls back to the selected repo's stored work mode.
+	const repoWorkMode = readRepoPreference(
 		prefs.modeByRepoId,
 		startRepositoryId,
 		START_SURFACE_MODE_FALLBACK,
 	);
+	const startMode: WorkspaceMode = prefs.chatModeActive ? "chat" : repoWorkMode;
 	const startBranchIntent = readRepoPreference(
 		prefs.branchIntentByRepoId,
 		startRepositoryId,
@@ -277,12 +280,29 @@ export function useStartSurfaceController(
 
 	const selectMode = useCallback(
 		(mode: WorkspaceMode) => {
-			if (!startRepository) return;
 			// pendingNewBranch is local-mode-only; clear it on any mode flip.
 			setStartPendingNewBranch(null);
+
+			// Chat is the top-level toggle — flip just the boolean, don't
+			// touch any repo-bound state. Works even with no repo selected
+			// (chat doesn't need one).
+			if (mode === "chat") {
+				if (appSettings.startSurfacePreferences.chatModeActive) return;
+				void updateSettings({
+					startSurfacePreferences: {
+						...appSettings.startSurfacePreferences,
+						chatModeActive: true,
+					},
+				});
+				return;
+			}
+
+			// Leaving chat back into a repo-bound mode requires a repo.
+			if (!startRepository) return;
 			void updateSettings({
 				startSurfacePreferences: {
 					...appSettings.startSurfacePreferences,
+					chatModeActive: false,
 					modeByRepoId: writeRepoPreference(
 						appSettings.startSurfacePreferences.modeByRepoId,
 						startRepository.id,


### PR DESCRIPTION
## Summary

Resolves Shift+Tab binding conflict between start surface (cycle repository) and workspace composer (toggle plan mode). Both wanted the same hotkey, causing scope-overlap logic to disable both.

**Solution:** Split `data-focus-scope` into surface-specific sibling scopes:
- `start-composer` — start surface only (cycle repository via Shift+Tab)
- `workspace-composer` — workspace only (toggle plan mode via Shift+Tab)
- Both inherit from `composer` scope so generic shortcuts still work

Sibling scopes bypass the overlap check, allowing both to stay enabled.

## Additional Changes

- Promote "Just chat" to a top-level `chatModeActive` toggle (was repo-bound)
- Add settings migration for legacy chat-mode entries in `modeByRepoId`
- Wire start surface cycle-repository into central shortcuts registry instead of ad-hoc keydown

## Test Plan

- [x] Unit tests updated: registry scope-overlap test + dual-bind isolation test
- [x] Start surface: Shift+Tab cycles repositories
- [x] Workspace composer: Shift+Tab toggles plan mode
- [x] Generic shortcuts (e.g. Cmd+T, model picker) still fire in both places
- [x] Settings migration: legacy chat entries become top-level toggle