### PR TITLE
fix: Shift+Tab repository cycling on start surface

### DIFF
--- a/.changeset/fix-new-thread-shift-tab-cycle-repo.md
+++ b/.changeset/fix-new-thread-shift-tab-cycle-repo.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix Shift+Tab on the new-thread page only cycling repositories when focus was inside the composer; the shortcut now works anywhere on the start surface.

--- a/src/features/shortcuts/use-app-shortcuts.test.tsx
+++ b/src/features/shortcuts/use-app-shortcuts.test.tsx
@@ -208,6 +208,42 @@ describe("useAppShortcuts", () => {
 		expect(cycleRepository).toHaveBeenCalledTimes(1);
 	});
 
+	it("fires cycleRepository on Shift+Tab when focus is on a start-surface button (not the composer itself)", () => {
+		const cycleRepository = vi.fn();
+
+		function Harness() {
+			useAppShortcuts({
+				overrides: {},
+				handlers: [
+					{
+						id: "startSurface.cycleRepository",
+						callback: cycleRepository,
+					},
+				],
+			});
+			return (
+				<div data-focus-scope="chat">
+					<div data-focus-scope="start-composer">
+						<button type="button" data-testid="repo-button">
+							Repo
+						</button>
+						<div data-focus-scope="start-composer">
+							<input data-testid="composer-input" />
+						</div>
+					</div>
+				</div>
+			);
+		}
+
+		const { getByTestId } = render(<Harness />);
+		(getByTestId("repo-button") as HTMLButtonElement).focus();
+
+		window.dispatchEvent(
+			new KeyboardEvent("keydown", { key: "Tab", code: "Tab", shiftKey: true }),
+		);
+		expect(cycleRepository).toHaveBeenCalledTimes(1);
+	});
+
 	it("does not fire composer-only shortcuts when chat focus is outside composer", () => {
 		const togglePlanMode = vi.fn();
 

--- a/src/features/workspace-start/index.tsx
+++ b/src/features/workspace-start/index.tsx
@@ -177,7 +177,10 @@ export function WorkspaceStartPage({
 	}, [onClosePreview, previewCard]);
 
 	return (
-		<div className="flex min-h-0 flex-1 justify-center">
+		<div
+			data-focus-scope="start-composer"
+			className="flex min-h-0 flex-1 justify-center"
+		>
 			<div className="relative h-full min-h-0 w-full max-w-5xl">
 				<div
 					className={cn(


### PR DESCRIPTION
## Summary
Fixed Shift+Tab not cycling repositories on the new-thread (workspace start) page when focus was outside the composer. The shortcut now works anywhere on the start surface.

## Changes
- Add `data-focus-scope="start-composer"` to WorkspaceStartPage container to enable proper focus scope handling
- Add test verifying Shift+Tab cycles repositories when focus is on a start-surface button

## Test plan
- Verify Shift+Tab cycles through repositories on the new-thread page with focus on different buttons
- Existing shortcut tests should pass