### PR TITLE
Fix: make terminal stop button clickable

### DIFF
--- a/.changeset/fix-terminal-stop-button-clickable.md
+++ b/.changeset/fix-terminal-stop-button-clickable.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix the inspector Run/Setup tabs' floating Stop/Rerun button only registering clicks on a thin strip near its bottom edge. The xterm WebGL link-layer canvas sits at `z-index: 2` and was painted over the upper portion of the button — the button now sits above the xterm canvas stack so the entire visible rectangle is clickable.

--- a/src/features/inspector/sections/run.tsx
+++ b/src/features/inspector/sections/run.tsx
@@ -263,8 +263,9 @@ export function RunTab({
 					</div>
 
 					{showFloatingAction && (
+						// z-20 keeps the button above xterm's link-layer canvas (z:2).
 						<div
-							className="absolute bottom-3 right-4"
+							className="absolute right-4 bottom-3 z-20"
 							style={
 								autoExpandEnabled
 									? {

--- a/src/features/inspector/sections/setup.tsx
+++ b/src/features/inspector/sections/setup.tsx
@@ -170,8 +170,9 @@ export function SetupTab({
 					</div>
 
 					{showFloatingAction && (
+						// z-20 keeps the button above xterm's link-layer canvas (z:2).
 						<div
-							className="absolute bottom-3 right-4"
+							className="absolute right-4 bottom-3 z-20"
 							style={
 								autoExpandEnabled
 									? {


### PR DESCRIPTION
## Summary
The terminal stop button (floating action button in the Run/Setup tabs) was not clickable because it was being rendered below xterm's link-layer canvas. This fix adds `z-20` to raise the button above the canvas layer.

## Changes
- Added `z-20` class to floating action button containers in both `run.tsx` and `setup.tsx`
- Added clarifying comment explaining the z-index reasoning
- Includes changeset entry for release notes

## Test plan
- [ ] Verify the stop button is clickable in the terminal Run tab
- [ ] Verify the stop button is clickable in the terminal Setup tab
- [ ] Confirm no regression in other overlays or UI elements