### PR TITLE
Fix: prevent number ticker animation replay on workspace switch

### DIFF
--- a/.changeset/inspector-change-counter-stable.md
+++ b/.changeset/inspector-change-counter-stable.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix the +/- line counters in the inspector's change list replaying their roll-in animation every time you switch workspace.

--- a/src/components/ui/number-ticker.tsx
+++ b/src/components/ui/number-ticker.tsx
@@ -7,17 +7,27 @@ interface NumberTickerProps extends ComponentPropsWithoutRef<"span"> {
 	value: number;
 	direction?: "up" | "down";
 	delay?: number;
+	/** When false, mount renders `value` directly and only later changes spring.
+	 * Use for numbers that are part of repeatedly remounted lists (e.g. inspector
+	 * change rows) where the entry animation reruns every workspace switch. */
+	animateOnMount?: boolean;
 }
 
 export function NumberTicker({
 	value,
 	direction = "up",
 	delay = 0,
+	animateOnMount = true,
 	className,
 	...props
 }: NumberTickerProps) {
 	const ref = useRef<HTMLSpanElement>(null);
-	const motionValue = useMotionValue(direction === "down" ? value : 0);
+	const initialMotion = animateOnMount
+		? direction === "down"
+			? value
+			: 0
+		: value;
+	const motionValue = useMotionValue(initialMotion);
 	const springValue = useSpring(motionValue, {
 		damping: 100,
 		stiffness: 200,

--- a/src/features/inspector/sections/changes.tsx
+++ b/src/features/inspector/sections/changes.tsx
@@ -1359,12 +1359,22 @@ function LineStats({
 		<span className="flex shrink-0 items-center gap-1 text-[10px] tabular-nums">
 			{insertions > 0 && (
 				<span className="text-chart-2">
-					+<NumberTicker value={insertions} className="text-chart-2" />
+					+
+					<NumberTicker
+						value={insertions}
+						animateOnMount={false}
+						className="text-chart-2"
+					/>
 				</span>
 			)}
 			{deletions > 0 && (
 				<span className="text-destructive">
-					−<NumberTicker value={deletions} className="text-destructive" />
+					−
+					<NumberTicker
+						value={deletions}
+						animateOnMount={false}
+						className="text-destructive"
+					/>
 				</span>
 			)}
 		</span>


### PR DESCRIPTION
## Summary

Fix the +/- line counters in the inspector's change list replaying their roll-in animation every time you switch workspace.

## Changes

- Add `animateOnMount` prop to `NumberTicker` component to optionally skip the roll-in animation on initial mount
- Use `animateOnMount={false}` in the inspector's change line counters (`insertions` and `deletions` display)
- Add changeset documenting this as a patch-level fix

## Why

The inspector's change list is conditionally rendered for each workspace, so switching workspaces remounts the component. This caused the animated number counters to replay their animation every time the user switched workspace, which was visually distracting and unnecessary.

## Testing

- Verify that when switching between workspaces, the +/- line counters in the inspector's changes section no longer animate
- Confirm that the animation still works correctly when initially viewing a workspace's changes