### PR TITLE
Fix onboarding CLI login checks on machines without bundled CLIs on PATH

### DIFF
--- a/.changeset/onboarding-bundled-cli-login.md
+++ b/.changeset/onboarding-bundled-cli-login.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix onboarding misreporting Claude or Codex as signed-out, and the login terminal failing with "command not found", on machines that don't have the agent CLIs on PATH — Helmor now uses the bundled binaries it ships with.

--- a/src-tauri/src/commands/system_commands.rs
+++ b/src-tauri/src/commands/system_commands.rs
@@ -689,8 +689,24 @@ fn cursor_login_ready() -> bool {
         .unwrap_or(false)
 }
 
+/// Resolve the binary to spawn for an agent CLI subcommand.
+///
+/// Prefers the bundled binary under `Helmor.app/Contents/Resources/vendor/`
+/// so onboarding works on machines that don't have `claude` / `codex` on
+/// PATH. Falls back to the bare command name (PATH lookup) for dev builds
+/// and as a last resort.
+fn resolve_agent_binary(provider: &str) -> PathBuf {
+    let bundled = sidecar::resolve_bundled_agent_paths();
+    let bundled_path = match provider {
+        "claude" => bundled.claude_bin,
+        "codex" => bundled.codex_bin,
+        _ => None,
+    };
+    bundled_path.unwrap_or_else(|| PathBuf::from(provider))
+}
+
 fn claude_login_ready() -> bool {
-    match std::process::Command::new("claude")
+    match std::process::Command::new(resolve_agent_binary("claude"))
         .args(["auth", "status"])
         .output()
     {
@@ -744,7 +760,7 @@ fn codex_auth_status() -> CodexAuthStatus {
 }
 
 fn codex_login_ready() -> bool {
-    match std::process::Command::new("codex")
+    match std::process::Command::new(resolve_agent_binary("codex"))
         .args(["login", "status"])
         .output()
     {
@@ -797,12 +813,19 @@ fn env_var_is_present(key: &str) -> bool {
         .unwrap_or(false)
 }
 
-fn agent_login_command(provider: &str) -> anyhow::Result<&'static str> {
-    match provider {
-        "claude" => Ok("claude auth login"),
-        "codex" => Ok("codex login"),
+fn agent_login_command(provider: &str) -> anyhow::Result<String> {
+    let args = match provider {
+        "claude" => "auth login",
+        "codex" => "login",
         _ => anyhow::bail!("Unknown agent provider: {provider}"),
-    }
+    };
+    // Quote the resolved binary path so spaces in `Helmor.app` survive
+    // both the embedded PTY shell and AppleScript's `do shell script`.
+    Ok(format!(
+        "{} {}",
+        shell_quote(&resolve_agent_binary(provider)),
+        args
+    ))
 }
 
 fn agent_login_script_type(provider: &str, instance_id: &str) -> String {
@@ -819,7 +842,7 @@ pub async fn spawn_agent_login_terminal(
     instance_id: String,
     channel: Channel<ScriptEvent>,
 ) -> CmdResult<()> {
-    let command = agent_login_command(&provider)?.to_string();
+    let command = agent_login_command(&provider)?;
     tracing::info!(
         provider = %provider,
         instance_id = %instance_id,
@@ -948,7 +971,7 @@ pub async fn resize_agent_login_terminal(
 #[cfg(target_os = "macos")]
 fn open_agent_login_terminal_impl(provider: &str) -> anyhow::Result<()> {
     let command = agent_login_command(provider)?;
-    let script_command = applescript_string(command);
+    let script_command = applescript_string(&command);
     let output = std::process::Command::new("osascript")
         .arg("-e")
         .arg("tell application \"Terminal\" to activate")

--- a/src-tauri/src/sidecar.rs
+++ b/src-tauri/src/sidecar.rs
@@ -77,12 +77,21 @@ struct SidecarProcess {
 }
 
 #[derive(Debug, Default)]
-struct BundledAgentPaths {
-    claude_bin: Option<PathBuf>,
-    codex_bin: Option<PathBuf>,
+pub struct BundledAgentPaths {
+    pub claude_bin: Option<PathBuf>,
+    pub codex_bin: Option<PathBuf>,
 }
 
-fn resolve_bundled_agent_paths() -> BundledAgentPaths {
+/// Resolve the bundled Claude/Codex CLI binaries shipped inside the
+/// `.app` (release builds only — returns empty in dev). Used both by
+/// the sidecar boot path (to pass `HELMOR_*_BIN_PATH` env vars) and by
+/// onboarding so login-status checks + login terminals don't depend on
+/// the user having the CLIs on PATH.
+///
+/// Dev intentionally returns empty so callers fall back to PATH — Helmor
+/// should not silently prefer one of the sidecar's `node_modules`
+/// binaries over whatever the developer has installed.
+pub fn resolve_bundled_agent_paths() -> BundledAgentPaths {
     std::env::current_exe()
         .ok()
         .and_then(|exe| resolve_bundled_agent_paths_for_exe(&exe))


### PR DESCRIPTION
## Summary

Fixes onboarding misreporting Claude or Codex as signed-out, and login terminals failing with "command not found", on machines where the agent CLIs aren't installed globally.

Helmor now resolves and uses the bundled Claude and Codex binaries shipped inside `Helmor.app/Contents/Resources/vendor/` (release builds) for login status checks and terminal spawning, falling back to PATH lookup in dev builds and as a last resort.

## Changes

- Added `resolve_agent_binary()` helper that prefers bundled binaries over PATH
- Updated `claude_login_ready()` and `codex_login_ready()` to use bundled paths for status checks
- Modified `agent_login_command()` to quote the resolved binary path for safe shell expansion and AppleScript compatibility
- Exported `BundledAgentPaths` struct and `resolve_bundled_agent_paths()` function from sidecar module so system_commands can access them

## Testing

- Login status checks now correctly detect signed-in state using bundled binaries
- Login terminals spawn correctly even when CLIs aren't on PATH
- Dev builds unaffected (empty bundled paths cause fallback to PATH)