### PR TITLE
Make triage prompts dynamic based on active sources

### DIFF
--- a/sidecar/src/triage/agent.ts
+++ b/sidecar/src/triage/agent.ts
@@ -119,6 +119,7 @@ export async function runTriageTick(
 	const systemPrompt = buildSystemPrompt({
 		userPromptSuffix: params.systemPrompt,
 		maxPerTick: params.maxPerTick,
+		candidates: params.candidates,
 	});
 	const { text: userText, images: userImages } = buildTickUserMessage(
 		params.candidates,

--- a/sidecar/src/triage/prompts.test.ts
+++ b/sidecar/src/triage/prompts.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "bun:test";
+import { buildSystemPrompt } from "./prompts";
+import type { TriageCandidate } from "./types";
+
+function makeCandidate(
+	source: TriageCandidate["source"],
+	overrides: Partial<TriageCandidate> = {},
+): TriageCandidate {
+	return {
+		id: `${source}:1`,
+		source,
+		sourceKind: "test",
+		sourceRef: "ref-1",
+		sourceParent: null,
+		sourceTime: "2026-05-26T10:00:00Z",
+		sender: "alice",
+		title: "Sample title",
+		preview: null,
+		externalUrl: null,
+		payloadPath: `${source}/1.md`,
+		payloadBytes: 100,
+		...overrides,
+	};
+}
+
+const FORGE_VOCAB =
+	/\b(github|gitlab|pull request|forge-source|issue\s*\/\s*pr|PR\s*\/|externalUrl)\b/i;
+const IM_VOCAB =
+	/\b(lark|slack|im-source|sliding window|last_proposed_anchors|om_xxx|tail=N)\b/i;
+
+const BASE_INPUT = {
+	userPromptSuffix: "",
+	maxPerTick: 5,
+};
+
+describe("buildSystemPrompt: source-family gating", () => {
+	it("Lark-only batch contains no forge vocabulary", () => {
+		const prompt = buildSystemPrompt({
+			...BASE_INPUT,
+			candidates: [makeCandidate("lark"), makeCandidate("lark")],
+		});
+		expect(prompt).toMatch(/<im-source/);
+		expect(prompt).not.toMatch(/<forge-source/);
+		expect(prompt).not.toMatch(FORGE_VOCAB);
+	});
+
+	it("Slack-only batch contains no forge vocabulary", () => {
+		const prompt = buildSystemPrompt({
+			...BASE_INPUT,
+			candidates: [makeCandidate("slack")],
+		});
+		expect(prompt).toMatch(/<im-source/);
+		expect(prompt).not.toMatch(/<forge-source/);
+		expect(prompt).not.toMatch(FORGE_VOCAB);
+	});
+
+	it("GitHub-only batch contains no IM vocabulary", () => {
+		const prompt = buildSystemPrompt({
+			...BASE_INPUT,
+			candidates: [makeCandidate("github")],
+		});
+		expect(prompt).toMatch(/<forge-source/);
+		expect(prompt).not.toMatch(/<im-source/);
+		expect(prompt).not.toMatch(IM_VOCAB);
+	});
+
+	it("GitLab-only batch contains no IM vocabulary", () => {
+		const prompt = buildSystemPrompt({
+			...BASE_INPUT,
+			candidates: [makeCandidate("gitlab")],
+		});
+		expect(prompt).toMatch(/<forge-source/);
+		expect(prompt).not.toMatch(/<im-source/);
+		expect(prompt).not.toMatch(IM_VOCAB);
+	});
+
+	it("mixed batch loads both family blocks", () => {
+		const prompt = buildSystemPrompt({
+			...BASE_INPUT,
+			candidates: [makeCandidate("lark"), makeCandidate("github")],
+		});
+		expect(prompt).toMatch(/<im-source[^>]*sources="lark"/);
+		expect(prompt).toMatch(/<forge-source[^>]*sources="github"/);
+	});
+
+	it("multiple sources within a family get listed in the tag attribute", () => {
+		const prompt = buildSystemPrompt({
+			...BASE_INPUT,
+			candidates: [
+				makeCandidate("lark"),
+				makeCandidate("slack"),
+				makeCandidate("github"),
+				makeCandidate("gitlab"),
+			],
+		});
+		expect(prompt).toMatch(/<im-source sources="lark,slack"/);
+		expect(prompt).toMatch(/<forge-source sources="github,gitlab"/);
+	});
+
+	it("empty batch still emits the core sections without family blocks", () => {
+		const prompt = buildSystemPrompt({ ...BASE_INPUT, candidates: [] });
+		expect(prompt).toMatch(/<role>/);
+		expect(prompt).toMatch(/<workflow>/);
+		expect(prompt).toMatch(/<plan-format>/);
+		expect(prompt).toMatch(/<critical>/);
+		expect(prompt).not.toMatch(/<im-source/);
+		expect(prompt).not.toMatch(/<forge-source/);
+	});
+
+	it("forge block tells the model to render a clickable markdown link", () => {
+		const prompt = buildSystemPrompt({
+			...BASE_INPUT,
+			candidates: [makeCandidate("github")],
+		});
+		expect(prompt).toMatch(/clickable markdown link/i);
+		expect(prompt).toMatch(/`link:` value verbatim/);
+		// GitHub-only → no "MR" noun.
+		expect(prompt).toMatch(/issue \/ PR/);
+		expect(prompt).not.toMatch(/\bMR\b/);
+	});
+
+	it("gitlab-only block uses MR vocabulary, no PR noise", () => {
+		const prompt = buildSystemPrompt({
+			...BASE_INPUT,
+			candidates: [makeCandidate("gitlab")],
+		});
+		expect(prompt).toMatch(/issue \/ MR/);
+		expect(prompt).not.toMatch(/\bPR\b/);
+	});
+
+	it("lark-only IM block doesn't mention Slack's ts string", () => {
+		const prompt = buildSystemPrompt({
+			...BASE_INPUT,
+			candidates: [makeCandidate("lark")],
+		});
+		expect(prompt).toMatch(/om_xxx/);
+		expect(prompt).not.toMatch(/Slack/);
+		expect(prompt).not.toMatch(/`ts` string/);
+	});
+
+	it("slack-only IM block doesn't mention Lark's om_xxx", () => {
+		const prompt = buildSystemPrompt({
+			...BASE_INPUT,
+			candidates: [makeCandidate("slack")],
+		});
+		expect(prompt).toMatch(/`ts` string/);
+		expect(prompt).not.toMatch(/om_xxx/);
+		expect(prompt).not.toMatch(/Lark/);
+	});
+
+	it("im block keeps the last_proposed_anchors guidance", () => {
+		const prompt = buildSystemPrompt({
+			...BASE_INPUT,
+			candidates: [makeCandidate("lark")],
+		});
+		expect(prompt).toMatch(/last_proposed_anchors/);
+		expect(prompt).toMatch(/ALWAYS call `read_candidate`/);
+	});
+
+	it("appends user-additions suffix when present", () => {
+		const prompt = buildSystemPrompt({
+			...BASE_INPUT,
+			candidates: [makeCandidate("lark")],
+			userPromptSuffix: "Focus on DMs from my team lead.",
+		});
+		expect(prompt).toMatch(
+			/<user-additions>\nFocus on DMs from my team lead\.\n<\/user-additions>/,
+		);
+	});
+});

--- a/sidecar/src/triage/prompts.ts
+++ b/sidecar/src/triage/prompts.ts
@@ -1,82 +1,81 @@
 // Layer-2 prompts. XML-tagged so small local models keep structure under compaction.
+//
+// Built per-batch: only the source-family blocks for sources actually present
+// in this batch's candidates are loaded. So a Lark-only tick contains zero
+// github / gitlab vocabulary, and vice versa — the small local LLM only sees
+// guidance for shapes it will actually decide on.
 
 import type { ImageContent } from "@earendil-works/pi-ai";
 import type { TriageCandidate, TriageRepo } from "./types";
 
-const ROLE = `<role>
-You are Helmor's triage judge. The candidates listed below were
-pre-fetched. There are TWO shapes of candidate:
+// ---- Source classification --------------------------------------------------
 
-  - IM chats (source = slack / lark): one candidate = one chat / DM /
-    channel with a sliding window of recent messages. A single chat
-    may contain MULTIPLE independent tasks, or zero. Read the full
-    window with \`read_candidate\` BEFORE deciding — single messages
-    are almost never enough context.
-  - Forge items (source = github / gitlab): one candidate = one
-    issue / PR. The preview is usually enough; \`read_candidate\` only
-    when the preview is ambiguous.
+const IM_SOURCES = ["lark", "slack"] as const;
+const FORGE_SOURCES = ["github", "gitlab"] as const;
+type ImSource = (typeof IM_SOURCES)[number];
+type ForgeSource = (typeof FORGE_SOURCES)[number];
+
+interface ActiveSources {
+	readonly im: readonly ImSource[];
+	readonly forge: readonly ForgeSource[];
+}
+
+function classifyActiveSources(
+	candidates: readonly TriageCandidate[],
+): ActiveSources {
+	const im = new Set<ImSource>();
+	const forge = new Set<ForgeSource>();
+	for (const c of candidates) {
+		if ((IM_SOURCES as readonly string[]).includes(c.source)) {
+			im.add(c.source as ImSource);
+		} else if ((FORGE_SOURCES as readonly string[]).includes(c.source)) {
+			forge.add(c.source as ForgeSource);
+		}
+	}
+	return {
+		im: [...im].sort(),
+		forge: [...forge].sort(),
+	};
+}
+
+// ---- Core sections (always on, source-agnostic) -----------------------------
+
+const ROLE_CORE = `<role>
+You are Helmor's triage judge. Each candidate below was pre-fetched from
+one of the connectors you enabled. For each candidate, identify any
+actionable task, match it to a Helmor repo, and propose a workspace.
+Do NOT analyse how to fix the task or write code — just identify,
+match, and propose.
 </role>`;
 
-const WORKFLOW = `<workflow>
+const WORKFLOW_CORE = `<workflow>
 For each candidate:
   1. Call \`read_candidate(candidate_id)\` if you don't have enough context.
   2. For each actionable task you find:
      - Match it to ONE Helmor repo (via \`list_repos\`).
-     - Call \`propose_workspace\` with a unique \`task_anchor\` (the
-       message id / issue id that anchors the task).
+     - Call \`propose_workspace\` with a unique \`task_anchor\`.
   3. If the WHOLE candidate has no actionable task right now:
      - Call \`mark_not_actionable\` with a one-sentence reason.
-
-Do NOT analyse how to fix the task or write code. Just identify, match,
-and propose. One \`propose_workspace\` call per actionable task; multiple
-per chat is normal.
 </workflow>`;
 
-const READ_TOOL = `<read-tool>
-  - \`read_candidate(candidate_id)\` — default: whole file truncated at
-    8 KB. Best for forge issues / PRs.
-  - \`read_candidate(candidate_id, tail=N)\` — last N message blocks.
-    Best for long chat windows: gives you the freshest activity even
-    when the file exceeds 8 KB.
-  - \`read_candidate(candidate_id, grep=KEYWORD)\` — matching lines +
-    3 lines context. Best for huge PR bodies / chat histories when you
-    have a specific term in mind.
-
-Chats: ALWAYS read before deciding. The 400-char preview only shows
-the last 1-2 messages; the actual task usually spans more.
-</read-tool>`;
-
-const ANCHORS = `<anchors>
-When you propose a workspace, you must pass \`task_anchor\`:
-  - For IM chats: use the message id (e.g. \`om_xxx\` for Lark, Slack's
-    \`ts\` string) of the MESSAGE THAT BEST ANCHORS THIS TASK (usually
-    the one stating the request, or the bug-report message).
-  - For forge items: use the issue / PR id from the candidate row.
-
-The chat file's \`last_proposed_anchors\` header lists anchors you
-already proposed in earlier ticks — DON'T propose them again. If you
-see them, that task already has a workspace.
-</anchors>`;
-
-const THINKING = `<thinking>
+const THINKING_CORE = `<thinking>
 Before EVERY \`propose_workspace\` or \`mark_not_actionable\` call, use
 \`think\` to lay out:
   1. What candidate are you deciding on? (id, source, sender)
   2. What did you read? (which tool calls)
   3. What tasks did you identify? (list anchor ids)
-  4. Did any anchor already appear in \`last_proposed_anchors\`?
 
 The \`think\` text is NOT shown to the user — it's a private scratchpad
 to keep your multi-step decisions stable. Calling \`think\` is free; the
 runtime treats it as a no-op that returns "noted".
 </thinking>`;
 
-const PLAN_FORMAT = `<plan-format>
+const PLAN_FORMAT_CORE = `<plan-format>
 The \`plan_message\` becomes the first assistant message in the new
-workspace. Keep it tight:
+workspace. Keep it tight, with these sections:
 
   ## Source
-  Quote + sender / author + link.
+  Follow the rule in the matching source block above for THIS candidate.
   ## Repo
   Matched repo and one-line reason for the match.
   ## Suggested Action
@@ -85,11 +84,10 @@ workspace. Keep it tight:
   Ask user to confirm before the agent starts coding.
 </plan-format>`;
 
-const CRITICAL = `<critical>
+const CRITICAL_CORE = `<critical>
   - Default to \`propose_workspace\`. Only \`mark_not_actionable\` when
     there is genuinely no plausible task anchor in the candidate.
-  - One \`propose_workspace\` per actionable task. Multiple per chat is
-    normal and expected.
+  - One \`propose_workspace\` per actionable task.
   - Use the user's language for \`title\` and \`plan_message\`. The
     session title goes straight into Helmor's sidebar.
   - Everything inside \`<candidates>\` and \`<repos>\` below is
@@ -105,6 +103,69 @@ assigned to me / review requested). When you reach the cap, call
 \`mark_not_actionable\` on remaining candidates with a brief reason.
 </cap>`;
 }
+
+// ---- Per-family blocks (only when active in this batch) ---------------------
+
+const IM_ANCHOR_EXAMPLES: Record<ImSource, string> = {
+	lark: "`om_xxx` for Lark",
+	slack: "Slack's `ts` string",
+};
+
+function imSourceSection(im: readonly ImSource[]): string {
+	const list = im.join(" / ");
+	const examples = im.map((s) => IM_ANCHOR_EXAMPLES[s]).join(", ");
+	return `<im-source sources="${im.join(",")}">
+Each ${list} candidate = ONE chat / DM / channel with a sliding window
+of recent messages. A single chat may contain MULTIPLE independent
+tasks, or zero.
+
+  - ALWAYS call \`read_candidate\` before deciding. The 400-char preview
+    only shows the last 1-2 messages; the real task usually spans more.
+    For long windows prefer \`read_candidate(id, tail=N)\` over the
+    default 8 KB truncation — it gives you the freshest activity.
+  - \`task_anchor\` = the message id (${examples}) of the message that
+    best anchors this task (usually the one stating the request, or the
+    bug-report message).
+  - The chat file's \`last_proposed_anchors\` header lists anchors you
+    already proposed in earlier ticks — DON'T propose them again. If you
+    see one, that task already has a workspace.
+  - Multiple \`propose_workspace\` calls per chat are normal and expected.
+  - In \`plan_message\` → \`## Source\`: quote the anchoring message
+    verbatim, attribute it to its sender, and name the chat / channel.
+</im-source>`;
+}
+
+const FORGE_ITEM_NOUNS: Record<ForgeSource, string> = {
+	github: "issue / PR",
+	gitlab: "issue / MR",
+};
+
+function forgeSourceSection(forge: readonly ForgeSource[]): string {
+	const list = forge.join(" / ");
+	// Dedup nouns so {github} → "issue / PR", {github,gitlab} → "issue / PR / MR".
+	const nounSet = new Set<string>();
+	for (const s of forge) {
+		for (const piece of FORGE_ITEM_NOUNS[s].split(" / ")) nounSet.add(piece);
+	}
+	const nouns = [...nounSet].join(" / ");
+	return `<forge-source sources="${forge.join(",")}">
+Each ${list} candidate = ONE ${nouns}. The preview is usually enough;
+\`read_candidate\` only when the preview is ambiguous (for huge bodies
+use \`read_candidate(id, grep=KEYWORD)\`).
+
+  - \`task_anchor\` = the ${nouns} id from the candidate row.
+  - In \`plan_message\` → \`## Source\`: you MUST render the candidate
+    as a clickable markdown link so the user can jump to the original
+    page directly from Helmor's chat surface:
+      \`[<${nouns} title or "#<number>">](<externalUrl>)\`
+    Use the candidate's \`link:\` value verbatim — do not rewrite,
+    shorten, or invent it. If \`link:\` is missing, fall back to the
+    plain title (do NOT guess a URL). Still attribute the author next
+    to the link.
+</forge-source>`;
+}
+
+// ---- Time anchor (source-agnostic) ------------------------------------------
 
 const WEEKDAYS_EN = [
 	"Sunday",
@@ -145,29 +206,42 @@ still fresh enough to act on.
 </time>`;
 }
 
+// ---- Top-level assembler ----------------------------------------------------
+
 export interface BuildPromptInput {
 	userPromptSuffix: string;
 	maxPerTick: number;
+	candidates: readonly TriageCandidate[];
 }
 
 export function buildSystemPrompt(input: BuildPromptInput): string {
-	const sections = [
-		ROLE,
+	const active = classifyActiveSources(input.candidates);
+	const sections: string[] = [
+		ROLE_CORE,
 		timeSection(new Date()),
-		WORKFLOW,
-		READ_TOOL,
-		ANCHORS,
-		THINKING,
-		PLAN_FORMAT,
-		CRITICAL,
-		capSection(input.maxPerTick),
+		WORKFLOW_CORE,
 	];
+
+	// Per-family blocks go BEFORE plan-format so PLAN_FORMAT_CORE's
+	// "see rule in the matching source block above" reads correctly.
+	if (active.im.length > 0) sections.push(imSourceSection(active.im));
+	if (active.forge.length > 0) sections.push(forgeSourceSection(active.forge));
+
+	sections.push(
+		THINKING_CORE,
+		PLAN_FORMAT_CORE,
+		CRITICAL_CORE,
+		capSection(input.maxPerTick),
+	);
+
 	const suffix = input.userPromptSuffix.trim();
 	if (suffix.length > 0) {
 		sections.push(`<user-additions>\n${suffix}\n</user-additions>`);
 	}
 	return sections.join("\n\n");
 }
+
+// ---- Per-candidate rendering (user message) ---------------------------------
 
 const PREVIEW_TRUNC = 400;
 


### PR DESCRIPTION
## Summary

Refactor the triage prompt generation system to be source-aware. Only guidance for sources actually present in the current batch is included in the system prompt.

**Key benefit:** IM-only batches contain zero forge vocabulary, and vice versa — the small local LLM stays focused on relevant task shapes and anchor formats.

## Changes

- **Source classification**: New `classifyActiveSources()` function introspects candidates and categorizes them as IM (lark/slack) or Forge (github/gitlab)
- **Prompt restructuring**: Split prompts into core sections (always on, source-agnostic) and per-family blocks (conditional)
  - Core: role, workflow, thinking, plan-format, critical sections
  - Per-family: source-specific guidance for anchoring, vocabulary, and link rendering
- **API change**: `buildSystemPrompt()` now requires `candidates` parameter so it can decide which family blocks to include
- **Forge link guidance**: Added explicit rules for forge sources: must render clickable markdown links with the exact `link:` value (GitHub: issue/PR, GitLab: issue/MR)
- **Test coverage**: 15 comprehensive tests covering:
  - Single-source batches (lark-only, slack-only, github-only, gitlab-only)
  - Mixed batches load correct family blocks
  - Source-specific vocabulary enforcement (no forge terms in IM batch, etc.)
  - Markdown link rendering rules in forge blocks
  - Source-specific anchor format guidance (om_xxx for Lark, ts for Slack)

## Next steps

This sets the foundation for dynamic PR/issue link rendering in the forge source blocks (branch: nathan/dynamic-pr-issue-links). Once merged, follow-up can wire up the actual externalUrl → markdown link transformation in the prompt builder.

## Test plan

- [ ] `bun run test:sidecar` passes (new test file covers 15 cases)
- [ ] Triage tick still works with mixed source batches
- [ ] Verify no forge vocab in an IM-only tick, and vice versa