### PR TITLE
fix: keep run action menu expanded

### DIFF
--- a/.changeset/quiet-terminals-stay.md
+++ b/.changeset/quiet-terminals-stay.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix the hover-expanded terminal panel from collapsing the moment you open the Run action dropdown, so the menu now opens at the expanded position instead of an empty patch of inspector chrome.

--- a/src/features/inspector/layout.tsx
+++ b/src/features/inspector/layout.tsx
@@ -476,6 +476,7 @@ export function InspectorTabsSection({
 										activeRunActionId={activeRunActionId}
 										onSelectRunAction={onSelectRunAction}
 										onCreateRunAction={onCreateRunAction}
+										onOpenChange={handleTabContextMenuOpenChange}
 									/>
 									<span
 										aria-hidden="true"
@@ -732,6 +733,7 @@ function RunActionsDropdown({
 	activeRunActionId,
 	onSelectRunAction,
 	onCreateRunAction,
+	onOpenChange,
 }: {
 	activeTab: string;
 	workspaceId: string | null;
@@ -739,6 +741,11 @@ function RunActionsDropdown({
 	activeRunActionId: string | null;
 	onSelectRunAction: (id: string) => void;
 	onCreateRunAction: () => void;
+	// Bridges Radix's open-state to the hover-zoom controller. Without this,
+	// the portaled menu fires `mouseleave` on the tabs container the moment
+	// the cursor enters a menu item, collapsing the panel mid-open. Same
+	// fix as the tab right-click ContextMenu above.
+	onOpenChange?: (open: boolean) => void;
 }) {
 	// Resolve which radio value should be checked. Falls back to the first
 	// action when the persisted id is missing or stale (recently deleted).
@@ -747,7 +754,7 @@ function RunActionsDropdown({
 		runActions[0]?.id ??
 		"";
 	return (
-		<DropdownMenu>
+		<DropdownMenu onOpenChange={onOpenChange}>
 			<DropdownMenuTrigger asChild>
 				<button
 					type="button"
@@ -797,15 +804,15 @@ function RunActionsDropdown({
 						<DropdownMenuSeparator />
 					</>
 				)}
-				{/* Mirror the radio items' shape: label on the left, glyph
-				    pinned absolute-right so the icon column lines up with
-				    the `✓` checkmark above (same `pr-8 + right-2` slot). */}
-				<DropdownMenuItem onSelect={onCreateRunAction} className="pr-8">
+				{/* Leading-icon shape: glyph on the left, label after. Sits in
+				    the normal flex flow (gap-1.5 from the shared item class)
+				    rather than mirroring the radio rows' right-pinned `✓`
+				    column — this is an action row, not a selection row, so
+				    the icon-then-label reading order signals "do" instead of
+				    "current". */}
+				<DropdownMenuItem onSelect={onCreateRunAction} className="gap-2">
+					<Plus className="size-3" strokeWidth={1.8} />
 					<span>Create</span>
-					<Plus
-						className="pointer-events-none absolute right-2 size-3.5"
-						strokeWidth={1.8}
-					/>
 				</DropdownMenuItem>
 			</DropdownMenuContent>
 		</DropdownMenu>


### PR DESCRIPTION
## What changed
- Forward the Run actions dropdown open state into the inspector tab hover controller.
- Keep the hover-expanded terminal panel from collapsing while the portaled dropdown menu is open.
- Adjust the Create action row to use a leading plus icon in normal flex flow.

## Why
Opening the Run action dropdown could trigger a mouseleave on the tabs container, collapsing the inspector panel and leaving the menu positioned over empty chrome instead of the expanded terminal panel.

## Follow-up / tests
- Pre-commit ran Biome on the staged frontend file during commit.
- No full test suite was run; this is a focused inspector UI behavior change.