### PR TITLE
Keep collapsed Context sidebar state on workspace switch

### DIFF
--- a/.changeset/steady-context-panels.md
+++ b/.changeset/steady-context-panels.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Keep a collapsed Context sidebar collapsed when switching workspaces.

--- a/src/shell/controllers/use-context-panel-controller.test.tsx
+++ b/src/shell/controllers/use-context-panel-controller.test.tsx
@@ -1,0 +1,58 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { type AppSettings, DEFAULT_SETTINGS } from "@/lib/settings";
+import { useContextPanelController } from "./use-context-panel-controller";
+import type { ShellViewMode } from "./use-selection-controller";
+
+function renderController(
+	overrides: {
+		appSettings?: Partial<AppSettings>;
+		viewMode?: ShellViewMode;
+		updateSettings?: (patch: Partial<AppSettings>) => void;
+	} = {},
+) {
+	const updateSettings = overrides.updateSettings ?? vi.fn();
+	const viewMode = overrides.viewMode ?? "conversation";
+	return {
+		updateSettings,
+		...renderHook(() =>
+			useContextPanelController({
+				appSettings: {
+					...DEFAULT_SETTINGS,
+					...overrides.appSettings,
+				},
+				areSettingsLoaded: true,
+				updateSettings,
+				getViewMode: () => viewMode,
+			}),
+		),
+	};
+}
+
+describe("useContextPanelController", () => {
+	it("keeps a manually collapsed workspace context sidebar collapsed on workspace sync", async () => {
+		const { result } = renderController({
+			appSettings: {
+				lastSurface: "workspace",
+				workspaceRightSidebarMode: "context",
+			},
+		});
+
+		await waitFor(() => {
+			expect(result.current.state.contextPanelOpen).toBe(true);
+		});
+
+		act(() => {
+			result.current.actions.setInspectorCollapsed(true);
+		});
+		expect(result.current.state.contextPanelOpen).toBe(false);
+
+		act(() => {
+			result.current.actions.syncToWorkspaceMode();
+		});
+
+		expect(result.current.state.rightSidebarMode).toBe("context");
+		expect(result.current.state.inspectorCollapsed).toBe(true);
+		expect(result.current.state.contextPanelOpen).toBe(false);
+	});
+});

--- a/src/shell/controllers/use-context-panel-controller.ts
+++ b/src/shell/controllers/use-context-panel-controller.ts
@@ -43,7 +43,7 @@ export type ContextPanelActions = {
 	closeStartContextPreview(): void;
 	// Called by AppShell's `handleSelectWorkspace` wrapper on every workspace
 	// click (including reselect) so the right sidebar follows the user's
-	// persisted preference.
+	// persisted content mode without overriding a manual collapse.
 	syncToWorkspaceMode(): void;
 	// Called by selection's `onStartOpened` to align the right sidebar with
 	// `startContextPanelOpen` and reveal the panel if it was collapsed.
@@ -181,9 +181,6 @@ export function useContextPanelController(
 
 	const syncToWorkspaceMode = useCallback(() => {
 		setRightSidebarMode(appSettings.workspaceRightSidebarMode);
-		if (appSettings.workspaceRightSidebarMode === "context") {
-			setInspectorCollapsed(false);
-		}
 	}, [appSettings.workspaceRightSidebarMode]);
 
 	const syncToStartMode = useCallback(() => {


### PR DESCRIPTION
## What changed
- Keep the workspace Context sidebar collapsed when switching workspaces if the user had collapsed the right sidebar.
- Add a controller regression test for the collapsed Context sidebar sync path.
- Add a patch changeset for the user-facing fix.

## Why it changed
Workspace switching was restoring the persisted Context sidebar mode and unconditionally expanding the right sidebar, which reopened the Inbox/Contexts panel after the user had manually collapsed it.

## Follow-up / test notes
- bun x biome check src/shell/controllers/use-context-panel-controller.ts src/shell/controllers/use-context-panel-controller.test.tsx .changeset/steady-context-panels.md --config-path=./biome.json
- bun x vitest run src/shell/controllers/use-context-panel-controller.test.tsx
- Pre-commit hook passed while creating commit bceaafed.