### PR TITLE
feat: land on start page after onboarding & enable chat-only mode

### DIFF
--- a/.changeset/start-page-and-menu-polish.md
+++ b/.changeset/start-page-and-menu-polish.md
@@ -1,0 +1,6 @@
+---
+"helmor": patch
+---
+
+- Land on the start page after finishing onboarding so users can chat immediately even before adding their first repository.
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -191,11 +191,16 @@ function MainApp() {
 	const completeOnboarding = useCallback(() => {
 		setSplashMounted(true);
 		setSplashVisible(true);
+		// Land on the start page; even without a repo the user can chat.
 		setAppSettings((previous) => ({
 			...(previous ?? DEFAULT_SETTINGS),
 			onboardingCompleted: true,
+			lastSurface: "workspace-start",
 		}));
-		void saveSettings({ onboardingCompleted: true });
+		void saveSettings({
+			onboardingCompleted: true,
+			lastSurface: "workspace-start",
+		});
 
 		requestAnimationFrame(() => {
 			requestAnimationFrame(hideSplashAfterBoot);
@@ -1645,7 +1650,9 @@ function AppShell({
 														onOpenFileReference={handleOpenFileReference}
 														composerOnly
 														composerWrapperClassName="w-full"
-														composerForceAvailable={Boolean(startRepository)}
+														composerForceAvailable={
+															Boolean(startRepository) || startMode === "chat"
+														}
 														composerContextKeyOverride={startComposerContextKey}
 														composerPlaceholder="Describe what you want to build"
 														composerCreateContext={startCreateContext}

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -92,7 +92,7 @@ function ContextMenuItem({
 			data-inset={inset}
 			data-variant={variant}
 			className={cn(
-				"group/context-menu-item relative flex cursor-interactive items-center gap-1 rounded-[5px] px-1.5 py-0.5 text-ui leading-5 outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-inset:pl-6 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5 focus:*:[svg]:text-accent-foreground data-[variant=destructive]:*:[svg]:text-destructive",
+				"group/context-menu-item relative flex cursor-interactive items-center gap-1.5 rounded-[5px] px-1.5 py-1 text-ui leading-4 outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-inset:pl-6 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5 focus:*:[svg]:text-accent-foreground data-[variant=destructive]:*:[svg]:text-destructive",
 				className,
 			)}
 			{...props}
@@ -113,7 +113,7 @@ function ContextMenuSubTrigger({
 			data-slot="context-menu-sub-trigger"
 			data-inset={inset}
 			className={cn(
-				"flex cursor-interactive items-center gap-1 rounded-[5px] px-1.5 py-0.5 text-ui leading-5 outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-inset:pl-6 data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
+				"flex cursor-interactive items-center gap-1.5 rounded-[5px] px-1.5 py-1 text-ui leading-4 outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-inset:pl-6 data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
 				className,
 			)}
 			{...props}
@@ -154,7 +154,7 @@ function ContextMenuCheckboxItem({
 			data-slot="context-menu-checkbox-item"
 			data-inset={inset}
 			className={cn(
-				"relative flex cursor-interactive items-center gap-1 rounded-[5px] py-0.5 pr-7 pl-1.5 text-ui leading-5 outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-inset:pl-6 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
+				"relative flex cursor-interactive items-center gap-1.5 rounded-[5px] py-1 pr-7 pl-1.5 text-ui leading-4 outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-inset:pl-6 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
 				className,
 			)}
 			checked={checked}
@@ -183,7 +183,7 @@ function ContextMenuRadioItem({
 			data-slot="context-menu-radio-item"
 			data-inset={inset}
 			className={cn(
-				"relative flex cursor-interactive items-center gap-1 rounded-[5px] py-0.5 pr-7 pl-1.5 text-ui leading-5 outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-inset:pl-6 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
+				"relative flex cursor-interactive items-center gap-1.5 rounded-[5px] py-1 pr-7 pl-1.5 text-ui leading-4 outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-inset:pl-6 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
 				className,
 			)}
 			{...props}

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/lib/utils";
 
 // Shared classes for every interactive row inside DropdownMenu / ContextMenu.
 const dropdownMenuItemClasses =
-	"gap-1.5 py-1 text-ui leading-5 [&_svg:not([class*='size-'])]:size-3.5";
+	"gap-1.5 py-1 text-ui leading-4 [&_svg:not([class*='size-'])]:size-3.5";
 
 function DropdownMenu({
 	...props

--- a/src/features/navigation/sidebar-view-popover.tsx
+++ b/src/features/navigation/sidebar-view-popover.tsx
@@ -236,7 +236,7 @@ export function SidebarViewPopover({
 								type="button"
 								role="radio"
 								aria-checked={checked}
-								className="flex h-7 w-full cursor-pointer items-center gap-2 rounded-md px-1.5 text-left text-ui hover:bg-accent/70 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50"
+								className="flex w-full cursor-pointer items-center gap-1.5 rounded-md px-1.5 py-1 text-left text-ui leading-4 hover:bg-accent/70 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50"
 								onClick={() =>
 									onGroupingChange?.(option.value as SidebarGrouping)
 								}
@@ -264,7 +264,7 @@ export function SidebarViewPopover({
 								type="button"
 								role="radio"
 								aria-checked={checked}
-								className="flex h-7 w-full cursor-pointer items-center gap-2 rounded-md px-1.5 text-left text-ui hover:bg-accent/70 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50"
+								className="flex w-full cursor-pointer items-center gap-1.5 rounded-md px-1.5 py-1 text-left text-ui leading-4 hover:bg-accent/70 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50"
 								onClick={() => onSortChange?.(option.value)}
 							>
 								<Icon className="size-3.5 shrink-0 text-muted-foreground" />

--- a/src/features/workspace-start/index.tsx
+++ b/src/features/workspace-start/index.tsx
@@ -1,5 +1,6 @@
 import {
 	ChevronDown,
+	FolderPlus,
 	GitBranch,
 	GitBranchPlus,
 	GitMerge,
@@ -20,6 +21,7 @@ import {
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
+	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
@@ -45,6 +47,7 @@ import type { ComposerInsertTarget } from "@/lib/composer-insert";
 import { useSettings } from "@/lib/settings";
 import type { ContextCard } from "@/lib/sources/types";
 import { cn } from "@/lib/utils";
+import { publishShellEvent } from "@/shell/event-bus";
 import { CreateBranchDialog } from "./create-branch-dialog";
 
 const PREVIEW_TRAFFIC_LIGHT_SPACER_WIDTH = 52;
@@ -409,7 +412,7 @@ export function WorkspaceStartPage({
 									<button
 										type="button"
 										disabled={repositories.length === 0}
-										className="inline-flex h-7 max-w-[13rem] cursor-interactive items-center gap-1 rounded-md px-1.5 text-small font-medium text-muted-foreground transition-colors hover:bg-muted/45 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+										className="inline-flex h-7 max-w-[13rem] cursor-interactive items-center gap-1 rounded-md px-1.5 text-ui font-medium text-muted-foreground transition-colors hover:bg-muted/45 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
 									>
 										{selectedRepository ? (
 											<>
@@ -466,7 +469,7 @@ export function WorkspaceStartPage({
 											// Chat mode is always enabled (no repo needed);
 											// other modes require a selected repository.
 											disabled={mode !== "chat" && !selectedRepository}
-											className="inline-flex h-7 cursor-interactive items-center gap-1 rounded-md px-1.5 text-small font-medium text-muted-foreground outline-none transition-colors hover:bg-muted/45 hover:text-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+											className="inline-flex h-7 cursor-interactive items-center gap-1 rounded-md px-1.5 text-ui font-medium text-muted-foreground outline-none transition-colors hover:bg-muted/45 hover:text-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
 										>
 											{mode === "local" ? (
 												<Laptop
@@ -512,30 +515,58 @@ export function WorkspaceStartPage({
 								className="w-fit min-w-36"
 								onCloseAutoFocus={(event) => event.preventDefault()}
 							>
-								<DropdownMenuItem
-									onClick={() => onModeChange("local")}
-									className="gap-2 pr-3"
-									data-checked={mode === "local" ? "true" : undefined}
-								>
-									<Laptop className="size-3.5" strokeWidth={1.8} />
-									<span>Work locally</span>
-								</DropdownMenuItem>
-								<DropdownMenuItem
-									onClick={() => onModeChange("worktree")}
-									className="gap-2 pr-3"
-									data-checked={mode === "worktree" ? "true" : undefined}
-								>
-									<Split className="size-3.5 rotate-90" strokeWidth={1.8} />
-									<span>New worktree</span>
-								</DropdownMenuItem>
-								<DropdownMenuItem
-									onClick={() => onModeChange("chat")}
-									className="gap-2 pr-3"
-									data-checked={mode === "chat" ? "true" : undefined}
-								>
-									<MessageCircle className="size-3.5" strokeWidth={1.8} />
-									<span>Just chat</span>
-								</DropdownMenuItem>
+								{repositories.length === 0 ? (
+									// No repos → swap the repo-bound modes for an "Add a
+									// repository" CTA that fires `helmor:open-add-repository`
+									// (sidebar listener opens its add-repo sub-menu).
+									<>
+										<DropdownMenuItem
+											onClick={() =>
+												publishShellEvent({ type: "open-add-repository" })
+											}
+											className="gap-2 pr-3"
+										>
+											<FolderPlus className="size-3.5" strokeWidth={1.8} />
+											<span>Add a repository…</span>
+										</DropdownMenuItem>
+										<DropdownMenuSeparator />
+										<DropdownMenuItem
+											onClick={() => onModeChange("chat")}
+											className="gap-2 pr-3"
+											data-checked="true"
+										>
+											<MessageCircle className="size-3.5" strokeWidth={1.8} />
+											<span>Just chat</span>
+										</DropdownMenuItem>
+									</>
+								) : (
+									<>
+										<DropdownMenuItem
+											onClick={() => onModeChange("local")}
+											className="gap-2 pr-3"
+											data-checked={mode === "local" ? "true" : undefined}
+										>
+											<Laptop className="size-3.5" strokeWidth={1.8} />
+											<span>Work locally</span>
+										</DropdownMenuItem>
+										<DropdownMenuItem
+											onClick={() => onModeChange("worktree")}
+											className="gap-2 pr-3"
+											data-checked={mode === "worktree" ? "true" : undefined}
+										>
+											<Split className="size-3.5 rotate-90" strokeWidth={1.8} />
+											<span>New worktree</span>
+										</DropdownMenuItem>
+										<DropdownMenuItem
+											onClick={() => onModeChange("chat")}
+											className="gap-2 pr-3"
+											data-checked={mode === "chat" ? "true" : undefined}
+										>
+											<MessageCircle className="size-3.5" strokeWidth={1.8} />
+											<span>Just chat</span>
+										</DropdownMenuItem>
+									</>
+								)}
 							</DropdownMenuContent>
 						</DropdownMenu>
 						{/* Branch intent picker. Worktree mode only. */}
@@ -547,7 +578,7 @@ export function WorkspaceStartPage({
 											<button
 												type="button"
 												disabled={!selectedRepository}
-												className="inline-flex h-7 cursor-interactive items-center gap-1 rounded-md px-1.5 text-small font-medium text-muted-foreground outline-none transition-colors hover:bg-muted/45 hover:text-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+												className="inline-flex h-7 cursor-interactive items-center gap-1 rounded-md px-1.5 text-ui font-medium text-muted-foreground outline-none transition-colors hover:bg-muted/45 hover:text-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
 											>
 												{branchIntent === "use_branch" ? (
 													<GitMerge
@@ -655,7 +686,7 @@ export function WorkspaceStartPage({
 											<button
 												type="button"
 												disabled={!selectedRepository}
-												className="inline-flex h-7 max-w-[13rem] cursor-interactive items-center gap-1 rounded-md px-1.5 text-small font-medium text-muted-foreground outline-none transition-colors hover:bg-muted/45 hover:text-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+												className="inline-flex h-7 max-w-[13rem] cursor-interactive items-center gap-1 rounded-md px-1.5 text-ui font-medium text-muted-foreground outline-none transition-colors hover:bg-muted/45 hover:text-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
 											>
 												<GitBranch
 													className="size-3.5 shrink-0"

--- a/src/shell/components/workspace-header-actions.tsx
+++ b/src/shell/components/workspace-header-actions.tsx
@@ -118,7 +118,6 @@ export function WorkspaceHeaderActions({
 										pushWorkspaceToast(String(e), "Failed to open Finder"),
 									);
 								}}
-								className="flex items-center gap-2"
 							>
 								<FolderOpen className="shrink-0" strokeWidth={1.8} />
 								<span className="flex-1">Finder</span>
@@ -140,7 +139,6 @@ export function WorkspaceHeaderActions({
 												),
 										);
 									}}
-									className="flex items-center gap-2"
 								>
 									<EditorIcon editorId={editor.id} className="shrink-0" />
 									<span className="flex-1">{editor.name}</span>

--- a/src/shell/controllers/use-start-surface-controller.ts
+++ b/src/shell/controllers/use-start-surface-controller.ts
@@ -147,7 +147,9 @@ export function useStartSurfaceController(
 		startRepositoryId,
 		START_SURFACE_MODE_FALLBACK,
 	);
-	const startMode: WorkspaceMode = prefs.chatModeActive ? "chat" : repoWorkMode;
+	// No repos → lock to chat (worktree/local can't run without one).
+	const startMode: WorkspaceMode =
+		repositories.length === 0 || prefs.chatModeActive ? "chat" : repoWorkMode;
 	const startBranchIntent = readRepoPreference(
 		prefs.branchIntentByRepoId,
 		startRepositoryId,


### PR DESCRIPTION
## Summary
- Redirect users to the start page after completing onboarding so they can chat immediately without needing a repository
- Enable the composer in chat mode even when no repository is selected
- Update the mode picker dropdown to show "Add a repository" option when no repos exist
- Fix menu item spacing and typography for consistency

## Changes
- `App.tsx`: Set `lastSurface: "workspace-start"` on onboarding completion; allow composer in start page chat mode
- `workspace-start/index.tsx`: Conditionally show repo selection modes vs. chat-only + add-repo option based on repository count
- `context-menu.tsx` & `dropdown-menu.tsx`: Adjust spacing (gap-1.5, py-1, leading-4) for better consistency
- `sidebar-view-popover.tsx`: Update button styling for consistency
- `workspace-header-actions.tsx`: Remove redundant className

## Test plan
- [ ] Complete onboarding flow and verify landing on start page
- [ ] With no repos, test the "Add a repository" flow from the mode picker
- [ ] With repos, verify all three modes (local, worktree, chat) appear correctly
- [ ] Test chat mode enabled on start page with and without a selected repository
- [ ] Verify menu items (context/dropdown) render with correct spacing