### PR TITLE
Add ArrowUp/Down history recall in composer

### DIFF
--- a/.announcements/composer-arrow-history-recall.json
+++ b/.announcements/composer-arrow-history-recall.json
@@ -1,0 +1,7 @@
+{
+	"items": [
+		{
+			"text": "Press ArrowUp / ArrowDown in the composer to step through previously-sent prompts for the current session — like bash or zsh."
+		}
+	]
+}

--- a/.changeset/composer-arrow-history-recall.md
+++ b/.changeset/composer-arrow-history-recall.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Add ArrowUp / ArrowDown history recall in the composer — at the first or last line of the input, the arrow keys step through previously-sent prompts for the current session, just like bash or zsh.

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -42,6 +42,7 @@ import {
 	workspaceLinkedDirectoriesQueryOptions,
 	workspaceSessionsQueryOptions,
 } from "@/lib/query-client";
+import { readSessionThread } from "@/lib/session-thread-cache";
 import { useSettings } from "@/lib/settings";
 import type { QueuedSubmit } from "@/lib/use-submit-queue";
 import { cn } from "@/lib/utils";
@@ -55,6 +56,10 @@ import {
 import { CodexGoalBanner } from "../panel/codex-goal-banner";
 import type { AddDirPickerEntry } from "./editor/add-dir/typeahead-plugin";
 import { WorkspaceComposer } from "./index";
+import {
+	extractInputHistoryFromThread,
+	type InputHistoryEntry,
+} from "./input-history";
 import type { PermissionPanelProps } from "./permission-panel";
 import type { StartSubmitMode } from "./start-submit-mode";
 import { SubmitQueueList } from "./submit-queue-list";
@@ -270,6 +275,15 @@ export const WorkspaceComposerContainer = memo(
 	}: WorkspaceComposerContainerProps) {
 		const queryClient = useQueryClient();
 		const { settings, updateSettings } = useSettings();
+		// Per-session input recall list. Resolved lazily from the live
+		// thread cache on every ArrowUp/Down — the plugin doesn't subscribe,
+		// so cache mutations between key presses are picked up automatically
+		// without re-rendering the composer.
+		const getInputHistory = useCallback((): readonly InputHistoryEntry[] => {
+			if (!displayedSessionId) return [];
+			const thread = readSessionThread(queryClient, displayedSessionId);
+			return extractInputHistoryFromThread(thread);
+		}, [displayedSessionId, queryClient]);
 		const startSubmitMode: StartSubmitMode =
 			settings.startSurfacePreferences.createState === "backlog"
 				? "saveForLater"
@@ -1100,6 +1114,7 @@ export const WorkspaceComposerContainer = memo(
 						startSubmitMode={startSubmitMode}
 						onStartSubmitModeChange={handleStartSubmitModeChange}
 						focusScope={focusScope}
+						getInputHistory={getInputHistory}
 					/>
 				</div>
 			</div>

--- a/src/features/composer/editor-ops.ts
+++ b/src/features/composer/editor-ops.ts
@@ -14,6 +14,31 @@ import type {
 	ComposerInsertItem,
 } from "@/lib/composer-insert";
 
+export type ComposerContentPart =
+	| { kind: "text"; text: string }
+	| { kind: "image"; path: string }
+	| { kind: "file"; path: string }
+	| { kind: "customTag"; customTag: ComposerCustomTag };
+
+function $appendComposerContentPart(
+	paragraph: ReturnType<typeof $createParagraphNode>,
+	part: ComposerContentPart,
+) {
+	if (part.kind === "text") {
+		if (part.text) paragraph.append($createTextNode(part.text));
+		return;
+	}
+	if (part.kind === "image") {
+		paragraph.append($createImageBadgeNode(part.path));
+		return;
+	}
+	if (part.kind === "file") {
+		paragraph.append($createFileBadgeNode(part.path));
+		return;
+	}
+	paragraph.append($createCustomTagBadgeNode(part.customTag));
+}
+
 export function $setEditorContent(
 	draft: string,
 	images: string[],
@@ -43,6 +68,16 @@ export function $setEditorContent(
 			paragraph.append($createTextNode(" "));
 		}
 		paragraph.append($createCustomTagBadgeNode(customTag));
+	}
+	root.append(paragraph);
+}
+
+export function $setEditorContentParts(parts: readonly ComposerContentPart[]) {
+	const root = $getRoot();
+	root.clear();
+	const paragraph = $createParagraphNode();
+	for (const part of parts) {
+		$appendComposerContentPart(paragraph, part);
 	}
 	root.append(paragraph);
 }

--- a/src/features/composer/editor/plugins/draft-persistence-plugin.tsx
+++ b/src/features/composer/editor/plugins/draft-persistence-plugin.tsx
@@ -9,6 +9,10 @@ import {
 import type { ComposerCustomTag } from "@/lib/composer-insert";
 import { $setEditorContent } from "../../editor-ops";
 import { $extractComposerContent } from "../utils";
+import {
+	HISTORY_RECALL_RESTORE_TAG,
+	HISTORY_RECALL_TAG,
+} from "./history-recall-plugin";
 
 const SAVE_DELAY_MS = 400;
 
@@ -48,6 +52,7 @@ export function DraftPersistencePlugin({
 	const initializedContextKeyRef = useRef<string | null>(null);
 	const saveTimerRef = useRef<number | null>(null);
 	const prevRestoreNonceRef = useRef(restoreNonce);
+	const recallActiveRef = useRef(false);
 
 	const clearDraftState = useCallback((targetContextKey: string) => {
 		clearPersistedDraft(targetContextKey);
@@ -59,6 +64,9 @@ export function DraftPersistencePlugin({
 				return;
 			}
 
+			if (recallActiveRef.current) {
+				return;
+			}
 			const editorState = editor.getEditorState().toJSON();
 			editor.read(() => {
 				const content = $extractComposerContent();
@@ -128,6 +136,7 @@ export function DraftPersistencePlugin({
 		if (previousContextKey && previousContextKey !== contextKey) {
 			cancelScheduledFlush();
 			flushDraft(previousContextKey);
+			recallActiveRef.current = false;
 			initializedContextKeyRef.current = null;
 		}
 
@@ -167,9 +176,25 @@ export function DraftPersistencePlugin({
 	}, [applyRestorePayload, restoreNonce]);
 
 	useEffect(() => {
-		return editor.registerUpdateListener(() => {
-			scheduleFlush(contextKey);
-		});
+		return editor.registerUpdateListener(
+			({ tags, dirtyElements, dirtyLeaves }) => {
+				// Recall plugin mutations carry HISTORY_RECALL_TAG — those are
+				// browsing previously-sent prompts, not authoring a new draft.
+				// Persisting them would overwrite the user's in-progress draft.
+				if (tags.has(HISTORY_RECALL_TAG)) {
+					recallActiveRef.current = true;
+					return;
+				}
+				if (tags.has(HISTORY_RECALL_RESTORE_TAG)) {
+					recallActiveRef.current = false;
+					return;
+				}
+				const hasContentChange = dirtyElements.size > 0 || dirtyLeaves.size > 0;
+				if (recallActiveRef.current && !hasContentChange) return;
+				if (hasContentChange) recallActiveRef.current = false;
+				scheduleFlush(contextKey);
+			},
+		);
 	}, [contextKey, editor, scheduleFlush]);
 
 	useEffect(() => {

--- a/src/features/composer/editor/plugins/history-recall-plugin.test.tsx
+++ b/src/features/composer/editor/plugins/history-recall-plugin.test.tsx
@@ -1,0 +1,316 @@
+/**
+ * Behavioural coverage for the ArrowUp/ArrowDown input-recall plugin.
+ *
+ * jsdom doesn't lay out content (every `getBoundingClientRect` returns
+ * the zero rect), which conveniently puts the caret-line probe in its
+ * "treat as both first AND last line" fallback — exactly the path we
+ * want at the start of recall when the editor is empty or single-line.
+ */
+
+import { QueryClientProvider } from "@tanstack/react-query";
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
+import type { SerializedEditorState } from "lexical";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentModelSection } from "@/lib/api";
+import { createHelmorQueryClient } from "@/lib/query-client";
+import {
+	__resetDraftCacheForTests,
+	loadPersistedDraft,
+	savePersistedDraft,
+} from "../../draft-storage";
+import { WorkspaceComposer } from "../../index";
+import type { InputHistoryEntry } from "../../input-history";
+import { historyRecallTestUtils } from "./history-recall-plugin";
+
+vi.mock("@tauri-apps/api/core", () => ({
+	invoke: vi.fn(),
+	convertFileSrc: vi.fn((path: string) => `asset://localhost${path}`),
+	Channel: class {
+		onmessage: ((event: unknown) => void) | null = null;
+	},
+}));
+
+vi.mock("@tauri-apps/plugin-opener", () => ({
+	openUrl: vi.fn(),
+}));
+
+const MODEL_SECTIONS = [
+	{
+		id: "claude",
+		label: "Claude",
+		options: [
+			{
+				id: "opus-1m",
+				provider: "claude",
+				label: "Opus",
+				cliModel: "opus-1m",
+				effortLevels: ["low", "medium", "high"],
+				supportsFastMode: true,
+			},
+		],
+	},
+] satisfies AgentModelSection[];
+
+let testCounter = 0;
+
+function textEntry(text: string): InputHistoryEntry {
+	return { parts: [{ kind: "text", text }] };
+}
+
+function rect(top: number, bottom: number): DOMRect {
+	return {
+		top,
+		bottom,
+		left: 0,
+		right: 100,
+		width: 100,
+		height: bottom - top,
+		x: 0,
+		y: top,
+		toJSON: () => ({}),
+	} as DOMRect;
+}
+
+function paragraphDraft(text: string): SerializedEditorState {
+	return {
+		root: {
+			type: "root",
+			version: 1,
+			format: "",
+			indent: 0,
+			direction: null,
+			children: [
+				{
+					type: "paragraph",
+					version: 1,
+					format: "",
+					indent: 0,
+					direction: null,
+					textFormat: 0,
+					textStyle: "",
+					children: [
+						{
+							type: "text",
+							version: 1,
+							text,
+							format: 0,
+							mode: "normal",
+							style: "",
+							detail: 0,
+						},
+					],
+				},
+			],
+		},
+	} as unknown as SerializedEditorState;
+}
+
+function renderComposer(
+	history: readonly InputHistoryEntry[],
+	onSubmit = vi.fn(),
+	contextKey?: string,
+) {
+	const queryClient = createHelmorQueryClient();
+	testCounter += 1;
+	const composerContextKey = contextKey ?? `session:recall-test-${testCounter}`;
+	const result = render(
+		<QueryClientProvider client={queryClient}>
+			<WorkspaceComposer
+				contextKey={composerContextKey}
+				onSubmit={onSubmit}
+				disabled={false}
+				submitDisabled={false}
+				sending={false}
+				selectedModelId="opus-1m"
+				modelSections={MODEL_SECTIONS}
+				onSelectModel={vi.fn()}
+				provider="claude"
+				effortLevel="high"
+				onSelectEffort={vi.fn()}
+				permissionMode="acceptEdits"
+				onChangePermissionMode={vi.fn()}
+				restoreImages={[]}
+				restoreFiles={[]}
+				restoreCustomTags={[]}
+				getInputHistory={() => history}
+			/>
+		</QueryClientProvider>,
+	);
+	return { ...result, contextKey: composerContextKey, onSubmit };
+}
+
+beforeEach(() => {
+	__resetDraftCacheForTests();
+});
+
+afterEach(() => {
+	cleanup();
+	window.localStorage.clear();
+	__resetDraftCacheForTests();
+});
+
+describe("HistoryRecallPlugin", () => {
+	it("treats the last content line as last even when the editor is taller", () => {
+		const root = document.createElement("div");
+		const paragraph = document.createElement("p");
+		const text = document.createTextNode("newest");
+		paragraph.append(text);
+		root.append(paragraph);
+		document.body.append(root);
+		const range = document.createRange();
+		range.setStart(text, text.textContent?.length ?? 0);
+		range.collapse(true);
+		const rangeRect = vi.fn(() => rect(2, 18));
+		Object.defineProperty(range, "getBoundingClientRect", {
+			configurable: true,
+			value: rangeRect,
+		});
+
+		const spies = [
+			vi.spyOn(root, "getBoundingClientRect").mockReturnValue(rect(0, 100)),
+			vi.spyOn(paragraph, "getBoundingClientRect").mockReturnValue(rect(0, 20)),
+			vi.spyOn(range, "cloneRange").mockReturnValue(range),
+			vi.spyOn(window, "getSelection").mockReturnValue({
+				rangeCount: 1,
+				getRangeAt: () => range,
+			} as unknown as Selection),
+		];
+
+		try {
+			expect(historyRecallTestUtils.caretLinePosition(root)).toEqual({
+				atFirstLine: true,
+				atLastLine: true,
+			});
+		} finally {
+			for (const spy of spies) spy.mockRestore();
+			root.remove();
+		}
+	});
+
+	it("does nothing when history is empty", async () => {
+		renderComposer([]);
+		const editor = screen.getByLabelText("Workspace input");
+		fireEvent.keyDown(editor, { key: "ArrowUp", code: "ArrowUp" });
+		// Empty editor should remain empty after a no-op recall press.
+		expect(editor.textContent ?? "").toBe("");
+	});
+
+	it("walks back through history on successive ArrowUp presses", async () => {
+		renderComposer([
+			textEntry("newest"),
+			textEntry("middle"),
+			textEntry("oldest"),
+		]);
+
+		const editor = screen.getByLabelText("Workspace input");
+		fireEvent.keyDown(editor, { key: "ArrowUp", code: "ArrowUp" });
+		await waitFor(() => expect(editor.textContent).toContain("newest"));
+
+		fireEvent.keyDown(editor, { key: "ArrowUp", code: "ArrowUp" });
+		await waitFor(() => expect(editor.textContent).toContain("middle"));
+
+		fireEvent.keyDown(editor, { key: "ArrowUp", code: "ArrowUp" });
+		await waitFor(() => expect(editor.textContent).toContain("oldest"));
+
+		// Past the oldest entry the editor sticks.
+		fireEvent.keyDown(editor, { key: "ArrowUp", code: "ArrowUp" });
+		await waitFor(() => expect(editor.textContent).toContain("oldest"));
+	});
+
+	it("ArrowDown from the newest entry restores the empty draft", async () => {
+		renderComposer([textEntry("newest")]);
+		const editor = screen.getByLabelText("Workspace input");
+
+		fireEvent.keyDown(editor, { key: "ArrowUp", code: "ArrowUp" });
+		await waitFor(() => expect(editor.textContent).toContain("newest"));
+
+		fireEvent.keyDown(editor, { key: "ArrowDown", code: "ArrowDown" });
+		await waitFor(() => expect(editor.textContent ?? "").toBe(""));
+	});
+
+	it("yields to IME composition (isComposing/keyCode 229)", async () => {
+		renderComposer([textEntry("should-not-recall")]);
+		const editor = screen.getByLabelText("Workspace input");
+
+		fireEvent.keyDown(editor, {
+			key: "ArrowUp",
+			code: "ArrowUp",
+			keyCode: 229,
+			isComposing: true,
+		});
+		// Plugin must not have applied the entry.
+		expect(editor.textContent ?? "").toBe("");
+	});
+
+	it("yields to modifier-combined ArrowUp (e.g. Shift+ArrowUp for selection)", async () => {
+		renderComposer([textEntry("should-not-recall")]);
+		const editor = screen.getByLabelText("Workspace input");
+
+		fireEvent.keyDown(editor, {
+			key: "ArrowUp",
+			code: "ArrowUp",
+			shiftKey: true,
+		});
+		expect(editor.textContent ?? "").toBe("");
+	});
+
+	it("preserves mention order and submits recalled image paths once", async () => {
+		const imagePath = "/Users/test/cache/paste/example.png";
+		const filePath = "src/app.tsx";
+		const onSubmit = vi.fn();
+		renderComposer(
+			[
+				{
+					parts: [
+						{ kind: "text", text: "看 " },
+						{ kind: "image", path: imagePath },
+						{ kind: "text", text: " 然后改 " },
+						{ kind: "file", path: filePath },
+						{ kind: "text", text: "。" },
+					],
+				},
+			],
+			onSubmit,
+		);
+		const editor = screen.getByLabelText("Workspace input");
+
+		fireEvent.keyDown(editor, { key: "ArrowUp", code: "ArrowUp" });
+		await waitFor(() => expect(editor.textContent).toContain("然后改"));
+		fireEvent.keyDown(editor, { key: "Enter", code: "Enter" });
+
+		await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+		const [prompt, images, files] = onSubmit.mock.calls[0];
+		expect(prompt).toBe(`看 @${imagePath} 然后改 @${filePath}。`);
+		expect(prompt.split(imagePath)).toHaveLength(2);
+		expect(images).toEqual([imagePath]);
+		expect(files).toEqual([filePath]);
+	});
+
+	it("does not persist the recalled history entry over the saved draft", async () => {
+		const contextKey = "session:recall-draft";
+		savePersistedDraft(contextKey, paragraphDraft("keep this draft"));
+		const { unmount } = renderComposer(
+			[textEntry("history prompt")],
+			vi.fn(),
+			contextKey,
+		);
+		const editor = screen.getByLabelText("Workspace input");
+
+		await waitFor(() =>
+			expect(editor.textContent).toContain("keep this draft"),
+		);
+		fireEvent.keyDown(editor, { key: "ArrowUp", code: "ArrowUp" });
+		await waitFor(() => expect(editor.textContent).toContain("history prompt"));
+		unmount();
+
+		const persisted = JSON.stringify(loadPersistedDraft(contextKey));
+		expect(persisted).toContain("keep this draft");
+		expect(persisted).not.toContain("history prompt");
+	});
+});

--- a/src/features/composer/editor/plugins/history-recall-plugin.tsx
+++ b/src/features/composer/editor/plugins/history-recall-plugin.tsx
@@ -1,0 +1,332 @@
+/**
+ * Shell-style input recall: ArrowUp/ArrowDown at the editor's first /
+ * last line walks back/forward through previously submitted prompts
+ * for the current session (per-session scope).
+ *
+ * Behavior matches bash/zsh/fish:
+ *   - Up at first line (or empty input): step to older history. The
+ *     content the user had in the composer before the first Up gets
+ *     snapshotted as the "in-progress draft" so a later Down past the
+ *     newest entry restores it verbatim.
+ *   - Down at last line: step to newer history; past the newest entry
+ *     the in-progress draft is restored and history mode exits.
+ *   - Mid-content Up/Down (cursor not at the line boundary) falls
+ *     through to Lexical's default caret movement.
+ *   - User edits inside a recalled entry exit history mode and drop
+ *     the saved in-progress draft — the recalled+edited text becomes
+ *     the new working draft.
+ *
+ * Guards (mirrored from `SubmitPlugin` so the three pieces of keyboard
+ * UX stay consistent):
+ *   - Active typeahead popup (slash / @-mention / add-dir picker)
+ *     keeps Arrow keys for menu navigation.
+ *   - IME composition (`isComposing` / `keyCode === 229`) yields to
+ *     the browser's candidate selector.
+ */
+
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { mergeRegister } from "@lexical/utils";
+import {
+	$getRoot,
+	COMMAND_PRIORITY_LOW,
+	KEY_ARROW_DOWN_COMMAND,
+	KEY_ARROW_UP_COMMAND,
+	type SerializedEditorState,
+} from "lexical";
+import { useCallback, useEffect, useRef } from "react";
+import { clearPersistedDraft, savePersistedDraft } from "../../draft-storage";
+import { $setEditorContent, $setEditorContentParts } from "../../editor-ops";
+import type { InputHistoryEntry } from "../../input-history";
+import { $extractComposerContent } from "../utils";
+
+/** Update tag stamped on every editor mutation the recall plugin
+ *  performs (applying a history entry, restoring the in-progress draft).
+ *  Sibling plugins watch for this tag to suppress side effects — most
+ *  importantly `DraftPersistencePlugin`, which would otherwise overwrite
+ *  the saved draft with whatever recalled prompt is currently on screen. */
+export const HISTORY_RECALL_TAG = "helmor-input-recall";
+export const HISTORY_RECALL_RESTORE_TAG = "helmor-input-recall-restore";
+
+const TYPEAHEAD_SELECTABLE_SELECTOR = "[data-typeahead-popup] [cmdk-item]";
+
+function isTypeaheadSelectable(): boolean {
+	if (typeof document === "undefined") return false;
+	return document.querySelector(TYPEAHEAD_SELECTABLE_SELECTOR) !== null;
+}
+
+function contentVerticalBounds(rootEl: HTMLElement): {
+	top: number;
+	bottom: number;
+} {
+	const rootRect = rootEl.getBoundingClientRect();
+	let top = Number.POSITIVE_INFINITY;
+	let bottom = Number.NEGATIVE_INFINITY;
+	for (const child of Array.from(rootEl.children)) {
+		const rect = child.getBoundingClientRect();
+		if (
+			rect.top === 0 &&
+			rect.bottom === 0 &&
+			rect.width === 0 &&
+			rect.height === 0
+		) {
+			continue;
+		}
+		top = Math.min(top, rect.top);
+		bottom = Math.max(bottom, rect.bottom);
+	}
+	if (!Number.isFinite(top) || !Number.isFinite(bottom)) {
+		return { top: rootRect.top, bottom: rootRect.bottom };
+	}
+	return { top, bottom };
+}
+
+function caretLinePosition(rootEl: HTMLElement): {
+	atFirstLine: boolean;
+	atLastLine: boolean;
+} {
+	// Fallback treats the caret as "on both boundaries" — the shell-style
+	// recall handler then runs on every Up/Down regardless of position.
+	// That's the right behavior for jsdom (no layout) and the empty-editor
+	// case (no measurable caret), and harmless in production for the
+	// single-line case where first === last line.
+	const fallback = { atFirstLine: true, atLastLine: true };
+	if (typeof window === "undefined") return fallback;
+	const selection = window.getSelection();
+	if (!selection || selection.rangeCount === 0) return fallback;
+	let range: Range;
+	try {
+		range = selection.getRangeAt(0).cloneRange();
+	} catch {
+		return fallback;
+	}
+	if (!rootEl.contains(range.startContainer)) return fallback;
+	range.collapse(true);
+	if (typeof range.getBoundingClientRect !== "function") return fallback;
+	let caretRect: DOMRect;
+	try {
+		caretRect = range.getBoundingClientRect();
+	} catch {
+		return fallback;
+	}
+	if (
+		caretRect.top === 0 &&
+		caretRect.left === 0 &&
+		caretRect.width === 0 &&
+		caretRect.height === 0
+	) {
+		const container =
+			range.startContainer instanceof Element
+				? range.startContainer
+				: (range.startContainer.parentElement ?? rootEl);
+		try {
+			caretRect = container.getBoundingClientRect();
+		} catch {
+			return fallback;
+		}
+	}
+	const contentBounds = contentVerticalBounds(rootEl);
+	const lineHeightRaw = parseFloat(getComputedStyle(rootEl).lineHeight);
+	const lineHeight =
+		Number.isFinite(lineHeightRaw) && lineHeightRaw > 0 ? lineHeightRaw : 20;
+	const threshold = lineHeight * 0.5;
+	return {
+		atFirstLine: caretRect.top - contentBounds.top < threshold,
+		atLastLine: contentBounds.bottom - caretRect.bottom < threshold,
+	};
+}
+
+export const historyRecallTestUtils = {
+	caretLinePosition,
+};
+
+type Props = {
+	/** Returns the per-session recall list, most-recent first. Called
+	 *  lazily on each ArrowUp/Down so the plugin always sees the latest
+	 *  cache without needing to re-render on every cache update. */
+	getHistory: () => readonly InputHistoryEntry[];
+	/** Resets recall state when the parent swaps sessions (a new
+	 *  `contextKey` means a new history scope). */
+	scopeKey: string;
+};
+
+export function HistoryRecallPlugin({ getHistory, scopeKey }: Props) {
+	const [editor] = useLexicalComposerContext();
+
+	// -1 = not in recall mode; 0 = most recent; history.length - 1 = oldest.
+	const indexRef = useRef<number>(-1);
+	const pendingDraftRef = useRef<SerializedEditorState | null>(null);
+	// Wrap `getHistory` in a ref so a fresh function identity from the
+	// parent on every render doesn't re-register the command listeners.
+	const getHistoryRef = useRef(getHistory);
+	useEffect(() => {
+		getHistoryRef.current = getHistory;
+	}, [getHistory]);
+
+	const exitRecallMode = useCallback(() => {
+		indexRef.current = -1;
+		pendingDraftRef.current = null;
+	}, []);
+
+	// Drop recall state whenever the composer's scope changes.
+	useEffect(() => {
+		exitRecallMode();
+	}, [exitRecallMode, scopeKey]);
+
+	const applyEntry = useCallback(
+		(entry: InputHistoryEntry) => {
+			editor.update(
+				() => {
+					$setEditorContentParts(entry.parts);
+					$getRoot().selectEnd();
+				},
+				{ tag: HISTORY_RECALL_TAG },
+			);
+		},
+		[editor],
+	);
+
+	const restoreDraft = useCallback(
+		(serialized: SerializedEditorState | null) => {
+			if (serialized) {
+				try {
+					const parsed = editor.parseEditorState(serialized);
+					editor.setEditorState(parsed, { tag: HISTORY_RECALL_RESTORE_TAG });
+					editor.update(
+						() => {
+							$getRoot().selectEnd();
+						},
+						{ tag: HISTORY_RECALL_RESTORE_TAG },
+					);
+					return;
+				} catch {
+					// Fall through to empty restore.
+				}
+			}
+			editor.update(
+				() => {
+					$setEditorContent("", [], [], []);
+				},
+				{ tag: HISTORY_RECALL_RESTORE_TAG },
+			);
+		},
+		[editor],
+	);
+
+	const snapshotCurrentDraft = useCallback((): SerializedEditorState => {
+		return editor.getEditorState().toJSON();
+	}, [editor]);
+
+	const handleArrow = useCallback(
+		(direction: "up" | "down", event: KeyboardEvent | null): boolean => {
+			if (event?.isComposing || event?.keyCode === 229) return false;
+			if (
+				event?.shiftKey ||
+				event?.altKey ||
+				event?.metaKey ||
+				event?.ctrlKey
+			) {
+				return false;
+			}
+			if (isTypeaheadSelectable()) return false;
+
+			const rootEl = editor.getRootElement();
+			if (!rootEl) return false;
+
+			const { atFirstLine, atLastLine } = caretLinePosition(rootEl);
+			if (direction === "up" && !atFirstLine) return false;
+			if (direction === "down" && !atLastLine) return false;
+
+			const history = getHistoryRef.current();
+			if (history.length === 0) return false;
+
+			const currentIndex = indexRef.current;
+
+			if (direction === "up") {
+				const nextIndex = Math.min(history.length - 1, currentIndex + 1);
+				if (nextIndex === currentIndex) {
+					// Already at the oldest entry — keep the focus where it
+					// is. Returning true prevents the caret from drifting to
+					// a previous DOM line as a side effect of the ArrowUp.
+					event?.preventDefault();
+					return true;
+				}
+				if (currentIndex < 0) {
+					// First step into recall: snapshot whatever the user
+					// had typed so a later Down past the newest entry can
+					// restore it.
+					const editorState = snapshotCurrentDraft();
+					editor.read(() => {
+						const content = $extractComposerContent();
+						const empty =
+							!content.text &&
+							content.images.length === 0 &&
+							content.files.length === 0 &&
+							content.customTags.length === 0;
+						pendingDraftRef.current = empty ? null : editorState;
+						if (empty) {
+							clearPersistedDraft(scopeKey);
+						} else {
+							savePersistedDraft(scopeKey, editorState);
+						}
+					});
+				}
+				indexRef.current = nextIndex;
+				const entry = history[nextIndex];
+				if (entry) applyEntry(entry);
+				event?.preventDefault();
+				return true;
+			}
+
+			// direction === "down"
+			if (currentIndex < 0) {
+				// Not in recall mode and Down at last line — let Lexical
+				// run its default (no-op when already at last line).
+				return false;
+			}
+			const nextIndex = currentIndex - 1;
+			if (nextIndex >= 0) {
+				indexRef.current = nextIndex;
+				const entry = history[nextIndex];
+				if (entry) applyEntry(entry);
+				event?.preventDefault();
+				return true;
+			}
+			// Stepping out: restore the saved in-progress draft.
+			const draft = pendingDraftRef.current;
+			pendingDraftRef.current = null;
+			restoreDraft(draft);
+			indexRef.current = -1;
+			event?.preventDefault();
+			return true;
+		},
+		[applyEntry, editor, restoreDraft, scopeKey, snapshotCurrentDraft],
+	);
+
+	useEffect(() => {
+		return mergeRegister(
+			editor.registerCommand(
+				KEY_ARROW_UP_COMMAND,
+				(event) => handleArrow("up", event),
+				COMMAND_PRIORITY_LOW,
+			),
+			editor.registerCommand(
+				KEY_ARROW_DOWN_COMMAND,
+				(event) => handleArrow("down", event),
+				COMMAND_PRIORITY_LOW,
+			),
+			editor.registerUpdateListener(({ tags, dirtyElements, dirtyLeaves }) => {
+				// Self-initiated updates (recall apply / draft restore) carry
+				// our tag. Ignore those — only genuine user edits should
+				// exit recall mode.
+				if (tags.has(HISTORY_RECALL_TAG)) return;
+				if (indexRef.current < 0) return;
+				// Selection-only changes (caret movement) shouldn't exit
+				// recall — only content mutations do.
+				if (dirtyElements.size === 0 && dirtyLeaves.size === 0) return;
+				exitRecallMode();
+			}),
+		);
+	}, [editor, exitRecallMode, handleArrow]);
+
+	return null;
+}

--- a/src/features/composer/index.tsx
+++ b/src/features/composer/index.tsx
@@ -74,6 +74,7 @@ import { EditablePlugin } from "./editor/plugins/editable-plugin";
 import { EditorRefPlugin } from "./editor/plugins/editor-ref-plugin";
 import { FileMentionPlugin } from "./editor/plugins/file-mention-plugin";
 import { HasContentPlugin } from "./editor/plugins/has-content-plugin";
+import { HistoryRecallPlugin } from "./editor/plugins/history-recall-plugin";
 import { PasteImagePlugin } from "./editor/plugins/paste-image-plugin";
 import { SlashCommandPlugin } from "./editor/plugins/slash-command-plugin";
 import { SubmitPlugin } from "./editor/plugins/submit-plugin";
@@ -81,6 +82,7 @@ import { $extractComposerContent } from "./editor/utils";
 import { $appendComposerInsertItems } from "./editor-ops";
 import { FastModeLottieIcon } from "./fast-mode-lottie-icon";
 import { GoalReplaceConfirm } from "./goal-replace-confirm";
+import type { InputHistoryEntry } from "./input-history";
 import { PermissionPanel, type PermissionPanelProps } from "./permission-panel";
 import type { StartSubmitMode } from "./start-submit-mode";
 import { UsageStatsIndicator } from "./usage-stats-indicator";
@@ -200,6 +202,10 @@ type WorkspaceComposerProps = {
 	 *  composer root and gates surface-only hotkeys (e.g. plan-mode toggle
 	 *  fires only inside `workspace-composer`, never on the start surface). */
 	focusScope?: "start-composer" | "workspace-composer";
+	/** Lazy getter for the per-session input recall list, most-recent
+	 *  first. Called by `HistoryRecallPlugin` on each ArrowUp/Down so the
+	 *  composer doesn't have to re-render when the thread cache changes. */
+	getInputHistory?: () => readonly InputHistoryEntry[];
 };
 
 const EMPTY_SLASH_COMMANDS: readonly SlashCommandEntry[] = [];
@@ -282,6 +288,7 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 	startSubmitMode = "startNow",
 	onStartSubmitModeChange,
 	focusScope = "workspace-composer",
+	getInputHistory,
 }: WorkspaceComposerProps) {
 	const instanceIdRef = useRef(
 		`composer-${Math.random().toString(36).slice(2, 10)}`,
@@ -792,6 +799,12 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 							restoreCustomTags={restoreCustomTags}
 							restoreNonce={restoreNonce}
 						/>
+						{getInputHistory ? (
+							<HistoryRecallPlugin
+								getHistory={getInputHistory}
+								scopeKey={contextKey}
+							/>
+						) : null}
 						<EditablePlugin disabled={inputDisabled} />
 						<HasContentPlugin onChange={setHasContent} />
 					</LexicalComposer>

--- a/src/features/composer/input-history.test.ts
+++ b/src/features/composer/input-history.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import type { ThreadMessageLike } from "@/lib/api";
+import {
+	extractInputHistoryFromThread,
+	inputHistoryEntryText,
+} from "./input-history";
+
+function userMsg(
+	id: string,
+	text: string,
+	mentions: string[] = [],
+): ThreadMessageLike {
+	const content: ThreadMessageLike["content"] = [];
+	if (text) {
+		content.push({ type: "text", id: `${id}:txt`, text });
+	}
+	mentions.forEach((path, index) => {
+		content.push({ type: "file-mention", id: `${id}:m:${index}`, path });
+	});
+	return { role: "user", id, content };
+}
+
+function assistantMsg(id: string): ThreadMessageLike {
+	return {
+		role: "assistant",
+		id,
+		content: [{ type: "text", id: `${id}:txt`, text: "ack" }],
+	};
+}
+
+describe("extractInputHistoryFromThread", () => {
+	it("returns an empty array for an undefined or empty thread", () => {
+		expect(extractInputHistoryFromThread(undefined)).toEqual([]);
+		expect(extractInputHistoryFromThread([])).toEqual([]);
+	});
+
+	it("returns user messages newest-first and skips non-user roles", () => {
+		const thread: ThreadMessageLike[] = [
+			userMsg("u1", "hello"),
+			assistantMsg("a1"),
+			userMsg("u2", "second"),
+			assistantMsg("a2"),
+			userMsg("u3", "third"),
+		];
+		const history = extractInputHistoryFromThread(thread);
+		expect(history.map(inputHistoryEntryText)).toEqual([
+			"third",
+			"second",
+			"hello",
+		]);
+	});
+
+	it("classifies file-mention paths into images vs files by extension", () => {
+		const thread: ThreadMessageLike[] = [
+			userMsg("u1", "look at ", [
+				"/abs/screenshot.PNG",
+				"/abs/notes.md",
+				"/abs/photo.jpeg",
+				"/abs/diagram.svg",
+				"/abs/script.ts",
+			]),
+		];
+		const [entry] = extractInputHistoryFromThread(thread);
+		expect(entry).toBeDefined();
+		const images =
+			entry?.parts
+				.filter((part) => part.kind === "image")
+				.map((part) => part.path) ?? [];
+		const files =
+			entry?.parts
+				.filter((part) => part.kind === "file")
+				.map((part) => part.path) ?? [];
+		expect(images.sort()).toEqual(
+			["/abs/diagram.svg", "/abs/photo.jpeg", "/abs/screenshot.PNG"].sort(),
+		);
+		expect(files.sort()).toEqual(["/abs/notes.md", "/abs/script.ts"].sort());
+	});
+
+	it("preserves the original prompt order as parts", () => {
+		const thread: ThreadMessageLike[] = [
+			{
+				role: "user",
+				id: "u1",
+				content: [
+					{ type: "text", id: "u1:t0", text: "fix " },
+					{ type: "file-mention", id: "u1:m0", path: "src/foo.ts" },
+					{ type: "text", id: "u1:t1", text: " please" },
+				],
+			},
+		];
+		const [entry] = extractInputHistoryFromThread(thread);
+		expect(entry?.parts).toEqual([
+			{ kind: "text", text: "fix " },
+			{ kind: "file", path: "src/foo.ts" },
+			{ kind: "text", text: " please" },
+		]);
+		expect(entry ? inputHistoryEntryText(entry) : "").toBe(
+			"fix @src/foo.ts please",
+		);
+	});
+
+	it("collapses consecutive duplicate prompts", () => {
+		const thread: ThreadMessageLike[] = [
+			userMsg("u1", "ls"),
+			assistantMsg("a1"),
+			userMsg("u2", "ls"),
+			assistantMsg("a2"),
+			userMsg("u3", "ls"),
+			assistantMsg("a3"),
+			userMsg("u4", "cd"),
+		];
+		const history = extractInputHistoryFromThread(thread);
+		expect(history.map(inputHistoryEntryText)).toEqual(["cd", "ls"]);
+	});
+
+	it("preserves repeated mention parts within a single entry", () => {
+		const thread: ThreadMessageLike[] = [
+			userMsg("u1", "look at ", ["src/a.ts", "src/a.ts", "src/b.ts"]),
+		];
+		const [entry] = extractInputHistoryFromThread(thread);
+		expect(entry?.parts).toEqual([
+			{ kind: "text", text: "look at " },
+			{ kind: "file", path: "src/a.ts" },
+			{ kind: "file", path: "src/a.ts" },
+			{ kind: "file", path: "src/b.ts" },
+		]);
+	});
+
+	it("skips empty user messages (no text and no mentions)", () => {
+		const thread: ThreadMessageLike[] = [
+			userMsg("u1", "hi"),
+			{ role: "user", id: "u2", content: [] },
+			userMsg("u3", "there"),
+		];
+		const history = extractInputHistoryFromThread(thread);
+		expect(history.map(inputHistoryEntryText)).toEqual(["there", "hi"]);
+	});
+});

--- a/src/features/composer/input-history.ts
+++ b/src/features/composer/input-history.ts
@@ -1,0 +1,70 @@
+import type { ThreadMessageLike } from "@/lib/api";
+import type { ComposerContentPart } from "./editor-ops";
+
+export type InputHistoryPart = Extract<
+	ComposerContentPart,
+	{ kind: "text" | "image" | "file" }
+>;
+
+export type InputHistoryEntry = {
+	parts: InputHistoryPart[];
+};
+
+const IMAGE_EXT_RE =
+	/\.(png|jpe?g|gif|webp|bmp|svg|heic|heif|avif|tiff?)(\?.*)?$/i;
+
+function isImagePath(path: string): boolean {
+	return IMAGE_EXT_RE.test(path);
+}
+
+function entryFromUserMessage(
+	message: ThreadMessageLike,
+): InputHistoryEntry | null {
+	const parts: InputHistoryPart[] = [];
+	for (const part of message.content) {
+		if (part.type === "text" && part.text) {
+			parts.push({ kind: "text", text: part.text });
+		} else if (part.type === "file-mention") {
+			parts.push({
+				kind: isImagePath(part.path) ? "image" : "file",
+				path: part.path,
+			});
+		}
+	}
+	if (parts.length === 0) return null;
+	return { parts };
+}
+
+function historyKey(entry: InputHistoryEntry): string {
+	return JSON.stringify(entry.parts);
+}
+
+export function inputHistoryEntryText(entry: InputHistoryEntry): string {
+	return entry.parts
+		.map((part) => (part.kind === "text" ? part.text : `@${part.path}`))
+		.join("");
+}
+
+/**
+ * Build the recall list for a session. Most-recent prompt first.
+ *
+ * Consecutive duplicates are collapsed (matching shell behaviour).
+ */
+export function extractInputHistoryFromThread(
+	thread: readonly ThreadMessageLike[] | undefined,
+): InputHistoryEntry[] {
+	if (!thread || thread.length === 0) return [];
+	const entries: InputHistoryEntry[] = [];
+	let lastKey: string | null = null;
+	for (let i = thread.length - 1; i >= 0; i--) {
+		const message = thread[i];
+		if (!message || message.role !== "user") continue;
+		const entry = entryFromUserMessage(message);
+		if (!entry) continue;
+		const key = historyKey(entry);
+		if (key === lastKey) continue;
+		lastKey = key;
+		entries.push(entry);
+	}
+	return entries;
+}


### PR DESCRIPTION
Closes #611 
## Summary
- Adds arrow key history navigation in the composer input
- When at the first or last line of the input, ArrowUp/Down navigate through previously-sent prompts for the current session
- Behavior matches bash/zsh shell history recall

## Changes
- New `HistoryRecallPlugin` that hooks into Lexical editor updates to detect arrow key navigation
- New `input-history.ts` module to extract browsable prompts from session thread
- Draft persistence plugin updated to ignore history-recall mutations (prevents overwriting user's draft)
- Editor operations enhanced with `$setEditorContentParts` for flexible content reconstruction
- Full test coverage for plugin and history extraction logic

## Test notes
- Unit tests in `history-recall-plugin.test.tsx` and `input-history.test.ts`
- Test cases cover: empty history, navigation bounds, draft preservation, multi-line content handling