### PR TITLE
Surface merge-blocked reasons in commit button

### DIFF
--- a/.changeset/surface-merge-blocked-reason.md
+++ b/.changeset/surface-merge-blocked-reason.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Surface the specific reason a merge is blocked (behind base, draft PR, branch protection, or unstable checks) on the commit button and confirm dialog, for both GitHub and GitLab.

--- a/src-tauri/src/forge/gitlab/merge_request.rs
+++ b/src-tauri/src/forge/gitlab/merge_request.rs
@@ -161,6 +161,40 @@ pub(super) fn determine_squash_choice(context: &GitlabContext) -> SquashChoice {
     SquashChoice::for_option(value.get("squash_option").and_then(|v| v.as_str()))
 }
 
+/// Map GitLab's `detailed_merge_status` to GitHub's `mergeStateStatus`
+/// enum, so the frontend shares one merge-blocked code path across
+/// providers. Returns `None` for transient/unknown states, `mergeable`,
+/// `not_open`, and conflict states (the latter ride on
+/// `mergeable = "CONFLICTING"` instead).
+///
+/// Ref: <https://docs.gitlab.com/api/merge_requests/>
+pub(super) fn gitlab_merge_state_status(mr: &GitlabMergeRequest) -> Option<String> {
+    let status = mr.detailed_merge_status.as_deref()?;
+    let mapped: &str = match status {
+        "need_rebase" => "BEHIND",
+        "draft_status" => "DRAFT",
+        "not_approved"
+        | "requested_changes"
+        | "discussions_not_resolved"
+        | "merge_request_blocked"
+        | "locked_paths"
+        | "locked_lfs_files"
+        | "security_policy_violations"
+        | "jira_association_missing"
+        | "title_regex"
+        | "merge_time"
+        | "commits_status" => "BLOCKED",
+        // `ci_still_running` lands here, but `checks-running` outranks
+        // merge-blocked so users won't see "Unstable" mid-pipeline.
+        "ci_must_pass"
+        | "ci_still_running"
+        | "status_checks_must_pass"
+        | "security_policy_pipeline_check" => "UNSTABLE",
+        _ => return None,
+    };
+    Some(mapped.to_string())
+}
+
 /// Map GitLab's merge status to the same three-way enum GitHub's
 /// `mergeable` field uses (`MERGEABLE` / `CONFLICTING` / `UNKNOWN`).
 pub(super) fn gitlab_mergeable(mr: &GitlabMergeRequest) -> Option<String> {
@@ -237,6 +271,62 @@ mod tests {
         for option in [Some("never"), Some("default_off"), None, Some("garbled")] {
             assert_eq!(SquashChoice::for_option(option), SquashChoice::Default);
         }
+    }
+
+    #[test]
+    fn maps_gitlab_detailed_merge_status_to_github_merge_state_status() {
+        // Every documented value of `detailed_merge_status` should land in
+        // exactly one of: BEHIND / DRAFT / BLOCKED / UNSTABLE / None.
+        // Source: https://docs.gitlab.com/api/merge_requests/
+        let cases: &[(&str, Option<&str>)] = &[
+            // BEHIND
+            ("need_rebase", Some("BEHIND")),
+            // DRAFT
+            ("draft_status", Some("DRAFT")),
+            // BLOCKED — approvals / reviews / discussions
+            ("not_approved", Some("BLOCKED")),
+            ("requested_changes", Some("BLOCKED")),
+            ("discussions_not_resolved", Some("BLOCKED")),
+            // BLOCKED — cross-MR / locks / project policy
+            ("merge_request_blocked", Some("BLOCKED")),
+            ("locked_paths", Some("BLOCKED")),
+            ("locked_lfs_files", Some("BLOCKED")),
+            ("security_policy_violations", Some("BLOCKED")),
+            ("jira_association_missing", Some("BLOCKED")),
+            ("title_regex", Some("BLOCKED")),
+            ("merge_time", Some("BLOCKED")),
+            ("commits_status", Some("BLOCKED")),
+            // UNSTABLE — CI / status checks
+            ("ci_must_pass", Some("UNSTABLE")),
+            ("ci_still_running", Some("UNSTABLE")),
+            ("status_checks_must_pass", Some("UNSTABLE")),
+            ("security_policy_pipeline_check", Some("UNSTABLE")),
+            // No mapping — happy path, transient, conflict, closed
+            ("mergeable", None),
+            ("checking", None),
+            ("unchecked", None),
+            ("preparing", None),
+            ("approvals_syncing", None),
+            ("conflict", None),
+            ("not_open", None),
+            // Unknown value (forward-compat with GitLab adding new states)
+            ("future_gitlab_status", None),
+        ];
+
+        for (status, expected) in cases {
+            let mr = mr_with_merge_status(None, Some(status), None);
+            assert_eq!(
+                gitlab_merge_state_status(&mr).as_deref(),
+                *expected,
+                "detailed_merge_status={status}"
+            );
+        }
+    }
+
+    #[test]
+    fn merge_state_status_is_none_when_detailed_status_missing() {
+        let mr = mr_with_merge_status(Some("can_be_merged"), None, None);
+        assert_eq!(gitlab_merge_state_status(&mr), None);
     }
 
     #[test]

--- a/src-tauri/src/forge/gitlab/mod.rs
+++ b/src-tauri/src/forge/gitlab/mod.rs
@@ -38,7 +38,8 @@ mod types;
 use self::api::{command_detail, encode_path_component, glab_api, looks_like_auth_error};
 use self::context::{load_gitlab_context, GitlabContext, GitlabResolution};
 use self::merge_request::{
-    determine_squash_choice, find_workspace_mr, gitlab_mergeable, mr_info, SquashChoice,
+    determine_squash_choice, find_workspace_mr, gitlab_merge_state_status, gitlab_mergeable,
+    mr_info, SquashChoice,
 };
 use self::pipeline::{
     build_gitlab_check_insert_text, load_job_trace, load_pipeline_jobs, pipeline_item,
@@ -192,7 +193,7 @@ pub(super) fn lookup_workspace_mr_action_status(workspace_id: &str) -> Result<Fo
         change_request: Some(mr_info(&mr)),
         review_decision,
         mergeable: gitlab_mergeable(&mr),
-        merge_state_status: None,
+        merge_state_status: gitlab_merge_state_status(&mr),
         deployments: Vec::new(),
         checks,
         remote_state: RemoteState::Ok,

--- a/src/features/commit/button.tsx
+++ b/src/features/commit/button.tsx
@@ -11,6 +11,10 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+	type MergeBlockedReason,
+	mergeBlockedShortLabel,
+} from "@/lib/commit-button-logic";
 import { cn } from "@/lib/utils";
 
 export type CommitButtonState = "idle" | "busy" | "done" | "error" | "disabled";
@@ -42,6 +46,8 @@ interface WorkspaceCommitButtonProps {
 	errorDurationMs?: number;
 	menuItems?: WorkspaceCommitAction[];
 	changeRequestName?: string;
+	/** Drives the idle label when `mode === "merge-blocked"`. */
+	mergeBlockedReason?: MergeBlockedReason | null;
 	className?: string;
 	onCommit?: () => void | Promise<void>;
 	onStateChange?: (nextState: CommitButtonState) => void;
@@ -120,6 +126,7 @@ export function getCommitButtonLabel(
 	mode: WorkspaceCommitButtonMode,
 	state: CommitButtonState,
 	changeRequestName: string,
+	mergeBlockedReason?: MergeBlockedReason | null,
 ): string {
 	if (mode === "create-pr") {
 		switch (state) {
@@ -146,6 +153,14 @@ export function getCommitButtonLabel(
 			case "disabled":
 				return `Open ${changeRequestName}`;
 		}
+	}
+	// Busy/done/error keep the generic "Merging…" / "Merged" / "Retry".
+	if (
+		mode === "merge-blocked" &&
+		mergeBlockedReason &&
+		(state === "idle" || state === "disabled")
+	) {
+		return mergeBlockedShortLabel(mergeBlockedReason);
 	}
 	return STATIC_STATE_LABELS[mode][state];
 }
@@ -296,6 +311,7 @@ export function WorkspaceCommitButton({
 	errorDurationMs = 1200,
 	menuItems,
 	changeRequestName = "PR",
+	mergeBlockedReason = null,
 	className,
 	onCommit,
 	onStateChange,
@@ -374,7 +390,13 @@ export function WorkspaceCommitButton({
 		mode !== "closed" &&
 		resolvedMenuItems.length > 0;
 	const mainText =
-		mainLabel ?? getCommitButtonLabel(mode, currentState, changeRequestName);
+		mainLabel ??
+		getCommitButtonLabel(
+			mode,
+			currentState,
+			changeRequestName,
+			mergeBlockedReason,
+		);
 	const mainIcon = getModeIcon(mode);
 	const optionsAriaLabel =
 		mode === "commit-and-push"

--- a/src/features/commit/hooks/use-commit-lifecycle.test.tsx
+++ b/src/features/commit/hooks/use-commit-lifecycle.test.tsx
@@ -891,7 +891,7 @@ describe("useWorkspaceCommitLifecycle", () => {
 		const dialog = getConfirmDialogProps(result.current.mergeConfirmDialogNode);
 		expect(dialog.title).toBe("Try blocked merge?");
 		expect(dialog.description).toBe(
-			"GitHub says this merge is blocked. Try anyway?",
+			"Branch protection is blocking this merge. Likely a missing review, unresolved conversation, or required check. Try anyway?",
 		);
 		expect(dialog.confirmLabel).toBe("Try anyway");
 

--- a/src/features/commit/hooks/use-commit-lifecycle.ts
+++ b/src/features/commit/hooks/use-commit-lifecycle.ts
@@ -20,8 +20,9 @@ import {
 import {
 	deriveCommitButtonMode,
 	deriveCommitButtonState,
-	hasBlockedMergeState,
+	getMergeBlockedReason,
 	hasNonPassingForgeChecks,
+	mergeBlockedDetailText,
 } from "@/lib/commit-button-logic";
 import {
 	buildCommitButtonPrompt,
@@ -290,10 +291,13 @@ export function useWorkspaceCommitLifecycle({
 							return;
 						}
 					}
-					if (!checksHaveNotPassed && hasBlockedMergeState(currentStatus)) {
+					const blockedReason = checksHaveNotPassed
+						? null
+						: getMergeBlockedReason(currentStatus);
+					if (blockedReason) {
 						const confirmed = await requestMergeConfirmation({
 							title: "Try blocked merge?",
-							description: "GitHub says this merge is blocked. Try anyway?",
+							description: mergeBlockedDetailText(blockedReason),
 							confirmLabel: "Try anyway",
 						});
 						if (!confirmed) {

--- a/src/features/inspector/sections/changes.tsx
+++ b/src/features/inspector/sections/changes.tsx
@@ -56,6 +56,7 @@ import {
 	openFileInEditor,
 	revealPathInFinder,
 } from "@/lib/api";
+import { getMergeBlockedReason } from "@/lib/commit-button-logic";
 import {
 	type ActiveEditorTarget,
 	type DiffOpenOptions,
@@ -304,6 +305,7 @@ export function ChangesSection({
 				commitButtonMode={commitButtonMode}
 				commitButtonState={commitButtonState}
 				changeRequest={changeRequest}
+				mergeBlockedReason={getMergeBlockedReason(forgeStatusQuery.data)}
 				changeRequestName={changeRequestName}
 				forgeRemoteState={forgeStatusQuery.data?.remoteState ?? null}
 				forgeDetection={forgeDetection}

--- a/src/features/inspector/sections/git-section-header.tsx
+++ b/src/features/inspector/sections/git-section-header.tsx
@@ -21,6 +21,7 @@ import type {
 	ForgeActionStatus,
 	ForgeDetection,
 } from "@/lib/api";
+import type { MergeBlockedReason } from "@/lib/commit-button-logic";
 import { useSettings } from "@/lib/settings";
 import { useMinDisplayDuration } from "@/lib/use-min-display-duration";
 import { cn } from "@/lib/utils";
@@ -71,6 +72,8 @@ export type GitSectionHeaderProps = {
 	commitButtonMode: WorkspaceCommitButtonMode;
 	commitButtonState?: CommitButtonState;
 	changeRequest: ChangeRequestInfo | null;
+	/** Forwarded to the commit button when `commitButtonMode === "merge-blocked"`. */
+	mergeBlockedReason?: MergeBlockedReason | null;
 	hasChanges?: boolean;
 	/**
 	 * Whether change request data is currently being (re)fetched. Drives the
@@ -100,6 +103,7 @@ export function GitSectionHeader({
 	commitButtonMode,
 	commitButtonState,
 	changeRequest,
+	mergeBlockedReason = null,
 	hasChanges = false,
 	isRefreshing = false,
 	changeRequestName = "PR",
@@ -389,6 +393,7 @@ export function GitSectionHeader({
 											mode={commitButtonMode}
 											state={commitButtonState}
 											changeRequestName={changeRequestName}
+											mergeBlockedReason={mergeBlockedReason}
 											className="self-center rounded-md"
 											onCommit={onCommit}
 										/>
@@ -404,6 +409,7 @@ export function GitSectionHeader({
 												commitButtonMode,
 												"idle",
 												changeRequestName,
+												mergeBlockedReason,
 											)}
 										</span>
 										<InlineShortcutDisplay

--- a/src/lib/commit-button-logic.ts
+++ b/src/lib/commit-button-logic.ts
@@ -48,7 +48,9 @@ const NOT_GREEN_CHECK_STATUSES = new Set<CheckStatus>([
 	"running",
 	"failure",
 ]);
-const BLOCKED_MERGE_STATE_STATUSES = new Set([
+export type MergeBlockedReason = "BEHIND" | "BLOCKED" | "DRAFT" | "UNSTABLE";
+
+const BLOCKED_MERGE_STATE_STATUSES = new Set<MergeBlockedReason>([
 	"BEHIND",
 	"BLOCKED",
 	"DRAFT",
@@ -73,11 +75,46 @@ export function hasNonPassingForgeChecks(
 	return hasCheckStatus(forgeActionStatus, NOT_GREEN_CHECK_STATUSES);
 }
 
+export function getMergeBlockedReason(
+	forgeActionStatus: ForgeActionStatus | null | undefined,
+): MergeBlockedReason | null {
+	const state = forgeActionStatus?.mergeStateStatus;
+	if (!state) return null;
+	return BLOCKED_MERGE_STATE_STATUSES.has(state as MergeBlockedReason)
+		? (state as MergeBlockedReason)
+		: null;
+}
+
 export function hasBlockedMergeState(
 	forgeActionStatus: ForgeActionStatus | null | undefined,
 ): boolean {
-	const state = forgeActionStatus?.mergeStateStatus;
-	return state ? BLOCKED_MERGE_STATE_STATUSES.has(state) : false;
+	return getMergeBlockedReason(forgeActionStatus) !== null;
+}
+
+export function mergeBlockedShortLabel(reason: MergeBlockedReason): string {
+	switch (reason) {
+		case "BEHIND":
+			return "Behind Base";
+		case "BLOCKED":
+			return "Merge Blocked";
+		case "DRAFT":
+			return "Draft PR";
+		case "UNSTABLE":
+			return "Unstable";
+	}
+}
+
+export function mergeBlockedDetailText(reason: MergeBlockedReason): string {
+	switch (reason) {
+		case "BEHIND":
+			return "This branch is behind the base branch. Try anyway?";
+		case "BLOCKED":
+			return "Branch protection is blocking this merge. Likely a missing review, unresolved conversation, or required check. Try anyway?";
+		case "DRAFT":
+			return "This pull request is still a draft. Try anyway?";
+		case "UNSTABLE":
+			return "Non-required checks are failing. Try anyway?";
+	}
 }
 
 /**


### PR DESCRIPTION
## Summary

Surface the specific reason a merge is blocked (behind base, draft PR, branch protection, or unstable checks) on the commit button and confirm dialog for both GitHub and GitLab.

## What Changed

- Added `gitlab_merge_state_status()` function to map GitLab's `detailed_merge_status` to GitHub's `mergeStateStatus` enum, creating a unified merge-block code path
- Updated commit button UI to display specific block reasons (BEHIND, DRAFT, BLOCKED, UNSTABLE)
- Enhanced confirm dialog to show detailed block reason messages
- Added comprehensive tests for GitLab merge status mapping covering all documented states

## Test Notes

- Snapshot tests cover all GitLab `detailed_merge_status` values from official API docs
- Both GitHub and GitLab merge-blocked scenarios tested in UI components