### PR TITLE
Fix context detail refresh and Slack rendering

### DIFF
--- a/.announcements/context-detail-auto-refresh.json
+++ b/.announcements/context-detail-auto-refresh.json
@@ -1,0 +1,11 @@
+{
+	"items": [
+		{
+			"text": "Slack, GitHub, and GitLab context detail panels now refresh automatically when you open them or refocus Helmor, and there's a manual refresh button in the toolbar.",
+			"action": {
+				"label": "Open Context",
+				"value": { "type": "setRightSidebarMode", "mode": "context" }
+			}
+		}
+	]
+}

--- a/.changeset/slack-context-revalidation-and-rendering.md
+++ b/.changeset/slack-context-revalidation-and-rendering.md
@@ -1,0 +1,9 @@
+---
+"helmor": patch
+---
+
+Polish Slack and Forge context details:
+- Refresh Slack, GitHub, and GitLab detail panels automatically when the panel opens or the window regains focus, plus a manual refresh button in the toolbar next to the open-externally / add-context controls.
+- Resolve Slack `<@U…>` user mentions to `@displayname` in thread snippets and message bodies so they read like the Slack client instead of opaque user ids.
+- Cap inline Slack image previews at half the message body width and display the full image at its natural aspect ratio, so tall screenshots no longer crop or leave letterbox padding around the frame.
+- Fix "Import from Slack desktop" failing with `AES-CBC Unpad Error` when the macOS Keychain holds multiple "Slack Safe Storage" entries (e.g. leftover Mac App Store key alongside the standalone build) by trying every candidate key and using the one that actually decrypts the cookie.

--- a/src-tauri/src/slack/api.rs
+++ b/src-tauri/src/slack/api.rs
@@ -288,6 +288,79 @@ pub fn users_info(team_id: &str, creds: &SlackCreds, user_id: &str) -> Result<Us
     Ok(info)
 }
 
+/// Resolve every `<@U…>` user-mention token in a Slack message body to
+/// the labeled form `<@U…|display_name>` using the cached `users.info`
+/// lookup. Idempotent — already-labeled mentions (`<@U…|name>`) and
+/// non-mention tokens are passed through unchanged.
+///
+/// Why this lives in the backend: the only way to resolve a Slack user
+/// id to a display name without nuking the workspace token is
+/// `users.info` (bulk `users.list` triggers Slack's anti-enumeration
+/// rule and revokes the xoxc/xoxd pair — see the module-level note).
+/// Per-id lookups are TTL-cached in this process, so a refresh of an
+/// active thread re-uses the 5 min cache hit instead of refetching
+/// each author. Frontend then renders the labeled form via
+/// `inlineMentionsForMarkdown` / `formatSlackTextPlain` which both
+/// already understood `<@U…|name>`.
+///
+/// On failure (network blip, deactivated account, etc.) we keep the
+/// raw `<@U…>` token rather than substituting a confusing fallback —
+/// frontend will still render it as `@U…`, matching today's behavior.
+pub fn resolve_mentions(team_id: &str, creds: &SlackCreds, text: &str) -> String {
+    // Cheap precheck: skip the scan entirely when no mention syntax is
+    // present. Most messages have no mentions so the inbox refresh
+    // shouldn't pay the cost of walking each body line.
+    if !text.contains("<@") {
+        return text.to_string();
+    }
+
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    while let Some(start_rel) = rest.find("<@") {
+        // Copy the segment before the token (UTF-8 safe — `find` returns
+        // a valid byte boundary).
+        out.push_str(&rest[..start_rel]);
+        let after_marker = &rest[start_rel + 2..];
+        if let Some(end_rel) = after_marker.find('>') {
+            let inner = &after_marker[..end_rel];
+            // Slack user ids: `U` or `W` then uppercase ASCII
+            // alphanumerics. Already-labeled (`U…|name`) and non-user
+            // tokens (e.g. broadcasts) pass through verbatim.
+            let is_user_id = !inner.contains('|')
+                && inner.starts_with(['U', 'W'])
+                && inner
+                    .chars()
+                    .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit());
+            if is_user_id {
+                let resolved = users_info(team_id, creds, inner)
+                    .map(|info| info.display_name)
+                    .ok();
+                if let Some(name) = resolved {
+                    out.push_str("<@");
+                    out.push_str(inner);
+                    out.push('|');
+                    out.push_str(&name);
+                    out.push('>');
+                    rest = &after_marker[end_rel + 1..];
+                    continue;
+                }
+            }
+            // Pass through the original token verbatim.
+            out.push_str("<@");
+            out.push_str(inner);
+            out.push('>');
+            rest = &after_marker[end_rel + 1..];
+        } else {
+            // No closing `>` — bail out and append the remainder as-is.
+            out.push_str("<@");
+            rest = after_marker;
+            break;
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
 /// `users.conversations` — lists conversations (channels, DMs, MPIMs) the
 /// authed user is a member of. We filter to `im` + `mpim` for the unread
 /// DM feed.

--- a/src-tauri/src/slack/desktop_scrape.rs
+++ b/src-tauri/src/slack/desktop_scrape.rs
@@ -405,6 +405,25 @@ fn parse_teams_json(json_text: &str) -> Result<Vec<TeamFromLeveldb>> {
 }
 
 /// Read `d` from Slack's Cookies SQLite and decrypt it.
+///
+/// Why this isn't just "read the key, decrypt the cookie": users who
+/// have ever installed both Slack builds (Mac App Store + standalone
+/// direct download) end up with *multiple* `"Slack Safe Storage"`
+/// entries in their login Keychain — one per build, each with a
+/// different `acct` label (`"Slack"`, `"Slack Key"`, `"Slack App Store
+/// Key"`) and a different AES password. A service-only `security`
+/// lookup returns the oldest entry, which is frequently the *wrong*
+/// build (e.g. App Store key when the user's running standalone).
+/// AES-CBC will still decrypt mechanically with the wrong key, but
+/// PKCS7 unpadding then fails with "Unpad Error" — confusing both for
+/// us and for the user.
+///
+/// Strategy: enumerate every candidate key (service-only first, then
+/// each historical `acct` label biased by which build is on disk),
+/// dedupe, and try `decrypt_chromium_cookie` with each in turn. The
+/// only reliable "is this the right key?" test is whether the ciphertext
+/// actually decrypts cleanly. First success wins; if all fail we
+/// surface every candidate's failure so support has a complete picture.
 #[cfg(target_os = "macos")]
 fn read_d_cookie(cookies_path: &Path, data_dir: &Path) -> Result<String> {
     if !cookies_path.exists() {
@@ -431,47 +450,77 @@ fn read_d_cookie(cookies_path: &Path, data_dir: &Path) -> Result<String> {
         )
         .context("No `d` cookie row found in Slack Cookies DB")?;
 
-    let key = read_safe_storage_key(data_dir)
+    let candidates = collect_safe_storage_keys(data_dir)
         .context("Couldn't read Slack's Safe Storage key from the macOS Keychain")?;
-    let xoxd = decrypt_chromium_cookie(&encrypted, &key, host_key.as_bytes())
-        .context("Failed to decrypt Slack `d` cookie")?;
-    Ok(xoxd)
+
+    let mut errors: Vec<String> = Vec::with_capacity(candidates.len());
+    for (label, key) in &candidates {
+        match decrypt_chromium_cookie(&encrypted, key, host_key.as_bytes()) {
+            Ok(value) if !value.is_empty() => {
+                tracing::debug!(
+                    keychain_account = %label,
+                    "Decrypted Slack `d` cookie",
+                );
+                return Ok(value);
+            }
+            Ok(_) => errors.push(format!("{label}: decrypted to empty string")),
+            Err(error) => errors.push(format!("{label}: {error}")),
+        }
+    }
+    bail!(
+        "Failed to decrypt Slack `d` cookie with any candidate Safe Storage key — the active Slack build's AES key wasn't among the {} keychain entries we tried. Details: {}",
+        candidates.len(),
+        errors.join("; ")
+    )
 }
 
+/// Collect every distinct Slack Safe Storage AES key Chromium might
+/// have stored in the login Keychain for this user.
+///
+/// Why we shell out to `/usr/bin/security` rather than going through
+/// the `keyring` crate / Security Framework directly: the item's ACL
+/// is restricted to binaries Slack signed, so a direct SF call returns
+/// "no matching entry"; spawning `security` causes macOS to show a
+/// one-time "Allow Helmor to access 'Slack Safe Storage'?" prompt and
+/// remember the approval. That tradeoff is fine — the user just
+/// clicked "Import from Slack desktop".
+///
+/// Order matters: service-only first (the future-proof path that
+/// survives Slack renaming the `acct` field), then a build-aware
+/// rotation through known historical names. Whichever entry decrypts
+/// the ciphertext first wins in `read_d_cookie`, so the ordering only
+/// affects how often we burn a wasted decrypt attempt — not
+/// correctness.
 #[cfg(target_os = "macos")]
-fn read_safe_storage_key(data_dir: &Path) -> Result<Vec<u8>> {
-    // Slack stashes its Safe Storage AES key in the user's login
-    // Keychain. We shell out to `/usr/bin/security` rather than going
-    // through the `keyring` crate / Security Framework directly: the
-    // item's ACL is restricted to binaries Slack signed, so a direct
-    // SF call returns "no matching entry"; spawning `security` causes
-    // macOS to show a one-time "Allow Helmor to access ‘Slack Safe
-    // Storage’?" prompt and remember the approval. That tradeoff is
-    // fine — the user just clicked "Import from Slack desktop".
-    //
-    // Lookup strategy: query by **service name only** (`-s
-    // "Slack Safe Storage"`). The service name is a stable protocol
-    // contract (Chromium `os_crypt_mac.mm` -> Electron `safeStorage`
-    // -> Slack), while the `acct` field is whatever label Slack picked
-    // and has been silently renamed at least once ("Slack" ->
-    // "Slack Key"). Account-list matching is a brittle whack-a-mole;
-    // service-only matching survives every rename.
-    //
-    // Fallback: if the service-only query somehow misses (e.g. stale
-    // duplicate entry returned first, or future macOS CLI behavior
-    // change), try the known account names too so we degrade
-    // gracefully instead of hard-failing.
+fn collect_safe_storage_keys(data_dir: &Path) -> Result<Vec<(String, Vec<u8>)>> {
+    let mut out: Vec<(String, Vec<u8>)> = Vec::new();
+    let mut push_unique = |label: String, key: Vec<u8>| {
+        if key.is_empty() {
+            return;
+        }
+        // Multiple `acct` entries often share the same AES key — only
+        // attempt decryption once per distinct key.
+        if out.iter().any(|(_, k)| k.as_slice() == key.as_slice()) {
+            return;
+        }
+        out.push((label, key));
+    };
+
+    // Service-only lookup first.
     match try_read_keychain_password(None) {
-        Ok(key) if !key.is_empty() => return Ok(key),
-        Ok(_) => {}
+        Ok(key) => push_unique("(service-only)".to_string(), key),
         Err(error) => {
-            tracing::warn!(error = %error, "Slack Safe Storage service-only lookup failed; trying known accounts")
+            tracing::warn!(
+                error = %error,
+                "Slack Safe Storage service-only lookup failed; will fall back to known accounts",
+            );
         }
     }
 
-    // Known historical account labels. Order biased by which Slack
-    // build is on disk so the (now rare) per-account ACL prompt
-    // happens once at most.
+    // Known historical account labels. Bias the order by which Slack
+    // build is on disk so the most likely key is tried first — the
+    // service-only entry above might still be the wrong build, in
+    // which case the build-aware first guess avoids a wasted decrypt.
     let accounts: &[&str] = if data_dir
         .to_string_lossy()
         .contains("com.tinyspeck.slackmacgap")
@@ -483,15 +532,18 @@ fn read_safe_storage_key(data_dir: &Path) -> Result<Vec<u8>> {
     let mut errors: Vec<String> = Vec::new();
     for account in accounts {
         match try_read_keychain_password(Some(account)) {
-            Ok(key) if !key.is_empty() => return Ok(key),
-            Ok(_) => errors.push(format!("{account}: empty")),
+            Ok(key) => push_unique((*account).to_string(), key),
             Err(error) => errors.push(format!("{account}: {error}")),
         }
     }
-    bail!(
-        "Slack Safe Storage key not found in Keychain (service-only lookup failed; also tried accounts {accounts:?}): {}",
-        errors.join("; ")
-    )
+
+    if out.is_empty() {
+        bail!(
+            "Slack Safe Storage key not found in Keychain (service-only lookup empty; also tried accounts {accounts:?}): {}",
+            errors.join("; ")
+        );
+    }
+    Ok(out)
 }
 
 #[cfg(target_os = "macos")]
@@ -680,6 +732,55 @@ mod tests {
         // SHA256, so the optional strip is a no-op.
         let recovered = decrypt_chromium_cookie(&payload, password, b".slack.com").unwrap();
         assert_eq!(recovered, "xoxd-abcdef-1234567890");
+    }
+
+    /// Smoke test the multi-key fallback shape: the wrong key must
+    /// return an error from `decrypt_chromium_cookie` (Unpad Error or
+    /// invalid UTF-8) — that's the failure signal `read_d_cookie`
+    /// uses to advance to the next candidate. The right key recovers
+    /// the original plaintext. Mirrors the real-world scenario where
+    /// Keychain holds both an "Slack App Store Key" entry (wrong
+    /// password) and a "Slack Key" entry (right password) for the
+    /// active standalone Slack build.
+    #[test]
+    fn decrypt_chromium_cookie_returns_err_for_wrong_key() {
+        use aes::cipher::block_padding::Pkcs7;
+        use aes::cipher::{BlockEncryptMut, KeyIvInit};
+        type Aes128CbcEnc = cbc::Encryptor<aes::Aes128>;
+
+        let correct_password = b"correct-build-key";
+        let wrong_password = b"other-build-key";
+        let plaintext = b"xoxd-real-token";
+
+        let mut key = [0u8; AES_KEY_LEN];
+        pbkdf2::pbkdf2::<hmac::Hmac<sha1::Sha1>>(
+            correct_password,
+            SAFE_STORAGE_SALT,
+            SAFE_STORAGE_ITERATIONS,
+            &mut key,
+        )
+        .unwrap();
+        let iv: [u8; 16] = [b' '; 16];
+        let mut buf = vec![0u8; plaintext.len() + 16];
+        buf[..plaintext.len()].copy_from_slice(plaintext);
+        let ct = Aes128CbcEnc::new(&key.into(), &iv.into())
+            .encrypt_padded_mut::<Pkcs7>(&mut buf, plaintext.len())
+            .unwrap();
+        let mut payload = Vec::with_capacity(3 + ct.len());
+        payload.extend_from_slice(CIPHER_PREFIX_V10);
+        payload.extend_from_slice(ct);
+
+        // Wrong key → error (Unpad or UTF-8). Caller treats this as
+        // "try the next candidate".
+        assert!(
+            decrypt_chromium_cookie(&payload, wrong_password, b".slack.com").is_err(),
+            "wrong key should fail decryption, not return garbage",
+        );
+        // Right key → exact plaintext recovery.
+        assert_eq!(
+            decrypt_chromium_cookie(&payload, correct_password, b".slack.com").unwrap(),
+            "xoxd-real-token",
+        );
     }
 
     #[test]

--- a/src-tauri/src/slack/detail.rs
+++ b/src-tauri/src/slack/detail.rs
@@ -75,8 +75,11 @@ fn convert_message(team_id: &str, creds: &SlackCreds, raw: RawMessage) -> SlackM
     // `attachments`, but skip the `files` placeholder branch. When a
     // message is purely a file share, the inline preview rendered from
     // `files` below replaces what would otherwise be `📎 N files` —
-    // we don't want both showing.
-    let text = api::extract_message_body(&raw);
+    // we don't want both showing. Then resolve `<@U…>` mentions to the
+    // labeled `<@U…|display>` form so the frontend can render
+    // human-readable `@names` instead of opaque user ids.
+    let body = api::extract_message_body(&raw);
+    let text = api::resolve_mentions(team_id, creds, &body);
     let reactions = raw
         .reactions
         .iter()

--- a/src-tauri/src/slack/inbox.rs
+++ b/src-tauri/src/slack/inbox.rs
@@ -153,7 +153,7 @@ fn convert_search_match(
     let permalink = raw.permalink.clone().unwrap_or_default();
     let ts_millis = api::ts_to_millis(&raw.ts);
 
-    let snippet_source = api::extract_display_text(&raw);
+    let snippet_source = api::resolve_mentions(team_id, creds, &api::extract_display_text(&raw));
     Ok(SlackInboxItem {
         id: format!("{}:{}:{}", team_id, channel.id, raw.ts),
         team_id: team_id.to_string(),
@@ -218,7 +218,8 @@ fn snippet_for_dm(
         .flatten()
         .unwrap_or_default();
     let ts_millis = api::ts_to_millis(&message.ts);
-    let snippet_source = api::extract_display_text(&message);
+    let snippet_source =
+        api::resolve_mentions(team_id, creds, &api::extract_display_text(&message));
     Ok(Some(SlackInboxItem {
         id: format!("{}:{}:{}", team_id, dm.id, message.ts),
         team_id: team_id.to_string(),

--- a/src/features/source-detail/common.tsx
+++ b/src/features/source-detail/common.tsx
@@ -1,3 +1,4 @@
+import { type UseQueryResult, useQuery } from "@tanstack/react-query";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { Check, Clock3, Copy, ExternalLink, RefreshCw } from "lucide-react";
 import { Suspense, useCallback, useState } from "react";
@@ -13,8 +14,13 @@ import {
 import { buildCardContextPayload } from "@/features/inbox/source-card";
 import { SourceIcon } from "@/features/inbox/source-icon";
 import { STATE_TONE_CLASS } from "@/features/inbox/state-tone";
+import { getInboxItemDetail } from "@/lib/api";
 import type { ComposerInsertTarget } from "@/lib/composer-insert";
-import type { ContextCard } from "@/lib/sources/types";
+import { helmorQueryKeys } from "@/lib/query-client";
+import type {
+	ContextCard,
+	ContextCardForgeDetailRef,
+} from "@/lib/sources/types";
 import { cn } from "@/lib/utils";
 
 /** Background revalidation contract shared across detail views. Wiring
@@ -24,6 +30,48 @@ export type DetailRefreshControl = {
 	refetch: () => void;
 	isFetching: boolean;
 };
+
+/** Adapt a React Query result into the `RefreshButton` contract. Pure
+ *  glue — kept here so individual detail-view files don't repeat the
+ *  same 3-line inline object. */
+export function toRefreshControl<T>(
+	query: UseQueryResult<T>,
+): DetailRefreshControl {
+	return {
+		refetch: () => void query.refetch(),
+		isFetching: query.isFetching,
+	};
+}
+
+/** Shared React Query setup for the forge (GitHub / GitLab) inbox-item
+ *  detail page. Every `*-view.tsx` in `github/` and `gitlab/` calls
+ *  this — same query key, same staleTime, same focus/mount sync
+ *  contract — so the wrapper view files reduce to type-narrowing the
+ *  result and forwarding to `GitHubDetailPage`. */
+export function useInboxItemDetailQuery(
+	detailRef: ContextCardForgeDetailRef | null,
+	cardId: string,
+) {
+	return useQuery({
+		queryKey: detailRef
+			? helmorQueryKeys.inboxItemDetail(
+					detailRef.provider,
+					detailRef.login,
+					detailRef.source,
+					detailRef.externalId,
+				)
+			: ["inboxItemDetail", "missing", cardId],
+		queryFn: () => getInboxItemDetail(detailRef!),
+		enabled: detailRef !== null,
+		staleTime: 60_000,
+		// Re-fetch every time the panel mounts (user opens a card) or
+		// the window regains focus — Slack/GitHub/GitLab items mutate
+		// quickly and users expect "open / refocus" to be a natural
+		// sync point.
+		refetchOnMount: "always",
+		refetchOnWindowFocus: "always",
+	});
+}
 
 export type SourceDetailProps = {
 	card: ContextCard;

--- a/src/features/source-detail/common.tsx
+++ b/src/features/source-detail/common.tsx
@@ -1,5 +1,5 @@
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { Check, Clock3, Copy, ExternalLink } from "lucide-react";
+import { Check, Clock3, Copy, ExternalLink, RefreshCw } from "lucide-react";
 import { Suspense, useCallback, useState } from "react";
 import { AppendContextButton } from "@/components/append-context-button";
 import { HelmorLogoAnimated } from "@/components/helmor-logo-animated";
@@ -17,6 +17,14 @@ import type { ComposerInsertTarget } from "@/lib/composer-insert";
 import type { ContextCard } from "@/lib/sources/types";
 import { cn } from "@/lib/utils";
 
+/** Background revalidation contract shared across detail views. Wiring
+ *  a query's `refetch` + `isFetching` into this is enough to surface
+ *  the toolbar refresh button. */
+export type DetailRefreshControl = {
+	refetch: () => void;
+	isFetching: boolean;
+};
+
 export type SourceDetailProps = {
 	card: ContextCard;
 	appendContextTarget?: ComposerInsertTarget;
@@ -29,6 +37,7 @@ export function GitHubDetailPage({
 	isLoading,
 	error,
 	kindLabel,
+	refresh,
 }: {
 	card: ContextCard;
 	appendContextTarget?: ComposerInsertTarget;
@@ -36,6 +45,7 @@ export function GitHubDetailPage({
 	isLoading?: boolean;
 	error?: Error | null;
 	kindLabel: string;
+	refresh?: DetailRefreshControl;
 }) {
 	const reference = parseExternalReference(card.externalId);
 	const markdownBody = description?.trim() || "No description provided.";
@@ -63,6 +73,7 @@ export function GitHubDetailPage({
 						appendContextTarget={appendContextTarget}
 						markdownBody={markdownBody}
 						copyDisabled={isLoading || Boolean(error)}
+						refresh={refresh}
 					/>
 				</div>
 			</header>
@@ -90,11 +101,13 @@ function SourceDetailActions({
 	appendContextTarget,
 	markdownBody,
 	copyDisabled,
+	refresh,
 }: {
 	card: ContextCard;
 	appendContextTarget?: ComposerInsertTarget;
 	markdownBody: string;
 	copyDisabled?: boolean;
+	refresh?: DetailRefreshControl;
 }) {
 	const [copied, setCopied] = useState(false);
 	const handleCopy = useCallback(() => {
@@ -107,6 +120,7 @@ function SourceDetailActions({
 
 	return (
 		<div className="flex shrink-0 items-center gap-1">
+			{refresh ? <RefreshButton refresh={refresh} /> : null}
 			<Tooltip>
 				<TooltipTrigger asChild>
 					<Button
@@ -161,6 +175,38 @@ function SourceDetailActions({
 				</TooltipContent>
 			</Tooltip>
 		</div>
+	);
+}
+
+/** Toolbar button that triggers a background refetch of the active
+ *  detail query. Spins the icon while the underlying query is fetching,
+ *  and disables the button so back-to-back clicks don't queue duplicate
+ *  refetches. Shared between Slack and Forge (GitHub/GitLab) detail
+ *  views — both wire a React Query `refetch` + `isFetching` pair into
+ *  the `refresh` prop. */
+export function RefreshButton({ refresh }: { refresh: DetailRefreshControl }) {
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<Button
+					type="button"
+					variant="ghost"
+					size="icon-xs"
+					aria-label="Refresh"
+					disabled={refresh.isFetching}
+					onClick={() => refresh.refetch()}
+					className="size-7 cursor-interactive rounded-md text-muted-foreground hover:bg-foreground/10 hover:text-foreground"
+				>
+					<RefreshCw
+						className={cn("size-[13px]", refresh.isFetching && "animate-spin")}
+						strokeWidth={1.8}
+					/>
+				</Button>
+			</TooltipTrigger>
+			<TooltipContent side="top">
+				{refresh.isFetching ? "Refreshing…" : "Refresh"}
+			</TooltipContent>
+		</Tooltip>
 	);
 }
 

--- a/src/features/source-detail/github/discussion-view.tsx
+++ b/src/features/source-detail/github/discussion-view.tsx
@@ -21,6 +21,8 @@ export function GitHubDiscussionView({
 		queryFn: () => getInboxItemDetail(detailRef!),
 		enabled: detailRef !== null,
 		staleTime: 60_000,
+		refetchOnMount: "always",
+		refetchOnWindowFocus: "always",
 	});
 	const detail =
 		detailQuery.data?.type === "github_discussion"
@@ -35,6 +37,14 @@ export function GitHubDiscussionView({
 			error={detailQuery.error}
 			isLoading={detailQuery.isLoading}
 			kindLabel="discussion"
+			refresh={
+				detailRef
+					? {
+							refetch: () => void detailQuery.refetch(),
+							isFetching: detailQuery.isFetching,
+						}
+					: undefined
+			}
 		/>
 	);
 }

--- a/src/features/source-detail/github/discussion-view.tsx
+++ b/src/features/source-detail/github/discussion-view.tsx
@@ -1,7 +1,9 @@
-import { useQuery } from "@tanstack/react-query";
-import { getInboxItemDetail } from "@/lib/api";
-import { helmorQueryKeys } from "@/lib/query-client";
-import { GitHubDetailPage, type SourceDetailProps } from "../common";
+import {
+	GitHubDetailPage,
+	type SourceDetailProps,
+	toRefreshControl,
+	useInboxItemDetailQuery,
+} from "../common";
 
 export function GitHubDiscussionView({
 	card,
@@ -9,21 +11,7 @@ export function GitHubDiscussionView({
 }: SourceDetailProps) {
 	const detailRef =
 		card.detailRef?.source === "github_discussion" ? card.detailRef : null;
-	const detailQuery = useQuery({
-		queryKey: detailRef
-			? helmorQueryKeys.inboxItemDetail(
-					detailRef.provider,
-					detailRef.login,
-					detailRef.source,
-					detailRef.externalId,
-				)
-			: ["inboxItemDetail", "missing", card.id],
-		queryFn: () => getInboxItemDetail(detailRef!),
-		enabled: detailRef !== null,
-		staleTime: 60_000,
-		refetchOnMount: "always",
-		refetchOnWindowFocus: "always",
-	});
+	const detailQuery = useInboxItemDetailQuery(detailRef, card.id);
 	const detail =
 		detailQuery.data?.type === "github_discussion"
 			? detailQuery.data.data
@@ -37,14 +25,7 @@ export function GitHubDiscussionView({
 			error={detailQuery.error}
 			isLoading={detailQuery.isLoading}
 			kindLabel="discussion"
-			refresh={
-				detailRef
-					? {
-							refetch: () => void detailQuery.refetch(),
-							isFetching: detailQuery.isFetching,
-						}
-					: undefined
-			}
+			refresh={detailRef ? toRefreshControl(detailQuery) : undefined}
 		/>
 	);
 }

--- a/src/features/source-detail/github/issue-view.tsx
+++ b/src/features/source-detail/github/issue-view.tsx
@@ -1,7 +1,9 @@
-import { useQuery } from "@tanstack/react-query";
-import { getInboxItemDetail } from "@/lib/api";
-import { helmorQueryKeys } from "@/lib/query-client";
-import { GitHubDetailPage, type SourceDetailProps } from "../common";
+import {
+	GitHubDetailPage,
+	type SourceDetailProps,
+	toRefreshControl,
+	useInboxItemDetailQuery,
+} from "../common";
 
 export function GitHubIssueView({
 	card,
@@ -9,24 +11,7 @@ export function GitHubIssueView({
 }: SourceDetailProps) {
 	const detailRef =
 		card.detailRef?.source === "github_issue" ? card.detailRef : null;
-	const detailQuery = useQuery({
-		queryKey: detailRef
-			? helmorQueryKeys.inboxItemDetail(
-					detailRef.provider,
-					detailRef.login,
-					detailRef.source,
-					detailRef.externalId,
-				)
-			: ["inboxItemDetail", "missing", card.id],
-		queryFn: () => getInboxItemDetail(detailRef!),
-		enabled: detailRef !== null,
-		staleTime: 60_000,
-		// Re-fetch every time the detail view mounts (user click) or the
-		// app window regains focus — same UX contract the user expects
-		// from a "refresh on visit" content surface.
-		refetchOnMount: "always",
-		refetchOnWindowFocus: "always",
-	});
+	const detailQuery = useInboxItemDetailQuery(detailRef, card.id);
 	const detail =
 		detailQuery.data?.type === "github_issue" ? detailQuery.data.data : null;
 
@@ -38,14 +23,7 @@ export function GitHubIssueView({
 			error={detailQuery.error}
 			isLoading={detailQuery.isLoading}
 			kindLabel="issue"
-			refresh={
-				detailRef
-					? {
-							refetch: () => void detailQuery.refetch(),
-							isFetching: detailQuery.isFetching,
-						}
-					: undefined
-			}
+			refresh={detailRef ? toRefreshControl(detailQuery) : undefined}
 		/>
 	);
 }

--- a/src/features/source-detail/github/issue-view.tsx
+++ b/src/features/source-detail/github/issue-view.tsx
@@ -21,6 +21,11 @@ export function GitHubIssueView({
 		queryFn: () => getInboxItemDetail(detailRef!),
 		enabled: detailRef !== null,
 		staleTime: 60_000,
+		// Re-fetch every time the detail view mounts (user click) or the
+		// app window regains focus — same UX contract the user expects
+		// from a "refresh on visit" content surface.
+		refetchOnMount: "always",
+		refetchOnWindowFocus: "always",
 	});
 	const detail =
 		detailQuery.data?.type === "github_issue" ? detailQuery.data.data : null;
@@ -33,6 +38,14 @@ export function GitHubIssueView({
 			error={detailQuery.error}
 			isLoading={detailQuery.isLoading}
 			kindLabel="issue"
+			refresh={
+				detailRef
+					? {
+							refetch: () => void detailQuery.refetch(),
+							isFetching: detailQuery.isFetching,
+						}
+					: undefined
+			}
 		/>
 	);
 }

--- a/src/features/source-detail/github/pull-request-view.tsx
+++ b/src/features/source-detail/github/pull-request-view.tsx
@@ -21,6 +21,8 @@ export function GitHubPullRequestView({
 		queryFn: () => getInboxItemDetail(detailRef!),
 		enabled: detailRef !== null,
 		staleTime: 60_000,
+		refetchOnMount: "always",
+		refetchOnWindowFocus: "always",
 	});
 	const detail =
 		detailQuery.data?.type === "github_pr" ? detailQuery.data.data : null;
@@ -33,6 +35,14 @@ export function GitHubPullRequestView({
 			error={detailQuery.error}
 			isLoading={detailQuery.isLoading}
 			kindLabel="pull request"
+			refresh={
+				detailRef
+					? {
+							refetch: () => void detailQuery.refetch(),
+							isFetching: detailQuery.isFetching,
+						}
+					: undefined
+			}
 		/>
 	);
 }

--- a/src/features/source-detail/github/pull-request-view.tsx
+++ b/src/features/source-detail/github/pull-request-view.tsx
@@ -1,7 +1,9 @@
-import { useQuery } from "@tanstack/react-query";
-import { getInboxItemDetail } from "@/lib/api";
-import { helmorQueryKeys } from "@/lib/query-client";
-import { GitHubDetailPage, type SourceDetailProps } from "../common";
+import {
+	GitHubDetailPage,
+	type SourceDetailProps,
+	toRefreshControl,
+	useInboxItemDetailQuery,
+} from "../common";
 
 export function GitHubPullRequestView({
 	card,
@@ -9,21 +11,7 @@ export function GitHubPullRequestView({
 }: SourceDetailProps) {
 	const detailRef =
 		card.detailRef?.source === "github_pr" ? card.detailRef : null;
-	const detailQuery = useQuery({
-		queryKey: detailRef
-			? helmorQueryKeys.inboxItemDetail(
-					detailRef.provider,
-					detailRef.login,
-					detailRef.source,
-					detailRef.externalId,
-				)
-			: ["inboxItemDetail", "missing", card.id],
-		queryFn: () => getInboxItemDetail(detailRef!),
-		enabled: detailRef !== null,
-		staleTime: 60_000,
-		refetchOnMount: "always",
-		refetchOnWindowFocus: "always",
-	});
+	const detailQuery = useInboxItemDetailQuery(detailRef, card.id);
 	const detail =
 		detailQuery.data?.type === "github_pr" ? detailQuery.data.data : null;
 
@@ -35,14 +23,7 @@ export function GitHubPullRequestView({
 			error={detailQuery.error}
 			isLoading={detailQuery.isLoading}
 			kindLabel="pull request"
-			refresh={
-				detailRef
-					? {
-							refetch: () => void detailQuery.refetch(),
-							isFetching: detailQuery.isFetching,
-						}
-					: undefined
-			}
+			refresh={detailRef ? toRefreshControl(detailQuery) : undefined}
 		/>
 	);
 }

--- a/src/features/source-detail/gitlab/issue-view.tsx
+++ b/src/features/source-detail/gitlab/issue-view.tsx
@@ -1,7 +1,9 @@
-import { useQuery } from "@tanstack/react-query";
-import { getInboxItemDetail } from "@/lib/api";
-import { helmorQueryKeys } from "@/lib/query-client";
-import { GitHubDetailPage, type SourceDetailProps } from "../common";
+import {
+	GitHubDetailPage,
+	type SourceDetailProps,
+	toRefreshControl,
+	useInboxItemDetailQuery,
+} from "../common";
 
 export function GitLabIssueView({
 	card,
@@ -9,21 +11,7 @@ export function GitLabIssueView({
 }: SourceDetailProps) {
 	const detailRef =
 		card.detailRef?.source === "gitlab_issue" ? card.detailRef : null;
-	const detailQuery = useQuery({
-		queryKey: detailRef
-			? helmorQueryKeys.inboxItemDetail(
-					detailRef.provider,
-					detailRef.login,
-					detailRef.source,
-					detailRef.externalId,
-				)
-			: ["inboxItemDetail", "missing", card.id],
-		queryFn: () => getInboxItemDetail(detailRef!),
-		enabled: detailRef !== null,
-		staleTime: 60_000,
-		refetchOnMount: "always",
-		refetchOnWindowFocus: "always",
-	});
+	const detailQuery = useInboxItemDetailQuery(detailRef, card.id);
 	const detail =
 		detailQuery.data?.type === "gitlab_issue" ? detailQuery.data.data : null;
 
@@ -35,14 +23,7 @@ export function GitLabIssueView({
 			error={detailQuery.error}
 			isLoading={detailQuery.isLoading}
 			kindLabel="issue"
-			refresh={
-				detailRef
-					? {
-							refetch: () => void detailQuery.refetch(),
-							isFetching: detailQuery.isFetching,
-						}
-					: undefined
-			}
+			refresh={detailRef ? toRefreshControl(detailQuery) : undefined}
 		/>
 	);
 }

--- a/src/features/source-detail/gitlab/issue-view.tsx
+++ b/src/features/source-detail/gitlab/issue-view.tsx
@@ -21,6 +21,8 @@ export function GitLabIssueView({
 		queryFn: () => getInboxItemDetail(detailRef!),
 		enabled: detailRef !== null,
 		staleTime: 60_000,
+		refetchOnMount: "always",
+		refetchOnWindowFocus: "always",
 	});
 	const detail =
 		detailQuery.data?.type === "gitlab_issue" ? detailQuery.data.data : null;
@@ -33,6 +35,14 @@ export function GitLabIssueView({
 			error={detailQuery.error}
 			isLoading={detailQuery.isLoading}
 			kindLabel="issue"
+			refresh={
+				detailRef
+					? {
+							refetch: () => void detailQuery.refetch(),
+							isFetching: detailQuery.isFetching,
+						}
+					: undefined
+			}
 		/>
 	);
 }

--- a/src/features/source-detail/gitlab/merge-request-view.tsx
+++ b/src/features/source-detail/gitlab/merge-request-view.tsx
@@ -21,6 +21,8 @@ export function GitLabMergeRequestView({
 		queryFn: () => getInboxItemDetail(detailRef!),
 		enabled: detailRef !== null,
 		staleTime: 60_000,
+		refetchOnMount: "always",
+		refetchOnWindowFocus: "always",
 	});
 	const detail =
 		detailQuery.data?.type === "gitlab_mr" ? detailQuery.data.data : null;
@@ -33,6 +35,14 @@ export function GitLabMergeRequestView({
 			error={detailQuery.error}
 			isLoading={detailQuery.isLoading}
 			kindLabel="merge request"
+			refresh={
+				detailRef
+					? {
+							refetch: () => void detailQuery.refetch(),
+							isFetching: detailQuery.isFetching,
+						}
+					: undefined
+			}
 		/>
 	);
 }

--- a/src/features/source-detail/gitlab/merge-request-view.tsx
+++ b/src/features/source-detail/gitlab/merge-request-view.tsx
@@ -1,7 +1,9 @@
-import { useQuery } from "@tanstack/react-query";
-import { getInboxItemDetail } from "@/lib/api";
-import { helmorQueryKeys } from "@/lib/query-client";
-import { GitHubDetailPage, type SourceDetailProps } from "../common";
+import {
+	GitHubDetailPage,
+	type SourceDetailProps,
+	toRefreshControl,
+	useInboxItemDetailQuery,
+} from "../common";
 
 export function GitLabMergeRequestView({
 	card,
@@ -9,21 +11,7 @@ export function GitLabMergeRequestView({
 }: SourceDetailProps) {
 	const detailRef =
 		card.detailRef?.source === "gitlab_mr" ? card.detailRef : null;
-	const detailQuery = useQuery({
-		queryKey: detailRef
-			? helmorQueryKeys.inboxItemDetail(
-					detailRef.provider,
-					detailRef.login,
-					detailRef.source,
-					detailRef.externalId,
-				)
-			: ["inboxItemDetail", "missing", card.id],
-		queryFn: () => getInboxItemDetail(detailRef!),
-		enabled: detailRef !== null,
-		staleTime: 60_000,
-		refetchOnMount: "always",
-		refetchOnWindowFocus: "always",
-	});
+	const detailQuery = useInboxItemDetailQuery(detailRef, card.id);
 	const detail =
 		detailQuery.data?.type === "gitlab_mr" ? detailQuery.data.data : null;
 
@@ -35,14 +23,7 @@ export function GitLabMergeRequestView({
 			error={detailQuery.error}
 			isLoading={detailQuery.isLoading}
 			kindLabel="merge request"
-			refresh={
-				detailRef
-					? {
-							refetch: () => void detailQuery.refetch(),
-							isFetching: detailQuery.isFetching,
-						}
-					: undefined
-			}
+			refresh={detailRef ? toRefreshControl(detailQuery) : undefined}
 		/>
 	);
 }

--- a/src/features/source-detail/slack/file-preview.tsx
+++ b/src/features/source-detail/slack/file-preview.tsx
@@ -8,16 +8,23 @@ import { cn } from "@/lib/utils";
  *  custom protocol; PDFs / audio / unknown types render as a tappable
  *  chip that opens the original file in the user's browser.
  *
- *  Layout: 2-up grid on wide messages, single column when narrow. We
- *  cap the rendered height per tile to keep long file lists from
- *  exploding the thread view. */
+ *  Layout: 2-up grid on wide messages, single column when narrow.
+ *  `justify-items-start` keeps each tile from being stretched by the
+ *  grid so the inner `<button>` (inline-block) can hug the image
+ *  exactly — no letterbox / empty padding inside the rounded frame.
+ *  `max-w-[50%]` on the single-file grid acts as an upper bound only,
+ *  not a forced width: a narrow landscape stays at its natural size,
+ *  a wide or tall image scales down to fit the cap. */
 export function SlackFilePreviewGrid({ files }: { files: SlackFileRef[] }) {
 	if (files.length === 0) return null;
 	return (
 		<div
 			className={cn(
-				"mt-1 grid gap-1.5",
-				files.length === 1 ? "grid-cols-1" : "grid-cols-2",
+				"mt-1 grid gap-1.5 justify-items-start",
+				// Single-file: ≤ 50% of message body width.
+				// Multi-file: 2-column grid (each tile already implicitly
+				// at ≤ 50% body via the column split).
+				files.length === 1 ? "grid-cols-1 max-w-[50%]" : "grid-cols-2",
 			)}
 		>
 			{files.map((file) => (
@@ -41,30 +48,35 @@ function SlackFilePreview({ file }: { file: SlackFileRef }) {
 
 function ImagePreview({ file }: { file: SlackFileRef }) {
 	if (!file.previewUrl) return <FileChip file={file} />;
-	// Aspect ratio from the original dimensions (when Slack reported
-	// them) keeps the layout from reflowing when the image loads.
-	const aspect =
-		file.width && file.height
-			? { aspectRatio: `${file.width} / ${file.height}` }
-			: undefined;
 	const sourceUrl = file.sourceUrl ?? file.previewUrl;
+	// The `<img>` is the sizing element: `width` / `height` attrs from
+	// Slack's reported dimensions give the browser an intrinsic size
+	// (no layout shift on load), and `w-auto h-auto max-w-full
+	// max-h-[60vh]` lets the browser scale it down to fit the
+	// (container-width × 60vh) box while preserving the natural
+	// aspect ratio. The wrapping `<button>` is `inline-block max-w-full`
+	// so it hugs the image exactly — no `w-full`, no forced
+	// `aspect-ratio`, no `object-contain` letterbox. The result: the
+	// rounded border traces the picture, not a fixed-size frame around
+	// it.
 	return (
 		<button
 			type="button"
 			onClick={() => sourceUrl && void openExternal(sourceUrl)}
 			className={cn(
-				"group relative overflow-hidden rounded-lg border border-border/60 bg-muted",
+				"group relative inline-block max-w-full overflow-hidden rounded-lg border border-border/60 bg-muted",
 				"cursor-interactive transition-colors",
 				"hover:border-border focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/70",
 			)}
-			style={aspect}
 		>
 			<img
 				src={file.previewUrl}
 				alt={file.name}
 				title={file.name}
 				loading="lazy"
-				className="block max-h-[420px] w-full object-cover"
+				width={file.width ?? undefined}
+				height={file.height ?? undefined}
+				className="block h-auto max-h-[60vh] w-auto max-w-full"
 			/>
 		</button>
 	);

--- a/src/features/source-detail/slack/file-preview.tsx
+++ b/src/features/source-detail/slack/file-preview.tsx
@@ -49,22 +49,17 @@ function SlackFilePreview({ file }: { file: SlackFileRef }) {
 function ImagePreview({ file }: { file: SlackFileRef }) {
 	if (!file.previewUrl) return <FileChip file={file} />;
 	const sourceUrl = file.sourceUrl ?? file.previewUrl;
-	// The `<img>` is the sizing element: `width` / `height` attrs from
-	// Slack's reported dimensions give the browser an intrinsic size
-	// (no layout shift on load), and `w-auto h-auto max-w-full
-	// max-h-[60vh]` lets the browser scale it down to fit the
-	// (container-width × 60vh) box while preserving the natural
-	// aspect ratio. The wrapping `<button>` is `inline-block max-w-full`
-	// so it hugs the image exactly — no `w-full`, no forced
-	// `aspect-ratio`, no `object-contain` letterbox. The result: the
-	// rounded border traces the picture, not a fixed-size frame around
-	// it.
+	// The `<img>` sizes itself: natural `width`/`height` attrs prevent
+	// layout shift, and `max-w-full` / `max-h-[60vh]` scale it down to
+	// fit the cell while preserving aspect ratio. The `<button>` is
+	// `inline-block` so the rounded border hugs the image — no
+	// letterbox.
 	return (
 		<button
 			type="button"
 			onClick={() => sourceUrl && void openExternal(sourceUrl)}
 			className={cn(
-				"group relative inline-block max-w-full overflow-hidden rounded-lg border border-border/60 bg-muted",
+				"inline-block max-w-full overflow-hidden rounded-lg border border-border/60 bg-muted",
 				"cursor-interactive transition-colors",
 				"hover:border-border focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/70",
 			)}

--- a/src/features/source-detail/slack/message.tsx
+++ b/src/features/source-detail/slack/message.tsx
@@ -3,6 +3,7 @@ import { LazyStreamdown } from "@/components/streamdown-loader";
 import type { SlackMessage } from "@/lib/api";
 import {
 	inlineEmojiForMarkdown,
+	inlineMentionsForMarkdown,
 	resolveEmoji,
 	type SlackEmoji,
 } from "@/lib/slack-text";
@@ -37,7 +38,13 @@ export function SlackMessageBubble({
 	// File-only messages render their attachments inline instead.
 	const placeholderNeeded = !trimmedText && message.files.length === 0;
 	const rawBody = trimmedText || (placeholderNeeded ? "_(empty message)_" : "");
-	const body = rawBody ? inlineEmojiForMarkdown(rawBody, emoji) : "";
+	// Run mention rewriting before emoji inlining so the markdown
+	// pass sees `@name` text, not the raw `<@U…|name>` escape — both
+	// are pure-string transforms and order is independent, but reading
+	// the chain top-down is easier when mentions resolve first.
+	const body = rawBody
+		? inlineEmojiForMarkdown(inlineMentionsForMarkdown(rawBody), emoji)
+		: "";
 	return (
 		<div className="flex gap-3 px-1 py-2">
 			<div className="shrink-0">

--- a/src/features/source-detail/slack/thread-view.tsx
+++ b/src/features/source-detail/slack/thread-view.tsx
@@ -15,7 +15,7 @@ import { useSlackEmojiMap } from "@/features/inbox/use-slack-emoji-map";
 import { slackGetThreadDetail } from "@/lib/api";
 import { helmorQueryKeys } from "@/lib/query-client";
 import type { SourceDetailProps } from "../common";
-import { formatRelativeTime } from "../common";
+import { formatRelativeTime, RefreshButton } from "../common";
 import { SlackMessageBubble } from "./message";
 
 const STALE_MS = 60_000;
@@ -49,6 +49,12 @@ export function SlackThreadView({
 			}),
 		enabled: parsed !== null,
 		staleTime: STALE_MS,
+		// Re-fetch every time the detail view mounts (user opens a card)
+		// and whenever the app window regains focus — Slack threads
+		// mutate quickly and the user expects "open / refocus" to be a
+		// natural sync point.
+		refetchOnMount: "always",
+		refetchOnWindowFocus: "always",
 	});
 
 	if (!parsed) {
@@ -88,6 +94,12 @@ export function SlackThreadView({
 						</span>
 					</div>
 					<div className="flex shrink-0 items-center gap-1">
+						<RefreshButton
+							refresh={{
+								refetch: () => void detailQuery.refetch(),
+								isFetching: detailQuery.isFetching,
+							}}
+						/>
 						<Tooltip>
 							<TooltipTrigger asChild>
 								<Button

--- a/src/features/source-detail/slack/thread-view.tsx
+++ b/src/features/source-detail/slack/thread-view.tsx
@@ -15,7 +15,7 @@ import { useSlackEmojiMap } from "@/features/inbox/use-slack-emoji-map";
 import { slackGetThreadDetail } from "@/lib/api";
 import { helmorQueryKeys } from "@/lib/query-client";
 import type { SourceDetailProps } from "../common";
-import { formatRelativeTime, RefreshButton } from "../common";
+import { formatRelativeTime, RefreshButton, toRefreshControl } from "../common";
 import { SlackMessageBubble } from "./message";
 
 const STALE_MS = 60_000;
@@ -94,12 +94,7 @@ export function SlackThreadView({
 						</span>
 					</div>
 					<div className="flex shrink-0 items-center gap-1">
-						<RefreshButton
-							refresh={{
-								refetch: () => void detailQuery.refetch(),
-								isFetching: detailQuery.isFetching,
-							}}
-						/>
+						<RefreshButton refresh={toRefreshControl(detailQuery)} />
 						<Tooltip>
 							<TooltipTrigger asChild>
 								<Button

--- a/src/lib/slack-text.test.ts
+++ b/src/lib/slack-text.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { BUILTIN_EMOJI } from "@/lib/slack-emoji-builtin";
 import {
 	formatSlackTextPlain,
+	inlineMentionsForMarkdown,
 	resolveEmoji,
 	type SlackEmoji,
 } from "./slack-text";
@@ -84,6 +85,33 @@ describe("formatSlackTextPlain", () => {
 			"<@U08P4HCEJS1|james> wouldn't shut up :joy:\n\nLet's go Team <@U08KK7P7X71|spencer>";
 		expect(formatSlackTextPlain(raw, { emoji: emojiTable() })).toBe(
 			"@james wouldn't shut up 😂 Let's go Team @spencer",
+		);
+	});
+});
+
+describe("inlineMentionsForMarkdown", () => {
+	it("rewrites labeled user mentions to @name", () => {
+		expect(inlineMentionsForMarkdown("<@U06RP8NFS4|caspian.zhao> 有bug")).toBe(
+			"@caspian.zhao 有bug",
+		);
+	});
+
+	it("rewrites unlabeled mentions to @USER fallback", () => {
+		expect(inlineMentionsForMarkdown("<@U0B6RP8NFS4> has joined")).toBe(
+			"@U0B6RP8NFS4 has joined",
+		);
+	});
+
+	it("rewrites channel mentions to #name", () => {
+		expect(inlineMentionsForMarkdown("see <#C03|eng-frontend>")).toBe(
+			"see #eng-frontend",
+		);
+		expect(inlineMentionsForMarkdown("see <#C03>")).toBe("see #C03");
+	});
+
+	it("leaves non-mention text untouched", () => {
+		expect(inlineMentionsForMarkdown("hello world :wave:")).toBe(
+			"hello world :wave:",
 		);
 	});
 });

--- a/src/lib/slack-text.tsx
+++ b/src/lib/slack-text.tsx
@@ -297,15 +297,9 @@ export function formatSlackTextPlain(
 	opts: { emoji?: Record<string, SlackEmoji> } = {},
 ): string {
 	if (!text) return "";
-	const replaced = text
-		// User mention with label: <@U123|name> → @name
-		.replace(/<@[UW][A-Z0-9]+\|([^>]+)>/g, "@$1")
-		// User mention without label: <@U123> → @U123
-		.replace(/<@([UW][A-Z0-9]+)>/g, "@$1")
-		// Channel mention with label: <#C123|name> → #name
-		.replace(/<#[CGD][A-Z0-9]+\|([^>]+)>/g, "#$1")
-		// Channel mention without label: <#C123> → #C123
-		.replace(/<#([CGD][A-Z0-9]+)>/g, "#$1")
+	// User + channel mention rewriting is shared with the markdown
+	// path; layer the link + emoji passes on top of it here.
+	const replaced = inlineMentionsForMarkdown(text)
 		// URL with label: <https://…|label> → label
 		.replace(/<(?:https?|mailto):[^|>\s]+\|([^>]+)>/g, "$1")
 		// Bare URL: <https://…> → https://…

--- a/src/lib/slack-text.tsx
+++ b/src/lib/slack-text.tsx
@@ -353,3 +353,25 @@ export function inlineEmojiForMarkdown(
 		return raw;
 	});
 }
+
+/** Rewrite Slack mention tokens inside a markdown string into plain
+ *  `@name` text so Streamdown renders them as readable handles instead
+ *  of the raw `<@U…>` escape sequence.
+ *
+ *    `<@U123|jane>` → `@jane`     (backend already resolved the label)
+ *    `<@U123>`      → `@U123`     (unresolved fallback — surfaced as-is)
+ *    `<#C123|name>` → `#name`
+ *    `<#C123>`      → `#C123`
+ *
+ *  We don't try to produce a styled "pill" inside the markdown stream;
+ *  doing so would require injecting HTML through the markdown renderer,
+ *  which fights Streamdown's sanitization. The visible result — a human
+ *  name with an `@` prefix — matches how Slack itself renders the
+ *  collapsed/notification form of a mention. */
+export function inlineMentionsForMarkdown(text: string): string {
+	return text
+		.replace(/<@[UW][A-Z0-9]+\|([^>]+)>/g, "@$1")
+		.replace(/<@([UW][A-Z0-9]+)>/g, "@$1")
+		.replace(/<#[CGD][A-Z0-9]+\|([^>]+)>/g, "#$1")
+		.replace(/<#([CGD][A-Z0-9]+)>/g, "#$1");
+}


### PR DESCRIPTION
## What changed
- Refresh Slack, GitHub, and GitLab context detail panels when opened or when Helmor regains focus.
- Added a manual refresh control to context detail toolbars.
- Resolve Slack user mention tokens to readable display names in inbox snippets and thread bodies.
- Adjust Slack inline image previews to preserve natural aspect ratio and avoid oversized/letterboxed frames.
- Make Slack desktop import try every candidate macOS Keychain Safe Storage key before failing.

## Why
Context detail views can go stale quickly, especially Slack threads and forge items. Slack messages were also exposing raw mention IDs and image previews could crop or frame content awkwardly. The desktop Slack import fix handles users with multiple Slack builds leaving stale Keychain entries behind.

## Test notes
- Pre-commit hook passed: Biome, cargo fmt, and cargo clippy with `-D warnings`.
- Added frontend coverage for Slack mention rewriting.
- Added Rust coverage for wrong-key Slack cookie decryption fallback behavior.