### PR TITLE
fix: Cmd+N opens Start Page with remembered mode, not forced worktree

### DIFF
--- a/.changeset/cmd-n-opens-start-page.md
+++ b/.changeset/cmd-n-opens-start-page.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix Cmd+N so it opens the Start Page honoring the per-repo remembered work mode instead of always forcing New Worktree; Shift+Cmd+N still opens Start Page in Just-chat mode.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1227,14 +1227,10 @@ function AppShell({
 			},
 			{
 				id: "workspace.new" as const,
-				// Force the start composer into worktree mode for this open;
-				// the persisted default mode is left untouched.
-				callback: () =>
-					publishShellEvent({ type: "open-new-workspace", mode: "worktree" }),
+				callback: () => publishShellEvent({ type: "open-new-workspace" }),
 			},
 			{
 				id: "workspace.justChat" as const,
-				// Same as `workspace.new` but lands in Just-chat mode.
 				callback: () =>
 					publishShellEvent({ type: "open-new-workspace", mode: "chat" }),
 			},

--- a/src/features/shortcuts/registry.ts
+++ b/src/features/shortcuts/registry.ts
@@ -96,7 +96,7 @@ export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
 	},
 	{
 		id: "workspace.new",
-		title: "Create new workspace (worktree)",
+		title: "Open Start Page",
 		group: "Workspace",
 		defaultHotkey: "Mod+N",
 		scopes: ["app"],
@@ -104,7 +104,7 @@ export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
 	},
 	{
 		id: "workspace.justChat",
-		title: "Create new workspace (just chat)",
+		title: "Open Start Page (Just chat)",
 		group: "Workspace",
 		defaultHotkey: "Mod+Shift+N",
 		scopes: ["app"],

--- a/src/features/workspace-start/index.tsx
+++ b/src/features/workspace-start/index.tsx
@@ -128,9 +128,6 @@ export function WorkspaceStartPage({
 		settings.shortcuts,
 		"startSurface.cycleRepository",
 	);
-	// Mode-picker shortcuts surfaced inside each menu item, matching the
-	// "label + kbd badges" pattern used elsewhere in the app.
-	const newWorktreeShortcut = getShortcut(settings.shortcuts, "workspace.new");
 	const justChatShortcut = getShortcut(
 		settings.shortcuts,
 		"workspace.justChat",
@@ -572,12 +569,6 @@ export function WorkspaceStartPage({
 										>
 											<Split className="size-3.5 rotate-90" strokeWidth={1.8} />
 											<span>New worktree</span>
-											{newWorktreeShortcut ? (
-												<InlineShortcutDisplay
-													hotkey={newWorktreeShortcut}
-													className="ml-auto text-muted-foreground"
-												/>
-											) : null}
 										</DropdownMenuItem>
 										<DropdownMenuItem
 											onClick={() => onModeChange("chat")}

--- a/src/shell/controllers/use-start-surface-controller.ts
+++ b/src/shell/controllers/use-start-surface-controller.ts
@@ -245,11 +245,9 @@ export function useStartSurfaceController(
 	}, [deps.viewMode]);
 
 	// Payload `mode` forces the initial mode for this open only; no payload
-	// honors the per-repo remembered mode.
+	// clears any prior transient override so the per-repo remembered mode wins.
 	useShellEvent("open-new-workspace", (event) => {
-		if (event.mode) {
-			setTransientModeOverride(event.mode);
-		}
+		setTransientModeOverride(event.mode ?? null);
 	});
 
 	// In local mode default to repo HEAD; worktree mode keeps stored default.

--- a/src/shell/controllers/use-start-surface-controller.ts
+++ b/src/shell/controllers/use-start-surface-controller.ts
@@ -244,10 +244,8 @@ export function useStartSurfaceController(
 		}
 	}, [deps.viewMode]);
 
-	// `Cmd+N` / `Cmd+Shift+N` publish this event with a `mode` payload to
-	// force the start composer's initial mode for the current open without
-	// writing to settings. Plain `open-new-workspace` (no payload) leaves
-	// the persisted preference untouched.
+	// Payload `mode` forces the initial mode for this open only; no payload
+	// honors the per-repo remembered mode.
 	useShellEvent("open-new-workspace", (event) => {
 		if (event.mode) {
 			setTransientModeOverride(event.mode);


### PR DESCRIPTION
## Summary

Fix the behavior of Cmd+N so it opens the Start Page and honors the per-repo remembered work mode instead of always forcing New Worktree mode. Cmd+Shift+N still opens Start Page in Just-chat mode.

## Changes

- Updated `workspace.new` shortcut to open Start Page without forcing a mode
- Updated shortcut labels to reflect new behavior (Cmd+N → "Open Start Page", Cmd+Shift+N → "Open Start Page (Just chat)")
- Removed mode-forcing logic from App.tsx
- Removed unused shortcut display for mode picker in start page menu
- Updated comments to be more concise

## Test notes

- Test Cmd+N opens Start Page with the currently remembered mode for the repository
- Test Cmd+Shift+N still forces Just-chat mode
- Verify shortcut labels display correctly in the shortcuts dialog