### PR TITLE
Adjust new workspace shortcuts

### DIFF
--- a/.announcements/new-workspace-shortcuts.json
+++ b/.announcements/new-workspace-shortcuts.json
@@ -1,0 +1,11 @@
+{
+	"items": [
+		{
+			"text": "Cmd+Shift+N now opens the new-workspace composer in Just-chat mode, and Cmd+N opens it in worktree mode.",
+			"action": {
+				"label": "Open Shortcuts",
+				"value": { "type": "openSettings", "section": "shortcuts" }
+			}
+		}
+	]
+}

--- a/.changeset/quiet-shortcuts-flip.md
+++ b/.changeset/quiet-shortcuts-flip.md
@@ -1,0 +1,8 @@
+---
+"helmor": patch
+---
+
+Refresh the new-workspace keyboard shortcuts:
+- Cmd+N opens the start composer directly in worktree mode.
+- Cmd+Shift+N now opens the start composer in Just-chat mode.
+- The previous Cmd+Shift+N "Add repository" binding is unbound by default and can be re-bound in Settings → Shortcuts.

--- a/src/App.shortcuts.test.tsx
+++ b/src/App.shortcuts.test.tsx
@@ -664,7 +664,7 @@ describe("App global navigation shortcuts", () => {
 		});
 	});
 
-	it("opens the workspace start composer on Command+N", async () => {
+	it("opens the workspace start composer in worktree mode on Command+N", async () => {
 		await renderAppReady();
 
 		fireEvent.keyDown(window, {
@@ -677,6 +677,8 @@ describe("App global navigation shortcuts", () => {
 		expect(
 			screen.getByRole("button", { name: "New Workspace" }),
 		).toBeDisabled();
+		// Mode picker trigger reflects the forced worktree mode.
+		expect(await screen.findByText("New worktree")).toBeInTheDocument();
 	});
 
 	it("focuses the start composer on Command+L", async () => {
@@ -699,7 +701,7 @@ describe("App global navigation shortcuts", () => {
 		});
 	});
 
-	it("opens the add repository menu on Command+Shift+N", async () => {
+	it("opens the workspace start composer in Just-chat mode on Command+Shift+N", async () => {
 		await renderAppReady();
 
 		fireEvent.keyDown(window, {
@@ -709,7 +711,31 @@ describe("App global navigation shortcuts", () => {
 			shiftKey: true,
 		});
 
-		await screen.findByRole("menuitem", { name: /Open project/i });
+		expect(await screen.findByLabelText("Workspace input")).toBeInTheDocument();
+		// Default persisted mode is `worktree`; the trigger label flipping to
+		// "Just chat" proves the Cmd+Shift+N transient override applied.
+		expect(await screen.findByText("Just chat")).toBeInTheDocument();
+	});
+
+	it("Command+N flips back to worktree even after a prior Command+Shift+N", async () => {
+		await renderAppReady();
+
+		fireEvent.keyDown(window, {
+			key: "n",
+			code: "KeyN",
+			metaKey: true,
+			shiftKey: true,
+		});
+		expect(await screen.findByText("Just chat")).toBeInTheDocument();
+
+		fireEvent.keyDown(window, {
+			key: "n",
+			code: "KeyN",
+			metaKey: true,
+		});
+		// Pressing Cmd+N while the start surface is already up replaces the
+		// transient override; the trigger label flips back to worktree.
+		expect(await screen.findByText("New worktree")).toBeInTheDocument();
 	});
 
 	it("toggles the context panel on Option+Command+C", async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -447,6 +447,7 @@ function AppShell({
 			repositories,
 			pushToast: pushWorkspaceToast,
 			getViewMode: () => selectionActions.getSnapshot().viewMode,
+			viewMode: selection.viewMode,
 			openWorkspaceStart: () => selectionActions.openStart(),
 			setViewMode: (mode) => selectionActions.setViewMode(mode),
 			selectWorkspace: (id) => handleSelectWorkspace(id),
@@ -1226,7 +1227,16 @@ function AppShell({
 			},
 			{
 				id: "workspace.new" as const,
-				callback: () => publishShellEvent({ type: "open-new-workspace" }),
+				// Force the start composer into worktree mode for this open;
+				// the persisted default mode is left untouched.
+				callback: () =>
+					publishShellEvent({ type: "open-new-workspace", mode: "worktree" }),
+			},
+			{
+				id: "workspace.justChat" as const,
+				// Same as `workspace.new` but lands in Just-chat mode.
+				callback: () =>
+					publishShellEvent({ type: "open-new-workspace", mode: "chat" }),
 			},
 			{
 				id: "workspace.addRepository" as const,

--- a/src/features/shortcuts/registry.ts
+++ b/src/features/shortcuts/registry.ts
@@ -96,9 +96,17 @@ export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
 	},
 	{
 		id: "workspace.new",
-		title: "Create new workspace",
+		title: "Create new workspace (worktree)",
 		group: "Workspace",
 		defaultHotkey: "Mod+N",
+		scopes: ["app"],
+		editable: true,
+	},
+	{
+		id: "workspace.justChat",
+		title: "Create new workspace (just chat)",
+		group: "Workspace",
+		defaultHotkey: "Mod+Shift+N",
 		scopes: ["app"],
 		editable: true,
 	},
@@ -106,7 +114,9 @@ export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
 		id: "workspace.addRepository",
 		title: "Add repository",
 		group: "Workspace",
-		defaultHotkey: "Mod+Shift+N",
+		// Unbound by default — Mod+Shift+N now opens the start composer in
+		// "Just chat" mode. Users can rebind from settings if they want.
+		defaultHotkey: null,
 		scopes: ["app"],
 		editable: true,
 	},

--- a/src/features/shortcuts/types.ts
+++ b/src/features/shortcuts/types.ts
@@ -4,6 +4,7 @@ export type ShortcutId =
 	| "workspace.quickSwitchNext"
 	| "workspace.quickSwitchPrevious"
 	| "workspace.new"
+	| "workspace.justChat"
 	| "workspace.addRepository"
 	| "workspace.filterSidebar"
 	| "workspace.copyPath"

--- a/src/features/workspace-start/index.tsx
+++ b/src/features/workspace-start/index.tsx
@@ -128,6 +128,13 @@ export function WorkspaceStartPage({
 		settings.shortcuts,
 		"startSurface.cycleRepository",
 	);
+	// Mode-picker shortcuts surfaced inside each menu item, matching the
+	// "label + kbd badges" pattern used elsewhere in the app.
+	const newWorktreeShortcut = getShortcut(settings.shortcuts, "workspace.new");
+	const justChatShortcut = getShortcut(
+		settings.shortcuts,
+		"workspace.justChat",
+	);
 
 	const selectNextRepository = useCallback(() => {
 		if (repositories.length === 0) {
@@ -540,6 +547,12 @@ export function WorkspaceStartPage({
 										>
 											<MessageCircle className="size-3.5" strokeWidth={1.8} />
 											<span>Just chat</span>
+											{justChatShortcut ? (
+												<InlineShortcutDisplay
+													hotkey={justChatShortcut}
+													className="ml-auto text-muted-foreground"
+												/>
+											) : null}
 										</DropdownMenuItem>
 									</>
 								) : (
@@ -559,6 +572,12 @@ export function WorkspaceStartPage({
 										>
 											<Split className="size-3.5 rotate-90" strokeWidth={1.8} />
 											<span>New worktree</span>
+											{newWorktreeShortcut ? (
+												<InlineShortcutDisplay
+													hotkey={newWorktreeShortcut}
+													className="ml-auto text-muted-foreground"
+												/>
+											) : null}
 										</DropdownMenuItem>
 										<DropdownMenuItem
 											onClick={() => onModeChange("chat")}
@@ -567,6 +586,12 @@ export function WorkspaceStartPage({
 										>
 											<MessageCircle className="size-3.5" strokeWidth={1.8} />
 											<span>Just chat</span>
+											{justChatShortcut ? (
+												<InlineShortcutDisplay
+													hotkey={justChatShortcut}
+													className="ml-auto text-muted-foreground"
+												/>
+											) : null}
 										</DropdownMenuItem>
 									</>
 								)}

--- a/src/shell/controllers/use-start-surface-controller.ts
+++ b/src/shell/controllers/use-start-surface-controller.ts
@@ -38,6 +38,7 @@ import { describeUnknownError } from "@/lib/workspace-helpers";
 import type { PushWorkspaceToast } from "@/lib/workspace-toast-context";
 import { EMPTY_STRING_LIST } from "@/shell/constants";
 import type { ShellViewMode } from "@/shell/controllers/use-selection-controller";
+import { useShellEvent } from "@/shell/event-bus";
 import {
 	useLatestRef,
 	useStableActions,
@@ -98,6 +99,8 @@ export type StartSurfaceControllerDeps = {
 	repositories: RepositoryCreateOption[];
 	pushToast: PushWorkspaceToast;
 	getViewMode(): ShellViewMode;
+	/** Reactive view-mode used to clear the one-shot mode override on exit. */
+	viewMode: ShellViewMode;
 	openWorkspaceStart(): void;
 	setViewMode(mode: ShellViewMode): void;
 	selectWorkspace(workspaceId: string): void;
@@ -137,6 +140,15 @@ export function useStartSurfaceController(
 	>(null);
 	const [startPendingLinkedDirectories, setStartPendingLinkedDirectories] =
 		useState<readonly string[]>(EMPTY_STRING_LIST);
+	// One-shot mode override set by the `Cmd+N` / `Cmd+Shift+N` shortcuts
+	// (carried via the `open-new-workspace` event's `mode` payload). Wins
+	// over the persisted preference for the lifetime of the current visit
+	// to the start surface. Cleared when the user (a) manually picks a
+	// different mode in the composer, or (b) leaves the start surface — so
+	// the next non-shortcut entry (e.g. sidebar "New workspace" button)
+	// falls back to the persisted default.
+	const [transientModeOverride, setTransientModeOverride] =
+		useState<WorkspaceMode | null>(null);
 
 	// Pickers read from settings; writes go through `updateSettings`.
 	const prefs = appSettings.startSurfacePreferences;
@@ -147,9 +159,15 @@ export function useStartSurfaceController(
 		startRepositoryId,
 		START_SURFACE_MODE_FALLBACK,
 	);
-	// No repos → lock to chat (worktree/local can't run without one).
+	// No repos → lock to chat (worktree/local can't run without one);
+	// the transient override is ignored in this case so `Cmd+N` falls back
+	// to chat cleanly. Otherwise, transient (shortcut-driven) > persisted
+	// prefs > per-repo work mode.
 	const startMode: WorkspaceMode =
-		repositories.length === 0 || prefs.chatModeActive ? "chat" : repoWorkMode;
+		repositories.length === 0
+			? "chat"
+			: (transientModeOverride ??
+				(prefs.chatModeActive ? "chat" : repoWorkMode));
 	const startBranchIntent = readRepoPreference(
 		prefs.branchIntentByRepoId,
 		startRepositoryId,
@@ -217,6 +235,25 @@ export function useStartSurfaceController(
 		setStartPendingLinkedDirectories(EMPTY_STRING_LIST);
 	}, [startRepositoryId]);
 
+	// Drop the one-shot mode override whenever we leave the start surface.
+	// Re-entry via a non-shortcut path (sidebar "New workspace" button,
+	// boot rehydration, etc.) should honor the user's persisted default.
+	useEffect(() => {
+		if (deps.viewMode !== "start") {
+			setTransientModeOverride(null);
+		}
+	}, [deps.viewMode]);
+
+	// `Cmd+N` / `Cmd+Shift+N` publish this event with a `mode` payload to
+	// force the start composer's initial mode for the current open without
+	// writing to settings. Plain `open-new-workspace` (no payload) leaves
+	// the persisted preference untouched.
+	useShellEvent("open-new-workspace", (event) => {
+		if (event.mode) {
+			setTransientModeOverride(event.mode);
+		}
+	});
+
 	// In local mode default to repo HEAD; worktree mode keeps stored default.
 	const startLocalCurrentBranchQuery = useQuery({
 		queryKey: ["repoCurrentBranch", startRepository?.id],
@@ -282,6 +319,9 @@ export function useStartSurfaceController(
 
 	const selectMode = useCallback(
 		(mode: WorkspaceMode) => {
+			// Manual pick supersedes any shortcut-driven override and gets
+			// persisted via the normal `updateSettings` path below.
+			setTransientModeOverride(null);
 			// pendingNewBranch is local-mode-only; clear it on any mode flip.
 			setStartPendingNewBranch(null);
 

--- a/src/shell/event-bus.ts
+++ b/src/shell/event-bus.ts
@@ -7,12 +7,17 @@
 // during the gradual migration.
 import { useEffect, useRef } from "react";
 import type { SettingsSection } from "@/features/settings/types";
+import type { WorkspaceMode } from "@/lib/api";
 
 export type ShellEvent =
 	| { type: "open-settings"; section?: SettingsSection }
 	| { type: "reload-settings" }
 	| { type: "open-model-picker" }
-	| { type: "open-new-workspace" }
+	// `mode` is a one-shot override: when set, the start surface forces the
+	// composer into that mode for this open without touching the user's
+	// persisted default (`startSurfacePreferences`). Unset = honor the
+	// persisted default.
+	| { type: "open-new-workspace"; mode?: WorkspaceMode }
 	| { type: "open-add-repository" }
 	| { type: "open-sidebar-filter" }
 	| { type: "run-script" }


### PR DESCRIPTION
## What changed
- Cmd+N now opens the new-workspace start composer in worktree mode.
- Cmd+Shift+N now opens the start composer in Just-chat mode.
- The previous default Cmd+Shift+N Add repository binding is now unbound by default but remains rebindable in Settings > Shortcuts.
- Added shortcut coverage plus a changeset and in-app announcement.

## Why
The new-workspace shortcuts now map directly to the two common start composer modes without mutating the user's persisted default mode.

## Follow-up / test notes
- Pre-commit ran Biome on staged JS/TS/JSON files during commit.
- No full test suite was run beyond the commit hook.