### PR TITLE
fix: prevent composer preview popover from overflowing screen on start page

### DIFF
--- a/.changeset/fix-startpage-composer-preview-overflow.md
+++ b/.changeset/fix-startpage-composer-preview-overflow.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix the composer preview popover running off the bottom of the screen when pasting a long-text pill or image on the start page — the preview now shrinks to fit the space between the composer and the screen edge.

--- a/src/components/inline-badge/preview-renderers.tsx
+++ b/src/components/inline-badge/preview-renderers.tsx
@@ -10,9 +10,13 @@ export type InlineBadgePreviewEditHandlers = {
 	onEditBlur: (nextText: string) => void;
 };
 
+// `--radix-popover-content-available-height` lets the body shrink when neither
+// side fits the fixed 520px (e.g. composer centered on the start surface).
+// Subtract 2.5rem for the title row. Fallback keeps the original 520px cap.
 const PREVIEW_VIEWPORT_CLASS =
-	"h-[min(60vh,520px)] overflow-y-auto overflow-x-hidden";
-const EDITOR_VIEWPORT_CLASS = "h-[min(60vh,520px)]";
+	"h-[min(60vh,520px,calc(var(--radix-popover-content-available-height,100vh)-2.5rem))] overflow-y-auto overflow-x-hidden";
+const EDITOR_VIEWPORT_CLASS =
+	"h-[min(60vh,520px,calc(var(--radix-popover-content-available-height,100vh)-2.5rem))]";
 
 function resolveLocalPreviewSrc(path: string) {
 	try {


### PR DESCRIPTION
## Summary

Fixes the composer preview popover running off the bottom of the screen when pasting a long-text pill or image on the start page.

## What changed

- Updated the preview viewport and editor viewport height calculations in `preview-renderers.tsx` to use Radix's `--radix-popover-content-available-height` CSS variable
- The popover now uses `min(60vh, 520px, calc(available-height - 2.5rem))` to dynamically shrink when there isn't enough vertical space
- Added a comment explaining the height calculation fallback

## Why

When the composer is centered on the start page, pasting a large inline badge (pill or image) would show a preview popover that extended beyond the visible viewport, requiring users to scroll. Now the preview intelligently constrains itself to the available space.

## Test notes

- Test on start page: paste a large image or multi-line text pill in the composer
- Verify the preview popover shrinks to fit the space between the composer and screen edge
- Verify normal sized previews still display at their full size (up to 520px) on pages with more vertical space