### PR TITLE
fix: composer scroll jumps when clicking or navigating

### DIFF
--- a/.changeset/fix-composer-scroll-jumps.md
+++ b/.changeset/fix-composer-scroll-jumps.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix the composer jumping to the bottom when you click into it, and not following the caret when you arrow up past the visible area.

--- a/src/features/composer/editor/plugins/auto-resize-plugin.tsx
+++ b/src/features/composer/editor/plugins/auto-resize-plugin.tsx
@@ -16,13 +16,16 @@ export function AutoResizePlugin({
 	const [editor] = useLexicalComposerContext();
 
 	useEffect(() => {
-		return editor.registerUpdateListener(() => {
+		return editor.registerUpdateListener(({ dirtyElements, dirtyLeaves }) => {
+			// Skip selection-only updates (click, arrow keys). Re-measuring on
+			// every selection change toggles overflow on/off via height="auto",
+			// which clobbers scrollTop and breaks native caret-into-view scroll.
+			if (dirtyElements.size === 0 && dirtyLeaves.size === 0) return;
 			const rootEl = editor.getRootElement();
 			if (!rootEl) return;
 			rootEl.style.height = "auto";
 			const next = Math.min(rootEl.scrollHeight, maxHeight);
 			rootEl.style.height = `${Math.max(next, minHeight)}px`;
-			rootEl.scrollTop = rootEl.scrollHeight;
 		});
 	}, [editor, minHeight, maxHeight]);
 


### PR DESCRIPTION
## What changed

Fixed a bug where the composer was jumping to the bottom when you clicked into it, and not following the caret when navigating with arrow keys.

## Why

The `AutoResizePlugin` was forcing `scrollTop = scrollHeight` on every editor update, including selection-only changes (clicks, arrow keys) that don't modify content. This prevented the native browser scroll-into-view behavior when navigating with arrow keys and constantly jumped the scroll position to the bottom.

## How

- Removed the forced `scrollTop` assignment that was clobbering native scrolling
- Added a check to skip re-measuring when there are no content changes (`dirtyElements` and `dirtyLeaves` are both empty)
- This allows selection-only updates to preserve scroll position while still auto-sizing the editor when content actually changes

## Testing

- Click into the composer and verify the view doesn't jump to the bottom
- Use arrow keys to navigate up/down in a multi-line message and verify the caret stays visible
- Type new content and verify the editor still auto-resizes correctly