### PR TITLE
feat: add experimental local LLM with on-device title and branch name generation

### DIFF
--- a/.announcements/local-llm-experimental.json
+++ b/.announcements/local-llm-experimental.json
@@ -1,0 +1,11 @@
+{
+	"items": [
+		{
+			"text": "Local LLM lands as a very experimental preview — it powers session title and branch name generation for now. More features coming soon.",
+			"action": {
+				"label": "Open Local LLM",
+				"value": { "type": "openSettings", "section": "experimental" }
+			}
+		}
+	]
+}

--- a/.changeset/local-llm-experimental-preview.md
+++ b/.changeset/local-llm-experimental-preview.md
@@ -1,0 +1,5 @@
+---
+"helmor": minor
+---
+
+Add an experimental Local LLM panel that runs session title and branch name generation on-device through a bundled llama-server.

--- a/sidecar/scripts/stage-vendor.ts
+++ b/sidecar/scripts/stage-vendor.ts
@@ -73,6 +73,22 @@ const CLAUDE_CODE_SHA256: Readonly<
 	},
 };
 
+// llama.cpp bundled binary. Drives `local_llm::Manager` (the
+// auto-rename / local-LLM stack). Versions are `b<N>` build tags from
+// github.com/ggml-org/llama.cpp/releases. Bumping the version: replace
+// LLAMA_VERSION and the matching arm64/x64 sha256 (computed below from
+// the upstream zip on first run; see DEV-fallback notes in
+// `downloadAndVerifyLlama`). Wipe sidecar/.bundle-cache when bumping
+// so the new archive isn't blocked by a wrong-sha cached copy.
+const LLAMA_VERSION = "b9294";
+// Leave entries blank to skip strict verification during local dev —
+// stage-vendor will warn + trust HTTPS, print the computed sha, and
+// proceed. Fill these in (and commit) to lock the build in CI.
+const LLAMA_SHA256: Readonly<{ arm64: string; x64: string }> = {
+	arm64: "8cb59947211ac84f84a3afe6db83e6b8167ef24e70ca3dde199df48ff6591e44",
+	x64: "72ba8001fe1ec75ff6d5fd0fe5be244f25d4c560c2501abbcfcbbfbac6b2d1c1",
+};
+
 // ---------------------------------------------------------------------------
 // Target detection — honor TAURI_TARGET_TRIPLE so cross-arch CI stages the
 // right binaries. Falls back to the host arch for `bun run dev` / local
@@ -508,6 +524,122 @@ function stageCodexBinary(target: TargetInfo): void {
 }
 
 // ---------------------------------------------------------------------------
+// llama.cpp — download official macOS binary release for the target arch.
+// Different from gh/glab: ships as a fat zip containing llama-server +
+// llama-cli + a pile of shared libs (libllama, libggml-*, libmtmd, ...).
+// We stage the whole bin/ directory as a unit so the dylib RPATHs that
+// upstream baked in (`@loader_path/.`) keep resolving.
+// ---------------------------------------------------------------------------
+
+/// Soft-verifying download: if `LLAMA_SHA256` for this arch is filled
+/// in we treat mismatches as fatal (release-build hardening); when it's
+/// empty we print the computed digest and trust HTTPS so dev runs
+/// aren't blocked by a missing pinned hash.
+function downloadAndVerifyLlama(
+	url: string,
+	dest: string,
+	expectedSha256: string,
+): void {
+	if (existsSync(dest)) {
+		const actual = sha256OfFile(dest);
+		if (!expectedSha256 || actual === expectedSha256) return;
+		console.warn(
+			`[stage-vendor] cached ${dest} has wrong sha256 (got ${actual}); re-downloading`,
+		);
+		rmSync(dest, { force: true });
+	}
+	console.log(`[stage-vendor] downloading ${url}`);
+	mkdirSync(dirname(dest), { recursive: true });
+	execFileSync("curl", ["-fL", "--retry", "3", "-o", dest, url], {
+		stdio: "inherit",
+	});
+	const actual = sha256OfFile(dest);
+	if (!expectedSha256) {
+		console.warn(
+			`[stage-vendor] LLAMA_SHA256 is blank for this arch — got ${actual}. ` +
+				"Fill it in to lock the version for CI / release builds.",
+		);
+		return;
+	}
+	if (actual !== expectedSha256) {
+		rmSync(dest, { force: true });
+		throw new Error(
+			`[stage-vendor] sha256 mismatch for ${url}\n  expected: ${expectedSha256}\n  actual:   ${actual}`,
+		);
+	}
+}
+
+function stageLlamaCppBinaries(target: TargetInfo): string {
+	ensureCacheDir();
+	const archSlug = target.arch === "arm64" ? "macos-arm64" : "macos-x64";
+	const slug = `llama-${LLAMA_VERSION}-bin-${archSlug}`;
+	// Upstream ships macOS builds as `.tar.gz` (not `.zip` like the
+	// Windows artefacts) — extension matters for both the cache file
+	// name and the extract command below.
+	const archive = join(BUNDLE_CACHE, `${slug}.tar.gz`);
+	const url = `https://github.com/ggml-org/llama.cpp/releases/download/${LLAMA_VERSION}/${slug}.tar.gz`;
+	downloadAndVerifyLlama(url, archive, LLAMA_SHA256[target.arch]);
+
+	const extractDir = join(BUNDLE_CACHE, slug);
+	freshExtractDir(extractDir);
+	execFileSync("tar", ["-xzf", archive, "-C", extractDir], {
+		stdio: "inherit",
+	});
+
+	// The archive nests everything under a single `llama-<ver>/` folder
+	// (binaries + dylibs side-by-side, no `bin/`). Earlier upstream
+	// shapes used `bin/` or `build/bin/` — probe both so future bumps
+	// keep working without script changes.
+	const candidates: string[] = [
+		...readdirSync(extractDir).flatMap((entry) => [
+			join(extractDir, entry),
+			join(extractDir, entry, "bin"),
+			join(extractDir, entry, "build", "bin"),
+		]),
+		join(extractDir, "bin"),
+		join(extractDir, "build", "bin"),
+	];
+	const binDir = candidates.find(
+		(p) => existsSync(p) && existsSync(join(p, "llama-server")),
+	);
+	if (!binDir) {
+		throw new Error(
+			`[stage-vendor] llama-server missing under ${extractDir} — checked ${candidates.join(", ")}`,
+		);
+	}
+
+	const dest = join(DIST_VENDOR, "llama-cpp");
+	freshExtractDir(dest);
+	// `cpSync` with `dereference: false` preserves the dylib version
+	// symlinks (libggml.dylib → libggml.0.dylib → libggml.0.11.0.dylib).
+	// Following them would balloon the bundle ~3× and break the
+	// upstream RPATH layout.
+	cpSync(binDir, dest, { recursive: true, dereference: false });
+	// Re-assert exec bit on every regular file — tarball preserves
+	// modes already, but cpSync between filesystems sometimes flips
+	// them and an un-executable `llama-server` would just fail to
+	// spawn with a confusing EACCES.
+	for (const entry of readdirSync(dest)) {
+		const path = join(dest, entry);
+		const stat = statSync(path);
+		if (
+			stat.isFile() &&
+			!entry.endsWith(".dylib") &&
+			!entry.endsWith(".metallib")
+		) {
+			chmodSync(path, 0o755);
+		}
+	}
+
+	// `llama-server` needs `allow-jit` / `allow-unsigned-executable-memory`
+	// under hardened runtime (same JSC story as the Bun-compiled sidecar
+	// binaries) — without them the server process aborts at first GGUF
+	// load on signed builds.
+	maybeSignMacBinary(join(dest, "llama-server"), true);
+	return dest;
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
@@ -531,9 +663,13 @@ stageCodexBinary(target);
 stageGhBinary(target.ghArch);
 stageGlabBinary(target.glabArch);
 
+// ----- llama.cpp (local LLM server for auto-rename / Local AI) -----
+stageLlamaCppBinaries(target);
+
 // ----- Summary -----
 console.log(`[stage-vendor] ✓ staged → ${DIST_VENDOR}`);
 console.log(`  claude-code ${humanSize(join(DIST_VENDOR, "claude-code"))}`);
 console.log(`  codex       ${humanSize(join(DIST_VENDOR, "codex"))}`);
 console.log(`  gh          ${humanSize(join(DIST_VENDOR, "gh"))}`);
 console.log(`  glab        ${humanSize(join(DIST_VENDOR, "glab"))}`);
+console.log(`  llama-cpp   ${humanSize(join(DIST_VENDOR, "llama-cpp"))}`);

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1854,6 +1854,7 @@ dependencies = [
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
  "tempfile",
+ "tokio",
  "toml 0.8.2",
  "tracing",
  "tracing-subscriber",
@@ -4052,12 +4053,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots",
 ]
@@ -4097,7 +4100,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -6181,6 +6184,19 @@ dependencies = [
  "indexmap 2.13.0",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,7 +26,12 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 rand = "0.10.0"
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = [
+    "blocking",
+    "json",
+    "rustls-tls",
+    "stream",
+] }
 rusqlite = { version = "0.31", features = ["bundled", "backup"] }
 r2d2 = "0.8"
 r2d2_sqlite = "0.24"
@@ -42,11 +47,23 @@ tauri-plugin-notification = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-window-state = "2"
+tokio = { version = "1", features = [
+    "fs",
+    "io-util",
+    "rt",
+    "sync",
+    "macros",
+    "time",
+] }
 notify = "7"
 notify-debouncer-full = "0.4"
 toml = "0.8"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["json", "env-filter", "chrono"] }
+tracing-subscriber = { version = "0.3", features = [
+    "json",
+    "env-filter",
+    "chrono",
+] }
 url = "2"
 uuid = { version = "1", features = ["v4"] }
 
@@ -85,11 +102,11 @@ codegen-units = 256          # max intra-crate parallelism
 incremental = false          # required for sccache compatibility
 
 [profile.dev.package."*"]
-debug = false                # deps don't need debug info at all
+debug = false       # deps don't need debug info at all
 opt-level = 0
 codegen-units = 256
 
 [profile.dev.build-override]
-debug = false                # build scripts & proc-macros: fastest possible
+debug = false       # build scripts & proc-macros: fastest possible
 opt-level = 0
 codegen-units = 256

--- a/src-tauri/src/agents/queries.rs
+++ b/src-tauri/src/agents/queries.rs
@@ -152,111 +152,165 @@ pub async fn generate_session_title(
         });
     }
 
-    let request_id = Uuid::new_v4().to_string();
-    // Skip the branch slug instruction in the prompt when we already know we
-    // won't apply it (local mode, already-renamed worktree, etc.). Saves a
-    // line of LLM output and the branch-rename instruction block of input.
-    let mut params = serde_json::json!({
-        "userMessage": request.user_message,
-        "branchRenamePrompt": branch_rename_prompt,
-        "generateBranch": should_generate_branch,
-    });
-    if let Some(model) = super::custom_providers::configured_models()
-        .into_iter()
-        .next()
-    {
-        if let Some(obj) = params.as_object_mut() {
-            obj.insert(
-                "claudeModel".to_string(),
-                Value::String(model.cli_model.clone()),
-            );
-            obj.insert(
-                "claudeEnvironment".to_string(),
-                serde_json::json!({
-                    "ANTHROPIC_BASE_URL": model.base_url,
-                    "ANTHROPIC_AUTH_TOKEN": model.api_key,
-                }),
-            );
+    // Cascade head: try the bundled local LLM first. On any failure
+    // (server not running, timeout, parse mismatch) fall through to
+    // the sidecar's cloud cascade (custom-claude → claude → codex →
+    // cursor). `TITLE_TIMEOUT` inside `local_llm::title` caps the
+    // attempt at ~15s so a stuck cold load can't block this path long.
+    let local_result: Option<(String, Option<String>)> = {
+        let user_message = request.user_message.clone();
+        let branch_prompt = branch_rename_prompt.clone();
+        let generate_branch = should_generate_branch;
+        let app_for_local = app.clone();
+        let session_id_for_log = request.session_id.clone();
+        match tauri::async_runtime::spawn_blocking(move || {
+            let manager = app_for_local.state::<crate::local_llm::Manager>();
+            manager
+                .inner()
+                .generate_title(&user_message, branch_prompt.as_deref(), generate_branch)
+        })
+        .await
+        {
+            Ok(Ok((title, branch))) => {
+                tracing::info!(
+                    session_id = %session_id_for_log,
+                    generated_title = %title,
+                    generated_branch = branch.as_deref().unwrap_or(""),
+                    "generate_session_title produced by local LLM (sidecar cascade skipped)"
+                );
+                Some((title, branch))
+            }
+            Ok(Err(error)) => {
+                tracing::debug!(
+                    session_id = %session_id_for_log,
+                    error = %error,
+                    "Local LLM title attempt failed; falling through to sidecar cascade"
+                );
+                None
+            }
+            Err(error) => {
+                tracing::warn!(
+                    session_id = %session_id_for_log,
+                    error = %error,
+                    "Local LLM title task join failed; falling through to sidecar cascade"
+                );
+                None
+            }
         }
-    }
-    let sidecar_req = crate::sidecar::SidecarRequest {
-        id: request_id.clone(),
-        method: "generateTitle".to_string(),
-        params,
     };
 
-    let rx = sidecar.subscribe(&request_id);
-
-    if let Err(e) = sidecar.send(&sidecar_req) {
-        sidecar.unsubscribe(&request_id);
-        return Err(anyhow::anyhow!("Sidecar send failed: {e}").into());
-    }
-
     let session_id = request.session_id.clone();
-    let result: (Option<String>, Option<String>) = tauri::async_runtime::spawn_blocking({
-        let rid = request_id;
-        let session_id_for_logs = session_id.clone();
-        move || {
-            let sidecar_state: tauri::State<'_, crate::sidecar::ManagedSidecar> = app.state();
-            let mut title: Option<String> = None;
-            let mut branch_name: Option<String> = None;
-
-            loop {
-                match rx.recv_timeout(TITLE_GEN_TIMEOUT) {
-                    Ok(event) => match event.event_type() {
-                        "titleGenerated" => {
-                            title = event
-                                .raw
-                                .get("title")
-                                .and_then(Value::as_str)
-                                .map(str::to_string)
-                                .filter(|text| !text.is_empty());
-                            branch_name = event
-                                .raw
-                                .get("branchName")
-                                .and_then(Value::as_str)
-                                .map(str::to_string)
-                                .filter(|branch| !branch.is_empty());
-                            tracing::debug!(
-                                session_id = %session_id_for_logs,
-                                generated_title = title.as_deref().unwrap_or(""),
-                                generated_branch = branch_name.as_deref().unwrap_or(""),
-                                "generate_session_title received titleGenerated"
-                            );
-                            break;
-                        }
-                        "error" => {
-                            let message = event
-                                .raw
-                                .get("message")
-                                .and_then(Value::as_str)
-                                .unwrap_or("Unknown error");
-                            tracing::error!("generate_session_title: sidecar error: {message}");
-                            break;
-                        }
-                        _ => {}
-                    },
-                    Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-                        tracing::error!(
-                            "generate_session_title: timed out after {TITLE_GEN_TIMEOUT:?}"
-                        );
-                        break;
-                    }
-                    Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-                        tracing::error!("generate_session_title: sidecar disconnected");
-                        break;
-                    }
+    let (generated_title, generated_branch): (Option<String>, Option<String>) =
+        if let Some((title, branch)) = local_result {
+            (Some(title), branch)
+        } else {
+            let request_id = Uuid::new_v4().to_string();
+            // Skip the branch slug instruction in the prompt when we already know we
+            // won't apply it (local mode, already-renamed worktree, etc.). Saves a
+            // line of LLM output and the branch-rename instruction block of input.
+            let mut params = serde_json::json!({
+                "userMessage": request.user_message,
+                "branchRenamePrompt": branch_rename_prompt,
+                "generateBranch": should_generate_branch,
+            });
+            if let Some(model) = super::custom_providers::configured_models()
+                .into_iter()
+                .next()
+            {
+                if let Some(obj) = params.as_object_mut() {
+                    obj.insert(
+                        "claudeModel".to_string(),
+                        Value::String(model.cli_model.clone()),
+                    );
+                    obj.insert(
+                        "claudeEnvironment".to_string(),
+                        serde_json::json!({
+                            "ANTHROPIC_BASE_URL": model.base_url,
+                            "ANTHROPIC_AUTH_TOKEN": model.api_key,
+                        }),
+                    );
                 }
             }
+            let sidecar_req = crate::sidecar::SidecarRequest {
+                id: request_id.clone(),
+                method: "generateTitle".to_string(),
+                params,
+            };
 
-            sidecar_state.unsubscribe(&rid);
-            (title, branch_name)
-        }
-    })
-    .await
-    .map_err(|e| anyhow::anyhow!("Title generation task failed: {e}"))?;
+            let rx = sidecar.subscribe(&request_id);
 
-    let (generated_title, generated_branch) = result;
+            if let Err(e) = sidecar.send(&sidecar_req) {
+                sidecar.unsubscribe(&request_id);
+                return Err(anyhow::anyhow!("Sidecar send failed: {e}").into());
+            }
+
+            let session_id_for_task = session_id.clone();
+            tauri::async_runtime::spawn_blocking({
+                let rid = request_id;
+                let session_id_for_logs = session_id_for_task;
+                move || {
+                    let sidecar_state: tauri::State<'_, crate::sidecar::ManagedSidecar> =
+                        app.state();
+                    let mut title: Option<String> = None;
+                    let mut branch_name: Option<String> = None;
+
+                    loop {
+                        match rx.recv_timeout(TITLE_GEN_TIMEOUT) {
+                            Ok(event) => match event.event_type() {
+                                "titleGenerated" => {
+                                    title = event
+                                        .raw
+                                        .get("title")
+                                        .and_then(Value::as_str)
+                                        .map(str::to_string)
+                                        .filter(|text| !text.is_empty());
+                                    branch_name = event
+                                        .raw
+                                        .get("branchName")
+                                        .and_then(Value::as_str)
+                                        .map(str::to_string)
+                                        .filter(|branch| !branch.is_empty());
+                                    tracing::debug!(
+                                        session_id = %session_id_for_logs,
+                                        generated_title = title.as_deref().unwrap_or(""),
+                                        generated_branch = branch_name.as_deref().unwrap_or(""),
+                                        "generate_session_title received titleGenerated"
+                                    );
+                                    break;
+                                }
+                                "error" => {
+                                    let message = event
+                                        .raw
+                                        .get("message")
+                                        .and_then(Value::as_str)
+                                        .unwrap_or("Unknown error");
+                                    tracing::error!(
+                                        "generate_session_title: sidecar error: {message}"
+                                    );
+                                    break;
+                                }
+                                _ => {}
+                            },
+                            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                                tracing::error!(
+                                    "generate_session_title: timed out after {TITLE_GEN_TIMEOUT:?}"
+                                );
+                                break;
+                            }
+                            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                                tracing::error!("generate_session_title: sidecar disconnected");
+                                break;
+                            }
+                        }
+                    }
+
+                    sidecar_state.unsubscribe(&rid);
+                    (title, branch_name)
+                }
+            })
+            .await
+            .map_err(|e| anyhow::anyhow!("Title generation task failed: {e}"))?
+        };
 
     if should_generate_title && generated_title.is_none() {
         tracing::error!(

--- a/src-tauri/src/commands/local_llm_commands.rs
+++ b/src-tauri/src/commands/local_llm_commands.rs
@@ -1,0 +1,250 @@
+use anyhow::Context as _;
+use tauri::ipc::Channel;
+use tauri::{AppHandle, Manager, State};
+
+use crate::{
+    commands::common::{run_blocking, CmdResult},
+    data_dir, downloads, local_llm,
+};
+
+#[tauri::command]
+pub async fn get_local_llm_status(
+    manager: State<'_, local_llm::Manager>,
+) -> CmdResult<local_llm::Status> {
+    Ok(manager.status())
+}
+
+/// Read-only curated catalog of supported GGUF models.
+#[tauri::command]
+pub async fn list_local_llm_catalog() -> CmdResult<Vec<local_llm::CatalogEntry>> {
+    Ok(local_llm::catalog::catalog())
+}
+
+/// Inspect an arbitrary `.gguf` file on disk and return its trained
+/// context window + estimated fp16 KV cache cost per token. The settings
+/// panel calls this for the user's Custom model path so the context
+/// slider can render real limits.
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelInspection {
+    pub architecture: String,
+    pub name: Option<String>,
+    pub context_length: u32,
+    pub kv_bytes_per_token: u32,
+    /// Pre-computed default with the current hardware tier, ready to
+    /// drop straight into the slider as the "Reset" target.
+    pub default_context_tokens: u32,
+}
+
+#[tauri::command]
+pub async fn inspect_local_llm_model(path: String) -> CmdResult<ModelInspection> {
+    run_blocking(move || {
+        // Users routinely paste paths with stray whitespace (drag-drop on
+        // some terminals, copy from a quoted log line, …). Trim once
+        // here so every downstream check (extension sniff, exists, magic)
+        // sees the canonical form.
+        let trimmed = path.trim();
+        if trimmed.is_empty() {
+            anyhow::bail!("Model path is empty");
+        }
+        build_inspection(std::path::Path::new(trimmed))
+    })
+    .await
+}
+
+/// Same inspection as `inspect_local_llm_model`, but keyed by catalog
+/// entry id — the panel uses this to read real GGUF metadata for an
+/// already-downloaded catalog model. Returns `None` when the file isn't
+/// downloaded yet (so the panel falls back to the catalog estimate).
+/// A parse error still bubbles up so the user sees the actual reason.
+#[tauri::command]
+pub async fn inspect_local_llm_catalog_entry(
+    entry_id: String,
+) -> CmdResult<Option<ModelInspection>> {
+    run_blocking(move || {
+        let entry = local_llm::catalog::catalog()
+            .into_iter()
+            .find(|e| e.id == entry_id)
+            .with_context(|| format!("unknown catalog entry id: {entry_id}"))?;
+        let first_file = entry.files.first().context("catalog entry has no files")?;
+        let path = data_dir::local_llm_models_dir()?.join(first_file);
+        if !path.exists() {
+            return Ok(None);
+        }
+        Ok(Some(build_inspection(&path)?))
+    })
+    .await
+}
+
+fn build_inspection(path: &std::path::Path) -> anyhow::Result<ModelInspection> {
+    let meta = local_llm::gguf::read_metadata(path)?;
+    let hw = local_llm::hardware::detect();
+    let default_context_tokens =
+        local_llm::compute_default_context_for_meta(&meta, hw.total_ram_gb);
+    Ok(ModelInspection {
+        architecture: meta.architecture.clone(),
+        name: meta.name.clone(),
+        context_length: meta.context_length,
+        kv_bytes_per_token: meta.kv_bytes_per_token(),
+        default_context_tokens,
+    })
+}
+
+/// Local-machine snapshot — CPU brand, total RAM, OS version, arch,
+/// and the catalog entry id we'd recommend for this RAM tier.
+#[tauri::command]
+pub async fn detect_local_llm_hardware() -> CmdResult<local_llm::HardwareSnapshot> {
+    Ok(local_llm::hardware::detect())
+}
+
+/// Subscribe to per-entry download status events and return the
+/// initial snapshot in one round-trip.
+#[tauri::command]
+pub async fn subscribe_local_llm_downloads(
+    manager: State<'_, downloads::DownloadsManager>,
+    on_event: Channel<downloads::AssetEvent>,
+) -> CmdResult<Vec<downloads::AssetStatus>> {
+    Ok(manager.subscribe(on_event))
+}
+
+/// Read-only snapshot — used to bootstrap a panel that already has a
+/// subscription, or just to debug from devtools.
+#[tauri::command]
+pub async fn list_local_llm_downloads(
+    manager: State<'_, downloads::DownloadsManager>,
+) -> CmdResult<Vec<downloads::AssetStatus>> {
+    Ok(manager.snapshot())
+}
+
+/// Start (or resume) downloading the asset for `entry_id`. Idempotent.
+#[tauri::command]
+pub async fn start_local_llm_download(app: AppHandle, entry_id: String) -> CmdResult<()> {
+    let manager = app.state::<downloads::DownloadsManager>();
+    manager.start(app.clone(), &entry_id)?;
+    Ok(())
+}
+
+/// Stop an in-flight download but keep the `.part` on disk so it can
+/// be resumed later. No-op if the worker isn't running.
+#[tauri::command]
+pub async fn pause_local_llm_download(
+    manager: State<'_, downloads::DownloadsManager>,
+    entry_id: String,
+) -> CmdResult<()> {
+    manager.pause(&entry_id);
+    Ok(())
+}
+
+/// Stop an in-flight download AND wipe the `.part` + final files from
+/// disk. Used by both the panel's Cancel and Delete affordances.
+#[tauri::command]
+pub async fn cancel_local_llm_download(
+    manager: State<'_, downloads::DownloadsManager>,
+    entry_id: String,
+) -> CmdResult<()> {
+    manager.cancel_and_delete(&entry_id)?;
+    Ok(())
+}
+
+/// Persist a per-model `-c` (runtime context tokens) override. The
+/// value is clamped to `[4096, entry.model_max_context_tokens]` and
+/// removed if it equals the catalog default. Restarts the server when
+/// it's running so the new context allocation takes effect.
+#[tauri::command]
+pub async fn set_local_llm_context_override(
+    app: AppHandle,
+    entry_id: String,
+    context_tokens: u32,
+) -> CmdResult<local_llm::Status> {
+    run_blocking(move || {
+        local_llm::set_context_override(&entry_id, context_tokens)?;
+        let manager = app.state::<local_llm::Manager>();
+        let prior = manager.status();
+        if prior.running || prior.starting {
+            // Fire-and-forget restart on a blocking thread. `ensure_started`
+            // short-circuits when the same model is live, so stop first —
+            // otherwise the new `-c` would never reach llama-server.
+            let app_clone = app.clone();
+            tauri::async_runtime::spawn_blocking(move || {
+                let manager = app_clone.state::<local_llm::Manager>();
+                manager.stop();
+                if let Err(error) = manager.start() {
+                    tracing::warn!(
+                        error = ?error,
+                        "auto-restart after context override failed"
+                    );
+                }
+            });
+        }
+        Ok(manager.status())
+    })
+    .await
+}
+
+/// Switch the bundled llama-server over to the GGUF managed by the
+/// given catalog entry. File must already be downloaded. Fires a
+/// (re)start when Local LLM is enabled so the new model loads right
+/// away; the UI's polled status query surfaces Starting → Running.
+#[tauri::command]
+pub async fn activate_local_llm_model(
+    app: AppHandle,
+    entry_id: String,
+) -> CmdResult<local_llm::Status> {
+    run_blocking(move || {
+        let entry = local_llm::catalog::catalog()
+            .into_iter()
+            .find(|e| e.id == entry_id)
+            .with_context(|| format!("unknown catalog entry id: {entry_id}"))?;
+        let first_file = entry.files.first().context("catalog entry has no files")?;
+        let path = data_dir::local_llm_models_dir()?.join(first_file);
+        if !path.exists() {
+            anyhow::bail!("model file not yet downloaded: {}", path.display());
+        }
+        local_llm::set_active_model_path(path.display().to_string())?;
+
+        let manager = app.state::<local_llm::Manager>();
+        if local_llm::load_settings().enabled {
+            let app_clone = app.clone();
+            tauri::async_runtime::spawn_blocking(move || {
+                let manager = app_clone.state::<local_llm::Manager>();
+                if let Err(error) = manager.start() {
+                    tracing::warn!(
+                        error = ?error,
+                        "auto-start after activate_local_llm_model failed"
+                    );
+                }
+            });
+        }
+        Ok(manager.status())
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn start_local_llm(app: AppHandle) -> CmdResult<local_llm::Status> {
+    run_blocking(move || {
+        let manager = app.state::<local_llm::Manager>();
+        manager.start()
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn stop_local_llm(app: AppHandle) -> CmdResult<()> {
+    run_blocking(move || {
+        let manager = app.state::<local_llm::Manager>();
+        manager.stop();
+        Ok(())
+    })
+    .await
+}
+
+/// Connection params for the running server (URL + bearer token + alias).
+/// `None` while stopped / starting / crashed. Voice Pilot reads this to
+/// POST chat completions directly into the user's configured brain.
+#[tauri::command]
+pub async fn get_local_llm_endpoint(
+    manager: State<'_, local_llm::Manager>,
+) -> CmdResult<Option<local_llm::Endpoint>> {
+    Ok(manager.endpoint())
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod editor_commands;
 pub(crate) mod editors;
 pub(crate) mod feedback_commands;
 pub(crate) mod forge_commands;
+pub(crate) mod local_llm_commands;
 pub(crate) mod repository_commands;
 pub(crate) mod script_commands;
 pub(crate) mod session_commands;

--- a/src-tauri/src/data_dir.rs
+++ b/src-tauri/src/data_dir.rs
@@ -125,6 +125,23 @@ pub fn query_cache_dir() -> Result<PathBuf> {
     cache_dir("query")
 }
 
+/// Returns the directory where Helmor-managed GGUF model files live.
+///
+/// Deliberately kept separate from `~/.cache/huggingface/hub/` — we
+/// don't share that cache with other local-LLM tools because (a) we
+/// need pause/resume + integrity checks that the HF cache loader
+/// doesn't expose, (b) we want the user to be able to disable Local
+/// LLM and reclaim disk by deleting one folder we own, (c) multi-part
+/// download orchestration needs predictable, atomic rename semantics
+/// that the HF cache layout doesn't guarantee.
+pub fn local_llm_models_dir() -> Result<PathBuf> {
+    let dir = data_dir()?.join("local-llm").join("models");
+    if !dir.exists() {
+        fs::create_dir_all(&dir).context("Failed to create Local LLM models directory")?;
+    }
+    Ok(dir)
+}
+
 /// Returns the Conductor source database path for import.
 /// This is the real Conductor database on the local machine.
 pub fn conductor_source_db_path() -> Option<PathBuf> {

--- a/src-tauri/src/downloads/hf.rs
+++ b/src-tauri/src/downloads/hf.rs
@@ -1,0 +1,66 @@
+//! HuggingFace `models/{repo}` manifest fetcher. Best-effort —
+//! callers downgrade to `Content-Length` + no integrity verification
+//! when the manifest can't be fetched (offline, private repo, etc).
+
+use std::collections::HashMap;
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct HfManifest {
+    pub per_file: HashMap<String, HfFileInfo>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct HfFileInfo {
+    pub size: Option<u64>,
+    pub sha256: Option<String>,
+}
+
+impl HfManifest {
+    /// Hit `GET /api/models/{repo}` and extract the `siblings` array
+    /// down to `{ size, sha256 }` per file. Resilient: returns Err
+    /// only on hard transport failures; missing fields per sibling
+    /// just leave the maps empty.
+    pub async fn fetch(client: &reqwest::Client, repo: &str) -> Result<Self> {
+        let url = format!("https://huggingface.co/api/models/{repo}");
+        let raw = client
+            .get(&url)
+            .send()
+            .await
+            .with_context(|| format!("GET {url}"))?
+            .error_for_status()
+            .with_context(|| format!("HF API {url}"))?
+            .json::<serde_json::Value>()
+            .await
+            .with_context(|| format!("decode HF manifest for {url}"))?;
+        let siblings = raw
+            .get("siblings")
+            .and_then(|s| s.as_array())
+            .cloned()
+            .unwrap_or_default();
+        let mut per_file = HashMap::new();
+        for sibling in siblings {
+            let Some(name) = sibling
+                .get("rfilename")
+                .and_then(|n| n.as_str())
+                .map(str::to_owned)
+            else {
+                continue;
+            };
+            let info = HfFileInfo {
+                size: sibling
+                    .get("size")
+                    .and_then(|s| s.as_u64())
+                    .or_else(|| sibling.pointer("/lfs/size").and_then(|s| s.as_u64())),
+                sha256: sibling
+                    .pointer("/lfs/sha256")
+                    .and_then(|s| s.as_str())
+                    .map(str::to_owned),
+            };
+            per_file.insert(name, info);
+        }
+        Ok(Self { per_file })
+    }
+}

--- a/src-tauri/src/downloads/mod.rs
+++ b/src-tauri/src/downloads/mod.rs
@@ -1,0 +1,30 @@
+//! General-purpose download / cache manager.
+//!
+//! Zero business concepts live in this module — no notion of "LLM
+//! catalog", "STT engine", or "Voice Pilot". Callers describe what
+//! they want as `Asset`s, register an `AssetProvider`, and the
+//! manager handles:
+//!
+//!   * Snapshot-from-disk (NotDownloaded / Downloading / Paused /
+//!     Downloaded / Failed) with on-demand rescan so manually placed
+//!     files are picked up.
+//!   * Resumable HTTP streaming with `Range:` headers + per-chunk
+//!     SHA-256 hashing.
+//!   * Optional tar.gz extraction after successful download.
+//!   * Pause vs. cancel (cancel wipes `.part`; pause keeps it).
+//!   * Subscriber channels: every state transition fans out to every
+//!     `Channel<AssetEvent>` registered through `subscribe()`.
+//!
+//! Designed to grow into the single place every long-running download
+//! in Helmor flows through (local AI weights, STT models, in-app
+//! updates that we control directly, future plugin packs, etc).
+
+mod hf;
+mod registry;
+mod types;
+mod worker;
+
+pub use registry::{AssetProvider, DownloadsManager};
+pub use types::{
+    ArchiveKind, Asset, AssetEvent, AssetEventKind, AssetSource, AssetState, AssetStatus,
+};

--- a/src-tauri/src/downloads/registry.rs
+++ b/src-tauri/src/downloads/registry.rs
@@ -1,0 +1,470 @@
+//! In-process registry for the generic downloads manager.
+//!
+//! Holds:
+//!   * one row per `Asset.id` (status snapshot, derived from disk)
+//!   * the active worker cancel flags (per id)
+//!   * the set of frontend subscribers (`Channel<AssetEvent>`)
+//!   * a reference to the host-app `AssetProvider` so `snapshot()`
+//!     and `subscribe()` can rebuild the catalog without callers
+//!     having to pass `assets` in every time
+//!
+//! Invariant: at most ONE worker per `Asset.id` is alive at any
+//! time. `start()` is the only entry point that spawns a worker.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use anyhow::{Context, Result};
+use tauri::ipc::Channel;
+use tauri::Manager;
+
+use super::types::{Asset, AssetEvent, AssetEventKind, AssetState, AssetStatus};
+use super::worker;
+
+/// Business adapter — supplies the current catalog of `Asset`s the
+/// manager should track. Implementations are typically zero-cost
+/// (catalog is hardcoded in Rust), so the trait method can be called
+/// on every snapshot without caching concerns.
+pub trait AssetProvider: Send + Sync {
+    fn assets(&self) -> Vec<Asset>;
+}
+
+#[derive(Default)]
+struct Inner {
+    /// Status by `Asset.id`. Re-derived from disk every time
+    /// `snapshot()` runs (so manually placed files are picked up),
+    /// except for ids that are currently active or pending cancel —
+    /// those are owned by their worker.
+    statuses: HashMap<String, AssetStatus>,
+    /// Active worker cancel flags. Presence implies status ==
+    /// Downloading. Worker drops its handle from this map on exit.
+    active: HashMap<String, Arc<AtomicBool>>,
+    /// Ids whose download was Cancelled (not Paused) by the user but
+    /// whose worker hasn't yet observed the cancel flag. `emit()`
+    /// filters out any incoming event for ids in this set so the
+    /// worker's last gasp `Paused` doesn't undo the cancel reset.
+    cancelling: HashSet<String>,
+    /// Frontend event channels. We never explicitly unsubscribe —
+    /// `Channel::send` returns Err for dead channels and we GC those
+    /// on the next broadcast pass.
+    subscribers: Vec<Channel<AssetEvent>>,
+    /// Memoised reqwest client. Built lazily on first use so panel
+    /// open doesn't pay for TLS handshakes the user may never trigger.
+    http: Option<reqwest::Client>,
+}
+
+/// The actual manager. Wraps `Inner` in a Mutex and holds the
+/// business-level `AssetProvider` that supplies the catalog of
+/// downloadable artefacts.
+pub struct DownloadsManager {
+    provider: Arc<dyn AssetProvider>,
+    inner: Mutex<Inner>,
+}
+
+impl DownloadsManager {
+    pub fn new(provider: Arc<dyn AssetProvider>) -> Self {
+        Self {
+            provider,
+            inner: Mutex::new(Inner::default()),
+        }
+    }
+
+    /// Snapshot of every registered asset's current state. Disk is
+    /// re-scanned on EVERY call (cheap — a handful of `stat` syscalls
+    /// per asset) so files the user drops in by hand are picked up
+    /// without restart. Active and cancelling ids are skipped so an
+    /// in-flight worker's streaming progress isn't clobbered.
+    pub fn snapshot(&self) -> Vec<AssetStatus> {
+        let assets = self.provider.assets();
+        let mut inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
+        Self::refresh_from_disk_locked(&mut inner, &assets);
+        let mut out: Vec<_> = inner.statuses.values().cloned().collect();
+        out.sort_by(|a, b| a.entry_id.cmp(&b.entry_id));
+        out
+    }
+
+    fn refresh_from_disk_locked(inner: &mut Inner, assets: &[Asset]) {
+        for asset in assets {
+            if inner.active.contains_key(&asset.id) {
+                continue;
+            }
+            if inner.cancelling.contains(&asset.id) {
+                continue;
+            }
+            inner
+                .statuses
+                .insert(asset.id.clone(), scan_asset_state(asset));
+        }
+    }
+
+    /// Register a frontend event channel. Returns the initial snapshot
+    /// so the caller can render without a separate `snapshot()` round
+    /// trip.
+    pub fn subscribe(&self, channel: Channel<AssetEvent>) -> Vec<AssetStatus> {
+        // Snapshot BEFORE pushing the subscriber: the snapshot call
+        // takes the lock, and we don't want subscribe() to deadlock
+        // against itself.
+        let initial = self.snapshot();
+        let mut inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
+        inner.subscribers.push(channel);
+        initial
+    }
+
+    /// Kick off a download for `asset_id`. No-op if it's already
+    /// running or already complete. Resumes from `.part` automatically
+    /// when present.
+    pub fn start(&self, app: tauri::AppHandle, asset_id: &str) -> Result<()> {
+        let asset = self
+            .provider
+            .assets()
+            .into_iter()
+            .find(|a| a.id == asset_id)
+            .with_context(|| format!("unknown asset id: {asset_id}"))?;
+
+        let cancel = Arc::new(AtomicBool::new(false));
+        {
+            let mut inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
+            // Re-sync from disk first so we don't kick off a download
+            // for an asset the user just dropped into the target dir.
+            let all_assets = self.provider.assets();
+            Self::refresh_from_disk_locked(&mut inner, &all_assets);
+            // Reject (no-op) if a previous worker is still alive — either
+            // mid-cancel teardown (would race over the `.part` and the
+            // post-cancel delete could nuke the new download) or simply
+            // already downloading / completed. The user can retry once
+            // the cancellation has settled.
+            if inner.active.contains_key(asset_id) || inner.cancelling.contains(asset_id) {
+                return Ok(());
+            }
+            if let Some(existing) = inner.statuses.get(asset_id) {
+                if matches!(
+                    existing.state,
+                    AssetState::Downloading | AssetState::Downloaded
+                ) {
+                    return Ok(());
+                }
+            }
+            inner.active.insert(asset_id.to_string(), cancel.clone());
+            let total = inner
+                .statuses
+                .get(asset_id)
+                .map(|s| s.total)
+                .unwrap_or(asset.estimated_bytes);
+            let downloaded = inner
+                .statuses
+                .get(asset_id)
+                .map(|s| s.downloaded)
+                .unwrap_or(0);
+            inner.statuses.insert(
+                asset_id.to_string(),
+                AssetStatus {
+                    entry_id: asset_id.to_string(),
+                    state: AssetState::Downloading,
+                    downloaded,
+                    total,
+                    error: None,
+                },
+            );
+        }
+
+        // Worker owns the cancel flag + the cloned Asset. AppHandle
+        // is Clone (Arc internally), so handing it off is free. The
+        // spawn-cleanup branch erases the active-map row regardless
+        // of whether the worker returned Ok or Err.
+        let asset_id = asset.id.clone();
+        let app_clone = app.clone();
+        let asset_for_cleanup = asset.clone();
+        tauri::async_runtime::spawn(async move {
+            let result = worker::run(app_clone.clone(), asset, cancel).await;
+            if let Err(error) = &result {
+                tracing::error!(
+                    error = ?error,
+                    asset_id = %asset_id,
+                    "download worker exited with error"
+                );
+            }
+            let registry = app_clone.state::<DownloadsManager>();
+            let was_cancelling = {
+                let mut inner = registry.inner.lock().unwrap_or_else(|p| p.into_inner());
+                inner.active.remove(&asset_id);
+                inner.cancelling.remove(&asset_id)
+            };
+            // Worker exit + cancel-pending → wipe whatever ended up
+            // on disk. We deliberately do this AFTER the worker
+            // dropped its file handle so on macOS the inode is fully
+            // released and the bytes are actually reclaimed.
+            if was_cancelling {
+                delete_asset_files(&asset_for_cleanup);
+            }
+        });
+        Ok(())
+    }
+
+    /// Soft stop: flip the cancel flag. Worker observes on its next
+    /// chunk boundary and emits a `Paused` event. The `.part` file is
+    /// left in place so the next `start()` resumes from where we
+    /// stopped.
+    pub fn pause(&self, asset_id: &str) {
+        let inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
+        if let Some(flag) = inner.active.get(asset_id) {
+            flag.store(true, Ordering::Release);
+        }
+    }
+
+    /// Hard stop: snap the entry back to NotDownloaded, wipe any
+    /// on-disk artefacts, and broadcast a `Cancelled` event so the
+    /// panel updates synchronously.
+    pub fn cancel_and_delete(&self, asset_id: &str) -> Result<()> {
+        let asset = self
+            .provider
+            .assets()
+            .into_iter()
+            .find(|a| a.id == asset_id)
+            .with_context(|| format!("unknown asset id: {asset_id}"))?;
+
+        let was_active;
+        {
+            let mut inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
+            was_active = match inner.active.get(asset_id) {
+                Some(flag) => {
+                    flag.store(true, Ordering::Release);
+                    inner.cancelling.insert(asset_id.to_string());
+                    true
+                }
+                None => false,
+            };
+            inner.statuses.insert(
+                asset_id.to_string(),
+                AssetStatus::not_downloaded(asset_id.to_string(), asset.estimated_bytes),
+            );
+            let event = AssetEvent {
+                entry_id: asset_id.to_string(),
+                kind: AssetEventKind::Cancelled {
+                    total: asset.estimated_bytes,
+                },
+            };
+            inner
+                .subscribers
+                .retain(|sub| sub.send(event.clone()).is_ok());
+        }
+
+        if !was_active {
+            delete_asset_files(&asset);
+        }
+        Ok(())
+    }
+
+    // -- helpers used by `worker` ---------------------------------------
+
+    /// Worker calls this on every state transition. We update the
+    /// in-memory snapshot AND broadcast to subscribers in one pass.
+    pub(super) fn emit(&self, event: AssetEvent) {
+        let mut inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
+        if inner.cancelling.contains(&event.entry_id) {
+            return;
+        }
+        let entry = inner
+            .statuses
+            .entry(event.entry_id.clone())
+            .or_insert_with(|| AssetStatus::not_downloaded(event.entry_id.clone(), 0));
+        match &event.kind {
+            AssetEventKind::Started { total } => {
+                entry.state = AssetState::Downloading;
+                entry.total = *total;
+                entry.error = None;
+            }
+            AssetEventKind::Progress {
+                downloaded, total, ..
+            } => {
+                entry.state = AssetState::Downloading;
+                entry.downloaded = *downloaded;
+                entry.total = *total;
+            }
+            AssetEventKind::Paused { downloaded, total } => {
+                entry.state = AssetState::Paused;
+                entry.downloaded = *downloaded;
+                entry.total = *total;
+            }
+            AssetEventKind::Cancelled { total } => {
+                entry.state = AssetState::NotDownloaded;
+                entry.downloaded = 0;
+                entry.total = *total;
+                entry.error = None;
+            }
+            AssetEventKind::Completed { downloaded, .. } => {
+                entry.state = AssetState::Downloaded;
+                entry.downloaded = *downloaded;
+                entry.total = *downloaded;
+                entry.error = None;
+            }
+            AssetEventKind::Failed { error, .. } => {
+                entry.state = AssetState::Failed;
+                entry.error = Some(error.clone());
+            }
+        }
+        inner
+            .subscribers
+            .retain(|sub| sub.send(event.clone()).is_ok());
+    }
+
+    /// Lazy reqwest client — caller-side clone is fine, the inner
+    /// connection pool is shared.
+    pub(super) fn http_client(&self) -> Result<reqwest::Client> {
+        let mut inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
+        if let Some(client) = &inner.http {
+            return Ok(client.clone());
+        }
+        let client = reqwest::Client::builder()
+            // HF resolves to CloudFront / blob CDNs. 60 s connect is
+            // generous for first DNS + TLS round trip on slow links.
+            .connect_timeout(std::time::Duration::from_secs(60))
+            // No global read timeout: large model downloads can run
+            // for an hour+; reqwest's per-chunk timeout still applies.
+            .user_agent(format!("helmor/{} downloads", env!("CARGO_PKG_VERSION")))
+            .build()
+            .context("build downloads HTTP client")?;
+        inner.http = Some(client.clone());
+        Ok(client)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// File-system helpers (asset-aware).
+// ---------------------------------------------------------------------------
+
+/// Best-effort removal of every artefact an asset could have left on
+/// disk — final files AND their `.part` counterparts. NotFound is
+/// ignored.
+fn delete_asset_files(asset: &Asset) {
+    for file in &asset.files {
+        let final_path = asset.target_dir.join(file);
+        let part_path = asset.target_dir.join(format!("{file}.part"));
+
+        for candidate in [final_path, part_path] {
+            match std::fs::remove_file(&candidate) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    tracing::warn!(
+                        error = %error,
+                        path = %candidate.display(),
+                        "failed to delete download artefact"
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// Disk scan: derive an `AssetStatus` purely from what's on disk.
+fn scan_asset_state(asset: &Asset) -> AssetStatus {
+    let mut downloaded: u64 = 0;
+    let mut all_complete = true;
+    let mut any_present = false;
+    let mut any_partial = false;
+    for file in &asset.files {
+        let final_path = asset.target_dir.join(file);
+        let part_path = asset.target_dir.join(format!("{file}.part"));
+        if let Ok(meta) = std::fs::metadata(&final_path) {
+            downloaded = downloaded.saturating_add(meta.len());
+            any_present = true;
+            continue;
+        }
+        all_complete = false;
+        if let Ok(meta) = std::fs::metadata(&part_path) {
+            downloaded = downloaded.saturating_add(meta.len());
+            any_partial = true;
+            any_present = true;
+        }
+    }
+    let state = if all_complete {
+        AssetState::Downloaded
+    } else if any_partial || any_present {
+        AssetState::Paused
+    } else {
+        AssetState::NotDownloaded
+    };
+    AssetStatus {
+        entry_id: asset.id.clone(),
+        state,
+        downloaded,
+        total: asset.estimated_bytes.max(downloaded),
+        error: None,
+    }
+}
+
+// Anchored at this file because `delete_asset_files` lives here too.
+#[cfg(test)]
+mod tests {
+    use super::super::types::ArchiveKind;
+    use super::*;
+    use std::fs;
+    use std::path::Path;
+    use tempfile::tempdir;
+
+    fn fake_asset(target_dir: &Path, files: &[&str]) -> Asset {
+        Asset {
+            id: "fake".into(),
+            target_dir: target_dir.to_path_buf(),
+            files: files.iter().map(|f| (*f).to_string()).collect(),
+            source: super::super::types::AssetSource::HuggingFace {
+                repo: "fake/repo".into(),
+            },
+            archive: ArchiveKind::None,
+            is_directory: false,
+            estimated_bytes: 1_000,
+        }
+    }
+
+    #[test]
+    fn scan_marks_manually_placed_single_file_as_downloaded() {
+        let dir = tempdir().expect("tempdir");
+        let asset = fake_asset(dir.path(), &["model.gguf"]);
+        fs::write(dir.path().join("model.gguf"), b"hello world").expect("write final");
+
+        let status = scan_asset_state(&asset);
+        assert!(
+            matches!(status.state, AssetState::Downloaded),
+            "expected Downloaded, got {:?}",
+            status.state
+        );
+        assert_eq!(status.downloaded, 11);
+    }
+
+    #[test]
+    fn scan_marks_part_file_as_paused() {
+        let dir = tempdir().expect("tempdir");
+        let asset = fake_asset(dir.path(), &["model.gguf"]);
+        fs::write(dir.path().join("model.gguf.part"), b"halfway").expect("write part");
+
+        let status = scan_asset_state(&asset);
+        assert!(matches!(status.state, AssetState::Paused));
+        assert_eq!(status.downloaded, 7);
+    }
+
+    #[test]
+    fn scan_marks_partial_multi_part_set_as_paused() {
+        let dir = tempdir().expect("tempdir");
+        let asset = fake_asset(dir.path(), &["part1.gguf", "part2.gguf", "part3.gguf"]);
+        fs::write(dir.path().join("part1.gguf"), b"first").expect("write part1");
+        fs::write(dir.path().join("part2.gguf"), b"second").expect("write part2");
+
+        let status = scan_asset_state(&asset);
+        assert!(
+            matches!(status.state, AssetState::Paused),
+            "expected Paused for partial multi-part set, got {:?}",
+            status.state
+        );
+        assert_eq!(status.downloaded, 11);
+    }
+
+    #[test]
+    fn scan_returns_not_downloaded_for_empty_dir() {
+        let dir = tempdir().expect("tempdir");
+        let asset = fake_asset(dir.path(), &["model.gguf"]);
+        let status = scan_asset_state(&asset);
+        assert!(matches!(status.state, AssetState::NotDownloaded));
+        assert_eq!(status.downloaded, 0);
+    }
+}

--- a/src-tauri/src/downloads/types.rs
+++ b/src-tauri/src/downloads/types.rs
@@ -1,0 +1,152 @@
+//! Wire types for the generic downloads manager.
+
+use std::path::PathBuf;
+
+use serde::Serialize;
+
+/// One downloadable artefact. A caller (e.g. `local_llm`) translates
+/// its domain catalog entries into a Vec of these and registers an
+/// `AssetProvider` with `DownloadsManager`.
+#[derive(Debug, Clone)]
+pub struct Asset {
+    /// Stable id — the manager keys state, events, and cancel flags
+    /// off this. Two `Asset`s with the same id are the same logical
+    /// download (newer registration replaces older).
+    pub id: String,
+    /// On-disk destination directory. The manager creates it if
+    /// missing. Multi-file assets (HF GGUF shards) live here as
+    /// peers; tar.gz assets extract their contents here.
+    pub target_dir: PathBuf,
+    /// File names relative to `target_dir`. For HF entries: every
+    /// shard, downloaded sequentially. For direct-URL entries:
+    /// `files[0]` is the on-disk name (or the extracted top-level
+    /// directory name for `ArchiveKind::TarGz`).
+    pub files: Vec<String>,
+    /// Where bytes come from.
+    pub source: AssetSource,
+    /// Post-download decoration (extract / verify-only / …).
+    pub archive: ArchiveKind,
+    /// On disk, is `files[0]` a directory (true for tar.gz-extracted
+    /// models) or a regular file?
+    pub is_directory: bool,
+    /// Catalog estimate of total bytes. Used as a UI fallback before
+    /// the first HTTP `Content-Length` arrives, and as the canonical
+    /// "size" reported when the artefact is already on disk.
+    pub estimated_bytes: u64,
+}
+
+/// Where the manager fetches bytes from. Only HuggingFace today (LLM
+/// GGUFs); the enum stays open so future direct-URL sources can plug
+/// in without churning the whole pipeline.
+#[derive(Debug, Clone)]
+pub enum AssetSource {
+    /// Resolved against `https://huggingface.co/{repo}/resolve/main/<file>`.
+    /// Manifest fetched best-effort for per-file size + SHA-256;
+    /// missing manifest falls back to HTTP `Content-Length` + no
+    /// integrity verification.
+    HuggingFace { repo: String },
+}
+
+/// What we do with the downloaded bytes once they hit `.part`. Only
+/// the rename path is exercised today — the enum is kept so the
+/// downloader stays generic if/when new archive formats need support.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ArchiveKind {
+    /// Rename `.part` to its final name and call it done.
+    #[default]
+    None,
+}
+
+/// State machine for one asset. Names match the four "cards on the
+/// wall" the UI shows + an explicit `Failed` so panels can surface
+/// retry affordances instead of silently bouncing back to NotDownloaded.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AssetState {
+    NotDownloaded,
+    Downloading,
+    Paused,
+    Downloaded,
+    Failed,
+}
+
+/// Snapshot of one asset's state, returned by `snapshot()` / `subscribe()`.
+/// Field name kept as `entry_id` (not `asset_id`) for wire compat with
+/// the `local_llm:*` IPC contract.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AssetStatus {
+    pub entry_id: String,
+    pub state: AssetState,
+    /// Bytes already on disk (sum of completed parts + current part).
+    pub downloaded: u64,
+    /// Total bytes expected. For not-yet-started downloads this is
+    /// the asset estimate; once the first part hits the network it's
+    /// replaced with the real `Content-Length`.
+    pub total: u64,
+    /// Last error message — only meaningful when `state == Failed`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl AssetStatus {
+    pub fn not_downloaded(entry_id: impl Into<String>, total: u64) -> Self {
+        Self {
+            entry_id: entry_id.into(),
+            state: AssetState::NotDownloaded,
+            downloaded: 0,
+            total,
+            error: None,
+        }
+    }
+}
+
+/// One streamed event from the download worker. Always carries
+/// `entry_id` so the frontend can route it to the right card.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AssetEvent {
+    pub entry_id: String,
+    #[serde(flatten)]
+    pub kind: AssetEventKind,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum AssetEventKind {
+    Started {
+        total: u64,
+    },
+    Progress {
+        downloaded: u64,
+        total: u64,
+        /// Smoothed instantaneous throughput (rolling over the last
+        /// emit window, ~250 ms).
+        bytes_per_sec: f64,
+    },
+    Paused {
+        downloaded: u64,
+        total: u64,
+    },
+    /// User-initiated full reset: stop the worker, wipe artefacts
+    /// from disk, snap status back to NotDownloaded. Distinct from
+    /// `Paused` so subscribers don't accidentally show a progress
+    /// bar at the partial state we just deleted.
+    Cancelled {
+        total: u64,
+    },
+    Completed {
+        downloaded: u64,
+        /// Absolute path of the artefact's "primary" file (multi-part
+        /// GGUFs report part 1; tar.gz reports the extracted dir).
+        /// Callers use this to wire the artefact into their runtime.
+        path: String,
+        sha256_verified: bool,
+    },
+    Failed {
+        error: String,
+        /// Set when the failure looks recoverable (network drop, 5xx,
+        /// rate limit) so the panel can surface a Retry affordance.
+        retryable: bool,
+    },
+}

--- a/src-tauri/src/downloads/worker.rs
+++ b/src-tauri/src/downloads/worker.rs
@@ -1,0 +1,413 @@
+//! The async body that actually pulls bytes from a remote source.
+//!
+//! One worker per `Asset.id`. Multi-part HF assets are downloaded
+//! sequentially (HF CDN doesn't reward parallel chunks per host, and
+//! sequential keeps the progress bar honest).
+//!
+//! Lifecycle:
+//!   1. Compute the total expected bytes (HF manifest or asset estimate).
+//!   2. Emit `Started`.
+//!   3. For each file: stream `Range:`-resumed bytes to `.part`,
+//!      hash them on the fly, throttled-emit `Progress`.
+//!   4. On EOF: verify SHA-256 (when manifest provided one), rename
+//!      `.part` to its final name.
+//!   5. Emit `Completed` once everything's on disk.
+//!
+//! Cancel observed at every chunk boundary — for a 5 GB download
+//! over a typical residential connection that's ~250 ms of polling
+//! granularity, plenty fast for "Pause" to feel instant.
+
+use std::io::SeekFrom;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Instant;
+
+use anyhow::{Context, Result};
+use sha2::{Digest, Sha256};
+use tauri::Manager;
+use tokio::fs::{File, OpenOptions};
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
+
+use super::hf::HfManifest;
+use super::registry::DownloadsManager;
+use super::types::{Asset, AssetEvent, AssetEventKind, AssetSource};
+
+/// Throttle progress events to ~4/sec. UI doesn't need finer
+/// granularity, and a flood of Channel sends starves the Tauri ipc
+/// thread on slow machines.
+const EMIT_INTERVAL: std::time::Duration = std::time::Duration::from_millis(250);
+
+/// Chunk-level fsync cadence. Reading from a network stream is
+/// dominated by socket latency; flushing every ~8 MB keeps disk-flush
+/// amortised without making a power-cut resume re-download more than
+/// a few seconds.
+const FSYNC_INTERVAL: u64 = 8 * 1024 * 1024;
+
+/// Per-chunk read timeout. The HTTP client only has a connect timeout
+/// — without an explicit chunk-level deadline a TCP connection that
+/// silently stops producing data (CDN edge wedge, NAT timeout, ISP
+/// rebalance) would wedge the worker forever and Pause/Cancel only
+/// fires on the *next* chunk boundary. 90 s is well above normal
+/// inter-chunk gaps for HF-served LFS objects (~ms range) while still
+/// surfacing a stuck stream within a useful window.
+const CHUNK_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(90);
+
+pub async fn run(app: tauri::AppHandle, asset: Asset, cancel: Arc<AtomicBool>) -> Result<()> {
+    tokio::fs::create_dir_all(&asset.target_dir)
+        .await
+        .with_context(|| format!("mkdir {}", asset.target_dir.display()))?;
+
+    let registry = app.state::<DownloadsManager>();
+    let client = registry.http_client()?;
+
+    match asset.source.clone() {
+        AssetSource::HuggingFace { repo } => run_hf(asset, &repo, cancel, &client, &registry).await,
+    }
+}
+
+async fn run_hf(
+    asset: Asset,
+    repo: &str,
+    cancel: Arc<AtomicBool>,
+    client: &reqwest::Client,
+    registry: &DownloadsManager,
+) -> Result<()> {
+    // Best-effort HF manifest. If this fails we still download (skip
+    // SHA-256 verification + trust HTTP Content-Length).
+    let manifest = match HfManifest::fetch(client, repo).await {
+        Ok(m) => Some(m),
+        Err(error) => {
+            tracing::warn!(
+                error = ?error,
+                repo,
+                "HF manifest fetch failed, continuing without integrity check"
+            );
+            None
+        }
+    };
+
+    let total_expected = compute_total_hf(&asset, manifest.as_ref());
+    registry.emit(AssetEvent {
+        entry_id: asset.id.clone(),
+        kind: AssetEventKind::Started {
+            total: total_expected,
+        },
+    });
+
+    let mut accumulated: u64 = 0;
+    let mut last_emit = Instant::now();
+    let mut last_bytes_marker = 0u64;
+    let mut any_sha_verified = false;
+
+    for file in &asset.files {
+        let final_path = asset.target_dir.join(file);
+        let part_path = asset.target_dir.join(format!("{file}.part"));
+
+        if let Ok(meta) = tokio::fs::metadata(&final_path).await {
+            accumulated = accumulated.saturating_add(meta.len());
+            continue;
+        }
+
+        let expected_size = manifest
+            .as_ref()
+            .and_then(|m| m.per_file.get(file))
+            .and_then(|info| info.size)
+            .unwrap_or(0);
+        let expected_sha256 = manifest
+            .as_ref()
+            .and_then(|m| m.per_file.get(file))
+            .and_then(|info| info.sha256.clone());
+
+        let url = format!("https://huggingface.co/{repo}/resolve/main/{file}");
+        let outcome = stream_to_part(
+            client,
+            &asset,
+            &url,
+            &part_path,
+            expected_size,
+            expected_sha256.as_deref(),
+            &cancel,
+            registry,
+            &mut accumulated,
+            total_expected,
+            &mut last_emit,
+            &mut last_bytes_marker,
+        )
+        .await;
+
+        match outcome {
+            Ok(FileOutcome::Completed { sha256_ok }) => {
+                tokio::fs::rename(&part_path, &final_path)
+                    .await
+                    .with_context(|| {
+                        format!("rename {} -> {}", part_path.display(), final_path.display())
+                    })?;
+                if sha256_ok {
+                    any_sha_verified = true;
+                }
+            }
+            Ok(FileOutcome::Paused { downloaded }) => {
+                registry.emit(AssetEvent {
+                    entry_id: asset.id.clone(),
+                    kind: AssetEventKind::Paused {
+                        downloaded,
+                        total: total_expected,
+                    },
+                });
+                return Ok(());
+            }
+            Err(error) => {
+                let retryable = is_retryable(&error);
+                registry.emit(AssetEvent {
+                    entry_id: asset.id.clone(),
+                    kind: AssetEventKind::Failed {
+                        error: format!("{error:#}"),
+                        retryable,
+                    },
+                });
+                return Err(error);
+            }
+        }
+    }
+
+    let primary = asset.target_dir.join(&asset.files[0]);
+    registry.emit(AssetEvent {
+        entry_id: asset.id.clone(),
+        kind: AssetEventKind::Completed {
+            downloaded: accumulated,
+            path: primary.display().to_string(),
+            sha256_verified: any_sha_verified,
+        },
+    });
+    Ok(())
+}
+
+enum FileOutcome {
+    Completed { sha256_ok: bool },
+    Paused { downloaded: u64 },
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn stream_to_part(
+    client: &reqwest::Client,
+    asset: &Asset,
+    url: &str,
+    part_path: &PathBuf,
+    expected_size: u64,
+    expected_sha256: Option<&str>,
+    cancel: &AtomicBool,
+    registry: &DownloadsManager,
+    accumulated: &mut u64,
+    total_expected: u64,
+    last_emit: &mut Instant,
+    last_bytes_marker: &mut u64,
+) -> Result<FileOutcome> {
+    let mut resume_from = tokio::fs::metadata(part_path)
+        .await
+        .map(|m| m.len())
+        .unwrap_or(0);
+    if expected_size > 0 && resume_from >= expected_size {
+        tokio::fs::remove_file(part_path).await.ok();
+        resume_from = 0;
+    }
+
+    let mut req = client.get(url);
+    if resume_from > 0 {
+        req = req.header("Range", format!("bytes={resume_from}-"));
+    }
+    let response = req.send().await.with_context(|| format!("GET {url}"))?;
+    let status = response.status();
+    if !status.is_success() && status.as_u16() != 206 {
+        anyhow::bail!("HTTP {status} from {url}");
+    }
+    let server_total = response
+        .content_length()
+        .map(|len| resume_from + len)
+        .unwrap_or(expected_size.max(resume_from));
+
+    let mut handle = if status == reqwest::StatusCode::OK && resume_from > 0 {
+        resume_from = 0;
+        OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(part_path)
+            .await
+            .with_context(|| format!("open {} (truncate)", part_path.display()))?
+    } else {
+        OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(part_path)
+            .await
+            .with_context(|| format!("open {}", part_path.display()))?
+    };
+    handle
+        .seek(SeekFrom::Start(resume_from))
+        .await
+        .with_context(|| format!("seek to {} in {}", resume_from, part_path.display()))?;
+
+    let mut hasher = Sha256::new();
+    if resume_from > 0 {
+        prime_hasher_from_file(part_path, resume_from, &mut hasher).await?;
+    }
+
+    let mut current_part_bytes = resume_from;
+    let mut bytes_since_fsync: u64 = 0;
+    let mut response = response;
+
+    loop {
+        if cancel.load(Ordering::Acquire) {
+            handle.flush().await.ok();
+            return Ok(FileOutcome::Paused {
+                downloaded: *accumulated + current_part_bytes,
+            });
+        }
+        // Bound each chunk read so a silently-stalled connection
+        // surfaces as a retryable failure instead of wedging Pause /
+        // Cancel until the OS gives up the socket.
+        let chunk = match tokio::time::timeout(CHUNK_READ_TIMEOUT, response.chunk()).await {
+            Ok(Ok(chunk)) => chunk,
+            Ok(Err(error)) => {
+                return Err(anyhow::Error::from(error))
+                    .with_context(|| format!("chunk from {url} after {current_part_bytes} bytes"));
+            }
+            Err(_) => {
+                anyhow::bail!(
+                    "chunk from {url} timed out after {current_part_bytes} bytes \
+                     (no data for {}s)",
+                    CHUNK_READ_TIMEOUT.as_secs(),
+                );
+            }
+        };
+        let Some(chunk) = chunk else {
+            break;
+        };
+        handle
+            .write_all(&chunk)
+            .await
+            .with_context(|| format!("write {} bytes to {}", chunk.len(), part_path.display()))?;
+        hasher.update(&chunk);
+        let n = chunk.len() as u64;
+        current_part_bytes = current_part_bytes.saturating_add(n);
+        bytes_since_fsync = bytes_since_fsync.saturating_add(n);
+        if bytes_since_fsync >= FSYNC_INTERVAL {
+            handle.flush().await.ok();
+            bytes_since_fsync = 0;
+        }
+
+        let overall = *accumulated + current_part_bytes;
+        if last_emit.elapsed() >= EMIT_INTERVAL {
+            let elapsed = last_emit.elapsed().as_secs_f64().max(1e-6);
+            let bps = (overall.saturating_sub(*last_bytes_marker) as f64) / elapsed;
+            registry.emit(AssetEvent {
+                entry_id: asset.id.clone(),
+                kind: AssetEventKind::Progress {
+                    downloaded: overall,
+                    total: total_expected
+                        .max(overall + server_total.saturating_sub(current_part_bytes)),
+                    bytes_per_sec: bps,
+                },
+            });
+            *last_emit = Instant::now();
+            *last_bytes_marker = overall;
+        }
+    }
+
+    handle.flush().await.ok();
+    handle.sync_all().await.ok();
+    drop(handle);
+
+    let sha256_ok = match expected_sha256 {
+        Some(expected) => {
+            let computed = hex::encode(hasher.finalize());
+            if !computed.eq_ignore_ascii_case(expected) {
+                anyhow::bail!(
+                    "SHA-256 mismatch for {}: expected {expected}, got {computed}",
+                    asset.id,
+                );
+            }
+            true
+        }
+        None => false,
+    };
+
+    *accumulated = accumulated.saturating_add(current_part_bytes);
+    Ok(FileOutcome::Completed { sha256_ok })
+}
+
+async fn prime_hasher_from_file(path: &PathBuf, bytes: u64, hasher: &mut Sha256) -> Result<()> {
+    let mut file = File::open(path)
+        .await
+        .with_context(|| format!("reopen {} for re-hash", path.display()))?;
+    let mut buf = vec![0u8; 1024 * 1024];
+    let mut remaining = bytes;
+    while remaining > 0 {
+        let want = std::cmp::min(buf.len() as u64, remaining) as usize;
+        let read = file
+            .read(&mut buf[..want])
+            .await
+            .with_context(|| format!("read {} for re-hash", path.display()))?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buf[..read]);
+        remaining = remaining.saturating_sub(read as u64);
+    }
+    Ok(())
+}
+
+fn compute_total_hf(asset: &Asset, manifest: Option<&HfManifest>) -> u64 {
+    if let Some(manifest) = manifest {
+        let mut sum: u64 = 0;
+        let mut all_known = true;
+        for file in &asset.files {
+            match manifest.per_file.get(file).and_then(|info| info.size) {
+                Some(size) => sum = sum.saturating_add(size),
+                None => {
+                    all_known = false;
+                    break;
+                }
+            }
+        }
+        if all_known {
+            return sum;
+        }
+    }
+    asset.estimated_bytes
+}
+
+fn is_retryable(error: &anyhow::Error) -> bool {
+    let msg = format!("{error:#}").to_ascii_lowercase();
+    msg.contains("timed out")
+        || msg.contains("timeout")
+        || msg.contains("connection reset")
+        || msg.contains("connection refused")
+        || msg.contains("temporarily")
+        || msg.contains("eof")
+        || msg.contains("503")
+        || msg.contains("504")
+        || msg.contains("502")
+        || msg.contains("429")
+}
+
+// hex encoding without pulling a crate
+mod hex {
+    pub fn encode(bytes: impl AsRef<[u8]>) -> String {
+        let mut out = String::with_capacity(bytes.as_ref().len() * 2);
+        for byte in bytes.as_ref() {
+            out.push(nibble(byte >> 4));
+            out.push(nibble(byte & 0x0F));
+        }
+        out
+    }
+    fn nibble(n: u8) -> char {
+        match n {
+            0..=9 => (b'0' + n) as char,
+            10..=15 => (b'a' + (n - 10)) as char,
+            _ => '?',
+        }
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ pub mod cli;
 pub(crate) mod codex_config;
 pub(crate) mod commands;
 pub mod data_dir;
+pub mod downloads;
 pub mod error;
 pub mod feedback;
 pub mod forge;
@@ -10,6 +11,7 @@ pub mod git;
 pub mod global_hotkey;
 pub mod image_store;
 mod import;
+pub mod local_llm;
 pub mod logging;
 pub mod maintenance;
 pub mod mcp;
@@ -43,6 +45,7 @@ pub use workspace::state as workspace_state;
 pub use workspace::status as workspace_status;
 pub use workspace::workspaces;
 
+use std::sync::Arc;
 use tauri::{Emitter, Manager};
 
 /// Initialise the database schema (call once at startup).
@@ -72,6 +75,13 @@ pub fn run() {
         .manage(agents::ActiveStreams::new())
         .manage(agents::SlashCommandCache::new())
         .manage(workspace::archive::ArchiveJobManager::new())
+        .manage(local_llm::Manager::default())
+        // Top-level downloads manager. The local-LLM catalog is supplied
+        // through `CatalogAssetProvider`; the downloads module itself
+        // stays business-agnostic.
+        .manage(downloads::DownloadsManager::new(Arc::new(
+            local_llm::CatalogAssetProvider,
+        )))
         .manage(git_watcher::GitWatcherManager::new())
         .manage(workspace::scripts::ScriptProcessManager::new())
         .manage(ui_sync::UiSyncManager::new())
@@ -213,6 +223,41 @@ pub fn run() {
             updater::spawn_interval_worker(app.handle().clone());
 
             agents::prewarm_slash_command_cache(app.handle());
+
+            // Reap any orphan llama-server from a prior Helmor process
+            // that was force-quit / crashed / hot-reloaded — its
+            // `local_llm::Manager::drop` never ran. Doing this BEFORE the
+            // auto-start guarantees we don't accumulate duplicates
+            // across dev reloads or unclean exits.
+            local_llm::sweep_orphan_server();
+
+            // Auto-start the bundled llama-server when the user has
+            // flipped Local LLM on in settings. Spawned so a slow
+            // first-time model download can't stall the rest of setup.
+            // `local_llm::Manager::drop` handles teardown on app exit.
+            let local_llm_handle = app.handle().clone();
+            if let Err(error) = std::thread::Builder::new()
+                .name("local-llm-autostart".into())
+                .spawn(move || {
+                    let settings = local_llm::load_settings();
+                    if !settings.enabled || !settings.auto_start {
+                        return;
+                    }
+                    let manager = local_llm_handle.state::<local_llm::Manager>();
+                    if let Err(error) = manager.start() {
+                        tracing::warn!(
+                            error = %format!("{error:#}"),
+                            "Local LLM auto-start failed"
+                        );
+                    }
+                })
+            {
+                tracing::error!(error = %error, "Failed to spawn local-llm autostart thread");
+            }
+
+            // Re-register the user's saved global hotkey at startup. Missing
+            // this leaves the hotkey unregistered after a cold launch until
+            // the user re-saves it in settings.
             if let Err(error) = global_hotkey::sync_from_settings(app.handle()) {
                 tracing::warn!(
                     error = %format!("{error:#}"),
@@ -273,6 +318,21 @@ pub fn run() {
             commands::settings_commands::get_app_settings,
             commands::settings_commands::get_claude_rate_limits,
             commands::settings_commands::get_codex_rate_limits,
+            commands::local_llm_commands::detect_local_llm_hardware,
+            commands::local_llm_commands::get_local_llm_status,
+            commands::local_llm_commands::list_local_llm_catalog,
+            commands::local_llm_commands::inspect_local_llm_model,
+            commands::local_llm_commands::inspect_local_llm_catalog_entry,
+            commands::local_llm_commands::list_local_llm_downloads,
+            commands::local_llm_commands::subscribe_local_llm_downloads,
+            commands::local_llm_commands::start_local_llm_download,
+            commands::local_llm_commands::pause_local_llm_download,
+            commands::local_llm_commands::cancel_local_llm_download,
+            commands::local_llm_commands::activate_local_llm_model,
+            commands::local_llm_commands::set_local_llm_context_override,
+            commands::local_llm_commands::start_local_llm,
+            commands::local_llm_commands::stop_local_llm,
+            commands::local_llm_commands::get_local_llm_endpoint,
             commands::system_commands::get_cli_status,
             commands::system_commands::get_data_info,
             commands::system_commands::get_agent_login_status,

--- a/src-tauri/src/local_llm/asset_provider.rs
+++ b/src-tauri/src/local_llm/asset_provider.rs
@@ -1,0 +1,36 @@
+//! Bridge between the LLM catalog and the generic `DownloadsManager`.
+//! Translates each `CatalogEntry` into an `Asset` so the downloads
+//! module never sees domain concepts.
+
+use crate::downloads::{ArchiveKind, Asset, AssetProvider, AssetSource};
+use crate::local_llm::catalog::{self, CatalogEntry};
+
+/// `AssetProvider` for every entry in `local_llm::catalog`. Stateless —
+/// the catalog is compile-time const, so re-deriving on every call is
+/// cheap and lets newly-added entries flow through without restart.
+pub struct CatalogAssetProvider;
+
+impl AssetProvider for CatalogAssetProvider {
+    fn assets(&self) -> Vec<Asset> {
+        let Ok(target_dir) = crate::data_dir::local_llm_models_dir() else {
+            tracing::warn!("local_llm_models_dir() failed; download manager has no assets");
+            return Vec::new();
+        };
+        catalog::catalog()
+            .into_iter()
+            .map(|entry| catalog_entry_to_asset(entry, &target_dir))
+            .collect()
+    }
+}
+
+fn catalog_entry_to_asset(entry: CatalogEntry, target_dir: &std::path::Path) -> Asset {
+    Asset {
+        id: entry.id,
+        target_dir: target_dir.to_path_buf(),
+        files: entry.files,
+        source: AssetSource::HuggingFace { repo: entry.repo },
+        archive: ArchiveKind::None,
+        is_directory: false,
+        estimated_bytes: entry.bytes,
+    }
+}

--- a/src-tauri/src/local_llm/catalog.rs
+++ b/src-tauri/src/local_llm/catalog.rs
@@ -1,0 +1,194 @@
+//! Curated LLM catalog driving the Local LLM settings panel. The
+//! downloads manager (via `CatalogAssetProvider`) reads this list to
+//! know what to fetch / verify; the panel renders the entries as a
+//! dropdown of pickable Qwen variants.
+//!
+//! Adding an entry = append to `catalog()`. The unit tests in this
+//! file enforce uniqueness + RAM-tier ordering so accidental catalog
+//! regressions surface in CI without a snapshot review.
+
+use serde::{Deserialize, Serialize};
+
+/// Fallback context window used when the running model is NOT a
+/// catalog entry (e.g. user pasted a custom `.gguf` path). 32K is a
+/// reasonable common-denominator — covers title generation, commit
+/// drafts, summaries without blowing the KV cache.
+pub const FALLBACK_CONTEXT_TOKENS: u32 = 32_768;
+
+/// Which subsystem owns this entry. Currently only LLM; kept as an
+/// enum so future entry kinds can be added without churning every
+/// catalog row.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum ModelKind {
+    /// Chat brain. Loaded by `local_llm::Manager` (llama-server).
+    #[default]
+    Llm,
+}
+
+/// One row in the curated model catalog the panel renders. HF GGUFs:
+/// the worker resolves `https://huggingface.co/{repo}/resolve/main/{file}`
+/// and fetches the HF manifest for per-file SHA-256 + sizes. KV cache
+/// shape and trained context window are deliberately NOT in here —
+/// those numbers are read from the GGUF header after download so the
+/// panel can't drift from what llama-server actually allocates.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CatalogEntry {
+    pub id: String,
+    pub repo: String,
+    /// Every GGUF file the model spans (multi-part shards listed in
+    /// load order; single-file models list one entry).
+    pub files: Vec<String>,
+    pub label: String,
+    pub quant: String,
+    pub bytes: u64,
+    pub min_ram_gb: u8,
+    pub recommended_for_gb: u8,
+    pub blurb: String,
+    /// Which subsystem this entry belongs to. Defaults to LLM so
+    /// existing entries don't need touching.
+    #[serde(default)]
+    pub kind: ModelKind,
+}
+
+/// Curated catalog. Sorted by `recommended_for_gb` ascending.
+pub fn catalog() -> Vec<CatalogEntry> {
+    vec![
+        CatalogEntry {
+            id: "qwen35-4b-q4".into(),
+            repo: "unsloth/Qwen3.5-4B-GGUF".into(),
+            files: vec!["Qwen3.5-4B-Q4_K_M.gguf".into()],
+            label: "Qwen3.5 4B".into(),
+            quant: "Q4_K_M".into(),
+            bytes: 2_500_000_000,
+            min_ram_gb: 8,
+            recommended_for_gb: 16,
+            blurb: "Compact starter — good for chat and simple drafts.".into(),
+            kind: ModelKind::Llm,
+        },
+        CatalogEntry {
+            id: "qwen35-9b-q4".into(),
+            repo: "unsloth/Qwen3.5-9B-GGUF".into(),
+            files: vec!["Qwen3.5-9B-Q4_K_M.gguf".into()],
+            label: "Qwen3.5 9B".into(),
+            quant: "Q4_K_M".into(),
+            bytes: 5_400_000_000,
+            min_ram_gb: 12,
+            recommended_for_gb: 24,
+            blurb: "Great all-rounder. Fits comfortably on 24 GB Macs.".into(),
+            kind: ModelKind::Llm,
+        },
+        CatalogEntry {
+            id: "qwen36-27b-q4".into(),
+            repo: "unsloth/Qwen3.6-27B-GGUF".into(),
+            files: vec!["Qwen3.6-27B-Q4_K_M.gguf".into()],
+            label: "Qwen3.6 27B".into(),
+            quant: "Q4_K_M".into(),
+            bytes: 16_200_000_000,
+            min_ram_gb: 20,
+            recommended_for_gb: 32,
+            blurb: "Dense flagship — solid coding model on 32 GB Macs.".into(),
+            kind: ModelKind::Llm,
+        },
+        CatalogEntry {
+            id: "qwen36-35b-a3b-q4".into(),
+            repo: "unsloth/Qwen3.6-35B-A3B-GGUF".into(),
+            files: vec!["Qwen3.6-35B-A3B-UD-Q4_K_M.gguf".into()],
+            label: "Qwen3.6 35B-A3B".into(),
+            quant: "Q4_K_M".into(),
+            bytes: 21_000_000_000,
+            min_ram_gb: 24,
+            recommended_for_gb: 32,
+            blurb: "Sparse MoE — 35B params, only ~3B active per token.".into(),
+            kind: ModelKind::Llm,
+        },
+        CatalogEntry {
+            id: "qwen36-35b-a3b-q8".into(),
+            repo: "unsloth/Qwen3.6-35B-A3B-GGUF".into(),
+            files: vec!["Qwen3.6-35B-A3B-Q8_0.gguf".into()],
+            label: "Qwen3.6 35B-A3B".into(),
+            quant: "Q8_0".into(),
+            bytes: 37_000_000_000,
+            min_ram_gb: 40,
+            recommended_for_gb: 48,
+            blurb: "Sweet spot — smart + fast. The 48-GB default.".into(),
+            kind: ModelKind::Llm,
+        },
+        CatalogEntry {
+            id: "qwen35-122b-a10b-q4".into(),
+            repo: "unsloth/Qwen3.5-122B-A10B-GGUF".into(),
+            files: vec![
+                "Qwen3.5-122B-A10B-Q4_K_M-00001-of-00003.gguf".into(),
+                "Qwen3.5-122B-A10B-Q4_K_M-00002-of-00003.gguf".into(),
+                "Qwen3.5-122B-A10B-Q4_K_M-00003-of-00003.gguf".into(),
+            ],
+            label: "Qwen3.5 122B-A10B".into(),
+            quant: "Q4_K_M".into(),
+            bytes: 73_000_000_000,
+            min_ram_gb: 80,
+            recommended_for_gb: 96,
+            blurb: "Frontier MoE — 122B params, ~10B active. 3 parts.".into(),
+            kind: ModelKind::Llm,
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn catalog_ids_are_unique() {
+        let entries = catalog();
+        let mut seen = HashSet::new();
+        for entry in &entries {
+            assert!(
+                seen.insert(entry.id.clone()),
+                "duplicate catalog id: {}",
+                entry.id
+            );
+        }
+    }
+
+    #[test]
+    fn catalog_is_non_empty_and_sorted_by_recommended_ram() {
+        let entries = catalog();
+        assert!(!entries.is_empty(), "catalog must not be empty");
+        for window in entries.windows(2) {
+            assert!(
+                window[0].recommended_for_gb <= window[1].recommended_for_gb,
+                "catalog must be ordered by recommended_for_gb (asc): {} ({}) then {} ({})",
+                window[0].id,
+                window[0].recommended_for_gb,
+                window[1].id,
+                window[1].recommended_for_gb,
+            );
+        }
+    }
+
+    #[test]
+    fn min_ram_never_exceeds_recommended_ram() {
+        for entry in catalog() {
+            assert!(
+                entry.min_ram_gb <= entry.recommended_for_gb,
+                "{}: min_ram_gb ({}) > recommended_for_gb ({})",
+                entry.id,
+                entry.min_ram_gb,
+                entry.recommended_for_gb,
+            );
+        }
+    }
+
+    #[test]
+    fn every_entry_has_at_least_one_file() {
+        for entry in catalog() {
+            assert!(
+                !entry.files.is_empty(),
+                "{}: files vector is empty — every catalog entry must list at least one artefact",
+                entry.id
+            );
+        }
+    }
+}

--- a/src-tauri/src/local_llm/chat.rs
+++ b/src-tauri/src/local_llm/chat.rs
@@ -1,0 +1,145 @@
+//! OpenAI-compatible chat client on top of the bundled `llama-server`,
+//! plus the truncation helper that keeps prompts inside the active
+//! model's context window. Implemented as additional `impl Manager`
+//! blocks so callers see a single API surface.
+
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use serde_json::json;
+
+use super::{manager::Manager, text::truncate_for_log, API_MODEL, CHAT_MAX_TOKENS};
+
+impl Manager {
+    /// Single-shot blocking chat call. Returns the assistant message
+    /// content as a trimmed string.
+    pub(crate) fn chat(
+        &self,
+        system_prompt: &str,
+        user_prompt: &str,
+        timeout: Duration,
+    ) -> Result<String> {
+        let (endpoint, token) = self
+            .current_endpoint_and_token()
+            .context("Local LLM server is not running")?;
+
+        let client = reqwest::blocking::Client::builder()
+            .timeout(timeout)
+            .build()
+            .context("build Local LLM HTTP client")?;
+        let response = client
+            .post(format!("{endpoint}/v1/chat/completions"))
+            .bearer_auth(token)
+            .json(&json!({
+                "model": API_MODEL,
+                "messages": [
+                    { "role": "system", "content": system_prompt },
+                    { "role": "user", "content": user_prompt }
+                ],
+                "temperature": 0.0,
+                "max_tokens": CHAT_MAX_TOKENS
+            }))
+            .send()
+            .context("call Local LLM chat endpoint")?;
+
+        // Always pull the body — llama-server stuffs the real reason
+        // (context-overflow, schema mismatch, …) into the response body.
+        let status = response.status();
+        let raw_body = response
+            .text()
+            .unwrap_or_else(|error| format!("<failed to read body: {error}>"));
+        if !status.is_success() {
+            anyhow::bail!(
+                "Local LLM chat returned HTTP {} — {}",
+                status,
+                summarize_error_body(&raw_body)
+            );
+        }
+        let body: serde_json::Value = serde_json::from_str(&raw_body)
+            .with_context(|| format!("parse Local LLM chat response (raw={raw_body})"))?;
+        let content = body["choices"][0]["message"]["content"]
+            .as_str()
+            .or_else(|| body["choices"][0]["message"]["reasoning_content"].as_str())
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        if content.is_empty() {
+            anyhow::bail!("Local LLM chat returned an empty message");
+        }
+        Ok(content)
+    }
+
+    /// Trim `user_message` so a `(system_prompt, user_message)` chat
+    /// call fits inside the active model's context window. Drops a
+    /// wedge from the middle and inserts a `[…truncated…]` marker.
+    ///
+    /// Uses a `~4 chars/token` proxy. Reserves `CHAT_MAX_TOKENS` plus
+    /// ~256 tokens of envelope. Never fails — degrades to "keep at
+    /// least 256 chars of tail" when the budget is pathological.
+    pub fn fit_user_message_to_context(&self, system_prompt: &str, user_message: &str) -> String {
+        const CHARS_PER_TOKEN: usize = 4;
+        const RESERVED_TOKENS: usize = CHAT_MAX_TOKENS as usize + 256;
+        const MIN_USER_CHARS: usize = 256;
+
+        let context_tokens = self.current_context_tokens() as usize;
+        if context_tokens == 0 {
+            return user_message.to_string();
+        }
+        let total_chars = context_tokens.saturating_mul(CHARS_PER_TOKEN);
+        let system_chars = system_prompt.chars().count();
+        let reserved_chars = RESERVED_TOKENS.saturating_mul(CHARS_PER_TOKEN) + system_chars;
+        let max_user_chars = total_chars
+            .saturating_sub(reserved_chars)
+            .max(MIN_USER_CHARS);
+
+        super::truncate_middle(user_message, max_user_chars)
+    }
+}
+
+/// Pull a human-readable message out of a llama-server error body. The
+/// server speaks OpenAI-shaped JSON; falls back to raw text otherwise.
+fn summarize_error_body(raw: &str) -> String {
+    const MAX_LEN: usize = 512;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return "<empty body>".to_string();
+    }
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(trimmed) {
+        if let Some(message) = value
+            .get("error")
+            .and_then(|e| e.get("message"))
+            .and_then(|m| m.as_str())
+        {
+            return truncate_for_log(message, MAX_LEN);
+        }
+        if let Some(message) = value.get("message").and_then(|m| m.as_str()) {
+            return truncate_for_log(message, MAX_LEN);
+        }
+    }
+    truncate_for_log(trimmed, MAX_LEN)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn summarize_error_body_extracts_openai_shape() {
+        let raw = r#"{"error":{"message":"the request exceeds the available context size (4096 tokens). prompt requires 5120 tokens.","type":"invalid_request_error","code":400}}"#;
+        let summary = summarize_error_body(raw);
+        assert!(summary.contains("exceeds the available context size"));
+        assert!(!summary.contains("invalid_request_error"));
+    }
+
+    #[test]
+    fn summarize_error_body_falls_back_to_plain_text() {
+        let summary = summarize_error_body("oom: cannot allocate kv cache");
+        assert_eq!(summary, "oom: cannot allocate kv cache");
+    }
+
+    #[test]
+    fn summarize_error_body_handles_empty() {
+        assert_eq!(summarize_error_body(""), "<empty body>");
+        assert_eq!(summarize_error_body("   \n  "), "<empty body>");
+    }
+}

--- a/src-tauri/src/local_llm/context.rs
+++ b/src-tauri/src/local_llm/context.rs
@@ -1,0 +1,200 @@
+//! Context-window budgeting: pick the right `-c` for the active model.
+//! Every input (trained max, KV bytes/token) comes from the GGUF
+//! header — catalog estimates are deliberately not used, so the panel
+//! display and the value llama-server actually allocates can't drift.
+
+use anyhow::{Context, Result};
+
+use super::{catalog, gguf, hardware, settings::load_settings, SETTINGS_KEY};
+
+/// Lower bound for the `-c` slider — going below 4K breaks routing on
+/// non-trivial prompts.
+pub const MIN_CONTEXT_TOKENS: u32 = 4_096;
+
+const CONTEXT_PRESETS: &[u32] = &[4_096, 8_192, 16_384, 32_768, 65_536, 131_072, 262_144];
+
+/// Pick the runtime `-c` value for `model_path`.
+///
+/// Both catalog and custom paths take the same route: read the GGUF
+/// header, then apply override → hardware-aware default. The only
+/// distinction is the settings-map key used for the override (catalog
+/// `entry.id` vs `custom:<absolute-path>`). When the GGUF can't be read
+/// (file not downloaded, corrupt header, unsupported version) we return
+/// the safe fallback constant so the caller can keep degraded service.
+pub(super) fn resolve_context_for_path(model_path: &str) -> u32 {
+    if model_path.trim().is_empty() {
+        return catalog::FALLBACK_CONTEXT_TOKENS;
+    }
+    let settings = load_settings();
+    let total_ram_gb = hardware::detect().total_ram_gb;
+    let path = std::path::Path::new(model_path);
+    let meta = match gguf::read_metadata(path) {
+        Ok(meta) => meta,
+        Err(error) => {
+            tracing::debug!(
+                model_path,
+                error = %error,
+                "GGUF metadata read failed; falling back to {}",
+                catalog::FALLBACK_CONTEXT_TOKENS,
+            );
+            return catalog::FALLBACK_CONTEXT_TOKENS;
+        }
+    };
+    let override_key = override_key_for_path(model_path);
+    if let Some(&override_value) = settings.context_overrides.get(&override_key) {
+        return override_value.clamp(MIN_CONTEXT_TOKENS, meta.context_length);
+    }
+    compute_default_context_for_meta(&meta, total_ram_gb)
+}
+
+/// Settings-map key for `context_overrides` entries on user-supplied
+/// GGUFs. Prefixed so it can't collide with a catalog id.
+pub fn custom_override_key(path: &str) -> String {
+    format!("custom:{path}")
+}
+
+/// Choose the override key for a model path: catalog `entry.id` when
+/// the path lives under our `local-llm/models/` cache, else `custom:<path>`.
+fn override_key_for_path(model_path: &str) -> String {
+    for entry in catalog::catalog() {
+        if let Some(first) = entry.files.first() {
+            let expected_suffix = format!("local-llm/models/{first}");
+            if model_path.ends_with(&expected_suffix) {
+                return entry.id;
+            }
+        }
+    }
+    custom_override_key(model_path)
+}
+
+/// Hardware-aware default `-c` driven by GGUF metadata. Picks the
+/// largest preset (powers of 2 from 4K to 256K) that:
+///   - stays under the model's trained context window
+///   - fits inside `(total_ram − os_reserve)` after the KV cache cost
+///
+/// `os_reserve` is `min(8 GB, total_ram × 10 %)`. Model-weight
+/// footprint isn't subtracted — the GGUF header doesn't carry it and
+/// `llama-server` caps its own allocation, so over-budgeting here just
+/// means the chosen preset gets clamped at startup, not OOMs.
+pub fn compute_default_context_for_meta(meta: &gguf::ModelMetadata, total_ram_gb: u8) -> u32 {
+    pick_best_preset(total_ram_gb, meta.kv_bytes_per_token(), meta.context_length)
+}
+
+fn pick_best_preset(
+    total_ram_gb: u8,
+    kv_bytes_per_token: u32,
+    model_max_context_tokens: u32,
+) -> u32 {
+    if total_ram_gb == 0 {
+        return MIN_CONTEXT_TOKENS;
+    }
+    let total = u64::from(total_ram_gb) * 1_073_741_824;
+    let os_reserve = (8u64 * 1_073_741_824).min(((total as f64) * 0.10) as u64);
+    let available = total.saturating_sub(os_reserve);
+    let kv_per = u64::from(kv_bytes_per_token).max(1);
+    let max_tokens = (available / kv_per) as u32;
+    let mut best = MIN_CONTEXT_TOKENS;
+    for &preset in CONTEXT_PRESETS {
+        if preset > model_max_context_tokens {
+            break;
+        }
+        if preset > max_tokens {
+            break;
+        }
+        best = preset;
+    }
+    best
+}
+
+/// Write a per-entry context override (or remove it when `value`
+/// matches the hardware-aware default — keeps settings tidy and lets
+/// the default re-evaluate if the user upgrades their Mac).
+///
+/// Both catalog entries and custom paths route through the GGUF
+/// metadata — the panel only renders the slider once inspect has
+/// succeeded, so by the time this is called we're guaranteed to have a
+/// real file to read.
+pub fn set_context_override(entry_id: &str, value: u32) -> Result<()> {
+    let path = if let Some(custom_path) = entry_id.strip_prefix("custom:") {
+        std::path::PathBuf::from(custom_path)
+    } else {
+        let entry = catalog::catalog()
+            .into_iter()
+            .find(|e| e.id == entry_id)
+            .with_context(|| format!("unknown catalog entry: {entry_id}"))?;
+        let first_file = entry.files.first().context("catalog entry has no files")?;
+        crate::data_dir::local_llm_models_dir()?.join(first_file)
+    };
+    let meta = gguf::read_metadata(&path)
+        .with_context(|| format!("read GGUF metadata for override target: {}", path.display()))?;
+    let clamped = value.clamp(MIN_CONTEXT_TOKENS, meta.context_length);
+    let default = compute_default_context_for_meta(&meta, hardware::detect().total_ram_gb);
+
+    let mut settings = load_settings();
+    if clamped == default {
+        settings.context_overrides.remove(entry_id);
+    } else {
+        settings
+            .context_overrides
+            .insert(entry_id.to_string(), clamped);
+    }
+    crate::settings::upsert_setting_json(SETTINGS_KEY, &settings)
+        .context("persist Local LLM context override")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a synthetic GGUF metadata that yields exactly
+    /// `kv_bytes_per_token` from the formula
+    /// `4 × kv_heads × head_dim × layers`. Holding kv_heads / head_count /
+    /// block_count at 1 leaves `embedding_length = kv_bytes_per_token / 4`.
+    fn meta(context_length: u32, kv_bytes_per_token: u32) -> gguf::ModelMetadata {
+        gguf::ModelMetadata {
+            architecture: "test".into(),
+            name: None,
+            context_length,
+            block_count: 1,
+            embedding_length: kv_bytes_per_token / 4,
+            head_count: 1,
+            kv_head_count: 1,
+        }
+    }
+
+    #[test]
+    fn picks_largest_preset_within_model_max_and_ram() {
+        // 64 KB/token at 16 GB → reserve = 1.6 GB → 14.4 GB / 64 KB ≈
+        // 235K tokens; clamps to model_max 128K.
+        let m = meta(131_072, 65_536);
+        assert_eq!(compute_default_context_for_meta(&m, 16), 131_072);
+    }
+
+    #[test]
+    fn scales_down_when_kv_eats_ram() {
+        // 256 KB/token at 32 GB → reserve = 3.2 GB → 28.8 GB / 256 KB ≈
+        // 117K → next preset down = 64K.
+        let m = meta(262_144, 262_144);
+        assert_eq!(compute_default_context_for_meta(&m, 32), 65_536);
+    }
+
+    #[test]
+    fn returns_min_when_kv_too_expensive_for_host() {
+        // 4 MB/token at 16 GB → max_tokens ≈ 3.6K, below the 4K floor.
+        let m = meta(262_144, 4_194_304);
+        assert_eq!(compute_default_context_for_meta(&m, 16), MIN_CONTEXT_TOKENS);
+    }
+
+    #[test]
+    fn returns_min_on_unknown_hardware() {
+        let m = meta(131_072, 65_536);
+        assert_eq!(compute_default_context_for_meta(&m, 0), MIN_CONTEXT_TOKENS);
+    }
+
+    #[test]
+    fn huge_macs_reach_model_max() {
+        let m = meta(262_144, 65_536);
+        assert_eq!(compute_default_context_for_meta(&m, 255), 262_144);
+    }
+}

--- a/src-tauri/src/local_llm/gguf.rs
+++ b/src-tauri/src/local_llm/gguf.rs
@@ -1,0 +1,458 @@
+//! Minimal GGUF metadata reader. Reads the header + KV pairs, skips
+//! the tensor index. Used by the Local LLM panel so custom GGUFs the
+//! user pastes in (outside our curated catalog) still get accurate
+//! "trained max context" + "KV cache bytes/token" estimates instead
+//! of falling back to a hand-wavy 32K guess.
+//!
+//! References:
+//!   - GGUF spec: https://github.com/ggml-org/ggml/blob/master/docs/gguf.md
+//!   - llama.cpp metadata key naming:
+//!     https://github.com/ggml-org/llama.cpp/blob/master/src/llama-arch.cpp
+//!
+//! We support GGUF v2 and v3 (the only versions llama-server still
+//! reads). v1 is a relic from 2023 — if we ever hit it the parser
+//! returns a clear error and the caller falls back to the constant.
+
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{BufReader, Read};
+use std::path::Path;
+
+use anyhow::{anyhow, Context, Result};
+
+const GGUF_MAGIC: u32 = 0x4655_4747; // b"GGUF" little-endian
+
+/// Upper bound on top-level metadata KV count. Real GGUFs sit at ~30-200
+/// KVs; even tokenizer-heavy models stay under 500. The header field is
+/// `u64` and we deref it into `HashMap::with_capacity`, so without a cap
+/// a corrupt / malicious file can force a massive allocation before we
+/// ever read a byte of payload. 10K is ~50× the largest legitimate count
+/// we've seen — buy headroom, bail past it.
+const MAX_METADATA_KV_COUNT: u64 = 10_000;
+
+/// Subset of GGUF metadata Helmor consumes. Other 30+ keys (rope params,
+/// quantization metadata, tokenizer vocab, ...) are read off the wire
+/// then dropped — we only keep what drives the context-window UI.
+#[derive(Debug, Clone)]
+pub struct ModelMetadata {
+    /// Architecture string from `general.architecture` (llama / qwen2 /
+    /// qwen3 / mistral / phi3 / gemma / ...). The other metadata keys
+    /// are namespaced under this prefix.
+    pub architecture: String,
+    /// `general.name` — friendly model label for the panel header. Often
+    /// missing or generic; callers should fall back to the filename.
+    pub name: Option<String>,
+    /// `<arch>.context_length` — the trained context window. UI clamps
+    /// the slider to this; below this the model just stays accurate,
+    /// above it accuracy collapses (positional encoding extrapolation).
+    pub context_length: u32,
+    /// Total transformer blocks (`<arch>.block_count`). Drives KV cache
+    /// sizing — every block has its own K + V tensor.
+    pub block_count: u32,
+    /// Model hidden size (`<arch>.embedding_length`). Combined with
+    /// head_count gives the per-head dim.
+    pub embedding_length: u32,
+    /// Query attention heads (`<arch>.attention.head_count`).
+    pub head_count: u32,
+    /// KV heads (`<arch>.attention.head_count_kv`). Equal to
+    /// `head_count` for plain MHA; smaller for GQA / MQA. Most modern
+    /// models (Llama 3, Qwen 2/3) are GQA so this is the bit that
+    /// makes KV cache 4-8× smaller than naive.
+    pub kv_head_count: u32,
+}
+
+impl ModelMetadata {
+    /// Bytes of fp16 KV cache per token. Matches what llama-server
+    /// actually allocates at startup when `-ctk f16 -ctv f16` (the
+    /// default). Formula: `2 (K and V) × kv_heads × head_dim × layers × 2 (fp16)`.
+    pub fn kv_bytes_per_token(&self) -> u32 {
+        if self.head_count == 0 {
+            return 0;
+        }
+        let head_dim = self.embedding_length / self.head_count.max(1);
+        let kv_heads = self.kv_head_count.max(1);
+        // 2 tensors (K, V) × kv_heads × head_dim × layers × 2 bytes (fp16)
+        // = 4 × kv_heads × head_dim × layers
+        kv_heads
+            .saturating_mul(head_dim)
+            .saturating_mul(self.block_count)
+            .saturating_mul(4)
+    }
+}
+
+/// One typed metadata value as parsed from the GGUF KV stream. We only
+/// expose the variants Helmor reads (scalar ints, strings); anything
+/// else is parsed and dropped silently so the cursor advances past it.
+#[derive(Debug, Clone)]
+enum MetaValue {
+    U64(u64),
+    String(String),
+    Other,
+}
+
+impl MetaValue {
+    fn as_u64(&self) -> Option<u64> {
+        match self {
+            MetaValue::U64(v) => Some(*v),
+            _ => None,
+        }
+    }
+    fn as_str(&self) -> Option<&str> {
+        match self {
+            MetaValue::String(v) => Some(v.as_str()),
+            _ => None,
+        }
+    }
+}
+
+pub fn read_metadata(path: &Path) -> Result<ModelMetadata> {
+    // Extension sniff first — turns "tried to read a .png" into a clear
+    // "unsupported file type" instead of "bad magic 89504e47".
+    let extension_ok = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.eq_ignore_ascii_case("gguf"))
+        .unwrap_or(false);
+    if !extension_ok {
+        return Err(anyhow!(
+            "Unsupported file type — only `.gguf` models are accepted (got {})",
+            path.display()
+        ));
+    }
+    if !path.is_file() {
+        return Err(anyhow!("File not found: {}", path.display()));
+    }
+    let file = File::open(path)
+        .with_context(|| format!("open {} for GGUF metadata read", path.display()))?;
+    // 1 MB buffer covers virtually every model's KV section in one read;
+    // the parser only needs sequential access, not random seeks.
+    let mut reader = BufReader::with_capacity(1024 * 1024, file);
+
+    let magic = read_u32(&mut reader)?;
+    if magic != GGUF_MAGIC {
+        return Err(anyhow!(
+            "Not a valid GGUF file — header magic mismatch (file may be truncated or in a different format)"
+        ));
+    }
+    let version = read_u32(&mut reader)?;
+    if !(2..=3).contains(&version) {
+        return Err(anyhow!(
+            "unsupported GGUF version {version} (Helmor reads v2 and v3)"
+        ));
+    }
+    // v2/v3 both use u64 counts here. v1 used u32, but we bail above.
+    let _tensor_count = read_u64(&mut reader)?;
+    let metadata_kv_count = read_u64(&mut reader)?;
+    if metadata_kv_count > MAX_METADATA_KV_COUNT {
+        return Err(anyhow!(
+            "absurd metadata KV count {metadata_kv_count} in GGUF header (cap {MAX_METADATA_KV_COUNT})"
+        ));
+    }
+
+    let mut kvs: HashMap<String, MetaValue> = HashMap::with_capacity(metadata_kv_count as usize);
+    for _ in 0..metadata_kv_count {
+        let key = read_string(&mut reader)?;
+        let value = read_value(&mut reader)?;
+        kvs.insert(key, value);
+    }
+
+    let architecture = kvs
+        .get("general.architecture")
+        .and_then(MetaValue::as_str)
+        .ok_or_else(|| anyhow!("GGUF missing `general.architecture`"))?
+        .to_string();
+
+    let name = kvs
+        .get("general.name")
+        .and_then(MetaValue::as_str)
+        .map(str::to_owned);
+
+    let arch_key = |suffix: &str| format!("{architecture}.{suffix}");
+    let lookup_u32 = |suffix: &str| -> Option<u32> {
+        kvs.get(&arch_key(suffix))
+            .and_then(MetaValue::as_u64)
+            .and_then(|v| u32::try_from(v).ok())
+    };
+
+    let context_length = lookup_u32("context_length")
+        .ok_or_else(|| anyhow!("GGUF missing `{architecture}.context_length`"))?;
+    let block_count = lookup_u32("block_count")
+        .ok_or_else(|| anyhow!("GGUF missing `{architecture}.block_count`"))?;
+    let embedding_length = lookup_u32("embedding_length")
+        .ok_or_else(|| anyhow!("GGUF missing `{architecture}.embedding_length`"))?;
+    let head_count = lookup_u32("attention.head_count")
+        .ok_or_else(|| anyhow!("GGUF missing `{architecture}.attention.head_count`"))?;
+    // GQA models declare a distinct `head_count_kv`; pure-MHA models
+    // (early Llama 2, some Mistral variants) omit it and we fall back
+    // to `head_count`.
+    let kv_head_count = lookup_u32("attention.head_count_kv").unwrap_or(head_count);
+
+    Ok(ModelMetadata {
+        architecture,
+        name,
+        context_length,
+        block_count,
+        embedding_length,
+        head_count,
+        kv_head_count,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Low-level decoders. Everything in GGUF is little-endian. The reader
+// is `Read` (sequential only) because GGUF metadata + tensor descriptors
+// stream front-to-back without needing seeks.
+// ---------------------------------------------------------------------------
+
+fn read_u8(reader: &mut impl Read) -> Result<u8> {
+    let mut buf = [0u8; 1];
+    reader.read_exact(&mut buf)?;
+    Ok(buf[0])
+}
+fn read_u16(reader: &mut impl Read) -> Result<u16> {
+    let mut buf = [0u8; 2];
+    reader.read_exact(&mut buf)?;
+    Ok(u16::from_le_bytes(buf))
+}
+fn read_u32(reader: &mut impl Read) -> Result<u32> {
+    let mut buf = [0u8; 4];
+    reader.read_exact(&mut buf)?;
+    Ok(u32::from_le_bytes(buf))
+}
+fn read_u64(reader: &mut impl Read) -> Result<u64> {
+    let mut buf = [0u8; 8];
+    reader.read_exact(&mut buf)?;
+    Ok(u64::from_le_bytes(buf))
+}
+fn read_i8(reader: &mut impl Read) -> Result<i8> {
+    Ok(read_u8(reader)? as i8)
+}
+fn read_i16(reader: &mut impl Read) -> Result<i16> {
+    Ok(read_u16(reader)? as i16)
+}
+fn read_i32(reader: &mut impl Read) -> Result<i32> {
+    Ok(read_u32(reader)? as i32)
+}
+fn read_i64(reader: &mut impl Read) -> Result<i64> {
+    Ok(read_u64(reader)? as i64)
+}
+fn read_f32(reader: &mut impl Read) -> Result<f32> {
+    Ok(f32::from_bits(read_u32(reader)?))
+}
+fn read_f64(reader: &mut impl Read) -> Result<f64> {
+    Ok(f64::from_bits(read_u64(reader)?))
+}
+fn read_bool(reader: &mut impl Read) -> Result<bool> {
+    Ok(read_u8(reader)? != 0)
+}
+fn read_string(reader: &mut impl Read) -> Result<String> {
+    let len = read_u64(reader)?;
+    if len > 64 * 1024 * 1024 {
+        // Largest legitimate string is the tokenizer vocab JSON ≪ 64 MB.
+        // Anything past this is a corrupt header — bail before alloc.
+        return Err(anyhow!("absurd string length {len} in GGUF metadata"));
+    }
+    let mut buf = vec![0u8; len as usize];
+    reader.read_exact(&mut buf)?;
+    String::from_utf8(buf).map_err(|e| anyhow!("non-UTF8 string in GGUF metadata: {e}"))
+}
+
+fn read_value(reader: &mut impl Read) -> Result<MetaValue> {
+    let type_id = read_u32(reader)?;
+    read_value_typed(reader, type_id)
+}
+
+fn read_value_typed(reader: &mut impl Read, type_id: u32) -> Result<MetaValue> {
+    match type_id {
+        0 => Ok(MetaValue::U64(read_u8(reader)? as u64)),
+        1 => Ok(MetaValue::U64(read_i8(reader)? as u64)),
+        2 => Ok(MetaValue::U64(read_u16(reader)? as u64)),
+        3 => Ok(MetaValue::U64(read_i16(reader)? as u64)),
+        4 => Ok(MetaValue::U64(read_u32(reader)? as u64)),
+        5 => Ok(MetaValue::U64(read_i32(reader)? as u64)),
+        6 => {
+            // Discard f32 value (we don't surface any float-typed keys).
+            let _ = read_f32(reader)?;
+            Ok(MetaValue::Other)
+        }
+        7 => {
+            let _ = read_bool(reader)?;
+            Ok(MetaValue::Other)
+        }
+        8 => Ok(MetaValue::String(read_string(reader)?)),
+        9 => {
+            // Array: inner type (u32) + length (u64) + values
+            let inner_type = read_u32(reader)?;
+            let len = read_u64(reader)?;
+            if len > 1024 * 1024 {
+                return Err(anyhow!("absurd array length {len} in GGUF metadata"));
+            }
+            for _ in 0..len {
+                read_value_typed(reader, inner_type)?;
+            }
+            Ok(MetaValue::Other)
+        }
+        10 => Ok(MetaValue::U64(read_u64(reader)?)),
+        11 => Ok(MetaValue::U64(read_i64(reader)? as u64)),
+        12 => {
+            let _ = read_f64(reader)?;
+            Ok(MetaValue::Other)
+        }
+        other => Err(anyhow!("unknown GGUF value type {other}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::{Builder, NamedTempFile};
+
+    fn gguf_tempfile() -> NamedTempFile {
+        Builder::new().suffix(".gguf").tempfile().unwrap()
+    }
+
+    /// Build a synthetic GGUF v3 header + just enough metadata KVs to
+    /// satisfy `read_metadata`. Mirrors what llama.cpp's `gguf-writer`
+    /// would produce for a typical model.
+    fn write_min_gguf(tensor_count: u64, kvs: Vec<(&str, Kv)>) -> NamedTempFile {
+        let mut file = gguf_tempfile();
+        let f = file.as_file_mut();
+        f.write_all(&GGUF_MAGIC.to_le_bytes()).unwrap();
+        f.write_all(&3u32.to_le_bytes()).unwrap();
+        f.write_all(&tensor_count.to_le_bytes()).unwrap();
+        f.write_all(&(kvs.len() as u64).to_le_bytes()).unwrap();
+        for (k, v) in kvs {
+            write_string(f, k);
+            v.write(f);
+        }
+        file
+    }
+
+    fn write_string(f: &mut std::fs::File, s: &str) {
+        f.write_all(&(s.len() as u64).to_le_bytes()).unwrap();
+        f.write_all(s.as_bytes()).unwrap();
+    }
+
+    enum Kv {
+        Str(String),
+        U32(u32),
+    }
+    impl Kv {
+        fn write(&self, f: &mut std::fs::File) {
+            match self {
+                Kv::Str(s) => {
+                    f.write_all(&8u32.to_le_bytes()).unwrap();
+                    write_string(f, s);
+                }
+                Kv::U32(v) => {
+                    f.write_all(&4u32.to_le_bytes()).unwrap();
+                    f.write_all(&v.to_le_bytes()).unwrap();
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn parses_minimal_llama_gguf() {
+        let file = write_min_gguf(
+            0,
+            vec![
+                ("general.architecture", Kv::Str("llama".into())),
+                ("general.name", Kv::Str("Llama 3 8B".into())),
+                ("llama.context_length", Kv::U32(8192)),
+                ("llama.block_count", Kv::U32(32)),
+                ("llama.embedding_length", Kv::U32(4096)),
+                ("llama.attention.head_count", Kv::U32(32)),
+                ("llama.attention.head_count_kv", Kv::U32(8)),
+            ],
+        );
+        let meta = read_metadata(file.path()).unwrap();
+        assert_eq!(meta.architecture, "llama");
+        assert_eq!(meta.name.as_deref(), Some("Llama 3 8B"));
+        assert_eq!(meta.context_length, 8192);
+        assert_eq!(meta.block_count, 32);
+        assert_eq!(meta.head_count, 32);
+        assert_eq!(meta.kv_head_count, 8);
+        // head_dim = 4096 / 32 = 128. KV/token = 4 × 8 × 128 × 32 = 131_072
+        assert_eq!(meta.kv_bytes_per_token(), 131_072);
+    }
+
+    #[test]
+    fn falls_back_to_head_count_when_kv_count_absent() {
+        // Pre-GQA MHA model — only one head_count present.
+        let file = write_min_gguf(
+            0,
+            vec![
+                ("general.architecture", Kv::Str("llama".into())),
+                ("llama.context_length", Kv::U32(2048)),
+                ("llama.block_count", Kv::U32(32)),
+                ("llama.embedding_length", Kv::U32(4096)),
+                ("llama.attention.head_count", Kv::U32(32)),
+            ],
+        );
+        let meta = read_metadata(file.path()).unwrap();
+        assert_eq!(meta.kv_head_count, 32);
+        // KV/token = 4 × 32 × 128 × 32 = 524_288
+        assert_eq!(meta.kv_bytes_per_token(), 524_288);
+    }
+
+    #[test]
+    fn rejects_files_without_gguf_extension() {
+        let mut file = NamedTempFile::new().unwrap();
+        file.as_file_mut().write_all(b"NOTGGUFBYTES").unwrap();
+        let err = read_metadata(file.path()).unwrap_err();
+        assert!(
+            err.to_string().contains("Unsupported file type"),
+            "expected extension reject, got {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_gguf_files_with_bad_magic() {
+        let mut file = gguf_tempfile();
+        file.as_file_mut().write_all(b"NOTGGUFBYTES").unwrap();
+        let err = read_metadata(file.path()).unwrap_err();
+        assert!(
+            err.to_string().contains("header magic mismatch"),
+            "expected magic mismatch, got {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_missing_files() {
+        let path = std::path::PathBuf::from("/tmp/helmor-does-not-exist-xyzzy.gguf");
+        let err = read_metadata(&path).unwrap_err();
+        assert!(
+            err.to_string().contains("File not found"),
+            "expected file-not-found, got {err}"
+        );
+    }
+
+    #[test]
+    fn requires_arch_specific_keys() {
+        let file = write_min_gguf(0, vec![("general.architecture", Kv::Str("llama".into()))]);
+        let err = read_metadata(file.path()).unwrap_err();
+        assert!(err.to_string().contains("context_length"));
+    }
+
+    #[test]
+    fn rejects_absurd_metadata_kv_count() {
+        // Header claims more KVs than the cap allows — must bail before
+        // touching the (effectively unbounded) HashMap allocation /
+        // payload-read loop. We hand-craft the header so we don't have
+        // to actually write 10K+ records.
+        let mut file = gguf_tempfile();
+        let f = file.as_file_mut();
+        f.write_all(&GGUF_MAGIC.to_le_bytes()).unwrap();
+        f.write_all(&3u32.to_le_bytes()).unwrap();
+        f.write_all(&0u64.to_le_bytes()).unwrap(); // tensor_count
+        f.write_all(&(MAX_METADATA_KV_COUNT + 1).to_le_bytes())
+            .unwrap();
+        let err = read_metadata(file.path()).unwrap_err();
+        assert!(
+            err.to_string().contains("absurd metadata KV count"),
+            "expected cap error, got {err}"
+        );
+    }
+}

--- a/src-tauri/src/local_llm/hardware.rs
+++ b/src-tauri/src/local_llm/hardware.rs
@@ -1,0 +1,243 @@
+//! Local-machine snapshot for the Local LLM settings panel.
+//!
+//! `detect()` returns a cached `HardwareSnapshot` so re-renders of the
+//! panel don't re-shell-out to `sw_vers`. RAM / CPU brand don't change
+//! mid-process and the OS version effectively doesn't either; OnceLock
+//! is correct here.
+//!
+//! macOS-only — we read `hw.memsize` and `machdep.cpu.brand_string`
+//! via `sysctlbyname` (cheap, no shell), and `productVersion` via the
+//! `sw_vers` CLI (no clean sysctl path for it on Apple Silicon).
+
+use std::ffi::CString;
+use std::sync::OnceLock;
+
+use serde::Serialize;
+
+use super::catalog::{self, CatalogEntry, ModelKind};
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HardwareSnapshot {
+    pub cpu_brand: String,
+    pub total_ram_gb: u8,
+    pub os_label: String,
+    pub arch: &'static str,
+    /// `id` of the catalog entry the hardware tier maps to. Frontend
+    /// uses this to paint the "Recommended" badge on exactly one card.
+    /// `None` only if the catalog is unexpectedly empty.
+    pub recommended_entry_id: Option<String>,
+}
+
+static SNAPSHOT: OnceLock<HardwareSnapshot> = OnceLock::new();
+
+pub fn detect() -> HardwareSnapshot {
+    SNAPSHOT.get_or_init(do_detect).clone()
+}
+
+#[cfg(target_os = "macos")]
+fn do_detect() -> HardwareSnapshot {
+    let total_bytes = sysctl_u64("hw.memsize").unwrap_or(0);
+    let total_gb = bytes_to_rounded_gb(total_bytes);
+    let cpu_brand =
+        sysctl_string("machdep.cpu.brand_string").unwrap_or_else(|| "Unknown CPU".to_string());
+    let os_label = read_macos_version()
+        .map(|v| format!("macOS {v}"))
+        .unwrap_or_else(|| "macOS".to_string());
+
+    HardwareSnapshot {
+        cpu_brand,
+        total_ram_gb: total_gb,
+        os_label,
+        arch: arch_label(),
+        recommended_entry_id: recommend_for_ram(total_gb),
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn do_detect() -> HardwareSnapshot {
+    // Helmor only ships on macOS today, but keep the non-macOS branch
+    // compilable so unit tests and future Linux/Windows ports don't
+    // explode. Backend returns a "best-effort unknown" snapshot; the
+    // frontend already handles that gracefully (no recommended badge,
+    // muted "Your Mac" row).
+    HardwareSnapshot {
+        cpu_brand: "Unknown CPU".to_string(),
+        total_ram_gb: 0,
+        os_label: std::env::consts::OS.to_string(),
+        arch: arch_label(),
+        recommended_entry_id: None,
+    }
+}
+
+fn arch_label() -> &'static str {
+    if cfg!(target_arch = "aarch64") {
+        "arm64"
+    } else if cfg!(target_arch = "x86_64") {
+        "x64"
+    } else {
+        "unknown"
+    }
+}
+
+fn bytes_to_rounded_gb(bytes: u64) -> u8 {
+    let gb = (bytes as f64) / 1_073_741_824.0;
+    // u8 ceiling (255 GB) is comfortably above any current shipping
+    // Mac (Studio Ultra tops out at 512 GB but it's vanishingly rare
+    // among Helmor users; we'd promote to u16 in the same week one
+    // shows up).
+    gb.round().clamp(0.0, u8::MAX as f64) as u8
+}
+
+#[cfg(target_os = "macos")]
+fn sysctl_u64(name: &str) -> Option<u64> {
+    let name_c = CString::new(name).ok()?;
+    let mut value: u64 = 0;
+    let mut size = std::mem::size_of::<u64>();
+    let ret = unsafe {
+        libc::sysctlbyname(
+            name_c.as_ptr(),
+            std::ptr::from_mut::<u64>(&mut value).cast::<std::ffi::c_void>(),
+            &mut size,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    (ret == 0).then_some(value)
+}
+
+#[cfg(target_os = "macos")]
+fn sysctl_string(name: &str) -> Option<String> {
+    let name_c = CString::new(name).ok()?;
+    // Two-call protocol: first probe the length, then read.
+    let mut size: usize = 0;
+    let ret = unsafe {
+        libc::sysctlbyname(
+            name_c.as_ptr(),
+            std::ptr::null_mut(),
+            &mut size,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if ret != 0 || size == 0 {
+        return None;
+    }
+    let mut buf = vec![0u8; size];
+    let ret = unsafe {
+        libc::sysctlbyname(
+            name_c.as_ptr(),
+            buf.as_mut_ptr().cast::<std::ffi::c_void>(),
+            &mut size,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if ret != 0 {
+        return None;
+    }
+    if let Some(&0) = buf.last() {
+        buf.pop();
+    }
+    String::from_utf8(buf).ok()
+}
+
+#[cfg(target_os = "macos")]
+fn read_macos_version() -> Option<String> {
+    let output = std::process::Command::new("sw_vers")
+        .arg("-productVersion")
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let raw = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if raw.is_empty() {
+        None
+    } else {
+        Some(raw)
+    }
+}
+
+/// Walk the catalog ascending by `recommended_for_gb` and keep the
+/// highest entry whose recommendation fits inside the machine's RAM.
+/// If even the smallest entry doesn't fit (very low-RAM machine), we
+/// still return the smallest so the panel has something to highlight —
+/// the user opts in by clicking through the "Needs N GB free" warning.
+fn recommend_for_ram(total_gb: u8) -> Option<String> {
+    let entries = catalog::catalog();
+    // STT entries share the catalog but are NOT chat brains — never
+    // recommend one as the user's default brain just because it fits.
+    let llm_entries: Vec<&CatalogEntry> = entries
+        .iter()
+        .filter(|e| e.kind == ModelKind::Llm)
+        .collect();
+    let mut best: Option<&CatalogEntry> = None;
+    for entry in &llm_entries {
+        if entry.recommended_for_gb <= total_gb {
+            best = Some(entry);
+        }
+    }
+    best.or_else(|| llm_entries.first().copied())
+        .map(|e| e.id.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bytes_to_rounded_gb_handles_typical_macs() {
+        // 16 GB unified memory (Apple counts 1 GB = 1024^3).
+        assert_eq!(bytes_to_rounded_gb(17_179_869_184), 16);
+        // 48 GB.
+        assert_eq!(bytes_to_rounded_gb(51_539_607_552), 48);
+        // 96 GB.
+        assert_eq!(bytes_to_rounded_gb(103_079_215_104), 96);
+        // 0 / unknown.
+        assert_eq!(bytes_to_rounded_gb(0), 0);
+    }
+
+    #[test]
+    fn recommend_for_ram_picks_highest_fitting_tier() {
+        // 16 GB → smallest 16-GB entry.
+        let id = recommend_for_ram(16).expect("catalog has entries");
+        assert_eq!(id, "qwen35-4b-q4");
+        // 24 GB → 9B.
+        assert_eq!(recommend_for_ram(24).as_deref(), Some("qwen35-9b-q4"));
+        // 32 GB → last 32-GB-tier entry (catalog order).
+        let id_32 = recommend_for_ram(32).expect("32 gb matches");
+        assert!(
+            id_32 == "qwen36-27b-q4" || id_32 == "qwen36-35b-a3b-q4",
+            "expected a 32-GB tier entry, got {id_32}",
+        );
+        // 48 GB → 35B-A3B Q8 (the sweet spot).
+        assert_eq!(recommend_for_ram(48).as_deref(), Some("qwen36-35b-a3b-q8"));
+        // 96 GB → 122B-A10B.
+        assert_eq!(
+            recommend_for_ram(96).as_deref(),
+            Some("qwen35-122b-a10b-q4")
+        );
+        // 128 GB → still the largest (capped at top).
+        assert_eq!(
+            recommend_for_ram(128).as_deref(),
+            Some("qwen35-122b-a10b-q4")
+        );
+    }
+
+    #[test]
+    fn recommend_for_ram_falls_back_to_smallest_when_below_floor() {
+        // 4 GB machine — below every entry. Still hand back the
+        // smallest so the panel has something to flag.
+        assert_eq!(recommend_for_ram(4).as_deref(), Some("qwen35-4b-q4"));
+    }
+
+    #[test]
+    fn detect_returns_a_snapshot_without_panicking() {
+        let snapshot = detect();
+        // Identity should be the same instance on repeat calls (OnceLock).
+        let second = detect();
+        assert_eq!(snapshot.arch, second.arch);
+        assert_eq!(snapshot.total_ram_gb, second.total_ram_gb);
+    }
+}

--- a/src-tauri/src/local_llm/manager.rs
+++ b/src-tauri/src/local_llm/manager.rs
@@ -1,0 +1,287 @@
+//! Bundled `llama-server` lifecycle: spawn / health-check / stop /
+//! orphan reaping. Public `Manager` is what the rest of the crate
+//! holds (registered as Tauri state in `lib.rs`); everything else here
+//! is private plumbing.
+
+use std::{path::PathBuf, sync::Mutex, time::Instant};
+
+use anyhow::Result;
+use serde_json::json;
+
+use super::{
+    context::resolve_context_for_path,
+    server,
+    settings::{load_settings, normalize_model, Endpoint, Status},
+    API_MODEL, GPU_LAYERS, LOG_TAG, REASONING_MODE, WARMUP_TIMEOUT,
+};
+
+#[derive(Default)]
+pub struct Manager {
+    /// Serializes `ensure_started` / `stop` so two concurrent starts
+    /// can't both spawn a child. Held across the entire spawn +
+    /// health-check window. `status()` must NOT take this lock — the UI
+    /// polls `status` while a slow cold-load is in flight.
+    start_lock: Mutex<()>,
+    server: Mutex<Option<server::ServerInstance>>,
+    starting: Mutex<bool>,
+    last_error: Mutex<Option<String>>,
+}
+
+impl Manager {
+    pub fn status(&self) -> Status {
+        let settings = load_settings();
+        let runtime_path = server::resolve_llama_server_path().ok();
+        let mut server = self.server.lock().unwrap_or_else(|p| p.into_inner());
+        let running = if let Some(running) = server.as_mut() {
+            if server::child_is_running(&mut running.child) {
+                true
+            } else {
+                *server = None;
+                false
+            }
+        } else {
+            false
+        };
+        let endpoint = server
+            .as_ref()
+            .filter(|_| running)
+            .map(|server| format!("http://127.0.0.1:{}", server.port));
+        let starting = *self.starting.lock().unwrap_or_else(|p| p.into_inner());
+        Status {
+            enabled: settings.enabled,
+            runtime_found: runtime_path.is_some(),
+            runtime_path: runtime_path.map(|path| path.display().to_string()),
+            starting,
+            running,
+            model: normalize_model(&settings.model),
+            api_model: API_MODEL.to_string(),
+            context_size: resolve_context_for_path(&normalize_model(&settings.model)),
+            gpu_layers: GPU_LAYERS.parse().unwrap_or(99),
+            reasoning_mode: REASONING_MODE.to_string(),
+            endpoint,
+            last_error: self
+                .last_error
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .clone(),
+        }
+    }
+
+    pub fn start(&self) -> Result<Status> {
+        let settings = load_settings();
+        self.ensure_started(&normalize_model(&settings.model))?;
+        Ok(self.status())
+    }
+
+    pub fn stop(&self) {
+        let _guard = self.start_lock.lock().unwrap_or_else(|p| p.into_inner());
+        self.kill_server();
+    }
+
+    /// Connection params for the running server — `None` while stopped
+    /// / starting / crashed. Voice Pilot calls this to POST chat
+    /// completions directly.
+    pub fn endpoint(&self) -> Option<Endpoint> {
+        self.with_live_server(|s| Endpoint {
+            url: format!("http://127.0.0.1:{}", s.port),
+            token: s.token.clone(),
+            api_model: API_MODEL.to_string(),
+        })
+    }
+
+    /// Active model's runtime `-c` value (token count). `0` when no
+    /// model is selected, so callers can branch instead of dividing by
+    /// zero.
+    pub fn current_context_tokens(&self) -> u32 {
+        let settings = load_settings();
+        let model_path = normalize_model(&settings.model);
+        if model_path.is_empty() {
+            return 0;
+        }
+        resolve_context_for_path(&model_path)
+    }
+
+    /// Internal helper for `chat.rs` — fishes out endpoint + token in a
+    /// single lock window.
+    pub(super) fn current_endpoint_and_token(&self) -> Option<(String, String)> {
+        self.with_live_server(|s| (format!("http://127.0.0.1:{}", s.port), s.token.clone()))
+    }
+
+    /// Lock the server slot, reap it if the child has died, then run `f`
+    /// on the live instance. Centralizes the "crashed → None" invariant
+    /// so every reader sees the same view as `status()` (which already
+    /// inlines this same check).
+    fn with_live_server<R>(&self, f: impl FnOnce(&server::ServerInstance) -> R) -> Option<R> {
+        let mut server = self.server.lock().unwrap_or_else(|p| p.into_inner());
+        if let Some(running) = server.as_mut() {
+            if server::child_is_running(&mut running.child) {
+                return Some(f(running));
+            }
+            *server = None;
+        }
+        None
+    }
+
+    /// Drop the current server, letting `ServerInstance::drop` kill the
+    /// child and remove the pid file. Caller is responsible for
+    /// serializing — `stop()` holds `start_lock`.
+    fn kill_server(&self) {
+        let mut server = self.server.lock().unwrap_or_else(|p| p.into_inner());
+        let _ = server.take();
+    }
+
+    fn ensure_started(&self, model: &str) -> Result<()> {
+        let _start_guard = self.start_lock.lock().unwrap_or_else(|p| p.into_inner());
+        {
+            let mut server = self.server.lock().unwrap_or_else(|p| p.into_inner());
+            if let Some(running) = server.as_mut() {
+                if running.model_path == model && server::child_is_running(&mut running.child) {
+                    return Ok(());
+                }
+                // Stale (different model or dead) — drop reaps it.
+                let _ = server.take();
+            }
+        }
+
+        let _starting = StartingFlag::new(&self.starting);
+        let instance = spawn_llm_server(model).inspect_err(|error| {
+            *self.last_error.lock().unwrap_or_else(|p| p.into_inner()) = Some(format!("{error:#}"));
+        })?;
+        let endpoint = format!("http://127.0.0.1:{}", instance.port);
+        let token = instance.token.clone();
+        *self.server.lock().unwrap_or_else(|p| p.into_inner()) = Some(instance);
+        *self.last_error.lock().unwrap_or_else(|p| p.into_inner()) = None;
+        // Fire-and-forget warmup so the first real request hits a hot
+        // model. Cold load can take 5–10s on first run.
+        spawn_warmup(endpoint, token);
+        Ok(())
+    }
+}
+
+impl Drop for Manager {
+    fn drop(&mut self) {
+        // App is exiting — no concurrent starts. ServerInstance::drop
+        // kills the child + removes the pid file.
+        self.kill_server();
+    }
+}
+
+struct StartingFlag<'a> {
+    starting: &'a Mutex<bool>,
+}
+
+impl<'a> StartingFlag<'a> {
+    fn new(starting: &'a Mutex<bool>) -> Self {
+        *starting.lock().unwrap_or_else(|p| p.into_inner()) = true;
+        Self { starting }
+    }
+}
+
+impl Drop for StartingFlag<'_> {
+    fn drop(&mut self) {
+        *self.starting.lock().unwrap_or_else(|p| p.into_inner()) = false;
+    }
+}
+
+/// Reap an orphan llama-server left by a prior Helmor process.
+pub fn sweep_orphan_server() {
+    let Ok(data_dir) = crate::data_dir::data_dir() else {
+        return;
+    };
+    server::sweep_orphan_pid(&data_dir.join("local-llm").join("server.pid"), LOG_TAG);
+}
+
+fn spawn_warmup(endpoint: String, token: String) {
+    std::thread::Builder::new()
+        .name("local-llm-warmup".to_string())
+        .spawn(move || {
+            let started = Instant::now();
+            let client = match reqwest::blocking::Client::builder()
+                .timeout(WARMUP_TIMEOUT)
+                .build()
+            {
+                Ok(c) => c,
+                Err(error) => {
+                    tracing::warn!(error = %error, "Local LLM warmup: build client failed");
+                    return;
+                }
+            };
+            match client
+                .post(format!("{endpoint}/v1/chat/completions"))
+                .bearer_auth(token)
+                .json(&json!({
+                    "model": API_MODEL,
+                    "messages": [
+                        { "role": "user", "content": "ping" }
+                    ],
+                    "temperature": 0.0,
+                    "max_tokens": 1
+                }))
+                .send()
+            {
+                Ok(response) if response.status().is_success() => {
+                    tracing::info!(
+                        duration_ms = started.elapsed().as_millis() as u64,
+                        "Local LLM warmup completed"
+                    );
+                }
+                Ok(response) => {
+                    tracing::warn!(
+                        status = %response.status(),
+                        "Local LLM warmup returned non-2xx"
+                    );
+                }
+                Err(error) => {
+                    tracing::warn!(error = %error, "Local LLM warmup failed");
+                }
+            }
+        })
+        .ok();
+}
+
+/// Build the `llama-server` arg vector for the LLM brain and spawn it
+/// through the shared helper. Keeps the LLM-specific flags (alias,
+/// reasoning off, log-disable) in one place.
+fn spawn_llm_server(model: &str) -> Result<server::ServerInstance> {
+    let context_size = resolve_context_for_path(model);
+    let mut args = llama_model_args(model)?;
+    args.extend([
+        "--alias".to_string(),
+        API_MODEL.to_string(),
+        "-c".to_string(),
+        context_size.to_string(),
+        "-ngl".to_string(),
+        GPU_LAYERS.to_string(),
+        "--reasoning".to_string(),
+        REASONING_MODE.to_string(),
+        "--log-disable".to_string(),
+    ]);
+
+    let data_dir = crate::data_dir::data_dir()?.join("local-llm");
+    server::spawn(server::SpawnArgs {
+        model_path: model.to_string(),
+        llama_args: args,
+        pid_path: data_dir.join("server.pid"),
+        hf_home: data_dir.join("hf"),
+        logs_dir: data_dir.join("logs"),
+        log_tag: LOG_TAG,
+    })
+}
+
+/// Resolve `model` to llama-server `--model` args. We deliberately only
+/// accept a local file path — the curated catalog drives all "fetch from
+/// HF" flows through our own download manager (with progress / pause /
+/// resume); shelling out to `llama-server -hf` would bypass that.
+fn llama_model_args(model: &str) -> Result<Vec<String>> {
+    let trimmed = model.trim();
+    if trimmed.is_empty() {
+        anyhow::bail!("No model selected. Pick a curated model or set a custom path.");
+    }
+    let pb = PathBuf::from(trimmed);
+    if !pb.is_file() {
+        anyhow::bail!(
+            "Model file not found: {trimmed}. Pick a curated model in Settings or point Custom model path at a real `.gguf` file."
+        );
+    }
+    Ok(vec!["--model".to_string(), trimmed.to_string()])
+}

--- a/src-tauri/src/local_llm/mod.rs
+++ b/src-tauri/src/local_llm/mod.rs
@@ -1,0 +1,37 @@
+//! Foundational local-LLM infrastructure: bundled `llama-server` lifecycle,
+//! GGUF model catalog, OpenAI-compatible chat client, hardware-aware
+//! context budgeting. Today this powers session-title generation and the
+//! Voice Pilot endpoint; future on-device features (commit drafts,
+//! code-review hints, …) layer on top.
+
+pub mod asset_provider;
+pub mod catalog;
+mod chat;
+mod context;
+pub mod gguf;
+pub mod hardware;
+mod manager;
+mod server;
+mod settings;
+mod text;
+mod title;
+
+pub use asset_provider::CatalogAssetProvider;
+pub use catalog::CatalogEntry;
+pub use context::{
+    compute_default_context_for_meta, custom_override_key, set_context_override, MIN_CONTEXT_TOKENS,
+};
+pub use hardware::HardwareSnapshot;
+pub use manager::{sweep_orphan_server, Manager};
+pub use settings::{load_settings, set_active_model_path, Endpoint, Settings, Status};
+pub use text::truncate_middle;
+
+const SETTINGS_KEY: &str = "app.local_llm";
+// Alias the bundled `llama-server` advertises to the OpenAI-compatible
+// API. Frontends POST to `model: helmor-local`.
+const API_MODEL: &str = "helmor-local";
+const GPU_LAYERS: &str = "99";
+const REASONING_MODE: &str = "off";
+const LOG_TAG: &str = "local-llm";
+const CHAT_MAX_TOKENS: u32 = 192;
+const WARMUP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);

--- a/src-tauri/src/local_llm/server.rs
+++ b/src-tauri/src/local_llm/server.rs
@@ -1,0 +1,319 @@
+//! Shared llama-server process primitives. Owns the bits that are
+//! identical across any future on-device model manager: spawning the
+//! bundled `llama-server` binary, waiting for it to become healthy,
+//! piping its logs through tracing, and reaping orphans across
+//! restarts.
+//!
+//! Manager-specific bits — which alias, which CLI flags, which pid file
+//! path — are passed in via `SpawnArgs`.
+
+use std::{
+    fs,
+    io::{BufRead, BufReader},
+    net::TcpListener,
+    path::{Path, PathBuf},
+    process::{Child, Command, Stdio},
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
+
+use anyhow::{Context, Result};
+
+/// A running `llama-server` child + its connection params, plus the
+/// pid file the manager owns on disk. `Drop` kills the child AND
+/// removes the pid file — this is the single invariant that keeps us
+/// leak-free across replacement / `Option::take` / panic-unwind / app
+/// exit.
+#[derive(Debug)]
+pub struct ServerInstance {
+    pub child: Child,
+    pub port: u16,
+    pub token: String,
+    pub model_path: String,
+    pub pid_path: PathBuf,
+    pub log_tag: &'static str,
+}
+
+impl Drop for ServerInstance {
+    fn drop(&mut self) {
+        if let Err(error) = self.child.kill() {
+            tracing::debug!(tag = self.log_tag, error = %error, "ServerInstance.drop: kill failed (already gone?)");
+        }
+        let _ = self.child.wait();
+        let _ = fs::remove_file(&self.pid_path);
+    }
+}
+
+/// Everything the caller wants the shared spawn helper to know about.
+/// `llama_args` is the full args vector handed to `llama-server`
+/// (the manager controls every flag — alias, ngl, jinja, reasoning,
+/// etc); this struct deliberately does NOT inject defaults. `hf_home`
+/// and `logs_dir` are set up by the caller because the LLM and STT
+/// managers share the same cache dir but write to different log paths.
+pub struct SpawnArgs {
+    pub model_path: String,
+    pub llama_args: Vec<String>,
+    pub pid_path: PathBuf,
+    pub hf_home: PathBuf,
+    pub logs_dir: PathBuf,
+    pub log_tag: &'static str,
+}
+
+/// Bind to an OS-assigned port and immediately drop the listener so
+/// llama-server can re-bind it. Used by both managers.
+pub fn free_port() -> Result<u16> {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).context("bind local AI port")?;
+    Ok(listener.local_addr()?.port())
+}
+
+/// Cheap "is the child still alive" check — `try_wait` returns
+/// `Ok(None)` when the child hasn't exited.
+pub fn child_is_running(child: &mut Child) -> bool {
+    matches!(child.try_wait(), Ok(None))
+}
+
+/// Resolve the bundled `llama-server` binary, honouring the dev
+/// override env var first, then the macOS Resources/ path, then the
+/// `sidecar/dist/vendor` path used in `bun run dev`. Single
+/// resolution function for the whole crate so the LLM and STT
+/// managers can't drift out of sync.
+pub fn resolve_llama_server_path() -> Result<PathBuf> {
+    if let Some(path) = std::env::var_os("HELMOR_LLAMA_SERVER_BIN_PATH") {
+        let path = PathBuf::from(path);
+        if path.is_file() {
+            return Ok(path);
+        }
+    }
+
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(contents) = exe.parent().and_then(|p| p.parent()) {
+            let path = contents
+                .join("Resources")
+                .join("vendor/llama-cpp/llama-server");
+            if path.is_file() {
+                return Ok(path);
+            }
+        }
+    }
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    for path in [
+        manifest_dir.join("../sidecar/dist/vendor/llama-cpp/llama-server"),
+        manifest_dir.join("../../sidecar/dist/vendor/llama-cpp/llama-server"),
+    ] {
+        if path.is_file() {
+            return Ok(path);
+        }
+    }
+
+    anyhow::bail!("Bundled llama-server was not found")
+}
+
+/// Spawn the bundled `llama-server` with the supplied args and wait
+/// for `/v1/models` to return 2xx. On success, writes the pid file
+/// and returns a `ServerInstance` whose Drop reaps everything.
+pub fn spawn(args: SpawnArgs) -> Result<ServerInstance> {
+    let bin = resolve_llama_server_path()?;
+    let port = free_port()?;
+    let token = format!("helmor-local-{}", uuid::Uuid::new_v4());
+
+    fs::create_dir_all(&args.hf_home).context("create local AI HF cache dir")?;
+    fs::create_dir_all(&args.logs_dir).context("create local AI logs dir")?;
+
+    // Inject the host / port / api-key into the caller-supplied flag
+    // list. The caller already provided every other flag they want
+    // (model path, alias, jinja, ngl, etc).
+    let mut full_args = args.llama_args.clone();
+    full_args.extend([
+        "--host".to_string(),
+        "127.0.0.1".to_string(),
+        "--port".to_string(),
+        port.to_string(),
+        "--api-key".to_string(),
+        token.clone(),
+    ]);
+
+    tracing::info!(
+        tag = args.log_tag,
+        path = %bin.display(),
+        port,
+        cache = %args.hf_home.display(),
+        "Starting bundled llama-server"
+    );
+
+    let mut child = Command::new(&bin)
+        .args(&full_args)
+        .env("HF_HOME", &args.hf_home)
+        .env("LLAMA_CACHE", args.hf_home.join("llama.cpp"))
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .with_context(|| format!("spawn bundled llama-server at {}", bin.display()))?;
+
+    let pid = child.id();
+    let last_stderr = pipe_child_logs(args.log_tag, &mut child);
+
+    if let Err(error) = wait_for_server(port, &token, &mut child, &last_stderr) {
+        // Health check failed — kill the child we just spawned so it
+        // doesn't linger when we return Err to the caller. Without this
+        // an unhealthy server would orphan since `ServerInstance` is
+        // never constructed.
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(error);
+    }
+
+    write_pid_file(&args.pid_path, pid);
+
+    Ok(ServerInstance {
+        child,
+        port,
+        token,
+        model_path: args.model_path,
+        pid_path: args.pid_path,
+        log_tag: args.log_tag,
+    })
+}
+
+/// Pipe stdout/stderr to the tracing log and ALSO remember the most
+/// recent non-empty stderr line in a shared slot, so a startup failure
+/// can quote the actual llama-server error message instead of leaving
+/// the user with "Timed out". Returns the slot so the health-check
+/// loop can read it.
+fn pipe_child_logs(tag: &'static str, child: &mut Child) -> Arc<Mutex<Option<String>>> {
+    let last_stderr = Arc::new(Mutex::new(None::<String>));
+    if let Some(stdout) = child.stdout.take() {
+        std::thread::Builder::new()
+            .name(format!("{tag}-stdout"))
+            .spawn(move || {
+                for line in BufReader::new(stdout)
+                    .lines()
+                    .map_while(std::result::Result::ok)
+                {
+                    tracing::debug!(tag, "stdout: {line}");
+                }
+            })
+            .ok();
+    }
+    if let Some(stderr) = child.stderr.take() {
+        let last_stderr_clone = last_stderr.clone();
+        std::thread::Builder::new()
+            .name(format!("{tag}-stderr"))
+            .spawn(move || {
+                for line in BufReader::new(stderr)
+                    .lines()
+                    .map_while(std::result::Result::ok)
+                {
+                    tracing::debug!(tag, "stderr: {line}");
+                    if !line.trim().is_empty() {
+                        *last_stderr_clone.lock().unwrap_or_else(|p| p.into_inner()) = Some(line);
+                    }
+                }
+            })
+            .ok();
+    }
+    last_stderr
+}
+
+fn wait_for_server(
+    port: u16,
+    token: &str,
+    child: &mut Child,
+    last_stderr: &Arc<Mutex<Option<String>>>,
+) -> Result<()> {
+    let endpoint = format!("http://127.0.0.1:{port}/v1/models");
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(2))
+        .build()
+        .context("build local AI health client")?;
+    // 60s is plenty for cold-load of a single-file model. Multi-part
+    // GGUFs mmap'd from disk can take a beat longer the first time;
+    // 180s was excessive and left the UI in "Starting" purgatory when
+    // the spawn was actually doomed.
+    let deadline = Instant::now() + Duration::from_secs(60);
+    let mut last_error: Option<String> = None;
+    while Instant::now() < deadline {
+        // Early-exit: if the child has already died (model file missing,
+        // bad args, etc.) there's no point polling HTTP for another
+        // minute. Quote the last stderr line so the caller has
+        // something actionable to show the user.
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let stderr_tail = last_stderr
+                    .lock()
+                    .unwrap_or_else(|p| p.into_inner())
+                    .clone()
+                    .unwrap_or_else(|| "no stderr captured".to_string());
+                anyhow::bail!("llama-server exited early (status {status}): {stderr_tail}");
+            }
+            Ok(None) => {}
+            Err(error) => {
+                tracing::warn!(error = %error, "try_wait on llama-server failed");
+            }
+        }
+        match client.get(&endpoint).bearer_auth(token).send() {
+            Ok(response) if response.status().is_success() => return Ok(()),
+            Ok(response) => last_error = Some(format!("HTTP {}", response.status())),
+            Err(error) => last_error = Some(error.to_string()),
+        }
+        std::thread::sleep(Duration::from_millis(500));
+    }
+    anyhow::bail!(
+        "Timed out waiting for local AI server at {endpoint} ({})",
+        last_error.unwrap_or_else(|| "no response".to_string())
+    )
+}
+
+fn write_pid_file(path: &Path, pid: u32) {
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    if let Err(error) = fs::write(path, pid.to_string()) {
+        tracing::warn!(error = %error, path = %path.display(), "Failed to write pid file");
+    }
+}
+
+/// Reap an orphan llama-server left behind by a prior Helmor process
+/// that was force-quit / crashed / hot-reloaded without running `Drop`.
+/// Called from the app setup hook before the auto-start, so we never
+/// spawn alongside a stale one. Verifies the pid is still ours by
+/// asking `ps` for its command name.
+pub fn sweep_orphan_pid(pid_path: &Path, tag: &str) {
+    let Ok(contents) = fs::read_to_string(pid_path) else {
+        return;
+    };
+    let Ok(pid) = contents.trim().parse::<i32>() else {
+        let _ = fs::remove_file(pid_path);
+        return;
+    };
+    if is_llama_server_pid(pid)
+        && Command::new("kill")
+            .args(["-TERM", &pid.to_string()])
+            .status()
+            .is_ok()
+    {
+        tracing::info!(tag, pid, "Reaped orphan llama-server from previous run");
+        // Give it a moment, then SIGKILL if still alive.
+        std::thread::sleep(Duration::from_millis(300));
+        if is_llama_server_pid(pid) {
+            let _ = Command::new("kill")
+                .args(["-KILL", &pid.to_string()])
+                .status();
+        }
+    }
+    let _ = fs::remove_file(pid_path);
+}
+
+fn is_llama_server_pid(pid: i32) -> bool {
+    let Ok(output) = Command::new("ps")
+        .args(["-p", &pid.to_string(), "-o", "comm="])
+        .output()
+    else {
+        return false;
+    };
+    if !output.status.success() {
+        return false;
+    }
+    let cmd = String::from_utf8_lossy(&output.stdout);
+    cmd.contains("llama-server")
+}

--- a/src-tauri/src/local_llm/settings.rs
+++ b/src-tauri/src/local_llm/settings.rs
@@ -1,0 +1,90 @@
+//! Persisted Local LLM settings + the shapes the manager reports back
+//! to the frontend.
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use super::SETTINGS_KEY;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Settings {
+    #[serde(default)]
+    pub enabled: bool,
+    /// Absolute path to a `.gguf` on disk. Empty = no model selected.
+    #[serde(default)]
+    pub model: String,
+    #[serde(default = "default_true")]
+    pub auto_start: bool,
+    /// Per-entry runtime context overrides (`-c` value). Keyed by
+    /// catalog entry id, or `custom:<absolute-path>` for user GGUFs.
+    /// Absent entry = use the hardware-aware default.
+    #[serde(default)]
+    pub context_overrides: std::collections::HashMap<String, u32>,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            model: String::new(),
+            auto_start: true,
+            context_overrides: std::collections::HashMap::new(),
+        }
+    }
+}
+
+/// Connection params for the running `llama-server`. The Voice Pilot
+/// frontend POSTs OpenAI-style chat completions directly at this URL.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Endpoint {
+    pub url: String,
+    pub token: String,
+    pub api_model: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Status {
+    pub enabled: bool,
+    pub runtime_found: bool,
+    pub runtime_path: Option<String>,
+    pub starting: bool,
+    pub running: bool,
+    pub model: String,
+    pub api_model: String,
+    pub context_size: u32,
+    pub gpu_layers: u32,
+    pub reasoning_mode: String,
+    pub endpoint: Option<String>,
+    pub last_error: Option<String>,
+}
+
+pub fn load_settings() -> Settings {
+    crate::settings::load_setting_json::<Settings>(SETTINGS_KEY)
+        .ok()
+        .flatten()
+        .unwrap_or_default()
+}
+
+/// Switch the model the bundled `llama-server` should load. Caller is
+/// responsible for restarting the server if it's running. Trims the
+/// stored value so a trailing whitespace pasted by the user doesn't
+/// leak into every downstream consumer (path comparison, GGUF inspect,
+/// llama-server `--model` arg).
+pub fn set_active_model_path(path: String) -> Result<()> {
+    let mut settings = load_settings();
+    settings.model = path.trim().to_string();
+    crate::settings::upsert_setting_json(SETTINGS_KEY, &settings)
+        .context("persist Local LLM model selection")?;
+    Ok(())
+}
+
+pub(super) fn normalize_model(model: &str) -> String {
+    model.trim().to_string()
+}
+
+const fn default_true() -> bool {
+    true
+}

--- a/src-tauri/src/local_llm/text.rs
+++ b/src-tauri/src/local_llm/text.rs
@@ -1,0 +1,72 @@
+//! Tiny text helpers shared by chat / error-summary code paths.
+
+/// Drop a wedge from the middle of `s` until it fits inside `max_chars`,
+/// preserving the head (40 %) and tail (60 %) and inserting a
+/// `[…truncated…]` marker in between. Returns the input unchanged when
+/// it already fits.
+pub fn truncate_middle(s: &str, max_chars: usize) -> String {
+    let total = s.chars().count();
+    if total <= max_chars {
+        return s.to_string();
+    }
+    const MARKER: &str = " […truncated…] ";
+    let marker_chars = MARKER.chars().count();
+    if max_chars <= marker_chars + 20 {
+        // Budget too small for head + marker + tail — keep the tail
+        // (most recent text is the most useful).
+        return s.chars().skip(total - max_chars).collect();
+    }
+    let usable = max_chars - marker_chars;
+    let head_chars = usable * 4 / 10;
+    let tail_chars = usable - head_chars;
+    let head: String = s.chars().take(head_chars).collect();
+    let tail: String = s.chars().skip(total - tail_chars).collect();
+    format!("{head}{MARKER}{tail}")
+}
+
+/// Truncate `s` to `max` chars, appending `…` when clipped. Used to
+/// keep llama-server error bodies log-friendly.
+pub(super) fn truncate_for_log(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let head: String = s.chars().take(max).collect();
+    format!("{head}…")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_middle_keeps_head_and_tail() {
+        let s: String = ('A'..='Z').chain('a'..='z').chain('0'..='9').collect();
+        assert!(s.chars().count() > 40);
+        let out = truncate_middle(&s, 40);
+        assert!(out.starts_with("ABCDE"), "kept head, got {out:?}");
+        assert!(out.ends_with("56789"), "kept tail, got {out:?}");
+        assert!(out.contains("truncated"), "marker present, got {out:?}");
+        assert!(out.chars().count() <= 40);
+    }
+
+    #[test]
+    fn truncate_middle_returns_input_when_already_fits() {
+        assert_eq!(truncate_middle("short", 100), "short");
+    }
+
+    #[test]
+    fn truncate_middle_falls_back_to_tail_when_budget_is_tiny() {
+        let s = "0123456789ABCDEF";
+        let out = truncate_middle(s, 8);
+        assert_eq!(out.chars().count(), 8);
+        assert!(out.ends_with("89ABCDEF"));
+    }
+
+    #[test]
+    fn truncate_for_log_appends_ellipsis_when_over_limit() {
+        let long = "x".repeat(1000);
+        let out = truncate_for_log(&long, 16);
+        assert_eq!(out.chars().count(), 17); // 16 chars + ellipsis
+        assert!(out.ends_with('…'));
+    }
+}

--- a/src-tauri/src/local_llm/title.rs
+++ b/src-tauri/src/local_llm/title.rs
@@ -1,0 +1,238 @@
+//! Title + branch-name generation via the bundled local LLM. First link
+//! in the title cascade defined in `agents::queries::generate_session_title`:
+//! when this succeeds we skip the sidecar (custom-claude → claude → codex
+//! → cursor) entirely. Any failure — server not ready, timeout, parse
+//! mismatch — bubbles up as an `Err` so the caller can fall through.
+//!
+//! Prompt + parser intentionally mirror `sidecar/src/title.ts` so the
+//! local model returns the same shape the sidecar managers do.
+
+use std::time::Duration;
+
+use anyhow::Result;
+
+use super::Manager;
+
+const TITLE_TIMEOUT: Duration = Duration::from_secs(15);
+
+const DEFAULT_BRANCH_RENAME_PROMPT: &str =
+    "When you generate the branch name segment for a new chat:
+
+- Base it on the user's first message.
+- Return a short English slug in lowercase with hyphens.
+- Omit any branch prefix such as `feat/` or usernames.
+- Favor clarity over cleverness.";
+
+const CUSTOM_PREFERENCES_INTRO: &str = "IMPORTANT: The following are the user's custom preferences. These preferences take precedence over any default guidelines or instructions provided above. When there is a conflict, always follow the user's preferences.";
+
+const TITLE_SYSTEM_PROMPT: &str = "You are a concise title generator. Follow the user's output-format instructions exactly. Return only the requested lines — no preamble, no explanations, no markdown fences.";
+
+impl Manager {
+    /// Generate `(title, optional branch_name)` from the user's first
+    /// message using the bundled local LLM.
+    ///
+    /// Returns `Err` on any failure (server not ready, chat failure,
+    /// empty/malformed output), letting the caller cascade to the
+    /// sidecar's cloud providers.
+    pub fn generate_title(
+        &self,
+        user_message: &str,
+        branch_rename_prompt: Option<&str>,
+        generate_branch: bool,
+    ) -> Result<(String, Option<String>)> {
+        if !self.is_ready() {
+            anyhow::bail!("Local LLM not ready");
+        }
+
+        // Long user messages (e.g. a pasted error log as the first
+        // prompt) get middle-truncated to fit the active model's
+        // context window. Otherwise the chat call would bounce back
+        // HTTP 400 and we'd cascade to the cloud unnecessarily.
+        let trimmed_user_message =
+            self.fit_user_message_to_context(TITLE_SYSTEM_PROMPT, user_message);
+
+        let user = build_title_prompt(&trimmed_user_message, branch_rename_prompt, generate_branch);
+        let raw = self.chat(TITLE_SYSTEM_PROMPT, &user, TITLE_TIMEOUT)?;
+        let (title, branch_name) = parse_title_response(&raw);
+
+        if title.is_empty() {
+            anyhow::bail!("Local LLM returned empty title (raw={raw:?})");
+        }
+        if generate_branch && branch_name.is_none() {
+            anyhow::bail!("Local LLM returned empty branch name (raw={raw:?})");
+        }
+        Ok((title, branch_name))
+    }
+
+    /// `enabled && server running` — gates whether a title attempt is
+    /// even worth trying. Re-uses `status()` so the same liveness check
+    /// the UI sees drives the cascade decision.
+    fn is_ready(&self) -> bool {
+        let status = self.status();
+        status.enabled && status.running
+    }
+}
+
+fn build_branch_rename_instructions(branch_rename_prompt: Option<&str>) -> String {
+    let trimmed_override = branch_rename_prompt
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    match trimmed_override {
+        None => DEFAULT_BRANCH_RENAME_PROMPT.to_string(),
+        Some(override_text) => format!(
+            "{DEFAULT_BRANCH_RENAME_PROMPT}\n\n{CUSTOM_PREFERENCES_INTRO}\n\n### User Preferences\n\n{override_text}"
+        ),
+    }
+}
+
+fn build_title_prompt(
+    user_message: &str,
+    branch_rename_prompt: Option<&str>,
+    generate_branch: bool,
+) -> String {
+    if !generate_branch {
+        return format!(
+            "Based on the following user message, generate a concise session title (use the same language as the user message, max 8 words).\n\n\
+             Output EXACTLY in this format (one line, nothing else):\n\
+             title: <the title>\n\n\
+             User message:\n{user_message}"
+        );
+    }
+    format!(
+        "Based on the following user message, generate TWO things:\n\
+         1. A concise session title (use the same language as the user message, max 8 words)\n\
+         2. A git branch name segment (English only, lowercase, hyphens for spaces, max 4 words, no prefix)\n\n\
+         Additional branch naming instructions:\n\
+         {branch_instructions}\n\n\
+         Output EXACTLY in this format (two lines, nothing else):\n\
+         title: <the title>\n\
+         branch: <the-branch-name>\n\n\
+         User message:\n{user_message}",
+        branch_instructions = build_branch_rename_instructions(branch_rename_prompt),
+    )
+}
+
+fn parse_title_response(raw: &str) -> (String, Option<String>) {
+    let mut title = String::new();
+    let mut branch = String::new();
+    for line in raw.lines() {
+        let trimmed = line.trim();
+        let lower = trimmed.to_ascii_lowercase();
+        if lower.starts_with("title:") {
+            title = strip_quotes(trimmed[6..].trim()).to_string();
+        } else if lower.starts_with("branch:") {
+            branch = sanitize_branch(trimmed[7..].trim());
+        }
+    }
+    // Same fallback as the sidecar's `parseTitleAndBranch`: if structured
+    // parsing failed but the model returned something, use the whole raw
+    // body as the title.
+    if title.is_empty() {
+        let r = raw.trim();
+        if !r.is_empty() {
+            title = strip_quotes(r).to_string();
+        }
+    }
+    let branch_opt = if branch.is_empty() {
+        None
+    } else {
+        Some(branch)
+    };
+    (title, branch_opt)
+}
+
+fn strip_quotes(s: &str) -> &str {
+    s.trim_matches(|c: char| {
+        matches!(
+            c,
+            '"' | '\'' | '\u{201c}' | '\u{201d}' | '\u{2018}' | '\u{2019}'
+        )
+    })
+    .trim()
+}
+
+fn sanitize_branch(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    let mut last_dash = false;
+    for ch in raw.chars() {
+        let allowed = ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-';
+        if allowed {
+            if ch == '-' {
+                if last_dash {
+                    continue;
+                }
+                last_dash = true;
+            } else {
+                last_dash = false;
+            }
+            out.push(ch);
+        }
+    }
+    while out.starts_with('-') {
+        out.remove(0);
+    }
+    while out.ends_with('-') {
+        out.pop();
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_canonical_two_line_output() {
+        let raw = "title: Fix the failing test\nbranch: fix-failing-test";
+        let (title, branch) = parse_title_response(raw);
+        assert_eq!(title, "Fix the failing test");
+        assert_eq!(branch.as_deref(), Some("fix-failing-test"));
+    }
+
+    #[test]
+    fn parses_title_only_when_branch_missing() {
+        let raw = "title: Just a title";
+        let (title, branch) = parse_title_response(raw);
+        assert_eq!(title, "Just a title");
+        assert!(branch.is_none());
+    }
+
+    #[test]
+    fn strips_smart_quotes_around_title() {
+        let raw = "title: \u{201c}Hello world\u{201d}";
+        let (title, _) = parse_title_response(raw);
+        assert_eq!(title, "Hello world");
+    }
+
+    #[test]
+    fn sanitizes_branch_invalid_chars_and_dashes() {
+        // Mirrors `sidecar/src/title.ts`'s `parseTitleAndBranch`: strips
+        // anything outside `[a-z0-9-]` (uppercase / underscores / spaces
+        // disappear without case-folding), then collapses runs of dashes
+        // and trims leading/trailing ones.
+        let raw = "title: Cleanup\nbranch: --fix_the-bug!! --";
+        let (_, branch) = parse_title_response(raw);
+        assert_eq!(branch.as_deref(), Some("fixthe-bug"));
+    }
+
+    #[test]
+    fn falls_back_to_raw_body_when_no_title_prefix() {
+        let raw = "Just a free-form title without label";
+        let (title, _) = parse_title_response(raw);
+        assert_eq!(title, "Just a free-form title without label");
+    }
+
+    #[test]
+    fn build_prompt_omits_branch_instructions_when_not_generating_branch() {
+        let prompt = build_title_prompt("fix the test", None, false);
+        assert!(prompt.contains("title: <the title>"));
+        assert!(!prompt.contains("branch:"));
+    }
+
+    #[test]
+    fn build_prompt_includes_custom_branch_preferences() {
+        let prompt = build_title_prompt("fix the test", Some("Always prefix with chore-"), true);
+        assert!(prompt.contains("User Preferences"));
+        assert!(prompt.contains("Always prefix with chore-"));
+    }
+}

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -1,0 +1,57 @@
+import * as SliderPrimitive from "@radix-ui/react-slider";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Slider({
+	className,
+	defaultValue,
+	value,
+	min = 0,
+	max = 100,
+	...props
+}: React.ComponentProps<typeof SliderPrimitive.Root>) {
+	const values = Array.isArray(value)
+		? value
+		: Array.isArray(defaultValue)
+			? defaultValue
+			: [min, max];
+
+	return (
+		<SliderPrimitive.Root
+			data-slot="slider"
+			defaultValue={defaultValue}
+			value={value}
+			min={min}
+			max={max}
+			className={cn(
+				"relative flex w-full touch-none select-none items-center data-[disabled]:opacity-50 data-[orientation=vertical]:h-full data-[orientation=vertical]:min-h-44 data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col",
+				className,
+			)}
+			{...props}
+		>
+			<SliderPrimitive.Track
+				data-slot="slider-track"
+				className={cn(
+					"bg-muted relative grow overflow-hidden rounded-full data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5",
+				)}
+			>
+				<SliderPrimitive.Range
+					data-slot="slider-range"
+					className={cn(
+						"bg-primary absolute data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full",
+					)}
+				/>
+			</SliderPrimitive.Track>
+			{values.map((_, index) => (
+				<SliderPrimitive.Thumb
+					data-slot="slider-thumb"
+					key={`thumb-${index}`}
+					className="border-primary bg-background ring-ring/50 block size-4 shrink-0 rounded-full border shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+				/>
+			))}
+		</SliderPrimitive.Root>
+	);
+}
+
+export { Slider };

--- a/src/features/settings/index.tsx
+++ b/src/features/settings/index.tsx
@@ -71,6 +71,7 @@ import { ConductorImportPanel } from "./panels/conductor-import";
 import { CursorProviderPanel } from "./panels/cursor-provider";
 import { DevToolsPanel } from "./panels/dev-tools";
 import { InboxSettingsPanel } from "./panels/inbox";
+import { LocalLlmPanel } from "./panels/local-llm";
 import { ClaudeCustomProvidersPanel } from "./panels/model-providers";
 import { RepositorySettingsPanel } from "./panels/repository-settings";
 
@@ -582,9 +583,13 @@ export const SettingsDialog = memo(function SettingsDialog({
 							)}
 
 							{activeSection === "experimental" && (
-								<div className="flex flex-col gap-3">
+								<SettingsGroup>
+									<LocalLlmPanel
+										settings={settings}
+										updateSettings={updateSettings}
+									/>
 									<CliInstallPanel />
-								</div>
+								</SettingsGroup>
 							)}
 
 							{activeSection === "import" && <ConductorImportPanel />}

--- a/src/features/settings/panels/local-llm.tsx
+++ b/src/features/settings/panels/local-llm.tsx
@@ -1,0 +1,1601 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Channel } from "@tauri-apps/api/core";
+import {
+	AlertCircle,
+	Check,
+	ChevronDown,
+	CircleHelp,
+	Cpu,
+	Download,
+	Loader2,
+	Pause,
+	Play,
+	RotateCcw,
+	Trash2,
+	Undo2,
+	X,
+} from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Slider } from "@/components/ui/slider";
+import { Switch } from "@/components/ui/switch";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+	activateLocalLlmModel,
+	cancelLocalLlmDownload,
+	detectLocalLlmHardware,
+	getLocalLlmStatus,
+	inspectLocalLlmCatalogEntry,
+	inspectLocalLlmModel,
+	type LocalLlmCatalogEntry,
+	type LocalLlmDownloadEvent,
+	type LocalLlmDownloadStatus,
+	listLocalLlmCatalog,
+	pauseLocalLlmDownload,
+	startLocalLlm,
+	startLocalLlmDownload,
+	stopLocalLlm,
+	subscribeLocalLlmDownloads,
+} from "@/lib/api";
+import type { AppSettings } from "@/lib/settings";
+import { cn } from "@/lib/utils";
+import { SettingsReleaseBadge } from "../components/release-marker";
+
+const LOCAL_LLM_STATUS_KEY = ["localLlmStatus"] as const;
+const LOCAL_LLM_CATALOG_KEY = ["localLlmCatalog"] as const;
+const LOCAL_LLM_HARDWARE_KEY = ["localLlmHardware"] as const;
+
+/// Sentinel selection value for the Curated Models picker. When the
+/// user has a valid Custom model path, the dropdown includes a Custom
+/// entry on top — selecting it focuses the panel on the custom path
+/// without touching any catalog entry.
+const CUSTOM_SLOT_ID = "__custom__";
+
+type DownloadRow = LocalLlmDownloadStatus & { bytesPerSec?: number };
+
+export function LocalLlmPanel({
+	settings,
+	updateSettings,
+}: {
+	settings: AppSettings;
+	updateSettings: (patch: Partial<AppSettings>) => void | Promise<void>;
+}) {
+	const queryClient = useQueryClient();
+	const statusQuery = useQuery({
+		queryKey: LOCAL_LLM_STATUS_KEY,
+		queryFn: getLocalLlmStatus,
+		// Poll always (not just when enabled) so the panel reflects
+		// startup errors / spawn-died transitions even while the user
+		// is still flipping the toggle.
+		refetchInterval: 2000,
+	});
+	const status = statusQuery.data;
+	const catalogQuery = useQuery({
+		queryKey: LOCAL_LLM_CATALOG_KEY,
+		queryFn: listLocalLlmCatalog,
+		staleTime: Number.POSITIVE_INFINITY,
+	});
+	// Catalog is shared with Voice Pilot — filter out STT entries so the
+	// LLM panel only shows chat brains. `kind` is optional on legacy
+	// entries, so anything without an explicit `kind` is treated as LLM.
+	const catalog = useMemo(
+		() =>
+			(catalogQuery.data ?? []).filter(
+				(entry) => (entry.kind ?? "llm") === "llm",
+			),
+		[catalogQuery.data],
+	);
+	const hardwareQuery = useQuery({
+		queryKey: LOCAL_LLM_HARDWARE_KEY,
+		queryFn: detectLocalLlmHardware,
+		staleTime: Number.POSITIVE_INFINITY,
+	});
+	const recommendedEntryId = hardwareQuery.data?.recommendedEntryId ?? null;
+
+	// Per-entry download state, patched by the streaming Channel.
+	const [downloads, setDownloads] = useState<Record<string, DownloadRow>>({});
+
+	useEffect(() => {
+		const channel = new Channel<LocalLlmDownloadEvent>();
+		let mounted = true;
+		channel.onmessage = (event) => {
+			if (!mounted) return;
+			setDownloads((prev) => applyDownloadEvent(prev, event));
+		};
+		void subscribeLocalLlmDownloads(channel).then((snapshot) => {
+			if (!mounted) return;
+			const next: Record<string, DownloadRow> = {};
+			for (const row of snapshot) {
+				next[row.entryId] = row;
+			}
+			setDownloads(next);
+		});
+		return () => {
+			mounted = false;
+		};
+	}, []);
+
+	const invalidateStatus = () =>
+		queryClient.invalidateQueries({ queryKey: LOCAL_LLM_STATUS_KEY });
+
+	// `hasModel` is the precondition for "toggling on actually does
+	// something". A non-empty model setting means either a curated
+	// entry was activated, or the user typed something into the
+	// Custom model path field. The backend will surface a clearer
+	// error via `lastError` if the path turns out to be invalid.
+	const hasModel = settings.localLlm.model.trim().length > 0;
+
+	const toggleMutation = useMutation({
+		mutationFn: async (enabled: boolean) => {
+			await updateSettings({
+				localLlm: { ...settings.localLlm, enabled },
+			});
+			if (!enabled) {
+				await stopLocalLlm();
+				return;
+			}
+			if (!hasModel) {
+				// No model to load — keep the toggle on as intent, the
+				// banner below explains what to do next.
+				return;
+			}
+			// Fire-and-forget. The bundled llama-server's cold-load can
+			// take 5–30 s; awaiting it would freeze the toggle and the
+			// rest of the panel. The polled status query catches up
+			// within ~2 s and renders the real Starting / Running /
+			// Stopped state including any error message.
+			void startLocalLlm().catch((error) => {
+				console.warn("[local-llm] start failed", error);
+				invalidateStatus();
+			});
+		},
+		onSettled: invalidateStatus,
+	});
+
+	const pending = toggleMutation.isPending;
+	const running = Boolean(status?.running);
+	const starting = Boolean(status?.starting);
+
+	// Match the currently active model setting to a catalog entry by
+	// comparing the resolved file path. The dropdown highlights this
+	// entry with an "Active" badge.
+	const activeEntryId = useMemo(() => {
+		return catalog.find((entry) => {
+			const expectedSuffix = `local-llm/models/${entry.files[0]}`;
+			return Boolean(status?.model?.endsWith(expectedSuffix));
+		})?.id;
+	}, [catalog, status?.model]);
+
+	const handleDownload = (entryId: string) => {
+		void startLocalLlmDownload(entryId);
+	};
+	const handlePause = (entryId: string) => {
+		void pauseLocalLlmDownload(entryId);
+	};
+	const handleResume = (entryId: string) => {
+		void startLocalLlmDownload(entryId);
+	};
+	const handleCancel = (entryId: string) => {
+		void cancelLocalLlmDownload(entryId);
+	};
+
+	// Shared context-override commit path. Catalog entries and custom
+	// GGUFs both round-trip through here so the restart-on-change behavior
+	// stays uniform.
+	const commitContextOverride = async (entryId: string, tokens: number) => {
+		const nextOverrides = {
+			...(settings.localLlm.contextOverrides ?? {}),
+			[entryId]: tokens,
+		};
+		await updateSettings({
+			localLlm: { ...settings.localLlm, contextOverrides: nextOverrides },
+		});
+		// `manager.start()` short-circuits when the model PATH is
+		// unchanged. Only `-c` differs here, so we have to stop first to
+		// force the spawn path that actually reads the new value.
+		if (running || starting) {
+			try {
+				await stopLocalLlm();
+			} catch (error) {
+				console.warn("[local-llm] stop before context restart failed", error);
+			}
+			void startLocalLlm().catch((error) => {
+				console.warn("[local-llm] restart after context change failed", error);
+				invalidateStatus();
+			});
+		}
+		invalidateStatus();
+	};
+	// Two-step delete for already-downloaded models. Mid-download Cancel
+	// reuses `handleCancel` directly — there's nothing on disk to lose.
+	const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
+	const deleteTargetEntry = useMemo(
+		() => catalog.find((entry) => entry.id === deleteTargetId) ?? null,
+		[catalog, deleteTargetId],
+	);
+	const handleDelete = (entryId: string) => {
+		setDeleteTargetId(entryId);
+	};
+	const confirmDelete = () => {
+		if (!deleteTargetId) return;
+		void cancelLocalLlmDownload(deleteTargetId);
+		setDeleteTargetId(null);
+	};
+
+	// Custom Model Path input is a *display-only* derivation: it only
+	// echoes `settings.localLlm.model` when the active path didn't come
+	// from a curated catalog entry. Otherwise the user sees just the
+	// placeholder, which is what they want when they're using a
+	// curated pick — the custom field shouldn't pretend to be edited.
+	const customPathValue = activeEntryId ? "" : settings.localLlm.model;
+
+	// Custom GGUFs aren't in our catalog, so we don't know their trained
+	// max / KV cache shape ahead of time. The inspect IPC reads the
+	// GGUF header on disk and surfaces both. Disabled when the user is
+	// running a catalog entry — that path already has the metadata
+	// compiled in.
+	const inspectQuery = useQuery({
+		queryKey: ["localLlmInspect", customPathValue] as const,
+		queryFn: () => inspectLocalLlmModel(customPathValue),
+		enabled: customPathValue.trim().length > 0,
+		staleTime: Number.POSITIVE_INFINITY,
+		retry: false,
+	});
+	const customInspect = inspectQuery.data ?? null;
+	const customOverrideKey = customPathValue
+		? `custom:${customPathValue}`
+		: null;
+
+	// `customActive` = the user has typed a valid GGUF path that the
+	// inspect IPC could parse. When that's the case the picker's default
+	// focus shifts to the Custom slot (above any catalog fallback) so
+	// the panel reflects "this is the model in use" rather than
+	// pretending some unrelated catalog entry is selected.
+	const customActive = customPathValue.length > 0 && customInspect !== null;
+	const customBasename = useMemo(() => {
+		if (!customPathValue) return null;
+		const tail = customPathValue.split("/").pop();
+		return tail && tail.length > 0 ? tail : customPathValue;
+	}, [customPathValue]);
+
+	// Dropdown selection: active catalog entry > custom (when valid) >
+	// recommended > first. Users can pick a different entry to inspect /
+	// download without affecting which one is "Active" (that's a
+	// separate `activateLocalLlmModel` action).
+	const defaultSelectedId = useMemo(() => {
+		if (activeEntryId) return activeEntryId;
+		if (customActive) return CUSTOM_SLOT_ID;
+		if (recommendedEntryId) return recommendedEntryId;
+		if (catalog.length > 0) return catalog[0].id;
+		return null;
+	}, [catalog, activeEntryId, customActive, recommendedEntryId]);
+	const [selectedId, setSelectedId] = useState<string | null>(null);
+	const effectiveSelectedId = selectedId ?? defaultSelectedId;
+	const isCustomSelected = effectiveSelectedId === CUSTOM_SLOT_ID;
+	const selectedEntry = isCustomSelected
+		? null
+		: (catalog.find((entry) => entry.id === effectiveSelectedId) ?? null);
+
+	// Selection = activation, but ONLY for entries the user explicitly
+	// picked from the dropdown. The trigger preview falls back to
+	// `defaultSelectedId` on mount; without this guard, opening the
+	// panel while running a custom GGUF + having a recommended catalog
+	// entry already on disk would silently activate the recommended
+	// entry and wipe out the custom path.
+	useEffect(() => {
+		if (!selectedId) return;
+		// Custom slot is just a UI focus — there's no catalog id to
+		// activate. Custom paths get committed through the dedicated
+		// Custom Model Path input (startLocalLlm in onCommit).
+		if (selectedId === CUSTOM_SLOT_ID) return;
+		if (selectedId === activeEntryId) return;
+		const row = downloads[selectedId];
+		if (row?.state !== "downloaded") return;
+		void activateLocalLlmModel(selectedId).then(() => {
+			invalidateStatus();
+		});
+	}, [selectedId, activeEntryId, downloads]);
+
+	// Catalog mode: when the selected entry is already on disk, ask the
+	// backend to read its GGUF metadata so the panel shows the same
+	// numbers it would for the same model pasted as a custom path. The
+	// catalog's hand-coded kv_bytes_per_token / model_max_context_tokens
+	// are estimates; GGUF is the source of truth.
+	const selectedDownloadState = selectedEntry
+		? (downloads[selectedEntry.id]?.state ?? "not_downloaded")
+		: null;
+	const catalogInspectQuery = useQuery({
+		queryKey: ["localLlmCatalogInspect", selectedEntry?.id] as const,
+		queryFn: () =>
+			selectedEntry
+				? inspectLocalLlmCatalogEntry(selectedEntry.id)
+				: Promise.resolve(null),
+		enabled: selectedEntry !== null && selectedDownloadState === "downloaded",
+		staleTime: Number.POSITIVE_INFINITY,
+		retry: false,
+	});
+	const catalogInspect = catalogInspectQuery.data ?? null;
+
+	// Friendly label of whatever the server has loaded right now.
+	// Renders as a secondary pill next to "Running" so the user can
+	// see at a glance which model is live.
+	const activeModelLabel = useMemo(() => {
+		if (!status?.model) return null;
+		const fromCatalog = catalog.find((entry) => entry.id === activeEntryId);
+		if (fromCatalog) return fromCatalog.label;
+		// Custom path — fall back to the file's basename so a long
+		// absolute path doesn't overflow the header.
+		const tail = status.model.split("/").pop();
+		return tail && tail.length > 0 ? tail : null;
+	}, [status?.model, catalog, activeEntryId]);
+	// Runtime context window the server is actually serving. Read
+	// straight from status (the backend's `-c` value), NOT from the
+	// model's theoretical max — those two are different and showing
+	// the model max is a footgun (user sees "128K" but the running
+	// llama-server caps at whatever we pass via `-c`).
+	const activeContextTokens = status?.contextSize ?? null;
+
+	// What `-c` value WOULD we use for the currently dropdown-selected
+	// entry? `catalogInspect` is required: we no longer trust the
+	// catalog's hand-coded kv/context estimates — the picker stays
+	// blank until the GGUF is on disk and inspected for real.
+	const contextTokensForSelected = useMemo(() => {
+		if (!selectedEntry || !catalogInspect) return null;
+		const override = settings.localLlm.contextOverrides?.[selectedEntry.id];
+		if (typeof override === "number" && override > 0) return override;
+		return catalogInspect.defaultContextTokens;
+	}, [selectedEntry, catalogInspect, settings.localLlm.contextOverrides]);
+
+	const contextTokensForCustom = useMemo(() => {
+		if (!customInspect || !customOverrideKey) return null;
+		const override = settings.localLlm.contextOverrides?.[customOverrideKey];
+		if (typeof override === "number" && override > 0) return override;
+		return customInspect.defaultContextTokens;
+	}, [customInspect, customOverrideKey, settings.localLlm.contextOverrides]);
+
+	const activeOrPaused = useMemo(() => {
+		const rows: Array<{ entry: LocalLlmCatalogEntry; download: DownloadRow }> =
+			[];
+		for (const entry of catalog) {
+			const row = downloads[entry.id];
+			if (row && (row.state === "downloading" || row.state === "paused")) {
+				rows.push({ entry, download: row });
+			}
+		}
+		return rows;
+	}, [catalog, downloads]);
+
+	return (
+		<div className="flex flex-col gap-3 py-5">
+			{/* Header row — title + release badge on the LEFT, master
+			    enable Switch on the RIGHT. Description stacks below.
+			    When the switch is off everything else hides — the panel
+			    collapses to just this header so it stays compact. */}
+			<div className="flex items-start justify-between gap-3">
+				<div className="min-w-0 flex-1">
+					<div className="flex flex-wrap items-center gap-1.5 text-[13px] font-medium leading-snug text-foreground">
+						<span className="min-w-0">Local LLM</span>
+						<SettingsReleaseBadge marker={{ kind: "feature" }} />
+					</div>
+					<p className="mt-1 text-[12px] leading-snug text-muted-foreground">
+						Today this server powers session title and branch name generation.
+						More features that run on your device are coming soon.
+					</p>
+				</div>
+				<Switch
+					checked={settings.localLlm.enabled}
+					disabled={pending}
+					onCheckedChange={(enabled) => toggleMutation.mutate(enabled)}
+				/>
+			</div>
+			{settings.localLlm.enabled ? (
+				<div className="flex w-full flex-col gap-3">
+					<StatusHeader
+						hasModel={hasModel}
+						running={running}
+						starting={starting}
+						endpoint={status?.endpoint ?? null}
+						activeModelLabel={activeModelLabel}
+						activeContextTokens={activeContextTokens}
+					/>
+					{!hasModel ? (
+						<NoticeBanner tone="warning">
+							No model selected. Pick one from the Models dropdown below to
+							start — including Custom if you already have a GGUF on disk.
+						</NoticeBanner>
+					) : null}
+
+					{status?.lastError && !starting ? (
+						<NoticeBanner
+							tone="error"
+							icon={<AlertCircle className="size-3.5" />}
+						>
+							{status.lastError}
+						</NoticeBanner>
+					) : null}
+
+					<ModelsSection
+						catalog={catalog}
+						loading={catalogQuery.isLoading}
+						selectedCatalogEntry={selectedEntry}
+						isCustomSelected={isCustomSelected}
+						customBasename={customBasename}
+						customIsActive={!activeEntryId && customActive && running}
+						activeEntryId={activeEntryId ?? null}
+						recommendedEntryId={recommendedEntryId}
+						downloads={downloads}
+						onSelect={setSelectedId}
+						onDownload={handleDownload}
+						onResume={handleResume}
+						onCancel={handleCancel}
+						onDelete={handleDelete}
+					/>
+
+					{activeOrPaused.length > 0 ? (
+						<DownloadsSection
+							rows={activeOrPaused}
+							onPause={handlePause}
+							onResume={handleResume}
+							onCancel={handleCancel}
+						/>
+					) : null}
+
+					{isCustomSelected ? (
+						<CustomModelPathSection
+							value={customPathValue}
+							disabled={pending}
+							onChange={(value) =>
+								updateSettings({
+									localLlm: { ...settings.localLlm, model: value },
+								})
+							}
+							onCommit={() => {
+								// Trim once on commit so the inspect IPC, catalog
+								// suffix match, and llama-server `--model` arg all
+								// see the canonical path. Bare whitespace = clear.
+								const trimmed = settings.localLlm.model.trim();
+								if (trimmed !== settings.localLlm.model) {
+									updateSettings({
+										localLlm: { ...settings.localLlm, model: trimmed },
+									});
+								}
+								if (trimmed.length === 0) return;
+								// Kick the server to pick up the new path. The
+								// backend is idempotent: same model + running →
+								// no-op; new path → kill old, start new.
+								void startLocalLlm().catch((error) => {
+									console.warn(
+										"[local-llm] start after custom path commit failed",
+										error,
+									);
+									invalidateStatus();
+								});
+							}}
+						/>
+					) : null}
+
+					{isCustomSelected && customInspect ? (
+						// Picker is focused on the Custom slot — slider drives
+						// the override keyed by `custom:<absolute-path>`.
+						<ContextSelector
+							target={{
+								id: customOverrideKey ?? `custom:${customPathValue}`,
+								modelMaxContextTokens: customInspect.contextLength,
+								kvBytesPerToken: customInspect.kvBytesPerToken,
+								// We don't track the GGUF size in inspect (it's not
+								// in the header). Pass 0 so the fit estimate is
+								// slightly generous; llama-server caps allocation
+								// itself so this can't OOM.
+								modelBytes: 0,
+							}}
+							totalRamGb={hardwareQuery.data?.totalRamGb ?? null}
+							currentTokens={contextTokensForCustom}
+							defaultTokens={customInspect.defaultContextTokens}
+							onCommit={commitContextOverride}
+						/>
+					) : selectedEntry && catalogInspect ? (
+						// Catalog entry, downloaded, GGUF inspected — slider
+						// uses real model metadata. If the entry isn't on
+						// disk yet (or the file moved / corrupted),
+						// `catalogInspect` is null and we render nothing.
+						// Pick the entry from the dropdown and the slider
+						// re-appears once it's downloaded.
+						<ContextSelector
+							target={{
+								id: selectedEntry.id,
+								modelMaxContextTokens: catalogInspect.contextLength,
+								kvBytesPerToken: catalogInspect.kvBytesPerToken,
+								modelBytes: selectedEntry.bytes,
+							}}
+							totalRamGb={hardwareQuery.data?.totalRamGb ?? null}
+							currentTokens={contextTokensForSelected}
+							defaultTokens={catalogInspect.defaultContextTokens}
+							onCommit={commitContextOverride}
+						/>
+					) : null}
+				</div>
+			) : null}
+			<ConfirmDialog
+				open={deleteTargetId !== null}
+				onOpenChange={(open) => {
+					if (!open) setDeleteTargetId(null);
+				}}
+				title="Delete this model?"
+				description={
+					deleteTargetEntry ? (
+						<>
+							This will remove{" "}
+							<span className="font-medium text-foreground">
+								{deleteTargetEntry.label}
+							</span>{" "}
+							({formatBytes(deleteTargetEntry.bytes)}) from disk. You'll have to
+							download it again to use it.
+						</>
+					) : (
+						"This will remove the model from disk."
+					)
+				}
+				confirmLabel="Delete"
+				onConfirm={confirmDelete}
+			/>
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Status row — dot pill (Off / Starting / Running / Stopped / No model)
+// + active-model + context pills inline. The master toggle lives in the
+// panel header above; this row is purely informational.
+// ---------------------------------------------------------------------------
+
+function StatusHeader({
+	hasModel,
+	running,
+	starting,
+	endpoint,
+	activeModelLabel,
+	activeContextTokens,
+}: {
+	hasModel: boolean;
+	running: boolean;
+	starting: boolean;
+	endpoint: string | null;
+	activeModelLabel: string | null;
+	activeContextTokens: number | null;
+}) {
+	let label: string;
+	let dotClass: string;
+	let showSpinner = false;
+	let showEndpoint = false;
+	if (starting) {
+		label = "Starting";
+		dotClass = "bg-amber-500";
+		showSpinner = true;
+	} else if (running) {
+		label = "Running";
+		dotClass = "bg-emerald-500";
+		showEndpoint = true;
+	} else if (!hasModel) {
+		label = "No model";
+		dotClass = "bg-amber-500";
+	} else {
+		label = "Stopped";
+		dotClass = "bg-destructive";
+	}
+
+	return (
+		<div className="flex min-w-0 items-center gap-2">
+			<Cpu className="size-4 shrink-0 text-muted-foreground" />
+			<div className="flex min-w-0 items-center gap-1.5 rounded-md border border-border bg-background px-2 py-0.5 text-[12px]">
+				{showSpinner ? (
+					<Loader2 className="size-3 animate-spin text-muted-foreground" />
+				) : (
+					<span
+						className={cn("size-2 shrink-0 rounded-full", dotClass)}
+						aria-hidden
+					/>
+				)}
+				<span className="font-medium text-foreground">{label}</span>
+				{showEndpoint && endpoint ? (
+					<span
+						className="font-mono text-[11px] text-muted-foreground/80"
+						title={stripScheme(endpoint)}
+					>
+						{formatEndpointPort(endpoint)}
+					</span>
+				) : null}
+			</div>
+			{running && activeModelLabel ? (
+				<span className="flex shrink-0 items-center rounded-md border border-border bg-background px-2 py-0.5 text-[12px] font-medium text-foreground">
+					{activeModelLabel}
+				</span>
+			) : null}
+			{running && activeContextTokens ? (
+				<span className="flex shrink-0 items-center rounded-md border border-border bg-background px-2 py-0.5 text-[12px] font-medium text-foreground">
+					{formatContext(activeContextTokens)}
+				</span>
+			) : null}
+		</div>
+	);
+}
+
+function stripScheme(url: string): string {
+	return url.replace(/^https?:\/\//, "");
+}
+
+/** Pull the port out of `http://127.0.0.1:52651` → `:52651`. The full
+ *  address is always loopback so the host part is noise; the port is
+ *  the only thing the user might need (e.g. to curl the endpoint). */
+function formatEndpointPort(endpoint: string): string {
+	try {
+		const port = new URL(endpoint).port;
+		if (port) return `:${port}`;
+	} catch {
+		// Fall through to the raw string if URL parsing fails.
+	}
+	return stripScheme(endpoint);
+}
+
+// ---------------------------------------------------------------------------
+// Notice banner (warning / error).
+// ---------------------------------------------------------------------------
+
+function NoticeBanner({
+	tone,
+	icon,
+	children,
+}: {
+	tone: "warning" | "error";
+	icon?: React.ReactNode;
+	children: React.ReactNode;
+}) {
+	const palette =
+		tone === "error"
+			? "border-destructive/30 bg-destructive/5 text-destructive"
+			: "border-amber-500/30 bg-amber-500/5 text-amber-600 dark:text-amber-400";
+	return (
+		<div
+			className={cn(
+				"flex items-start gap-2 rounded-md border px-3 py-2 text-[12px]",
+				palette,
+			)}
+		>
+			{icon ? <span className="mt-0.5 shrink-0">{icon}</span> : null}
+			<span className="leading-5">{children}</span>
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Models section — dropdown picker. Trigger shows the currently
+// selected entry; opening lets the user swap focus to any other
+// catalog entry. The contextual CTA row below the trigger drives
+// download / use / delete actions for whichever entry is selected.
+// ---------------------------------------------------------------------------
+
+function ModelsSection({
+	catalog,
+	loading,
+	selectedCatalogEntry,
+	isCustomSelected,
+	customBasename,
+	customIsActive,
+	activeEntryId,
+	recommendedEntryId,
+	downloads,
+	onSelect,
+	onDownload,
+	onResume,
+	onCancel,
+	onDelete,
+}: {
+	catalog: LocalLlmCatalogEntry[];
+	loading: boolean;
+	selectedCatalogEntry: LocalLlmCatalogEntry | null;
+	/// `true` when the picker is focused on the Custom slot rather than
+	/// any catalog entry.
+	isCustomSelected: boolean;
+	/// File basename to render in the Custom slot (path tail). Null when
+	/// no Custom path is set.
+	customBasename: string | null;
+	/// `true` when the running server is loaded with the Custom path
+	/// (not a catalog entry). Used to flag the Custom slot as live.
+	customIsActive: boolean;
+	activeEntryId: string | null;
+	recommendedEntryId: string | null;
+	downloads: Record<string, DownloadRow>;
+	/// Receives a catalog id or `CUSTOM_SLOT_ID`.
+	onSelect: (id: string) => void;
+	onDownload: (id: string) => void;
+	onResume: (id: string) => void;
+	onCancel: (id: string) => void;
+	onDelete: (id: string) => void;
+}) {
+	const [open, setOpen] = useState(false);
+
+	if (loading) {
+		return (
+			<div className="grid gap-1.5">
+				<Label className="text-[12px] text-muted-foreground">Models</Label>
+				<div className="flex items-center gap-1.5 text-[12px] text-muted-foreground">
+					<Loader2 className="size-3 animate-spin" />
+					Loading models…
+				</div>
+			</div>
+		);
+	}
+	if (!selectedCatalogEntry && !isCustomSelected) return null;
+
+	const selectedState =
+		selectedCatalogEntry !== null
+			? (downloads[selectedCatalogEntry.id]?.state ?? "not_downloaded")
+			: "not_downloaded";
+	const isSelectedActive =
+		selectedCatalogEntry !== null && activeEntryId === selectedCatalogEntry.id;
+	const isSelectedRecommended =
+		selectedCatalogEntry !== null &&
+		recommendedEntryId === selectedCatalogEntry.id;
+
+	return (
+		<div className="grid gap-1.5">
+			<Label className="text-[12px] text-muted-foreground">Models</Label>
+			<div className="flex items-center gap-1.5">
+				<DropdownMenu open={open} onOpenChange={setOpen}>
+					<DropdownMenuTrigger asChild>
+						<button
+							type="button"
+							className="flex h-8 min-w-0 flex-1 items-center justify-between gap-2 rounded-lg border border-border bg-background px-2.5 text-[12px] hover:bg-muted/40"
+						>
+							{isCustomSelected ? (
+								<>
+									<div className="flex min-w-0 items-center gap-1.5">
+										<span className="truncate font-medium text-foreground">
+											Custom
+										</span>
+										{customBasename ? (
+											<span className="truncate text-muted-foreground">
+												{customBasename}
+											</span>
+										) : null}
+									</div>
+									<div className="flex shrink-0 items-center gap-2">
+										{customIsActive ? (
+											<Badge className="rounded-full border-foreground/30 bg-foreground/10 px-1.5 py-0 text-[10px] font-medium text-foreground">
+												Active
+											</Badge>
+										) : null}
+										<ChevronDown
+											className="size-3 text-muted-foreground"
+											strokeWidth={2}
+										/>
+									</div>
+								</>
+							) : selectedCatalogEntry ? (
+								<>
+									<div className="flex min-w-0 items-center gap-1.5">
+										<span className="truncate font-medium text-foreground">
+											{selectedCatalogEntry.label}
+										</span>
+										<QuantBadge quant={selectedCatalogEntry.quant} />
+									</div>
+									<div className="flex shrink-0 items-center gap-2">
+										<StateIndicator
+											state={selectedState}
+											active={isSelectedActive}
+											recommended={isSelectedRecommended}
+										/>
+										<span className="tabular-nums text-muted-foreground">
+											{formatBytes(selectedCatalogEntry.bytes)}
+										</span>
+										<ChevronDown
+											className="size-3 text-muted-foreground"
+											strokeWidth={2}
+										/>
+									</div>
+								</>
+							) : null}
+						</button>
+					</DropdownMenuTrigger>
+					<DropdownMenuContent
+						align="start"
+						side="bottom"
+						sideOffset={4}
+						className="min-w-[440px]"
+					>
+						<DropdownMenuItem
+							onClick={() => onSelect(CUSTOM_SLOT_ID)}
+							className="flex flex-col items-start gap-0.5 py-2"
+						>
+							<div className="flex w-full items-center justify-between gap-2">
+								<div className="flex min-w-0 items-center gap-1.5">
+									{isCustomSelected ? (
+										<Check className="size-3 shrink-0 text-foreground" />
+									) : (
+										<span className="size-3 shrink-0" />
+									)}
+									<span className="truncate font-medium text-foreground">
+										Custom
+									</span>
+									{customBasename ? (
+										<span className="truncate text-muted-foreground">
+											{customBasename}
+										</span>
+									) : null}
+								</div>
+								<div className="flex shrink-0 items-center gap-2">
+									{customIsActive ? (
+										<Badge className="rounded-full border-foreground/30 bg-foreground/10 px-1.5 py-0 text-[10px] font-medium text-foreground">
+											Active
+										</Badge>
+									) : null}
+								</div>
+							</div>
+							<p className="pl-[18px] text-[11px] leading-4 text-muted-foreground">
+								Use your own GGUF file. Set the path below.
+							</p>
+						</DropdownMenuItem>
+						{catalog.map((entry) => {
+							const entryState = downloads[entry.id]?.state ?? "not_downloaded";
+							const entryActive = activeEntryId === entry.id;
+							const entryRecommended = recommendedEntryId === entry.id;
+							const isThisRowChecked =
+								!isCustomSelected && entry.id === selectedCatalogEntry?.id;
+							return (
+								<DropdownMenuItem
+									key={entry.id}
+									onClick={() => onSelect(entry.id)}
+									className="flex flex-col items-start gap-0.5 py-2"
+								>
+									<div className="flex w-full items-center justify-between gap-2">
+										<div className="flex min-w-0 items-center gap-1.5">
+											{isThisRowChecked ? (
+												<Check className="size-3 shrink-0 text-foreground" />
+											) : (
+												<span className="size-3 shrink-0" />
+											)}
+											<span className="truncate font-medium text-foreground">
+												{entry.label}
+											</span>
+											<QuantBadge quant={entry.quant} />
+										</div>
+										<div className="flex shrink-0 items-center gap-2">
+											<StateIndicator
+												state={entryState}
+												active={entryActive}
+												recommended={entryRecommended}
+											/>
+											<span className="tabular-nums text-muted-foreground">
+												{formatBytes(entry.bytes)}
+											</span>
+										</div>
+									</div>
+									<p className="pl-[18px] text-[11px] leading-4 text-muted-foreground">
+										{entry.blurb}
+									</p>
+								</DropdownMenuItem>
+							);
+						})}
+					</DropdownMenuContent>
+				</DropdownMenu>
+				{/* Contextual download / delete buttons only apply to catalog
+				    entries — Custom path activation goes through the
+				    Custom Model Path input's onCommit. */}
+				{selectedCatalogEntry && !isCustomSelected ? (
+					<ContextualActions
+						state={selectedState}
+						active={isSelectedActive}
+						onDownload={() => onDownload(selectedCatalogEntry.id)}
+						onResume={() => onResume(selectedCatalogEntry.id)}
+						onCancel={() => onCancel(selectedCatalogEntry.id)}
+						onDelete={() => onDelete(selectedCatalogEntry.id)}
+					/>
+				) : null}
+			</div>
+		</div>
+	);
+}
+
+function QuantBadge({ quant }: { quant: string }) {
+	return (
+		<Badge
+			variant="outline"
+			className="rounded-sm px-1 py-0 text-[10px] font-normal text-muted-foreground"
+		>
+			{quant}
+		</Badge>
+	);
+}
+
+const GB = 1_073_741_824; // 1024 ** 3
+const TIGHT_RAM_FRACTION = 0.7;
+const OVER_RAM_FRACTION = 0.9;
+const CONTEXT_STEP = 4096;
+const MIN_CONTEXT_TOKENS = 4096;
+
+function snapContext(value: number, max: number): number {
+	const snapped = Math.round(value / CONTEXT_STEP) * CONTEXT_STEP;
+	return Math.min(Math.max(snapped, MIN_CONTEXT_TOKENS), max);
+}
+
+/** Slider for the runtime `-c` value, with help tooltip + live KV
+ *  cache readout. Dragging changes the local preview (pending);
+ *  Apply commits through the regular settings pipeline so React state
+ *  and backend both update + the server restarts if needed.
+ *
+ *  Every numeric input is GGUF-derived truth from the inspect IPC —
+ *  callers gate rendering on inspect succeeding so we never paint
+ *  catalog estimates here. */
+type ContextSelectorTarget = {
+	/// Settings-map key the override is persisted under. Catalog entries
+	/// use their `id`; custom paths use `custom:<absolute-path>` (matches
+	/// the Rust-side `custom_override_key`).
+	id: string;
+	modelMaxContextTokens: number;
+	kvBytesPerToken: number;
+	/// Bytes of weights on disk. Catalog reports it from the entry; for
+	/// custom paths the caller passes 0 (we under-estimate footprint but
+	/// never over-budget — llama-server caps allocation anyway).
+	modelBytes: number;
+};
+
+function ContextSelector({
+	target,
+	totalRamGb,
+	currentTokens,
+	defaultTokens,
+	onCommit,
+}: {
+	target: ContextSelectorTarget;
+	totalRamGb: number | null;
+	currentTokens: number | null;
+	/// Hardware-aware default from the inspect IPC. The slider's Reset
+	/// affordance snaps back to this.
+	defaultTokens: number;
+	onCommit: (entryId: string, tokens: number) => void;
+}) {
+	const maxTokens = target.modelMaxContextTokens;
+	const [pending, setPending] = useState<number | null>(null);
+
+	useEffect(() => {
+		// Drop the preview whenever the committed value updates (apply
+		// succeeded, or user switched to a different model).
+		setPending(null);
+	}, [currentTokens, target.id]);
+
+	if (!currentTokens) return null;
+
+	const effective = pending ?? currentTokens;
+	const hasPending = pending !== null && pending !== currentTokens;
+	const totalRamBytes = totalRamGb ? totalRamGb * GB : null;
+	const kvBytes = effective * target.kvBytesPerToken;
+	const totalBytes = target.modelBytes + kvBytes;
+	const fit: "ok" | "tight" | "over" =
+		totalRamBytes === null
+			? "ok"
+			: totalBytes > totalRamBytes * OVER_RAM_FRACTION
+				? "over"
+				: totalBytes > totalRamBytes * TIGHT_RAM_FRACTION
+					? "tight"
+					: "ok";
+
+	const fitColor =
+		fit === "over"
+			? "text-destructive"
+			: fit === "tight"
+				? "text-amber-600 dark:text-amber-400"
+				: "text-muted-foreground";
+	const canReset = pending !== null ? true : currentTokens !== defaultTokens;
+	const canApply = hasPending && fit !== "over";
+
+	// CSS grid with explicit column widths. Every left-side slot is
+	// fixed so dragging the slider only swaps text inside slots —
+	// nothing moves. Column 5 is a `1fr` spacer that absorbs slack,
+	// keeping the action buttons pinned to the right while the memory
+	// readout (col 4) stays at its natural `auto` width and never gets
+	// truncated.
+	return (
+		<div className="grid grid-cols-[auto_144px_44px_auto_1fr_auto] items-center gap-3 text-[12px]">
+			<div className="flex shrink-0 items-center gap-1">
+				<Label className="text-[12px] text-muted-foreground">Context</Label>
+				{/* SettingsDialog renders outside AppShell's TooltipProvider. */}
+				<TooltipProvider>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<button
+								type="button"
+								className="cursor-help text-muted-foreground hover:text-foreground"
+								aria-label="What is context size?"
+							>
+								<CircleHelp className="size-3.5" strokeWidth={1.8} />
+							</button>
+						</TooltipTrigger>
+						<TooltipContent
+							side="top"
+							className="max-w-[280px] text-[11px] leading-5"
+						>
+							The total token budget for input + generated output combined.
+							Bigger context lets you send longer prompts but uses more RAM and
+							takes longer to start.
+							<br />
+							<br />
+							If you're unsure, the default ({formatContext(defaultTokens)}) is
+							sized to fit your hardware — leave it as is.
+						</TooltipContent>
+					</Tooltip>
+				</TooltipProvider>
+			</div>
+
+			<Slider
+				value={[effective]}
+				min={MIN_CONTEXT_TOKENS}
+				max={maxTokens}
+				step={CONTEXT_STEP}
+				onValueChange={(values) => {
+					const raw = values[0] ?? currentTokens;
+					setPending(snapContext(raw, maxTokens));
+				}}
+			/>
+
+			{/* Current value — right-aligned in a 44 px slot so even
+			    "256K" still anchors its K to the same x-position the
+			    "32K" K sits at. Digits grow leftward, slider stays put. */}
+			<span
+				className={cn(
+					"text-right font-medium tabular-nums",
+					hasPending ? "text-primary" : "text-foreground",
+				)}
+			>
+				{formatContext(effective)}
+			</span>
+
+			{/* Memory readout — `auto` column + `whitespace-nowrap` so the
+			    string is always shown in full. Compact format drops the
+			    redundant middle "GB" so "KV 12.9 GB · 33.9/48 GB" reads
+			    cleanly. Color carries the fit state (no extra warn text
+			    so the width doesn't change character by character). */}
+			<span className={cn("whitespace-nowrap tabular-nums", fitColor)}>
+				KV {formatBytes(kvBytes)}
+				{totalRamGb
+					? ` · ${formatBytes(totalBytes).replace(" GB", "")}/${totalRamGb} GB`
+					: ""}
+			</span>
+
+			{/* `1fr` spacer absorbs leftover width so buttons stick to
+			    the right edge without forcing the memory column to
+			    shrink. */}
+			<div aria-hidden />
+
+			{/* Actions — both buttons ALWAYS rendered, just disabled
+			    when not applicable. Reset has a dual semantic (discard
+			    pending preview OR revert committed override); its
+			    tooltip clarifies which one will fire. */}
+			<div className="flex shrink-0 items-center gap-1.5">
+				<Button
+					type="button"
+					size="xs"
+					variant="ghost"
+					disabled={!canReset}
+					onClick={() => {
+						if (pending !== null) {
+							setPending(null);
+							return;
+						}
+						if (currentTokens !== defaultTokens) {
+							onCommit(target.id, defaultTokens);
+						}
+					}}
+					title={
+						pending !== null ? "Discard pending change" : "Reset to default"
+					}
+				>
+					<Undo2 className="size-3" strokeWidth={1.8} />
+					Reset
+				</Button>
+				<Button
+					type="button"
+					size="xs"
+					variant="default"
+					disabled={!canApply}
+					onClick={() => {
+						if (pending !== null) onCommit(target.id, pending);
+					}}
+				>
+					Apply
+				</Button>
+			</div>
+		</div>
+	);
+}
+
+/**
+ * One status indicator per row. Priority: Active (filled primary pill)
+ * > Downloading / Paused / Failed (filled tinted pill) > Downloaded
+ * (small green check icon, no text — saves horizontal space) >
+ * Recommended (filled sky pill).
+ */
+function StateIndicator({
+	state,
+	active,
+	recommended,
+}: {
+	state: LocalLlmDownloadStatus["state"];
+	active: boolean;
+	recommended: boolean;
+}) {
+	// Pill rules:
+	//   - downloaded → "Downloaded" pill (explicit "it's here" signal)
+	//   - not_downloaded → no pill (silence by default; just Recommended)
+	//   - in-flight states (downloading / paused / failed) → their own pill
+	// `active` isn't a pill — the panel header carries the live-running
+	// signal so the dropdown row stays uncluttered.
+	void active;
+	if (state === "downloading") {
+		return (
+			<Badge className="rounded-full border-foreground/30 bg-foreground/10 px-1.5 py-0 text-[10px] font-medium text-foreground">
+				Downloading
+			</Badge>
+		);
+	}
+	if (state === "paused") {
+		return (
+			<Badge className="rounded-full border-muted-foreground/30 bg-muted/40 px-1.5 py-0 text-[10px] font-medium text-muted-foreground">
+				Paused
+			</Badge>
+		);
+	}
+	if (state === "failed") {
+		return (
+			<Badge className="rounded-full border-destructive/30 bg-destructive/15 px-1.5 py-0 text-[10px] font-medium text-destructive">
+				Failed
+			</Badge>
+		);
+	}
+	if (state === "downloaded") {
+		return (
+			<Badge className="rounded-full border-muted-foreground/30 bg-muted/40 px-1.5 py-0 text-[10px] font-medium text-muted-foreground">
+				Downloaded
+			</Badge>
+		);
+	}
+	// not_downloaded — Recommended is the only pill that surfaces.
+	if (!recommended) return null;
+	return (
+		<Badge className="rounded-full border-emerald-500/30 bg-emerald-500/15 px-1.5 py-0 text-[10px] font-medium text-emerald-700 dark:text-emerald-300">
+			Recommended
+		</Badge>
+	);
+}
+
+/** CTAs live on their own row below the dropdown so the trigger never
+ *  truncates and Delete (which is destructive) gets the visual weight
+ *  it deserves. */
+function ContextualActions({
+	state,
+	active,
+	onDownload,
+	onResume,
+	onCancel,
+	onDelete,
+}: {
+	state: LocalLlmDownloadStatus["state"];
+	active: boolean;
+	onDownload: () => void;
+	onResume: () => void;
+	onCancel: () => void;
+	onDelete: () => void;
+}) {
+	// Selection = activation, so we never render "Use this model" any
+	// more. The only contextual CTA on the row is whatever's
+	// reasonable for the entry's current state:
+	//   - downloaded → Delete (red)
+	//   - downloading → Cancel (red)
+	//   - paused → Resume (default) + Cancel (red)
+	//   - failed → Retry (default) + Cancel (red)
+	//   - not_downloaded → Download (default)
+	// All buttons sized `sm` (h-7) to match the dropdown trigger.
+	void active;
+	if (state === "downloaded") {
+		return (
+			<Button type="button" size="sm" variant="destructive" onClick={onDelete}>
+				<Trash2 className="size-3.5" strokeWidth={1.8} />
+				Delete
+			</Button>
+		);
+	}
+	if (state === "downloading") {
+		return (
+			<Button type="button" size="sm" variant="destructive" onClick={onCancel}>
+				<X className="size-3.5" strokeWidth={1.8} />
+				Cancel
+			</Button>
+		);
+	}
+	if (state === "paused") {
+		return (
+			<>
+				<Button type="button" size="sm" variant="default" onClick={onResume}>
+					<Play className="size-3.5" strokeWidth={1.8} />
+					Resume
+				</Button>
+				<Button
+					type="button"
+					size="sm"
+					variant="destructive"
+					onClick={onCancel}
+				>
+					<X className="size-3.5" strokeWidth={1.8} />
+					Cancel
+				</Button>
+			</>
+		);
+	}
+	if (state === "failed") {
+		return (
+			<>
+				<Button type="button" size="sm" variant="default" onClick={onDownload}>
+					<RotateCcw className="size-3.5" strokeWidth={1.8} />
+					Retry
+				</Button>
+				<Button
+					type="button"
+					size="sm"
+					variant="destructive"
+					onClick={onCancel}
+				>
+					<X className="size-3.5" strokeWidth={1.8} />
+					Cancel
+				</Button>
+			</>
+		);
+	}
+	return (
+		<Button type="button" size="sm" variant="default" onClick={onDownload}>
+			<Download className="size-3.5" strokeWidth={1.8} />
+			Download
+		</Button>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Downloads section — only when there are in-flight or paused rows.
+// ---------------------------------------------------------------------------
+
+function DownloadsSection({
+	rows,
+	onPause,
+	onResume,
+	onCancel,
+}: {
+	rows: Array<{ entry: LocalLlmCatalogEntry; download: DownloadRow }>;
+	onPause: (id: string) => void;
+	onResume: (id: string) => void;
+	onCancel: (id: string) => void;
+}) {
+	return (
+		<div className="grid gap-2 rounded-md border border-border/50 bg-muted/20 p-3">
+			<div className="text-[11px] uppercase tracking-wide text-muted-foreground">
+				Downloads
+			</div>
+			<div className="grid gap-3">
+				{rows.map(({ entry, download }) => (
+					<DownloadRowView
+						key={entry.id}
+						entry={entry}
+						download={download}
+						onPause={() => onPause(entry.id)}
+						onResume={() => onResume(entry.id)}
+						onCancel={() => onCancel(entry.id)}
+					/>
+				))}
+			</div>
+		</div>
+	);
+}
+
+function DownloadRowView({
+	entry,
+	download,
+	onPause,
+	onResume,
+	onCancel,
+}: {
+	entry: LocalLlmCatalogEntry;
+	download: DownloadRow;
+	onPause: () => void;
+	onResume: () => void;
+	onCancel: () => void;
+}) {
+	const paused = download.state === "paused";
+	return (
+		<div className="grid gap-1.5 text-[12px]">
+			<div className="flex min-w-0 items-center justify-between gap-2">
+				<div className="flex min-w-0 items-center gap-2">
+					<span className="truncate font-medium text-foreground">
+						{entry.label}
+					</span>
+					<QuantBadge quant={entry.quant} />
+				</div>
+				<div className="flex shrink-0 items-center gap-1.5">
+					{paused ? (
+						<Button
+							type="button"
+							size="xs"
+							variant="outline"
+							onClick={onResume}
+						>
+							<Play className="size-3" strokeWidth={1.8} />
+							Resume
+						</Button>
+					) : (
+						<Button type="button" size="xs" variant="outline" onClick={onPause}>
+							<Pause className="size-3" strokeWidth={1.8} />
+							Pause
+						</Button>
+					)}
+					<Button type="button" size="xs" variant="outline" onClick={onCancel}>
+						<X className="size-3" strokeWidth={1.8} />
+						Cancel
+					</Button>
+				</div>
+			</div>
+			<DownloadProgress
+				downloaded={download.downloaded}
+				total={download.total}
+				bytesPerSec={download.bytesPerSec ?? 0}
+				paused={paused}
+			/>
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Custom model path.
+// ---------------------------------------------------------------------------
+
+function CustomModelPathSection({
+	value,
+	disabled,
+	onChange,
+	onCommit,
+}: {
+	value: string;
+	disabled: boolean;
+	onChange: (value: string) => void;
+	/** Called when the user signals "this is the path I want" — either
+	 *  by blurring the input or pressing Enter. Parent uses this to
+	 *  kick off / restart the server so the new path takes effect
+	 *  without a separate Apply button. */
+	onCommit: () => void;
+}) {
+	return (
+		<div className="grid gap-1.5">
+			<div className="flex items-center gap-1">
+				<Label
+					htmlFor="local-llm-model"
+					className="text-[12px] text-muted-foreground"
+				>
+					Custom model path
+				</Label>
+				{/* SettingsDialog renders outside AppShell's TooltipProvider. */}
+				<TooltipProvider>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<button
+								type="button"
+								className="cursor-help text-muted-foreground hover:text-foreground"
+								aria-label="About custom model path"
+							>
+								<CircleHelp className="size-3.5" strokeWidth={1.8} />
+							</button>
+						</TooltipTrigger>
+						<TooltipContent
+							side="top"
+							className="max-w-[260px] text-[11px] leading-5"
+						>
+							{/* Wrapped in <span> so the inline <code> doesn't split
+							    text into multiple flex items in TooltipContent's
+							    inline-flex layout. */}
+							<span>
+								Point this at a <code>.gguf</code> you've downloaded yourself.
+								Curated models above take precedence — clear this field to
+								switch back to the picker.
+							</span>
+						</TooltipContent>
+					</Tooltip>
+				</TooltipProvider>
+			</div>
+			<Input
+				id="local-llm-model"
+				value={value}
+				placeholder="/path/to/model.gguf"
+				disabled={disabled}
+				onChange={(event) => onChange(event.currentTarget.value)}
+				onBlur={onCommit}
+				onKeyDown={(event) => {
+					if (event.key === "Enter") {
+						event.preventDefault();
+						event.currentTarget.blur();
+					}
+				}}
+			/>
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Atoms.
+// ---------------------------------------------------------------------------
+
+function DownloadProgress({
+	downloaded,
+	total,
+	bytesPerSec,
+	paused,
+}: {
+	downloaded: number;
+	total: number;
+	bytesPerSec: number;
+	paused: boolean;
+}) {
+	const hasTotal = total > 0 && downloaded <= total;
+	const percent = hasTotal
+		? Math.min(100, Math.round((downloaded / total) * 100))
+		: null;
+	const etaLabel =
+		!paused && bytesPerSec > 0 && hasTotal && downloaded < total
+			? formatEta((total - downloaded) / bytesPerSec)
+			: null;
+	return (
+		<div className="grid gap-1">
+			<div className="h-1 w-full overflow-hidden rounded-full bg-muted/40">
+				{percent !== null ? (
+					<div
+						className={cn(
+							"h-full transition-[width] duration-200 ease-out",
+							paused ? "bg-foreground/30" : "bg-foreground/70",
+						)}
+						style={{ width: `${percent}%` }}
+					/>
+				) : (
+					<div className="h-full w-1/3 animate-pulse bg-foreground/50" />
+				)}
+			</div>
+			<div className="flex justify-between text-[11px] tabular-nums text-muted-foreground">
+				<span>
+					{hasTotal
+						? `${formatBytes(downloaded)} / ${formatBytes(total)}${percent !== null ? ` · ${percent}%` : ""}`
+						: formatBytes(downloaded)}
+				</span>
+				<span>
+					{paused
+						? "Paused"
+						: bytesPerSec > 0
+							? `${formatBytes(bytesPerSec)}/s${etaLabel ? ` · ${etaLabel} left` : ""}`
+							: downloaded === 0
+								? "Connecting…"
+								: null}
+				</span>
+			</div>
+		</div>
+	);
+}
+
+function formatEta(seconds: number): string {
+	if (!Number.isFinite(seconds) || seconds <= 0) return "";
+	if (seconds < 90) return `${Math.ceil(seconds)}s`;
+	const minutes = Math.ceil(seconds / 60);
+	if (minutes < 90) return `${minutes}m`;
+	const hours = Math.floor(minutes / 60);
+	const rem = minutes % 60;
+	return rem === 0 ? `${hours}h` : `${hours}h${rem}m`;
+}
+
+function applyDownloadEvent(
+	prev: Record<string, DownloadRow>,
+	event: LocalLlmDownloadEvent,
+): Record<string, DownloadRow> {
+	const current = prev[event.entryId];
+	const next = { ...prev };
+	switch (event.kind) {
+		case "started":
+			next[event.entryId] = {
+				entryId: event.entryId,
+				state: "downloading",
+				downloaded: current?.downloaded ?? 0,
+				total: event.total,
+				bytesPerSec: 0,
+			};
+			break;
+		case "progress":
+			next[event.entryId] = {
+				entryId: event.entryId,
+				state: "downloading",
+				downloaded: event.downloaded,
+				total: event.total,
+				// Keep the last non-zero rate so a momentary 0 (HF
+				// rate-limit window, brief stall) doesn't blank the
+				// "X MB/s" readout. A genuinely stuck download surfaces
+				// through the `failed` event (chunk-read timeout in the
+				// worker) — until then we'd rather show stale speed
+				// than make the row look frozen mid-download.
+				bytesPerSec:
+					event.bytesPerSec > 0
+						? event.bytesPerSec
+						: (current?.bytesPerSec ?? 0),
+			};
+			break;
+		case "paused":
+			next[event.entryId] = {
+				entryId: event.entryId,
+				state: "paused",
+				downloaded: event.downloaded,
+				total: event.total,
+				bytesPerSec: 0,
+			};
+			break;
+		case "cancelled":
+			next[event.entryId] = {
+				entryId: event.entryId,
+				state: "not_downloaded",
+				downloaded: 0,
+				total: event.total,
+				bytesPerSec: 0,
+			};
+			break;
+		case "completed":
+			next[event.entryId] = {
+				entryId: event.entryId,
+				state: "downloaded",
+				downloaded: event.downloaded,
+				total: event.downloaded,
+				bytesPerSec: 0,
+			};
+			break;
+		case "failed":
+			next[event.entryId] = {
+				entryId: event.entryId,
+				state: "failed",
+				downloaded: current?.downloaded ?? 0,
+				total: current?.total ?? 0,
+				error: event.error,
+				bytesPerSec: 0,
+			};
+			break;
+	}
+	return next;
+}
+
+function formatContext(tokens: number): string {
+	if (tokens >= 1_048_576) {
+		return `${Math.round(tokens / 1_048_576)}M`;
+	}
+	return `${Math.round(tokens / 1024)}K`;
+}
+
+function formatBytes(n: number): string {
+	if (n >= 1_000_000_000) {
+		return `${(n / 1_000_000_000).toFixed(1)} GB`;
+	}
+	if (n >= 1_000_000) {
+		return `${(n / 1_000_000).toFixed(0)} MB`;
+	}
+	if (n >= 1_000) {
+		return `${(n / 1_000).toFixed(0)} KB`;
+	}
+	return `${Math.round(n)} B`;
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -125,6 +125,21 @@ export type DataInfo = {
 
 export type AgentProvider = "claude" | "codex" | "cursor";
 
+export type LocalLlmStatus = {
+	enabled: boolean;
+	runtimeFound: boolean;
+	runtimePath?: string | null;
+	starting: boolean;
+	running: boolean;
+	model: string;
+	apiModel: string;
+	contextSize: number;
+	gpuLayers: number;
+	reasoningMode: string;
+	endpoint?: string | null;
+	lastError?: string | null;
+};
+
 export type AgentModelOption = {
 	id: string;
 	provider: AgentProvider;
@@ -2702,6 +2717,193 @@ export async function revealPathInFinder(path: string): Promise<void> {
 
 export async function copyImageToClipboard(path: string): Promise<void> {
 	await invoke("copy_image_to_clipboard", { path });
+}
+
+export async function getLocalLlmStatus(): Promise<LocalLlmStatus> {
+	return await invoke<LocalLlmStatus>("get_local_llm_status");
+}
+
+export async function startLocalLlm(): Promise<LocalLlmStatus> {
+	return await invoke<LocalLlmStatus>("start_local_llm");
+}
+
+export async function stopLocalLlm(): Promise<void> {
+	await invoke("stop_local_llm");
+}
+
+export type LocalLlmCatalogEntry = {
+	id: string;
+	repo: string;
+	/** Every GGUF file required to load the model. Single-file models
+	 *  list one entry; multi-part shards (HF splits anything >50 GB)
+	 *  list all parts in load order. The downloader fetches them all
+	 *  and llama-server is pointed at part 1; it auto-discovers the
+	 *  rest. */
+	files: string[];
+	label: string;
+	quant: string;
+	bytes: number;
+	minRamGb: number;
+	recommendedForGb: number;
+	blurb: string;
+	/** Which subsystem the entry belongs to. Always "llm" today; kept
+	 *  as a discriminator so future entry kinds can land without
+	 *  churning every consumer. */
+	kind?: "llm";
+};
+
+export async function listLocalLlmCatalog(): Promise<LocalLlmCatalogEntry[]> {
+	return await invoke<LocalLlmCatalogEntry[]>("list_local_llm_catalog");
+}
+
+/** GGUF metadata snapshot for an arbitrary user-supplied `.gguf` file.
+ *  Lets the panel render real context limits + KV cache estimates for
+ *  Custom model paths (outside the curated catalog). When the file
+ *  can't be parsed (corrupt header, unsupported arch) the IPC errors
+ *  out and the UI falls back to a static "32K" hint. */
+export type LocalLlmModelInspection = {
+	architecture: string;
+	name: string | null;
+	contextLength: number;
+	kvBytesPerToken: number;
+	defaultContextTokens: number;
+};
+
+export async function inspectLocalLlmModel(
+	path: string,
+): Promise<LocalLlmModelInspection> {
+	return await invoke<LocalLlmModelInspection>("inspect_local_llm_model", {
+		path,
+	});
+}
+
+/** Read real GGUF metadata for a downloaded catalog entry. Returns
+ *  `null` when the file isn't on disk yet (panel falls back to the
+ *  catalog estimate). Lets the context selector show the same numbers
+ *  for catalog and custom models. */
+export async function inspectLocalLlmCatalogEntry(
+	entryId: string,
+): Promise<LocalLlmModelInspection | null> {
+	return await invoke<LocalLlmModelInspection | null>(
+		"inspect_local_llm_catalog_entry",
+		{ entryId },
+	);
+}
+
+export type LocalLlmHardwareSnapshot = {
+	cpuBrand: string;
+	totalRamGb: number;
+	osLabel: string;
+	arch: string;
+	/** Catalog entry id the hardware tier maps to. The panel paints a
+	 *  "Recommended" badge on exactly this card. Null when the catalog
+	 *  is empty or the OS is unsupported. */
+	recommendedEntryId: string | null;
+};
+
+export async function detectLocalLlmHardware(): Promise<LocalLlmHardwareSnapshot> {
+	return await invoke<LocalLlmHardwareSnapshot>("detect_local_llm_hardware");
+}
+
+export type LocalLlmDownloadState =
+	| "not_downloaded"
+	| "downloading"
+	| "paused"
+	| "downloaded"
+	| "failed";
+
+export type LocalLlmDownloadStatus = {
+	entryId: string;
+	state: LocalLlmDownloadState;
+	downloaded: number;
+	total: number;
+	error?: string;
+};
+
+/** Streaming event from the bundled download worker. The `kind`
+ *  discriminator matches the Rust enum variants. */
+export type LocalLlmDownloadEvent =
+	| { entryId: string; kind: "started"; total: number }
+	| {
+			entryId: string;
+			kind: "progress";
+			downloaded: number;
+			total: number;
+			bytesPerSec: number;
+	  }
+	| { entryId: string; kind: "paused"; downloaded: number; total: number }
+	| { entryId: string; kind: "cancelled"; total: number }
+	| {
+			entryId: string;
+			kind: "completed";
+			downloaded: number;
+			path: string;
+			sha256Verified: boolean;
+	  }
+	| {
+			entryId: string;
+			kind: "failed";
+			error: string;
+			retryable: boolean;
+	  };
+
+export async function subscribeLocalLlmDownloads(
+	onEvent: Channel<LocalLlmDownloadEvent>,
+): Promise<LocalLlmDownloadStatus[]> {
+	return await invoke<LocalLlmDownloadStatus[]>(
+		"subscribe_local_llm_downloads",
+		{
+			onEvent,
+		},
+	);
+}
+
+export async function listLocalLlmDownloads(): Promise<
+	LocalLlmDownloadStatus[]
+> {
+	return await invoke<LocalLlmDownloadStatus[]>("list_local_llm_downloads");
+}
+
+export async function startLocalLlmDownload(entryId: string): Promise<void> {
+	await invoke("start_local_llm_download", { entryId });
+}
+
+export async function pauseLocalLlmDownload(entryId: string): Promise<void> {
+	await invoke("pause_local_llm_download", { entryId });
+}
+
+export async function cancelLocalLlmDownload(entryId: string): Promise<void> {
+	await invoke("cancel_local_llm_download", { entryId });
+}
+
+export async function activateLocalLlmModel(
+	entryId: string,
+): Promise<LocalLlmStatus> {
+	return await invoke<LocalLlmStatus>("activate_local_llm_model", { entryId });
+}
+
+export async function setLocalLlmContextOverride(
+	entryId: string,
+	contextTokens: number,
+): Promise<LocalLlmStatus> {
+	return await invoke<LocalLlmStatus>("set_local_llm_context_override", {
+		entryId,
+		contextTokens,
+	});
+}
+
+/** Connection params for the running local LLM `llama-server`. Voice
+ *  Pilot reads this to POST OpenAI-compatible chat completions with
+ *  tool schemas directly to the user's configured local model. `null`
+ *  while the server is stopped / starting / crashed. */
+export type LocalLlmEndpoint = {
+	url: string;
+	token: string;
+	apiModel: string;
+};
+
+export async function getLocalLlmEndpoint(): Promise<LocalLlmEndpoint | null> {
+	return await invoke<LocalLlmEndpoint | null>("get_local_llm_endpoint");
 }
 
 /**

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -135,6 +135,16 @@ export type CursorProviderSettings = {
 	cachedModels: CursorCachedModel[] | null;
 };
 
+export type LocalLlmSettings = {
+	enabled: boolean;
+	model: string;
+	autoStart: boolean;
+	/** Per-catalog-entry runtime `-c` overrides. Absent key = use the
+	 *  catalog default. Backend keeps this map in sync via
+	 *  `setLocalLlmContextOverride`. */
+	contextOverrides?: Record<string, number>;
+};
+
 /** Per-account toggles for which item kinds the inbox should pull from
  * a given forge login. Keyed externally by `<provider>:<login>` (e.g.
  * `github:octocat`). Missing keys default to all `true` — newly added
@@ -279,6 +289,7 @@ export type AppSettings = {
 	shortcuts: ShortcutOverrides;
 	claudeCustomProviders: ClaudeCustomProviderSettings;
 	cursorProvider: CursorProviderSettings;
+	localLlm: LocalLlmSettings;
 	inboxSourceConfig: InboxSourceConfig;
 	startSurfacePreferences: StartSurfacePreferences;
 	/** Sidebar grouping mode. Persisted to localStorage (sync read on boot
@@ -376,6 +387,12 @@ export const DEFAULT_SETTINGS: AppSettings = {
 		apiKey: "",
 		enabledModelIds: null,
 		cachedModels: null,
+	},
+	localLlm: {
+		enabled: false,
+		model: "",
+		autoStart: true,
+		contextOverrides: {},
 	},
 	inboxSourceConfig: { accounts: {} },
 	startSurfacePreferences: DEFAULT_START_SURFACE_PREFERENCES,
@@ -530,6 +547,7 @@ const SETTINGS_KEY_MAP: Record<
 	shortcuts: "app.shortcuts",
 	claudeCustomProviders: "app.claude_custom_providers",
 	cursorProvider: "app.cursor_provider",
+	localLlm: "app.local_llm",
 	inboxSourceConfig: "app.inbox_source_config",
 	startSurfacePreferences: "app.start_surface_preferences",
 };
@@ -983,6 +1001,41 @@ function parseClaudeCustomProviderSettings(
 	}
 }
 
+function parseLocalLlmSettings(raw: string | undefined): LocalLlmSettings {
+	if (!raw) return DEFAULT_SETTINGS.localLlm;
+	try {
+		const parsed = JSON.parse(raw) as Partial<LocalLlmSettings>;
+		const overrides: Record<string, number> = {};
+		if (
+			parsed.contextOverrides &&
+			typeof parsed.contextOverrides === "object"
+		) {
+			for (const [key, value] of Object.entries(parsed.contextOverrides)) {
+				if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+					overrides[key] = value;
+				}
+			}
+		}
+		return {
+			enabled:
+				typeof parsed.enabled === "boolean"
+					? parsed.enabled
+					: DEFAULT_SETTINGS.localLlm.enabled,
+			model:
+				typeof parsed.model === "string"
+					? parsed.model
+					: DEFAULT_SETTINGS.localLlm.model,
+			autoStart:
+				typeof parsed.autoStart === "boolean"
+					? parsed.autoStart
+					: DEFAULT_SETTINGS.localLlm.autoStart,
+			contextOverrides: overrides,
+		};
+	} catch {
+		return DEFAULT_SETTINGS.localLlm;
+	}
+}
+
 /** Read an integer setting bounded to [min, max] with a default fallback.
  *  Used for font sizes so corrupted or out-of-range values can't render
  *  the UI unreadable. */
@@ -1150,6 +1203,7 @@ export async function loadSettings(): Promise<AppSettings> {
 			cursorProvider: parseCursorProviderSettings(
 				raw[SETTINGS_KEY_MAP.cursorProvider],
 			),
+			localLlm: parseLocalLlmSettings(raw[SETTINGS_KEY_MAP.localLlm]),
 			inboxSourceConfig: parseInboxSourceConfig(
 				raw[SETTINGS_KEY_MAP.inboxSourceConfig],
 			),
@@ -1195,6 +1249,7 @@ export async function saveSettings(patch: Partial<AppSettings>): Promise<void> {
 				key === "shortcuts" ||
 				key === "claudeCustomProviders" ||
 				key === "cursorProvider" ||
+				key === "localLlm" ||
 				key === "inboxSourceConfig" ||
 				key === "startSurfacePreferences"
 					? JSON.stringify(value)


### PR DESCRIPTION
## Summary

Introduces an **experimental** Local LLM feature that runs session title and branch name generation on-device using a bundled llama-server, eliminating the need for cloud API calls for these workloads.

## Changes

- **Backend (Rust)**
  - New `local_llm` module: manager, server, chat API, model catalog, hardware detection, GGUF format support
  - Model download/registry management via Hugging Face
  - New `downloads` module for asset staging and verification
  - Tauri commands for model lifecycle and inference
  - Data dir handling for model persistence

- **Frontend (React)**
  - New experimental Local LLM settings panel with model selection and parameter tuning
  - Slider UI component for model configuration
  - Integration with existing settings infrastructure

- **Dependencies**
  - llama-cpp-rs for local inference
  - serde/serde_json for model metadata
  - New vendored downloads for bundled llama-server binary

## Status

🧪 **Experimental Preview** — Very early. Currently powers:
- Session title generation
- Branch name generation

More features coming soon. Feedback welcome.

## Testing

- Pre-commit hooks passed: biome, cargo fmt, cargo clippy
- All Rust clippy warnings resolved
- Settings properly persist model configuration

## Notes

- Models are downloaded on-demand and cached in the data directory
- Hardware detection determines optimal inference parameters
- Users can configure model selection and inference behavior via Settings → Experimental