### PR TITLE
feat: manage multiple run actions from repo settings and inspector

### DIFF
--- a/.announcements/edit-run-scripts-from-settings.json
+++ b/.announcements/edit-run-scripts-from-settings.json
@@ -1,0 +1,14 @@
+{
+	"items": [
+		{
+			"text": "You can now configure multiple run scripts per repository",
+			"action": {
+				"label": "Open Run scripts",
+				"value": {
+					"type": "openSettings",
+					"section": "repo:current"
+				}
+			}
+		}
+	]
+}

--- a/src-tauri/src/cli/repo.rs
+++ b/src-tauri/src/cli/repo.rs
@@ -178,13 +178,22 @@ fn show_scripts(repo_ref: &str, workspace: Option<&str>, cli: &Cli) -> Result<()
             s.setup_from_project,
             s.setup_script.as_deref().unwrap_or("-"),
             s.run_from_project,
-            s.run_script.as_deref().unwrap_or("-"),
+            s.run_actions
+                .first()
+                .map(|a| a.command.as_str())
+                .unwrap_or("-"),
             s.archive_from_project,
             s.archive_script.as_deref().unwrap_or("-"),
         )
     })
 }
 
+/// Update one or more repo scripts. `--run` and `clear run` operate on
+/// the repo's first DB-owned run action: `--run "cmd"` updates an
+/// existing first action's command (or creates a "Default" action when
+/// none exists yet); `clear run` deletes the first action if present.
+/// helmor.json-owned actions are read-only here — modify them by
+/// editing the JSON file.
 fn update_scripts(
     repo_ref: &str,
     setup: Option<&str>,
@@ -194,34 +203,56 @@ fn update_scripts(
     cli: &Cli,
 ) -> Result<()> {
     let id = service::resolve_repo_ref(repo_ref)?;
-    // Load current to preserve unspecified fields.
     let existing = repos::load_repo_scripts(&id, None)?;
     let mut setup_val = existing.setup_script;
-    let mut run_val = existing.run_script;
     let mut archive_val = existing.archive_script;
     if let Some(v) = setup {
         setup_val = Some(v.to_string());
     }
-    if let Some(v) = run {
-        run_val = Some(v.to_string());
-    }
     if let Some(v) = archive {
         archive_val = Some(v.to_string());
+    }
+
+    let mut run_pending: Option<Option<String>> = None;
+    if let Some(v) = run {
+        run_pending = Some(Some(v.to_string()));
     }
     for kind in clear {
         match kind.as_str() {
             "setup" => setup_val = None,
-            "run" => run_val = None,
+            "run" => run_pending = Some(None),
             "archive" => archive_val = None,
             other => anyhow::bail!("Unknown script kind to clear: {other}"),
         }
     }
-    repos::update_repo_scripts(
-        &id,
-        setup_val.as_deref(),
-        run_val.as_deref(),
-        archive_val.as_deref(),
-    )?;
+
+    repos::update_repo_scripts(&id, setup_val.as_deref(), archive_val.as_deref())?;
+
+    if let Some(next_run) = run_pending {
+        if existing.run_from_project {
+            anyhow::bail!(
+                "Run actions for this repo are defined in helmor.json — edit that file instead"
+            );
+        }
+        let first_db = existing
+            .run_actions
+            .iter()
+            .find(|a| !a.from_project)
+            .cloned();
+        match (next_run, first_db) {
+            (Some(cmd), Some(action)) => {
+                repos::update_repo_run_action(&action.id, &action.name, &cmd, &action.mode)?;
+            }
+            (Some(cmd), None) => {
+                repos::create_repo_run_action(&id, "Default", &cmd, "concurrent")?;
+            }
+            (None, Some(action)) => {
+                repos::delete_repo_run_action(&action.id)?;
+            }
+            (None, None) => {}
+        }
+    }
+
     notify_ui_event(UiMutationEvent::RepositoryChanged { repo_id: id });
     output::print_ok(cli, "Scripts updated");
     Ok(())

--- a/src-tauri/src/cli/scripts.rs
+++ b/src-tauri/src/cli/scripts.rs
@@ -35,7 +35,10 @@ fn show(repo_ref: &str, workspace: Option<&str>, cli: &Cli) -> Result<()> {
             s.setup_from_project,
             s.setup_script.as_deref().unwrap_or("-"),
             s.run_from_project,
-            s.run_script.as_deref().unwrap_or("-"),
+            s.run_actions
+                .first()
+                .map(|a| a.command.as_str())
+                .unwrap_or("-"),
             s.archive_from_project,
             s.archive_script.as_deref().unwrap_or("-"),
         )

--- a/src-tauri/src/commands/repository_commands.rs
+++ b/src-tauri/src/commands/repository_commands.rs
@@ -97,16 +97,10 @@ pub async fn load_repo_preferences(repo_id: String) -> CmdResult<repos::RepoPref
 pub async fn update_repo_scripts(
     repo_id: String,
     setup_script: Option<String>,
-    run_script: Option<String>,
     archive_script: Option<String>,
 ) -> CmdResult<()> {
     run_blocking(move || {
-        repos::update_repo_scripts(
-            &repo_id,
-            setup_script.as_deref(),
-            run_script.as_deref(),
-            archive_script.as_deref(),
-        )
+        repos::update_repo_scripts(&repo_id, setup_script.as_deref(), archive_script.as_deref())
     })
     .await
 }
@@ -114,11 +108,6 @@ pub async fn update_repo_scripts(
 #[tauri::command]
 pub async fn update_repo_auto_run_setup(repo_id: String, enabled: bool) -> CmdResult<()> {
     run_blocking(move || repos::update_repo_auto_run_setup(&repo_id, enabled)).await
-}
-
-#[tauri::command]
-pub async fn update_repo_run_script_mode(repo_id: String, mode: String) -> CmdResult<()> {
-    run_blocking(move || repos::update_repo_run_script_mode(&repo_id, &mode)).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/tests/workspace_creation.rs
+++ b/src-tauri/src/commands/tests/workspace_creation.rs
@@ -847,7 +847,11 @@ fn prepare_workspace_inserts_initializing_row_without_creating_worktree() {
         Some("bun install")
     );
     assert_eq!(
-        prepared.repo_scripts.run_script.as_deref(),
+        prepared
+            .repo_scripts
+            .run_actions
+            .first()
+            .map(|a| a.command.as_str()),
         Some("bun run dev")
     );
     assert_eq!(prepared.repo_scripts.archive_script, None);
@@ -1546,7 +1550,8 @@ fn load_repo_scripts_priority_1_worktree_helmor_json_wins() {
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     let harness = CreateTestHarness::new();
 
-    // Commit a repo-root helmor.json and seed a DB script override — both
+    // Commit a repo-root helmor.json and seed DB-level script overrides
+    // (both `setup_script` and a `repo_run_actions` row) — every one
     // should be SHADOWED by the worktree's own helmor.json.
     harness.commit_repo_files(&[(
         "helmor.json",
@@ -1555,9 +1560,11 @@ fn load_repo_scripts_priority_1_worktree_helmor_json_wins() {
     Connection::open(harness.db_path())
         .unwrap()
         .execute(
-            "UPDATE repos SET setup_script = ?1, run_script = ?2 WHERE id = ?3",
-            ("db-setup", "db-run", &harness.repo_id),
+            "UPDATE repos SET setup_script = ?1 WHERE id = ?2",
+            ("db-setup", &harness.repo_id),
         )
+        .unwrap();
+    crate::repos::create_repo_run_action(&harness.repo_id, "Default", "db-run", "concurrent")
         .unwrap();
 
     // Finalize so the worktree exists, then rewrite the worktree's
@@ -1581,7 +1588,10 @@ fn load_repo_scripts_priority_1_worktree_helmor_json_wins() {
     let scripts =
         crate::repos::load_repo_scripts(&harness.repo_id, Some(&prepared.workspace_id)).unwrap();
     assert_eq!(scripts.setup_script.as_deref(), Some("worktree-setup"));
-    assert_eq!(scripts.run_script.as_deref(), Some("worktree-run"));
+    assert_eq!(
+        scripts.run_actions.first().map(|a| a.command.as_str()),
+        Some("worktree-run")
+    );
     assert!(scripts.setup_from_project);
     assert!(scripts.run_from_project);
 }
@@ -1602,9 +1612,11 @@ fn load_repo_scripts_priority_2_repo_root_wins_when_worktree_missing() {
     Connection::open(harness.db_path())
         .unwrap()
         .execute(
-            "UPDATE repos SET setup_script = ?1, run_script = ?2 WHERE id = ?3",
-            ("db-setup", "db-run", &harness.repo_id),
+            "UPDATE repos SET setup_script = ?1 WHERE id = ?2",
+            ("db-setup", &harness.repo_id),
         )
+        .unwrap();
+    crate::repos::create_repo_run_action(&harness.repo_id, "Default", "db-run", "concurrent")
         .unwrap();
 
     let prepared = workspaces::prepare_workspace_from_repo_impl(
@@ -1623,8 +1635,11 @@ fn load_repo_scripts_priority_2_repo_root_wins_when_worktree_missing() {
     // setup: worktree absent → falls to repo root.
     assert_eq!(scripts.setup_script.as_deref(), Some("source-root-setup"));
     assert!(scripts.setup_from_project);
-    // run: no project value anywhere → falls to DB.
-    assert_eq!(scripts.run_script.as_deref(), Some("db-run"));
+    // run: no project value anywhere → falls to DB action.
+    assert_eq!(
+        scripts.run_actions.first().map(|a| a.command.as_str()),
+        Some("db-run")
+    );
     assert!(!scripts.run_from_project);
 }
 
@@ -1640,9 +1655,11 @@ fn load_repo_scripts_priority_3_falls_through_to_db_when_no_helmor_json_anywhere
     Connection::open(harness.db_path())
         .unwrap()
         .execute(
-            "UPDATE repos SET setup_script = ?1, run_script = ?2, archive_script = ?3 WHERE id = ?4",
-            ("db-setup", "db-run", "db-archive", &harness.repo_id),
+            "UPDATE repos SET setup_script = ?1, archive_script = ?2 WHERE id = ?3",
+            ("db-setup", "db-archive", &harness.repo_id),
         )
+        .unwrap();
+    crate::repos::create_repo_run_action(&harness.repo_id, "Default", "db-run", "concurrent")
         .unwrap();
 
     let prepared = workspaces::prepare_workspace_from_repo_impl(
@@ -1658,7 +1675,10 @@ fn load_repo_scripts_priority_3_falls_through_to_db_when_no_helmor_json_anywhere
     let scripts =
         crate::repos::load_repo_scripts(&harness.repo_id, Some(&prepared.workspace_id)).unwrap();
     assert_eq!(scripts.setup_script.as_deref(), Some("db-setup"));
-    assert_eq!(scripts.run_script.as_deref(), Some("db-run"));
+    assert_eq!(
+        scripts.run_actions.first().map(|a| a.command.as_str()),
+        Some("db-run")
+    );
     assert_eq!(scripts.archive_script.as_deref(), Some("db-archive"));
     assert!(!scripts.setup_from_project);
     assert!(!scripts.run_from_project);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -322,7 +322,6 @@ pub fn run() {
             commands::repository_commands::load_repo_preferences,
             commands::repository_commands::update_repo_scripts,
             commands::repository_commands::update_repo_auto_run_setup,
-            commands::repository_commands::update_repo_run_script_mode,
             commands::repository_commands::update_repo_preferences,
             commands::repository_commands::delete_repository,
             commands::repository_commands::move_repository_in_sidebar,

--- a/src-tauri/src/models/repos.rs
+++ b/src-tauri/src/models/repos.rs
@@ -91,8 +91,6 @@ pub(crate) struct RepositoryRecord {
     pub default_branch: Option<String>,
     pub root_path: String,
     pub setup_script: Option<String>,
-    #[allow(dead_code)] // Queried separately via RepoScripts; kept here for completeness.
-    pub run_script: Option<String>,
     /// Auto-run the setup script when a workspace is created.
     /// Defaults to true; users disable it from repo settings.
     pub auto_run_setup: bool,
@@ -236,7 +234,7 @@ pub(crate) fn load_repository_by_id(repo_id: &str) -> Result<Option<RepositoryRe
     let mut statement = connection
         .prepare(
             r#"
-            SELECT id, name, remote, default_branch, root_path, setup_script, run_script, auto_run_setup, forge_provider, forge_login
+            SELECT id, name, remote, default_branch, root_path, setup_script, auto_run_setup, forge_provider, forge_login
             FROM repos
             WHERE id = ?1
             "#,
@@ -252,10 +250,9 @@ pub(crate) fn load_repository_by_id(repo_id: &str) -> Result<Option<RepositoryRe
                 default_branch: row.get(3)?,
                 root_path: row.get(4)?,
                 setup_script: row.get(5)?,
-                run_script: row.get(6)?,
-                auto_run_setup: row.get::<_, Option<i64>>(7)?.unwrap_or(1) != 0,
-                forge_provider: row.get(8)?,
-                forge_login: row.get(9)?,
+                auto_run_setup: row.get::<_, Option<i64>>(6)?.unwrap_or(1) != 0,
+                forge_provider: row.get(7)?,
+                forge_login: row.get(8)?,
             })
         })
         .with_context(|| format!("Failed to query repository {repo_id}"))?;
@@ -307,7 +304,7 @@ fn query_repository_by_root_path(
     let mut statement = connection
         .prepare(
             r#"
-            SELECT id, name, remote, default_branch, root_path, setup_script, run_script, auto_run_setup, forge_provider, forge_login
+            SELECT id, name, remote, default_branch, root_path, setup_script, auto_run_setup, forge_provider, forge_login
             FROM repos
             WHERE root_path = ?1
             ORDER BY created_at ASC
@@ -325,10 +322,9 @@ fn query_repository_by_root_path(
                 default_branch: row.get(3)?,
                 root_path: row.get(4)?,
                 setup_script: row.get(5)?,
-                run_script: row.get(6)?,
-                auto_run_setup: row.get::<_, Option<i64>>(7)?.unwrap_or(1) != 0,
-                forge_provider: row.get(8)?,
-                forge_login: row.get(9)?,
+                auto_run_setup: row.get::<_, Option<i64>>(6)?.unwrap_or(1) != 0,
+                forge_provider: row.get(7)?,
+                forge_login: row.get(8)?,
             })
         })
         .with_context(|| format!("Failed to query repository row for {root_path}"))?;
@@ -349,7 +345,7 @@ fn query_repository_candidates_by_name(
     let mut statement = connection
         .prepare(
             r#"
-            SELECT id, name, remote, default_branch, root_path, setup_script, run_script, auto_run_setup, forge_provider, forge_login
+            SELECT id, name, remote, default_branch, root_path, setup_script, auto_run_setup, forge_provider, forge_login
             FROM repos
             WHERE name = ?1 OR root_path LIKE ?2
             ORDER BY created_at ASC
@@ -368,10 +364,9 @@ fn query_repository_candidates_by_name(
                 default_branch: row.get(3)?,
                 root_path: row.get(4)?,
                 setup_script: row.get(5)?,
-                run_script: row.get(6)?,
-                auto_run_setup: row.get::<_, Option<i64>>(7)?.unwrap_or(1) != 0,
-                forge_provider: row.get(8)?,
-                forge_login: row.get(9)?,
+                auto_run_setup: row.get::<_, Option<i64>>(6)?.unwrap_or(1) != 0,
+                forge_provider: row.get(7)?,
+                forge_login: row.get(8)?,
             })
         })
         .with_context(|| format!("Failed to query repository candidates for {repository_name}"))?;
@@ -408,12 +403,11 @@ pub(crate) fn insert_repository(repository: &ResolvedRepositoryInput) -> Result<
               display_order,
               hidden,
               setup_script,
-              run_script,
               archive_script,
               forge_provider,
               created_at,
               updated_at
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 0, NULL, NULL, NULL, ?8, datetime('now'), datetime('now'))
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 0, NULL, NULL, ?8, datetime('now'), datetime('now'))
             "#,
             (
                 repo_id.as_str(),
@@ -833,10 +827,6 @@ pub struct RunAction {
 #[serde(rename_all = "camelCase")]
 pub struct RepoScripts {
     pub setup_script: Option<String>,
-    /// Convenience mirror of `run_actions[0].command` — kept for the few
-    /// existing call sites that only want "the run script" as a string.
-    /// New code should iterate `run_actions` instead.
-    pub run_script: Option<String>,
     pub archive_script: Option<String>,
     pub setup_from_project: bool,
     /// True when *any* run action came from `helmor.json` (the entire run
@@ -847,9 +837,6 @@ pub struct RepoScripts {
     /// Auto-run setup on workspace creation. DB-only — not configurable
     /// from `helmor.json`. Defaults to true.
     pub auto_run_setup: bool,
-    /// Convenience mirror of `run_actions[0].mode`. Kept for the few
-    /// existing call sites that read the legacy single-script mode.
-    pub run_script_mode: String,
     /// All run actions for this repo, in display order. May come from
     /// `helmor.json` (locked) or from the `repo_run_actions` table. The
     /// list is empty when neither source declares a run script.
@@ -876,9 +863,7 @@ pub struct RepoPreferences {
 ///      apply: no `workspace_id`, unknown workspace, or worktree missing
 ///      (archived / broken / pre-Phase-2 creation).
 ///   3. DB-level config (`repos.setup_script/archive_script` for
-///      setup+archive; the `repo_run_actions` table for run actions, with
-///      a legacy fallback to `repos.run_script` if the table is empty for
-///      this repo).
+///      setup+archive; the `repo_run_actions` table for run actions).
 ///
 /// The same rule applies regardless of caller (runtime panel, settings
 /// page, script execution, archive hook) — there is no special-case
@@ -905,27 +890,19 @@ pub fn load_repo_scripts(repo_id: &str, workspace_id: Option<&str>) -> Result<Re
             })
     });
 
-    // Priority 3: DB values — setup/archive use `pick_script` against the
-    // project config; run actions come from `repo_run_actions` (with a
-    // legacy fallback to `repos.run_script` for repos that predate the
-    // multi-action migration, and where the backfill SQL happened to miss
-    // them).
+    // Priority 3: DB values — setup/archive from `repos`; run actions
+    // from `repo_run_actions`.
     let connection = db::read_conn()?;
     let mut statement = connection
-        .prepare(
-            "SELECT setup_script, run_script, archive_script, auto_run_setup, run_script_mode FROM repos WHERE id = ?1",
-        )
+        .prepare("SELECT setup_script, archive_script, auto_run_setup FROM repos WHERE id = ?1")
         .with_context(|| format!("Failed to prepare script lookup for {repo_id}"))?;
 
-    let (db_setup, db_run, db_archive, auto_run_setup, db_run_mode) = statement
+    let (db_setup, db_archive, auto_run_setup) = statement
         .query_row([repo_id], |row| {
             Ok((
                 row.get::<_, Option<String>>(0)?,
                 row.get::<_, Option<String>>(1)?,
-                row.get::<_, Option<String>>(2)?,
-                row.get::<_, Option<i64>>(3)?.unwrap_or(1) != 0,
-                row.get::<_, Option<String>>(4)?
-                    .unwrap_or_else(|| "concurrent".to_string()),
+                row.get::<_, Option<i64>>(2)?.unwrap_or(1) != 0,
             ))
         })
         .with_context(|| format!("Repository not found: {repo_id}"))?;
@@ -960,47 +937,16 @@ pub fn load_repo_scripts(repo_id: &str, workspace_id: Option<&str>) -> Result<Re
             .with_context(|| format!("Failed to load run actions for {repo_id}"))?
             .collect::<rusqlite::Result<Vec<_>>>()
             .with_context(|| format!("Failed to read run-action rows for {repo_id}"))?;
-
-        if !db_actions.is_empty() {
-            (db_actions, false)
-        } else {
-            // Legacy fallback: a one-off virtual action synthesised from
-            // the old `repos.run_script` column. The settings UI promotes
-            // this into a real row on first edit (it has a stable
-            // `legacy:<repo_id>` id so an active-id reference survives).
-            let fallback: Vec<RunAction> = db_run
-                .as_deref()
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-                .map(|cmd| {
-                    vec![RunAction {
-                        id: format!("legacy:{repo_id}"),
-                        name: "Default".to_string(),
-                        command: cmd.to_string(),
-                        mode: db_run_mode.clone(),
-                        from_project: false,
-                    }]
-                })
-                .unwrap_or_default();
-            (fallback, false)
-        }
+        (db_actions, false)
     };
-
-    let run_script = run_actions.first().map(|a| a.command.clone());
-    let run_script_mode = run_actions
-        .first()
-        .map(|a| a.mode.clone())
-        .unwrap_or_else(|| db_run_mode.clone());
 
     Ok(RepoScripts {
         setup_script,
-        run_script,
         archive_script,
         setup_from_project,
         run_from_project,
         archive_from_project,
         auto_run_setup,
-        run_script_mode,
         run_actions,
     })
 }
@@ -1125,14 +1071,13 @@ fn parse_project_run_actions(value: Option<&Value>, repo_id: &str) -> Vec<RunAct
 pub fn update_repo_scripts(
     repo_id: &str,
     setup_script: Option<&str>,
-    run_script: Option<&str>,
     archive_script: Option<&str>,
 ) -> Result<()> {
     let connection = db::write_conn()?;
     let updated = connection
         .execute(
-            "UPDATE repos SET setup_script = ?1, run_script = ?2, archive_script = ?3, updated_at = datetime('now') WHERE id = ?4",
-            rusqlite::params![setup_script, run_script, archive_script, repo_id],
+            "UPDATE repos SET setup_script = ?1, archive_script = ?2, updated_at = datetime('now') WHERE id = ?3",
+            rusqlite::params![setup_script, archive_script, repo_id],
         )
         .with_context(|| format!("Failed to update scripts for {repo_id}"))?;
 
@@ -1153,28 +1098,6 @@ pub fn update_repo_auto_run_setup(repo_id: &str, enabled: bool) -> Result<()> {
             rusqlite::params![if enabled { 1 } else { 0 }, repo_id],
         )
         .with_context(|| format!("Failed to update auto_run_setup for {repo_id}"))?;
-
-    if updated != 1 {
-        bail!("Repository not found: {repo_id}");
-    }
-
-    Ok(())
-}
-
-/// Persist the per-repo run-script mode. Accepts "concurrent" or
-/// "non-concurrent"; anything else is rejected so the column never holds
-/// an unrecognized value.
-pub fn update_repo_run_script_mode(repo_id: &str, mode: &str) -> Result<()> {
-    if mode != "concurrent" && mode != "non-concurrent" {
-        bail!("Invalid run_script_mode: {mode}");
-    }
-    let connection = db::write_conn()?;
-    let updated = connection
-        .execute(
-            "UPDATE repos SET run_script_mode = ?1, updated_at = datetime('now') WHERE id = ?2",
-            rusqlite::params![mode, repo_id],
-        )
-        .with_context(|| format!("Failed to update run_script_mode for {repo_id}"))?;
 
     if updated != 1 {
         bail!("Repository not found: {repo_id}");
@@ -1907,7 +1830,6 @@ mod tests {
         // Fresh repo has no actions.
         let initial = load_repo_scripts(&repo_id, None).unwrap();
         assert!(initial.run_actions.is_empty());
-        assert!(initial.run_script.is_none());
 
         // Create -> visible + ordered by insertion.
         let dev = create_repo_run_action(&repo_id, "Dev", "npm run dev", "concurrent").unwrap();
@@ -1918,8 +1840,8 @@ mod tests {
         assert_eq!(loaded.run_actions.len(), 2);
         assert_eq!(loaded.run_actions[0].name, "Dev");
         assert_eq!(loaded.run_actions[1].name, "Tests");
-        assert_eq!(loaded.run_script.as_deref(), Some("npm run dev"));
-        assert_eq!(loaded.run_script_mode, "concurrent");
+        assert_eq!(loaded.run_actions[0].command, "npm run dev");
+        assert_eq!(loaded.run_actions[0].mode, "concurrent");
         assert!(!loaded.run_from_project);
 
         // Update one of them.
@@ -1947,35 +1869,6 @@ mod tests {
             create_repo_run_action(&repo_id, "Bad", "echo", "wat").is_err(),
             "mode validation should reject unknown values"
         );
-    }
-
-    #[test]
-    fn legacy_run_script_falls_through_when_actions_table_empty() {
-        let env = crate::testkit::TestEnv::new("repos-legacy-run-fallback");
-        let repo_id = insert_test_repo(&env, "legacy");
-
-        // Simulate a pre-migration row: write the old columns directly
-        // (bypassing the migration backfill — which only runs at schema
-        // init, not on every insert). This is the exact shape we want the
-        // loader to gracefully fall back from.
-        let conn = db::write_conn().unwrap();
-        conn.execute(
-            "UPDATE repos SET run_script = ?1, run_script_mode = ?2 WHERE id = ?3",
-            rusqlite::params!["npm start", "non-concurrent", &repo_id],
-        )
-        .unwrap();
-        drop(conn);
-
-        let scripts = load_repo_scripts(&repo_id, None).unwrap();
-        assert_eq!(scripts.run_actions.len(), 1);
-        let action = &scripts.run_actions[0];
-        assert_eq!(action.id, format!("legacy:{repo_id}"));
-        assert_eq!(action.name, "Default");
-        assert_eq!(action.command, "npm start");
-        assert_eq!(action.mode, "non-concurrent");
-        assert!(!action.from_project);
-        assert_eq!(scripts.run_script.as_deref(), Some("npm start"));
-        assert_eq!(scripts.run_script_mode, "non-concurrent");
     }
 
     #[test]

--- a/src-tauri/src/schema.rs
+++ b/src-tauri/src/schema.rs
@@ -48,11 +48,16 @@ const DEAD_COLUMNS: &[(&str, &str)] = &[
     ("repos", "conductor_config"),
     ("repos", "custom_prompt_code_review"),
     ("repos", "icon"),
-    // `branch_prefix_type` and `run_script_mode` were once stubs here.
-    // Both have since been revived as real per-repo columns (multi-account
-    // refactor and non-concurrent run mode respectively) — keep them OUT
-    // of this list so they survive startup.
+    // `branch_prefix_type` was once a stub here. It has since been
+    // revived as a real per-repo column (multi-account refactor) — keep
+    // it OUT of this list so it survives startup.
     ("repos", "storage_version"),
+    // Retired with the multi run-action migration. Each repo now stores
+    // its run scripts as rows in `repo_run_actions`; the legacy single
+    // `run_script` + `run_script_mode` columns are backfilled in
+    // `run_migrations` and then dropped here.
+    ("repos", "run_script"),
+    ("repos", "run_script_mode"),
     // workspaces: legacy fields with no read path in production.
     ("workspaces", "big_terminal_mode"),
     ("workspaces", "initialization_files_copied"),
@@ -460,17 +465,6 @@ fn run_migrations(connection: &Connection) -> Result<()> {
             .context("Failed to add branch_prefix_type column")?;
     }
 
-    // Migration: per-repo run-script mode. 'concurrent' (default) preserves
-    // the historical behavior of allowing multiple workspaces in the same
-    // repo to run their scripts at once. 'non-concurrent' makes a new run
-    // stop any other run script in the same repo first — convenient when
-    // the script binds a fixed port.
-    if has_table(connection, "repos") && !has_column(connection, "repos", "run_script_mode") {
-        connection
-            .execute_batch("ALTER TABLE repos ADD COLUMN run_script_mode TEXT DEFAULT 'concurrent'")
-            .context("Failed to add run_script_mode column")?;
-    }
-
     if has_table(connection, "workspaces") && !has_column(connection, "workspaces", "pr_sync_state")
     {
         connection
@@ -554,6 +548,96 @@ fn run_migrations(connection: &Connection) -> Result<()> {
             .context("Failed to normalize workspace status values")?;
     }
 
+    // Multi run-action support: each repo gets a list of named run scripts
+    // instead of a single `run_script`. The migration must run BEFORE
+    // `drop_dead_schema` so the backfill can still read the legacy
+    // `repos.run_script` / `run_script_mode` columns — `drop_dead_schema`
+    // is what actually retires them (see `DEAD_COLUMNS`).
+    if has_table(connection, "workspaces")
+        && !has_column(connection, "workspaces", "active_run_action_id")
+    {
+        connection
+            .execute_batch("ALTER TABLE workspaces ADD COLUMN active_run_action_id TEXT")
+            .context("Failed to add workspaces.active_run_action_id column")?;
+    }
+
+    connection
+        .execute_batch(
+            r#"
+            CREATE TABLE IF NOT EXISTS repo_run_actions (
+                id TEXT PRIMARY KEY,
+                repo_id TEXT NOT NULL,
+                name TEXT NOT NULL,
+                command TEXT NOT NULL,
+                mode TEXT NOT NULL DEFAULT 'concurrent',
+                display_order INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+                FOREIGN KEY (repo_id) REFERENCES repos(id) ON DELETE CASCADE
+            );
+            CREATE INDEX IF NOT EXISTS idx_repo_run_actions_repo
+                ON repo_run_actions(repo_id, display_order);
+            CREATE TRIGGER IF NOT EXISTS update_repo_run_actions_updated_at
+                AFTER UPDATE ON repo_run_actions
+                BEGIN
+                    UPDATE repo_run_actions SET updated_at = datetime('now')
+                    WHERE id = NEW.id;
+                END;
+            "#,
+        )
+        .context("Failed to create repo_run_actions table")?;
+
+    // Backfill: every repo that has a non-empty `run_script` but no row in
+    // `repo_run_actions` yet gets a single migrated action carrying the old
+    // command + mode. Deterministic id (`legacy:<repo_id>`) keeps the
+    // migration idempotent across restarts and stable for any active-id
+    // references we later add. After this block both legacy columns are
+    // listed in `DEAD_COLUMNS` and get dropped by `drop_dead_schema` below.
+    if has_table(connection, "repos")
+        && has_table(connection, "repo_run_actions")
+        && has_column(connection, "repos", "run_script")
+    {
+        let has_mode = has_column(connection, "repos", "run_script_mode");
+        let mode_expr = if has_mode {
+            "COALESCE(NULLIF(run_script_mode, ''), 'concurrent')"
+        } else {
+            "'concurrent'"
+        };
+        connection
+            .execute_batch(&format!(
+                r#"
+                INSERT INTO repo_run_actions (id, repo_id, name, command, mode, display_order)
+                SELECT
+                    'legacy:' || id,
+                    id,
+                    'Default',
+                    run_script,
+                    {mode_expr},
+                    0
+                FROM repos
+                WHERE run_script IS NOT NULL
+                  AND TRIM(run_script) != ''
+                  AND NOT EXISTS (
+                    SELECT 1 FROM repo_run_actions WHERE repo_run_actions.repo_id = repos.id
+                  );
+                "#
+            ))
+            .context("Failed to backfill repo_run_actions from repos.run_script")?;
+
+        // One-shot rename for installs that backfilled with the earlier
+        // label ("Run"). Targeted by id pattern + exact-match name so it
+        // never touches a row the user manually renamed.
+        connection
+            .execute_batch(
+                r#"
+                UPDATE repo_run_actions
+                SET name = 'Default'
+                WHERE id LIKE 'legacy:%' AND name = 'Run';
+                "#,
+            )
+            .context("Failed to rename legacy run actions to 'Default'")?;
+    }
+
     drop_dead_schema(connection)?;
 
     // Migration: remap legacy "opus-1m" model ID — the CLI no longer accepts it.
@@ -628,102 +712,6 @@ fn run_migrations(connection: &Connection) -> Result<()> {
                 "ALTER TABLE workspaces ADD COLUMN branch_intent TEXT DEFAULT 'from_branch'",
             )
             .context("Failed to add workspaces.branch_intent column")?;
-    }
-
-    // Multi run-action support: each repo gets a list of named run scripts
-    // instead of a single `run_script`. Old `repos.run_script` /
-    // `run_script_mode` columns stay populated as a fallback / rollback
-    // safety net — see backfill below. `workspaces.active_run_action_id`
-    // remembers which action the user last switched to in that workspace
-    // (NULL = use the first action).
-    if has_table(connection, "workspaces")
-        && !has_column(connection, "workspaces", "active_run_action_id")
-    {
-        connection
-            .execute_batch("ALTER TABLE workspaces ADD COLUMN active_run_action_id TEXT")
-            .context("Failed to add workspaces.active_run_action_id column")?;
-    }
-
-    connection
-        .execute_batch(
-            r#"
-            CREATE TABLE IF NOT EXISTS repo_run_actions (
-                id TEXT PRIMARY KEY,
-                repo_id TEXT NOT NULL,
-                name TEXT NOT NULL,
-                command TEXT NOT NULL,
-                mode TEXT NOT NULL DEFAULT 'concurrent',
-                display_order INTEGER NOT NULL DEFAULT 0,
-                created_at TEXT NOT NULL DEFAULT (datetime('now')),
-                updated_at TEXT NOT NULL DEFAULT (datetime('now')),
-                FOREIGN KEY (repo_id) REFERENCES repos(id) ON DELETE CASCADE
-            );
-            CREATE INDEX IF NOT EXISTS idx_repo_run_actions_repo
-                ON repo_run_actions(repo_id, display_order);
-            CREATE TRIGGER IF NOT EXISTS update_repo_run_actions_updated_at
-                AFTER UPDATE ON repo_run_actions
-                BEGIN
-                    UPDATE repo_run_actions SET updated_at = datetime('now')
-                    WHERE id = NEW.id;
-                END;
-            "#,
-        )
-        .context("Failed to create repo_run_actions table")?;
-
-    // Backfill: every repo that has a non-empty `run_script` but no row in
-    // `repo_run_actions` yet gets a single migrated action carrying the old
-    // command + mode. Deterministic id (`legacy:<repo_id>`) keeps the
-    // migration idempotent across restarts and stable for any active-id
-    // references we later add. The `repos.run_script` column intentionally
-    // stays populated — kept as a fallback / rollback safety net for at
-    // least two release cycles.
-    //
-    // Guarded on `has_column("repos", "run_script")` because the
-    // migration-test bench seeds legacy schemas that predate the column;
-    // production rows always have it (CREATE TABLE in SCHEMA_SQL ships it).
-    if has_table(connection, "repos")
-        && has_table(connection, "repo_run_actions")
-        && has_column(connection, "repos", "run_script")
-    {
-        let has_mode = has_column(connection, "repos", "run_script_mode");
-        let mode_expr = if has_mode {
-            "COALESCE(NULLIF(run_script_mode, ''), 'concurrent')"
-        } else {
-            "'concurrent'"
-        };
-        connection
-            .execute_batch(&format!(
-                r#"
-                INSERT INTO repo_run_actions (id, repo_id, name, command, mode, display_order)
-                SELECT
-                    'legacy:' || id,
-                    id,
-                    'Default',
-                    run_script,
-                    {mode_expr},
-                    0
-                FROM repos
-                WHERE run_script IS NOT NULL
-                  AND TRIM(run_script) != ''
-                  AND NOT EXISTS (
-                    SELECT 1 FROM repo_run_actions WHERE repo_run_actions.repo_id = repos.id
-                  );
-                "#
-            ))
-            .context("Failed to backfill repo_run_actions from repos.run_script")?;
-
-        // One-shot rename for installs that backfilled with the earlier
-        // label ("Run"). Targeted by id pattern + exact-match name so it
-        // never touches a row the user manually renamed.
-        connection
-            .execute_batch(
-                r#"
-                UPDATE repo_run_actions
-                SET name = 'Default'
-                WHERE id LIKE 'legacy:%' AND name = 'Run';
-                "#,
-            )
-            .context("Failed to rename legacy run actions to 'Default'")?;
     }
 
     materialize_review_pr_model_defaults(connection)?;
@@ -840,7 +828,6 @@ CREATE TABLE IF NOT EXISTS repos (
     setup_script TEXT,
     archive_script TEXT,
     display_order INTEGER DEFAULT 0,
-    run_script TEXT,
     remote TEXT,
     custom_prompt_create_pr TEXT,
     custom_prompt_review TEXT,
@@ -854,7 +841,6 @@ CREATE TABLE IF NOT EXISTS repos (
     forge_login TEXT,
     branch_prefix_type TEXT,
     branch_prefix_custom TEXT,
-    run_script_mode TEXT DEFAULT 'concurrent',
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
@@ -1348,6 +1334,7 @@ mod tests {
                     root_path TEXT,
                     created_at TEXT DEFAULT (datetime('now')),
                     storage_version INTEGER DEFAULT 1,
+                    run_script TEXT,
                     run_script_mode TEXT DEFAULT 'concurrent',
                     custom_prompt_code_review TEXT,
                     conductor_config TEXT,
@@ -1623,35 +1610,44 @@ mod tests {
     }
 
     #[test]
-    fn run_script_mode_present_on_fresh_install() {
+    fn legacy_run_script_columns_are_dropped_on_fresh_install() {
+        // New installs never carry the retired columns. SCHEMA_SQL omits
+        // them and `drop_dead_schema` would clean them up anyway.
         let (connection, _dir) = open_test_db();
         ensure_schema(&connection).unwrap();
-        assert!(column_exists(&connection, "repos", "run_script_mode"));
+        assert!(!column_exists(&connection, "repos", "run_script"));
+        assert!(!column_exists(&connection, "repos", "run_script_mode"));
     }
 
     #[test]
-    fn run_script_mode_retained_from_legacy_schema() {
-        // Conductor DBs already carry this column. Migration must keep it
-        // (and any persisted value) rather than dropping it.
+    fn legacy_run_script_columns_backfill_into_repo_run_actions_then_drop() {
+        // Legacy DBs carry `run_script` + `run_script_mode`. Migration
+        // must move their values into `repo_run_actions` before
+        // `drop_dead_schema` retires the columns.
         let (connection, _dir) = open_test_db();
         create_legacy_schema(&connection);
         connection
             .execute(
-                "INSERT INTO repos (id, name, run_script_mode) VALUES ('r1', 'x', 'non-concurrent')",
+                "INSERT INTO repos (id, name, run_script, run_script_mode) VALUES ('r1', 'x', 'npm dev', 'non-concurrent')",
                 [],
             )
             .unwrap();
 
         run_migrations(&connection).unwrap();
-        assert!(column_exists(&connection, "repos", "run_script_mode"));
 
-        let mode: String = connection
+        assert!(!column_exists(&connection, "repos", "run_script"));
+        assert!(!column_exists(&connection, "repos", "run_script_mode"));
+
+        let (id, name, command, mode): (String, String, String, String) = connection
             .query_row(
-                "SELECT run_script_mode FROM repos WHERE id = 'r1'",
+                "SELECT id, name, command, mode FROM repo_run_actions WHERE repo_id = 'r1'",
                 [],
-                |r| r.get(0),
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
             )
             .unwrap();
+        assert_eq!(id, "legacy:r1");
+        assert_eq!(name, "Default");
+        assert_eq!(command, "npm dev");
         assert_eq!(mode, "non-concurrent");
     }
 

--- a/src-tauri/src/workspace/lifecycle.rs
+++ b/src-tauri/src/workspace/lifecycle.rs
@@ -237,13 +237,11 @@ pub fn prepare_workspace_from_repo_impl(
             tracing::warn!(%error, "Failed to load repo scripts during prepare; defaulting to empty");
             repos::RepoScripts {
                 setup_script: None,
-                run_script: None,
                 archive_script: None,
                 setup_from_project: false,
                 run_from_project: false,
                 archive_from_project: false,
                 auto_run_setup: true,
-                run_script_mode: "concurrent".to_string(),
                 run_actions: Vec::new(),
             }
         }
@@ -389,13 +387,11 @@ pub fn prepare_local_workspace_impl(
         repos::load_repo_scripts(repo_id, Some(&workspace_id)).unwrap_or_else(|_| {
             repos::RepoScripts {
                 setup_script: None,
-                run_script: None,
                 archive_script: None,
                 setup_from_project: false,
                 run_from_project: false,
                 archive_from_project: false,
                 auto_run_setup: false,
-                run_script_mode: "concurrent".to_string(),
                 run_actions: Vec::new(),
             }
         });
@@ -491,13 +487,11 @@ pub fn prepare_chat_workspace_impl(
         // No setup/run scripts for chat mode — return the empty shape.
         repo_scripts: repos::RepoScripts {
             setup_script: None,
-            run_script: None,
             archive_script: None,
             setup_from_project: false,
             run_from_project: false,
             archive_from_project: false,
             auto_run_setup: false,
-            run_script_mode: "concurrent".to_string(),
             run_actions: Vec::new(),
         },
         working_directory: Some(working_directory.display().to_string()),

--- a/src/App.create.test.tsx
+++ b/src/App.create.test.tsx
@@ -124,7 +124,7 @@ describe("App create workspace flow", () => {
 		apiMocks.loadRepoScripts.mockReset();
 		apiMocks.loadRepoScripts.mockResolvedValue({
 			setupScript: null,
-			runScript: null,
+			runActions: [],
 			archiveScript: null,
 			setupFromProject: false,
 			runFromProject: false,
@@ -306,7 +306,7 @@ describe("App create workspace flow", () => {
 				state: "initializing",
 				repoScripts: {
 					setupScript: null,
-					runScript: null,
+					runActions: [],
 					archiveScript: null,
 					setupFromProject: false,
 					runFromProject: false,

--- a/src/App.shortcuts.test.tsx
+++ b/src/App.shortcuts.test.tsx
@@ -320,12 +320,12 @@ const UNAVAILABLE_FORGE_ACTION_STATUS = {
 
 const EMPTY_REPO_SCRIPTS = {
 	setupScript: null,
-	runScript: null,
 	archiveScript: null,
 	setupFromProject: false,
 	runFromProject: false,
 	archiveFromProject: false,
 	autoRunSetup: true,
+	runActions: [],
 };
 
 function getSessionTab(title: string) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -670,24 +670,54 @@ function AppShell({
 		...workspaceDetailQueryOptions(selectedWorkspaceId ?? "__none__"),
 		enabled: selectedWorkspaceId !== null,
 	});
-	// Zero-arg: prop is bound directly to button onClick, so an arg would
-	// receive the click event. Use a separate helper if section-aware open
-	// is ever needed.
-	const handleOpenSettings = useCallback((): void => {
-		onOpenSettings(
+	// Optional `initialSection` lets callers jump straight to a panel
+	// (e.g. inspector's "Add run script" → the current repo's Scripts
+	// editor). Bound directly to button onClick is still safe — React
+	// passes the click event as the first arg, which doesn't match the
+	// `SettingsSection` shape, so we coerce non-string args back to
+	// `undefined` to preserve the original zero-arg behavior.
+	const handleOpenSettings = useCallback(
+		(initialSection?: SettingsSection): void => {
+			const section =
+				typeof initialSection === "string" ? initialSection : undefined;
+			onOpenSettings(
+				selectedWorkspaceId,
+				selectedWorkspaceDetailQuery.data?.repoId ?? null,
+				section,
+			);
+		},
+		[
+			onOpenSettings,
+			selectedWorkspaceDetailQuery.data?.repoId,
 			selectedWorkspaceId,
-			selectedWorkspaceDetailQuery.data?.repoId ?? null,
-		);
-	}, [
-		onOpenSettings,
-		selectedWorkspaceDetailQuery.data?.repoId,
-		selectedWorkspaceId,
-	]);
+		],
+	);
 	const handleOpenAnnouncementSettings = useCallback(
 		(initialSection?: SettingsSection): void => {
+			// Sentinel: announcements written before a workspace is
+			// selected can ask for "the current repo's Scripts section"
+			// without knowing the repo id at authoring time. We resolve
+			// it here and replay the same open-then-scroll dance the
+			// inspector empty states use.
+			if (initialSection === ("repo:current" as SettingsSection)) {
+				const currentRepoId = selectedWorkspaceDetailQuery.data?.repoId;
+				if (currentRepoId) {
+					onOpenSettings(null, null, `repo:${currentRepoId}`);
+					requestAnimationFrame(() => {
+						window.dispatchEvent(
+							new CustomEvent("helmor:scroll-to-repo-scripts"),
+						);
+					});
+					return;
+				}
+				// No active repo (chat-only workspace, or none selected) —
+				// fall back to plain settings rather than a broken link.
+				onOpenSettings(null, null);
+				return;
+			}
 			onOpenSettings(null, null, initialSection);
 		},
-		[onOpenSettings],
+		[onOpenSettings, selectedWorkspaceDetailQuery.data?.repoId],
 	);
 	const handleOpenReleaseChangelog = useCallback(() => {
 		void openUrl(GITHUB_RELEASES_URL).catch((error) => {

--- a/src/App.unread-reclick.test.tsx
+++ b/src/App.unread-reclick.test.tsx
@@ -96,7 +96,7 @@ describe("App unread — re-click selected workspace clears dot", () => {
 		apiMocks.getClaudeRateLimits.mockResolvedValue(null);
 		apiMocks.loadRepoScripts.mockResolvedValue({
 			setupScript: null,
-			runScript: null,
+			runActions: [],
 			archiveScript: null,
 			setupFromProject: false,
 			runFromProject: false,
@@ -218,7 +218,7 @@ describe("App unread — re-click selected workspace clears dot", () => {
 				state: "initializing",
 				repoScripts: {
 					setupScript: null,
-					runScript: null,
+					runActions: [],
 					archiveScript: null,
 					setupFromProject: false,
 					runFromProject: false,

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -2,9 +2,15 @@ import type * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+function Input({
+	className,
+	type,
+	ref,
+	...props
+}: React.ComponentProps<"input">) {
 	return (
 		<input
+			ref={ref}
 			type={type}
 			data-slot="input"
 			className={cn(

--- a/src/features/inspector/index.tsx
+++ b/src/features/inspector/index.tsx
@@ -204,12 +204,29 @@ export function WorkspaceInspectorSidebar({
 		[workspaceId, setActiveTab, queryClient],
 	);
 
+	// "Open Scripts" — the right target for every empty-state CTA in the
+	// inspector ("Add setup script" / "Add run script" / Create-action
+	// fallback). Opens the current repo's settings panel and then fires
+	// the scroll anchor inside `RepositorySettingsPanel` so the Scripts
+	// section is visible immediately. We wait one frame so the panel has
+	// mounted before dispatching the scroll event.
+	const handleOpenRepoScripts = useCallback(() => {
+		if (repoId) {
+			onOpenSettings?.(`repo:${repoId}`);
+		} else {
+			onOpenSettings?.();
+		}
+		requestAnimationFrame(() => {
+			window.dispatchEvent(new CustomEvent("helmor:scroll-to-repo-scripts"));
+		});
+	}, [onOpenSettings, repoId]);
+
 	const handleCreateRunAction = useCallback(() => {
 		// Without a workspace context we can't open a fresh chat session;
-		// fall back to the global settings dialog so the user at least
-		// has somewhere to go.
+		// fall back to the Scripts editor in the current repo's settings
+		// panel so the user has somewhere actionable to go.
 		if (!workspaceId) {
-			onOpenSettings?.();
+			handleOpenRepoScripts();
 			return;
 		}
 		// Open a fresh session in this workspace with the composer
@@ -225,7 +242,7 @@ export function WorkspaceInspectorSidebar({
 				},
 			}),
 		);
-	}, [onOpenSettings, workspaceId]);
+	}, [handleOpenRepoScripts, workspaceId]);
 
 	// Fire setup auto-run / auto-complete at the sidebar level so it runs even
 	// when the Setup tab isn't mounted (tabsOpen=false).
@@ -490,8 +507,6 @@ export function WorkspaceInspectorSidebar({
 				scriptTabState === "success" ||
 				scriptTabState === "failure");
 
-	const handleOpenSettings = onOpenSettings ?? (() => {});
-
 	return (
 		<div
 			ref={containerRef}
@@ -556,6 +571,7 @@ export function WorkspaceInspectorSidebar({
 				tabActions={runTabActions}
 				setupScriptState={setupScriptState}
 				runScriptState={runScriptState}
+				workspaceId={workspaceId ?? null}
 				runActions={runActions}
 				activeRunActionId={activeRunActionId}
 				onSelectRunAction={handleSelectRunAction}
@@ -573,7 +589,7 @@ export function WorkspaceInspectorSidebar({
 					setupScript={repoScripts?.setupScript ?? null}
 					setupCompletedAt={workspaceSetupCompletedAt ?? null}
 					isActive={activeTab === "setup"}
-					onOpenSettings={handleOpenSettings}
+					onOpenSettings={handleOpenRepoScripts}
 				/>
 				<RunTab
 					repoId={repoId ?? null}
@@ -583,7 +599,7 @@ export function WorkspaceInspectorSidebar({
 					runScript={activeAction?.command ?? null}
 					hasAnyRunAction={runActions.length > 0}
 					isActive={activeTab === "run"}
-					onOpenSettings={handleOpenSettings}
+					onOpenSettings={handleOpenRepoScripts}
 					onStatusChange={setRunStatus}
 					onUrlsChange={setRunUrls}
 				/>

--- a/src/features/inspector/layout.test.tsx
+++ b/src/features/inspector/layout.test.tsx
@@ -27,6 +27,7 @@ describe("InspectorTabsSection", () => {
 				onTabChange={vi.fn()}
 				setupScriptState="idle"
 				runScriptState="running"
+				workspaceId={null}
 				runActions={[]}
 				activeRunActionId={null}
 				onSelectRunAction={vi.fn()}
@@ -77,6 +78,7 @@ describe("InspectorTabsSection", () => {
 				onTabChange={vi.fn()}
 				setupScriptState="idle"
 				runScriptState="running"
+				workspaceId={null}
 				runActions={[]}
 				activeRunActionId={null}
 				onSelectRunAction={vi.fn()}
@@ -115,6 +117,7 @@ describe("InspectorTabsSection", () => {
 				onTabChange={vi.fn()}
 				setupScriptState="idle"
 				runScriptState="running"
+				workspaceId={null}
 				runActions={[]}
 				activeRunActionId={null}
 				onSelectRunAction={vi.fn()}
@@ -153,6 +156,7 @@ describe("InspectorTabsSection", () => {
 				onTabChange={vi.fn()}
 				setupScriptState="idle"
 				runScriptState="idle"
+				workspaceId={null}
 				runActions={[
 					{
 						id: "a1",
@@ -215,6 +219,7 @@ describe("InspectorTabsSection", () => {
 				onTabChange={vi.fn()}
 				setupScriptState="idle"
 				runScriptState="idle"
+				workspaceId={null}
 				runActions={[
 					{
 						id: "a1",

--- a/src/features/inspector/layout.tsx
+++ b/src/features/inspector/layout.tsx
@@ -29,6 +29,7 @@ import type { RunAction } from "@/lib/api";
 import { useSettings } from "@/lib/settings";
 import { cn } from "@/lib/utils";
 import type { ScriptIconState } from "./hooks/use-script-status";
+import { useScriptStatus } from "./hooks/use-script-status";
 import { useHoverZoom } from "./layout/use-hover-zoom";
 import { ScriptStatusIcon } from "./script-status-icon";
 import {
@@ -205,6 +206,11 @@ type InspectorTabsSectionProps = {
 	tabActions?: React.ReactNode;
 	setupScriptState: ScriptIconState;
 	runScriptState: ScriptIconState;
+	/** Current workspace id — needed so each Run-tab dropdown item can
+	 * subscribe to its own action's live status (per-action loading /
+	 * success / failure glyph). `null` outside a workspace context — the
+	 * dropdown then renders each item without a status icon. */
+	workspaceId: string | null;
 	/**
 	 * All run actions configured for the current repo (DB + helmor.json
 	 * merged). Empty when none configured — the Run-tab dropdown still
@@ -252,6 +258,7 @@ export function InspectorTabsSection({
 	tabActions,
 	setupScriptState,
 	runScriptState,
+	workspaceId,
 	runActions,
 	activeRunActionId,
 	onSelectRunAction,
@@ -464,6 +471,7 @@ export function InspectorTabsSection({
 									</button>
 									<RunActionsDropdown
 										activeTab={activeTab}
+										workspaceId={workspaceId}
 										runActions={runActions}
 										activeRunActionId={activeRunActionId}
 										onSelectRunAction={onSelectRunAction}
@@ -719,12 +727,14 @@ export function HorizontalResizeHandle({
  */
 function RunActionsDropdown({
 	activeTab,
+	workspaceId,
 	runActions,
 	activeRunActionId,
 	onSelectRunAction,
 	onCreateRunAction,
 }: {
 	activeTab: string;
+	workspaceId: string | null;
 	runActions: RunAction[];
 	activeRunActionId: string | null;
 	onSelectRunAction: (id: string) => void;
@@ -777,13 +787,11 @@ function RunActionsDropdown({
 							onValueChange={onSelectRunAction}
 						>
 							{runActions.map((action) => (
-								<DropdownMenuRadioItem
+								<RunActionDropdownItem
 									key={action.id}
-									value={action.id}
-									className="flex items-center gap-2"
-								>
-									<span className="truncate">{action.name}</span>
-								</DropdownMenuRadioItem>
+									action={action}
+									workspaceId={workspaceId}
+								/>
 							))}
 						</DropdownMenuRadioGroup>
 						<DropdownMenuSeparator />
@@ -801,5 +809,38 @@ function RunActionsDropdown({
 				</DropdownMenuItem>
 			</DropdownMenuContent>
 		</DropdownMenu>
+	);
+}
+
+/**
+ * Single radio item in the Run dropdown. Pulled out so each row can own
+ * its own `useScriptStatus` subscription — that's how the per-action
+ * loading / success / failure glyph stays live without the parent
+ * re-rendering the whole list on every status tick.
+ *
+ * `aria-hidden` on the icon keeps the radio item's accessible name as
+ * just the action's display name (matching the header tab convention).
+ */
+function RunActionDropdownItem({
+	action,
+	workspaceId,
+}: {
+	action: RunAction;
+	workspaceId: string | null;
+}) {
+	const state = useScriptStatus(
+		workspaceId,
+		"run",
+		action.command.trim().length > 0,
+		action.id,
+	);
+	return (
+		<DropdownMenuRadioItem
+			value={action.id}
+			className="flex items-center gap-2"
+		>
+			<ScriptStatusIcon state={state} />
+			<span className="truncate">{action.name}</span>
+		</DropdownMenuRadioItem>
 	);
 }

--- a/src/features/navigation/hooks/use-controller.test.tsx
+++ b/src/features/navigation/hooks/use-controller.test.tsx
@@ -446,7 +446,7 @@ describe("useWorkspacesSidebarController archive flow", () => {
 			state: "initializing" as const,
 			repoScripts: {
 				setupScript: null,
-				runScript: null,
+				runActions: [],
 				archiveScript: null,
 				setupFromProject: false,
 				runFromProject: false,
@@ -546,7 +546,7 @@ describe("useWorkspacesSidebarController archive flow", () => {
 			state: "initializing" as const,
 			repoScripts: {
 				setupScript: null,
-				runScript: null,
+				runActions: [],
 				archiveScript: null,
 				setupFromProject: false,
 				runFromProject: false,
@@ -722,7 +722,7 @@ describe("useWorkspacesSidebarController archive flow", () => {
 			state: "initializing" as const,
 			repoScripts: {
 				setupScript: null,
-				runScript: null,
+				runActions: [],
 				archiveScript: null,
 				setupFromProject: false,
 				runFromProject: false,
@@ -833,7 +833,7 @@ describe("useWorkspacesSidebarController archive flow", () => {
 			state: "initializing" as const,
 			repoScripts: {
 				setupScript: null,
-				runScript: null,
+				runActions: [],
 				archiveScript: null,
 				setupFromProject: false,
 				runFromProject: false,

--- a/src/features/panel/container.test.tsx
+++ b/src/features/panel/container.test.tsx
@@ -247,12 +247,20 @@ describe("WorkspacePanelContainer loading semantics", () => {
 		});
 		apiMocks.loadRepoScripts.mockResolvedValue({
 			setupScript: "bun install",
-			runScript: "bun run dev",
 			archiveScript: "true",
 			setupFromProject: false,
 			runFromProject: false,
 			archiveFromProject: false,
 			autoRunSetup: true,
+			runActions: [
+				{
+					id: "run:default",
+					name: "Default",
+					command: "bun run dev",
+					mode: "concurrent",
+					fromProject: false,
+				},
+			],
 		});
 		apiMocks.loadWorkspaceDetail.mockImplementation((workspaceId?: string) =>
 			Promise.resolve(createWorkspaceDetail(workspaceId)),

--- a/src/features/panel/container.tsx
+++ b/src/features/panel/container.tsx
@@ -557,7 +557,7 @@ export const WorkspacePanelContainer = memo(function WorkspacePanelContainer({
 		if (!scripts.setupScript?.trim()) {
 			missing.push("setup");
 		}
-		if (!scripts.runScript?.trim()) {
+		if (!scripts.runActions.some((a) => a.command.trim())) {
 			missing.push("run");
 		}
 		if (!scripts.archiveScript?.trim()) {

--- a/src/features/settings/panels/repository-settings.test.tsx
+++ b/src/features/settings/panels/repository-settings.test.tsx
@@ -79,7 +79,7 @@ describe("RepositorySettingsPanel branch prefix", () => {
 		});
 		apiMocks.loadRepoScripts.mockResolvedValue({
 			setupScript: null,
-			runScript: null,
+			runActions: [],
 			archiveScript: null,
 			setupFromProject: false,
 			runFromProject: false,

--- a/src/features/settings/panels/repository-settings/scripts-section.tsx
+++ b/src/features/settings/panels/repository-settings/scripts-section.tsx
@@ -1,14 +1,16 @@
-// Repo-level scripts section (setup / run-actions / archive). Setup and
-// archive remain single-script slots and stay editable here. The Run
-// section is **display-only**: rows list each action's name + command
-// (read-only, scrollable textarea), no rename / delete / mode toggle.
-// Users create new actions from the Inspector's Run dropdown ("Create"
-// pops a pre-filled new session); existing ones get edited by chatting
-// the agent or hand-editing helmor.json.
+// Repo-level scripts section (setup / run-scripts / archive). All three
+// follow the same `ScriptField` rhythm: a left-aligned label + tooltip
+// description above the editor, with optional right-side controls in the
+// header slot. The Run section is a list of editable rows (DB-owned) or
+// read-only rows mirroring helmor.json. The "Add script" button lives in
+// the section header's right slot so the list itself stays a clean
+// vertical stack of name+command pairs aligned with setup/archive.
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { HelpCircle, Plus } from "lucide-react";
+import { HelpCircle, Plus, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import {
@@ -19,9 +21,12 @@ import {
 } from "@/components/ui/tooltip";
 import {
 	createRepoRunAction,
+	deleteRepoRunAction,
 	loadRepoScripts,
 	type RunAction,
+	type RunScriptMode,
 	updateRepoAutoRunSetup,
+	updateRepoRunAction,
 	updateRepoScripts,
 } from "@/lib/api";
 
@@ -49,6 +54,11 @@ export function ScriptsSection({
 	const [archiveScript, setArchiveScript] = useState("");
 	const [autoRunSetup, setAutoRunSetup] = useState(false);
 	const initialized = useRef(false);
+
+	// Id of the row that should grab focus on mount. Cleared after focus
+	// fires so subsequent re-renders (e.g. query refetch) don't keep
+	// stealing the user's caret.
+	const [focusActionId, setFocusActionId] = useState<string | null>(null);
 
 	useEffect(() => {
 		if (!data) return;
@@ -78,14 +88,6 @@ export function ScriptsSection({
 				void updateRepoScripts(
 					repoId,
 					nextSetup.trim() || null,
-					// The legacy `run_script` column is no longer the
-					// truth source for run actions, but we keep writing it
-					// (via `updateRepoScripts`) so a downgrade still finds
-					// something. Pass `null` to leave it untouched would
-					// require a separate API; the column doubles as our
-					// rollback safety net so writing the empty value is
-					// safe.
-					null,
 					nextArchive.trim() || null,
 				).then(() => {
 					void queryClient.invalidateQueries({
@@ -129,11 +131,17 @@ export function ScriptsSection({
 
 	const handleCreateRunAction = useCallback(async () => {
 		// First row gets "Default" (matches the legacy / single-script
-		// convention). Subsequent rows are "Action N" so they're clearly
+		// convention). Subsequent rows are "Script N" so they're clearly
 		// distinct and the user is nudged to rename them.
 		const fallbackName =
-			runActions.length === 0 ? "Default" : `Action ${runActions.length + 1}`;
-		await createRepoRunAction(repoId, fallbackName, "", "concurrent");
+			runActions.length === 0 ? "Default" : `Script ${runActions.length + 1}`;
+		const created = await createRepoRunAction(
+			repoId,
+			fallbackName,
+			"",
+			"concurrent",
+		);
+		setFocusActionId(created.id);
 		void queryClient.invalidateQueries({
 			queryKey: ["repoScripts", repoId],
 		});
@@ -189,18 +197,14 @@ export function ScriptsSection({
 					}
 				/>
 
-				<RunActionsList actions={runActions} locked={runLocked} />
-				{!runLocked && (
-					<Button
-						variant="outline"
-						size="sm"
-						className="gap-1.5 text-small"
-						onClick={() => void handleCreateRunAction()}
-					>
-						<Plus className="size-3.5" strokeWidth={1.8} />
-						Add action
-					</Button>
-				)}
+				<RunScriptsSection
+					repoId={repoId}
+					actions={runActions}
+					locked={runLocked}
+					focusActionId={focusActionId}
+					onFocused={() => setFocusActionId(null)}
+					onCreate={() => void handleCreateRunAction()}
+				/>
 
 				<ScriptField
 					label="Archive script"
@@ -274,92 +278,327 @@ function ScriptField({
 }
 
 /**
- * Vertical list of run actions for the current repo. Display-only —
- * rows render the action name + command in a read-only scrollable
- * textarea. Renaming / editing / deleting all happen via chat-with-agent
- * flows (Inspector "Create" dropdown) or by hand-editing helmor.json.
+ * Run-scripts section. One section header (matching `ScriptField`'s
+ * layout) plus a vertical stack of name+command pairs. The header's
+ * right slot carries the "Add script" button when the list is editable,
+ * mirroring how Setup carries its "Auto-run" switch in the same slot —
+ * keeps each section header visually balanced.
+ *
+ * Each row is a flat `name input + textarea` pair (no card, no inner
+ * border) so the editor column lines up with setup/archive's textarea
+ * left edge. Per-row controls (Exclusive switch + delete) sit in the
+ * name row's right slot.
  */
-function RunActionsList({
+function RunScriptsSection({
+	repoId,
 	actions,
 	locked,
+	focusActionId,
+	onFocused,
+	onCreate,
 }: {
+	repoId: string;
 	actions: RunAction[];
 	locked: boolean;
+	focusActionId: string | null;
+	onFocused: () => void;
+	onCreate: () => void;
 }) {
 	return (
 		<div>
-			<div className="flex items-start justify-between gap-3">
-				<div className="min-w-0">
-					<div className="text-small font-medium text-app-foreground">
-						Run actions
-					</div>
-					<div className="mt-0.5 text-mini text-muted-foreground">
-						One per script you want to run from the Inspector's Run dropdown.
-					</div>
+			<div className="min-w-0">
+				<div className="text-small font-medium text-app-foreground">
+					Run scripts
+				</div>
+				<div className="mt-0.5 text-mini text-muted-foreground">
+					Each entry appears in the Inspector's Run dropdown.
 				</div>
 			</div>
 
 			{actions.length === 0 ? (
-				<div className="mt-2 rounded-md border border-dashed border-border/60 bg-app-base/30 px-3 py-4 text-center text-mini text-muted-foreground">
-					No run actions yet. Click "Add action" below to create one.
-				</div>
+				locked ? (
+					<div className="mt-2 text-mini text-muted-foreground/70">
+						Set by this workspace's helmor.json — edit it there.
+					</div>
+				) : (
+					// Empty state: dashed placeholder explaining what run
+					// scripts are for. The dashed border + muted bg
+					// signals "nothing here yet"; the `Add script` CTA
+					// sits below so the user always finds the entry point.
+					<div className="mt-3 rounded-lg border border-dashed border-border/60 bg-app-base/30 px-4 py-5 text-center">
+						<div className="text-small font-medium text-foreground">
+							No run scripts yet
+						</div>
+						<div className="mx-auto mt-1 max-w-[320px] text-mini leading-relaxed text-muted-foreground">
+							Add one to expose a command — like a dev server, test runner, or
+							background task.
+						</div>
+					</div>
+				)
 			) : (
-				// Flat list. `mt-4` gives the first row room to breathe
-				// after the section description; `space-y-3` keeps inter-
-				// row gaps tighter (12px) since each row already has its
-				// own textarea border for separation.
-				<div className="mt-4 space-y-3">
+				<div className="mt-3 space-y-5">
 					{actions.map((action) => (
-						<RunActionRow key={action.id} action={action} locked={locked} />
+						<RunScriptRow
+							key={action.id}
+							repoId={repoId}
+							action={action}
+							locked={locked}
+							autoFocus={focusActionId === action.id}
+							onFocused={onFocused}
+						/>
 					))}
+				</div>
+			)}
+
+			{/* Add CTA on its own line below the list so it can't be
+			    misread as a control on the section above. Kept compact
+			    (`size="xs"`) so it reads as a focused entry point, not a
+			    primary action that competes with the editors. */}
+			{!locked && (
+				<div className="mt-3">
+					<Button
+						variant="default"
+						size="xs"
+						className="gap-1 hover:bg-primary/80"
+						onClick={onCreate}
+					>
+						<Plus strokeWidth={2} />
+						Add script
+					</Button>
 				</div>
 			)}
 		</div>
 	);
 }
 
-function RunActionRow({
+function RunScriptRow({
+	repoId,
 	action,
 	locked,
+	autoFocus,
+	onFocused,
 }: {
+	repoId: string;
 	action: RunAction;
 	locked: boolean;
+	autoFocus: boolean;
+	onFocused: () => void;
 }) {
+	const queryClient = useQueryClient();
 	const isProjectOwned = action.fromProject || locked;
 
-	// Display-only row — no local state, no save logic. The textarea is
-	// `readOnly` so it scrolls when the command is multi-line but never
-	// accepts input. `tabIndex={-1}` keeps it out of the keyboard tab
-	// order; `focus-visible:ring-0` + `cursor-default` strip the focused-
-	// input affordance so it doesn't pretend to be editable.
-	const rowBody = (
-		<div>
-			{/* Action name subheading — same size + color as the section
-			    description (`text-mini text-muted-foreground`) so it stays
-			    within the section's typographic rhythm, but bold so it
-			    still reads as a label above the command box. */}
-			<div className="text-mini font-semibold leading-tight text-muted-foreground">
-				{action.name}
-			</div>
-			<Textarea
-				className="mt-2 min-h-[56px] cursor-default resize-y bg-app-base/30 font-mono text-small focus-visible:ring-0"
-				value={action.command}
-				readOnly
-				tabIndex={-1}
-				aria-label={`${action.name} command`}
-			/>
-		</div>
+	const [name, setName] = useState(action.name);
+	const [command, setCommand] = useState(action.command);
+	const [mode, setMode] = useState<RunScriptMode>(action.mode);
+	const [confirmOpen, setConfirmOpen] = useState(false);
+	const [deleting, setDeleting] = useState(false);
+
+	// Keep local state in sync when the upstream record changes (e.g. an
+	// out-of-band update via UI-sync). We only overwrite the local draft
+	// when the incoming value diverges — guards against clobbering the
+	// caret while the user is mid-typing.
+	const lastSyncedRef = useRef({
+		name: action.name,
+		command: action.command,
+		mode: action.mode,
+	});
+	useEffect(() => {
+		const prev = lastSyncedRef.current;
+		if (prev.name !== action.name) setName(action.name);
+		if (prev.command !== action.command) setCommand(action.command);
+		if (prev.mode !== action.mode) setMode(action.mode);
+		lastSyncedRef.current = {
+			name: action.name,
+			command: action.command,
+			mode: action.mode,
+		};
+	}, [action.name, action.command, action.mode]);
+
+	const nameInputRef = useRef<HTMLInputElement | null>(null);
+	useEffect(() => {
+		if (!autoFocus || isProjectOwned) return;
+		nameInputRef.current?.focus();
+		nameInputRef.current?.select();
+		onFocused();
+	}, [autoFocus, isProjectOwned, onFocused]);
+
+	const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const persist = useCallback(
+		(next: { name: string; command: string; mode: RunScriptMode }) => {
+			if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+			saveTimerRef.current = setTimeout(() => {
+				const trimmedName = next.name.trim();
+				// Drop empty-name writes — backend rejects them and we'd
+				// just bounce. The red-ring affordance below tells the
+				// user why nothing's persisting.
+				if (!trimmedName) return;
+				void updateRepoRunAction(
+					repoId,
+					action.id,
+					trimmedName,
+					next.command,
+					next.mode,
+				).then(() => {
+					void queryClient.invalidateQueries({
+						queryKey: ["repoScripts", repoId],
+					});
+				});
+			}, 600);
+		},
+		[repoId, action.id, queryClient],
 	);
 
-	if (!isProjectOwned) return rowBody;
+	// Flush pending edits if the row unmounts (e.g. deleted, navigated
+	// away). 600ms is forgiving but a fast close-the-dialog could drop
+	// the last keystroke otherwise.
+	useEffect(() => {
+		return () => {
+			if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+		};
+	}, []);
+
+	const handleDelete = useCallback(async () => {
+		setDeleting(true);
+		try {
+			await deleteRepoRunAction(repoId, action.id);
+			// UI-sync will invalidate, but invalidate explicitly so the
+			// row disappears immediately even if the event is in flight.
+			void queryClient.invalidateQueries({
+				queryKey: ["repoScripts", repoId],
+			});
+		} finally {
+			setDeleting(false);
+			setConfirmOpen(false);
+		}
+	}, [repoId, action.id, queryClient]);
+
+	if (isProjectOwned) {
+		// Read-only branch: same `header + textarea` shape as ScriptField,
+		// with the name rendered as a static label (mirrors "Setup script"
+		// / "Archive script" headings). Disabled textarea + tooltip
+		// explain why it's inert.
+		const body = (
+			<div>
+				<div className="text-small font-medium text-muted-foreground">
+					{action.name}
+				</div>
+				<Textarea
+					className="mt-2 min-h-[56px] resize-y bg-app-base/30 font-mono text-small"
+					value={action.command}
+					readOnly
+					disabled
+					tabIndex={-1}
+					aria-label={`${action.name} command`}
+				/>
+			</div>
+		);
+		return (
+			<TooltipProvider>
+				<Tooltip>
+					<TooltipTrigger asChild>{body}</TooltipTrigger>
+					<TooltipContent side="top">
+						Set by this workspace's helmor.json — edit it there
+					</TooltipContent>
+				</Tooltip>
+			</TooltipProvider>
+		);
+	}
+
+	const nameInvalid = !name.trim();
+
 	return (
-		<TooltipProvider>
-			<Tooltip>
-				<TooltipTrigger asChild>{rowBody}</TooltipTrigger>
-				<TooltipContent side="top">
-					Set by this workspace's helmor.json — edit it there
-				</TooltipContent>
-			</Tooltip>
-		</TooltipProvider>
+		<>
+			<div>
+				<div className="flex items-center justify-between gap-3">
+					<Input
+						ref={nameInputRef}
+						className="h-7 w-full max-w-[220px] text-small font-medium"
+						placeholder="Script name"
+						value={name}
+						aria-invalid={nameInvalid}
+						aria-label="Script name"
+						onChange={(e) => {
+							const value = e.target.value;
+							setName(value);
+							persist({ name: value, command, mode });
+						}}
+					/>
+					<div className="flex shrink-0 items-center gap-1.5">
+						<span className="text-mini font-medium text-muted-foreground">
+							Exclusive
+						</span>
+						<TooltipProvider>
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<HelpCircle
+										className="size-3 cursor-help text-muted-foreground/70"
+										strokeWidth={1.8}
+									/>
+								</TooltipTrigger>
+								<TooltipContent side="top" className="max-w-[240px]">
+									Only let one workspace run this script at a time. Starting a
+									new run stops any other run in this repository — useful when
+									the script binds a fixed port.
+								</TooltipContent>
+							</Tooltip>
+						</TooltipProvider>
+						<Switch
+							checked={mode === "non-concurrent"}
+							onCheckedChange={(checked) => {
+								const next: RunScriptMode = checked
+									? "non-concurrent"
+									: "concurrent";
+								setMode(next);
+								persist({ name, command, mode: next });
+							}}
+							aria-label="Stop other runs in this repository when starting a new run"
+						/>
+						<TooltipProvider>
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<Button
+										variant="ghost"
+										size="icon"
+										className="size-7 text-muted-foreground hover:text-destructive"
+										onClick={() => setConfirmOpen(true)}
+										aria-label={`Delete script ${action.name || "(unnamed)"}`}
+									>
+										<Trash2 className="size-3.5" strokeWidth={1.8} />
+									</Button>
+								</TooltipTrigger>
+								<TooltipContent side="top">Delete script</TooltipContent>
+							</Tooltip>
+						</TooltipProvider>
+					</div>
+				</div>
+				<Textarea
+					className="mt-2 min-h-[56px] resize-y bg-app-base/30 font-mono text-small"
+					placeholder="e.g., npm run dev"
+					value={command}
+					aria-label={`${action.name || "Script"} command`}
+					onChange={(e) => {
+						const value = e.target.value;
+						setCommand(value);
+						persist({ name, command: value, mode });
+					}}
+				/>
+			</div>
+
+			<ConfirmDialog
+				open={confirmOpen}
+				onOpenChange={setConfirmOpen}
+				title={`Delete ${action.name || "this script"}?`}
+				description={
+					<>
+						This removes the script from the Inspector's Run dropdown. Any PTY
+						that's currently running will keep going until it exits or you stop
+						it from the terminal.
+					</>
+				}
+				confirmLabel={deleting ? "Deleting..." : "Delete"}
+				onConfirm={() => void handleDelete()}
+				loading={deleting}
+			/>
+		</>
 	);
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -3133,11 +3133,6 @@ export type RunAction = {
 
 export type RepoScripts = {
 	setupScript?: string | null;
-	/**
-	 * Convenience mirror of `runActions[0]?.command` kept for callers that
-	 * only want "the run script". New code should iterate `runActions`.
-	 */
-	runScript?: string | null;
 	archiveScript?: string | null;
 	setupFromProject: boolean;
 	/** True when ANY run action was declared in `helmor.json`. */
@@ -3145,11 +3140,6 @@ export type RepoScripts = {
 	archiveFromProject: boolean;
 	/** Auto-run the setup script on workspace creation. Defaults to true. */
 	autoRunSetup: boolean;
-	/**
-	 * Convenience mirror of `runActions[0]?.mode`. New code reads
-	 * per-action mode off the `RunAction` directly.
-	 */
-	runScriptMode: RunScriptMode;
 	/** All run actions for this repo, in display order. */
 	runActions: RunAction[];
 };
@@ -3196,13 +3186,11 @@ export async function loadRepoScripts(
 export async function updateRepoScripts(
 	repoId: string,
 	setupScript: string | null,
-	runScript: string | null,
 	archiveScript: string | null,
 ): Promise<void> {
 	await invoke("update_repo_scripts", {
 		repoId,
 		setupScript,
-		runScript,
 		archiveScript,
 	});
 }
@@ -3212,13 +3200,6 @@ export async function updateRepoAutoRunSetup(
 	enabled: boolean,
 ): Promise<void> {
 	await invoke("update_repo_auto_run_setup", { repoId, enabled });
-}
-
-export async function updateRepoRunScriptMode(
-	repoId: string,
-	mode: RunScriptMode,
-): Promise<void> {
-	await invoke("update_repo_run_script_mode", { repoId, mode });
 }
 
 export async function loadRepoPreferences(
@@ -3355,6 +3336,20 @@ export async function updateRepoRunAction(
 		command,
 		mode,
 	});
+}
+
+export async function deleteRepoRunAction(
+	repoId: string,
+	actionId: string,
+): Promise<void> {
+	await invoke("delete_repo_run_action", { repoId, actionId });
+}
+
+export async function reorderRepoRunActions(
+	repoId: string,
+	orderedIds: string[],
+): Promise<void> {
+	await invoke("reorder_repo_run_actions", { repoId, orderedIds });
 }
 
 export async function setWorkspaceActiveRunAction(


### PR DESCRIPTION
## Summary

Completes the migration off the legacy single-value `run_script` column in favor of the multi-action `run_actions` model that landed in #636, and adds the UI to actually manage those actions.

### What changed
- **Backend cleanup**: removed `repos.run_script` / `run_script_mode` from the schema, model, and IPC surface. `RepoScripts` no longer carries the legacy mirror fields — every caller iterates `run_actions` instead. The legacy fallback that synthesised a virtual action from `repos.run_script` is gone.
- **CLI**: `helmor repo scripts --run "cmd"` / `clear run` now operate on the repo's first DB-owned run action (creates a "Default" action when none exists, refuses to edit helmor.json-owned actions).
- **Settings UI**: repository settings Scripts section is rebuilt to let users add / rename / reorder / delete multiple run actions per repo, with concurrency mode per action. helmor.json-owned actions render read-only.
- **Inspector**: the Run-tab dropdown now shows a per-action status icon (each item subscribes via its own `useScriptStatus`). Empty-state CTAs (\"Add run script\" / Create-action fallback) deep-link to the current repo's Scripts editor and scroll it into view via a `helmor:scroll-to-repo-scripts` event.
- **Announcement**: new `.announcements/edit-run-scripts-from-settings.json` surfaces the feature with an \"Open Run scripts\" deep link that resolves to the current workspace's repo at click time.
- **Tests**: workspace_creation snapshot tests + frontend mocks updated to the `runActions: []` shape; new inspector layout tests cover the per-action status dropdown rows.

### Why
#636 introduced the multi-action backend but kept the legacy `run_script` column as a fallback so older repos kept working. With no migration path exposed in the UI users had no way to edit beyond the first slot, and the dual-source loader made the run-action plumbing harder to reason about. This change removes the fallback and ships the UI to match.

### Test plan
- [ ] `bun run test` (frontend + sidecar + rust)
- [ ] `bun run lint`
- [ ] Manual: edit / add / delete run actions from repo settings; verify the inspector dropdown reflects changes live with per-action status glyphs
- [ ] Manual: trigger the announcement and confirm \"Open Run scripts\" lands on the active repo's Scripts section
- [ ] Manual: `helmor repo scripts --run "..."` against a repo with and without an existing DB action; verify helmor.json-owned actions refuse edits