### PR TITLE
Fix CLI send deadlock, queue loss, and Just-Chat preamble

### DIFF
--- a/.changeset/quiet-chats-unstick.md
+++ b/.changeset/quiet-chats-unstick.md
@@ -1,0 +1,8 @@
+---
+"helmor": patch
+---
+
+Three fixes for sending prompts from the CLI and chatting outside a workspace:
+- Fix `helmor send` failing with `Failed to borrow write connection: timed out waiting for connection` when an agent dispatches prompts to running workspaces.
+- Fix concurrent CLI sends silently dropping every prompt past the first one — the App now picks up each queued prompt in turn instead of discarding the rest while only dispatching the oldest.
+- Fix "Just Chat" sessions being told they were bound to a workspace with a working directory and a target branch, which previously led the agent into nonsensical `git` and PR commands.

--- a/.changeset/tidy-tabs-cleanup.md
+++ b/.changeset/tidy-tabs-cleanup.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Add a Cleanup button next to Rerun in the Run tab that runs the action's configured `stopCommand` standalone — lets you tear down lingering side effects (docker containers, daemons) left by `supabase start` / `docker compose up` style commands after they exit, so the next Rerun isn't sabotaged by "already running" state.

--- a/src-tauri/src/agents/streaming/mod.rs
+++ b/src-tauri/src/agents/streaming/mod.rs
@@ -114,9 +114,11 @@ pub(super) fn stream_via_sidecar(
     // borrow the read pool again on the hot path. Re-rendered every
     // turn so even mid-conversation orchestration asks ("spawn me 3
     // more workspaces") still see the helmor-cli skill cue.
-    let helmor_prefix = build_helmor_system_prompt_for_session(
+    let helmor_prefix = build_helmor_system_prompt_for_workspace(
         request.helmor_session_id.as_deref(),
-        session_row.as_ref(),
+        session_row
+            .as_ref()
+            .and_then(|(_, _, workspace_id)| workspace_id.as_deref()),
         working_directory,
     );
 
@@ -1229,49 +1231,39 @@ fn build_exit_plan_review_message(
 
 /// Build the Helmor system-prompt prefix that gets prepended to the
 /// agent's wire payload. Returns `None` when we can't resolve enough
-/// context (no helmor_session_id or no workspace row found) — callers
-/// fall through to "no Helmor prefix this turn" rather than blocking
-/// the send.
+/// context (missing workspace id, or the workspace row is gone) —
+/// callers fall through to "no Helmor prefix this turn" rather than
+/// blocking the send.
+///
+/// Exposed `pub(crate)` so both the in-app streaming path and the
+/// standalone-CLI path in `service::send_message` share the same
+/// preamble builder — keeps Chat-vs-workspace routing and all the
+/// workspace-bound fields in one place.
 ///
 /// Lookups against the workspace record happen against the read pool;
-/// failures degrade gracefully (we still build the prompt with
-/// whatever we managed to resolve).
-fn build_helmor_system_prompt_for_session(
+/// failures degrade gracefully.
+pub(crate) fn build_helmor_system_prompt_for_workspace(
     helmor_session_id: Option<&str>,
-    session_row: Option<&(Option<String>, Option<String>, Option<String>)>,
+    workspace_id: Option<&str>,
     working_directory: &std::path::Path,
 ) -> Option<String> {
-    use crate::agents::system_prompt::{build_helmor_system_prompt, HelmorSystemPromptContext};
-
-    let workspace_id = session_row.and_then(|(_, _, workspace_id)| workspace_id.clone())?;
-
-    let workspace_record = crate::models::workspaces::load_workspace_record_by_id(&workspace_id)
-        .ok()
-        .flatten();
-
-    // Workspace label: `<repo>/<directory>`. Falls back to the bare
-    // workspace id when the row is missing so the agent still gets a
-    // self-locating cue.
-    let workspace_label = match workspace_record.as_ref() {
-        Some(record) => format!("{}/{}", record.repo_name, record.directory_name),
-        None => workspace_id.clone(),
+    use crate::agents::system_prompt::{
+        build_helmor_chat_prompt, build_helmor_system_prompt, HelmorChatPromptContext,
+        HelmorSystemPromptContext,
     };
 
-    // Target branch: prefer the user-configured intended target,
-    // fall back to the repo's default branch. Wrap as `origin/<x>`
-    // so the diff/PR hints are immediately usable.
-    let target_branch_raw = workspace_record.as_ref().and_then(|record| {
-        record
-            .intended_target_branch
-            .clone()
-            .or_else(|| record.default_branch.clone())
-            .filter(|s| !s.trim().is_empty())
-    });
-    let base_branch = target_branch_raw.clone();
-    let target_branch = target_branch_raw.as_deref().map(|b| format!("origin/{b}"));
+    let workspace_id = workspace_id?;
 
-    let linked_directories =
-        crate::agents::streaming::lookup_workspace_linked_directories(helmor_session_id);
+    // Skip the preamble entirely when we can't resolve the workspace
+    // row. The agent gets no Helmor framing this turn rather than a
+    // degraded one with a UUID-as-workspace-label and a misleading
+    // "target branch not configured" nag — matches the function's
+    // doc-comment contract ("Returns `None` when ... no workspace row
+    // found"). Orphan sessions (workspace deleted but session row
+    // lingering) are the realistic trigger.
+    let record = crate::models::workspaces::load_workspace_record_by_id(workspace_id)
+        .ok()
+        .flatten()?;
 
     // CLI invocation the agent should call. On release this is the
     // canonical `helmor` symlink on PATH; on dev it's the absolute
@@ -1283,6 +1275,35 @@ fn build_helmor_system_prompt_for_session(
     // dev instances' agents would silently talk to the wrong build.
     // See `crate::cli::agent_invocation_path` for the full rationale.
     let cli_command_name = crate::cli::agent_invocation_path();
+
+    // Chat-mode workspaces have no repo / no worktree / no target
+    // branch. The workspace-bound preamble would inject misleading
+    // hints (a synthetic workspace label, a `~/helmor/chats/...`
+    // working directory the user never sees, a "configure a target
+    // branch" nag, and a `.agent-contexts/` scratch dir that lives in
+    // a non-git directory). Route them through the smaller chat-only
+    // template instead.
+    if record.mode.is_chat() {
+        return Some(build_helmor_chat_prompt(&HelmorChatPromptContext {
+            cli_command_name,
+        }));
+    }
+
+    let workspace_label = format!("{}/{}", record.repo_name, record.directory_name);
+
+    // Target branch: prefer the user-configured intended target,
+    // fall back to the repo's default branch. Wrap as `origin/<x>`
+    // so the diff/PR hints are immediately usable.
+    let target_branch_raw = record
+        .intended_target_branch
+        .clone()
+        .or_else(|| record.default_branch.clone())
+        .filter(|s| !s.trim().is_empty());
+    let base_branch = target_branch_raw.clone();
+    let target_branch = target_branch_raw.as_deref().map(|b| format!("origin/{b}"));
+
+    let linked_directories =
+        crate::agents::streaming::lookup_workspace_linked_directories(helmor_session_id);
 
     let ctx = HelmorSystemPromptContext {
         workspace_label,

--- a/src-tauri/src/agents/system_prompt.rs
+++ b/src-tauri/src/agents/system_prompt.rs
@@ -7,7 +7,7 @@
 //! inside Helmor" preamble stitched onto the front of the user's
 //! prompt. The preamble:
 //!
-//! - Names the kanban card the agent is running on (so an agent
+//! - Names the workspace the agent is running on (so an agent
 //!   spawned into a second workspace knows which one it is).
 //! - Tells the agent where its working directory + target branch are,
 //!   plus any `/add-dir`-linked directories.
@@ -49,7 +49,7 @@ use std::fmt::Write;
 /// Context the prompt template consumes. Construct once per send.
 #[derive(Debug, Clone)]
 pub struct HelmorSystemPromptContext {
-    /// Human-friendly label for the current kanban card. Format
+    /// Human-friendly label for the current workspace. Format
     /// `<repo>/<workspace-directory>` so the agent's self-locating
     /// statement matches what the user sees in the sidebar.
     pub workspace_label: String,
@@ -85,6 +85,18 @@ pub struct HelmorSystemPromptContext {
     pub cli_command_name: String,
 }
 
+/// Context the chat-mode prompt template consumes. Chat sessions are
+/// not bound to a repository or worktree, so the workspace label /
+/// working directory / target branch / `.agent-contexts/` story
+/// doesn't apply — we surface a smaller preamble that only carries
+/// the bits a "Just Chat" agent actually needs.
+#[derive(Debug, Clone)]
+pub struct HelmorChatPromptContext {
+    /// Same CLI invocation rules as
+    /// [`HelmorSystemPromptContext::cli_command_name`].
+    pub cli_command_name: String,
+}
+
 /// Render the preamble. Deterministic, no I/O, side-effect-free —
 /// safe to call from any context. The result already trims trailing
 /// whitespace so the consumer can `format!("{prefix}\n\n{rest}")`
@@ -96,7 +108,7 @@ pub fn build_helmor_system_prompt(ctx: &HelmorSystemPromptContext) -> String {
     out.push_str("You are running inside Helmor, a Mac app that lets the user run many coding agents in parallel.\n");
     let _ = writeln!(
         out,
-        "You are working on the kanban card `{}`. The user is watching this conversation live in Helmor's GUI.",
+        "You are working on the workspace `{}`. The user is watching this conversation live in Helmor's GUI.",
         ctx.workspace_label,
     );
     let _ = writeln!(
@@ -149,6 +161,35 @@ pub fn build_helmor_system_prompt(ctx: &HelmorSystemPromptContext) -> String {
     out
 }
 
+/// Render the "Just Chat" variant of the preamble. Used for
+/// `WorkspaceMode::Chat` sessions that have no repo / no worktree /
+/// no target branch — the workspace-bound prompt's workspace label,
+/// working directory, target branch, and `.agent-contexts/` lines
+/// would all be either wrong or misleading there. Same `<helmor_context>`
+/// envelope so logs / SDK clients can spot Helmor's preamble at a glance.
+pub fn build_helmor_chat_prompt(ctx: &HelmorChatPromptContext) -> String {
+    let mut out = String::with_capacity(384);
+
+    out.push_str("<helmor_context>\n");
+    out.push_str("You are running inside Helmor, a Mac app that lets the user run many coding agents in parallel.\n");
+    out.push_str(
+        "This is a \"Just Chat\" session — it is not bound to any repository or workspace, so there is no working directory, no target branch, and no git context. Do not assume a project structure, and do not run commands that need one (no `git`, no project-relative file edits, no PRs) unless the user explicitly points you at one.\n",
+    );
+
+    let _ = write!(
+        out,
+        "\nHelmor itself is scriptable via `{cli}`. When you need to operate Helmor (spawn workspaces, dispatch ship actions, read other agents' sessions, etc.), run `{cli} --help` or `{cli} <subcommand> --help` — each subcommand's help block includes examples you can copy. Invoke `{cli}` verbatim; do NOT verify it first with `which`, `file`, `--version`, or by searching `target/debug` — it is already the binary this Helmor instance owns, and pre-verifying eats your turn.\n",
+        cli = ctx.cli_command_name,
+    );
+
+    out.push_str(
+        "\nIf the user asks for help with Helmor itself, point them at the feedback button at the bottom of Helmor's sidebar.\n",
+    );
+
+    out.push_str("</helmor_context>");
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -164,8 +205,8 @@ mod tests {
         }
     }
 
-    /// Sanity: every kanban-aware field reaches the rendered prompt so
-    /// the agent can self-locate.
+    /// Sanity: every workspace-aware field reaches the rendered prompt
+    /// so the agent can self-locate.
     #[test]
     fn renders_workspace_label_and_root_path() {
         let prompt = build_helmor_system_prompt(&ctx_with_defaults());
@@ -338,6 +379,79 @@ mod tests {
     #[test]
     fn output_is_wrapped_in_helmor_context_tag() {
         let prompt = build_helmor_system_prompt(&ctx_with_defaults());
+        assert!(prompt.starts_with("<helmor_context>"));
+        assert!(prompt.ends_with("</helmor_context>"));
+    }
+
+    // ── Chat-mode preamble ────────────────────────────────────────────
+
+    fn chat_ctx() -> HelmorChatPromptContext {
+        HelmorChatPromptContext {
+            cli_command_name: "helmor".to_string(),
+        }
+    }
+
+    /// Chat sessions have no repo / no worktree / no target branch /
+    /// no `.agent-contexts/` story. Pin that none of the workspace-
+    /// bound lines leak into the chat preamble — a regression that
+    /// reintroduces any of these would mislead the agent into looking
+    /// for a git context that doesn't exist.
+    #[test]
+    fn chat_prompt_omits_workspace_bound_lines() {
+        let prompt = build_helmor_chat_prompt(&chat_ctx());
+        assert!(
+            !prompt.contains("You are working on the workspace"),
+            "chat prompt must not pin a workspace (chat sessions aren't bound to one)"
+        );
+        assert!(
+            !prompt.contains("Your working directory is"),
+            "chat prompt must not pin a working directory"
+        );
+        assert!(
+            !prompt.contains("Target branch for this workspace"),
+            "chat prompt must not advertise a target branch"
+        );
+        assert!(
+            !prompt.contains("gh pr create"),
+            "chat prompt must not pre-substitute PR creation commands"
+        );
+        assert!(
+            !prompt.contains(".agent-contexts/"),
+            "chat prompt must not advertise the agent-contexts scratch dir"
+        );
+        assert!(
+            !prompt.contains("linked directories"),
+            "chat prompt must not mention `/add-dir` linked directories"
+        );
+    }
+
+    /// Chat sessions must be self-locating: the agent should know it's
+    /// a "Just Chat" session and adjust expectations (no project, no
+    /// PR). Pin the user-facing language so a future refactor doesn't
+    /// silently drop the disclosure.
+    #[test]
+    fn chat_prompt_states_it_is_chat_and_warns_against_assuming_repo() {
+        let prompt = build_helmor_chat_prompt(&chat_ctx());
+        assert!(prompt.contains("Just Chat"));
+        assert!(prompt.contains("not bound to any repository"));
+    }
+
+    /// CLI section + feedback pointer apply to chat sessions too —
+    /// they can still drive Helmor and still need to report bugs.
+    #[test]
+    fn chat_prompt_keeps_cli_and_feedback_sections() {
+        let prompt = build_helmor_chat_prompt(&chat_ctx());
+        assert!(prompt.contains("`helmor`"));
+        assert!(prompt.contains("`helmor --help`"));
+        assert!(prompt.contains("do NOT verify"));
+        assert!(prompt.contains("feedback button"));
+    }
+
+    /// Same `<helmor_context>` envelope so log viewers / SDK clients
+    /// can spot the preamble regardless of which template emitted it.
+    #[test]
+    fn chat_prompt_is_wrapped_in_helmor_context_tag() {
+        let prompt = build_helmor_chat_prompt(&chat_ctx());
         assert!(prompt.starts_with("<helmor_context>"));
         assert!(prompt.ends_with("</helmor_context>"));
     }

--- a/src-tauri/src/cli/args.rs
+++ b/src-tauri/src/cli/args.rs
@@ -51,7 +51,7 @@ const EXAMPLES_WORKSPACE_LIST: &str =
     # Just the ones in a single repo
     helmor workspace list --repo dohooo/hello
 
-    # Filter by kanban status
+    # Filter by status group
     helmor workspace list --status review";
 
 const EXAMPLES_WORKSPACE_RUN_ACTION: &str =

--- a/src-tauri/src/commands/script_commands.rs
+++ b/src-tauri/src/commands/script_commands.rs
@@ -252,6 +252,77 @@ pub async fn stop_repo_script(
     Ok(manager.kill(&key))
 }
 
+/// Run a run action's configured `stop_command` as a standalone script
+/// (no preceding main process to terminate). The state machine for the
+/// frontend Run tab treats `exited` as "clean slate", but commands like
+/// `supabase start` / `docker compose up` leave side effects (containers,
+/// daemons) that outlive the spawned process. The Cleanup button surfaces
+/// the user-configured stop command after exit so they can tear down those
+/// side effects without re-running the failed start.
+///
+/// Reuses the same process slot (`"run:<id>"`) as the start script, so the
+/// frontend's terminal output buffer and per-action status indicator
+/// naturally reflect the cleanup run. We deliberately do NOT call
+/// `kill_others_in_repo` — for concurrent-mode actions, another workspace
+/// may legitimately be running the same action and that run is independent
+/// of this workspace's cleanup. Same-key replacement within this workspace
+/// is handled atomically by `register()` inside `spawn_script`.
+#[tauri::command]
+pub async fn execute_repo_stop_command(
+    app: AppHandle,
+    manager: State<'_, ScriptProcessManager>,
+    repo_id: String,
+    workspace_id: String,
+    action_id: String,
+    channel: Channel<ScriptEvent>,
+) -> CmdResult<()> {
+    let ws = Some(workspace_id.clone());
+    let rid = repo_id.clone();
+    let aid = Some(action_id.clone());
+    let action = match tauri::async_runtime::spawn_blocking(move || {
+        resolve_run_target(&rid, ws.as_deref(), aid.as_deref())
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("spawn_blocking join failed: {e}"))?
+    {
+        Ok(a) => a,
+        Err(e) => {
+            let _ = channel.send(ScriptEvent::Error {
+                message: e.to_string(),
+            });
+            return Ok(());
+        }
+    };
+
+    let Some(stop_command) = action
+        .stop_command
+        .as_ref()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+    else {
+        let _ = channel.send(ScriptEvent::Error {
+            message: format!("No stop command configured for action: {}", action.name),
+        });
+        return Ok(());
+    };
+
+    let process_type = run_script_type(&action.id);
+
+    spawn_script(
+        app,
+        manager,
+        repo_id,
+        process_type,
+        Some(workspace_id),
+        stop_command,
+        channel,
+        // Cleanup itself has no further cleanup — None preserves the
+        // pre-feature SIGTERM→SIGKILL path if the user stops it mid-flight.
+        None,
+    )
+    .await
+}
+
 /// Write raw bytes to the PTY master of a running script. The kernel's tty
 /// line discipline turns `\x03` into SIGINT for the foreground process group,
 /// so this is what makes Ctrl+C inside the terminal tab actually work.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -439,6 +439,7 @@ pub fn run() {
             commands::repository_commands::move_repository_in_sidebar,
             commands::repository_commands::retry_repo_forge_binding,
             commands::script_commands::execute_repo_script,
+            commands::script_commands::execute_repo_stop_command,
             commands::script_commands::stop_repo_script,
             commands::script_commands::write_repo_script_stdin,
             commands::script_commands::resize_repo_script,

--- a/src-tauri/src/mcp/catalog.rs
+++ b/src-tauri/src/mcp/catalog.rs
@@ -31,7 +31,7 @@ pub(super) fn tool_catalog() -> Vec<Value> {
             add_response_options(json!({
                 "type": "object",
                 "properties": {
-                    "status": { "type": "string", "description": "Filter by stored workspace status. Accepts a kanban lane id (progress/done/review/backlog/canceled) or the canonical status string (in-progress/done/...)." },
+                    "status": { "type": "string", "description": "Filter by stored workspace status. Accepts a status group id (progress/done/review/backlog/canceled) or the canonical status string (in-progress/done/...)." },
                     "repo": { "type": "string", "description": "Repository UUID or name" },
                     "archived": { "type": "boolean", "description": "If true, list archived workspaces instead of active ones." },
                     "limit": { "type": "integer", "description": "Max rows to return (1-50, default 20)" }
@@ -63,7 +63,7 @@ pub(super) fn tool_catalog() -> Vec<Value> {
         ),
         tool_def(
             "helmor_workspace_set_status",
-            "Move a workspace into a different kanban lane. Use this when the user verbally moves a workspace to done/review/backlog/in-progress/canceled. Canceled and Done are destructive-feeling; callers should confirm with the user first.",
+            "Move a workspace into a different status group. Use this when the user verbally moves a workspace to done/review/backlog/in-progress/canceled. Canceled and Done are destructive-feeling; callers should confirm with the user first.",
             add_response_options(json!({
                 "type": "object",
                 "properties": {
@@ -71,7 +71,7 @@ pub(super) fn tool_catalog() -> Vec<Value> {
                     "status": {
                         "type": "string",
                         "enum": ["in-progress", "done", "review", "backlog", "canceled"],
-                        "description": "Target status. Accepts kanban group ids (progress = in-progress)."
+                        "description": "Target status. Accepts status group ids (progress = in-progress)."
                     }
                 },
                 "required": ["ref", "status"]

--- a/src-tauri/src/mcp/tools/tests.rs
+++ b/src-tauri/src/mcp/tools/tests.rs
@@ -146,7 +146,7 @@ fn workspace_run_action_rejects_unknown_actions() {
 }
 
 #[test]
-fn workspace_status_matches_accepts_kanban_and_canonical() {
+fn workspace_status_matches_accepts_group_id_and_canonical() {
     // group_id form
     assert!(workspace_status_matches(
         &WorkspaceStatus::InProgress,

--- a/src-tauri/src/mcp/tools/workspace.rs
+++ b/src-tauri/src/mcp/tools/workspace.rs
@@ -142,7 +142,7 @@ pub(super) fn tool_workspace_create(args: &Value) -> Result<String> {
 pub(super) fn tool_workspace_set_status(args: &Value) -> Result<String> {
     let ws_ref = required_str(args, "ref")?;
     let status_raw = required_str(args, "status")?;
-    // Accept both the kebab-case stored value AND the kanban group id —
+    // Accept both the kebab-case stored value AND the status group id —
     // "progress" maps to "in-progress" the same way the GUI does.
     let canonical = if status_raw.eq_ignore_ascii_case("progress") {
         "in-progress".to_string()

--- a/src-tauri/src/service.rs
+++ b/src-tauri/src/service.rs
@@ -6,7 +6,7 @@
 use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
-use rusqlite::params;
+use rusqlite::{params, OptionalExtension};
 use serde::Serialize;
 use serde_json::Value;
 use uuid::Uuid;
@@ -183,9 +183,15 @@ pub fn send_message(
     // and streams through its shared sidecar so the frontend sees live
     // updates. The CLI prints a short confirmation instead of streaming.
     if is_app_running() {
-        // Persist user message so the app's conversation container
-        // shows the optimistic user bubble right away.
-        let conn = crate::models::db::write_conn()?;
+        // All three writes (user message, session pin, pending send) go
+        // through ONE pooled connection inside ONE transaction. The
+        // write pool's max_size is 1, so holding a borrow across nested
+        // calls that also grab `write_conn()` self-deadlocks the pool
+        // until the 30s `connection_timeout` fires — that's the
+        // "Failed to borrow write connection: timed out waiting for
+        // connection" we used to surface when CLI sends raced. Single
+        // borrow + single tx eliminates both the deadlock and the
+        // partial-write window.
         let timestamp = crate::models::db::current_timestamp()?;
         let user_msg_id = Uuid::new_v4().to_string();
         let user_content = serde_json::json!({
@@ -193,36 +199,51 @@ pub fn send_message(
             "text": params.prompt,
         })
         .to_string();
-        conn.execute(
-            r#"INSERT INTO session_messages
-               (id, session_id, role, content, created_at, sent_at)
-               VALUES (?1, ?2, 'user', ?3, ?4, ?4)"#,
-            params![user_msg_id, session_id, user_content, timestamp],
-        )?;
+        let pending_id = Uuid::new_v4().to_string();
+        {
+            let mut conn = crate::models::db::write_conn()?;
+            let tx = conn.transaction()?;
+            // Persist user message so the app's conversation container
+            // shows the optimistic user bubble right away.
+            tx.execute(
+                r#"INSERT INTO session_messages
+                   (id, session_id, role, content, created_at, sent_at)
+                   VALUES (?1, ?2, 'user', ?3, ?4, ?4)"#,
+                params![user_msg_id, session_id, user_content, timestamp],
+            )?;
 
-        // Pin the resolved model + (optional) permission_mode onto the
-        // session row before queuing. The App composer reads these off
-        // `currentSession` when it auto-submits the drained prompt — so
-        // without this the row still has model=NULL and the composer
-        // falls back to settings.defaultModelId, ignoring the CLI's
-        // --model / --plan override.
-        conn.execute(
-            "UPDATE sessions SET model = ?2, permission_mode = COALESCE(?3, permission_mode), updated_at = ?4 WHERE id = ?1",
-            params![
-                session_id,
-                model_id,
-                params.permission_mode.as_deref(),
-                timestamp,
-            ],
-        )?;
+            // Pin the resolved model + (optional) permission_mode onto
+            // the session row before queuing. The App composer reads
+            // these off `currentSession` when it auto-submits the
+            // drained prompt — without this the row still has
+            // model=NULL and the composer falls back to
+            // settings.defaultModelId, ignoring the CLI's
+            // --model / --plan override.
+            tx.execute(
+                "UPDATE sessions SET model = ?2, permission_mode = COALESCE(?3, permission_mode), updated_at = ?4 WHERE id = ?1",
+                params![
+                    session_id,
+                    model_id,
+                    params.permission_mode.as_deref(),
+                    timestamp,
+                ],
+            )?;
 
-        insert_pending_cli_send(
-            &workspace_id,
-            &session_id,
-            &params.prompt,
-            Some(&model_id),
-            params.permission_mode.as_deref(),
-        )?;
+            tx.execute(
+                r#"INSERT INTO pending_cli_sends
+                   (id, workspace_id, session_id, prompt, model_id, permission_mode)
+                   VALUES (?1, ?2, ?3, ?4, ?5, ?6)"#,
+                params![
+                    pending_id,
+                    workspace_id,
+                    session_id,
+                    params.prompt,
+                    Some(&model_id),
+                    params.permission_mode.as_deref()
+                ],
+            )?;
+            tx.commit()?;
+        }
 
         let _ = crate::ui_sync::notify_running_app(
             crate::ui_sync::UiMutationEvent::PendingCliSendQueued {
@@ -268,9 +289,24 @@ pub fn send_message(
             crate::agents::lookup_workspace_linked_directories(Some(&session_id));
     }
 
+    // Prepend the same Helmor `<helmor_context>` preamble the in-app
+    // streaming path uses, so a CLI-launched agent self-locates and
+    // sees the chat-vs-workspace framing. Persisted user message
+    // (further down) still stores `params.prompt` only, matching the
+    // in-app contract that the DB never sees the preamble.
+    let helmor_prefix = crate::agents::streaming::build_helmor_system_prompt_for_workspace(
+        Some(&session_id),
+        Some(&workspace_id),
+        std::path::Path::new(&cwd),
+    );
+    let wire_prompt = match helmor_prefix.as_deref() {
+        Some(helmor) => format!("{helmor}\n\nUser request:\n{}", params.prompt),
+        None => params.prompt.clone(),
+    };
+
     let mut payload = serde_json::json!({
         "sessionId": session_id,
-        "prompt": params.prompt,
+        "prompt": wire_prompt,
         "model": model.cli_model,
         "cwd": cwd,
         "provider": model.provider,
@@ -557,7 +593,17 @@ pub struct PendingCliSend {
 }
 
 /// Insert a pending send so the App's frontend can pick it up on focus.
-pub fn insert_pending_cli_send(
+///
+/// **Test-only.** Production used to call this from `send_message`'s
+/// App-delegation branch, but that path now performs the INSERT inline
+/// inside a transaction that already holds the (single) writer
+/// connection — calling this helper while still holding the writer
+/// would self-deadlock the `max_size=1` write pool. The helper is kept
+/// for `drain_pending_cli_sends` round-trip tests; gating it on
+/// `#[cfg(test)]` makes the deprecation explicit so a future caller
+/// can't accidentally reintroduce the deadlock.
+#[cfg(test)]
+fn insert_pending_cli_send(
     workspace_id: &str,
     session_id: &str,
     prompt: &str,
@@ -575,16 +621,30 @@ pub fn insert_pending_cli_send(
     Ok(id)
 }
 
-/// Read and delete all pending sends in one atomic operation.
-/// Returns them oldest-first so the App processes them in order.
+/// Drain the **single oldest** pending send, returning it as a
+/// zero-or-one Vec, and delete only that row.
+///
+/// We intentionally do NOT drain the whole queue in one call. The
+/// frontend's `processPendingCliSends` consumes `sends[0]` and routes
+/// the UI to that one workspace/session — older code drained the whole
+/// table at once, which meant any prompt past the first was deleted
+/// from the queue but never dispatched (orphan user bubbles, no
+/// agent reply). Each `PendingCliSendQueued` event triggers a fresh
+/// drain, so a one-at-a-time contract turns N pending rows into N
+/// dispatches with no races.
+///
+/// Returns an empty Vec when the queue is empty. Vec (not Option) so
+/// the existing Tauri command + frontend type signature stays
+/// backwards-compatible — frontend already does `if (sends.length === 0)
+/// return; const first = sends[0];`, which works unchanged.
 pub fn drain_pending_cli_sends() -> Result<Vec<PendingCliSend>> {
     let conn = crate::models::db::write_conn()?;
     let mut stmt = conn.prepare(
         "SELECT id, workspace_id, session_id, prompt, model_id, permission_mode, created_at
-         FROM pending_cli_sends ORDER BY datetime(created_at) ASC",
+         FROM pending_cli_sends ORDER BY datetime(created_at) ASC LIMIT 1",
     )?;
-    let rows: Vec<PendingCliSend> = stmt
-        .query_map([], |row| {
+    let row: Option<PendingCliSend> = stmt
+        .query_row([], |row| {
             Ok(PendingCliSend {
                 id: row.get(0)?,
                 workspace_id: row.get(1)?,
@@ -594,16 +654,19 @@ pub fn drain_pending_cli_sends() -> Result<Vec<PendingCliSend>> {
                 permission_mode: row.get(5)?,
                 created_at: row.get(6)?,
             })
-        })?
-        .collect::<std::result::Result<Vec<_>, _>>()
+        })
+        .optional()
         .context("Failed to read pending CLI sends")?;
 
-    if !rows.is_empty() {
-        conn.execute("DELETE FROM pending_cli_sends", [])
-            .context("Failed to delete pending CLI sends")?;
+    if let Some(ref send) = row {
+        conn.execute(
+            "DELETE FROM pending_cli_sends WHERE id = ?1",
+            params![send.id],
+        )
+        .context("Failed to delete pending CLI send")?;
     }
 
-    Ok(rows)
+    Ok(row.into_iter().collect())
 }
 
 /// Check if the Helmor App is running by testing the MCP bridge port.
@@ -696,7 +759,12 @@ mod tests {
     }
 
     #[test]
-    fn drain_returns_oldest_first() {
+    fn drain_returns_one_oldest_at_a_time_in_order() {
+        // Regression for the multi-CLI-send queue-loss bug: the drain
+        // used to return + delete every row in one call, but the
+        // frontend only dispatches sends[0] per call — older entries
+        // were silently dropped. Pin that the queue now drains ONE row
+        // per call, oldest first, leaving the rest for subsequent calls.
         let _lock = TEST_ENV_LOCK.lock().unwrap();
         let _dir = TestDataDir::new("drain-order");
 
@@ -705,10 +773,16 @@ mod tests {
         std::thread::sleep(std::time::Duration::from_millis(50));
         insert_pending_cli_send("ws-1", "sess-b", "second", None, None).unwrap();
 
-        let sends = drain_pending_cli_sends().unwrap();
-        assert_eq!(sends.len(), 2);
-        assert_eq!(sends[0].prompt, "first");
-        assert_eq!(sends[1].prompt, "second");
+        let first = drain_pending_cli_sends().unwrap();
+        assert_eq!(first.len(), 1, "first drain must take only one row");
+        assert_eq!(first[0].prompt, "first");
+
+        let second = drain_pending_cli_sends().unwrap();
+        assert_eq!(second.len(), 1, "second drain must take the next row");
+        assert_eq!(second[0].prompt, "second");
+
+        let third = drain_pending_cli_sends().unwrap();
+        assert!(third.is_empty(), "queue must be empty after both drained");
     }
 
     #[test]

--- a/src-tauri/src/workspace/workspaces.rs
+++ b/src-tauri/src/workspace/workspaces.rs
@@ -330,7 +330,7 @@ pub fn mark_workspace_unread(workspace_id: &str) -> Result<()> {
 }
 
 /// Guard for status/pin operations: chat workspaces live in their own
-/// bucket and don't participate in the kanban (status / pinned). All
+/// bucket and don't participate in workspace status / pinning. All
 /// three commands bail rather than silently no-op so the call site
 /// (frontend menu, automated PR-sync) can surface the rejection.
 fn assert_not_chat(transaction: &Transaction<'_>, workspace_id: &str) -> Result<()> {
@@ -2108,8 +2108,8 @@ mod tests {
 
     // ── Chat-mode workspace tests ────────────────────────────────────────
     //
-    // Chat workspaces are a parallel universe to the kanban: own bucket,
-    // own scratch dir, no git. The tests below pin the contract that
+    // Chat workspaces are a parallel universe to the status grouping:
+    // own bucket, own scratch dir, no git. The tests below pin the contract that
     // (a) prepare lays a row + dir down, (b) the drag-policy walls
     // around the bucket hold both directions, (c) permanently_delete
     // really wipes the scratch dir, and (d) archive is a pure DB flip.

--- a/src/features/inspector/index.tsx
+++ b/src/features/inspector/index.tsx
@@ -611,6 +611,7 @@ export function WorkspaceInspectorSidebar({
 					activeRunActionId={activeRunActionId}
 					activeRunActionName={activeAction?.name ?? null}
 					runScript={activeAction?.command ?? null}
+					stopCommand={activeAction?.stopCommand ?? null}
 					hasAnyRunAction={runActions.length > 0}
 					isActive={activeTab === "run"}
 					onOpenSettings={handleOpenRepoScripts}

--- a/src/features/inspector/script-store.ts
+++ b/src/features/inspector/script-store.ts
@@ -1,5 +1,6 @@
 import {
 	executeRepoScript,
+	executeRepoStopCommand,
 	resizeRepoScript,
 	type ScriptEvent,
 	stopRepoScript,
@@ -155,11 +156,25 @@ export function getScriptState(
 	return entries.get(key(workspaceId, scriptType, actionId)) ?? null;
 }
 
-export function startScript(
-	repoId: string,
-	scriptType: ScriptKind,
+/**
+ * Shared entry-management + event-handling for any backend script
+ * invocation that streams `ScriptEvent`s into the Run / Setup tab. Both
+ * `startScript` (run the configured command) and `cleanupScript` (run the
+ * configured `stopCommand` standalone) wrap this — they only differ in
+ * which Tauri command spawns the process.
+ *
+ * `invokeBackend` is the IPC call: it receives the event handler that
+ * routes events into the entry's buffer / listeners. `failureLabel`
+ * prefixes the error chunk printed when the IPC itself rejects (rare —
+ * usually a backend `?` propagation), so users see whether the failure
+ * was during the start path or the cleanup path.
+ */
+function runScriptInternal(
 	workspaceId: string,
-	actionId?: string | null,
+	scriptType: ScriptKind,
+	actionId: string | null | undefined,
+	invokeBackend: (onEvent: (event: ScriptEvent) => void) => Promise<void>,
+	failureLabel: string,
 ) {
 	const k = key(workspaceId, scriptType, actionId);
 
@@ -199,91 +214,85 @@ export function startScript(
 		emitWorkspaceRunStatus(workspaceId, "running", null);
 	}
 
-	executeRepoScript(
-		repoId,
-		scriptType,
-		(event: ScriptEvent) => {
-			if (entries.get(k) !== entry) return;
-
-			switch (event.type) {
-				case "started":
-					break;
-				case "stopping":
-					entry.stopping = true;
-					listeners.get(k)?.onStoppingChange?.(true);
-					break;
-				case "stdout":
-				case "stderr": {
-					appendChunk(entry, event.data);
-					listeners.get(k)?.onChunk(event.data);
-
-					// Cheap short-circuit: once a dev server has settled into
-					// steady-state, ~every chunk is HMR / request-log noise with
-					// no URL. Skip the regex work when the chunk can't possibly
-					// contain one. `event.data.includes("http")` is a plain
-					// substring scan — ~100x faster than the ANSI+URL regex
-					// combo and totally safe (any real localhost URL has "http"
-					// verbatim in bytes, even when wrapped in ANSI).
-					//
-					// We still run detection on every chunk until we've seen at
-					// least one URL, so the initial banner is never missed.
-					if (entry.urls.length > 0 && !event.data.includes("http")) {
-						break;
-					}
-
-					// Scan the fresh chunk for dev-server URLs. We keep a deduped,
-					// first-seen-ordered list on the entry and only fire the listener
-					// when something actually changed.
-					const fresh = extractLocalUrls(event.data);
-					if (fresh.length > 0) {
-						const seen = new Set(entry.urls.map(dedupUrlKey));
-						let changed = false;
-						for (const url of fresh) {
-							const k2 = dedupUrlKey(url);
-							if (!seen.has(k2)) {
-								seen.add(k2);
-								entry.urls.push(url);
-								changed = true;
-							}
-						}
-						if (changed) {
-							listeners.get(k)?.onUrlsChange?.([...entry.urls]);
-						}
-					}
-					break;
-				}
-				case "exited":
-					entry.status = "exited";
-					entry.exitCode = event.code;
-					clearStopping();
-					listeners.get(k)?.onStatusChange("exited");
-					emitStatus(k, "exited", event.code);
-					if (scriptType === "run") {
-						emitWorkspaceRunStatus(workspaceId, "exited", event.code);
-					}
-					break;
-				case "error": {
-					const msg = `\r\n\x1b[31m${event.message}\x1b[0m\r\n`;
-					appendChunk(entry, msg);
-					entry.status = "exited";
-					// No exit code from the backend here — treat as failure.
-					entry.exitCode = entry.exitCode ?? 1;
-					clearStopping();
-					listeners.get(k)?.onChunk(msg);
-					listeners.get(k)?.onStatusChange("exited");
-					emitStatus(k, "exited", entry.exitCode);
-					if (scriptType === "run") {
-						emitWorkspaceRunStatus(workspaceId, "exited", entry.exitCode);
-					}
-					break;
-				}
-			}
-		},
-		workspaceId,
-		actionId ?? null,
-	).catch((err) => {
+	invokeBackend((event: ScriptEvent) => {
 		if (entries.get(k) !== entry) return;
-		const msg = `\r\n\x1b[31mFailed to start: ${err}\x1b[0m\r\n`;
+
+		switch (event.type) {
+			case "started":
+				break;
+			case "stopping":
+				entry.stopping = true;
+				listeners.get(k)?.onStoppingChange?.(true);
+				break;
+			case "stdout":
+			case "stderr": {
+				appendChunk(entry, event.data);
+				listeners.get(k)?.onChunk(event.data);
+
+				// Cheap short-circuit: once a dev server has settled into
+				// steady-state, ~every chunk is HMR / request-log noise with
+				// no URL. Skip the regex work when the chunk can't possibly
+				// contain one. `event.data.includes("http")` is a plain
+				// substring scan — ~100x faster than the ANSI+URL regex
+				// combo and totally safe (any real localhost URL has "http"
+				// verbatim in bytes, even when wrapped in ANSI).
+				//
+				// We still run detection on every chunk until we've seen at
+				// least one URL, so the initial banner is never missed.
+				if (entry.urls.length > 0 && !event.data.includes("http")) {
+					break;
+				}
+
+				// Scan the fresh chunk for dev-server URLs. We keep a deduped,
+				// first-seen-ordered list on the entry and only fire the listener
+				// when something actually changed.
+				const fresh = extractLocalUrls(event.data);
+				if (fresh.length > 0) {
+					const seen = new Set(entry.urls.map(dedupUrlKey));
+					let changed = false;
+					for (const url of fresh) {
+						const k2 = dedupUrlKey(url);
+						if (!seen.has(k2)) {
+							seen.add(k2);
+							entry.urls.push(url);
+							changed = true;
+						}
+					}
+					if (changed) {
+						listeners.get(k)?.onUrlsChange?.([...entry.urls]);
+					}
+				}
+				break;
+			}
+			case "exited":
+				entry.status = "exited";
+				entry.exitCode = event.code;
+				clearStopping();
+				listeners.get(k)?.onStatusChange("exited");
+				emitStatus(k, "exited", event.code);
+				if (scriptType === "run") {
+					emitWorkspaceRunStatus(workspaceId, "exited", event.code);
+				}
+				break;
+			case "error": {
+				const msg = `\r\n\x1b[31m${event.message}\x1b[0m\r\n`;
+				appendChunk(entry, msg);
+				entry.status = "exited";
+				// No exit code from the backend here — treat as failure.
+				entry.exitCode = entry.exitCode ?? 1;
+				clearStopping();
+				listeners.get(k)?.onChunk(msg);
+				listeners.get(k)?.onStatusChange("exited");
+				emitStatus(k, "exited", entry.exitCode);
+				if (scriptType === "run") {
+					emitWorkspaceRunStatus(workspaceId, "exited", entry.exitCode);
+				}
+				break;
+			}
+		}
+	}).catch((err) => {
+		if (entries.get(k) !== entry) return;
+		const msg = `\r\n\x1b[31m${failureLabel}: ${err}\x1b[0m\r\n`;
 		appendChunk(entry, msg);
 		entry.status = "exited";
 		entry.exitCode = entry.exitCode ?? 1;
@@ -295,6 +304,52 @@ export function startScript(
 			emitWorkspaceRunStatus(workspaceId, "exited", entry.exitCode);
 		}
 	});
+}
+
+export function startScript(
+	repoId: string,
+	scriptType: ScriptKind,
+	workspaceId: string,
+	actionId?: string | null,
+) {
+	runScriptInternal(
+		workspaceId,
+		scriptType,
+		actionId,
+		(onEvent) =>
+			executeRepoScript(
+				repoId,
+				scriptType,
+				onEvent,
+				workspaceId,
+				actionId ?? null,
+			),
+		"Failed to start",
+	);
+}
+
+/**
+ * Run a run action's configured `stopCommand` as a standalone script.
+ * Surfaces the Cleanup button: lets the user tear down side effects
+ * (containers, daemons) left behind by a start that already exited, so
+ * the next Rerun isn't sabotaged by "already running" state.
+ *
+ * Uses the same store key as `startScript` for this action, so the Run
+ * tab's terminal output and per-action status indicator naturally reflect
+ * the cleanup run as if it were a regular invocation.
+ */
+export function cleanupScript(
+	repoId: string,
+	workspaceId: string,
+	actionId: string,
+) {
+	runScriptInternal(
+		workspaceId,
+		"run",
+		actionId,
+		(onEvent) => executeRepoStopCommand(repoId, workspaceId, actionId, onEvent),
+		"Failed to run stop command",
+	);
 }
 
 export function stopScript(

--- a/src/features/inspector/sections/run.test.tsx
+++ b/src/features/inspector/sections/run.test.tsx
@@ -17,6 +17,7 @@ import { RunTab } from "./run";
 
 const apiMocks = vi.hoisted(() => ({
 	executeRepoScript: vi.fn(),
+	executeRepoStopCommand: vi.fn(),
 	stopRepoScript: vi.fn(),
 	writeRepoScriptStdin: vi.fn(),
 	resizeRepoScript: vi.fn(),
@@ -27,6 +28,7 @@ vi.mock("@/lib/api", async (importOriginal) => {
 	return {
 		...actual,
 		executeRepoScript: apiMocks.executeRepoScript,
+		executeRepoStopCommand: apiMocks.executeRepoStopCommand,
 		stopRepoScript: apiMocks.stopRepoScript,
 		writeRepoScriptStdin: apiMocks.writeRepoScriptStdin,
 		resizeRepoScript: apiMocks.resizeRepoScript,
@@ -47,6 +49,7 @@ const defaults = {
 	activeRunActionId: "action-1" as string | null,
 	activeRunActionName: "Default" as string | null,
 	runScript: "npm test" as string | null,
+	stopCommand: null as string | null,
 	hasAnyRunAction: true,
 	isActive: true,
 	onOpenSettings: vi.fn(),
@@ -115,6 +118,7 @@ function renderRun(
 describe("RunTab", () => {
 	beforeEach(() => {
 		apiMocks.executeRepoScript.mockReset().mockResolvedValue(undefined);
+		apiMocks.executeRepoStopCommand.mockReset().mockResolvedValue(undefined);
 		apiMocks.stopRepoScript.mockReset().mockResolvedValue(true);
 		apiMocks.writeRepoScriptStdin.mockReset().mockResolvedValue(true);
 		apiMocks.resizeRepoScript.mockReset().mockResolvedValue(true);
@@ -263,5 +267,122 @@ describe("RunTab", () => {
 				screen.getByRole("button", { name: /rerun/i }),
 			).toBeInTheDocument();
 		});
+	});
+
+	// ── Cleanup button ─────────────────────────────────────────────────────
+
+	it("does not show Cleanup button before the action has run", () => {
+		renderRun(
+			{ stopCommand: "supabase stop" },
+			{ settings: { terminalHoverExpansion: false } },
+		);
+
+		expect(
+			screen.queryByRole("button", { name: /run stop command/i }),
+		).not.toBeInTheDocument();
+	});
+
+	it("does not show Cleanup button while the script is running", async () => {
+		const user = userEvent.setup();
+		renderRun(
+			{ stopCommand: "supabase stop" },
+			{ settings: { terminalHoverExpansion: false } },
+		);
+
+		await user.click(screen.getByRole("button", { name: /^run$/i }));
+
+		// While running, the floating area shows Stop only — the existing
+		// stopRepoScript path already runs `stopCommand` as part of cleanup,
+		// so a separate Cleanup button would be redundant.
+		expect(
+			screen.queryByRole("button", { name: /run stop command/i }),
+		).not.toBeInTheDocument();
+	});
+
+	it("shows Cleanup button after exit when stopCommand is configured", async () => {
+		const user = userEvent.setup();
+
+		let onEvent: (e: unknown) => void = () => {};
+		apiMocks.executeRepoScript.mockImplementation(
+			(_r: string, _t: string, cb: (e: unknown) => void) => {
+				onEvent = cb;
+				return Promise.resolve();
+			},
+		);
+
+		renderRun(
+			{ stopCommand: "supabase stop" },
+			{ settings: { terminalHoverExpansion: false } },
+		);
+		await user.click(screen.getByRole("button", { name: /^run$/i }));
+
+		onEvent({ type: "exited", code: 1 });
+
+		await waitFor(() => {
+			expect(
+				screen.getByRole("button", { name: /run stop command/i }),
+			).toBeInTheDocument();
+		});
+		// Rerun is still there — Cleanup sits alongside, not in place of.
+		expect(screen.getByRole("button", { name: /rerun/i })).toBeInTheDocument();
+	});
+
+	it("does not show Cleanup button when stopCommand is empty/whitespace", async () => {
+		const user = userEvent.setup();
+
+		let onEvent: (e: unknown) => void = () => {};
+		apiMocks.executeRepoScript.mockImplementation(
+			(_r: string, _t: string, cb: (e: unknown) => void) => {
+				onEvent = cb;
+				return Promise.resolve();
+			},
+		);
+
+		renderRun(
+			{ stopCommand: "   " },
+			{ settings: { terminalHoverExpansion: false } },
+		);
+		await user.click(screen.getByRole("button", { name: /^run$/i }));
+		onEvent({ type: "exited", code: 0 });
+
+		await waitFor(() => {
+			expect(
+				screen.getByRole("button", { name: /rerun/i }),
+			).toBeInTheDocument();
+		});
+		expect(
+			screen.queryByRole("button", { name: /run stop command/i }),
+		).not.toBeInTheDocument();
+	});
+
+	it("clicking Cleanup invokes executeRepoStopCommand", async () => {
+		const user = userEvent.setup();
+
+		let onEvent: (e: unknown) => void = () => {};
+		apiMocks.executeRepoScript.mockImplementation(
+			(_r: string, _t: string, cb: (e: unknown) => void) => {
+				onEvent = cb;
+				return Promise.resolve();
+			},
+		);
+
+		renderRun(
+			{ stopCommand: "supabase stop" },
+			{ settings: { terminalHoverExpansion: false } },
+		);
+		await user.click(screen.getByRole("button", { name: /^run$/i }));
+		onEvent({ type: "exited", code: 1 });
+
+		const cleanupButton = await screen.findByRole("button", {
+			name: /run stop command/i,
+		});
+		await user.click(cleanupButton);
+
+		expect(apiMocks.executeRepoStopCommand).toHaveBeenCalledWith(
+			"repo-1",
+			"ws-1",
+			"action-1",
+			expect.any(Function),
+		);
 	});
 });

--- a/src/features/inspector/sections/run.tsx
+++ b/src/features/inspector/sections/run.tsx
@@ -1,5 +1,12 @@
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { ExternalLink, Play, RotateCcw, Settings2, Square } from "lucide-react";
+import {
+	CircleStop,
+	ExternalLink,
+	Play,
+	RotateCcw,
+	Settings2,
+	Square,
+} from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
 	type TerminalHandle,
@@ -19,6 +26,7 @@ import { extractPort } from "../detect-urls";
 import { TABS_EASING, TABS_HOVER_TRANSITION_MS, useTabsZoom } from "../layout";
 import {
 	attach,
+	cleanupScript,
 	detach,
 	resizeScript,
 	type ScriptStatus,
@@ -43,6 +51,12 @@ type RunTabProps = {
 	/** `RunAction.command` for the active action, or `null` when no action
 	 * is selected. Used to decide which placeholder copy to render. */
 	runScript: string | null;
+	/** `RunAction.stopCommand` for the active action, or `null` when none
+	 * is configured. When set AND the user has run this action at least
+	 * once this session, a Cleanup button appears alongside Rerun so the
+	 * user can tear down side effects (containers, daemons) left by an
+	 * exited start before retrying. */
+	stopCommand: string | null;
 	/** True when at least one run action is configured. Drives whether the
 	 * empty state offers "Add run script" (no actions yet) or the per-action
 	 * empty state with the Run button. */
@@ -158,6 +172,7 @@ export function RunTab({
 	activeRunActionId,
 	activeRunActionName,
 	runScript,
+	stopCommand,
 	hasAnyRunAction,
 	isActive,
 	onOpenSettings,
@@ -248,6 +263,18 @@ export function RunTab({
 		stopScript(repoId, "run", workspaceId, activeRunActionId);
 	}, [repoId, workspaceId, activeRunActionId]);
 
+	// Run the configured `stopCommand` standalone. Available after the
+	// action has been run at least once this session (so the user has a
+	// reason to clean up) — clears terminal & flips status to "running"
+	// for the duration of the cleanup, then back to "exited".
+	const handleCleanup = useCallback(() => {
+		if (!repoId || !workspaceId || !activeRunActionId) return;
+		termRef.current?.clear();
+		setStatus("running");
+		setHasRun(true);
+		cleanupScript(repoId, workspaceId, activeRunActionId);
+	}, [repoId, workspaceId, activeRunActionId]);
+
 	// Forward keystrokes to the PTY. The backend silently ignores writes
 	// when no script is live, so we don't gate this on status.
 	const handleData = useCallback(
@@ -267,11 +294,21 @@ export function RunTab({
 	);
 
 	const hasScript = !!runScript?.trim();
+	const trimmedStopCommand = stopCommand?.trim() ?? "";
 	const autoExpandEnabled = settings.terminalHoverExpansion;
 	// Auto-expand off → zoom never fires, so anchor the button unconditionally.
 	const showFloatingAction =
 		(status === "running" || status === "exited") &&
 		(autoExpandEnabled ? isZoomPresented : true);
+	// Cleanup is only useful after the action has actually started something —
+	// before the first run there's nothing to tear down. Hidden while the
+	// script is running (the existing Stop button covers that case, since
+	// `stopRepoScript` already runs `stopCommand` as part of SIGTERM cleanup).
+	const showCleanupButton =
+		status === "exited" &&
+		hasRun &&
+		!!trimmedStopCommand &&
+		!!activeRunActionId;
 
 	return (
 		<div
@@ -296,9 +333,9 @@ export function RunTab({
 					</div>
 
 					{showFloatingAction && (
-						// z-20 keeps the button above xterm's link-layer canvas (z:2).
+						// z-20 keeps the buttons above xterm's link-layer canvas (z:2).
 						<div
-							className="absolute right-4 bottom-3 z-20"
+							className="absolute right-4 bottom-3 z-20 flex items-center gap-2"
 							style={
 								autoExpandEnabled
 									? {
@@ -309,6 +346,24 @@ export function RunTab({
 									: undefined
 							}
 						>
+							{showCleanupButton && (
+								// Surfaces the user-configured `stopCommand` after the
+								// start has exited — for commands like `supabase start`
+								// / `docker compose up` that leave containers running
+								// after the spawned process dies. Without this, Rerun
+								// is sabotaged by "already running" state and the user
+								// has to drop to a real terminal to recover.
+								<Button
+									variant="outline"
+									size="sm"
+									className="text-small shadow-sm backdrop-blur-sm transition-none"
+									onClick={handleCleanup}
+									title={`Run stop command: ${trimmedStopCommand}`}
+									aria-label={`Run stop command: ${trimmedStopCommand}`}
+								>
+									<CircleStop className="size-3" strokeWidth={2} />
+								</Button>
+							)}
 							<Button
 								variant={status === "running" ? "destructive" : "secondary"}
 								size="sm"

--- a/src/features/navigation/index.tsx
+++ b/src/features/navigation/index.tsx
@@ -455,7 +455,7 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 				continue;
 			}
 
-			// The Chats bucket has no kanban semantics — when no chat
+			// The Chats bucket has no status-group semantics — when no chat
 			// workspaces exist, drop the section entirely (header + gap)
 			// so the sidebar isn't littered with an always-empty bucket.
 			// Status / repo buckets keep their empty header because users
@@ -757,7 +757,7 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 					? item.group.rows[0]
 					: undefined;
 
-				// The dedicated "chats" bucket has no kanban semantics —
+				// The dedicated "chats" bucket has no status-group semantics —
 				// surface it with a MessageCircle glyph that mirrors the
 				// chat-mode UI elsewhere (start-page picker, panel header).
 				const isChatGroup = item.group.id === "chats";

--- a/src/features/navigation/workspace-hover-card.tsx
+++ b/src/features/navigation/workspace-hover-card.tsx
@@ -659,7 +659,7 @@ export function WorkspaceHoverCard({
 								</span>
 							) : null}
 						</div>
-						{/* Chat workspaces have no git context and no kanban
+						{/* Chat workspaces have no git context and no workspace
 						 *  status — the entire right-side cluster (branch +
 						 *  diff chips + status dot) is meaningless for them. */}
 						{row.mode !== "chat" ? (

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -3785,6 +3785,32 @@ export async function stopRepoScript(
 }
 
 /**
+ * Run a run action's configured `stopCommand` as a standalone script —
+ * no preceding main process to terminate. Drives the inspector's
+ * "Cleanup" button, which the user clicks after a start exited (cleanly
+ * or otherwise) to tear down side effects (docker containers, daemons)
+ * that the start spawned but didn't clean up itself.
+ *
+ * Output streams through the same channel shape as `executeRepoScript`,
+ * so the Run tab's terminal naturally shows cleanup output.
+ */
+export async function executeRepoStopCommand(
+	repoId: string,
+	workspaceId: string,
+	actionId: string,
+	onEvent: (event: ScriptEvent) => void,
+): Promise<void> {
+	const channel = new Channel<ScriptEvent>();
+	channel.onmessage = onEvent;
+	await invoke("execute_repo_stop_command", {
+		repoId,
+		workspaceId,
+		actionId,
+		channel,
+	});
+}
+
+/**
  * Send raw bytes to a running script's PTY master. The kernel's tty line
  * discipline translates `\x03` into SIGINT for the foreground process group,
  * so passing `\x03` here is how Ctrl+C in the terminal tab actually kills


### PR DESCRIPTION
## Summary

Three correctness fixes around `helmor send` and chat-only sessions, plus a kanban → workspace/status-group terminology cleanup since the project no longer ships a kanban UI.

- **Self-deadlock on `helmor send`** (`service.rs` App-delegation branch). The outer `write_conn()` borrow + nested `insert_pending_cli_send()` call both grabbed the same `max_size=1` writer pool — guaranteed self-deadlock surfacing as `Failed to borrow write connection: timed out waiting for connection` after 30s. Merged the three writes (user message, session pin, pending send) into one rusqlite transaction.
- **Concurrent CLI sends silently dropping prompts past the first.** `drain_pending_cli_sends` deleted the whole queue at once but the frontend only dispatched `sends[0]`. Now it drains one oldest row per call, and each `PendingCliSendQueued` event triggers its own drain — N pending rows become N dispatches.
- **Just-Chat preamble.** Chat-mode sessions previously got the workspace-bound preamble: a synthetic kanban label, a hidden `~/helmor/chats/...` working directory, "configure a target branch" PR nag, `.agent-contexts/` scratch dir. New `build_helmor_chat_prompt()` gives them a minimal Helmor preamble instead. The same builder is now invoked from the standalone CLI path (app not running) too, so all four dispatch combinations (in-app × CLI × chat × workspace) share one preamble source.
- **Kanban → workspace/status-group rename** across prompt text, MCP tool descriptions, CLI help, internal comments, and one test name. `app.kanban_view_state` in `LEGACY_SETTING_KEYS` deliberately stays for user-data migration.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` — zero warnings
- [x] `cargo test --lib agents::system_prompt` — 16/16 (4 new chat-prompt contract tests)
- [x] `cargo test --lib service::tests` — 7/7 (`drain_returns_one_oldest_at_a_time_in_order` pins the new drain contract)
- [x] `cargo test --lib mcp::tools` — 11/11 (renamed test still green)
- [x] `cargo test --tests` — 1254/1255 (only `kill_terminates_running_script_quickly` flaked under concurrent load; passes in isolation; unrelated to this diff — `git diff --name-only HEAD~..HEAD -- src-tauri/src/workspace/scripts.rs` is empty)
- [ ] Manual: run two `helmor send --workspace <A> ... & helmor send --workspace <B> ...` in parallel — both prompts now dispatch instead of one timing out and the other being silently swallowed
- [ ] Manual: start a Just-Chat workspace, send a prompt — agent's first message no longer mentions a fake kanban card / working directory / target branch