### PR TITLE
fix: prevent workspace changes refresh interval when working directory is undefined

### DIFF
--- a/src/features/conversation/hooks/use-streaming.ts
+++ b/src/features/conversation/hooks/use-streaming.ts
@@ -885,8 +885,9 @@ export function useConversationStreaming({
 				};
 
 				const changesRefreshInterval = window.setInterval(() => {
+					if (!workingDirectory) return;
 					void queryClient.invalidateQueries({
-						queryKey: ["workspaceChanges"],
+						queryKey: helmorQueryKeys.workspaceChanges(workingDirectory),
 					});
 				}, 3_000);
 


### PR DESCRIPTION
## Summary

Fixes a bug where the workspace changes refresh interval could attempt to invalidate queries without a valid working directory context.

## Changes

- Added guard check to skip the interval callback if `workingDirectory` is not set
- Replaced hardcoded query key string with proper query key factory function `helmorQueryKeys.workspaceChanges(workingDirectory)`
- Ensures query invalidation only occurs when the required context is available

## Test plan

- Verify the interval callback is skipped when no working directory is active
- Confirm workspace changes still refresh correctly when a working directory is selected
- Check that no console errors occur during transitions between sessions/workspaces