### PR TITLE
feat: add optional stopCommand per run action for graceful cleanup

### DIFF
--- a/.announcements/run-action-stop-command.json
+++ b/.announcements/run-action-stop-command.json
@@ -1,0 +1,14 @@
+{
+	"items": [
+		{
+			"text": "Each run script can now declare an optional cleanup command that runs when you click Stop — handy for docker compose, supabase, or anything with external resources to tear down. A second Stop click force-kills if you don't want to wait.",
+			"action": {
+				"label": "Open Run scripts",
+				"value": {
+					"type": "openSettings",
+					"section": "repo:current"
+				}
+			}
+		}
+	]
+}

--- a/.changeset/gentle-eagles-cleanup.md
+++ b/.changeset/gentle-eagles-cleanup.md
@@ -1,0 +1,5 @@
+---
+"helmor": minor
+---
+
+Add an optional `stopCommand` per run action that runs as graceful cleanup when you click Stop, with a second click force-killing the process if you don't want to wait.

--- a/src-tauri/src/cli/repo.rs
+++ b/src-tauri/src/cli/repo.rs
@@ -241,10 +241,16 @@ fn update_scripts(
             .cloned();
         match (next_run, first_db) {
             (Some(cmd), Some(action)) => {
-                repos::update_repo_run_action(&action.id, &action.name, &cmd, &action.mode)?;
+                repos::update_repo_run_action(
+                    &action.id,
+                    &action.name,
+                    &cmd,
+                    &action.mode,
+                    action.stop_command.clone(),
+                )?;
             }
             (Some(cmd), None) => {
-                repos::create_repo_run_action(&id, "Default", &cmd, "concurrent")?;
+                repos::create_repo_run_action(&id, "Default", &cmd, "concurrent", None)?;
             }
             (None, Some(action)) => {
                 repos::delete_repo_run_action(&action.id)?;

--- a/src-tauri/src/commands/script_commands.rs
+++ b/src-tauri/src/commands/script_commands.rs
@@ -2,7 +2,7 @@ use tauri::ipc::Channel;
 use tauri::{AppHandle, State};
 
 use crate::repos::{self, RunAction};
-use crate::workspace::scripts::{ScriptContext, ScriptEvent, ScriptProcessManager};
+use crate::workspace::scripts::{ScriptContext, ScriptEvent, ScriptProcessManager, ScriptStop};
 
 use super::common::CmdResult;
 
@@ -90,6 +90,7 @@ pub async fn execute_repo_script(
             workspace_id,
             action.command,
             channel,
+            action.stop_command,
         )
         .await;
     }
@@ -123,10 +124,12 @@ pub async fn execute_repo_script(
         workspace_id,
         script,
         channel,
+        None,
     )
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn spawn_script(
     app: AppHandle,
     manager: State<'_, ScriptProcessManager>,
@@ -135,6 +138,7 @@ async fn spawn_script(
     workspace_id: Option<String>,
     script: String,
     channel: Channel<ScriptEvent>,
+    stop_command: Option<String>,
 ) -> CmdResult<()> {
     let (repo, workspace) = tauri::async_runtime::spawn_blocking({
         let repo_id = repo_id.clone();
@@ -190,6 +194,16 @@ async fn spawn_script(
     };
     let mgr = manager.inner().clone();
 
+    // Build the graceful-stop bundle now (while we still own `context` /
+    // `working_dir` / `channel`). `None` keeps the pre-feature kill path
+    // exactly as it was: SIGTERM → 200ms → SIGKILL with no detour.
+    let script_stop = stop_command.map(|cmd| ScriptStop {
+        command: cmd,
+        event_tx: channel.clone(),
+        ctx: context.clone(),
+        working_dir: working_dir.clone(),
+    });
+
     // Setup-completion hook keys on the literal `"setup"` script_type — run
     // actions (which carry a `"run:<id>"` script_type now) never trigger it.
     let is_setup = script_type == "setup";
@@ -203,6 +217,7 @@ async fn spawn_script(
             &working_dir,
             &context,
             channel.clone(),
+            script_stop,
         ) {
             Ok(Some(0)) if is_setup => {
                 if let Some(ws_id) = &workspace_id {
@@ -291,10 +306,19 @@ pub async fn create_repo_run_action(
     name: String,
     command: String,
     mode: String,
+    stop_command: Option<String>,
 ) -> CmdResult<repos::RunAction> {
     let result = tauri::async_runtime::spawn_blocking({
         let repo_id = repo_id.clone();
-        move || repos::create_repo_run_action(&repo_id, name.trim(), command.trim(), &mode)
+        move || {
+            repos::create_repo_run_action(
+                &repo_id,
+                name.trim(),
+                command.trim(),
+                &mode,
+                stop_command,
+            )
+        }
     })
     .await
     .map_err(|e| anyhow::anyhow!("spawn_blocking join failed: {e}"))??;
@@ -316,10 +340,19 @@ pub async fn update_repo_run_action(
     name: String,
     command: String,
     mode: String,
+    stop_command: Option<String>,
 ) -> CmdResult<()> {
     tauri::async_runtime::spawn_blocking({
         let action_id = action_id.clone();
-        move || repos::update_repo_run_action(&action_id, name.trim(), command.trim(), &mode)
+        move || {
+            repos::update_repo_run_action(
+                &action_id,
+                name.trim(),
+                command.trim(),
+                &mode,
+                stop_command,
+            )
+        }
     })
     .await
     .map_err(|e| anyhow::anyhow!("spawn_blocking join failed: {e}"))??;

--- a/src-tauri/src/commands/tests/workspace_creation.rs
+++ b/src-tauri/src/commands/tests/workspace_creation.rs
@@ -1564,7 +1564,7 @@ fn load_repo_scripts_priority_1_worktree_helmor_json_wins() {
             ("db-setup", &harness.repo_id),
         )
         .unwrap();
-    crate::repos::create_repo_run_action(&harness.repo_id, "Default", "db-run", "concurrent")
+    crate::repos::create_repo_run_action(&harness.repo_id, "Default", "db-run", "concurrent", None)
         .unwrap();
 
     // Finalize so the worktree exists, then rewrite the worktree's
@@ -1616,7 +1616,7 @@ fn load_repo_scripts_priority_2_repo_root_wins_when_worktree_missing() {
             ("db-setup", &harness.repo_id),
         )
         .unwrap();
-    crate::repos::create_repo_run_action(&harness.repo_id, "Default", "db-run", "concurrent")
+    crate::repos::create_repo_run_action(&harness.repo_id, "Default", "db-run", "concurrent", None)
         .unwrap();
 
     let prepared = workspaces::prepare_workspace_from_repo_impl(
@@ -1659,7 +1659,7 @@ fn load_repo_scripts_priority_3_falls_through_to_db_when_no_helmor_json_anywhere
             ("db-setup", "db-archive", &harness.repo_id),
         )
         .unwrap();
-    crate::repos::create_repo_run_action(&harness.repo_id, "Default", "db-run", "concurrent")
+    crate::repos::create_repo_run_action(&harness.repo_id, "Default", "db-run", "concurrent", None)
         .unwrap();
 
     let prepared = workspaces::prepare_workspace_from_repo_impl(

--- a/src-tauri/src/models/repos.rs
+++ b/src-tauri/src/models/repos.rs
@@ -821,6 +821,13 @@ pub struct RunAction {
     /// True when this action's name/command/mode come from a
     /// `helmor.json` declaration (settings UI shows the row read-only).
     pub from_project: bool,
+    /// Optional graceful-stop command. When set, clicking Stop runs this
+    /// shell snippet (same env + cwd as `command`) to completion before
+    /// helmor signals the main process. The user can short-circuit a
+    /// long-running cleanup by re-clicking Stop ("Force Stop"). `None`
+    /// preserves today's behavior exactly. JSON field name: `stopCommand`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop_command: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -920,18 +927,26 @@ pub fn load_repo_scripts(repo_id: &str, workspace_id: Option<&str>) -> Result<Re
     } else {
         let mut stmt = connection
             .prepare(
-                "SELECT id, name, command, mode FROM repo_run_actions \
+                "SELECT id, name, command, mode, stop_command \
+                 FROM repo_run_actions \
                  WHERE repo_id = ?1 ORDER BY display_order ASC, created_at ASC, id ASC",
             )
             .with_context(|| format!("Failed to prepare run-actions lookup for {repo_id}"))?;
         let db_actions: Vec<RunAction> = stmt
             .query_map([repo_id], |row| {
+                let stop_command: Option<String> = row
+                    .get::<_, Option<String>>(4)?
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(ToOwned::to_owned);
                 Ok(RunAction {
                     id: row.get(0)?,
                     name: row.get(1)?,
                     command: row.get(2)?,
                     mode: row.get(3)?,
                     from_project: false,
+                    stop_command,
                 })
             })
             .with_context(|| format!("Failed to load run actions for {repo_id}"))?
@@ -1032,6 +1047,7 @@ fn parse_project_run_actions(value: Option<&Value>, repo_id: &str) -> Vec<RunAct
             command: trimmed.to_string(),
             mode: "concurrent".to_string(),
             from_project: true,
+            stop_command: None,
         }];
     }
     if let Some(array) = value.as_array() {
@@ -1055,12 +1071,22 @@ fn parse_project_run_actions(value: Option<&Value>, repo_id: &str) -> Vec<RunAct
                     _ => "concurrent",
                 }
                 .to_string();
+                // Flat `stopCommand` — blank/missing strings drop the
+                // cleanup config entirely so we never half-configure a
+                // graceful stop.
+                let stop_command = obj
+                    .get("stopCommand")
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(ToOwned::to_owned);
                 Some(RunAction {
                     id: format!("project:{repo_id}:{idx}"),
                     name: name.to_string(),
                     command: command.to_string(),
                     mode,
                     from_project: true,
+                    stop_command,
                 })
             })
             .collect();
@@ -1122,8 +1148,15 @@ pub fn create_repo_run_action(
     name: &str,
     command: &str,
     mode: &str,
+    stop_command: Option<String>,
 ) -> Result<RunAction> {
     let mode = validate_run_mode(mode)?;
+    // Trim blank / whitespace-only input to `None` — settings UI clears
+    // the row by emptying the input, and we don't persist a no-op.
+    let stop_command = stop_command.and_then(|s| {
+        let trimmed = s.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_string())
+    });
     let id = format!("run:{}", uuid::Uuid::new_v4());
     let connection = db::write_conn()?;
     let next_order: i64 = connection
@@ -1135,9 +1168,18 @@ pub fn create_repo_run_action(
         .with_context(|| format!("Failed to compute next display_order for {repo_id}"))?;
     connection
         .execute(
-            "INSERT INTO repo_run_actions (id, repo_id, name, command, mode, display_order) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-            rusqlite::params![id, repo_id, name, command, mode, next_order],
+            "INSERT INTO repo_run_actions \
+             (id, repo_id, name, command, mode, display_order, stop_command) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            rusqlite::params![
+                id,
+                repo_id,
+                name,
+                command,
+                mode,
+                next_order,
+                stop_command.as_deref(),
+            ],
         )
         .with_context(|| format!("Failed to insert run action for {repo_id}"))?;
     Ok(RunAction {
@@ -1146,25 +1188,34 @@ pub fn create_repo_run_action(
         command: command.to_string(),
         mode: mode.to_string(),
         from_project: false,
+        stop_command,
     })
 }
 
-/// Update an existing run action's name, command, and mode in place.
-/// Returns an error if no row matched — callers should treat that as
-/// "stale id, refresh the list" rather than swallowing it.
+/// Update an existing run action's name, command, mode, and graceful-stop
+/// config in place. Returns an error if no row matched — callers should
+/// treat that as "stale id, refresh the list" rather than swallowing it.
 pub fn update_repo_run_action(
     action_id: &str,
     name: &str,
     command: &str,
     mode: &str,
+    stop_command: Option<String>,
 ) -> Result<()> {
     let mode = validate_run_mode(mode)?;
+    let stop_command = stop_command.and_then(|s| {
+        let trimmed = s.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_string())
+    });
     let connection = db::write_conn()?;
     let updated = connection
         .execute(
-            "UPDATE repo_run_actions SET name = ?1, command = ?2, mode = ?3, \
-             updated_at = datetime('now') WHERE id = ?4",
-            rusqlite::params![name, command, mode, action_id],
+            "UPDATE repo_run_actions \
+             SET name = ?1, command = ?2, mode = ?3, \
+                 stop_command = ?4, \
+                 updated_at = datetime('now') \
+             WHERE id = ?5",
+            rusqlite::params![name, command, mode, stop_command.as_deref(), action_id,],
         )
         .with_context(|| format!("Failed to update run action {action_id}"))?;
     if updated != 1 {
@@ -1832,9 +1883,10 @@ mod tests {
         assert!(initial.run_actions.is_empty());
 
         // Create -> visible + ordered by insertion.
-        let dev = create_repo_run_action(&repo_id, "Dev", "npm run dev", "concurrent").unwrap();
+        let dev =
+            create_repo_run_action(&repo_id, "Dev", "npm run dev", "concurrent", None).unwrap();
         let tests =
-            create_repo_run_action(&repo_id, "Tests", "npm test", "non-concurrent").unwrap();
+            create_repo_run_action(&repo_id, "Tests", "npm test", "non-concurrent", None).unwrap();
 
         let loaded = load_repo_scripts(&repo_id, None).unwrap();
         assert_eq!(loaded.run_actions.len(), 2);
@@ -1842,10 +1894,11 @@ mod tests {
         assert_eq!(loaded.run_actions[1].name, "Tests");
         assert_eq!(loaded.run_actions[0].command, "npm run dev");
         assert_eq!(loaded.run_actions[0].mode, "concurrent");
+        assert!(loaded.run_actions[0].stop_command.is_none());
         assert!(!loaded.run_from_project);
 
         // Update one of them.
-        update_repo_run_action(&dev.id, "Dev Server", "pnpm dev", "non-concurrent").unwrap();
+        update_repo_run_action(&dev.id, "Dev Server", "pnpm dev", "non-concurrent", None).unwrap();
         let after_update = load_repo_scripts(&repo_id, None).unwrap();
         assert_eq!(after_update.run_actions[0].name, "Dev Server");
         assert_eq!(after_update.run_actions[0].command, "pnpm dev");
@@ -1866,9 +1919,91 @@ mod tests {
         // Invalid mode is rejected outright (column constraint is enforced
         // at the Rust layer, not by SQLite).
         assert!(
-            create_repo_run_action(&repo_id, "Bad", "echo", "wat").is_err(),
+            create_repo_run_action(&repo_id, "Bad", "echo", "wat", None).is_err(),
             "mode validation should reject unknown values"
         );
+    }
+
+    #[test]
+    fn run_actions_stop_command_round_trips_through_db() {
+        let env = crate::testkit::TestEnv::new("repos-run-actions-stop");
+        let repo_id = insert_test_repo(&env, "actions");
+
+        // Create with a stop command, then verify load + serde.
+        let with_stop = create_repo_run_action(
+            &repo_id,
+            "DB",
+            "supabase start && tail -f log",
+            "concurrent",
+            Some("supabase stop".to_string()),
+        )
+        .unwrap();
+        assert_eq!(
+            with_stop.stop_command.as_deref(),
+            Some("supabase stop"),
+            "stop_command round-trips on create"
+        );
+
+        // Loaded action carries the same shape.
+        let loaded = load_repo_scripts(&repo_id, None).unwrap();
+        let row = loaded
+            .run_actions
+            .iter()
+            .find(|a| a.id == with_stop.id)
+            .expect("created row visible on reload");
+        assert_eq!(row.stop_command.as_deref(), Some("supabase stop"));
+
+        // Update drops the stop command (None) → loaded row has no stop.
+        update_repo_run_action(&with_stop.id, "DB", "echo", "concurrent", None).unwrap();
+        let cleared = load_repo_scripts(&repo_id, None).unwrap();
+        let row = cleared
+            .run_actions
+            .iter()
+            .find(|a| a.id == with_stop.id)
+            .unwrap();
+        assert!(
+            row.stop_command.is_none(),
+            "passing None on update clears stop_command"
+        );
+
+        // Blank string (only whitespace) is treated as None — settings
+        // UI clears the field by emptying the input, we must not persist
+        // an empty command.
+        update_repo_run_action(
+            &with_stop.id,
+            "DB",
+            "echo",
+            "concurrent",
+            Some("   ".to_string()),
+        )
+        .unwrap();
+        let reloaded = load_repo_scripts(&repo_id, None).unwrap();
+        let row = reloaded
+            .run_actions
+            .iter()
+            .find(|a| a.id == with_stop.id)
+            .unwrap();
+        assert!(
+            row.stop_command.is_none(),
+            "blank stop_command drops to None"
+        );
+
+        // Setting a fresh non-blank command updates cleanly.
+        update_repo_run_action(
+            &with_stop.id,
+            "DB",
+            "echo",
+            "concurrent",
+            Some("docker compose down".to_string()),
+        )
+        .unwrap();
+        let again = load_repo_scripts(&repo_id, None).unwrap();
+        let row = again
+            .run_actions
+            .iter()
+            .find(|a| a.id == with_stop.id)
+            .unwrap();
+        assert_eq!(row.stop_command.as_deref(), Some("docker compose down"));
     }
 
     #[test]
@@ -1916,5 +2051,42 @@ mod tests {
         assert!(parse_project_run_actions(None, repo_id).is_empty());
         assert!(parse_project_run_actions(Some(&Value::String("  ".into())), repo_id).is_empty());
         assert!(parse_project_run_actions(Some(&Value::Bool(true)), repo_id).is_empty());
+    }
+
+    #[test]
+    fn project_run_actions_parse_stop_command() {
+        let repo_id = "test-repo";
+
+        let array_value: Value = serde_json::from_str(
+            r#"[
+                {"name": "Cmd",      "command": "supabase start", "stopCommand": "supabase stop"},
+                {"name": "Blank",    "command": "echo",           "stopCommand": "  "},
+                {"name": "WrongTyp", "command": "echo",           "stopCommand": 42},
+                {"name": "NoStop",   "command": "echo"}
+            ]"#,
+        )
+        .unwrap();
+        let many = parse_project_run_actions(Some(&array_value), repo_id);
+        assert_eq!(many.len(), 4);
+
+        assert_eq!(
+            many[0].stop_command.as_deref(),
+            Some("supabase stop"),
+            "stopCommand parses"
+        );
+
+        assert!(
+            many[1].stop_command.is_none(),
+            "blank stopCommand drops to None"
+        );
+        assert!(
+            many[2].stop_command.is_none(),
+            "non-string stopCommand drops to None"
+        );
+        assert!(many[3].stop_command.is_none(), "no stopCommand key → None");
+
+        // String form never carries stop.
+        let single = parse_project_run_actions(Some(&Value::String("npm dev".into())), repo_id);
+        assert!(single[0].stop_command.is_none());
     }
 }

--- a/src-tauri/src/schema.rs
+++ b/src-tauri/src/schema.rs
@@ -587,6 +587,19 @@ fn run_migrations(connection: &Connection) -> Result<()> {
         )
         .context("Failed to create repo_run_actions table")?;
 
+    // Optional graceful-stop command per run action. `stop_command` is a
+    // shell snippet helmor runs when the user clicks Stop, blocking the
+    // SIGTERM/SIGKILL of the main process until it exits (Force Stop
+    // re-click short-circuits). Nullable — existing rows are unaffected
+    // and continue to use today's `escalating_kill` flow.
+    if has_table(connection, "repo_run_actions")
+        && !has_column(connection, "repo_run_actions", "stop_command")
+    {
+        connection
+            .execute_batch("ALTER TABLE repo_run_actions ADD COLUMN stop_command TEXT")
+            .context("Failed to add repo_run_actions.stop_command column")?;
+    }
+
     // Backfill: every repo that has a non-empty `run_script` but no row in
     // `repo_run_actions` yet gets a single migrated action carrying the old
     // command + mode. Deterministic id (`legacy:<repo_id>`) keeps the

--- a/src-tauri/src/workspace/scripts.rs
+++ b/src-tauri/src/workspace/scripts.rs
@@ -17,11 +17,28 @@ use tauri::ipc::Channel;
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum ScriptEvent {
-    Started { pid: u32, command: String },
-    Stdout { data: String },
-    Stderr { data: String },
-    Exited { code: Option<i32> },
-    Error { message: String },
+    Started {
+        pid: u32,
+        command: String,
+    },
+    Stdout {
+        data: String,
+    },
+    Stderr {
+        data: String,
+    },
+    /// Emitted at the moment a configured `stop.command` starts running.
+    /// Frontends flip the run-action card to a "Stopping…" affordance so
+    /// the Stop button becomes "Force Stop" (which short-circuits the
+    /// cleanup and goes straight to SIGKILL on re-click).
+    /// Only emitted when a stop command is actually configured.
+    Stopping,
+    Exited {
+        code: Option<i32>,
+    },
+    Error {
+        message: String,
+    },
 }
 
 /// Key = (repo_id, script_type, workspace_id)
@@ -32,6 +49,20 @@ const PROCESS_KILL_TIMEOUT: Duration = Duration::from_millis(500);
 const PTY_POLL_INTERVAL: Duration = Duration::from_millis(25);
 const PTY_WRITE_RETRY: Duration = Duration::from_millis(5);
 const PTY_WRITE_DEADLINE: Duration = Duration::from_millis(500);
+const STOP_COMMAND_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Graceful-stop bundle: the user-provided cleanup command + everything
+/// `graceful_kill` needs to spawn it (same env, same cwd, output piped
+/// back into the run-action's terminal channel). Built by callers that
+/// resolve a `RunAction.stop` block; kept in `ProcessHandle` so the Stop
+/// path can reach it without an extra DB lookup.
+#[derive(Clone)]
+pub struct ScriptStop {
+    pub command: String,
+    pub event_tx: Channel<ScriptEvent>,
+    pub ctx: ScriptContext,
+    pub working_dir: String,
+}
 
 /// Metadata we track per live script so Stop, stdin, and resize can reach it
 /// without owning the `Child`. The owner of the `Child` is `run_script`, which
@@ -50,6 +81,22 @@ struct ProcessHandle {
     /// burst). Keeping this alive is what makes Ctrl+C and typing work —
     /// without it, the PTY master would close right after the initial command.
     stdin: Arc<Mutex<std::fs::File>>,
+    /// Per-action graceful-stop config. `None` keeps today's behavior:
+    /// SIGTERM → 200ms → SIGKILL with no detour through stop.command.
+    stop: Option<Arc<ScriptStop>>,
+    /// CAS'd to `true` the first time `graceful_kill` runs for this
+    /// handle. A second Stop click while stop.command is still in flight
+    /// CAS'es back true → graceful_kill skips the wait and SIGKILLs the
+    /// main process immediately (frontend renders this as "Force Stop").
+    stopping: Arc<AtomicBool>,
+    /// pgid of the in-flight stop.command. Set by the first
+    /// `graceful_kill` thread once it has spawned the cleanup process,
+    /// cleared when that process exits. The Force Stop path (and the
+    /// rerun / kill_others / kill_all paths) read this under lock and
+    /// `killpg(SIGKILL)` it so the cleanup process doesn't outlive the
+    /// user's intent — otherwise restarting a workspace or quitting
+    /// Helmor would leak the background sleep / docker compose down.
+    stop_pgid: Arc<Mutex<Option<libc::pid_t>>>,
 }
 
 #[derive(Clone, Default)]
@@ -66,12 +113,21 @@ impl ScriptProcessManager {
     /// can find it. If a handle for this key already exists (user clicked
     /// Run again while the previous run was alive), we mark the old one as
     /// killed and signal it — its own `run_script` will reap.
+    ///
+    /// The collision branch (and `kill_others_in_repo` / `kill_all` below)
+    /// intentionally bypasses *running* `stop.command` — graceful cleanup
+    /// is wired only for the explicit Stop button path. But any
+    /// `stop.command` *already in flight* from a prior Stop click is
+    /// SIGKILL'd here so it doesn't outlive the new operation; otherwise
+    /// rerun / kill_others / kill_all would leak the background cleanup
+    /// process.
     fn register(
         &self,
         key: ProcessKey,
         pid: libc::pid_t,
         pgid: libc::pid_t,
         stdin: Arc<Mutex<std::fs::File>>,
+        stop: Option<ScriptStop>,
     ) -> Arc<AtomicBool> {
         let killed = Arc::new(AtomicBool::new(false));
         let handle = ProcessHandle {
@@ -79,10 +135,14 @@ impl ScriptProcessManager {
             pgid,
             killed: killed.clone(),
             stdin,
+            stop: stop.map(Arc::new),
+            stopping: Arc::new(AtomicBool::new(false)),
+            stop_pgid: Arc::new(Mutex::new(None)),
         };
         let mut map = self.processes.lock().expect("process map poisoned");
         if let Some(old) = map.insert(key, handle) {
             old.killed.store(true, Ordering::Release);
+            kill_in_flight_stop_command(&old.stop_pgid);
             escalating_kill(old.pid, old.pgid);
         }
         killed
@@ -122,6 +182,7 @@ impl ScriptProcessManager {
         let count = victims.len();
         for h in victims {
             h.killed.store(true, Ordering::Release);
+            kill_in_flight_stop_command(&h.stop_pgid);
             escalating_kill(h.pid, h.pgid);
         }
         count
@@ -148,6 +209,7 @@ impl ScriptProcessManager {
         let count = victims.len();
         for h in victims {
             h.killed.store(true, Ordering::Release);
+            kill_in_flight_stop_command(&h.stop_pgid);
             escalating_kill(h.pid, h.pgid);
         }
         count
@@ -157,7 +219,20 @@ impl ScriptProcessManager {
     /// escalating to SIGKILL after `PROCESS_TERM_TIMEOUT`. Returns true if
     /// there was a live handle to signal.
     ///
-    /// Does **not** reap — `run_script`'s `child.wait()` still owns that.
+    /// When the handle carries a `stop.command`, that runs first (output
+    /// piped into the same script channel) and the SIGTERM/SIGKILL only
+    /// runs after it exits. A second `kill()` call while stop.command is
+    /// still in flight short-circuits straight to SIGKILL — the
+    /// frontend's "Force Stop" button uses this. The stop.command branch
+    /// runs on a background thread so the Tauri IPC call returns
+    /// immediately; the `killed` flag is flipped synchronously so racing
+    /// readers still report a clean kill exit code.
+    ///
+    /// When the handle has **no** stop.command configured, this stays on
+    /// the caller's thread (matching the pre-feature behavior exactly)
+    /// — avoiding an extra thread spawn per Stop click for the 95% of
+    /// run actions that don't need a graceful cleanup. Does **not**
+    /// reap — `run_script`'s `child.wait()` still owns that.
     pub fn kill(&self, key: &ProcessKey) -> bool {
         let handle = {
             let map = self.processes.lock().expect("process map poisoned");
@@ -166,7 +241,14 @@ impl ScriptProcessManager {
         match handle {
             Some(h) => {
                 h.killed.store(true, Ordering::Release);
-                escalating_kill(h.pid, h.pgid);
+                // Fast path: no stop.command and not in the middle of one
+                // → behave exactly as the pre-feature code did
+                // (inline signal sequence, no background thread).
+                if h.stop.is_none() && !h.stopping.load(Ordering::Acquire) {
+                    escalating_kill(h.pid, h.pgid);
+                } else {
+                    std::thread::spawn(move || graceful_kill(h));
+                }
                 true
             }
             None => false,
@@ -305,6 +387,238 @@ fn is_process_group_gone(pgid: libc::pid_t) -> bool {
     false
 }
 
+/// SIGKILL any `stop.command` cleanup tree currently published in
+/// `pgid_slot`. Used by `register()` collision, `kill_others_in_repo`,
+/// and `kill_all` — they bypass running a *new* `stop.command` but must
+/// not leak one that's already in flight from a prior Stop click. No-op
+/// when no cleanup is running. Mirrors the Force Stop short-circuit at
+/// the top of `graceful_kill`.
+fn kill_in_flight_stop_command(pgid_slot: &Mutex<Option<libc::pid_t>>) {
+    let stop_pgid = *pgid_slot.lock().expect("stop_pgid mutex poisoned");
+    if let Some(pgid) = stop_pgid {
+        unsafe {
+            libc::killpg(pgid, libc::SIGKILL);
+        }
+    }
+}
+
+/// Outcome of running a configured `stop.command`. Each branch carries
+/// enough info for `graceful_kill` to print a single human-readable
+/// line into the run-action's terminal before signalling the main
+/// process via `escalating_kill` (which happens unconditionally).
+enum StopOutcome {
+    CleanExit,
+    NonZeroExit(Option<i32>),
+    SpawnFailed(String),
+}
+
+/// Spawn `command` via `/bin/sh -c`, stream its stdout/stderr into the
+/// supplied `event_tx`, and block until it exits. There is no timeout —
+/// the user controls escalation via the "Force Stop" re-click, which
+/// SIGKILL's the cleanup tree through `pgid_slot` and short-circuits
+/// the wait.
+///
+/// The child is placed into its own process group via `setsid` so a
+/// concurrent Force Stop (or rerun / kill_others / kill_all) that
+/// reads `pgid_slot` can `killpg` the whole tree — a docker compose
+/// down that itself shells out wouldn't otherwise be reachable.
+/// Output is piped rather than PTY-allocated because cleanup commands
+/// rarely benefit from a TTY and the simpler plumbing keeps the
+/// failure surface small.
+///
+/// `pgid_slot` is published with the spawned child's process group id
+/// once it's known, and cleared before this function returns.
+fn run_stop_command(
+    command: &str,
+    working_dir: &str,
+    ctx: &ScriptContext,
+    event_tx: &Channel<ScriptEvent>,
+    pgid_slot: &Mutex<Option<libc::pid_t>>,
+) -> StopOutcome {
+    let mut cmd = Command::new("/bin/sh");
+    cmd.arg("-c")
+        .arg(command)
+        .current_dir(working_dir)
+        .env("TERM", "xterm-256color")
+        .env("FORCE_COLOR", "1")
+        .env("CLICOLOR_FORCE", "1")
+        .env("HELMOR_ROOT_PATH", &ctx.root_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    if let Some(wp) = &ctx.workspace_path {
+        cmd.env("HELMOR_WORKSPACE_PATH", wp);
+    }
+    if let Some(wn) = &ctx.workspace_name {
+        cmd.env("HELMOR_WORKSPACE_NAME", wn);
+    }
+    if let Some(db) = &ctx.default_branch {
+        cmd.env("HELMOR_DEFAULT_BRANCH", db);
+    }
+    if let (Some(base), Some(count)) = (ctx.port_base, ctx.port_count) {
+        cmd.env("HELMOR_PORT", base.to_string());
+        cmd.env("HELMOR_PORT_COUNT", count.to_string());
+    }
+
+    unsafe {
+        cmd.pre_exec(|| {
+            if libc::setsid() == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+
+    let mut child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => return StopOutcome::SpawnFailed(format!("{e}")),
+    };
+    let pid = child.id() as libc::pid_t;
+    let pgid = unsafe { libc::getpgid(pid) };
+
+    // Publish pgid so a concurrent Force Stop can SIGKILL the cleanup
+    // tree. Always cleared before return (deferred via the `outcome`
+    // binding below).
+    *pgid_slot.lock().expect("stop_pgid mutex poisoned") = Some(pgid);
+
+    // Pipe stdout / stderr through dedicated reader threads so the user
+    // sees progress in the same xterm as the main run output. The
+    // variant constructor tags bytes as Stdout / Stderr so terminal
+    // styling (red for stderr) survives.
+    fn pipe_to_channel<R: Read + Send + 'static>(
+        name: &'static str,
+        mut reader: R,
+        tx: Channel<ScriptEvent>,
+        wrap: fn(String) -> ScriptEvent,
+    ) -> Option<std::thread::JoinHandle<()>> {
+        std::thread::Builder::new()
+            .name(name.into())
+            .spawn(move || {
+                let mut buf = [0u8; 4096];
+                while let Ok(n) = reader.read(&mut buf) {
+                    if n == 0 {
+                        break;
+                    }
+                    let data = String::from_utf8_lossy(&buf[..n]).into_owned();
+                    let _ = tx.send(wrap(data));
+                }
+            })
+            .ok()
+    }
+    let stdout_thread = child.stdout.take().and_then(|s| {
+        pipe_to_channel("stop-cmd-stdout", s, event_tx.clone(), |data| {
+            ScriptEvent::Stdout { data }
+        })
+    });
+    let stderr_thread = child.stderr.take().and_then(|s| {
+        pipe_to_channel("stop-cmd-stderr", s, event_tx.clone(), |data| {
+            ScriptEvent::Stderr { data }
+        })
+    });
+
+    let outcome = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                if status.success() {
+                    break StopOutcome::CleanExit;
+                }
+                break StopOutcome::NonZeroExit(status.code());
+            }
+            Ok(None) => {
+                std::thread::sleep(STOP_COMMAND_POLL_INTERVAL);
+            }
+            Err(e) => {
+                // Don't leak the child + its reader threads on a
+                // try_wait failure — SIGKILL the pgid (or pid as
+                // fallback) and reap so the pipe ends close.
+                unsafe {
+                    if pgid > 0 {
+                        libc::killpg(pgid, libc::SIGKILL);
+                    }
+                    libc::kill(pid, libc::SIGKILL);
+                }
+                let _ = child.wait();
+                break StopOutcome::SpawnFailed(format!("try_wait failed: {e}"));
+            }
+        }
+    };
+
+    // Drain the pipes so the user sees the last bytes before the kill
+    // message — the threads exit naturally when read() returns 0 / Err.
+    if let Some(h) = stdout_thread {
+        let _ = h.join();
+    }
+    if let Some(h) = stderr_thread {
+        let _ = h.join();
+    }
+
+    // Clear the published pgid before returning. Force Stop reading
+    // after this point sees `None` and skips the SIGKILL — the cleanup
+    // is already done so no signal is needed.
+    *pgid_slot.lock().expect("stop_pgid mutex poisoned") = None;
+
+    outcome
+}
+
+/// Graceful Stop sequence for one process handle:
+///
+///   1. First `kill()` flips `stopping`. If a stop.command is configured
+///      we emit `Stopping`, run it (output piped into the script's
+///      channel), then proceed to `escalating_kill` on the main pid.
+///   2. A second `kill()` while we're still inside step 1 short-circuits:
+///      it CAS'es `stopping` true a second time and jumps straight to
+///      `escalating_kill`. The frontend renders this as "Force Stop".
+///   3. With no stop.command configured the call is identical to the
+///      pre-feature path — straight to `escalating_kill`.
+fn graceful_kill(handle: ProcessHandle) {
+    // Race guard: if `stopping` was already true this is a re-click
+    // ("Force Stop"). Kill the in-flight cleanup tree so the first
+    // graceful_kill thread isn't left waiting on an abandoned child,
+    // then escalating_kill the main process. Both threads converge
+    // safely — the first one's wait() returns and its own
+    // escalating_kill sees the dead pid and no-ops.
+    if handle.stopping.swap(true, Ordering::AcqRel) {
+        kill_in_flight_stop_command(&handle.stop_pgid);
+        escalating_kill(handle.pid, handle.pgid);
+        return;
+    }
+
+    if let Some(stop) = handle.stop.as_deref() {
+        let _ = stop.event_tx.send(ScriptEvent::Stopping);
+        let _ = stop.event_tx.send(ScriptEvent::Stdout {
+            data: format!(
+                "\r\n\x1b[2m[Helmor] Running stop.command: {}\x1b[0m\r\n",
+                stop.command
+            ),
+        });
+        let started = Instant::now();
+        let outcome = run_stop_command(
+            &stop.command,
+            &stop.working_dir,
+            &stop.ctx,
+            &stop.event_tx,
+            &handle.stop_pgid,
+        );
+        let elapsed_ms = started.elapsed().as_millis();
+        let footer = match outcome {
+            StopOutcome::CleanExit => format!(
+                "\r\n\x1b[2m[Helmor] stop.command exited cleanly in {elapsed_ms}ms\x1b[0m\r\n"
+            ),
+            StopOutcome::NonZeroExit(code) => format!(
+                "\r\n\x1b[33m[Helmor] stop.command exited with code {} after {elapsed_ms}ms\x1b[0m\r\n",
+                code.map(|c| c.to_string()).unwrap_or_else(|| "?".to_string())
+            ),
+            StopOutcome::SpawnFailed(err) => format!(
+                "\r\n\x1b[33m[Helmor] stop.command failed to spawn ({err}) — proceeding with force-kill\x1b[0m\r\n"
+            ),
+        };
+        let _ = stop.event_tx.send(ScriptEvent::Stdout { data: footer });
+    }
+
+    escalating_kill(handle.pid, handle.pgid);
+}
+
 /// Workspace context passed to scripts as environment variables.
 #[derive(Clone, Default)]
 pub struct ScriptContext {
@@ -396,6 +710,10 @@ fn wrapped_script_for_shell(shell_path: &str, script: &str) -> String {
 /// send additional input (arrow keys, Ctrl+C, responses to prompts) through
 /// `ScriptProcessManager::write_stdin`. The wrapped command's final `exit`
 /// is what ends the session on normal completion.
+///
+/// `stop` carries the optional graceful-stop config attached to the
+/// originating `RunAction`. Setup / archive scripts have no notion of
+/// stop.command and should pass `None`.
 #[allow(clippy::too_many_arguments)]
 pub fn run_script(
     manager: &ScriptProcessManager,
@@ -406,6 +724,7 @@ pub fn run_script(
     working_dir: &str,
     context: &ScriptContext,
     channel: Channel<ScriptEvent>,
+    stop: Option<ScriptStop>,
 ) -> Result<Option<i32>> {
     let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
     run_script_with_shell(
@@ -420,6 +739,7 @@ pub fn run_script(
         &shell,
         &["-i", "-l"],
         None,
+        stop,
     )
 }
 
@@ -458,6 +778,7 @@ pub fn run_terminal_session(
         &shell,
         &["-i", "-l"],
         boot_input,
+        None,
     )
 }
 
@@ -488,6 +809,7 @@ pub(crate) fn run_script_with_shell(
     shell_path: &str,
     shell_args: &[&str],
     boot_input: Option<&str>,
+    stop: Option<ScriptStop>,
 ) -> Result<Option<i32>> {
     if let Some(s) = script {
         if s.trim().is_empty() {
@@ -588,7 +910,7 @@ pub(crate) fn run_script_with_shell(
         script_type.to_string(),
         workspace_id.map(str::to_string),
     );
-    let killed = manager.register(key.clone(), pid, pgid, stdin.clone());
+    let killed = manager.register(key.clone(), pid, pgid, stdin.clone(), stop);
 
     // Single reader on the PTY master — stdout+stderr are merged by the PTY.
     // Uses poll(2) so the kernel wakes the thread the instant data is
@@ -787,7 +1109,7 @@ mod tests {
             .open("/dev/null")
             .expect("open /dev/null");
         let stdin_arc = Arc::new(Mutex::new(stdin));
-        let killed = mgr.register(key, pid, pgid, stdin_arc);
+        let killed = mgr.register(key, pid, pgid, stdin_arc, None);
         (child, pid, pgid, killed)
     }
 
@@ -972,6 +1294,7 @@ mod tests {
                 "/bin/sh",
                 &[],
                 None,
+                None,
             )
         });
 
@@ -1092,6 +1415,7 @@ mod tests {
                 "/bin/sh",
                 &[],
                 None,
+                None,
             )
         });
 
@@ -1174,6 +1498,7 @@ mod tests {
                 ch,
                 "/bin/sh",
                 &[],
+                None,
                 None,
             )
         });
@@ -1265,6 +1590,7 @@ mod tests {
                 "/bin/sh",
                 &[],
                 None,
+                None,
             )
         });
 
@@ -1329,6 +1655,7 @@ mod tests {
             make_channel(),
             shell_path,
             shell_args,
+            None,
             None,
         )
         .unwrap()
@@ -1422,6 +1749,7 @@ mod tests {
             "/bin/sh",
             &[],
             None,
+            None,
         )
         .unwrap();
         assert_eq!(exit, Some(0));
@@ -1496,6 +1824,7 @@ mod tests {
             "/bin/sh",
             &[],
             None,
+            None,
         )
         .unwrap();
         assert_eq!(exit, Some(0));
@@ -1534,7 +1863,17 @@ mod tests {
             port_base: None,
             port_count: None,
         };
-        let result = run_script(&mgr, "r", "s", None, "  ", "/tmp", &ctx, make_channel());
+        let result = run_script(
+            &mgr,
+            "r",
+            "s",
+            None,
+            "  ",
+            "/tmp",
+            &ctx,
+            make_channel(),
+            None,
+        );
         assert!(result.is_err());
     }
 
@@ -1559,5 +1898,228 @@ mod tests {
         let mgr = ScriptProcessManager::new();
         let key: ProcessKey = ("nope".into(), "run".into(), None);
         assert!(!mgr.kill(&key));
+    }
+
+    // ── graceful_kill (stop.command) ───────────────────────────────────────
+
+    /// Build a Channel that forwards `(type, optional data)` of every
+    /// ScriptEvent into a Receiver. Tests use this to wait for specific
+    /// events (Stopping, Exited) and to assert that stop.command output
+    /// landed in the same stream as the main run output.
+    fn capture_events() -> (
+        Channel<ScriptEvent>,
+        mpsc::Receiver<(String, Option<String>)>,
+    ) {
+        let (tx, rx) = mpsc::channel::<(String, Option<String>)>();
+        let ch = Channel::<ScriptEvent>::new(move |msg| {
+            if let tauri::ipc::InvokeResponseBody::Json(json) = msg {
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(&json) {
+                    let ev_type = v
+                        .get("type")
+                        .and_then(|t| t.as_str())
+                        .map(String::from)
+                        .unwrap_or_default();
+                    let data = v.get("data").and_then(|d| d.as_str()).map(String::from);
+                    let _ = tx.send((ev_type, data));
+                }
+            }
+            Ok(())
+        });
+        (ch, rx)
+    }
+
+    /// Block until either an event with `type == ev_type` arrives, or
+    /// `timeout` elapses. Returns the data payload (if any).
+    fn wait_for_event(
+        rx: &mpsc::Receiver<(String, Option<String>)>,
+        ev_type: &str,
+        timeout: Duration,
+    ) -> Option<Option<String>> {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            if let Ok((t, data)) = rx.recv_timeout(Duration::from_millis(100)) {
+                if t == ev_type {
+                    return Some(data);
+                }
+            }
+        }
+        None
+    }
+
+    fn empty_ctx() -> ScriptContext {
+        ScriptContext {
+            root_path: std::env::temp_dir().display().to_string(),
+            workspace_path: None,
+            workspace_name: None,
+            default_branch: None,
+            port_base: None,
+            port_count: None,
+        }
+    }
+
+    /// Stop.command exits cleanly → backend emits Stopping, streams the
+    /// command's stdout into the same channel, and then SIGTERMs the run
+    /// process. The run script reports None for its exit code because
+    /// `killed` was flipped.
+    ///
+    /// Marked `#[ignore]` because each graceful_kill test spawns multiple
+    /// subprocesses (run shell, stop.command, reader threads) and a full
+    /// `cargo test --lib` already runs ~1100 tests in parallel. Adding
+    /// this kind of fork/exec load to the default suite makes a couple of
+    /// pre-existing PTY tests in this module flake under heavy macOS
+    /// scheduling. Run explicitly with
+    /// `cargo test --lib graceful_kill -- --ignored`, or include it in a
+    /// focused `workspace::scripts` filter where the parallel load stays
+    /// well under the flakiness threshold.
+    #[test]
+    #[ignore = "fork-heavy; run via `cargo test graceful_kill -- --ignored`"]
+    fn graceful_kill_runs_stop_command_then_escalates() {
+        let mgr = Arc::new(ScriptProcessManager::new());
+        let ctx = empty_ctx();
+        let key: ProcessKey = ("repo".into(), "run".into(), Some("ws".into()));
+
+        let (ch, rx) = capture_events();
+
+        let stop = ScriptStop {
+            command: "echo HELMOR_STOP_CALLED".to_string(),
+            event_tx: ch.clone(),
+            ctx: ctx.clone(),
+            working_dir: std::env::temp_dir().display().to_string(),
+        };
+
+        let mgr_c = mgr.clone();
+        let key_c = key.clone();
+        let tempdir = std::env::temp_dir().display().to_string();
+        let ctx_for_thread = ctx.clone();
+        let handle = std::thread::spawn(move || {
+            run_script_with_shell(
+                &mgr_c,
+                &key_c.0,
+                &key_c.1,
+                key_c.2.as_deref(),
+                Some("sleep 60"),
+                &tempdir,
+                &ctx_for_thread,
+                ch,
+                "/bin/sh",
+                &[],
+                None,
+                Some(stop),
+            )
+        });
+
+        // Wait until run_script registers, then click Stop.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            if mgr.processes.lock().unwrap().contains_key(&key) {
+                break;
+            }
+            assert!(Instant::now() < deadline, "run_script never registered");
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        let start = Instant::now();
+        assert!(mgr.kill(&key), "kill should find the live handle");
+
+        // The Stopping event must arrive before the run process exits.
+        assert!(
+            wait_for_event(&rx, "stopping", Duration::from_secs(2)).is_some(),
+            "Stopping event must fire when stop.command is configured"
+        );
+
+        // Wait for Exited.
+        assert!(
+            wait_for_event(&rx, "exited", Duration::from_secs(5)).is_some(),
+            "run process should exit after stop.command + SIGTERM"
+        );
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "graceful kill took too long: {elapsed:?}"
+        );
+
+        // The run_script thread returns once child.wait() completes —
+        // killed flag was set, so exit code is None.
+        let result = handle.join().unwrap();
+        assert_eq!(
+            result.unwrap(),
+            None,
+            "killed scripts should report None exit"
+        );
+    }
+
+    /// Second `kill()` while stop.command is still running short-circuits
+    /// straight to SIGKILL on the main process. The Force Stop button
+    /// uses exactly this path. See the sibling test for why `#[ignore]`.
+    #[test]
+    #[ignore = "fork-heavy; run via `cargo test graceful_kill -- --ignored`"]
+    fn graceful_kill_force_stop_on_second_click_short_circuits() {
+        let mgr = Arc::new(ScriptProcessManager::new());
+        let ctx = empty_ctx();
+        let key: ProcessKey = ("repo".into(), "run".into(), Some("ws".into()));
+
+        let (ch, rx) = capture_events();
+
+        // Long-running stop.command — without the re-click escalation
+        // this test would block until the sleep naturally finishes.
+        let stop = ScriptStop {
+            command: "/bin/sleep 30".to_string(),
+            event_tx: ch.clone(),
+            ctx: ctx.clone(),
+            working_dir: std::env::temp_dir().display().to_string(),
+        };
+
+        let mgr_c = mgr.clone();
+        let key_c = key.clone();
+        let tempdir = std::env::temp_dir().display().to_string();
+        let ctx_for_thread = ctx.clone();
+        let handle = std::thread::spawn(move || {
+            run_script_with_shell(
+                &mgr_c,
+                &key_c.0,
+                &key_c.1,
+                key_c.2.as_deref(),
+                Some("sleep 60"),
+                &tempdir,
+                &ctx_for_thread,
+                ch,
+                "/bin/sh",
+                &[],
+                None,
+                Some(stop),
+            )
+        });
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            if mgr.processes.lock().unwrap().contains_key(&key) {
+                break;
+            }
+            assert!(Instant::now() < deadline, "run_script never registered");
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        // First click — wait for Stopping to confirm we're inside the
+        // graceful window before issuing the second click.
+        assert!(mgr.kill(&key));
+        assert!(
+            wait_for_event(&rx, "stopping", Duration::from_secs(2)).is_some(),
+            "Stopping must fire on first kill"
+        );
+
+        // Second click — short-circuit to SIGKILL.
+        let start_force = Instant::now();
+        assert!(mgr.kill(&key));
+        assert!(
+            wait_for_event(&rx, "exited", Duration::from_secs(5)).is_some(),
+            "Force Stop should exit promptly, not wait 30s for stop.command"
+        );
+        let force_elapsed = start_force.elapsed();
+        assert!(
+            force_elapsed < Duration::from_secs(3),
+            "Force Stop took too long: {force_elapsed:?}"
+        );
+
+        let _ = handle.join();
     }
 }

--- a/src-tauri/tests/schema_migrations.rs
+++ b/src-tauri/tests/schema_migrations.rs
@@ -70,6 +70,26 @@ fn workspaces_port_columns(
         .unwrap()
 }
 
+fn repo_run_actions_stop_columns(
+    connection: &rusqlite::Connection,
+) -> Vec<(String, String, i64, Option<String>)> {
+    let mut statement = connection
+        .prepare(
+            "SELECT name, type, \"notnull\", dflt_value
+             FROM pragma_table_info('repo_run_actions')
+             WHERE name LIKE 'stop_%'
+             ORDER BY name",
+        )
+        .unwrap();
+    statement
+        .query_map([], |row| {
+            Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
+        })
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+}
+
 #[test]
 fn repos_branch_prefix_override_migration_is_idempotent() {
     let connection = rusqlite::Connection::open_in_memory().unwrap();
@@ -252,5 +272,66 @@ fn workspaces_port_range_migration_adds_columns_when_missing() {
     assert_yaml_snapshot!(
         "workspaces_port_range_migration",
         workspaces_port_columns(&connection)
+    );
+}
+
+#[test]
+fn repo_run_actions_stop_command_migration_adds_column_when_missing() {
+    let connection = rusqlite::Connection::open_in_memory().unwrap();
+    // Pre-existing repo_run_actions table from before stop_command — must
+    // also have the parent `repos` row + `repos.id` PK so the FK in
+    // repo_run_actions can resolve when ensure_schema rebuilds anything.
+    // Seed one action so we can assert the migration leaves it intact
+    // with a NULL stop_command (existing rows must not be back-filled).
+    connection
+        .execute_batch(
+            r#"
+            CREATE TABLE repos (
+                id TEXT PRIMARY KEY,
+                name TEXT,
+                default_branch TEXT,
+                root_path TEXT,
+                created_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+            INSERT INTO repos (id, name) VALUES ('r1', 'demo');
+            CREATE TABLE repo_run_actions (
+                id TEXT PRIMARY KEY,
+                repo_id TEXT NOT NULL,
+                name TEXT NOT NULL,
+                command TEXT NOT NULL,
+                mode TEXT NOT NULL DEFAULT 'concurrent',
+                display_order INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+                FOREIGN KEY (repo_id) REFERENCES repos(id) ON DELETE CASCADE
+            );
+            INSERT INTO repo_run_actions (id, repo_id, name, command)
+            VALUES ('a1', 'r1', 'Dev', 'npm run dev');
+            "#,
+        )
+        .unwrap();
+
+    schema::ensure_schema(&connection).unwrap();
+    // Idempotency: a second pass must NOT error, even though the column
+    // now exists. The guard is `!has_column(...)`.
+    schema::ensure_schema(&connection).unwrap();
+
+    // The pre-existing row's stop_command must still be NULL — the
+    // migration adds the column but never back-fills.
+    let stop_command: Option<String> = connection
+        .query_row(
+            "SELECT stop_command FROM repo_run_actions WHERE id = 'a1'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(
+        stop_command.is_none(),
+        "existing repo_run_actions rows must keep stop_command NULL after migration"
+    );
+
+    assert_yaml_snapshot!(
+        "repo_run_actions_stop_command_migration",
+        repo_run_actions_stop_columns(&connection)
     );
 }

--- a/src-tauri/tests/snapshots/schema_migrations__repo_run_actions_stop_command_migration.snap
+++ b/src-tauri/tests/snapshots/schema_migrations__repo_run_actions_stop_command_migration.snap
@@ -1,0 +1,8 @@
+---
+source: tests/schema_migrations.rs
+expression: repo_run_actions_stop_columns(&connection)
+---
+- - stop_command
+  - TEXT
+  - 0
+  - ~

--- a/src/features/inspector/script-store.ts
+++ b/src/features/inspector/script-store.ts
@@ -17,6 +17,13 @@ type Listener = {
 	onStatusChange: (status: ScriptStatus) => void;
 	onUrlsChange?: (urls: string[]) => void;
 	/**
+	 * `true` while a configured `stopCommand` is running (Stop button
+	 * renders as "Force Stop"); `false` when it finishes or the entry is
+	 * reset by a fresh `startScript`. Only fires for actions that
+	 * configure a `stopCommand`.
+	 */
+	onStoppingChange?: (stopping: boolean) => void;
+	/**
 	 * Called at the start of a fresh `startScript` invocation. Gives any
 	 * already-attached listener a chance to clear its terminal so output from
 	 * a previous run is not mixed with the new run's chunks — important when
@@ -55,6 +62,10 @@ export type ScriptEntry = {
 	 * as new chunks arrive. Empty when the script hasn't printed any banner.
 	 */
 	urls: string[];
+	/** True while a configured `stopCommand` is running. Drives the
+	 * "Force Stop" button — a second Stop click while true escalates to
+	 * SIGKILL backend-side. */
+	stopping: boolean;
 };
 
 /** Append a chunk and evict from the head until under the byte cap. */
@@ -148,8 +159,20 @@ export function startScript(
 		status: "running",
 		exitCode: null,
 		urls: [],
+		stopping: false,
 	};
 	entries.set(k, entry);
+
+	// Flip `stopping` back to false (and notify) if the entry was mid-
+	// graceful-stop when this final event arrived. Called from every
+	// `exited` / `error` / `.catch` path so the Force Stop button label
+	// always clears on exit.
+	const clearStopping = () => {
+		if (entry.stopping) {
+			entry.stopping = false;
+			listeners.get(k)?.onStoppingChange?.(false);
+		}
+	};
 
 	listeners.get(k)?.onStatusChange("running");
 	// Reset URL listener to empty — previous run's URLs don't apply.
@@ -167,6 +190,10 @@ export function startScript(
 
 			switch (event.type) {
 				case "started":
+					break;
+				case "stopping":
+					entry.stopping = true;
+					listeners.get(k)?.onStoppingChange?.(true);
 					break;
 				case "stdout":
 				case "stderr": {
@@ -211,6 +238,7 @@ export function startScript(
 				case "exited":
 					entry.status = "exited";
 					entry.exitCode = event.code;
+					clearStopping();
 					listeners.get(k)?.onStatusChange("exited");
 					emitStatus(k, "exited", event.code);
 					if (scriptType === "run") {
@@ -223,6 +251,7 @@ export function startScript(
 					entry.status = "exited";
 					// No exit code from the backend here — treat as failure.
 					entry.exitCode = entry.exitCode ?? 1;
+					clearStopping();
 					listeners.get(k)?.onChunk(msg);
 					listeners.get(k)?.onStatusChange("exited");
 					emitStatus(k, "exited", entry.exitCode);
@@ -241,6 +270,7 @@ export function startScript(
 		appendChunk(entry, msg);
 		entry.status = "exited";
 		entry.exitCode = entry.exitCode ?? 1;
+		clearStopping();
 		listeners.get(k)?.onChunk(msg);
 		listeners.get(k)?.onStatusChange("exited");
 		emitStatus(k, "exited", entry.exitCode);

--- a/src/features/inspector/sections/run.tsx
+++ b/src/features/inspector/sections/run.tsx
@@ -166,6 +166,7 @@ export function RunTab({
 }: RunTabProps) {
 	const termRef = useRef<TerminalHandle | null>(null);
 	const [status, setStatus] = useState<ScriptStatus>("idle");
+	const [stopping, setStopping] = useState(false);
 	const [hasRun, setHasRun] = useState(false);
 	const { isZoomPresented, isHoverExpanded } = useTabsZoom();
 	const { settings } = useSettings();
@@ -182,6 +183,7 @@ export function RunTab({
 			onUrlsChange?.([]);
 			setHasRun(false);
 			setStatus("idle");
+			setStopping(false);
 			termRef.current?.clear();
 			return;
 		}
@@ -192,6 +194,7 @@ export function RunTab({
 			{
 				onChunk: (data) => termRef.current?.write(data),
 				onStatusChange: setStatus,
+				onStoppingChange: setStopping,
 				onUrlsChange: (urls) => onUrlsChange?.(urls),
 				// When a fresh run is triggered externally (e.g. Cmd+R while
 				// this tab is mounted), wipe the terminal so old output
@@ -199,6 +202,7 @@ export function RunTab({
 				onReset: () => {
 					termRef.current?.clear();
 					setHasRun(true);
+					setStopping(false);
 				},
 			},
 			activeRunActionId,
@@ -207,6 +211,7 @@ export function RunTab({
 		if (existing) {
 			setHasRun(true);
 			setStatus(existing.status);
+			setStopping(existing.stopping);
 			// Replay URLs already detected on this entry so the parent's state
 			// mirrors the store the moment the component mounts.
 			onUrlsChange?.([...existing.urls]);
@@ -222,6 +227,7 @@ export function RunTab({
 		} else {
 			setHasRun(false);
 			setStatus("idle");
+			setStopping(false);
 			onUrlsChange?.([]);
 			termRef.current?.clear();
 		}
@@ -309,13 +315,21 @@ export function RunTab({
 								className="text-small shadow-sm backdrop-blur-sm transition-none"
 								onClick={status === "running" ? handleStop : handleRun}
 								disabled={status === "exited" && !hasScript}
+								// Title clarifies the escalation semantic when a
+								// cleanup command is still running — second click
+								// short-circuits to SIGKILL on the backend.
+								title={stopping ? "Skip cleanup and force-kill" : undefined}
 							>
 								{status === "running" ? (
 									<Square className="size-3" strokeWidth={2} />
 								) : (
 									<RotateCcw className="size-3" strokeWidth={2} />
 								)}
-								{status === "running" ? "Stop" : "Rerun"}
+								{status === "running"
+									? stopping
+										? "Force Stop"
+										: "Stop"
+									: "Rerun"}
 								{runShortcut ? (
 									<InlineShortcutDisplay
 										hotkey={runShortcut}

--- a/src/features/settings/panels/repository-settings/scripts-section.tsx
+++ b/src/features/settings/panels/repository-settings/scripts-section.tsx
@@ -6,10 +6,21 @@
 // the section header's right slot so the list itself stays a clean
 // vertical stack of name+command pairs aligned with setup/archive.
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { HelpCircle, Plus, Trash2 } from "lucide-react";
+import {
+	Check,
+	ChevronDown,
+	HelpCircle,
+	Pencil,
+	Plus,
+	Trash2,
+} from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
-import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import {
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
@@ -29,6 +40,7 @@ import {
 	updateRepoRunAction,
 	updateRepoScripts,
 } from "@/lib/api";
+import { cn } from "@/lib/utils";
 
 export function ScriptsSection({
 	repoId,
@@ -278,16 +290,14 @@ function ScriptField({
 }
 
 /**
- * Run-scripts section. One section header (matching `ScriptField`'s
- * layout) plus a vertical stack of name+command pairs. The header's
- * right slot carries the "Add script" button when the list is editable,
- * mirroring how Setup carries its "Auto-run" switch in the same slot —
- * keeps each section header visually balanced.
- *
- * Each row is a flat `name input + textarea` pair (no card, no inner
- * border) so the editor column lines up with setup/archive's textarea
- * left edge. Per-row controls (Exclusive switch + delete) sit in the
- * name row's right slot.
+ * Run-scripts section. One section header plus a vertical stack of
+ * collapsible cards — each card is one run action. Collapsed cards show
+ * just the name, the first line of the command, and the Exclusive
+ * toggle; expanding reveals the full editor (name + command + optional
+ * Stop command / Timeout) along with the Edit (pencil) + Delete
+ * buttons. This mirrors the {@link RepositoryPreferencesSection}'s
+ * accordion pattern so the Settings tab reads as a consistent stack of
+ * progressive-disclosure sections.
  */
 function RunScriptsSection({
 	repoId,
@@ -336,7 +346,7 @@ function RunScriptsSection({
 					</div>
 				)
 			) : (
-				<div className="mt-3 space-y-5">
+				<div className="mt-3 space-y-2">
 					{actions.map((action) => (
 						<RunScriptRow
 							key={action.id}
@@ -371,6 +381,17 @@ function RunScriptsSection({
 	);
 }
 
+/**
+ * One row in the Run scripts list — a collapsible card whose collapsed
+ * header shows just the essentials (name + first-line of the command +
+ * Exclusive toggle) and whose expanded body reveals the full editor.
+ * Edit mode is gated behind a pencil button so accidental clicks on a
+ * row don't put the user into an editable state.
+ *
+ * Read-only (`isProjectOwned`) actions reuse the same collapsible
+ * skeleton but with the Exclusive switch disabled, no Edit / Delete
+ * buttons, and inputs that never become editable.
+ */
 function RunScriptRow({
 	repoId,
 	action,
@@ -387,11 +408,22 @@ function RunScriptRow({
 	const queryClient = useQueryClient();
 	const isProjectOwned = action.fromProject || locked;
 
+	const [open, setOpen] = useState(false);
+	const [editing, setEditing] = useState(false);
+
 	const [name, setName] = useState(action.name);
 	const [command, setCommand] = useState(action.command);
 	const [mode, setMode] = useState<RunScriptMode>(action.mode);
-	const [confirmOpen, setConfirmOpen] = useState(false);
+	const [stopCommand, setStopCommand] = useState(action.stopCommand ?? "");
+	// Inline 2-click delete: first click flips this to `true` and the
+	// trash icon swaps to a check; second click actually deletes. Auto-
+	// resets after `DELETE_CONFIRM_RESET_MS` of inactivity so an
+	// abandoned confirm doesn't quietly stay armed.
+	const [confirmingDelete, setConfirmingDelete] = useState(false);
 	const [deleting, setDeleting] = useState(false);
+	const deleteResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+		null,
+	);
 
 	// Keep local state in sync when the upstream record changes (e.g. an
 	// out-of-band update via UI-sync). We only overwrite the local draft
@@ -401,30 +433,49 @@ function RunScriptRow({
 		name: action.name,
 		command: action.command,
 		mode: action.mode,
+		stopCommand: action.stopCommand ?? "",
 	});
 	useEffect(() => {
 		const prev = lastSyncedRef.current;
+		const nextStopCommand = action.stopCommand ?? "";
 		if (prev.name !== action.name) setName(action.name);
 		if (prev.command !== action.command) setCommand(action.command);
 		if (prev.mode !== action.mode) setMode(action.mode);
+		if (prev.stopCommand !== nextStopCommand) setStopCommand(nextStopCommand);
 		lastSyncedRef.current = {
 			name: action.name,
 			command: action.command,
 			mode: action.mode,
+			stopCommand: nextStopCommand,
 		};
-	}, [action.name, action.command, action.mode]);
+	}, [action.name, action.command, action.mode, action.stopCommand]);
 
 	const nameInputRef = useRef<HTMLInputElement | null>(null);
+
+	// Fresh-row affordance: when the parent flags this row as the one
+	// that should grab focus (e.g. the user just clicked "Add script"),
+	// open the card, switch to edit mode, and focus the name input.
 	useEffect(() => {
 		if (!autoFocus || isProjectOwned) return;
-		nameInputRef.current?.focus();
-		nameInputRef.current?.select();
-		onFocused();
+		setOpen(true);
+		setEditing(true);
+		// Defer focus until the collapsible has rendered its content.
+		const id = window.setTimeout(() => {
+			nameInputRef.current?.focus();
+			nameInputRef.current?.select();
+			onFocused();
+		}, 0);
+		return () => window.clearTimeout(id);
 	}, [autoFocus, isProjectOwned, onFocused]);
 
 	const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const persist = useCallback(
-		(next: { name: string; command: string; mode: RunScriptMode }) => {
+		(next: {
+			name: string;
+			command: string;
+			mode: RunScriptMode;
+			stopCommand: string;
+		}) => {
 			if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
 			saveTimerRef.current = setTimeout(() => {
 				const trimmedName = next.name.trim();
@@ -432,12 +483,15 @@ function RunScriptRow({
 				// just bounce. The red-ring affordance below tells the
 				// user why nothing's persisting.
 				if (!trimmedName) return;
+				// Build the stop command: empty / whitespace → null.
+				const trimmedStopCommand = next.stopCommand.trim();
 				void updateRepoRunAction(
 					repoId,
 					action.id,
 					trimmedName,
 					next.command,
 					next.mode,
+					trimmedStopCommand || null,
 				).then(() => {
 					void queryClient.invalidateQueries({
 						queryKey: ["repoScripts", repoId],
@@ -468,137 +522,330 @@ function RunScriptRow({
 			});
 		} finally {
 			setDeleting(false);
-			setConfirmOpen(false);
+			setConfirmingDelete(false);
 		}
 	}, [repoId, action.id, queryClient]);
 
-	if (isProjectOwned) {
-		// Read-only branch: same `header + textarea` shape as ScriptField,
-		// with the name rendered as a static label (mirrors "Setup script"
-		// / "Archive script" headings). Disabled textarea + tooltip
-		// explain why it's inert.
-		const body = (
-			<div>
-				<div className="text-small font-medium text-muted-foreground">
-					{action.name}
-				</div>
-				<Textarea
-					className="mt-2 min-h-[56px] resize-y bg-app-base/30 font-mono text-small"
-					value={action.command}
-					readOnly
-					disabled
-					tabIndex={-1}
-					aria-label={`${action.name} command`}
-				/>
-			</div>
-		);
-		return (
-			<TooltipProvider>
-				<Tooltip>
-					<TooltipTrigger asChild>{body}</TooltipTrigger>
-					<TooltipContent side="top">
-						Set by this workspace's helmor.json — edit it there
-					</TooltipContent>
-				</Tooltip>
-			</TooltipProvider>
-		);
-	}
+	// Auto-reset the armed-delete state after a short window of
+	// inactivity. 3s is enough for a deliberate second click but short
+	// enough that an abandoned confirm doesn't sit armed indefinitely.
+	const DELETE_CONFIRM_RESET_MS = 3000;
+	useEffect(() => {
+		if (!confirmingDelete) return;
+		if (deleteResetTimerRef.current) {
+			clearTimeout(deleteResetTimerRef.current);
+		}
+		deleteResetTimerRef.current = setTimeout(() => {
+			setConfirmingDelete(false);
+		}, DELETE_CONFIRM_RESET_MS);
+		return () => {
+			if (deleteResetTimerRef.current) {
+				clearTimeout(deleteResetTimerRef.current);
+				deleteResetTimerRef.current = null;
+			}
+		};
+	}, [confirmingDelete]);
+
+	const handleDeleteClick = useCallback(() => {
+		if (deleting) return;
+		if (!confirmingDelete) {
+			setConfirmingDelete(true);
+			return;
+		}
+		void handleDelete();
+	}, [confirmingDelete, deleting, handleDelete]);
 
 	const nameInvalid = !name.trim();
+	// First line of the command, truncated by CSS to a single row in the
+	// collapsed header. Empty fallback so new rows still render
+	// something usable in the chip.
+	const firstCommandLine =
+		command.split("\n").find((line) => line.trim().length > 0) ?? "";
+	// Show the Stop command row only when editing or when it carries a
+	// value — view-mode stays clean for the 99% of actions that don't
+	// configure one.
+	const showStopRow = editing || stopCommand.trim().length > 0;
+
+	const handleOpenChange = (next: boolean) => {
+		setOpen(next);
+		// Collapsing the card always exits edit mode and clears any armed
+		// delete — otherwise reopening would unexpectedly show editable
+		// inputs or fire a delete on the first click.
+		if (!next) {
+			setEditing(false);
+			setConfirmingDelete(false);
+		}
+	};
 
 	return (
-		<>
-			<div>
-				<div className="flex items-center justify-between gap-3">
-					<Input
-						ref={nameInputRef}
-						className="h-7 w-full max-w-[220px] text-small font-medium"
-						placeholder="Script name"
-						value={name}
-						aria-invalid={nameInvalid}
-						aria-label="Script name"
-						onChange={(e) => {
-							const value = e.target.value;
-							setName(value);
-							persist({ name: value, command, mode });
-						}}
-					/>
-					<div className="flex shrink-0 items-center gap-1.5">
-						<span className="text-mini font-medium text-muted-foreground">
-							Exclusive
-						</span>
-						<TooltipProvider>
-							<Tooltip>
-								<TooltipTrigger asChild>
-									<HelpCircle
-										className="size-3 cursor-help text-muted-foreground/70"
-										strokeWidth={1.8}
-									/>
-								</TooltipTrigger>
-								<TooltipContent side="top" className="max-w-[240px]">
-									Only let one workspace run this script at a time. Starting a
-									new run stops any other run in this repository — useful when
-									the script binds a fixed port.
-								</TooltipContent>
-							</Tooltip>
-						</TooltipProvider>
-						<Switch
-							checked={mode === "non-concurrent"}
-							onCheckedChange={(checked) => {
-								const next: RunScriptMode = checked
-									? "non-concurrent"
-									: "concurrent";
-								setMode(next);
-								persist({ name, command, mode: next });
-							}}
-							aria-label="Stop other runs in this repository when starting a new run"
+		<Collapsible
+			open={open}
+			onOpenChange={handleOpenChange}
+			className="rounded-lg border border-app-border/40 bg-app-base/20"
+		>
+			{/* Header: stays clickable even with the Exclusive switch on
+				    the right by splitting trigger and controls. */}
+			<div className="flex items-center gap-2 px-3 py-2">
+				<CollapsibleTrigger asChild>
+					<button
+						type="button"
+						className="flex min-w-0 flex-1 cursor-interactive items-center gap-2 text-left"
+						aria-label={`${open ? "Collapse" : "Expand"} ${action.name || "script"}`}
+					>
+						<ChevronDown
+							className={cn(
+								"size-3.5 shrink-0 text-app-muted transition-transform",
+								open && "rotate-180",
+							)}
+							strokeWidth={1.8}
 						/>
-						<TooltipProvider>
-							<Tooltip>
-								<TooltipTrigger asChild>
-									<Button
-										variant="ghost"
-										size="icon"
-										className="size-7 text-muted-foreground hover:text-destructive"
-										onClick={() => setConfirmOpen(true)}
-										aria-label={`Delete script ${action.name || "(unnamed)"}`}
-									>
-										<Trash2 className="size-3.5" strokeWidth={1.8} />
-									</Button>
-								</TooltipTrigger>
-								<TooltipContent side="top">Delete script</TooltipContent>
-							</Tooltip>
-						</TooltipProvider>
-					</div>
+						<span
+							className={cn(
+								"text-small font-medium",
+								name.trim()
+									? "text-foreground"
+									: "text-muted-foreground italic",
+							)}
+						>
+							{name.trim() || "(unnamed)"}
+						</span>
+						<span className="min-w-0 flex-1 truncate text-mini font-mono text-muted-foreground">
+							{firstCommandLine || "(no command)"}
+						</span>
+					</button>
+				</CollapsibleTrigger>
+				<div className="flex shrink-0 items-center gap-1.5">
+					<span className="text-mini font-medium text-muted-foreground">
+						Exclusive
+					</span>
+					<TooltipProvider>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<HelpCircle
+									className="size-3 cursor-help text-muted-foreground/70"
+									strokeWidth={1.8}
+								/>
+							</TooltipTrigger>
+							<TooltipContent side="top" className="max-w-[240px]">
+								Only let one workspace run this script at a time. Starting a new
+								run stops any other run in this repository — useful when the
+								script binds a fixed port.
+							</TooltipContent>
+						</Tooltip>
+					</TooltipProvider>
+					<Switch
+						checked={mode === "non-concurrent"}
+						disabled={isProjectOwned}
+						onCheckedChange={(checked) => {
+							if (isProjectOwned) return;
+							const next: RunScriptMode = checked
+								? "non-concurrent"
+								: "concurrent";
+							setMode(next);
+							persist({
+								name,
+								command,
+								mode: next,
+								stopCommand,
+							});
+						}}
+						aria-label="Stop other runs in this repository when starting a new run"
+					/>
 				</div>
-				<Textarea
-					className="mt-2 min-h-[56px] resize-y bg-app-base/30 font-mono text-small"
-					placeholder="e.g., npm run dev"
-					value={command}
-					aria-label={`${action.name || "Script"} command`}
-					onChange={(e) => {
-						const value = e.target.value;
-						setCommand(value);
-						persist({ name, command: value, mode });
-					}}
-				/>
 			</div>
 
-			<ConfirmDialog
-				open={confirmOpen}
-				onOpenChange={setConfirmOpen}
-				title={`Delete ${action.name || "this script"}?`}
-				description={
-					<>
-						This removes the script from the Inspector's Run dropdown. Any PTY
-						that's currently running will keep going until it exits or you stop
-						it from the terminal.
-					</>
-				}
-				confirmLabel={deleting ? "Deleting..." : "Delete"}
-				onConfirm={() => void handleDelete()}
-				loading={deleting}
-			/>
-		</>
+			<CollapsibleContent>
+				<div className="border-t border-app-border/30 px-3 pt-3 pb-1.5">
+					{/* Script name */}
+					<div className="text-mini font-medium text-muted-foreground">
+						Script name
+					</div>
+					{editing ? (
+						<Input
+							ref={nameInputRef}
+							className="mt-1 h-7 text-small font-medium"
+							placeholder="Script name"
+							value={name}
+							aria-invalid={nameInvalid}
+							aria-label="Script name"
+							onChange={(e) => {
+								const value = e.target.value;
+								setName(value);
+								persist({
+									name: value,
+									command,
+									mode,
+									stopCommand,
+								});
+							}}
+						/>
+					) : (
+						<div className="mt-1 text-small font-medium text-foreground">
+							{name.trim() || (
+								<span className="text-muted-foreground italic">(unnamed)</span>
+							)}
+						</div>
+					)}
+
+					{/* Command */}
+					<div className="mt-3 text-mini font-medium text-muted-foreground">
+						Command
+					</div>
+					{editing ? (
+						<Textarea
+							className="mt-1 min-h-[56px] resize-y bg-app-base/30 font-mono text-small"
+							placeholder="e.g., npm run dev"
+							value={command}
+							aria-label={`${action.name || "Script"} command`}
+							onChange={(e) => {
+								const value = e.target.value;
+								setCommand(value);
+								persist({
+									name,
+									command: value,
+									mode,
+									stopCommand,
+								});
+							}}
+						/>
+					) : (
+						<pre className="mt-1 whitespace-pre-wrap break-all font-mono text-small text-foreground">
+							{command || (
+								<span className="text-muted-foreground italic">(empty)</span>
+							)}
+						</pre>
+					)}
+
+					{/* Stop command — only rendered when set OR while
+						    editing. Reuses Command's Textarea styling so the
+						    two read as a pair. */}
+					{showStopRow ? (
+						<>
+							<div className="mt-3 flex items-center gap-1 text-mini font-medium text-muted-foreground">
+								Stop command
+								<TooltipProvider>
+									<Tooltip>
+										<TooltipTrigger asChild>
+											<HelpCircle
+												className="size-3 cursor-help text-muted-foreground/70"
+												strokeWidth={1.8}
+											/>
+										</TooltipTrigger>
+										<TooltipContent side="top" className="max-w-[280px]">
+											Optional cleanup command run when you click Stop. Useful
+											for scripts that manage external resources (docker compose
+											down, supabase stop). Same env + cwd as the main command.
+										</TooltipContent>
+									</Tooltip>
+								</TooltipProvider>
+							</div>
+							{editing ? (
+								<Textarea
+									className="mt-1 min-h-[56px] resize-y bg-app-base/30 font-mono text-small"
+									placeholder="e.g., docker compose down"
+									value={stopCommand}
+									aria-label={`${action.name || "Script"} stop command`}
+									onChange={(e) => {
+										const value = e.target.value;
+										setStopCommand(value);
+										persist({
+											name,
+											command,
+											mode,
+											stopCommand: value,
+										});
+									}}
+								/>
+							) : (
+								<pre className="mt-1 whitespace-pre-wrap break-all font-mono text-small text-foreground">
+									{stopCommand || (
+										<span className="text-muted-foreground italic">
+											(empty)
+										</span>
+									)}
+								</pre>
+							)}
+						</>
+					) : null}
+
+					{/* Bottom-right toolbar: Edit (pencil) + Delete. Gated
+						    to the expanded state so a misclick on a collapsed
+						    row can't trash anything. For project-owned actions
+						    we swap the buttons out for a small "Managed by
+						    helmor.json" hint in the same slot (same align,
+						    same vertical rhythm) so the user knows why the
+						    controls aren't there. */}
+					{!isProjectOwned ? (
+						<div className="mt-2 flex items-center justify-end gap-1">
+							<TooltipProvider>
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<Button
+											variant={editing ? "secondary" : "ghost"}
+											size="icon"
+											className={cn(
+												"size-7",
+												editing
+													? "text-primary"
+													: "text-muted-foreground hover:text-foreground",
+											)}
+											onClick={() => setEditing((prev) => !prev)}
+											aria-pressed={editing}
+											aria-label={editing ? "Stop editing" : "Edit"}
+										>
+											{editing ? (
+												<Check className="size-3.5" strokeWidth={2} />
+											) : (
+												<Pencil className="size-3.5" strokeWidth={1.8} />
+											)}
+										</Button>
+									</TooltipTrigger>
+									<TooltipContent side="top">
+										{editing ? "Done editing" : "Edit"}
+									</TooltipContent>
+								</Tooltip>
+							</TooltipProvider>
+							<TooltipProvider>
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<Button
+											variant={confirmingDelete ? "destructive" : "ghost"}
+											size="icon"
+											className={cn(
+												"size-7",
+												!confirmingDelete &&
+													"text-muted-foreground hover:text-destructive",
+											)}
+											onClick={handleDeleteClick}
+											disabled={deleting}
+											aria-label={
+												confirmingDelete
+													? `Confirm delete ${action.name || "(unnamed)"}`
+													: `Delete script ${action.name || "(unnamed)"}`
+											}
+										>
+											{confirmingDelete ? (
+												<Check className="size-3.5" strokeWidth={2} />
+											) : (
+												<Trash2 className="size-3.5" strokeWidth={1.8} />
+											)}
+										</Button>
+									</TooltipTrigger>
+									<TooltipContent side="top">
+										{confirmingDelete
+											? "Click again to confirm"
+											: "Delete script"}
+									</TooltipContent>
+								</Tooltip>
+							</TooltipProvider>
+						</div>
+					) : (
+						<div className="mt-2 flex h-7 items-center justify-end text-mini text-muted-foreground/70">
+							Managed by helmor.json — edit the file to add or change
+						</div>
+					)}
+				</div>
+			</CollapsibleContent>
+		</Collapsible>
 	);
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -3122,6 +3122,10 @@ export type RunScriptMode = "concurrent" | "non-concurrent";
  * per repo (e.g. "Dev server", "Tests"); each gets its own dropdown entry
  * and PTY lifecycle. `fromProject` is true when the entry comes from a
  * `helmor.json` declaration — the settings UI renders it read-only.
+ *
+ * `stopCommand`: optional cleanup shell snippet. When set, clicking Stop
+ * runs this to completion (same env + cwd as `command`) before helmor
+ * signals the main process. Second Stop click short-circuits to SIGKILL.
  */
 export type RunAction = {
 	id: string;
@@ -3129,6 +3133,7 @@ export type RunAction = {
 	command: string;
 	mode: RunScriptMode;
 	fromProject: boolean;
+	stopCommand?: string;
 };
 
 export type RepoScripts = {
@@ -3157,6 +3162,9 @@ export type ScriptEvent =
 	| { type: "started"; pid: number; command: string }
 	| { type: "stdout"; data: string }
 	| { type: "stderr"; data: string }
+	/** Backend started running the configured `stopCommand`. Frontends
+	 * flip the Stop button to "Force Stop" until `exited` fires. */
+	| { type: "stopping" }
 	| { type: "exited"; code: number | null }
 	| { type: "error"; message: string };
 
@@ -3313,12 +3321,14 @@ export async function createRepoRunAction(
 	name: string,
 	command: string,
 	mode: RunScriptMode,
+	stopCommand?: string | null,
 ): Promise<RunAction> {
 	return invoke<RunAction>("create_repo_run_action", {
 		repoId,
 		name,
 		command,
 		mode,
+		stopCommand: stopCommand ?? null,
 	});
 }
 
@@ -3328,6 +3338,7 @@ export async function updateRepoRunAction(
 	name: string,
 	command: string,
 	mode: RunScriptMode,
+	stopCommand?: string | null,
 ): Promise<void> {
 	await invoke("update_repo_run_action", {
 		repoId,
@@ -3335,6 +3346,7 @@ export async function updateRepoRunAction(
 		name,
 		command,
 		mode,
+		stopCommand: stopCommand ?? null,
 	});
 }
 


### PR DESCRIPTION
## Summary

Add an optional `stopCommand` field per run action so user-defined cleanup scripts (docker compose down, supabase stop, tailscale down, etc.) run to completion before Helmor signals the main process.

- **Stop**: when `stopCommand` is set, clicking Stop runs it as graceful cleanup; output streams to the same terminal so the user sees progress.
- **Force Stop**: a second Stop click while cleanup is in flight SIGKILLs both the cleanup tree and the main process — no fixed timeout, the user decides when to escalate.
- **Process-leak fixes**: workspace switch / app quit / re-Run now SIGKILL any in-flight cleanup so a previously-running `docker compose down` doesn't outlive the user's intent (was the original motivation for the feature).

helmor.json shape (flat):
```jsonc
{
  "scripts": {
    "run": [{
      "name": "DB",
      "command": "./run-db.sh",
      "stopCommand": "./stop-db.sh"
    }]
  }
}
```

## Test plan

- [x] `cargo test --tests` (incl. new `repo_run_actions_stop_command_migration_adds_column_when_missing` snapshot)
- [x] `cargo test --lib graceful_kill -- --ignored` (force-stop short-circuit + run-and-escalate paths)
- [x] `bun run test:frontend` (1263/1263)
- [x] `bun run test:sidecar` (247/247)
- [x] `cargo clippy --all-targets -- -D warnings` (zero warnings)
- [x] `bun run lint` + `bun run typecheck`
- [x] Manual smoke: stopCommand exits non-zero → main process still SIGTERMs normally (no misleading "falling back to SIGKILL")
- [x] Manual smoke: Stop → countdown cleanup → main process exits after cleanup completes
- [x] Manual smoke: Stop → re-click → Force Stop kills cleanup + main < 1s
- [x] Manual smoke: Stop → start Run on another workspace mid-cleanup → old cleanup is reaped (no orphan sleep / docker compose down)

## Release metadata

- `.changeset/gentle-eagles-cleanup.md` (minor bump)
- `.announcements/run-action-stop-command.json` — in-app toast with "Open Run scripts" action that deep-links to the current repo's Scripts section (reuses the `repo:current` sentinel from the 0.23.5 multi-action announcement)