### PR TITLE
Reduce terminal input latency with poll(2) and WebGL rendering

### DIFF
--- a/.changeset/snappy-terminal-typing.md
+++ b/.changeset/snappy-terminal-typing.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Reduce input latency in the embedded terminal so fast typing no longer feels laggy or drops characters on lower-spec hardware.

--- a/bun.lock
+++ b/bun.lock
@@ -41,6 +41,7 @@
         "@tauri-apps/plugin-opener": "2.5.3",
         "@testing-library/user-event": "14.6.1",
         "@xterm/addon-fit": "^0.11.0",
+        "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -1577,6 +1578,8 @@
     "@webcontainer/env": ["@webcontainer/env@1.1.1", "", {}, "sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng=="],
 
     "@xterm/addon-fit": ["@xterm/addon-fit@0.11.0", "", {}, "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g=="],
+
+    "@xterm/addon-webgl": ["@xterm/addon-webgl@0.19.0", "", {}, "sha512-b3fMOsyLVuCeNJWxolACEUED0vm7qC0cy4wRvf3oURSzDTYVQiGPhTnhWZwIHdvC48Y+oLhvYXnY4XDXPoJo6A=="],
 
     "@xterm/xterm": ["@xterm/xterm@6.0.0", "", {}, "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg=="],
 

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
 		"@tauri-apps/plugin-opener": "2.5.3",
 		"@testing-library/user-event": "14.6.1",
 		"@xterm/addon-fit": "^0.11.0",
+		"@xterm/addon-webgl": "^0.19.0",
 		"@xterm/xterm": "^6.0.0",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",

--- a/src-tauri/src/workspace/scripts.rs
+++ b/src-tauri/src/workspace/scripts.rs
@@ -591,6 +591,11 @@ pub(crate) fn run_script_with_shell(
     let killed = manager.register(key.clone(), pid, pgid, stdin.clone());
 
     // Single reader on the PTY master — stdout+stderr are merged by the PTY.
+    // Uses poll(2) so the kernel wakes the thread the instant data is
+    // readable instead of the legacy 25ms `sleep` loop. The PTY master keeps
+    // O_NONBLOCK so we can drain everything available after each wake without
+    // re-entering poll for each chunk; write_stdin also benefits (PTY full
+    // → WouldBlock instead of blocking the IPC thread).
     let ch = channel.clone();
     let stop_reader = Arc::new(AtomicBool::new(false));
     let stop_reader_in_thread = stop_reader.clone();
@@ -599,32 +604,66 @@ pub(crate) fn run_script_with_shell(
         .spawn(move || {
             let mut master = unsafe { std::fs::File::from_raw_fd(master_fd) };
             let mut buf = [0u8; 4096];
+            // 100ms tick is just a stop-flag fallback — kill() also closes
+            // the PTY which triggers EIO/POLLHUP and wakes us instantly.
+            const POLL_TIMEOUT_MS: libc::c_int = 100;
             loop {
                 if stop_reader_in_thread.load(Ordering::Relaxed) {
                     break;
                 }
 
-                match master.read(&mut buf) {
-                    Ok(0) => break,
-                    Ok(n) => {
-                        let data = String::from_utf8_lossy(&buf[..n]).into_owned();
-                        let _ = ch.send(ScriptEvent::Stdout { data });
+                let mut pfd = libc::pollfd {
+                    fd: master_fd,
+                    events: libc::POLLIN,
+                    revents: 0,
+                };
+                let ret = unsafe { libc::poll(&mut pfd, 1, POLL_TIMEOUT_MS) };
+                if ret < 0 {
+                    let err = std::io::Error::last_os_error();
+                    if err.kind() == std::io::ErrorKind::Interrupted {
+                        continue;
                     }
-                    Err(e) => {
-                        // master_fd is non-blocking, so an idle PTY (Terminal
-                        // tab waiting for keystrokes) returns EAGAIN every
-                        // poll. Sleep + continue without logging — otherwise
-                        // the debug log floods at PTY_POLL_INTERVAL frequency.
-                        if e.kind() == std::io::ErrorKind::WouldBlock {
-                            std::thread::sleep(PTY_POLL_INTERVAL);
-                            continue;
+                    tracing::debug!(error = %err, "PTY poll failed");
+                    break;
+                }
+                if ret == 0 {
+                    // Timeout — re-check stop flag and re-poll.
+                    continue;
+                }
+                // POLLHUP / POLLERR fire when the slave fd is closed (child
+                // exited). We still try to read first so any pending bytes
+                // ahead of the hangup are delivered.
+                let revents = pfd.revents;
+                let hung_up = revents & (libc::POLLHUP | libc::POLLERR | libc::POLLNVAL) != 0;
+
+                // Drain everything available in this wake cycle.
+                let mut should_exit = hung_up;
+                loop {
+                    match master.read(&mut buf) {
+                        Ok(0) => {
+                            should_exit = true;
+                            break;
                         }
-                        // EIO is expected when the child exits and slave closes.
-                        if e.raw_os_error() != Some(libc::EIO) {
-                            tracing::debug!(error = %e, "PTY read error");
+                        Ok(n) => {
+                            let data = String::from_utf8_lossy(&buf[..n]).into_owned();
+                            let _ = ch.send(ScriptEvent::Stdout { data });
                         }
-                        break;
+                        Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                            // Drained for now — back to poll().
+                            break;
+                        }
+                        Err(e) => {
+                            // EIO is expected when the child exits and slave closes.
+                            if e.raw_os_error() != Some(libc::EIO) {
+                                tracing::debug!(error = %e, "PTY read error");
+                            }
+                            should_exit = true;
+                            break;
+                        }
                     }
+                }
+                if should_exit {
+                    break;
                 }
             }
         })

--- a/src/components/terminal-output.tsx
+++ b/src/components/terminal-output.tsx
@@ -1,5 +1,6 @@
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { FitAddon } from "@xterm/addon-fit";
+import { WebglAddon } from "@xterm/addon-webgl";
 import { type ILinkProvider, type ITheme, Terminal } from "@xterm/xterm";
 import { memo, useEffect, useRef } from "react";
 import { resolveCssColor } from "@/lib/css-color";
@@ -305,6 +306,25 @@ function TerminalOutputImpl({
 		terminal.loadAddon(fit);
 		terminal.open(container);
 
+		// GPU renderer — drops per-frame cost on low-spec laptops. DOM
+		// renderer does an O(visible_cells) layout/paint per write; WebGL
+		// blits from a glyph atlas. `contextlost` fires on GPU reset /
+		// long sleep / driver crash; we dispose and let xterm fall back
+		// to the built-in DOM renderer automatically.
+		let webgl: WebglAddon | null = null;
+		try {
+			const addon = new WebglAddon();
+			addon.onContextLoss(() => {
+				addon.dispose();
+				webgl = null;
+			});
+			terminal.loadAddon(addon);
+			webgl = addon;
+		} catch {
+			// WebGL unavailable (headless / very old GPU). DOM renderer stays.
+			webgl = null;
+		}
+
 		// Translate macOS Cmd combos to readline control codes.
 		terminal.attachCustomKeyEventHandler((event) => {
 			if (event.type !== "keydown") return true;
@@ -465,6 +485,7 @@ function TerminalOutputImpl({
 			resizeObserver.disconnect();
 			terminalRefitListeners.delete(refitListener);
 			terminalWriteFlushListeners.delete(flushSuspendedWrites);
+			webgl?.dispose();
 			terminal.dispose();
 			xtermRef.current = null;
 			fitRef.current = null;


### PR DESCRIPTION
## Summary

Eliminates input latency in the embedded terminal by:
- **PTY I/O**: Replaced 25ms sleep-based polling with `poll(2)`, allowing kernel to wake instantly when data arrives, instead of batching output in 25ms chunks.
- **Rendering**: Added xterm WebGL renderer addon (GPU-accelerated glyph atlas blits) to reduce per-frame cost on low-spec hardware. Falls back gracefully to DOM renderer if GPU is unavailable.
- **Buffering**: Drains all available PTY output in one poll wake to eliminate buffering delays.

## Test plan

- [x] Fast typing in the terminal should feel immediate (no perceptible lag)
- [x] Terminal rendering on low-spec hardware (Intel Iris, M1 etc.) should be smooth
- [x] GPU unavailable (headless, very old GPUs) — falls back to DOM renderer automatically
- [x] Long-running scripts (e.g. `npm install`, `cargo build`) should stream output smoothly