### PR TITLE
perf: restore 60 FPS on sidebar / inspector drag with large file lists

### DIFF
--- a/.changeset/smooth-inspector-resize.md
+++ b/.changeset/smooth-inspector-resize.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Restore 60 FPS on inspector and sidebar / inspector drag with thousands of changed files.

--- a/src-tauri/src/schema.rs
+++ b/src-tauri/src/schema.rs
@@ -726,7 +726,57 @@ fn run_migrations(connection: &Connection) -> Result<()> {
             .context("Failed to rename legacy run actions to 'Default'")?;
     }
 
+    materialize_review_pr_model_defaults(connection)?;
+
     Ok(())
+}
+
+/// Promote NULL review_*/pr_* rows to explicit copies of the current
+/// defaults, so changing the default later doesn't drag them along.
+/// Idempotent via anti-join; gated on `app.default_model_id` being set.
+fn materialize_review_pr_model_defaults(connection: &Connection) -> Result<()> {
+    if !has_table(connection, "settings") {
+        return Ok(());
+    }
+    connection
+        .execute_batch(
+            r#"
+            INSERT INTO settings (key, value)
+            SELECT 'app.review_model_id', value FROM settings
+            WHERE key = 'app.default_model_id' AND value != ''
+              AND NOT EXISTS (SELECT 1 FROM settings WHERE key = 'app.review_model_id');
+
+            INSERT INTO settings (key, value)
+            SELECT 'app.pr_model_id', value FROM settings
+            WHERE key = 'app.default_model_id' AND value != ''
+              AND NOT EXISTS (SELECT 1 FROM settings WHERE key = 'app.pr_model_id');
+
+            INSERT INTO settings (key, value)
+            SELECT 'app.review_effort', value FROM settings
+            WHERE key = 'app.default_effort' AND value != ''
+              AND EXISTS (SELECT 1 FROM settings WHERE key = 'app.default_model_id' AND value != '')
+              AND NOT EXISTS (SELECT 1 FROM settings WHERE key = 'app.review_effort');
+
+            INSERT INTO settings (key, value)
+            SELECT 'app.pr_effort', value FROM settings
+            WHERE key = 'app.default_effort' AND value != ''
+              AND EXISTS (SELECT 1 FROM settings WHERE key = 'app.default_model_id' AND value != '')
+              AND NOT EXISTS (SELECT 1 FROM settings WHERE key = 'app.pr_effort');
+
+            INSERT INTO settings (key, value)
+            SELECT 'app.review_fast_mode', value FROM settings
+            WHERE key = 'app.default_fast_mode'
+              AND EXISTS (SELECT 1 FROM settings WHERE key = 'app.default_model_id' AND value != '')
+              AND NOT EXISTS (SELECT 1 FROM settings WHERE key = 'app.review_fast_mode');
+
+            INSERT INTO settings (key, value)
+            SELECT 'app.pr_fast_mode', value FROM settings
+            WHERE key = 'app.default_fast_mode'
+              AND EXISTS (SELECT 1 FROM settings WHERE key = 'app.default_model_id' AND value != '')
+              AND NOT EXISTS (SELECT 1 FROM settings WHERE key = 'app.pr_fast_mode');
+            "#,
+        )
+        .context("Failed to materialize review/pr model defaults")
 }
 
 /// One-shot init for rows that still carry `display_order = 0` — the column
@@ -1626,5 +1676,129 @@ mod tests {
             stored.as_deref(),
             Some(r#"{"totalTokens":12,"maxTokens":100}"#)
         );
+    }
+
+    fn read_setting(conn: &Connection, key: &str) -> Option<String> {
+        conn.query_row("SELECT value FROM settings WHERE key = ?1", [key], |r| {
+            r.get(0)
+        })
+        .ok()
+    }
+
+    fn insert_setting(conn: &Connection, key: &str, value: &str) {
+        conn.execute(
+            "INSERT INTO settings (key, value) VALUES (?1, ?2)",
+            [key, value],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn review_pr_defaults_materialized_when_default_model_set() {
+        let (conn, _dir) = open_test_db();
+        ensure_schema(&conn).unwrap();
+        insert_setting(&conn, "app.default_model_id", "claude-sonnet-4");
+        insert_setting(&conn, "app.default_effort", "high");
+        insert_setting(&conn, "app.default_fast_mode", "false");
+
+        run_migrations(&conn).unwrap();
+
+        assert_eq!(
+            read_setting(&conn, "app.review_model_id").as_deref(),
+            Some("claude-sonnet-4")
+        );
+        assert_eq!(
+            read_setting(&conn, "app.pr_model_id").as_deref(),
+            Some("claude-sonnet-4")
+        );
+        assert_eq!(
+            read_setting(&conn, "app.review_effort").as_deref(),
+            Some("high")
+        );
+        assert_eq!(
+            read_setting(&conn, "app.pr_effort").as_deref(),
+            Some("high")
+        );
+        assert_eq!(
+            read_setting(&conn, "app.review_fast_mode").as_deref(),
+            Some("false")
+        );
+        assert_eq!(
+            read_setting(&conn, "app.pr_fast_mode").as_deref(),
+            Some("false")
+        );
+
+        // Idempotent — second run is a no-op.
+        run_migrations(&conn).unwrap();
+        assert_eq!(
+            read_setting(&conn, "app.review_model_id").as_deref(),
+            Some("claude-sonnet-4")
+        );
+    }
+
+    #[test]
+    fn review_pr_defaults_skip_when_default_model_absent() {
+        // No default_model_id → no promotion (consumers handle the fallback).
+        let (conn, _dir) = open_test_db();
+        ensure_schema(&conn).unwrap();
+        insert_setting(&conn, "app.default_effort", "high");
+        insert_setting(&conn, "app.default_fast_mode", "true");
+
+        run_migrations(&conn).unwrap();
+
+        assert!(read_setting(&conn, "app.review_model_id").is_none());
+        assert!(read_setting(&conn, "app.pr_model_id").is_none());
+        assert!(read_setting(&conn, "app.review_effort").is_none());
+        assert!(read_setting(&conn, "app.pr_effort").is_none());
+        assert!(read_setting(&conn, "app.review_fast_mode").is_none());
+        assert!(read_setting(&conn, "app.pr_fast_mode").is_none());
+    }
+
+    #[test]
+    fn review_pr_defaults_preserve_existing_user_overrides() {
+        let (conn, _dir) = open_test_db();
+        ensure_schema(&conn).unwrap();
+        insert_setting(&conn, "app.default_model_id", "claude-sonnet-4");
+        insert_setting(&conn, "app.default_effort", "high");
+        insert_setting(&conn, "app.default_fast_mode", "false");
+        // User already decoupled review_model_id explicitly.
+        insert_setting(&conn, "app.review_model_id", "gpt-5");
+        insert_setting(&conn, "app.review_effort", "low");
+
+        run_migrations(&conn).unwrap();
+
+        // User overrides untouched.
+        assert_eq!(
+            read_setting(&conn, "app.review_model_id").as_deref(),
+            Some("gpt-5")
+        );
+        assert_eq!(
+            read_setting(&conn, "app.review_effort").as_deref(),
+            Some("low")
+        );
+        // Other unset fields still get materialized.
+        assert_eq!(
+            read_setting(&conn, "app.pr_model_id").as_deref(),
+            Some("claude-sonnet-4")
+        );
+        assert_eq!(
+            read_setting(&conn, "app.pr_effort").as_deref(),
+            Some("high")
+        );
+    }
+
+    #[test]
+    fn review_pr_defaults_skip_empty_default_model_id() {
+        // Empty string == null sentinel.
+        let (conn, _dir) = open_test_db();
+        ensure_schema(&conn).unwrap();
+        insert_setting(&conn, "app.default_model_id", "");
+        insert_setting(&conn, "app.default_effort", "high");
+
+        run_migrations(&conn).unwrap();
+
+        assert!(read_setting(&conn, "app.review_model_id").is_none());
+        assert!(read_setting(&conn, "app.pr_model_id").is_none());
+        assert!(read_setting(&conn, "app.review_effort").is_none());
     }
 }

--- a/src-tauri/src/workspace/scripts.rs
+++ b/src-tauri/src/workspace/scripts.rs
@@ -991,8 +991,11 @@ mod tests {
         // kill_all held the map lock past the signal, the unregister
         // would have blocked and this join would hang.
         let _ = runner.join().unwrap();
+        // Real path is sub-second (PROCESS_TERM + PROCESS_KILL = 700ms
+        // upper bound). 5s headroom for CI load; a real regression
+        // (deadlock / missed signal) hangs indefinitely and still trips.
         assert!(
-            start.elapsed() < Duration::from_secs(3),
+            start.elapsed() < Duration::from_secs(5),
             "kill_all + reap took too long: {:?}",
             start.elapsed()
         );
@@ -1109,8 +1112,9 @@ mod tests {
 
         assert!(mgr.kill(&key), "kill should find the handle");
         let result = handle.join().unwrap();
+        // 5s headroom for CI load; real path is sub-second.
         assert!(
-            start.elapsed() < Duration::from_secs(3),
+            start.elapsed() < Duration::from_secs(5),
             "Stop took too long: {:?}",
             start.elapsed()
         );

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -21,18 +21,16 @@ vi.mock("@tauri-apps/plugin-dialog", () => ({
 
 const SIDEBAR_WIDTH_STORAGE_KEY = "helmor.workspaceSidebarWidth";
 const INSPECTOR_WIDTH_STORAGE_KEY = "helmor.workspaceInspectorWidth";
-const SIDEBAR_WIDTH_VAR = "--shell-sidebar-width";
-const INSPECTOR_WIDTH_VAR = "--shell-inspector-width";
 
-// `use-panels.ts` writes the width vars on the pane element itself (not
-// documentElement) so the resize-driven style invalidation stays inside the
-// pane subtree — see comments in use-panels.ts for the why.
-function getShellWidthVar(name: string): string {
-	const target = name === SIDEBAR_WIDTH_VAR ? "sidebar" : "inspector";
+// `use-panels.ts` writes inline `style.width` directly on the pane element
+// (not as a CSS custom property) so the per-frame drag work doesn't trigger a
+// WebKit subtree-wide style invalidation. The test reads back the same inline
+// width to confirm React state → inline-style sync via `useLayoutEffect`.
+function getPaneInlineWidth(target: "sidebar" | "inspector"): string {
 	const pane = document.querySelector(
 		`[data-shell-pane="${target}"]`,
 	) as HTMLElement | null;
-	return pane?.style.getPropertyValue(name) ?? "";
+	return pane?.style.width ?? "";
 }
 
 describe("App", () => {
@@ -91,8 +89,8 @@ describe("App", () => {
 		expect(inspector).toHaveClass("bg-inspector");
 		expect(inspector).toHaveClass("overflow-hidden");
 		// Width driven by CSS var — assert on the documentElement var, not inline style.
-		expect(getShellWidthVar(SIDEBAR_WIDTH_VAR)).toBe("336px");
-		expect(getShellWidthVar(INSPECTOR_WIDTH_VAR)).toBe("336px");
+		expect(getPaneInlineWidth("sidebar")).toBe("336px");
+		expect(getPaneInlineWidth("inspector")).toBe("336px");
 		expect(screen.getByLabelText("Inspector section Git")).toBeInTheDocument();
 		expect(
 			screen.getByLabelText("Inspector section Actions"),
@@ -118,11 +116,10 @@ describe("App", () => {
 		).toBeInTheDocument();
 		expect(resizeHandle).toHaveAttribute("aria-valuenow", "336");
 		expect(inspectorResizeHandle).toHaveAttribute("aria-valuenow", "336");
-		// Position driven by CSS var; inline style is expressed as calc(var(...) - X).
+		// Position is written as inline `right` directly on the handle
+		// (`useShellPanels.writePaneSize` keeps a `width - hitArea` offset).
 		expect(inspectorResizeHandle).toHaveStyle({ width: "20px" });
-		expect(inspectorResizeHandle.style.right).toBe(
-			`calc(var(--shell-inspector-width, 336px) - 20px)`,
-		);
+		expect(inspectorResizeHandle.style.right).toBe("316px");
 		expect(safeAreas).toHaveLength(1);
 		expect(groupsScrollRegion).toHaveClass("overflow-y-auto");
 		expect(groupsScrollRegion).toHaveClass("flex-1");
@@ -194,27 +191,25 @@ describe("App", () => {
 			render(<App />);
 			await screen.findByRole("main", { name: "Application shell" });
 
-			// Section heights are driven by CSS variables on the inspector
-			// container so that mid-drag mousemove can update them without
-			// going through React. Verify the container has the right vars
-			// written via useLayoutEffect (synchronous, runs before first paint).
+			// Section heights are written directly as inline `style.height` so
+			// mid-drag mousemove can update them without going through React.
+			// CSS custom properties are avoided because WebKit invalidates the
+			// entire subtree's computed style on any `setProperty()`, which
+			// caps inspector drags at ~28 FPS once the panel has many nodes.
+			// Verify the layout effect wrote the correct heights synchronously
+			// (runs before first paint). Container is 900px tall with 3 section
+			// headers (33×3=99), leaving 801px body budget. Defaults: changes
+			// body 240, actions body absorbs slack (801−240=561), tabs body 0.
 			await waitFor(() => {
-				const container = screen.getByLabelText("Inspector section Git")
-					.parentElement as HTMLElement;
-				expect(
-					container.style.getPropertyValue("--inspector-changes-body-height"),
-				).toBe("240px");
+				expect(screen.getByLabelText("Inspector section Git")).toHaveStyle({
+					height: "273px", // 33 header + 240 body
+				});
 			});
-			const container = screen.getByLabelText("Inspector section Git")
-				.parentElement as HTMLElement;
-			expect(
-				container.style.getPropertyValue("--inspector-actions-body-height"),
-			).toBe("561px");
-			expect(
-				container.style.getPropertyValue("--inspector-tabs-body-height"),
-			).toBe("0px");
+			expect(screen.getByLabelText("Inspector section Actions")).toHaveStyle({
+				height: "594px", // 33 header + 561 body (slack absorber)
+			});
 			// Tabs wrapper is collapsed (tabsOpen=false default) so its height
-			// is fixed at the section-header constant — not driven by the var.
+			// is pinned to the section-header constant.
 			const tabsWrapper = screen.getByLabelText("Inspector section Tabs")
 				.parentElement?.parentElement;
 			expect(tabsWrapper).toHaveStyle({
@@ -233,23 +228,29 @@ describe("App", () => {
 			name: "Resize sidebar",
 		});
 
-		fireEvent.mouseDown(resizeHandle, { clientX: 336 });
+		// `useShellPanels` drives drag via pointer events + `setPointerCapture`
+		// — so subsequent pointermove/pointerup must target the capture node
+		// (the separator), not `window`.
+		fireEvent.pointerDown(resizeHandle, {
+			pointerId: 1,
+			button: 0,
+			clientX: 336,
+		});
 
 		await waitFor(() => {
 			expect(document.body.style.cursor).toBe("ew-resize");
 		});
 
-		fireEvent.mouseMove(window, { clientX: 360 });
+		fireEvent.pointerMove(resizeHandle, { pointerId: 1, clientX: 360 });
 
-		// During drag, width is driven via the CSS var (to avoid React renders),
-		// so assert on the documentElement var rather than inline width.
-		// Note: aria-valuenow doesn't update mid-drag (the separator doesn't
-		// re-render) — it syncs on mouseup.
+		// During drag, width is driven via inline `style.width` on the pane;
+		// aria-valuenow only syncs on pointerup (the separator doesn't re-render
+		// mid-drag).
 		await waitFor(() => {
-			expect(getShellWidthVar(SIDEBAR_WIDTH_VAR)).toBe("360px");
+			expect(getPaneInlineWidth("sidebar")).toBe("360px");
 		});
 
-		fireEvent.mouseUp(window);
+		fireEvent.pointerUp(resizeHandle, { pointerId: 1 });
 
 		await waitFor(() => {
 			expect(document.body.style.cursor).toBe("");
@@ -267,19 +268,23 @@ describe("App", () => {
 			name: "Resize inspector sidebar",
 		});
 
-		fireEvent.mouseDown(resizeHandle, { clientX: 1200 });
+		fireEvent.pointerDown(resizeHandle, {
+			pointerId: 1,
+			button: 0,
+			clientX: 1200,
+		});
 
 		await waitFor(() => {
 			expect(document.body.style.cursor).toBe("ew-resize");
 		});
 
-		fireEvent.mouseMove(window, { clientX: 1172 });
+		fireEvent.pointerMove(resizeHandle, { pointerId: 1, clientX: 1172 });
 
 		await waitFor(() => {
-			expect(getShellWidthVar(INSPECTOR_WIDTH_VAR)).toBe("364px");
+			expect(getPaneInlineWidth("inspector")).toBe("364px");
 		});
 
-		fireEvent.mouseUp(window);
+		fireEvent.pointerUp(resizeHandle, { pointerId: 1 });
 
 		await waitFor(() => {
 			expect(document.body.style.cursor).toBe("");
@@ -300,8 +305,8 @@ describe("App", () => {
 
 		// Width is exposed via the CSS var; the React state sync writes it immediately after mount.
 		await waitFor(() => {
-			expect(getShellWidthVar(SIDEBAR_WIDTH_VAR)).toBe("404px");
-			expect(getShellWidthVar(INSPECTOR_WIDTH_VAR)).toBe("388px");
+			expect(getPaneInlineWidth("sidebar")).toBe("404px");
+			expect(getPaneInlineWidth("inspector")).toBe("388px");
 		});
 		expect(
 			screen.getByRole("separator", { name: "Resize sidebar" }),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -364,16 +364,6 @@ function AppShell({
 		[],
 	);
 	const {
-		handleResizeKeyDown,
-		handleResizeStart,
-		inspectorWidth,
-		isInspectorResizing,
-		isSidebarResizing,
-		sidebarCollapsed,
-		sidebarWidth,
-		setSidebarCollapsed,
-	} = useShellPanels();
-	const {
 		settings: appSettings,
 		isLoaded: areSettingsLoaded,
 		updateSettings,
@@ -489,6 +479,16 @@ function AppShell({
 	const startLinkedDirectoriesController =
 		startSurface.startLinkedDirectoriesController;
 	const inspectorCollapsed = contextPanel.inspectorCollapsed;
+	const {
+		handleResizeKeyDown,
+		handleResizeStart,
+		inspectorWidth,
+		isInspectorResizing,
+		isSidebarResizing,
+		sidebarCollapsed,
+		sidebarWidth,
+		setSidebarCollapsed,
+	} = useShellPanels();
 	const rightSidebarMode = contextPanel.rightSidebarMode;
 	const workspacePreviewCard = contextPanel.workspacePreviewCard;
 	const workspacePreviewActive = contextPanel.workspacePreviewActive;
@@ -670,20 +670,19 @@ function AppShell({
 		...workspaceDetailQueryOptions(selectedWorkspaceId ?? "__none__"),
 		enabled: selectedWorkspaceId !== null,
 	});
-	const handleOpenSettings = useCallback(
-		(initialSection?: SettingsSection): void => {
-			onOpenSettings(
-				selectedWorkspaceId,
-				selectedWorkspaceDetailQuery.data?.repoId ?? null,
-				initialSection,
-			);
-		},
-		[
-			onOpenSettings,
-			selectedWorkspaceDetailQuery.data?.repoId,
+	// Zero-arg: prop is bound directly to button onClick, so an arg would
+	// receive the click event. Use a separate helper if section-aware open
+	// is ever needed.
+	const handleOpenSettings = useCallback((): void => {
+		onOpenSettings(
 			selectedWorkspaceId,
-		],
-	);
+			selectedWorkspaceDetailQuery.data?.repoId ?? null,
+		);
+	}, [
+		onOpenSettings,
+		selectedWorkspaceDetailQuery.data?.repoId,
+		selectedWorkspaceId,
+	]);
 	const handleOpenAnnouncementSettings = useCallback(
 		(initialSection?: SettingsSection): void => {
 			onOpenSettings(null, null, initialSection);
@@ -722,6 +721,23 @@ function AppShell({
 		exitEditorMode: () => selectionActions.setViewMode("conversation"),
 	});
 	const editorSession = editorSessionState.editorSession;
+	// Stable identity so downstream `React.memo` boundaries hold.
+	const activeEditorTarget = useMemo(
+		() =>
+			editorSession
+				? {
+						path: editorSession.path,
+						originalRef: editorSession.originalRef,
+						modifiedRef: editorSession.modifiedRef,
+					}
+				: null,
+		[
+			editorSession?.path,
+			editorSession?.originalRef,
+			editorSession?.modifiedRef,
+			editorSession,
+		],
+	);
 	const handleOpenEditorFile = editorSessionActions.openFile;
 	const handleOpenFileReference = editorSessionActions.openFileReference;
 	const handleEditorSessionChange = editorSessionActions.changeSession;
@@ -1539,7 +1555,7 @@ function AppShell({
 											collapsed={sidebarCollapsed}
 											resizing={isSidebarResizing}
 											width={sidebarWidth}
-											onMouseDown={handleResizeStart("sidebar")}
+											onPointerDown={handleResizeStart("sidebar")}
 											onKeyDown={handleResizeKeyDown("sidebar")}
 										/>
 									</>
@@ -1784,7 +1800,7 @@ function AppShell({
 												collapsed={inspectorCollapsed}
 												resizing={isInspectorResizing}
 												width={inspectorWidth}
-												onMouseDown={handleResizeStart("inspector")}
+												onPointerDown={handleResizeStart("inspector")}
 												onKeyDown={handleResizeKeyDown("inspector")}
 											/>
 											<ShellInspectorPane
@@ -1826,15 +1842,7 @@ function AppShell({
 													selectedWorkspaceDetailQuery.data ?? null
 												}
 												displayedSessionId={displayedSessionId}
-												activeEditor={
-													editorSession
-														? {
-																path: editorSession.path,
-																originalRef: editorSession.originalRef,
-																modifiedRef: editorSession.modifiedRef,
-															}
-														: null
-												}
+												activeEditor={activeEditorTarget}
 												preferredEditor={preferredEditor}
 												onOpenEditorFile={handleOpenEditorFile}
 												onCommitAction={handleCommitAction}

--- a/src/components/terminal-output.tsx
+++ b/src/components/terminal-output.tsx
@@ -441,9 +441,14 @@ function TerminalOutputImpl({
 		};
 		terminalWriteFlushListeners.add(flushSuspendedWrites);
 
-		// Re-resolve CSS variables when app light/dark mode changes.
+		// Resync xterm theme on `<html>` class changes; rAF-coalesced.
+		let themeScheduled = 0;
 		const themeObserver = new MutationObserver(() => {
-			terminal.options.theme = resolveTerminalTheme();
+			if (themeScheduled) return;
+			themeScheduled = requestAnimationFrame(() => {
+				themeScheduled = 0;
+				terminal.options.theme = resolveTerminalTheme();
+			});
 		});
 		themeObserver.observe(document.documentElement, {
 			attributes: true,
@@ -477,6 +482,10 @@ function TerminalOutputImpl({
 			if (fitTimer !== null) {
 				window.clearTimeout(fitTimer);
 				fitTimer = null;
+			}
+			if (themeScheduled) {
+				cancelAnimationFrame(themeScheduled);
+				themeScheduled = 0;
 			}
 			dataSub.dispose();
 			resizeSub.dispose();

--- a/src/features/inspector/hooks/use-inspector.ts
+++ b/src/features/inspector/hooks/use-inspector.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import {
 	type MouseEvent as ReactMouseEvent,
+	type RefObject,
 	useCallback,
 	useEffect,
 	useLayoutEffect,
@@ -21,17 +22,17 @@ import {
 	getInitialChangesHeight,
 	getInitialTabsHeight,
 	getInitialTabsOpen,
-	INSPECTOR_ACTIONS_BODY_VAR,
 	INSPECTOR_ACTIONS_OPEN_STORAGE_KEY,
 	INSPECTOR_ACTIVE_TAB_STORAGE_KEY,
-	INSPECTOR_CHANGES_BODY_VAR,
 	INSPECTOR_CHANGES_HEIGHT_STORAGE_KEY,
 	INSPECTOR_SECTION_HEADER_HEIGHT,
-	INSPECTOR_TABS_BODY_VAR,
 	INSPECTOR_TABS_HEIGHT_STORAGE_KEY,
 	INSPECTOR_TABS_OPEN_STORAGE_KEY,
 } from "../layout";
 import { getScriptState, startScript, stopScript } from "../script-store";
+
+// Stable empty-array reference for the `changesQuery.data ?? ...` fallback.
+const EMPTY_CHANGES: InspectorFileItem[] = [];
 
 // Inspector layout model
 // ----------------------
@@ -70,17 +71,35 @@ type ResizeState = {
 	tabsOpen: boolean;
 };
 
-function writeBodyVars(container: HTMLElement | null, sizes: DerivedSizes) {
-	if (!container) return;
-	container.style.setProperty(
-		INSPECTOR_CHANGES_BODY_VAR,
-		`${sizes.changesBody}px`,
-	);
-	container.style.setProperty(
-		INSPECTOR_ACTIONS_BODY_VAR,
-		`${sizes.actionsBody}px`,
-	);
-	container.style.setProperty(INSPECTOR_TABS_BODY_VAR, `${sizes.tabsBody}px`);
+type SectionRefs = {
+	changes: RefObject<HTMLElement | null>;
+	actions: RefObject<HTMLElement | null>;
+	tabsWrapper: RefObject<HTMLDivElement | null>;
+};
+
+// Inline `style.height` per section instead of CSS variables; CSS-var writes
+// invalidate the whole subtree's computed style under WebKit.
+function writeBodyHeights(
+	refs: SectionRefs,
+	sizes: DerivedSizes,
+	options: { actionsOpen: boolean; tabsOpen: boolean },
+) {
+	const changes = refs.changes.current;
+	if (changes) {
+		changes.style.height = `${INSPECTOR_SECTION_HEADER_HEIGHT + sizes.changesBody}px`;
+	}
+	const actions = refs.actions.current;
+	if (actions) {
+		actions.style.height = options.actionsOpen
+			? `${INSPECTOR_SECTION_HEADER_HEIGHT + sizes.actionsBody}px`
+			: `${INSPECTOR_SECTION_HEADER_HEIGHT}px`;
+	}
+	const tabsWrapper = refs.tabsWrapper.current;
+	if (tabsWrapper) {
+		tabsWrapper.style.height = options.tabsOpen
+			? `${INSPECTOR_SECTION_HEADER_HEIGHT + sizes.tabsBody}px`
+			: `${INSPECTOR_SECTION_HEADER_HEIGHT}px`;
+	}
 }
 
 type UseWorkspaceInspectorSidebarArgs = {
@@ -190,8 +209,14 @@ export function useWorkspaceInspectorSidebar({
 	const [resizeState, setResizeState] = useState<ResizeState | null>(null);
 
 	const containerRef = useRef<HTMLDivElement>(null);
-	const tabsWrapperRef = useRef<HTMLDivElement>(null);
+	const changesRef = useRef<HTMLElement>(null);
 	const actionsRef = useRef<HTMLElement>(null);
+	const tabsWrapperRef = useRef<HTMLDivElement>(null);
+	const sectionRefsRef = useRef<SectionRefs>({
+		changes: changesRef,
+		actions: actionsRef,
+		tabsWrapper: tabsWrapperRef,
+	});
 
 	useLayoutEffect(() => {
 		const element = containerRef.current;
@@ -238,19 +263,17 @@ export function useWorkspaceInspectorSidebar({
 		[bodyBudget, actionsOpen, tabsOpen, storedChangesBody, storedTabsBody],
 	);
 
-	// During drag, mousemove writes the CSS vars directly and React state
-	// stays stale until mouseup commits. This effect only handles non-drag
-	// cases (toggle, keyboard step, initial mount); the isResizingRef gate
-	// prevents stale state from clobbering the live mousemove values mid-drag.
+	// Gate so the non-drag effect doesn't clobber the live ref-written
+	// heights during mousemove.
 	const isResizingRef = useRef(false);
 	useLayoutEffect(() => {
 		if (isResizingRef.current) return;
-		writeBodyVars(containerRef.current, {
-			changesBody,
-			actionsBody,
-			tabsBody,
-		});
-	}, [changesBody, actionsBody, tabsBody]);
+		writeBodyHeights(
+			sectionRefsRef.current,
+			{ changesBody, actionsBody, tabsBody },
+			{ actionsOpen, tabsOpen },
+		);
+	}, [changesBody, actionsBody, tabsBody, actionsOpen, tabsOpen]);
 
 	useEffect(() => {
 		try {
@@ -372,7 +395,7 @@ export function useWorkspaceInspectorSidebar({
 		...workspaceChangesQueryOptions(workspaceRootPath ?? ""),
 		enabled: changesQueryEnabled,
 	});
-	const changes: InspectorFileItem[] = changesQuery.data ?? [];
+	const changes: InspectorFileItem[] = changesQuery.data ?? EMPTY_CHANGES;
 
 	const prevChangesRef = useRef<Map<string, string> | null>(null);
 	const prevRootPathRef = useRef(workspaceRootPath);
@@ -435,7 +458,7 @@ export function useWorkspaceInspectorSidebar({
 		const releaseWriteSuspend = suspendTerminalWrites();
 
 		const captured = resizeState;
-		const container = containerRef.current;
+		const refs = sectionRefsRef.current;
 
 		let pendingMove: globalThis.MouseEvent | null = null;
 		let animationFrameId: number | null = null;
@@ -472,8 +495,8 @@ export function useWorkspaceInspectorSidebar({
 				);
 			}
 
-			// Derive sizes and write CSS vars directly — no setState, no React
-			// render. The three sections read via var(--inspector-X-body-height).
+			// Drag-time inline writes — bypass React render + CSS-var
+			// invalidation.
 			const sizes = deriveSizes({
 				bodyBudget: captured.bodyBudget,
 				actionsOpen: captured.actionsOpen,
@@ -481,7 +504,10 @@ export function useWorkspaceInspectorSidebar({
 				storedChangesBody: lastStoredChanges,
 				storedTabsBody: lastStoredTabs,
 			});
-			writeBodyVars(container, sizes);
+			writeBodyHeights(refs, sizes, {
+				actionsOpen: captured.actionsOpen,
+				tabsOpen: captured.tabsOpen,
+			});
 		};
 
 		const handleMouseMove = (event: globalThis.MouseEvent) => {
@@ -517,6 +543,17 @@ export function useWorkspaceInspectorSidebar({
 		document.body.style.cursor = "ns-resize";
 		document.body.style.userSelect = "none";
 
+		// Hit-test absorber so WebKit's `:hover` recompute doesn't cascade
+		// through the Changes subtree on every mousemove.
+		const overlay = document.createElement("div");
+		overlay.style.position = "fixed";
+		overlay.style.inset = "0";
+		overlay.style.zIndex = "2147483647";
+		overlay.style.cursor = "ns-resize";
+		overlay.setAttribute("data-helmor-resize-overlay", "");
+		overlay.setAttribute("aria-hidden", "true");
+		document.body.appendChild(overlay);
+
 		window.addEventListener("mousemove", handleMouseMove);
 		window.addEventListener("mouseup", handleMouseUp);
 
@@ -529,6 +566,7 @@ export function useWorkspaceInspectorSidebar({
 			releaseWriteSuspend();
 			document.body.style.cursor = previousCursor;
 			document.body.style.userSelect = previousUserSelect;
+			overlay.remove();
 			window.removeEventListener("mousemove", handleMouseMove);
 			window.removeEventListener("mouseup", handleMouseUp);
 		};
@@ -560,12 +598,11 @@ export function useWorkspaceInspectorSidebar({
 	);
 
 	return {
-		actionsHeight: actionsBody,
 		actionsOpen,
 		actionsRef,
 		activeTab,
 		changes,
-		changesHeight: changesBody,
+		changesRef,
 		containerRef,
 		flashingPaths,
 		handleResizeStart,
@@ -577,7 +614,6 @@ export function useWorkspaceInspectorSidebar({
 		repoScripts,
 		scriptsLoaded,
 		setActiveTab,
-		tabsBodyHeight: tabsBody,
 		tabsOpen,
 		tabsWrapperRef,
 	};

--- a/src/features/inspector/index.tsx
+++ b/src/features/inspector/index.tsx
@@ -150,12 +150,11 @@ export function WorkspaceInspectorSidebar({
 }: WorkspaceInspectorSidebarProps) {
 	const queryClient = useQueryClient();
 	const {
-		actionsHeight,
 		actionsOpen,
 		actionsRef,
 		activeTab,
 		changes,
-		changesHeight,
+		changesRef,
 		containerRef,
 		flashingPaths,
 		handleResizeStart,
@@ -167,7 +166,6 @@ export function WorkspaceInspectorSidebar({
 		repoScripts,
 		scriptsLoaded,
 		setActiveTab,
-		tabsBodyHeight,
 		tabsOpen,
 		tabsWrapperRef,
 	} = useWorkspaceInspectorSidebar({
@@ -503,6 +501,7 @@ export function WorkspaceInspectorSidebar({
 			)}
 		>
 			<ChangesSection
+				sectionRef={changesRef}
 				workspaceId={workspaceId ?? null}
 				workspaceRootPath={workspaceRootPath ?? null}
 				workspaceBranch={workspaceBranch ?? null}
@@ -519,7 +518,6 @@ export function WorkspaceInspectorSidebar({
 				commitButtonState={commitButtonState}
 				changeRequest={changeRequest ?? null}
 				forgeIsRefreshing={forgeIsRefreshing}
-				bodyHeight={changesHeight}
 			/>
 			{actionsOpen ? (
 				<HorizontalResizeHandle
@@ -535,7 +533,6 @@ export function WorkspaceInspectorSidebar({
 				sectionRef={actionsRef}
 				open={actionsOpen}
 				onToggle={handleToggleActions}
-				bodyHeight={actionsHeight}
 				onCommitAction={onCommitAction}
 				onReviewAction={onReviewAction}
 				currentSessionId={currentSessionId ?? null}
@@ -569,7 +566,6 @@ export function WorkspaceInspectorSidebar({
 				onToggleTerminalHoverZoom={handleToggleTerminalHoverZoom}
 				canSpawnTerminal={canSpawnTerminal}
 				canHoverExpand={canHoverExpand}
-				bodyHeight={tabsBodyHeight}
 			>
 				<SetupTab
 					repoId={repoId ?? null}

--- a/src/features/inspector/layout.test.tsx
+++ b/src/features/inspector/layout.test.tsx
@@ -36,7 +36,6 @@ describe("InspectorTabsSection", () => {
 				onCloseTerminal={vi.fn()}
 				onToggleTerminalHoverZoom={vi.fn()}
 				canSpawnTerminal={false}
-				bodyHeight={128}
 				canHoverExpand
 			>
 				<div>Terminal body</div>
@@ -87,7 +86,6 @@ describe("InspectorTabsSection", () => {
 				onCloseTerminal={vi.fn()}
 				onToggleTerminalHoverZoom={vi.fn()}
 				canSpawnTerminal={false}
-				bodyHeight={128}
 				canHoverExpand
 			>
 				<div>Terminal body</div>
@@ -126,7 +124,6 @@ describe("InspectorTabsSection", () => {
 				onCloseTerminal={vi.fn()}
 				onToggleTerminalHoverZoom={vi.fn()}
 				canSpawnTerminal={false}
-				bodyHeight={128}
 				canHoverExpand={false}
 			>
 				<div>Placeholder body</div>
@@ -180,7 +177,6 @@ describe("InspectorTabsSection", () => {
 				onCloseTerminal={vi.fn()}
 				onToggleTerminalHoverZoom={vi.fn()}
 				canSpawnTerminal={false}
-				bodyHeight={128}
 				canHoverExpand
 			>
 				<div>Body</div>
@@ -243,7 +239,6 @@ describe("InspectorTabsSection", () => {
 				onCloseTerminal={vi.fn()}
 				onToggleTerminalHoverZoom={vi.fn()}
 				canSpawnTerminal={false}
-				bodyHeight={128}
 				canHoverExpand
 			>
 				<div>Body</div>

--- a/src/features/inspector/layout.tsx
+++ b/src/features/inspector/layout.tsx
@@ -55,13 +55,6 @@ export const TABS_BLUR_HOLD_UNTIL_MS = TABS_HOVER_TRANSITION_MS - 50;
 export const INSPECTOR_SECTION_HEADER_HEIGHT = 33;
 const TABS_WRAPPER_COLLAPSED_MIN_HEIGHT_PX = INSPECTOR_SECTION_HEADER_HEIGHT;
 
-// CSS variables written on the inspector container by `useWorkspaceInspectorSidebar`.
-// Vars written directly by mousemove during drag — same strategy as
-// shell/use-panels.ts horizontal drag, skipping React per frame.
-export const INSPECTOR_CHANGES_BODY_VAR = "--inspector-changes-body-height";
-export const INSPECTOR_ACTIONS_BODY_VAR = "--inspector-actions-body-height";
-export const INSPECTOR_TABS_BODY_VAR = "--inspector-tabs-body-height";
-
 // Inspector layout persistence
 export const INSPECTOR_ACTIONS_OPEN_STORAGE_KEY =
 	"helmor.workspaceInspectorActionsOpen";
@@ -241,7 +234,6 @@ type InspectorTabsSectionProps = {
 	onToggleTerminalHoverZoom: (instanceId: string, disabled: boolean) => void;
 	/** False when there's no repo/workspace context — disables the "+" button. */
 	canSpawnTerminal: boolean;
-	bodyHeight: number;
 	/**
 	 * Gate for the hover-to-zoom effect. When false, hovering the body does
 	 * nothing — used so we only zoom when there's actual terminal output worth
@@ -269,7 +261,6 @@ export function InspectorTabsSection({
 	onCloseTerminal,
 	onToggleTerminalHoverZoom,
 	canSpawnTerminal,
-	bodyHeight,
 	canHoverExpand,
 	children,
 }: InspectorTabsSectionProps) {
@@ -322,15 +313,8 @@ export function InspectorTabsSection({
 				"relative flex min-h-0 shrink-0 flex-col",
 				!isZoomPresented && "overflow-hidden",
 			)}
-			style={{
-				// Height via CSS var, written by useWorkspaceInspectorSidebar's
-				// mousemove during drag — skips React renders. Collapsed state pins
-				// to the header height to keep the parent flex column stable.
-				height: open
-					? `calc(${TABS_WRAPPER_COLLAPSED_MIN_HEIGHT_PX}px + var(${INSPECTOR_TABS_BODY_VAR}, ${bodyHeight}px))`
-					: `${TABS_WRAPPER_COLLAPSED_MIN_HEIGHT_PX}px`,
-				minHeight: `${TABS_WRAPPER_COLLAPSED_MIN_HEIGHT_PX}px`,
-			}}
+			// Height written via `wrapperRef` by `useWorkspaceInspectorSidebar`.
+			style={{ minHeight: `${TABS_WRAPPER_COLLAPSED_MIN_HEIGHT_PX}px` }}
 		>
 			<div
 				data-tabs-zoomed={isZoomPresented ? "true" : undefined}

--- a/src/features/inspector/sections/actions.tsx
+++ b/src/features/inspector/sections/actions.tsx
@@ -48,9 +48,7 @@ import { resolveRepoPreferencePrompt } from "@/lib/repo-preferences-prompts";
 import { requestSidebarReconcile } from "@/lib/sidebar-mutation-gate";
 import { cn } from "@/lib/utils";
 import {
-	INSPECTOR_ACTIONS_BODY_VAR,
 	INSPECTOR_SECTION_HEADER_CLASS,
-	INSPECTOR_SECTION_HEADER_HEIGHT,
 	INSPECTOR_SECTION_TITLE_CLASS,
 } from "../layout";
 
@@ -109,7 +107,6 @@ type ActionsSectionProps = {
 	sectionRef?: React.RefObject<HTMLElement | null>;
 	open: boolean;
 	onToggle: () => void;
-	bodyHeight: number;
 	onCommitAction?: (mode: WorkspaceCommitButtonMode) => Promise<void>;
 	onReviewAction?: () => Promise<void>;
 	currentSessionId?: string | null;
@@ -161,7 +158,6 @@ export function ActionsSection({
 	sectionRef,
 	open,
 	onToggle,
-	bodyHeight,
 	onCommitAction,
 	onReviewAction,
 	currentSessionId,
@@ -328,14 +324,7 @@ export function ActionsSection({
 			className={cn(
 				"flex min-h-0 shrink-0 flex-col overflow-hidden border-b border-border/60 bg-sidebar transition-colors",
 			)}
-			style={{
-				// Height via CSS var, written by mousemove during drag. Collapsed
-				// state pins to the header height (skips calc); fallback covers
-				// the mount frame before the layout effect writes the var.
-				height: open
-					? `calc(${INSPECTOR_SECTION_HEADER_HEIGHT}px + var(${INSPECTOR_ACTIONS_BODY_VAR}, ${bodyHeight}px))`
-					: `${INSPECTOR_SECTION_HEADER_HEIGHT}px`,
-			}}
+			// Height written via `sectionRef` by `useWorkspaceInspectorSidebar`.
 		>
 			<div
 				className={cn(
@@ -365,13 +354,10 @@ export function ActionsSection({
 			</div>
 
 			{open && (
-				<div className="min-h-0">
+				<div className="min-h-0 flex-1">
 					<ScrollArea
 						aria-label="Actions panel body"
-						className="min-h-0 bg-muted/18 text-mini"
-						style={{
-							height: `var(${INSPECTOR_ACTIONS_BODY_VAR}, ${bodyHeight}px)`,
-						}}
+						className="h-full min-h-0 bg-muted/18 text-mini"
 					>
 						{showHelpersGroup && (
 							<>

--- a/src/features/inspector/sections/changes.tsx
+++ b/src/features/inspector/sections/changes.tsx
@@ -19,7 +19,7 @@ import {
 	PlusIcon,
 	Undo2Icon,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { AnimatedShinyText } from "@/components/ui/animated-shiny-text";
 import { Badge } from "@/components/ui/badge";
@@ -65,10 +65,6 @@ import {
 import { buildRemoteFileUrl } from "@/lib/remote-file-url";
 import { cn } from "@/lib/utils";
 import { useWorkspaceToast } from "@/lib/workspace-toast-context";
-import {
-	INSPECTOR_CHANGES_BODY_VAR,
-	INSPECTOR_SECTION_HEADER_HEIGHT,
-} from "../layout";
 import { useChangesState } from "./changes/use-changes-state";
 import { useGitMutations } from "./changes/use-git-mutations";
 import { GitSectionHeader } from "./git-section-header";
@@ -105,11 +101,13 @@ type ChangesSectionProps = {
 	changeRequest: ChangeRequestInfo | null;
 	/** Cold-fetch indicator owned by App; drives the git-header shimmer. */
 	forgeIsRefreshing?: boolean;
-	/** Height of the changes body (excluding the section header). */
-	bodyHeight: number;
+	/** Ref handed to the inspector's resize hook so it can write `style.height`
+	 * directly during drag, bypassing React and CSS custom-property
+	 * invalidation. */
+	sectionRef?: React.RefObject<HTMLElement | null>;
 };
 
-export function ChangesSection({
+function ChangesSectionImpl({
 	workspaceId,
 	workspaceRootPath,
 	workspaceBranch,
@@ -126,7 +124,7 @@ export function ChangesSection({
 	commitButtonState,
 	changeRequest,
 	forgeIsRefreshing = false,
-	bodyHeight,
+	sectionRef,
 }: ChangesSectionProps) {
 	const queryClient = useQueryClient();
 	const {
@@ -277,17 +275,12 @@ export function ChangesSection({
 
 	return (
 		<section
+			ref={sectionRef}
 			aria-label="Inspector section Git"
 			className="flex min-h-0 shrink-0 flex-col overflow-hidden border-b border-border/60 bg-sidebar"
-			style={{
-				// Height var written by mousemove directly; fallback covers the first
-				// mount frame before the layout effect runs.
-				height: `calc(${INSPECTOR_SECTION_HEADER_HEIGHT}px + var(${INSPECTOR_CHANGES_BODY_VAR}, ${bodyHeight}px))`,
-				// Full containment isolates the file-list reflow (rows + Radix triggers
-				// + truncate spans) from the rest of the page during inspector drag.
-				// Section already has overflow-hidden, so `paint` doesn't change clipping.
-				contain: "layout style paint",
-			}}
+			// Height written via `sectionRef` by `useWorkspaceInspectorSidebar`
+			// — kept out of JSX so incidental re-renders can't clobber it.
+			style={{ contain: "layout style paint" }}
 		>
 			<GitSectionHeader
 				commitButtonMode={commitButtonMode}
@@ -398,6 +391,10 @@ export function ChangesSection({
 		</section>
 	);
 }
+
+// memo so root state changes that don't touch Changes props (e.g. opening
+// Settings) skip this subtree entirely.
+export const ChangesSection = memo(ChangesSectionImpl);
 
 type StageActionKind = "stage" | "unstage";
 

--- a/src/features/settings/index.tsx
+++ b/src/features/settings/index.tsx
@@ -1,6 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { CheckCircle2, ChevronDown, HelpCircle, Settings } from "lucide-react";
-import { memo, useEffect, useRef, useState } from "react";
+import { memo, useEffect, useState } from "react";
 import { ModelIcon } from "@/components/model-icon";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
@@ -138,48 +138,12 @@ export const SettingsDialog = memo(function SettingsDialog({
 	const modelSections = modelSectionsQuery.data ?? [];
 	const allModels = modelSections.flatMap((s) => s.options);
 
-	// Materialize null Review/PR fields once per dialog open. Each model row
-	// (default / review / pr) owns its three controls (model, effort, fast
-	// mode) independently — `null` was the legacy "follow default" sentinel,
-	// but that coupling caused review/pr displays to flip whenever the
-	// default row changed. We promote nulls to explicit copies of the
-	// current default values so the three rows are fully decoupled going
-	// forward. Wait until `defaultModelId` is set so we don't materialize
-	// to `null` on first launch.
-	const hasMaterialized = useRef(false);
-	useEffect(() => {
-		if (!open) {
-			hasMaterialized.current = false;
-			return;
-		}
-		if (hasMaterialized.current) return;
-		if (settings.defaultModelId === null) return;
-
-		const patch: Partial<AppSettings> = {};
-		if (settings.reviewModelId === null) {
-			patch.reviewModelId = settings.defaultModelId;
-		}
-		if (settings.reviewEffort === null) {
-			patch.reviewEffort = settings.defaultEffort;
-		}
-		if (settings.reviewFastMode === null) {
-			patch.reviewFastMode = settings.defaultFastMode;
-		}
-		if (settings.prModelId === null) {
-			patch.prModelId = settings.defaultModelId;
-		}
-		if (settings.prEffort === null) {
-			patch.prEffort = settings.defaultEffort;
-		}
-		if (settings.prFastMode === null) {
-			patch.prFastMode = settings.defaultFastMode;
-		}
-
-		hasMaterialized.current = true;
-		if (Object.keys(patch).length > 0) {
-			void updateSettings(patch);
-		}
-	}, [open, settings, updateSettings]);
+	// Note: null review/pr model fields used to be promoted to default
+	// values here on every dialog open. That migration now runs once in
+	// `materialize_review_pr_model_defaults` (src-tauri/src/schema.rs) at
+	// schema upgrade time. Consumers fall back to `?? settings.defaultX`
+	// for the brief window between first-time default-set and next
+	// cold-start, which is what the existing UI bindings already do.
 
 	useEffect(() => {
 		if (open) {

--- a/src/lib/css-color.test.ts
+++ b/src/lib/css-color.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { invalidateCssColorCache, resolveCssColor } from "./css-color";
+
+// jsdom doesn't actually resolve var() through Canvas, so we don't assert
+// the literal hex result. The behavioural contract we DO care about here:
+//   1. Repeated lookups go through Canvas at most once per cache generation.
+//   2. Alpha overrides bucket independently.
+//   3. invalidateCssColorCache() reopens the path for the next lookup.
+
+describe("resolveCssColor cache", () => {
+	beforeEach(() => {
+		invalidateCssColorCache();
+	});
+
+	it("caches repeated lookups within a generation", () => {
+		const spy = vi.spyOn(window, "getComputedStyle");
+		resolveCssColor("rgb(10, 20, 30)");
+		resolveCssColor("rgb(10, 20, 30)");
+		resolveCssColor("rgb(10, 20, 30)");
+		expect(spy).toHaveBeenCalledTimes(1);
+		spy.mockRestore();
+	});
+
+	it("distinguishes alpha overrides in the cache", () => {
+		const spy = vi.spyOn(window, "getComputedStyle");
+		resolveCssColor("rgb(10, 20, 30)");
+		resolveCssColor("rgb(10, 20, 30)", 0.5);
+		resolveCssColor("rgb(10, 20, 30)");
+		resolveCssColor("rgb(10, 20, 30)", 0.5);
+		// Two distinct cache keys → two computeStyle calls.
+		expect(spy).toHaveBeenCalledTimes(2);
+		spy.mockRestore();
+	});
+
+	it("re-runs the resolver after invalidateCssColorCache", () => {
+		const spy = vi.spyOn(window, "getComputedStyle");
+		resolveCssColor("rgb(10, 20, 30)");
+		expect(spy).toHaveBeenCalledTimes(1);
+		resolveCssColor("rgb(10, 20, 30)");
+		expect(spy).toHaveBeenCalledTimes(1);
+		invalidateCssColorCache();
+		resolveCssColor("rgb(10, 20, 30)");
+		expect(spy).toHaveBeenCalledTimes(2);
+		spy.mockRestore();
+	});
+});

--- a/src/lib/css-color.ts
+++ b/src/lib/css-color.ts
@@ -2,6 +2,13 @@ let cssColorProbe: HTMLDivElement | null = null;
 let cssColorCanvas: CanvasRenderingContext2D | null = null;
 let unsupportedColorSentinel: CanvasGradient | null = null;
 
+// Memoize resolved colors; invalidate on every `<html>` class change.
+const cssColorCache = new Map<string, string>();
+
+export function invalidateCssColorCache(): void {
+	cssColorCache.clear();
+}
+
 function getCssColorProbe(): HTMLDivElement {
 	if (!cssColorProbe) {
 		cssColorProbe = document.createElement("div");
@@ -35,6 +42,10 @@ function toHexByte(n: number): string {
 }
 
 export function resolveCssColor(value: string, alphaOverride?: number): string {
+	const cacheKey = `${value}::${alphaOverride ?? ""}`;
+	const hit = cssColorCache.get(cacheKey);
+	if (hit !== undefined) return hit;
+
 	const probe = getCssColorProbe();
 	probe.style.backgroundColor = "";
 	probe.style.backgroundColor = value;
@@ -61,5 +72,7 @@ export function resolveCssColor(value: string, alphaOverride?: number): string {
 		alphaOverride === undefined ? baseAlpha : Math.round(alphaOverride * 255);
 	const alphaHex = alpha >= 255 ? "" : toHexByte(alpha);
 
-	return `#${toHexByte(r)}${toHexByte(g)}${toHexByte(b)}${alphaHex}`;
+	const result = `#${toHexByte(r)}${toHexByte(g)}${toHexByte(b)}${alphaHex}`;
+	cssColorCache.set(cacheKey, result);
+	return result;
 }

--- a/src/lib/monaco-runtime.ts
+++ b/src/lib/monaco-runtime.ts
@@ -400,9 +400,8 @@ async function ensureRuntime(): Promise<MonacoRuntime> {
 	return runtimePromise;
 }
 
-// Sync Monaco theme with `<html>` class changes. Re-defines both themes on
-// every class mutation — light/dark toggle AND preset theme switch both flip
-// CSS variables, so the editor `colors` map must be recomputed.
+// Resync Monaco theme on `<html>` class changes; rAF-coalesced because one
+// user-visible switch flips multiple classes in a row.
 function installThemeObserver(monaco: MonacoModule) {
 	if (
 		typeof document === "undefined" ||
@@ -410,13 +409,18 @@ function installThemeObserver(monaco: MonacoModule) {
 	) {
 		return;
 	}
+	let scheduled = 0;
 	const syncTheme = () => {
+		scheduled = 0;
 		const nextTheme = detectInitialTheme();
 		defineHelmorThemes(monaco);
 		desiredTheme = nextTheme;
 		monaco.editor.setTheme(themeId(nextTheme));
 	};
-	const observer = new MutationObserver(syncTheme);
+	const observer = new MutationObserver(() => {
+		if (scheduled) return;
+		scheduled = requestAnimationFrame(syncTheme);
+	});
 	observer.observe(document.documentElement, {
 		attributes: true,
 		attributeFilter: ["class"],

--- a/src/shell/components/shell-inspector-pane.tsx
+++ b/src/shell/components/shell-inspector-pane.tsx
@@ -1,6 +1,7 @@
 // Right inspector pane — toggles between the workspace inspector tabs and
 // the context-cards sidebar (which serves both the start and the workspace
 // surface). Receives every piece of state it needs as props from AppShell.
+import { useLayoutEffect, useRef } from "react";
 import type {
 	CommitButtonState,
 	WorkspaceCommitButtonMode,
@@ -108,8 +109,21 @@ export function ShellInspectorPane({
 		return `${remote}/${target}`;
 	})();
 
+	// Inline width written via ref so each remount re-applies it.
+	const asideRef = useRef<HTMLElement>(null);
+	const innerRef = useRef<HTMLDivElement>(null);
+	useLayoutEffect(() => {
+		if (asideRef.current) {
+			asideRef.current.style.width = collapsed ? "0px" : `${width}px`;
+		}
+		if (innerRef.current) {
+			innerRef.current.style.width = `${width}px`;
+		}
+	}, [width, collapsed]);
+
 	return (
 		<aside
+			ref={asideRef}
 			aria-hidden={collapsed}
 			aria-label="Inspector sidebar"
 			data-shell-pane="inspector"
@@ -120,24 +134,18 @@ export function ShellInspectorPane({
 					: "transition-[width] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]",
 				collapsed ? "pointer-events-none" : "",
 			)}
-			// Width driven by a CSS var written on THIS element (not documentElement)
-			// during drag — keeps style invalidation inside the pane subtree.
-			// `contain: layout style` further isolates the inspector's inner layout
-			// (~4000 elements) from the outer shell. Skip `paint` so the tabs
-			// hover-zoom can still overflow (`has-[[data-tabs-zoomed=true]]:overflow-visible`).
-			style={{
-				contain: "layout style",
-				width: collapsed ? 0 : `var(--shell-inspector-width, ${width}px)`,
-			}}
+			// `paint` omitted so the tabs hover-zoom can overflow.
+			style={{ contain: "layout style" }}
 		>
 			<div
+				ref={innerRef}
+				data-shell-pane-inner="inspector"
 				className={cn(
 					"h-full shrink-0 transition-[opacity,transform] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]",
 					collapsed
 						? "translate-x-full opacity-0"
 						: "translate-x-0 opacity-100",
 				)}
-				style={{ width: `var(--shell-inspector-width, ${width}px)` }}
 			>
 				{rightSidebarMode === "context" ? (
 					<WorkspaceStartContextSidebar

--- a/src/shell/components/shell-resize-separator.tsx
+++ b/src/shell/components/shell-resize-separator.tsx
@@ -1,7 +1,13 @@
 // Vertical drag handle used between the workspace sidebar / main pane and
 // between the main pane / inspector. Identical visuals + behaviour, only
 // the side (`"sidebar"` vs `"inspector"`) and offset rules differ.
-import type { CSSProperties, KeyboardEvent, MouseEvent } from "react";
+import {
+	type CSSProperties,
+	type KeyboardEvent,
+	type PointerEvent as ReactPointerEvent,
+	useLayoutEffect,
+	useRef,
+} from "react";
 import { cn } from "@/lib/utils";
 import {
 	MAX_SIDEBAR_WIDTH,
@@ -14,7 +20,7 @@ type Props = {
 	collapsed: boolean;
 	resizing: boolean;
 	width: number;
-	onMouseDown: (event: MouseEvent<HTMLDivElement>) => void;
+	onPointerDown: (event: ReactPointerEvent<HTMLDivElement>) => void;
 	onKeyDown: (event: KeyboardEvent<HTMLDivElement>) => void;
 };
 
@@ -23,24 +29,29 @@ export function ShellResizeSeparator({
 	collapsed,
 	resizing,
 	width,
-	onMouseDown,
+	onPointerDown,
 	onKeyDown,
 }: Props) {
-	// Position also CSS-var driven so the handle follows the pane during drag without React renders.
-	const containerStyle: CSSProperties =
-		side === "sidebar"
-			? {
-					left: collapsed
-						? `${-SIDEBAR_RESIZE_HIT_AREA / 2}px`
-						: `calc(var(--shell-sidebar-width, ${width}px) - ${SIDEBAR_RESIZE_HIT_AREA / 2}px)`,
-					width: `${SIDEBAR_RESIZE_HIT_AREA}px`,
-				}
-			: {
-					right: collapsed
-						? `${-SIDEBAR_RESIZE_HIT_AREA}px`
-						: `calc(var(--shell-inspector-width, ${width}px) - ${SIDEBAR_RESIZE_HIT_AREA}px)`,
-					width: `${SIDEBAR_RESIZE_HIT_AREA}px`,
-				};
+	// Inline position written via ref so each remount re-applies it; the
+	// drag pipeline updates the same node per-frame.
+	const ref = useRef<HTMLDivElement>(null);
+	useLayoutEffect(() => {
+		const node = ref.current;
+		if (!node) return;
+		if (side === "sidebar") {
+			node.style.left = collapsed
+				? `${-SIDEBAR_RESIZE_HIT_AREA / 2}px`
+				: `${width - SIDEBAR_RESIZE_HIT_AREA / 2}px`;
+		} else {
+			node.style.right = collapsed
+				? `${-SIDEBAR_RESIZE_HIT_AREA}px`
+				: `${width - SIDEBAR_RESIZE_HIT_AREA}px`;
+		}
+	}, [side, collapsed, width]);
+
+	const containerStyle: CSSProperties = {
+		width: `${SIDEBAR_RESIZE_HIT_AREA}px`,
+	};
 
 	const transitionAxis = side === "sidebar" ? "left" : "right";
 	const handleClass =
@@ -50,6 +61,7 @@ export function ShellResizeSeparator({
 
 	return (
 		<div
+			ref={ref}
 			role="separator"
 			tabIndex={collapsed ? -1 : 0}
 			aria-hidden={collapsed}
@@ -59,7 +71,7 @@ export function ShellResizeSeparator({
 			aria-valuemax={MAX_SIDEBAR_WIDTH}
 			aria-valuenow={width}
 			data-shell-resize={side}
-			onMouseDown={onMouseDown}
+			onPointerDown={onPointerDown}
 			onKeyDown={onKeyDown}
 			className={cn(
 				"group absolute inset-y-0 z-30 cursor-ew-resize touch-none outline-none",

--- a/src/shell/components/shell-sidebar-pane.tsx
+++ b/src/shell/components/shell-sidebar-pane.tsx
@@ -1,6 +1,7 @@
 // Left workspace sidebar — workspaces list, app-update button, sidebar
 // collapse, and the settings entry button at the bottom.
 import { PanelLeftClose } from "lucide-react";
+import { useLayoutEffect, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import {
 	Tooltip,
@@ -65,8 +66,21 @@ export function ShellSidebarPane({
 	onOpenSettings,
 	pushWorkspaceToast,
 }: Props) {
+	// Inline width written via ref so each remount re-applies it.
+	const asideRef = useRef<HTMLElement>(null);
+	const innerRef = useRef<HTMLDivElement>(null);
+	useLayoutEffect(() => {
+		if (asideRef.current) {
+			asideRef.current.style.width = collapsed ? "0px" : `${width}px`;
+		}
+		if (innerRef.current) {
+			innerRef.current.style.width = `${width}px`;
+		}
+	}, [width, collapsed]);
+
 	return (
 		<aside
+			ref={asideRef}
 			aria-hidden={collapsed}
 			aria-label="Workspace sidebar"
 			data-helmor-sidebar-root
@@ -78,20 +92,16 @@ export function ShellSidebarPane({
 					: "transition-[width] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]",
 				collapsed ? "pointer-events-none" : "",
 			)}
-			// Width driven by a CSS var written on THIS element (not documentElement)
-			// during drag — keeps style invalidation inside the pane subtree.
-			style={{
-				width: collapsed ? 0 : `var(--shell-sidebar-width, ${width}px)`,
-			}}
 		>
 			<div
+				ref={innerRef}
+				data-shell-pane-inner="sidebar"
 				className={cn(
 					"relative flex h-full shrink-0 flex-col transition-[opacity,transform] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]",
 					collapsed
 						? "-translate-x-full opacity-0"
 						: "translate-x-0 opacity-100",
 				)}
-				style={{ width: `var(--shell-sidebar-width, ${width}px)` }}
 			>
 				<div className="min-h-0 flex-1">
 					<WorkspacesSidebarContainer

--- a/src/shell/hooks/use-ensure-default-model.test.tsx
+++ b/src/shell/hooks/use-ensure-default-model.test.tsx
@@ -3,6 +3,7 @@ import { renderHook } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { createHelmorQueryClient, helmorQueryKeys } from "@/lib/query-client";
+import type { AppSettings } from "@/lib/settings";
 import { DEFAULT_SETTINGS, SettingsContext } from "@/lib/settings";
 import { useEnsureDefaultModel } from "./use-ensure-default-model";
 
@@ -19,6 +20,7 @@ function renderUseEnsureDefaultModel(args: {
 			cliModel: string;
 		}>;
 	}>;
+	settingsOverrides?: Partial<AppSettings>;
 }) {
 	const queryClient = createHelmorQueryClient();
 	queryClient.setQueryData(helmorQueryKeys.agentModelSections, args.sections);
@@ -31,6 +33,7 @@ function renderUseEnsureDefaultModel(args: {
 					settings: {
 						...DEFAULT_SETTINGS,
 						defaultModelId: args.defaultModelId,
+						...args.settingsOverrides,
 					},
 					isLoaded: true,
 					updateSettings,
@@ -72,7 +75,52 @@ describe("useEnsureDefaultModel", () => {
 			],
 		});
 
-		expect(updateSettings).toHaveBeenCalledWith({ defaultModelId: "opus-1m" });
+		// Materializes review/pr fields alongside the default so a fresh
+		// install doesn't depend on the next cold-start migration.
+		expect(updateSettings).toHaveBeenCalledWith({
+			defaultModelId: "opus-1m",
+			reviewModelId: "opus-1m",
+			prModelId: "opus-1m",
+			reviewEffort: DEFAULT_SETTINGS.defaultEffort,
+			prEffort: DEFAULT_SETTINGS.defaultEffort,
+			reviewFastMode: DEFAULT_SETTINGS.defaultFastMode,
+			prFastMode: DEFAULT_SETTINGS.defaultFastMode,
+		});
+	});
+
+	it("preserves existing non-null review/pr overrides when materializing", () => {
+		const { updateSettings } = renderUseEnsureDefaultModel({
+			defaultModelId: "gpt-legacy",
+			sections: [
+				{
+					id: "claude",
+					label: "Claude Code",
+					status: "ready",
+					options: [
+						{
+							id: "opus-1m",
+							provider: "claude",
+							label: "Opus",
+							cliModel: "opus-1m",
+						},
+					],
+				},
+				{ id: "codex", label: "Codex", status: "unavailable", options: [] },
+			],
+			settingsOverrides: {
+				reviewModelId: "user-custom-review",
+				reviewEffort: "low",
+				prFastMode: true,
+			},
+		});
+
+		expect(updateSettings).toHaveBeenCalledWith({
+			defaultModelId: "opus-1m",
+			// reviewModelId / reviewEffort / prFastMode preserved (already set).
+			prModelId: "opus-1m",
+			prEffort: DEFAULT_SETTINGS.defaultEffort,
+			reviewFastMode: DEFAULT_SETTINGS.defaultFastMode,
+		});
 	});
 
 	it("preserves an invalid saved model while any provider is still in error", () => {

--- a/src/shell/hooks/use-ensure-default-model.ts
+++ b/src/shell/hooks/use-ensure-default-model.ts
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useEffect } from "react";
 import type { AgentModelSection } from "@/lib/api";
 import { agentModelSectionsQueryOptions } from "@/lib/query-client";
-import { useSettings } from "@/lib/settings";
+import { type AppSettings, useSettings } from "@/lib/settings";
 import { findModelOption } from "@/lib/workspace-helpers";
 
 const KNOWN_MODEL_PROVIDERS = ["claude", "codex"] as const;
@@ -55,6 +55,35 @@ export function useEnsureDefaultModel() {
 			allOptions[0]?.id ??
 			null;
 		if (!pick) return;
-		updateSettings({ defaultModelId: pick });
-	}, [isLoaded, sections, settings.defaultModelId, updateSettings]);
+
+		// Materialize null review/pr fields alongside the default so a fresh
+		// install doesn't depend on the next cold-start migration.
+		const patch: Partial<AppSettings> = { defaultModelId: pick };
+		if (settings.reviewModelId === null) patch.reviewModelId = pick;
+		if (settings.prModelId === null) patch.prModelId = pick;
+		if (settings.reviewEffort === null) {
+			patch.reviewEffort = settings.defaultEffort;
+		}
+		if (settings.prEffort === null) patch.prEffort = settings.defaultEffort;
+		if (settings.reviewFastMode === null) {
+			patch.reviewFastMode = settings.defaultFastMode;
+		}
+		if (settings.prFastMode === null) {
+			patch.prFastMode = settings.defaultFastMode;
+		}
+		updateSettings(patch);
+	}, [
+		isLoaded,
+		sections,
+		settings.defaultModelId,
+		settings.reviewModelId,
+		settings.prModelId,
+		settings.reviewEffort,
+		settings.prEffort,
+		settings.reviewFastMode,
+		settings.prFastMode,
+		settings.defaultEffort,
+		settings.defaultFastMode,
+		updateSettings,
+	]);
 }

--- a/src/shell/hooks/use-panels.ts
+++ b/src/shell/hooks/use-panels.ts
@@ -1,29 +1,20 @@
 import {
 	type KeyboardEvent,
-	type MouseEvent,
+	type PointerEvent as ReactPointerEvent,
 	useCallback,
 	useEffect,
-	useLayoutEffect,
 	useState,
 } from "react";
 import {
 	clampSidebarWidth,
 	getInitialSidebarWidth,
 	INSPECTOR_WIDTH_STORAGE_KEY,
+	SIDEBAR_RESIZE_HIT_AREA,
 	SIDEBAR_RESIZE_STEP,
 	SIDEBAR_WIDTH_STORAGE_KEY,
 } from "@/shell/layout";
 
 type ResizeTarget = "sidebar" | "inspector";
-
-type ResizeState = {
-	pointerX: number;
-	sidebarWidth: number;
-	target: ResizeTarget;
-};
-
-export const SIDEBAR_WIDTH_VAR = "--shell-sidebar-width";
-export const INSPECTOR_WIDTH_VAR = "--shell-inspector-width";
 
 // Module-level resize state store. Kept out of React state so subscribers
 // don't re-render on drag start/end — they only flush via the listener.
@@ -50,31 +41,11 @@ function setResizingActive(active: boolean) {
 	}
 }
 
-// Writing custom properties on `documentElement` forces a document-wide style
-// invalidation pass on every change. With Monaco's ~2900 cached CSS rules in
-// the document after the editor has been opened once, that per-frame work
-// blows past the budget on drag (60ms+/frame). Writing the var on the pane +
-// separator subtrees instead confines invalidation to those subtrees — combined
-// with `contain: layout style` on the pane, the rest of the shell stays cold.
-function writeWidthVar(target: ResizeTarget, width: number) {
-	if (typeof document === "undefined") return;
-	const varName =
-		target === "sidebar" ? SIDEBAR_WIDTH_VAR : INSPECTOR_WIDTH_VAR;
-	const value = `${width}px`;
-	const pane = document.querySelector<HTMLElement>(
-		`[data-shell-pane="${target}"]`,
-	);
-	const separator = document.querySelector<HTMLElement>(
-		`[data-shell-resize="${target}"]`,
-	);
-	pane?.style.setProperty(varName, value);
-	separator?.style.setProperty(varName, value);
-}
-
-// No module-load seed: each pane / separator falls back to React state via
-// `var(--shell-x-width, ${width}px)`, and `useState(getInitialSidebarWidth)`
-// initializes state from localStorage before the first render, so the fallback
-// already shows the correct width on the first paint.
+// Non-drag inline width writes live in the pane components (they own
+// ref + useLayoutEffect so re-mounts always re-write). Drag-time writes
+// happen inside `handleResizeStart`. CSS variables are avoided here
+// because WebKit invalidates the whole subtree's computed style on every
+// `setProperty()`.
 
 export function useShellPanels() {
 	const [sidebarWidth, setSidebarWidth] = useState(getInitialSidebarWidth);
@@ -82,19 +53,11 @@ export function useShellPanels() {
 	const [inspectorWidth, setInspectorWidth] = useState(() =>
 		getInitialSidebarWidth(INSPECTOR_WIDTH_STORAGE_KEY),
 	);
-	const [resizeState, setResizeState] = useState<ResizeState | null>(null);
-
-	// React state → CSS var sync. Only fires for non-drag cases (keyboard
-	// step, initial mount, mouseup commit). During drag, mousemove writes
-	// the var directly and React state is stale — but setProperty with the
-	// same value is a no-op.
-	useLayoutEffect(() => {
-		writeWidthVar("sidebar", sidebarWidth);
-	}, [sidebarWidth]);
-
-	useLayoutEffect(() => {
-		writeWidthVar("inspector", inspectorWidth);
-	}, [inspectorWidth]);
+	// Drives the `resizing` UI prop on separators; the drag state machine
+	// itself lives in the `handleResizeStart` closure.
+	const [resizingTarget, setResizingTarget] = useState<ResizeTarget | null>(
+		null,
+	);
 
 	useEffect(() => {
 		try {
@@ -124,99 +87,117 @@ export function useShellPanels() {
 		}
 	}, [inspectorWidth]);
 
-	useEffect(() => {
-		if (!resizeState) {
-			return;
-		}
-
-		setResizingActive(true);
-
-		// Cache pane + separator refs once so the 60Hz flush doesn't re-querySelector.
-		const targetPane = document.querySelector<HTMLElement>(
-			`[data-shell-pane="${resizeState.target}"]`,
-		);
-		const targetSeparator = document.querySelector<HTMLElement>(
-			`[data-shell-resize="${resizeState.target}"]`,
-		);
-		const varName =
-			resizeState.target === "sidebar"
-				? SIDEBAR_WIDTH_VAR
-				: INSPECTOR_WIDTH_VAR;
-
-		let pendingWidth: number | null = null;
-		let rafId: number | null = null;
-
-		// Drag-time path: only writes the CSS var on the pane + separator
-		// subtrees, never touches React or documentElement.
-		const flushVar = () => {
-			rafId = null;
-			if (pendingWidth === null) return;
-			const value = `${pendingWidth}px`;
-			targetPane?.style.setProperty(varName, value);
-			targetSeparator?.style.setProperty(varName, value);
-		};
-
-		const handleMouseMove = (event: globalThis.MouseEvent) => {
-			const deltaX = event.clientX - resizeState.pointerX;
-			const rawWidth =
-				resizeState.target === "sidebar"
-					? resizeState.sidebarWidth + deltaX
-					: resizeState.sidebarWidth - deltaX;
-			pendingWidth = clampSidebarWidth(rawWidth);
-			if (rafId === null) {
-				rafId = window.requestAnimationFrame(flushVar);
-			}
-		};
-
-		const handleMouseUp = () => {
-			if (rafId !== null) {
-				window.cancelAnimationFrame(rafId);
-				rafId = null;
-			}
-			flushVar();
-			// Commit the final CSS var value back to React state for
-			// persistence and any width-dependent non-drag consumers.
-			const finalWidth = pendingWidth;
-			if (finalWidth !== null) {
-				if (resizeState.target === "sidebar") {
-					setSidebarWidth(finalWidth);
-				} else {
-					setInspectorWidth(finalWidth);
-				}
-			}
-			setResizingActive(false);
-			setResizeState(null);
-		};
-		const previousCursor = document.body.style.cursor;
-		const previousUserSelect = document.body.style.userSelect;
-
-		document.body.style.cursor = "ew-resize";
-		document.body.style.userSelect = "none";
-
-		window.addEventListener("mousemove", handleMouseMove);
-		window.addEventListener("mouseup", handleMouseUp);
-
-		return () => {
-			if (rafId !== null) {
-				window.cancelAnimationFrame(rafId);
-			}
-			setResizingActive(false);
-			document.body.style.cursor = previousCursor;
-			document.body.style.userSelect = previousUserSelect;
-			window.removeEventListener("mousemove", handleMouseMove);
-			window.removeEventListener("mouseup", handleMouseUp);
-		};
-	}, [resizeState]);
-
 	const handleResizeStart = useCallback(
-		(target: ResizeTarget) => (event: MouseEvent<HTMLDivElement>) => {
+		(target: ResizeTarget) => (event: ReactPointerEvent<HTMLDivElement>) => {
 			if (event.button !== 0) return;
 			event.preventDefault();
-			setResizeState({
-				pointerX: event.clientX,
-				sidebarWidth: target === "sidebar" ? sidebarWidth : inspectorWidth,
-				target,
-			});
+
+			// Pointer capture routes all subsequent pointer events back here
+			// even when the cursor leaves the OS window. Swallow the
+			// `NotFoundError` synthetic `PointerEvent`s throw in tests.
+			const node = event.currentTarget;
+			const pointerId = event.pointerId;
+			try {
+				node.setPointerCapture(pointerId);
+			} catch {}
+
+			const startX = event.clientX;
+			const startWidth = target === "sidebar" ? sidebarWidth : inspectorWidth;
+			const targetPane = document.querySelector<HTMLElement>(
+				`[data-shell-pane="${target}"]`,
+			);
+			const targetInner = document.querySelector<HTMLElement>(
+				`[data-shell-pane-inner="${target}"]`,
+			);
+
+			let pendingWidth: number = startWidth;
+			let rafId: number | null = null;
+
+			// Drag-time inline writes — bypass React render + CSS-var
+			// invalidation to keep per-frame cost in the microsecond range.
+			const flushInlineSize = () => {
+				rafId = null;
+				const widthPx = `${pendingWidth}px`;
+				if (targetPane) targetPane.style.width = widthPx;
+				if (targetInner) targetInner.style.width = widthPx;
+				if (target === "sidebar") {
+					node.style.left = `${pendingWidth - SIDEBAR_RESIZE_HIT_AREA / 2}px`;
+				} else {
+					node.style.right = `${pendingWidth - SIDEBAR_RESIZE_HIT_AREA}px`;
+				}
+			};
+
+			const handlePointerMove = (moveEvent: globalThis.PointerEvent) => {
+				if (moveEvent.pointerId !== pointerId) return;
+				const deltaX = moveEvent.clientX - startX;
+				const rawWidth =
+					target === "sidebar" ? startWidth + deltaX : startWidth - deltaX;
+				pendingWidth = clampSidebarWidth(rawWidth);
+				if (rafId === null) {
+					rafId = window.requestAnimationFrame(flushInlineSize);
+				}
+			};
+
+			const previousCursor = document.body.style.cursor;
+			const previousUserSelect = document.body.style.userSelect;
+			document.body.style.cursor = "ew-resize";
+			document.body.style.userSelect = "none";
+
+			// Full-window overlay absorbs hit-testing so WebKit's `:hover`
+			// recompute doesn't cascade through the inspector subtree on
+			// every mousemove. Must stay `pointer-events: auto` — pointer
+			// capture handles event routing but not hit-test freezing.
+			const overlay = document.createElement("div");
+			overlay.style.position = "fixed";
+			overlay.style.inset = "0";
+			overlay.style.zIndex = "2147483647";
+			overlay.style.cursor = "ew-resize";
+			overlay.setAttribute("data-helmor-resize-overlay", "");
+			overlay.setAttribute("aria-hidden", "true");
+			document.body.appendChild(overlay);
+
+			let settled = false;
+			const finish = () => {
+				if (settled) return;
+				settled = true;
+
+				if (rafId !== null) {
+					window.cancelAnimationFrame(rafId);
+					rafId = null;
+				}
+				flushInlineSize();
+
+				if (target === "sidebar") {
+					setSidebarWidth(pendingWidth);
+				} else {
+					setInspectorWidth(pendingWidth);
+				}
+
+				try {
+					node.releasePointerCapture(pointerId);
+				} catch {}
+				node.removeEventListener("pointermove", handlePointerMove);
+				node.removeEventListener("pointerup", finish);
+				node.removeEventListener("pointercancel", finish);
+				node.removeEventListener("lostpointercapture", finish);
+
+				document.body.style.cursor = previousCursor;
+				document.body.style.userSelect = previousUserSelect;
+				overlay.remove();
+
+				setResizingTarget(null);
+				setResizingActive(false);
+			};
+
+			node.addEventListener("pointermove", handlePointerMove);
+			node.addEventListener("pointerup", finish);
+			// W3C fallbacks for OS-pre-empted gestures / capture lost without
+			// a normal pointerup.
+			node.addEventListener("pointercancel", finish);
+			node.addEventListener("lostpointercapture", finish);
+
+			setResizingTarget(target);
+			setResizingActive(true);
 		},
 		[sidebarWidth, inspectorWidth],
 	);
@@ -258,8 +239,8 @@ export function useShellPanels() {
 		handleResizeKeyDown,
 		handleResizeStart,
 		inspectorWidth,
-		isInspectorResizing: resizeState?.target === "inspector",
-		isSidebarResizing: resizeState?.target === "sidebar",
+		isInspectorResizing: resizingTarget === "inspector",
+		isSidebarResizing: resizingTarget === "sidebar",
 		sidebarCollapsed,
 		sidebarWidth,
 		setInspectorWidth,

--- a/src/shell/hooks/use-theme-application.ts
+++ b/src/shell/hooks/use-theme-application.ts
@@ -3,6 +3,7 @@
 // the rest of the app picks up the right tokens without each component
 // reaching into settings.
 import { useEffect } from "react";
+import { invalidateCssColorCache } from "@/lib/css-color";
 import {
 	type ColorTheme,
 	resolveTheme,
@@ -65,10 +66,11 @@ export function useThemeApplication(opts: ThemeApplicationOptions): void {
 			if (preset && preset !== "default") {
 				root.classList.add(`theme-${preset}`);
 			}
-			// Monaco's theme is synced via a MutationObserver inside
-			// `monaco-runtime.ts` — avoid importing it here to keep Monaco out
-			// of the critical boot path and out of tests that never open the
-			// editor.
+			// CSS variables changed — drop cached resolutions.
+			invalidateCssColorCache();
+			// Monaco's theme is synced via a MutationObserver in
+			// `monaco-runtime.ts`; not imported here to stay off the boot
+			// path.
 		};
 
 		apply();


### PR DESCRIPTION
## Summary

Two WebKit-specific issues were capping the horizontal sidebar/inspector drag and the inspector's vertical Actions/Scripts dividers to ~28–30 FPS on workspaces with thousands of changed files. This branch fixes both, independent of file-list size.

### What changed

- **No more CSS custom properties on the dragged ancestors.** Every frame used to call `setProperty()` on a node high in the tree; WebKit invalidates the entire subtree's computed style on any inherited custom-property write (it can't statically prove which `var()` lookups are affected). With ~10k Changes-subtree nodes and ~22k Inspector-subtree nodes, that was ~31ms and ~76ms per frame respectively. Pane heights and widths are now written as inline `style.height` / `style.width` directly on each section's / pane's own element via the resize hook's refs.
- **Transparent full-window overlay during drag** so native mousemove hit-testing resolves to a single element with no `:hover`-dependent styling. WebKit's `:hover` recompute would otherwise traverse the whole subtree (plus dense `hover:bg-*` Tailwind selectors) on every mousemove. Synthetic JS events skip this pipeline, which is why the perf loss only ever showed up under a hardware pointer.
- **Pointer capture for pane drags** (`setPointerCapture` on `pointerdown`) routes all subsequent pointer events back to the separator even when the cursor leaves the OS window — no more `window` listeners or `blur` / `visibilitychange` cleanup.
- **Width/height writes owned by the pane components themselves** (ref + `useLayoutEffect`) so they re-fire on every (re-)mount. AppShell conditionally renders both panes, so a hook-owned write would silently miss a remount and the separator could collapse to `x=0`.
- **Materialize review/pr default-following fields in the schema migration** instead of doing it on every settings-dialog open via an IPC roundtrip. Also patches `useEnsureDefaultModel` to materialize them alongside the default model on a fresh install (with a new test covering preservation of user-set overrides).
- Small comment-density cleanup across the touched files — kept the why, dropped the essay.

### Why

Real users with large repos were reporting unusable drag perf. Profiling pointed at WebKit's conservative style-invalidation rules around custom properties + the `:hover` recompute pipeline; both are WebKit-only, both vanish once the drag pipeline stops touching shared ancestors and gets out of the hit-test path.

### Test plan

- [ ] `bun run test` (frontend + sidecar + rust)
- [ ] `bun run lint`
- [ ] Manual drag of the sidebar / inspector separator on a workspace with thousands of changed files — sustained 60 FPS under hardware mouse.
- [ ] Manual drag of the Actions / Scripts vertical dividers on the same workspace.
- [ ] Toggle Actions / Scripts open/closed; toggle light/dark and preset themes; verify Monaco + xterm retint correctly.
- [ ] Open Settings dialog with a fresh install; review/pr fields should already be materialized (no IPC roundtrip on open).