### PR TITLE
feat(remote): add helmor-server binary + JSON-RPC framing (F1 of #453)

### DIFF
--- a/docs/remote-server-f1.md
+++ b/docs/remote-server-f1.md
@@ -1,0 +1,163 @@
+# Remote Server (F1)
+
+Foundation for Helmor's remote-workspace feature — issue
+[#453](https://github.com/dohooo/helmor/issues/453). This doc covers
+the F1 slice: the `helmor-server` binary, the JSON-RPC framing it
+speaks, the handshake gate, and two read-only methods (`ping`,
+`runtime.health`).
+
+F2-F7 layer on top:
+
+- **F2** — SSH transport + daemon spawn over an existing SSH session.
+- **F3** — Agent attach + chat reattach + local persistence.
+- **F4** — Port forwarding (independent of F3/F5).
+- **F5** — Auto-reconnect + connection state machine.
+- **F6** — Daemon event journal + replay-from-seq + history rebuild.
+- **F7** — Journal durability across daemon restarts.
+
+Each lands as its own reviewable PR; this one freezes the wire
+shape every later slice builds on.
+
+## Binary modes
+
+The `helmor-server` binary is a single Rust target with two CLI
+modes, picked by the first flag:
+
+- `--version` / `-V` — print version + protocol, exit 0. Used by
+  the auto-install probe a later PR will add.
+- `--serve-stdio` (default) — read framed JSON-RPC requests from
+  stdin, write responses to stdout. Suitable for a local desktop
+  spawning the binary directly (the local-loopback path that
+  drives the protocol's integration tests).
+
+A future PR adds `--daemon` (long-lived, Unix-socket-backed) +
+`--ensure-daemon` (idempotent "is the daemon running?" probe).
+
+## Wire shape
+
+JSON-RPC 2.0 over newline-delimited stdin/stdout. One message per
+line. Two envelope shapes:
+
+```json
+// Request
+{ "jsonrpc": "2.0", "id": 7, "method": "ping", "params": { "counter": 1 } }
+
+// Response (success)
+{ "jsonrpc": "2.0", "id": 7, "result": { "counter": 1, "serverTime": "2026-05-20T12:00:00.000Z" } }
+
+// Response (error)
+{ "jsonrpc": "2.0", "id": 7, "error": { "code": -32601, "message": "unknown method: foo.bar" } }
+```
+
+`id` is either a number, a string, or `null` (notification — no
+response). All field names use `camelCase`; Rust types are
+`#[serde(rename_all = "camelCase")]`.
+
+### Reserved error codes
+
+| Code | Name | Meaning |
+| --- | --- | --- |
+| `-32600` | `InvalidRequest` | Malformed envelope. |
+| `-32601` | `MethodNotFound` | Unknown method name. |
+| `-32602` | `InvalidParams` | Method exists but params don't match. |
+| `-32603` | `InternalError` | Server-side serialization failure. |
+| `-32000` | `IncompatibleProtocol` | `initialize` rejected a major mismatch. |
+| `-32001` | `NotInitialized` | Method called before the handshake. |
+| `-32002` | `HandlerFailed` | Handler returned an underlying error. |
+
+## Protocol versioning
+
+- Current version: `0.1.0` (see
+  [`src-tauri/src/remote/protocol.rs`](../src-tauri/src/remote/protocol.rs)
+  `PROTOCOL_VERSION`).
+- Semver — bumped on **envelope** shape changes, not on method
+  additions (those are forward-compatible via `MethodNotFound`).
+- `0.x` is treated as pre-stable: two peers must match on
+  `<major>.<minor>` (so `0.1.x` ↔ `0.1.y` is fine, `0.1.x` ↔
+  `0.2.x` is not). Once `1.0` ships the standard "majors match"
+  semantics apply.
+- The desktop client passes its expected `protocolVersion` in the
+  `initialize` params; the server returns
+  [`IncompatibleProtocol`](#reserved-error-codes) when the major
+  doesn't match.
+
+## Methods (F1)
+
+### `initialize`
+
+Mandatory first method. Must be called before any other method.
+
+**Params**:
+```json
+{
+  "protocolVersion": "0.1.0",
+  "clientName": "helmor-desktop",
+  "clientVersion": "0.22.1"
+}
+```
+
+**Result**:
+```json
+{
+  "protocolVersion": "0.1.0",
+  "serverVersion": "0.0.0",
+  "hostname": "dev.box"
+}
+```
+
+### `ping`
+
+Liveness probe. Used by the desktop's future heartbeat loop.
+
+**Params**: `{ "counter": <u64> }` (defaults to 0).
+
+**Result**: `{ "counter": <echo>, "serverTime": "<rfc3339>" }`.
+
+### `runtime.health`
+
+Identify the host. Used by the desktop's diagnostics panel.
+
+**Params**: `{}` (empty).
+
+**Result**:
+```json
+{
+  "kind": "local",
+  "hostname": "dev.box",
+  "serverVersion": "0.0.0"
+}
+```
+
+`kind` is `"local"` for the daemon binary running on the remote
+host. A later phase may expose `"remote"` when a daemon proxies to
+another daemon, etc.
+
+## Out of scope
+
+F1 deliberately omits:
+
+- **SSH transport** — the binary speaks stdin/stdout. F2 adds the
+  SSH-tunneled socket.
+- **Auth** — no credential handling. SSH key resolution flows
+  through the user's existing `~/.ssh/config` once F2 lands.
+- **Workspace ops, terminals, agents** — F3 / later.
+- **Persistent state** — no daemon, no journal, no on-disk
+  history. F6 / F7 introduce those.
+
+## Trying it locally
+
+```bash
+cd src-tauri
+cargo build --bin helmor-server
+echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"0.1.0","clientName":"test"}}' \
+  | target/debug/helmor-server --serve-stdio
+```
+
+Expected output:
+
+```json
+{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"0.1.0","serverVersion":"0.0.0","hostname":"unknown-host"}}
+```
+
+Set `HOSTNAME=foo` to pin the hostname; set `HELMOR_LOG=debug` to
+see the binary's tracing output on stderr.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -68,6 +68,14 @@ path = "src/bin/helmor-cli.rs"
 name = "gen_pipeline_fixture"
 path = "src/bin/gen_pipeline_fixture.rs"
 
+# Upstream F1: minimal headless server binary. Reads framed JSON-RPC
+# requests from stdin, writes responses to stdout. Out-of-scope for
+# this slice: SSH transport, agent bridge, terminals, workspace ops.
+# Each lands as its own follow-up PR per the upstream roadmap.
+[[bin]]
+name = "helmor-server"
+path = "src/bin/helmor-server.rs"
+
 [dev-dependencies]
 insta = { version = "1", features = ["yaml", "glob"] }
 tempfile = "3"

--- a/src-tauri/src/bin/helmor-server.rs
+++ b/src-tauri/src/bin/helmor-server.rs
@@ -1,0 +1,132 @@
+//! `helmor-server` — F1 upstream slice.
+//!
+//! Headless daemon binary for Helmor's remote-workspace feature
+//! (issue #453). This first slice exposes only the protocol +
+//! handshake + a couple of read-only methods so the wire shape can
+//! be reviewed before larger surfaces (SSH transport, agent bridge,
+//! workspace ops, terminals) layer on top in F2-F7.
+//!
+//! Two modes, picked by the first CLI flag:
+//!
+//! - `--serve-stdio` (default) — read framed JSON-RPC requests from
+//!   stdin, write responses to stdout. Suitable for a local desktop
+//!   spawning the binary directly (the local-loopback test path).
+//! - `--version` / `-V` — print version + protocol, exit 0. Used by
+//!   the auto-install probe a future PR will add.
+//!
+//! See `docs/remote-server-architecture.md` for the broader design;
+//! this binary ships the foundation it builds on.
+
+use std::io::{self, BufReader, Write};
+use std::process::ExitCode;
+use std::sync::{Arc, Mutex};
+
+use helmor_lib::remote::{
+    self, dispatch_request, read_frame, write_frame, FrameError, JsonRpcRequest, JsonRpcResponse,
+    ServerContext,
+};
+
+fn main() -> ExitCode {
+    let mode = parse_mode();
+    match mode {
+        Mode::Version => {
+            // CLI introspection. A future install-probe will run
+            // `<bin> --version` to detect whether a compatible binary
+            // is already deployed; this branch answers that probe
+            // without booting the RPC loop.
+            println!("helmor-server {}", env!("CARGO_PKG_VERSION"));
+            println!("protocol {}", remote::PROTOCOL_VERSION);
+            ExitCode::SUCCESS
+        }
+        Mode::ServeStdio => run_serve_stdio(),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Mode {
+    ServeStdio,
+    Version,
+}
+
+fn parse_mode() -> Mode {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.iter().any(|a| a == "--version" || a == "-V") {
+        return Mode::Version;
+    }
+    // Default keeps the binary usable in tests + the local-loopback
+    // path without an explicit flag.
+    Mode::ServeStdio
+}
+
+fn run_serve_stdio() -> ExitCode {
+    init_stderr_logging();
+
+    let server_version = env!("CARGO_PKG_VERSION").to_string();
+    let hostname = read_hostname();
+    let ctx = ServerContext::new(server_version, hostname);
+
+    // One stdout writer behind a mutex so response frames can't
+    // interleave with anything else we might write in future
+    // phases (notifications etc.).
+    let stdout_writer: Arc<Mutex<Box<dyn Write + Send>>> =
+        Arc::new(Mutex::new(Box::new(io::stdout())));
+
+    tracing::info!(
+        version = env!("CARGO_PKG_VERSION"),
+        protocol = remote::PROTOCOL_VERSION,
+        "helmor-server: ready"
+    );
+
+    let stdin = io::stdin().lock();
+    let mut reader = BufReader::new(stdin);
+
+    loop {
+        let req = match read_frame::<_, JsonRpcRequest>(&mut reader) {
+            Ok(req) => req,
+            Err(FrameError::Eof) => {
+                tracing::info!("helmor-server: peer closed cleanly, exiting");
+                return ExitCode::SUCCESS;
+            }
+            Err(err) => {
+                tracing::error!(error = %err, "helmor-server: frame read failed; exiting");
+                return ExitCode::FAILURE;
+            }
+        };
+
+        if let Some(response) = dispatch_request(&ctx, req) {
+            if let Err(err) = write_response(&stdout_writer, &response) {
+                tracing::error!(error = %err, "helmor-server: write failed; exiting");
+                return ExitCode::FAILURE;
+            }
+        }
+    }
+}
+
+fn write_response(
+    writer: &Arc<Mutex<Box<dyn Write + Send>>>,
+    response: &JsonRpcResponse,
+) -> Result<(), FrameError> {
+    let mut handle = writer.lock().expect("stdout mutex poisoned");
+    write_frame(&mut *handle, response)
+}
+
+fn init_stderr_logging() {
+    use tracing_subscriber::EnvFilter;
+    // Defaults stay quiet; operators bump via `HELMOR_LOG=debug` so
+    // the binary doesn't spam stderr in normal use.
+    let filter = EnvFilter::try_from_env("HELMOR_LOG").unwrap_or_else(|_| EnvFilter::new("warn"));
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(io::stderr)
+        .try_init();
+}
+
+fn read_hostname() -> String {
+    // `gethostname` would pull in another crate; `uname -n` (libc)
+    // would too. The HOST env var covers the common case + the
+    // unknown-host fallback keeps the binary usable in test rigs
+    // that don't have a hostname set.
+    std::env::var("HOST")
+        .or_else(|_| std::env::var("HOSTNAME"))
+        .unwrap_or_else(|_| "unknown-host".to_string())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ pub mod mcp;
 pub mod models;
 pub mod pipeline;
 pub mod rate_limits;
+pub mod remote;
 pub mod schema;
 pub mod service;
 mod shell_env;

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -1,0 +1,29 @@
+//! Headless remote daemon (F1 upstream slice).
+//!
+//! `helmor-server` is the binary that runs on a remote host so a
+//! Helmor desktop can render its UI locally while the workspace,
+//! terminals, and agents live elsewhere — analogous to Zed's remote
+//! development, JetBrains Gateway, or VS Code Remote-SSH (issue
+//! #453).
+//!
+//! This module hosts the JSON-RPC framing + dispatch surface the
+//! daemon serves. F1 lands the foundation:
+//!
+//! - Wire envelope: JSON-RPC 2.0 over newline-delimited stdin/stdout.
+//! - Protocol version handshake (`initialize`).
+//! - Two read-only methods (`ping`, `runtime.health`) so an operator
+//!   can verify the binary is alive + which host it's running on.
+//! - No SSH transport, no agent bridge, no workspace ops — those land
+//!   in F2-F7 once F1 is reviewed + merged.
+//!
+//! The architecture this slice is the first step of is documented in
+//! `docs/remote-server-architecture.md`.
+
+pub mod protocol;
+pub mod server;
+
+pub use protocol::{
+    read_frame, write_frame, FrameError, JsonRpcError, JsonRpcId, JsonRpcMessage, JsonRpcRequest,
+    JsonRpcResponse, PROTOCOL_VERSION,
+};
+pub use server::{dispatch_request, ServerContext};

--- a/src-tauri/src/remote/protocol.rs
+++ b/src-tauri/src/remote/protocol.rs
@@ -1,0 +1,303 @@
+//! JSON-RPC 2.0 framing for the headless `helmor-server` daemon.
+//!
+//! Newline-delimited JSON. One message per line. The binary reads
+//! requests from stdin, writes responses to stdout. The client
+//! (today: a future SSH-tunneled desktop call; F2+) plays the
+//! mirror image: write a request, read a response.
+//!
+//! We deliberately don't pull in `jsonrpc-core` or a similar crate.
+//! The wire shape we need is small (request / response / error
+//! envelope) + keeping the types in-crate makes them easy to evolve
+//! alongside the method catalogue in [`super::server`].
+
+use std::io::{BufRead, Write};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Wire-level version of the Helmor remote protocol. The client sends
+/// it in the `initialize` handshake and the server rejects with
+/// [`error_codes::INCOMPATIBLE_PROTOCOL`] if the major doesn't match.
+/// Bumped on **envelope** changes (rare); method additions are
+/// forward-compatible via the catalogue + `MethodNotFound` errors.
+///
+/// `0.x` while the surface is still evolving. Promote to `1.0` once
+/// the wire shape is frozen for downstream consumers.
+pub const PROTOCOL_VERSION: &str = "0.1.0";
+
+/// Reserved JSON-RPC error codes. The 32000+ range is "implementation
+/// defined" per the spec; we use it for protocol-level state errors
+/// the spec doesn't enumerate.
+pub mod error_codes {
+    pub const INVALID_REQUEST: i32 = -32600;
+    pub const METHOD_NOT_FOUND: i32 = -32601;
+    pub const INVALID_PARAMS: i32 = -32602;
+    pub const INTERNAL_ERROR: i32 = -32603;
+    /// `initialize` rejected because the client's protocol major
+    /// doesn't match the server's. Custom (implementation-defined).
+    pub const INCOMPATIBLE_PROTOCOL: i32 = -32000;
+    /// A non-`initialize` method was called before the handshake.
+    pub const NOT_INITIALIZED: i32 = -32001;
+    /// Handler returned `Err` for a reason the spec doesn't cover
+    /// (e.g. an underlying `git` invocation failed). Caller gets the
+    /// underlying message inside `error.message`.
+    pub const HANDLER_FAILED: i32 = -32002;
+}
+
+/// JSON-RPC 2.0 `id` field. Numbers + strings both legal per spec;
+/// `Null` covers notifications. Untagged so the serialization matches
+/// `1`, `"abc"`, `null` literally.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum JsonRpcId {
+    Num(u64),
+    Str(String),
+    #[default]
+    Null,
+}
+
+impl JsonRpcId {
+    pub fn is_notification(&self) -> bool {
+        matches!(self, Self::Null)
+    }
+}
+
+/// JSON-RPC 2.0 request envelope. `params` is `None` when the caller
+/// omitted the field; defaults to an empty object on the wire so
+/// handlers can decode an empty params struct.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonRpcRequest {
+    pub jsonrpc: String,
+    #[serde(default)]
+    pub id: JsonRpcId,
+    pub method: String,
+    #[serde(default)]
+    pub params: Value,
+}
+
+impl JsonRpcRequest {
+    pub fn new(id: JsonRpcId, method: impl Into<String>, params: Value) -> Self {
+        Self {
+            jsonrpc: "2.0".into(),
+            id,
+            method: method.into(),
+            params,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonRpcResponse {
+    pub jsonrpc: String,
+    pub id: JsonRpcId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<JsonRpcError>,
+}
+
+impl JsonRpcResponse {
+    pub fn success(id: JsonRpcId, result: Value) -> Self {
+        Self {
+            jsonrpc: "2.0".into(),
+            id,
+            result: Some(result),
+            error: None,
+        }
+    }
+
+    pub fn failure(id: JsonRpcId, error: JsonRpcError) -> Self {
+        Self {
+            jsonrpc: "2.0".into(),
+            id,
+            result: None,
+            error: Some(error),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonRpcError {
+    pub code: i32,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data: Option<Value>,
+}
+
+impl JsonRpcError {
+    pub fn new(code: i32, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            data: None,
+        }
+    }
+}
+
+/// Marker for either side of the wire (request or response). Used by
+/// the framing helpers below so a peer-aware reader can call one
+/// function regardless of which direction it's reading.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum JsonRpcMessage {
+    Request(JsonRpcRequest),
+    Response(JsonRpcResponse),
+}
+
+/// Read one newline-delimited JSON frame off `reader`.
+///
+/// `T` must deserialize as a JSON-RPC envelope (request or response).
+/// An empty / closed stream returns [`FrameError::Eof`]; malformed
+/// frames return [`FrameError::Parse`] (the caller decides whether
+/// to log + recover or tear the connection down).
+pub fn read_frame<R: BufRead, T: serde::de::DeserializeOwned>(
+    reader: &mut R,
+) -> Result<T, FrameError> {
+    let mut line = String::new();
+    let n = reader.read_line(&mut line).map_err(FrameError::Io)?;
+    if n == 0 {
+        return Err(FrameError::Eof);
+    }
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        // Some clients double-flush; treat a blank line as a no-op
+        // and recurse for the next frame.
+        return read_frame::<R, T>(reader);
+    }
+    serde_json::from_str(trimmed).map_err(FrameError::Parse)
+}
+
+/// Write `value` as a newline-delimited JSON frame.
+///
+/// One `write_all` for the body + one `write_all` for the newline +
+/// a `flush` so the receiver sees it without buffering delay.
+pub fn write_frame<W: Write, T: Serialize>(writer: &mut W, value: &T) -> Result<(), FrameError> {
+    let serialized = serde_json::to_string(value).map_err(FrameError::Parse)?;
+    writer
+        .write_all(serialized.as_bytes())
+        .map_err(FrameError::Io)?;
+    writer.write_all(b"\n").map_err(FrameError::Io)?;
+    writer.flush().map_err(FrameError::Io)?;
+    Ok(())
+}
+
+#[derive(Debug)]
+pub enum FrameError {
+    /// Peer closed the connection. Normal at end-of-session; the
+    /// caller exits its loop cleanly.
+    Eof,
+    /// `serde_json` failed to round-trip the line. The caller usually
+    /// logs + reads the next frame, because dropping the connection
+    /// on a single bad payload is too aggressive.
+    Parse(serde_json::Error),
+    /// Underlying `io::Read` / `io::Write` failure. Caller exits the
+    /// loop — the channel is gone.
+    Io(std::io::Error),
+}
+
+impl std::fmt::Display for FrameError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Eof => write!(f, "peer closed the connection"),
+            Self::Parse(err) => write!(f, "frame parse error: {err}"),
+            Self::Io(err) => write!(f, "frame io error: {err}"),
+        }
+    }
+}
+
+impl std::error::Error for FrameError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn round_trips_a_request_envelope() {
+        let req = JsonRpcRequest::new(
+            JsonRpcId::Num(7),
+            "ping",
+            serde_json::json!({ "counter": 1 }),
+        );
+        let mut buf = Vec::new();
+        write_frame(&mut buf, &req).unwrap();
+        let mut reader = Cursor::new(buf);
+        let decoded: JsonRpcRequest = read_frame(&mut reader).unwrap();
+        assert_eq!(decoded.jsonrpc, "2.0");
+        assert_eq!(decoded.method, "ping");
+        assert!(matches!(decoded.id, JsonRpcId::Num(7)));
+        assert_eq!(decoded.params["counter"], 1);
+    }
+
+    #[test]
+    fn round_trips_a_response_success_envelope() {
+        let resp = JsonRpcResponse::success(JsonRpcId::Num(7), serde_json::json!({ "ok": true }));
+        let mut buf = Vec::new();
+        write_frame(&mut buf, &resp).unwrap();
+        let mut reader = Cursor::new(buf);
+        let decoded: JsonRpcResponse = read_frame(&mut reader).unwrap();
+        assert!(decoded.result.is_some());
+        assert!(decoded.error.is_none());
+    }
+
+    #[test]
+    fn round_trips_a_response_error_envelope() {
+        let resp = JsonRpcResponse::failure(
+            JsonRpcId::Num(7),
+            JsonRpcError::new(error_codes::METHOD_NOT_FOUND, "unknown method: foo"),
+        );
+        let mut buf = Vec::new();
+        write_frame(&mut buf, &resp).unwrap();
+        let mut reader = Cursor::new(buf);
+        let decoded: JsonRpcResponse = read_frame(&mut reader).unwrap();
+        assert!(decoded.result.is_none());
+        let err = decoded.error.expect("error envelope must round-trip");
+        assert_eq!(err.code, error_codes::METHOD_NOT_FOUND);
+    }
+
+    #[test]
+    fn eof_returns_eof_variant_not_a_parse_error() {
+        let mut reader = Cursor::new(Vec::new());
+        match read_frame::<_, JsonRpcRequest>(&mut reader) {
+            Err(FrameError::Eof) => {}
+            other => panic!("expected Eof, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn blank_lines_are_skipped() {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"\n\n");
+        let req = JsonRpcRequest::new(JsonRpcId::Num(1), "ping", serde_json::json!({}));
+        write_frame(&mut buf, &req).unwrap();
+        let mut reader = Cursor::new(buf);
+        let decoded: JsonRpcRequest = read_frame(&mut reader).unwrap();
+        assert_eq!(decoded.method, "ping");
+    }
+
+    #[test]
+    fn parse_failure_surfaces_via_parse_variant() {
+        let mut reader = Cursor::new(b"not json\n".to_vec());
+        match read_frame::<_, JsonRpcRequest>(&mut reader) {
+            Err(FrameError::Parse(_)) => {}
+            other => panic!("expected Parse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn id_serialises_as_number_string_or_null() {
+        assert_eq!(serde_json::to_string(&JsonRpcId::Num(42)).unwrap(), "42");
+        assert_eq!(
+            serde_json::to_string(&JsonRpcId::Str("abc".into())).unwrap(),
+            "\"abc\""
+        );
+        assert_eq!(serde_json::to_string(&JsonRpcId::Null).unwrap(), "null");
+    }
+
+    #[test]
+    fn null_id_marks_a_notification() {
+        assert!(JsonRpcId::Null.is_notification());
+        assert!(!JsonRpcId::Num(1).is_notification());
+        assert!(!JsonRpcId::Str("abc".into()).is_notification());
+    }
+}

--- a/src-tauri/src/remote/server.rs
+++ b/src-tauri/src/remote/server.rs
@@ -1,0 +1,456 @@
+//! JSON-RPC method dispatch for the F1 daemon slice.
+//!
+//! Three pieces:
+//!   - [`ServerContext`] — per-connection state. F1 just carries the
+//!     server's version + hostname + the post-`initialize` gate flag.
+//!     Later phases (F2-F7) will add the runtime, agent bridge,
+//!     terminal registry, etc.
+//!   - [`Method`] / [`dispatch_request`] — name → handler routing.
+//!   - The handlers themselves — `initialize`, `ping`, `runtime.health`.
+//!
+//! Handlers stay tiny + pure: `fn(ctx, params) -> Result<R,
+//! JsonRpcError>`. The dispatcher owns the version-check gate, the
+//! params deserialisation, and the response envelope.
+
+use std::str::FromStr;
+use std::sync::Mutex;
+
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::protocol::{
+    error_codes, JsonRpcError, JsonRpcId, JsonRpcRequest, JsonRpcResponse, PROTOCOL_VERSION,
+};
+
+/// Per-connection state. F1 keeps it deliberately small — later
+/// phases will add the runtime, the agent bridge, the terminal
+/// registry, etc.
+pub struct ServerContext {
+    initialized: Mutex<bool>,
+    server_version: String,
+    hostname: String,
+}
+
+impl ServerContext {
+    pub fn new(server_version: impl Into<String>, hostname: impl Into<String>) -> Self {
+        Self {
+            initialized: Mutex::new(false),
+            server_version: server_version.into(),
+            hostname: hostname.into(),
+        }
+    }
+
+    /// `true` after a successful `initialize`. Every other method
+    /// rejects with [`error_codes::NOT_INITIALIZED`] until then so a
+    /// confused client (or a probing port-scanner) can't poke state
+    /// without the handshake.
+    pub fn is_initialized(&self) -> bool {
+        *self
+            .initialized
+            .lock()
+            .expect("server context mutex poisoned")
+    }
+
+    /// Server binary version — surfaced in `initialize` responses.
+    pub fn server_version(&self) -> &str {
+        &self.server_version
+    }
+
+    /// Hostname — surfaced in `initialize` + `runtime.health`.
+    pub fn hostname(&self) -> &str {
+        &self.hostname
+    }
+
+    fn mark_initialized(&self) {
+        *self
+            .initialized
+            .lock()
+            .expect("server context mutex poisoned") = true;
+    }
+}
+
+/// Strongly-typed method catalogue. Keeping this as an enum (rather
+/// than matching on `&str` inline) lets the dispatcher branch
+/// exhaustively + lets `methods.rs` test the round-trip of
+/// `as_str` / `from_str`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Method {
+    Initialize,
+    Ping,
+    RuntimeHealth,
+}
+
+impl Method {
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Initialize => "initialize",
+            Self::Ping => "ping",
+            Self::RuntimeHealth => "runtime.health",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnknownMethod(pub String);
+
+impl std::fmt::Display for UnknownMethod {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "unknown remote method: {:?}", self.0)
+    }
+}
+
+impl std::error::Error for UnknownMethod {}
+
+impl FromStr for Method {
+    type Err = UnknownMethod;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "initialize" => Ok(Self::Initialize),
+            "ping" => Ok(Self::Ping),
+            "runtime.health" => Ok(Self::RuntimeHealth),
+            _ => Err(UnknownMethod(value.to_string())),
+        }
+    }
+}
+
+// ── method types ──────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InitializeParams {
+    /// Wire protocol version the client speaks (see
+    /// [`super::protocol::PROTOCOL_VERSION`]). Server rejects with
+    /// `IncompatibleProtocol` when the major doesn't match.
+    pub protocol_version: String,
+    /// Human-readable client name (e.g. `"helmor-desktop"`).
+    pub client_name: String,
+    /// Client binary version. Optional — older clients omitted it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_version: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InitializeResult {
+    pub protocol_version: String,
+    pub server_version: String,
+    pub hostname: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PingParams {
+    /// Opaque counter the client increments so its echo loop can
+    /// pair responses with requests without leaning on JSON-RPC
+    /// `id`. Defaults to 0 so a sender that doesn't care can pass
+    /// `{}`.
+    #[serde(default)]
+    pub counter: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PingResult {
+    pub counter: u64,
+    /// Server-side timestamp (RFC 3339, millisecond precision).
+    /// Useful for time-skew debugging across the wire.
+    pub server_time: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeHealthParams {}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeHealthResult {
+    /// `"local"` for the daemon binary running on the remote host.
+    /// Later phases may expose `"remote"` when a daemon proxies to
+    /// another daemon, etc.
+    pub kind: String,
+    pub hostname: String,
+    pub server_version: String,
+}
+
+// ── dispatch ──────────────────────────────────────────────────────
+
+/// Decode a JSON-RPC request, dispatch to the matching handler, and
+/// build the response envelope. Notifications (`id == null`) get
+/// `None` back so the binary's write loop skips the response write.
+pub fn dispatch_request(ctx: &ServerContext, req: JsonRpcRequest) -> Option<JsonRpcResponse> {
+    let id = req.id.clone();
+    let method: Method = match req.method.parse() {
+        Ok(m) => m,
+        Err(_) => {
+            return wrap_error(
+                &id,
+                error_codes::METHOD_NOT_FOUND,
+                format!("unknown method: {}", req.method),
+            );
+        }
+    };
+
+    // Handshake gate.
+    if method != Method::Initialize && !ctx.is_initialized() {
+        return wrap_error(
+            &id,
+            error_codes::NOT_INITIALIZED,
+            "client must call `initialize` before any other method",
+        );
+    }
+
+    let outcome: Result<Value, JsonRpcError> = match method {
+        Method::Initialize => {
+            handle::<InitializeParams, _, _>(req.params, |params| handle_initialize(ctx, params))
+        }
+        Method::Ping => handle::<PingParams, _, _>(req.params, handle_ping),
+        Method::RuntimeHealth => handle::<RuntimeHealthParams, _, _>(req.params, |params| {
+            handle_runtime_health(ctx, params)
+        }),
+    };
+
+    let response = match outcome {
+        Ok(result) => JsonRpcResponse::success(id.clone(), result),
+        Err(err) => JsonRpcResponse::failure(id.clone(), err),
+    };
+    if id.is_notification() {
+        None
+    } else {
+        Some(response)
+    }
+}
+
+fn handle<P, R, F>(raw: Value, handler: F) -> Result<Value, JsonRpcError>
+where
+    P: DeserializeOwned,
+    R: Serialize,
+    F: FnOnce(P) -> Result<R, JsonRpcError>,
+{
+    let params: P = serde_json::from_value(raw)
+        .map_err(|err| JsonRpcError::new(error_codes::INVALID_PARAMS, format!("params: {err}")))?;
+    let result = handler(params)?;
+    serde_json::to_value(result).map_err(|err| {
+        JsonRpcError::new(
+            error_codes::INTERNAL_ERROR,
+            format!("serialise result: {err}"),
+        )
+    })
+}
+
+fn wrap_error(id: &JsonRpcId, code: i32, message: impl Into<String>) -> Option<JsonRpcResponse> {
+    if id.is_notification() {
+        return None;
+    }
+    Some(JsonRpcResponse::failure(
+        id.clone(),
+        JsonRpcError::new(code, message),
+    ))
+}
+
+// ── handlers ──────────────────────────────────────────────────────
+
+fn handle_initialize(
+    ctx: &ServerContext,
+    params: InitializeParams,
+) -> Result<InitializeResult, JsonRpcError> {
+    if !major_versions_match(&params.protocol_version, PROTOCOL_VERSION) {
+        return Err(JsonRpcError::new(
+            error_codes::INCOMPATIBLE_PROTOCOL,
+            format!(
+                "incompatible protocol: client speaks {} but server speaks {}",
+                params.protocol_version, PROTOCOL_VERSION
+            ),
+        ));
+    }
+    ctx.mark_initialized();
+    Ok(InitializeResult {
+        protocol_version: PROTOCOL_VERSION.to_string(),
+        server_version: ctx.server_version().to_string(),
+        hostname: ctx.hostname().to_string(),
+    })
+}
+
+fn handle_ping(params: PingParams) -> Result<PingResult, JsonRpcError> {
+    use chrono::SecondsFormat;
+    Ok(PingResult {
+        counter: params.counter,
+        server_time: chrono::Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true),
+    })
+}
+
+fn handle_runtime_health(
+    ctx: &ServerContext,
+    _params: RuntimeHealthParams,
+) -> Result<RuntimeHealthResult, JsonRpcError> {
+    Ok(RuntimeHealthResult {
+        kind: "local".to_string(),
+        hostname: ctx.hostname().to_string(),
+        server_version: ctx.server_version().to_string(),
+    })
+}
+
+/// Compare semver majors. `0.x` versions are treated as
+/// "majors == major + minor" so two `0.1.*` peers see each other as
+/// compatible but a `0.1.*` peer rejects a `0.2.*` peer. Once we
+/// reach `1.0` the standard "majors match" semantics kick in.
+fn major_versions_match(a: &str, b: &str) -> bool {
+    fn major_minor(v: &str) -> Option<(u32, u32)> {
+        let mut parts = v.split('.');
+        let major = parts.next()?.parse().ok()?;
+        let minor = parts.next()?.parse().ok().unwrap_or(0);
+        Some((major, minor))
+    }
+    match (major_minor(a), major_minor(b)) {
+        (Some((maj_a, min_a)), Some((maj_b, min_b))) => {
+            if maj_a == 0 || maj_b == 0 {
+                maj_a == maj_b && min_a == min_b
+            } else {
+                maj_a == maj_b
+            }
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx() -> ServerContext {
+        ServerContext::new("0.0.0-test", "test.host")
+    }
+
+    fn initialize(ctx: &ServerContext) {
+        let req = JsonRpcRequest::new(
+            JsonRpcId::Num(1),
+            "initialize",
+            serde_json::json!({
+                "protocolVersion": PROTOCOL_VERSION,
+                "clientName": "test-client",
+            }),
+        );
+        let resp = dispatch_request(ctx, req).expect("initialize must respond");
+        assert!(resp.error.is_none(), "initialize failed: {resp:?}");
+        assert!(ctx.is_initialized());
+    }
+
+    #[test]
+    fn method_roundtrips_through_str() {
+        for m in [Method::Initialize, Method::Ping, Method::RuntimeHealth] {
+            assert_eq!(m.as_str().parse::<Method>().unwrap(), m);
+        }
+    }
+
+    #[test]
+    fn unknown_method_returns_method_not_found() {
+        let req = JsonRpcRequest::new(JsonRpcId::Num(1), "foo.bar", serde_json::json!({}));
+        let resp = dispatch_request(&ctx(), req).expect("response expected");
+        let err = resp.error.expect("error expected");
+        assert_eq!(err.code, error_codes::METHOD_NOT_FOUND);
+    }
+
+    #[test]
+    fn pre_initialize_calls_are_rejected() {
+        let req = JsonRpcRequest::new(JsonRpcId::Num(1), "ping", serde_json::json!({}));
+        let resp = dispatch_request(&ctx(), req).expect("response expected");
+        let err = resp.error.expect("error expected");
+        assert_eq!(err.code, error_codes::NOT_INITIALIZED);
+    }
+
+    #[test]
+    fn initialize_accepts_matching_major() {
+        let ctx = ctx();
+        initialize(&ctx);
+    }
+
+    #[test]
+    fn initialize_rejects_incompatible_major() {
+        let ctx = ctx();
+        let req = JsonRpcRequest::new(
+            JsonRpcId::Num(1),
+            "initialize",
+            serde_json::json!({
+                "protocolVersion": "9.0.0",
+                "clientName": "test-client",
+            }),
+        );
+        let resp = dispatch_request(&ctx, req).expect("response expected");
+        let err = resp.error.expect("error expected");
+        assert_eq!(err.code, error_codes::INCOMPATIBLE_PROTOCOL);
+        assert!(!ctx.is_initialized());
+    }
+
+    #[test]
+    fn ping_echoes_counter_after_initialize() {
+        let ctx = ctx();
+        initialize(&ctx);
+        let req = JsonRpcRequest::new(
+            JsonRpcId::Num(2),
+            "ping",
+            serde_json::json!({ "counter": 42 }),
+        );
+        let resp = dispatch_request(&ctx, req).expect("response expected");
+        let result = resp.result.expect("result expected");
+        assert_eq!(result["counter"], 42);
+        assert!(result["serverTime"].is_string());
+    }
+
+    #[test]
+    fn runtime_health_returns_kind_local_and_hostname() {
+        let ctx = ctx();
+        initialize(&ctx);
+        let req = JsonRpcRequest::new(JsonRpcId::Num(3), "runtime.health", serde_json::json!({}));
+        let resp = dispatch_request(&ctx, req).expect("response expected");
+        let result = resp.result.expect("result expected");
+        assert_eq!(result["kind"], "local");
+        assert_eq!(result["hostname"], "test.host");
+        assert_eq!(result["serverVersion"], "0.0.0-test");
+    }
+
+    #[test]
+    fn notification_id_null_suppresses_response() {
+        let ctx = ctx();
+        initialize(&ctx);
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".into(),
+            id: JsonRpcId::Null,
+            method: "ping".into(),
+            params: serde_json::json!({}),
+        };
+        assert!(dispatch_request(&ctx, req).is_none());
+    }
+
+    #[test]
+    fn invalid_params_returns_invalid_params() {
+        let ctx = ctx();
+        initialize(&ctx);
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".into(),
+            id: JsonRpcId::Num(4),
+            method: "ping".into(),
+            // counter must be a u64 — passing a string forces a
+            // params decode failure.
+            params: serde_json::json!({ "counter": "not a number" }),
+        };
+        let resp = dispatch_request(&ctx, req).expect("response expected");
+        let err = resp.error.expect("error expected");
+        assert_eq!(err.code, error_codes::INVALID_PARAMS);
+    }
+
+    #[test]
+    fn major_zero_matches_on_minor_too() {
+        // Two `0.1.x` peers should accept each other.
+        assert!(major_versions_match("0.1.0", "0.1.5"));
+        // A `0.1.x` peer rejects a `0.2.x` peer (we treat 0.x as
+        // pre-stable; minor bumps are breaking).
+        assert!(!major_versions_match("0.1.0", "0.2.0"));
+    }
+
+    #[test]
+    fn post_one_zero_matches_majors_only() {
+        assert!(major_versions_match("1.5.0", "1.0.0"));
+        assert!(!major_versions_match("1.0.0", "2.0.0"));
+    }
+}

--- a/src-tauri/tests/remote_server_handshake.rs
+++ b/src-tauri/tests/remote_server_handshake.rs
@@ -1,0 +1,136 @@
+//! End-to-end integration test for the `helmor-server` F1 slice.
+//!
+//! Spawns the built binary, writes a JSON-RPC `initialize` request
+//! to stdin, reads the response from stdout, asserts on the
+//! envelope shape. Catches regressions in the wire framing +
+//! handshake gate that pure unit tests can't reach (binary boot,
+//! tracing init, stdio flushing).
+
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Command, Stdio};
+
+use helmor_lib::remote::{JsonRpcId, JsonRpcRequest, JsonRpcResponse, PROTOCOL_VERSION};
+
+fn helmor_server_bin() -> std::path::PathBuf {
+    // CARGO_BIN_EXE_<name> is populated by cargo for integration
+    // tests so we don't have to guess the target dir layout.
+    std::path::PathBuf::from(env!("CARGO_BIN_EXE_helmor-server"))
+}
+
+fn spawn_server() -> std::process::Child {
+    Command::new(helmor_server_bin())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        // Set HOSTNAME so the response carries a stable value across
+        // hosts the test might run on.
+        .env("HOSTNAME", "ci-test.host")
+        .spawn()
+        .expect("spawn helmor-server")
+}
+
+fn write_request(child: &mut std::process::Child, req: &JsonRpcRequest) {
+    let stdin = child.stdin.as_mut().expect("stdin captured");
+    let line = serde_json::to_string(req).unwrap();
+    stdin.write_all(line.as_bytes()).unwrap();
+    stdin.write_all(b"\n").unwrap();
+    stdin.flush().unwrap();
+}
+
+fn read_response(child: &mut std::process::Child) -> JsonRpcResponse {
+    let stdout = child.stdout.as_mut().expect("stdout captured");
+    let mut reader = BufReader::new(stdout);
+    let mut line = String::new();
+    reader.read_line(&mut line).unwrap();
+    serde_json::from_str(line.trim()).expect("response is valid JSON-RPC")
+}
+
+#[test]
+fn initialize_followed_by_ping_round_trips_through_the_binary() {
+    let mut child = spawn_server();
+
+    // Step 1: handshake.
+    let init = JsonRpcRequest::new(
+        JsonRpcId::Num(1),
+        "initialize",
+        serde_json::json!({
+            "protocolVersion": PROTOCOL_VERSION,
+            "clientName": "integration-test",
+        }),
+    );
+    write_request(&mut child, &init);
+    let init_resp = read_response(&mut child);
+    let result = init_resp.result.expect("initialize returned a result");
+    assert_eq!(result["protocolVersion"], PROTOCOL_VERSION);
+    assert_eq!(result["hostname"], "ci-test.host");
+
+    // Step 2: ping after handshake.
+    let ping = JsonRpcRequest::new(
+        JsonRpcId::Num(2),
+        "ping",
+        serde_json::json!({ "counter": 99 }),
+    );
+    write_request(&mut child, &ping);
+    let ping_resp = read_response(&mut child);
+    let result = ping_resp.result.expect("ping returned a result");
+    assert_eq!(result["counter"], 99);
+    assert!(result["serverTime"].is_string());
+
+    // Step 3: runtime.health.
+    let health = JsonRpcRequest::new(JsonRpcId::Num(3), "runtime.health", serde_json::json!({}));
+    write_request(&mut child, &health);
+    let health_resp = read_response(&mut child);
+    let result = health_resp
+        .result
+        .expect("runtime.health returned a result");
+    assert_eq!(result["kind"], "local");
+    assert_eq!(result["hostname"], "ci-test.host");
+
+    // Close stdin so the binary exits cleanly.
+    drop(child.stdin.take());
+    let status = child.wait().expect("binary exits");
+    assert!(status.success(), "binary exited non-zero: {status:?}");
+}
+
+#[test]
+fn pre_initialize_calls_get_rejected_with_not_initialized() {
+    let mut child = spawn_server();
+
+    let ping = JsonRpcRequest::new(JsonRpcId::Num(1), "ping", serde_json::json!({}));
+    write_request(&mut child, &ping);
+    let resp = read_response(&mut child);
+    let err = resp.error.expect("ping pre-initialize returns an error");
+    // Don't pin the exact code — the test should pass even if we
+    // adjust the code constant later. Just assert it surfaces as
+    // an error envelope referencing the handshake.
+    assert!(
+        err.message.to_lowercase().contains("initialize"),
+        "error message should mention initialize: {}",
+        err.message
+    );
+
+    drop(child.stdin.take());
+    let _ = child.wait();
+}
+
+#[test]
+fn version_flag_prints_semver_and_protocol_lines_and_exits_zero() {
+    let output = Command::new(helmor_server_bin())
+        .arg("--version")
+        .output()
+        .expect("spawn helmor-server --version");
+    assert!(output.status.success(), "--version exit non-zero");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut lines = stdout.lines();
+    let bin_line = lines.next().expect("at least one stdout line");
+    let protocol_line = lines.next().expect("a protocol line");
+    assert!(
+        bin_line.starts_with("helmor-server "),
+        "first line should be `helmor-server <semver>`: {bin_line:?}",
+    );
+    assert!(
+        protocol_line.starts_with("protocol "),
+        "second line should be `protocol <semver>`: {protocol_line:?}",
+    );
+    assert!(protocol_line.contains(PROTOCOL_VERSION));
+}


### PR DESCRIPTION
## Summary

First slice of remote-workspace support — issue #453. Lands the foundation every later phase builds on:

- New \`helmor-server\` binary that speaks **JSON-RPC 2.0 over newline-delimited stdin/stdout**.
- A protocol-version handshake gate (\`initialize\`).
- Two read-only methods (\`ping\`, \`runtime.health\`) so an operator can verify the binary is alive.

The wire shape this freezes is what every later phase builds on. Out of scope for this PR — each lands as its own follow-up:

| Phase | Scope |
| --- | --- |
| **F2** | SSH transport + daemon spawn over an existing SSH session. |
| **F3** | Agent attach + chat reattach + local DB persistence + UI sync. |
| **F4** | Port forwarding (independent of F3/F5). |
| **F5** | Auto-reconnect + connection state machine. |
| **F6** | Daemon event journal + replay-from-seq + history rebuild. |
| **F7** | Journal durability across daemon restarts. |

## What's in the PR

- \`src-tauri/src/remote/protocol.rs\` — JSON-RPC envelope types (\`JsonRpcRequest\` / \`JsonRpcResponse\` / \`JsonRpcError\` / \`JsonRpcId\`), reserved error codes, newline-delimited framing helpers (\`read_frame\` / \`write_frame\`). Blank-line tolerance + EOF-vs-parse distinction.
- \`src-tauri/src/remote/server.rs\` — \`ServerContext\` (server version + hostname + post-\`initialize\` gate), strongly-typed \`Method\` catalog, \`dispatch_request\` (handler routing + response envelope construction + notification suppression).
- Three methods:
  - \`initialize\` — protocol-version handshake. \`0.x\` peers must match on \`<major>.<minor>\`; once we promote to \`1.0\`, standard "majors match" applies.
  - \`ping\` — echo counter + RFC 3339 server timestamp. Drives a future heartbeat loop.
  - \`runtime.health\` — \`{ kind: "local", hostname, serverVersion }\` for a future diagnostics panel.
- \`src-tauri/src/bin/helmor-server.rs\` — binary with two CLI modes: \`--version\` / \`-V\` (print version + protocol, exit 0) and \`--serve-stdio\` (default; loop reading/writing frames).
- \`docs/remote-server-f1.md\` — architecture + wire-shape reference.

## Test plan

- [x] 8 protocol unit tests (envelope round-trip, EOF behaviour, blank lines, parse failure, id variants).
- [x] 10 dispatcher unit tests (method round-trip, unknown method, pre-initialize gate, version match/mismatch, ping echo, runtime.health shape, notification suppression, invalid params, semver matching).
- [x] 3 end-to-end integration tests in \`tests/remote_server_handshake.rs\` that drive the built binary via stdin/stdout: full handshake → ping → runtime.health round-trip, pre-initialize rejection, \`--version\` output.
- [x] \`cargo clippy --bin helmor-server --lib --tests -- -D warnings\` — clean.

## Trying it locally

\`\`\`bash
cd src-tauri
cargo build --bin helmor-server
echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"0.1.0","clientName":"test"}}' \\
  | target/debug/helmor-server --serve-stdio
\`\`\`

Returns:

\`\`\`json
{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"0.1.0","serverVersion":"<binary version>","hostname":"<HOSTNAME>"}}
\`\`\`

## Notes for review

- The protocol is intentionally minimal in F1 — the goal is to lock the **envelope shape** before larger surfaces layer on. Method additions are forward-compatible (unknown methods return \`MethodNotFound\`), so F2-F7 can extend the catalog without bumping \`PROTOCOL_VERSION\`.
- No external dependencies added — \`chrono\`, \`tracing\`, \`tracing-subscriber\`, \`serde\`, \`serde_json\` were already in \`Cargo.toml\`.
- The binary is registered as a new \`[[bin]]\` entry in \`src-tauri/Cargo.toml\` and lives alongside the existing \`helmor-cli\` + \`gen_pipeline_fixture\` binaries; the desktop app is unaffected.

Happy to slice further or split if any of this should land separately.