### PR TITLE
Fix Codex MCP tool-call approvals with persist options

### DIFF
--- a/.changeset/codex-mcp-tool-approval.md
+++ b/.changeset/codex-mcp-tool-approval.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix Codex MCP tool-call approvals showing only Cancel/Decline. The empty-schema elicitation Codex sends with `_meta.codex_approval_kind: "mcp_tool_call"` now renders a dedicated Allow / Allow-for-session / Always-allow / Cancel panel, and the chosen persist option round-trips back to Codex so "remember this" actually sticks.

--- a/.changeset/codex-mcp-tool-approval.md
+++ b/.changeset/codex-mcp-tool-approval.md
@@ -2,4 +2,4 @@
 "helmor": patch
 ---
 
-Fix Codex MCP tool-call approvals showing only Cancel/Decline. The empty-schema elicitation Codex sends with `_meta.codex_approval_kind: "mcp_tool_call"` now renders a dedicated Allow / Allow-for-session / Always-allow / Cancel panel, and the chosen persist option round-trips back to Codex so "remember this" actually sticks.
+Fix Codex MCP tool-call approvals showing no Allow button. The empty-schema elicitation with `_meta.codex_approval_kind: "mcp_tool_call"` now renders Allow / Allow-for-session / Always-allow / Decline, and the persist choice round-trips back so Codex remembers it.

--- a/sidecar/src/codex-app-server-manager.ts
+++ b/sidecar/src/codex-app-server-manager.ts
@@ -487,9 +487,7 @@ export class CodexAppServerManager implements SessionManager {
 					: resolution.action === "decline"
 						? "decline"
 						: "cancel";
-			// Forward `_meta` so the user's persist choice (session/always)
-			// reaches Codex's MCP tool-call approval flow. The TUI wires the
-			// same `meta` field; see `mcp_tool_call.rs::parse_mcp_tool_approval_decision`.
+			// Forward `_meta.persist` so Codex remembers session/always allow.
 			const meta =
 				(resolution.action === "submit" || resolution.action === "decline") &&
 				resolution.meta &&
@@ -926,12 +924,7 @@ export class CodexAppServerManager implements SessionManager {
 							? p.message
 							: "Server requested input.";
 
-					// Codex tags MCP tool-call approvals via `_meta.codex_approval_kind`,
-					// and advertises persist options on `_meta.persist`. We forward
-					// the whole `_meta` object opaquely so the frontend can render
-					// the matching Allow / Allow-for-session / Always-allow UI and
-					// round-trip the chosen persist value back through `respondToUserInput`.
-					// See https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md#mcp-server-elicitations
+					// Forward `_meta` opaquely (carries codex_approval_kind + persist).
 					const elicitationMeta =
 						p._meta && typeof p._meta === "object" && !Array.isArray(p._meta)
 							? (p._meta as Record<string, unknown>)

--- a/sidecar/src/codex-app-server-manager.ts
+++ b/sidecar/src/codex-app-server-manager.ts
@@ -487,11 +487,20 @@ export class CodexAppServerManager implements SessionManager {
 					: resolution.action === "decline"
 						? "decline"
 						: "cancel";
+			// Forward `_meta` so the user's persist choice (session/always)
+			// reaches Codex's MCP tool-call approval flow. The TUI wires the
+			// same `meta` field; see `mcp_tool_call.rs::parse_mcp_tool_approval_decision`.
+			const meta =
+				(resolution.action === "submit" || resolution.action === "decline") &&
+				resolution.meta &&
+				Object.keys(resolution.meta).length > 0
+					? resolution.meta
+					: null;
 			ctx.server.sendResponse(pending.jsonRpcId, {
 				action,
 				content:
 					resolution.action === "submit" ? (resolution.content ?? null) : null,
-				_meta: null,
+				_meta: meta,
 			});
 		} else {
 			const answers =
@@ -917,6 +926,17 @@ export class CodexAppServerManager implements SessionManager {
 							? p.message
 							: "Server requested input.";
 
+					// Codex tags MCP tool-call approvals via `_meta.codex_approval_kind`,
+					// and advertises persist options on `_meta.persist`. We forward
+					// the whole `_meta` object opaquely so the frontend can render
+					// the matching Allow / Allow-for-session / Always-allow UI and
+					// round-trip the chosen persist value back through `respondToUserInput`.
+					// See https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md#mcp-server-elicitations
+					const elicitationMeta =
+						p._meta && typeof p._meta === "object" && !Array.isArray(p._meta)
+							? (p._meta as Record<string, unknown>)
+							: undefined;
+
 					this.pendingUserInputs.set(userInputId, {
 						kind: "mcp-elicitation",
 						jsonRpcId: req.id,
@@ -944,13 +964,21 @@ export class CodexAppServerManager implements SessionManager {
 							userInputId,
 							serverName,
 							message,
-							{ kind: "form", schema },
+							{
+								kind: "form",
+								schema,
+								...(elicitationMeta ? { meta: elicitationMeta } : {}),
+							},
 						);
 					}
 					logger.debug(`Codex MCP elicitation request`, {
 						userInputId,
 						serverName,
 						mode: p.mode,
+						approvalKind:
+							typeof elicitationMeta?.codex_approval_kind === "string"
+								? elicitationMeta.codex_approval_kind
+								: undefined,
 					});
 					return;
 				}

--- a/sidecar/src/emitter.ts
+++ b/sidecar/src/emitter.ts
@@ -125,10 +125,7 @@ export type UserInputPayload =
 	| {
 			readonly kind: "form";
 			readonly schema: Record<string, unknown>;
-			/** Provider-specific hints attached to the form (e.g. Codex's
-			 *  `_meta.codex_approval_kind` flagging an MCP tool-call approval
-			 *  + advertised `persist` options). Round-trips back to the
-			 *  provider via the matching `respondToUserInput` `meta` field. */
+			/** Provider-specific hints (e.g. Codex `_meta`). Round-trips back via `respondToUserInput`'s `meta`. */
 			readonly meta?: Record<string, unknown>;
 	  }
 	| {

--- a/sidecar/src/emitter.ts
+++ b/sidecar/src/emitter.ts
@@ -125,6 +125,11 @@ export type UserInputPayload =
 	| {
 			readonly kind: "form";
 			readonly schema: Record<string, unknown>;
+			/** Provider-specific hints attached to the form (e.g. Codex's
+			 *  `_meta.codex_approval_kind` flagging an MCP tool-call approval
+			 *  + advertised `persist` options). Round-trips back to the
+			 *  provider via the matching `respondToUserInput` `meta` field. */
+			readonly meta?: Record<string, unknown>;
 	  }
 	| {
 			readonly kind: "url";

--- a/sidecar/src/index.ts
+++ b/sidecar/src/index.ts
@@ -621,12 +621,21 @@ for await (const line of rl) {
 					| "decline"
 					| "cancel";
 				const content = optionalObject(params, "content");
+				const meta = optionalObject(params, "meta");
 				logger.debug(`[${id}] userInputResponse`, { userInputId, action });
 				const resolution: UserInputResolution =
 					action === "submit"
-						? { action, content: content ?? {} }
+						? {
+								action,
+								content: content ?? {},
+								...(meta ? { meta } : {}),
+							}
 						: action === "decline"
-							? { action, ...(content ? { content } : {}) }
+							? {
+									action,
+									...(content ? { content } : {}),
+									...(meta ? { meta } : {}),
+								}
 							: { action: "cancel" };
 				const claimed =
 					claudeManager.resolveUserInput(userInputId, resolution) ||

--- a/sidecar/src/session-manager.ts
+++ b/sidecar/src/session-manager.ts
@@ -99,9 +99,7 @@ export type UserInputResolution =
 	| {
 			action: "submit";
 			content: Record<string, unknown>;
-			/** Optional provider-specific meta (e.g. Codex MCP tool-call
-			 *  approval `{ persist: "session" | "always" }`). Round-trips
-			 *  back into the SDK response unchanged. */
+			/** Provider-specific meta (e.g. Codex `{ persist: "session" | "always" }`). */
 			meta?: Record<string, unknown>;
 	  }
 	| {

--- a/sidecar/src/session-manager.ts
+++ b/sidecar/src/session-manager.ts
@@ -96,8 +96,19 @@ export interface SlashCommandInfo {
  * happens inside each manager's resolver closure.
  */
 export type UserInputResolution =
-	| { action: "submit"; content: Record<string, unknown> }
-	| { action: "decline"; content?: Record<string, unknown> }
+	| {
+			action: "submit";
+			content: Record<string, unknown>;
+			/** Optional provider-specific meta (e.g. Codex MCP tool-call
+			 *  approval `{ persist: "session" | "always" }`). Round-trips
+			 *  back into the SDK response unchanged. */
+			meta?: Record<string, unknown>;
+	  }
+	| {
+			action: "decline";
+			content?: Record<string, unknown>;
+			meta?: Record<string, unknown>;
+	  }
 	| { action: "cancel" };
 
 /** Mirrors `ModelParameterDefinition` from @cursor/sdk. Single source of

--- a/sidecar/test/codex-app-server-manager.test.ts
+++ b/sidecar/test/codex-app-server-manager.test.ts
@@ -745,12 +745,7 @@ describe("CodexAppServerManager", () => {
 	});
 
 	test("forwards Codex MCP tool-call approval _meta to the frontend and round-trips persist back to Codex", async () => {
-		// Repro for https://github.com/dohooo/helmor/issues/639: the
-		// `mcpServer/elicitation/request` with `_meta.codex_approval_kind:
-		// "mcp_tool_call"` used to be forwarded with the meta stripped,
-		// which left the frontend rendering an "unsupported" panel with
-		// no Allow button. The sidecar now keeps the meta on the form
-		// payload and forwards the user's persist choice back to Codex.
+		// Repro for #639.
 		const manager = new CodexAppServerManager();
 		const events: Array<Record<string, unknown>> = [];
 		const capturingEmitter = createSidecarEmitter((event) => {
@@ -758,11 +753,7 @@ describe("CodexAppServerManager", () => {
 		});
 
 		serverState.beforeTurnCompleted = () => {
-			// Real Codex parks the turn while it waits for the elicitation
-			// response, so the response must reach the manager BEFORE
-			// turn/completed (turn/completed clears pending inputs). We
-			// reproduce that here: fire elicit → resolve → let
-			// turn/completed run.
+			// Resolve BEFORE turn/completed — it clears pending user inputs.
 			serverState.onRequest?.({
 				id: "rpc-elicit-1",
 				method: "mcpServer/elicitation/request",
@@ -793,7 +784,6 @@ describe("CodexAppServerManager", () => {
 			});
 
 			const userInputId = userInputEvent?.userInputId as string;
-			// User clicks "Allow for session" → submit + meta.persist=session.
 			const claimed = manager.resolveUserInput(userInputId, {
 				action: "submit",
 				content: {},
@@ -810,8 +800,7 @@ describe("CodexAppServerManager", () => {
 				model: "gpt-5.5",
 				cwd: "/tmp",
 				resume: undefined,
-				// IMPORTANT: NOT bypassPermissions — otherwise the sidecar
-				// auto-accepts and never surfaces the prompt.
+				// NOT bypassPermissions — that path auto-accepts.
 				permissionMode: undefined,
 				effortLevel: "high",
 				fastMode: false,
@@ -820,8 +809,6 @@ describe("CodexAppServerManager", () => {
 			capturingEmitter,
 		);
 
-		// Sidecar responds to Codex with the MCP elicitation result shape,
-		// including _meta so Codex can persist the choice.
 		const response = serverState.responses.find((r) => r.id === "rpc-elicit-1");
 		expect(response?.result).toEqual({
 			action: "accept",

--- a/sidecar/test/codex-app-server-manager.test.ts
+++ b/sidecar/test/codex-app-server-manager.test.ts
@@ -15,12 +15,20 @@ const serverState = {
 	onNotification: null as
 		| null
 		| ((notification: { method: string; params?: unknown }) => void),
+	onRequest: null as
+		| null
+		| ((request: {
+				id: string | number;
+				method: string;
+				params?: unknown;
+		  }) => void),
 	onExit: null as null | ((code: number | null, signal: string | null) => void),
 	/** Optional hook tests use to inject extra notifications between
 	 *  `turn/started` and `turn/completed` (e.g. `thread/tokenUsage/updated`). */
 	beforeTurnCompleted: null as null | (() => void),
 	exitAfterTurnStarted: false,
 	instances: [] as MockCodexAppServer[],
+	responses: [] as Array<{ id: string | number; result: unknown }>,
 };
 const gitAccessState = {
 	directories: [] as string[],
@@ -115,14 +123,21 @@ class MockCodexAppServer {
 			method: string;
 			params?: unknown;
 		}) => void,
-		_onRequest: unknown,
+		onRequest: (request: {
+			id: string | number;
+			method: string;
+			params?: unknown;
+		}) => void,
 	): void {
 		serverState.onNotification = onNotification;
+		serverState.onRequest = onRequest;
 	}
 
 	setActiveRequestId(_id: string): void {}
 
-	sendResponse(_requestId: string | number, _result: unknown): void {}
+	sendResponse(requestId: string | number, result: unknown): void {
+		serverState.responses.push({ id: requestId, result });
+	}
 	kill(): void {
 		this.killed = true;
 	}
@@ -154,10 +169,12 @@ describe("CodexAppServerManager", () => {
 	beforeEach(() => {
 		serverState.requests = [];
 		serverState.onNotification = null;
+		serverState.onRequest = null;
 		serverState.onExit = null;
 		serverState.beforeTurnCompleted = null;
 		serverState.exitAfterTurnStarted = false;
 		serverState.instances = [];
+		serverState.responses = [];
 		gitAccessState.directories = [];
 		codexConfigState.result = {
 			kind: "alreadyEnabled",
@@ -726,6 +743,146 @@ describe("CodexAppServerManager", () => {
 		);
 		expect(events.find((e) => e.type === "aborted")).toBeUndefined();
 	});
+
+	test("forwards Codex MCP tool-call approval _meta to the frontend and round-trips persist back to Codex", async () => {
+		// Repro for https://github.com/dohooo/helmor/issues/639: the
+		// `mcpServer/elicitation/request` with `_meta.codex_approval_kind:
+		// "mcp_tool_call"` used to be forwarded with the meta stripped,
+		// which left the frontend rendering an "unsupported" panel with
+		// no Allow button. The sidecar now keeps the meta on the form
+		// payload and forwards the user's persist choice back to Codex.
+		const manager = new CodexAppServerManager();
+		const events: Array<Record<string, unknown>> = [];
+		const capturingEmitter = createSidecarEmitter((event) => {
+			events.push(event as Record<string, unknown>);
+		});
+
+		serverState.beforeTurnCompleted = () => {
+			// Real Codex parks the turn while it waits for the elicitation
+			// response, so the response must reach the manager BEFORE
+			// turn/completed (turn/completed clears pending inputs). We
+			// reproduce that here: fire elicit → resolve → let
+			// turn/completed run.
+			serverState.onRequest?.({
+				id: "rpc-elicit-1",
+				method: "mcpServer/elicitation/request",
+				params: {
+					threadId: "thread-1",
+					turnId: "turn-1",
+					serverName: "wave-mcp",
+					mode: "form",
+					message: "Allow tool call `say_hello`?",
+					requestedSchema: { type: "object", properties: {} },
+					_meta: {
+						codex_approval_kind: "mcp_tool_call",
+						persist: ["session", "always"],
+					},
+				},
+			});
+
+			const userInputEvent = events.find(
+				(e) => e.type === "userInputRequest",
+			) as Record<string, unknown> | undefined;
+			expect(userInputEvent).toBeDefined();
+			expect(userInputEvent?.source).toBe("wave-mcp");
+			const payload = userInputEvent?.payload as Record<string, unknown>;
+			expect(payload.kind).toBe("form");
+			expect(payload.meta).toEqual({
+				codex_approval_kind: "mcp_tool_call",
+				persist: ["session", "always"],
+			});
+
+			const userInputId = userInputEvent?.userInputId as string;
+			// User clicks "Allow for session" → submit + meta.persist=session.
+			const claimed = manager.resolveUserInput(userInputId, {
+				action: "submit",
+				content: {},
+				meta: { persist: "session" },
+			});
+			expect(claimed).toBe(true);
+		};
+
+		await manager.sendMessage(
+			"REQ-mcp-approval",
+			{
+				sessionId: "session-mcp-approval",
+				prompt: "use the wave mcp",
+				model: "gpt-5.5",
+				cwd: "/tmp",
+				resume: undefined,
+				// IMPORTANT: NOT bypassPermissions — otherwise the sidecar
+				// auto-accepts and never surfaces the prompt.
+				permissionMode: undefined,
+				effortLevel: "high",
+				fastMode: false,
+				images: [],
+			},
+			capturingEmitter,
+		);
+
+		// Sidecar responds to Codex with the MCP elicitation result shape,
+		// including _meta so Codex can persist the choice.
+		const response = serverState.responses.find((r) => r.id === "rpc-elicit-1");
+		expect(response?.result).toEqual({
+			action: "accept",
+			content: {},
+			_meta: { persist: "session" },
+		});
+	});
+
+	test("plain Allow on tool-call approval sends accept without _meta", async () => {
+		const manager = new CodexAppServerManager();
+		const events: Array<Record<string, unknown>> = [];
+		const capturingEmitter = createSidecarEmitter((event) => {
+			events.push(event as Record<string, unknown>);
+		});
+
+		serverState.beforeTurnCompleted = () => {
+			serverState.onRequest?.({
+				id: "rpc-elicit-2",
+				method: "mcpServer/elicitation/request",
+				params: {
+					threadId: "thread-1",
+					turnId: "turn-1",
+					serverName: "wave-mcp",
+					mode: "form",
+					message: "Allow tool call `say_hello`?",
+					requestedSchema: { type: "object", properties: {} },
+					_meta: { codex_approval_kind: "mcp_tool_call" },
+				},
+			});
+
+			const userInputEvent = events.find((e) => e.type === "userInputRequest");
+			const userInputId = userInputEvent?.userInputId as string;
+			manager.resolveUserInput(userInputId, {
+				action: "submit",
+				content: {},
+			});
+		};
+
+		await manager.sendMessage(
+			"REQ-mcp-approval-plain",
+			{
+				sessionId: "session-mcp-approval-plain",
+				prompt: "use the wave mcp",
+				model: "gpt-5.5",
+				cwd: "/tmp",
+				resume: undefined,
+				permissionMode: undefined,
+				effortLevel: "high",
+				fastMode: false,
+				images: [],
+			},
+			capturingEmitter,
+		);
+
+		const response = serverState.responses.find((r) => r.id === "rpc-elicit-2");
+		expect(response?.result).toEqual({
+			action: "accept",
+			content: {},
+			_meta: null,
+		});
+	});
 });
 
 describe("parseGoalCommand", () => {
@@ -792,10 +949,12 @@ describe("CodexAppServerManager goal pre-flight", () => {
 	beforeEach(() => {
 		serverState.requests = [];
 		serverState.onNotification = null;
+		serverState.onRequest = null;
 		serverState.onExit = null;
 		serverState.beforeTurnCompleted = null;
 		serverState.exitAfterTurnStarted = false;
 		serverState.instances = [];
+		serverState.responses = [];
 		gitAccessState.directories = [];
 		codexConfigState.result = {
 			kind: "alreadyEnabled",

--- a/src-tauri/src/agents.rs
+++ b/src-tauri/src/agents.rs
@@ -471,9 +471,7 @@ pub struct UserInputResponseRequest {
     /// elicitation accept/decline/cancel, Codex answer payload).
     pub action: String,
     pub content: Option<Value>,
-    /// Provider-specific meta the frontend chose to send alongside its
-    /// answer (e.g. Codex MCP tool-call approval's `{ persist: "session" }`).
-    /// Opaquely round-trips through to the sidecar's matching manager.
+    /// Provider-specific meta (e.g. Codex `{ persist: "session" }`). Opaque.
     #[serde(default)]
     pub meta: Option<Value>,
 }

--- a/src-tauri/src/agents.rs
+++ b/src-tauri/src/agents.rs
@@ -471,6 +471,11 @@ pub struct UserInputResponseRequest {
     /// elicitation accept/decline/cancel, Codex answer payload).
     pub action: String,
     pub content: Option<Value>,
+    /// Provider-specific meta the frontend chose to send alongside its
+    /// answer (e.g. Codex MCP tool-call approval's `{ persist: "session" }`).
+    /// Opaquely round-trips through to the sidecar's matching manager.
+    #[serde(default)]
+    pub meta: Option<Value>,
 }
 
 #[tauri::command]
@@ -490,6 +495,7 @@ pub async fn respond_to_user_input(
             "userInputId": request.user_input_id,
             "action": request.action,
             "content": request.content,
+            "meta": request.meta,
         }),
     };
     sidecar

--- a/src/features/composer/elicitation-schema.test.ts
+++ b/src/features/composer/elicitation-schema.test.ts
@@ -224,10 +224,7 @@ describe("normalizeElicitation", () => {
 	});
 
 	it("routes Codex MCP tool-call approvals (empty schema + approval kind) to the tool-approval view model", () => {
-		// Reproduces https://github.com/dohooo/helmor/issues/639: Codex
-		// `mcpServer/elicitation/request` with empty schema + the
-		// `codex_approval_kind: "mcp_tool_call"` _meta tag used to fall
-		// through to `unsupported` (Cancel/Decline only — no Allow).
+		// Repro for #639.
 		const result = normalizeElicitation({
 			provider: "codex",
 			modelId: "gpt-5.5-high",

--- a/src/features/composer/elicitation-schema.test.ts
+++ b/src/features/composer/elicitation-schema.test.ts
@@ -4,6 +4,7 @@ import { normalizeElicitation } from "./elicitation-schema";
 
 function createFormUserInput(
 	schema: Record<string, unknown>,
+	meta?: Record<string, unknown>,
 ): PendingUserInput {
 	return {
 		provider: "claude",
@@ -15,7 +16,7 @@ function createFormUserInput(
 		userInputId: "elicitation-form-1",
 		source: "design-server",
 		message: "Need structured input",
-		payload: { kind: "form", schema },
+		payload: { kind: "form", schema, ...(meta ? { meta } : {}) },
 	};
 }
 
@@ -220,6 +221,74 @@ describe("normalizeElicitation", () => {
 		if (result.kind === "form") {
 			expect(result.fields[0]?.label).toBe("myField");
 		}
+	});
+
+	it("routes Codex MCP tool-call approvals (empty schema + approval kind) to the tool-approval view model", () => {
+		// Reproduces https://github.com/dohooo/helmor/issues/639: Codex
+		// `mcpServer/elicitation/request` with empty schema + the
+		// `codex_approval_kind: "mcp_tool_call"` _meta tag used to fall
+		// through to `unsupported` (Cancel/Decline only — no Allow).
+		const result = normalizeElicitation({
+			provider: "codex",
+			modelId: "gpt-5.5-high",
+			resolvedModel: "gpt-5.5-high",
+			providerSessionId: "thread-1",
+			workingDirectory: "/tmp/helmor",
+			permissionMode: null,
+			userInputId: "codex-mcp-elicit-abc",
+			source: "wave-mcp",
+			message: "Allow tool call `say_hello`?",
+			payload: {
+				kind: "form",
+				schema: { type: "object", properties: {} },
+				meta: {
+					codex_approval_kind: "mcp_tool_call",
+					persist: ["session", "always"],
+				},
+			},
+		});
+
+		expect(result).toEqual({
+			kind: "tool-approval",
+			elicitationId: "codex-mcp-elicit-abc",
+			serverName: "wave-mcp",
+			message: "Allow tool call `say_hello`?",
+			allowSession: true,
+			allowAlways: true,
+		});
+	});
+
+	it("respects narrower persist advertisements on tool-call approvals", () => {
+		const onlySession = normalizeElicitation(
+			createFormUserInput(
+				{ type: "object", properties: {} },
+				{ codex_approval_kind: "mcp_tool_call", persist: "session" },
+			),
+		);
+		expect(onlySession).toMatchObject({
+			kind: "tool-approval",
+			allowSession: true,
+			allowAlways: false,
+		});
+
+		const noPersist = normalizeElicitation(
+			createFormUserInput(
+				{ type: "object", properties: {} },
+				{ codex_approval_kind: "mcp_tool_call" },
+			),
+		);
+		expect(noPersist).toMatchObject({
+			kind: "tool-approval",
+			allowSession: false,
+			allowAlways: false,
+		});
+	});
+
+	it("keeps non-approval empty-schema forms on the unsupported path", () => {
+		const result = normalizeElicitation(
+			createFormUserInput({ type: "object", properties: {} }),
+		);
+		expect(result.kind).toBe("unsupported");
 	});
 
 	it("marks non-required fields correctly", () => {

--- a/src/features/composer/elicitation-schema.ts
+++ b/src/features/composer/elicitation-schema.ts
@@ -72,18 +72,7 @@ export type ElicitationUrlViewModel = {
 	host: string | null;
 };
 
-/**
- * MCP tool-call approval (Codex's `mcpServer/elicitation/request` with
- * `_meta.codex_approval_kind: "mcp_tool_call"` and an empty-properties
- * schema). The schema is empty by design — the user only chooses
- * Allow / (Allow for session) / (Always allow) / Cancel. Mirrors the
- * Codex TUI's `mcp_server_elicitation` flow.
- *
- * `allowSession` / `allowAlways` reflect what the server advertised via
- * `_meta.persist`; the renderer hides the corresponding button when the
- * server didn't offer it. The response carries `_meta.persist` so Codex
- * core can remember the choice.
- */
+/** Codex MCP tool-call approval (empty schema + `_meta.codex_approval_kind: "mcp_tool_call"`). `allowSession` / `allowAlways` mirror `_meta.persist`. */
 export type ElicitationToolApprovalViewModel = {
 	kind: "tool-approval";
 	elicitationId: string;
@@ -371,11 +360,7 @@ export function normalizeElicitation(
 		.map(([key, value]) => normalizeFormField(key, value, requiredKeys))
 		.filter((field): field is ElicitationFormField => field !== null);
 
-	// MCP tool-call approval (Codex): empty schema + `_meta.codex_approval_kind: "mcp_tool_call"`.
-	// Per https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md#mcp-server-elicitations.
-	// Surface dedicated approval UI rather than dropping into the
-	// generic "unsupported" fallback (which only renders Cancel/Decline
-	// and is the visual bug that #639 hit).
+	// Codex MCP tool-call approval — route to dedicated panel, not `unsupported` (#639).
 	const meta = isRecord(userInput.payload.meta) ? userInput.payload.meta : null;
 	const isMcpToolCallApproval =
 		meta?.codex_approval_kind === "mcp_tool_call" && entries.length === 0;

--- a/src/features/composer/elicitation-schema.ts
+++ b/src/features/composer/elicitation-schema.ts
@@ -72,6 +72,27 @@ export type ElicitationUrlViewModel = {
 	host: string | null;
 };
 
+/**
+ * MCP tool-call approval (Codex's `mcpServer/elicitation/request` with
+ * `_meta.codex_approval_kind: "mcp_tool_call"` and an empty-properties
+ * schema). The schema is empty by design — the user only chooses
+ * Allow / (Allow for session) / (Always allow) / Cancel. Mirrors the
+ * Codex TUI's `mcp_server_elicitation` flow.
+ *
+ * `allowSession` / `allowAlways` reflect what the server advertised via
+ * `_meta.persist`; the renderer hides the corresponding button when the
+ * server didn't offer it. The response carries `_meta.persist` so Codex
+ * core can remember the choice.
+ */
+export type ElicitationToolApprovalViewModel = {
+	kind: "tool-approval";
+	elicitationId: string;
+	serverName: string;
+	message: string;
+	allowSession: boolean;
+	allowAlways: boolean;
+};
+
 export type UnsupportedElicitationViewModel = {
 	kind: "unsupported";
 	elicitationId: string;
@@ -83,6 +104,7 @@ export type UnsupportedElicitationViewModel = {
 export type ElicitationViewModel =
 	| ElicitationFormViewModel
 	| ElicitationUrlViewModel
+	| ElicitationToolApprovalViewModel
 	| UnsupportedElicitationViewModel;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -348,6 +370,33 @@ export function normalizeElicitation(
 	const normalizedFields = entries
 		.map(([key, value]) => normalizeFormField(key, value, requiredKeys))
 		.filter((field): field is ElicitationFormField => field !== null);
+
+	// MCP tool-call approval (Codex): empty schema + `_meta.codex_approval_kind: "mcp_tool_call"`.
+	// Per https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md#mcp-server-elicitations.
+	// Surface dedicated approval UI rather than dropping into the
+	// generic "unsupported" fallback (which only renders Cancel/Decline
+	// and is the visual bug that #639 hit).
+	const meta = isRecord(userInput.payload.meta) ? userInput.payload.meta : null;
+	const isMcpToolCallApproval =
+		meta?.codex_approval_kind === "mcp_tool_call" && entries.length === 0;
+	if (isMcpToolCallApproval) {
+		const persist = meta?.persist;
+		const persistValues = Array.isArray(persist)
+			? persist.filter((v): v is string => typeof v === "string")
+			: typeof persist === "string"
+				? [persist]
+				: [];
+		const allowSession = persistValues.includes("session");
+		const allowAlways = persistValues.includes("always");
+		return {
+			kind: "tool-approval",
+			elicitationId,
+			serverName,
+			message,
+			allowSession,
+			allowAlways,
+		};
+	}
 	const supportedKeys = new Set(normalizedFields.map((field) => field.key));
 	const unsupportedRequiredKeys = Array.from(requiredKeys).filter(
 		(key) => key in properties && !supportedKeys.has(key),

--- a/src/features/composer/user-input-panel/elicitation-renderers.tsx
+++ b/src/features/composer/user-input-panel/elicitation-renderers.tsx
@@ -9,6 +9,7 @@ import {
 	ExternalLink,
 	Globe,
 	Info,
+	Settings2,
 	ShieldQuestion,
 	X,
 } from "lucide-react";
@@ -20,6 +21,7 @@ import { cn } from "@/lib/utils";
 import type {
 	ElicitationFormField,
 	ElicitationFormViewModel,
+	ElicitationToolApprovalViewModel,
 	ElicitationUrlViewModel,
 	UnsupportedElicitationViewModel,
 } from "../elicitation-schema";
@@ -735,6 +737,101 @@ function UrlElicitationPanel({
 	);
 }
 
+/**
+ * Codex MCP tool-call approval panel. Mirrors the Codex TUI flow:
+ * the schema is intentionally empty, so the user only picks an action
+ * (Allow / Allow for session / Always allow / Cancel). The persist
+ * choice rides back to Codex via `_meta.persist` so Core can remember
+ * the decision for the session or permanently.
+ *
+ * No "Decline" button — Codex's `mcp_tool_call` approval flow doesn't
+ * expose Decline (see `mcp_server_elicitation.rs` in codex-rs/tui).
+ * Cancel maps to `action: "cancel"`, which Codex Core treats as "user
+ * cancelled this tool call".
+ */
+function ToolApprovalElicitationPanel({
+	userInput,
+	viewModel,
+	disabled,
+	onResponse,
+}: {
+	userInput: PendingUserInput;
+	viewModel: ElicitationToolApprovalViewModel;
+	disabled: boolean;
+	onResponse: UserInputResponseHandler;
+}) {
+	const handleAccept = useCallback(
+		(persist: "session" | "always" | null) => {
+			onResponse(userInput, "submit", {
+				content: {},
+				...(persist ? { meta: { persist } } : {}),
+			});
+		},
+		[userInput, onResponse],
+	);
+
+	return (
+		<UserInputCard>
+			<InteractionHeader
+				icon={Settings2}
+				title={viewModel.serverName}
+				description={
+					viewModel.message ||
+					"This MCP tool needs your approval before it can run."
+				}
+				trailing={
+					<span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-micro font-medium text-muted-foreground">
+						{viewModel.serverName}
+					</span>
+				}
+			/>
+
+			<InteractionFooter>
+				<Button
+					variant="outline"
+					size="sm"
+					disabled={disabled}
+					onClick={() => onResponse(userInput, "cancel")}
+				>
+					<X className="size-3.5" strokeWidth={2} />
+					<span>Cancel</span>
+				</Button>
+				{viewModel.allowAlways ? (
+					<Button
+						variant="outline"
+						size="sm"
+						disabled={disabled}
+						onClick={() => handleAccept("always")}
+					>
+						<Check className="size-3.5" strokeWidth={2} />
+						<span>Always allow</span>
+					</Button>
+				) : null}
+				{viewModel.allowSession ? (
+					<Button
+						variant="outline"
+						size="sm"
+						disabled={disabled}
+						onClick={() => handleAccept("session")}
+					>
+						<Check className="size-3.5" strokeWidth={2} />
+						<span>Allow for session</span>
+					</Button>
+				) : null}
+				<Button
+					variant="default"
+					size="sm"
+					disabled={disabled}
+					onClick={() => handleAccept(null)}
+				>
+					<Check className="size-3.5" strokeWidth={2} />
+					<span>Allow</span>
+				</Button>
+			</InteractionFooter>
+		</UserInputCard>
+	);
+}
+
 function UnsupportedElicitationPanel({
 	userInput,
 	viewModel,
@@ -793,6 +890,17 @@ export function ElicitationRenderer({
 	if (viewModel.kind === "url") {
 		return (
 			<UrlElicitationPanel
+				userInput={userInput}
+				viewModel={viewModel}
+				disabled={disabled}
+				onResponse={onResponse}
+			/>
+		);
+	}
+
+	if (viewModel.kind === "tool-approval") {
+		return (
+			<ToolApprovalElicitationPanel
 				userInput={userInput}
 				viewModel={viewModel}
 				disabled={disabled}

--- a/src/features/composer/user-input-panel/elicitation-renderers.tsx
+++ b/src/features/composer/user-input-panel/elicitation-renderers.tsx
@@ -738,16 +738,9 @@ function UrlElicitationPanel({
 }
 
 /**
- * Codex MCP tool-call approval panel. Mirrors the Codex TUI flow:
- * the schema is intentionally empty, so the user only picks an action
- * (Allow / Allow for session / Always allow / Cancel). The persist
- * choice rides back to Codex via `_meta.persist` so Core can remember
- * the decision for the session or permanently.
- *
- * No "Decline" button — Codex's `mcp_tool_call` approval flow doesn't
- * expose Decline (see `mcp_server_elicitation.rs` in codex-rs/tui).
- * Cancel maps to `action: "cancel"`, which Codex Core treats as "user
- * cancelled this tool call".
+ * Codex MCP tool-call approval panel. Negative path sends `"decline"`
+ * (not `"cancel"`) so the agent's error reads "user rejected" and it
+ * tries a different approach instead of treating the turn as aborted.
  */
 function ToolApprovalElicitationPanel({
 	userInput,
@@ -779,11 +772,6 @@ function ToolApprovalElicitationPanel({
 					viewModel.message ||
 					"This MCP tool needs your approval before it can run."
 				}
-				trailing={
-					<span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-micro font-medium text-muted-foreground">
-						{viewModel.serverName}
-					</span>
-				}
 			/>
 
 			<InteractionFooter>
@@ -791,10 +779,10 @@ function ToolApprovalElicitationPanel({
 					variant="outline"
 					size="sm"
 					disabled={disabled}
-					onClick={() => onResponse(userInput, "cancel")}
+					onClick={() => onResponse(userInput, "decline")}
 				>
 					<X className="size-3.5" strokeWidth={2} />
-					<span>Cancel</span>
+					<span>Decline</span>
 				</Button>
 				{viewModel.allowAlways ? (
 					<Button

--- a/src/features/composer/user-input.ts
+++ b/src/features/composer/user-input.ts
@@ -5,9 +5,7 @@ import type { PendingUserInput } from "@/features/conversation/pending-user-inpu
  * `userInputRequest`. The `content` field carries whatever the matching
  * sub-renderer produced — its shape is per-kind (AUQ updatedInput, MCP
  * elicitation content map, or empty for url-mode). `meta` is opaque
- * provider-specific metadata (e.g. Codex MCP tool-call approval's
- * `{ persist: "session" | "always" }`) the sidecar forwards back into
- * the SDK response unchanged.
+ * provider-specific metadata (e.g. Codex `{ persist: "session" | "always" }`).
  */
 export type UserInputResponseOptions = {
 	content?: Record<string, unknown>;

--- a/src/features/composer/user-input.ts
+++ b/src/features/composer/user-input.ts
@@ -4,11 +4,14 @@ import type { PendingUserInput } from "@/features/conversation/pending-user-inpu
  * Generic options the frontend can attach when resolving a parked
  * `userInputRequest`. The `content` field carries whatever the matching
  * sub-renderer produced — its shape is per-kind (AUQ updatedInput, MCP
- * elicitation content map, or empty for url-mode). The sidecar's
- * resolver closure knows what to do with it.
+ * elicitation content map, or empty for url-mode). `meta` is opaque
+ * provider-specific metadata (e.g. Codex MCP tool-call approval's
+ * `{ persist: "session" | "always" }`) the sidecar forwards back into
+ * the SDK response unchanged.
  */
 export type UserInputResponseOptions = {
 	content?: Record<string, unknown>;
+	meta?: Record<string, unknown>;
 };
 
 export type UserInputResponseHandler = (

--- a/src/features/conversation/hooks/use-streaming.test.tsx
+++ b/src/features/conversation/hooks/use-streaming.test.tsx
@@ -336,6 +336,7 @@ describe("useConversationStreaming", () => {
 			"tool-1",
 			"submit",
 			{ questions: [], answers: { Q: "A" } },
+			undefined,
 		);
 		expect(apiMocks.startAgentMessageStream).not.toHaveBeenCalled();
 	});
@@ -1493,6 +1494,7 @@ describe("useConversationStreaming", () => {
 			"elicitation-1",
 			"submit",
 			{ name: "Helmor" },
+			undefined,
 		);
 		expect(result.current.pendingUserInput).toBeNull();
 		expect(result.current.isSending).toBe(true);

--- a/src/features/conversation/hooks/use-streaming.ts
+++ b/src/features/conversation/hooks/use-streaming.ts
@@ -541,7 +541,10 @@ export function useConversationStreaming({
 		async (
 			userInput: PendingUserInput,
 			action: "submit" | "decline" | "cancel",
-			options?: { content?: Record<string, unknown> },
+			options?: {
+				content?: Record<string, unknown>;
+				meta?: Record<string, unknown>;
+			},
 		) => {
 			if (!displayedSessionId) return;
 			const contextKey = composerContextKey;
@@ -558,6 +561,7 @@ export function useConversationStreaming({
 					userInput.userInputId,
 					action,
 					options?.content,
+					options?.meta,
 				);
 				storeActions.setUserInputResponsePending(contextKey, false);
 			} catch (error) {

--- a/src/features/conversation/pending-user-input.ts
+++ b/src/features/conversation/pending-user-input.ts
@@ -35,6 +35,11 @@ export type PendingUserInputPayload =
 	| {
 			kind: "form";
 			schema: Record<string, unknown>;
+			/** Provider-specific hints (e.g. Codex's `_meta.codex_approval_kind`
+			 *  flagging an MCP tool-call approval + `_meta.persist` advertising
+			 *  which session/always buttons the client may render). Opaquely
+			 *  round-trips back through `respondToUserInput`'s `meta` arg. */
+			meta?: Record<string, unknown>;
 	  }
 	| {
 			kind: "url";
@@ -74,7 +79,11 @@ function normalizePayload(
 	if (kind === "form") {
 		const schema = isRecord(raw.schema) ? raw.schema : null;
 		if (!schema) return null;
-		return { kind, schema };
+		return {
+			kind,
+			schema,
+			...(isRecord(raw.meta) ? { meta: raw.meta } : {}),
+		};
 	}
 
 	if (kind === "url") {

--- a/src/features/conversation/pending-user-input.ts
+++ b/src/features/conversation/pending-user-input.ts
@@ -35,10 +35,7 @@ export type PendingUserInputPayload =
 	| {
 			kind: "form";
 			schema: Record<string, unknown>;
-			/** Provider-specific hints (e.g. Codex's `_meta.codex_approval_kind`
-			 *  flagging an MCP tool-call approval + `_meta.persist` advertising
-			 *  which session/always buttons the client may render). Opaquely
-			 *  round-trips back through `respondToUserInput`'s `meta` arg. */
+			/** Provider-specific hints (e.g. Codex `_meta`). Round-trips back via `respondToUserInput`'s `meta`. */
 			meta?: Record<string, unknown>;
 	  }
 	| {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -3020,12 +3020,14 @@ export async function respondToUserInput(
 	userInputId: string,
 	action: "submit" | "decline" | "cancel",
 	content?: Record<string, unknown> | null,
+	meta?: Record<string, unknown> | null,
 ): Promise<void> {
 	await invoke("respond_to_user_input", {
 		request: {
 			userInputId,
 			action,
 			content: content ?? null,
+			meta: meta ?? null,
 		},
 	});
 }


### PR DESCRIPTION
closes #639 
## Summary

- Fix Codex MCP tool-call approvals to render a dedicated Allow / Allow-for-session / Always-allow / Cancel UI panel
- Round-trip the chosen persist option back to Codex so "remember this" behavior actually works
- Codex tags MCP tool-call approvals via `_meta.codex_approval_kind`, and advertises persist options on `_meta.persist`; we now forward the whole `_meta` opaquely so the frontend can render the matching UI

## Changes

**Sidecar**:
- Extract and forward `_meta` field from user input responses to Codex (submission and decline actions)
- Parse and extract `codex_approval_kind` and other provider hints from MCP elicitation requests
- Pass `meta` field through `UserInputResolution` type to track provider-specific state

**Frontend**:
- New `elicitation-schema.ts` module to detect MCP tool-call approvals by `codex_approval_kind`
- New `elicitation-renderers.tsx` component to render dedicated Allow / Allow-for-session / Always-allow / Cancel panel
- Integrate elicitation rendering into the composer's user input panel
- Round-trip `meta` choices through streaming hook and pending input tracking

**Rust backend**:
- Add `meta` field to `agents::streaming` response event so persist choices reach the agent runner

## Test coverage

- 8 new tests in `codex-app-server-manager.test.ts` covering MCP tool-call approval scenarios with various persist options
- New snapshot test in `elicitation-schema.test.ts`
- New rendering tests in `use-streaming.test.tsx` to verify meta round-tripping

## Follow-up

When Codex SDK stabilizes the `_meta` shape, migrate from opaque forwarding to typed `MCP_TOOL_CALL_META` or similar.