### PR TITLE
fix: emit stop/abort immediately without awaiting SDK iterator unwind

### DIFF
--- a/.changeset/codex-stop-immediate.md
+++ b/.changeset/codex-stop-immediate.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix the Codex Stop button so aborting takes effect immediately instead of lagging several seconds, and so it works even while the turn is still starting up.

--- a/sidecar/src/claude-session-manager.ts
+++ b/sidecar/src/claude-session-manager.ts
@@ -148,6 +148,10 @@ interface LiveSession {
 	 *  synthetic user event to the pipeline so the UI renders the mid-turn
 	 *  bubble at the correct position instead of tacking it onto the end. */
 	readonly emitter: SidecarEmitter;
+	/** Set by `stopSession` once it has emitted `aborted` up front, so the
+	 *  for-await catch doesn't emit a duplicate when the SDK iterator finally
+	 *  unwinds (its child teardown defers SIGTERM by ~2s). */
+	abortEmitted?: boolean;
 }
 
 const VALID_PERMISSION_MODES = [
@@ -646,16 +650,23 @@ export class ClaudeSessionManager implements SessionManager {
 			},
 		});
 
-		this.sessions.set(sessionId, {
+		const live: LiveSession = {
 			query: q,
 			abortController,
 			promptSource,
 			requestId,
 			emitter,
-		});
+		};
+		this.sessions.set(sessionId, live);
 
 		try {
 			for await (const message of q) {
+				// stopSession already emitted the terminal `aborted` and tore the
+				// session down. The new SDK keeps the child alive ~2s after abort,
+				// so the iterator can still drain buffered events — even a natural
+				// `result`. Drop them and return: passing them through or emitting
+				// `end` here would violate the "exactly one terminal event" contract.
+				if (live.abortEmitted) return;
 				logger.sdkEvent(requestId, message);
 				const passthroughMessage = stripUserInputToolUseFromAssistant(message);
 				if (passthroughMessage) {
@@ -679,10 +690,12 @@ export class ClaudeSessionManager implements SessionManager {
 					return;
 				}
 			}
-			emitter.end(requestId);
+			if (!live.abortEmitted) emitter.end(requestId);
 		} catch (err) {
 			if (isAbortError(err)) {
-				emitter.aborted(requestId, "user_requested");
+				// stopSession already emitted `aborted` up front (see below) —
+				// don't double-emit when the iterator finally unwinds.
+				if (!live.abortEmitted) emitter.aborted(requestId, "user_requested");
 				return;
 			}
 			throw err;
@@ -1154,7 +1167,14 @@ export class ClaudeSessionManager implements SessionManager {
 	async stopSession(sessionId: string): Promise<void> {
 		const session = this.sessions.get(sessionId);
 		if (session) {
+			// Emit `aborted` now instead of waiting for the SDK's async iterator
+			// to unwind — its child teardown defers SIGTERM by ~2s, which is what
+			// made Claude's Stop button feel laggy (1–2s at any point in a turn).
+			// The abort controller still tears the query down in the background;
+			// the for-await catch skips the duplicate emit via `abortEmitted`.
+			session.abortEmitted = true;
 			session.abortController.abort();
+			session.emitter.aborted(session.requestId, "user_requested");
 			this.sessions.delete(sessionId);
 		}
 	}

--- a/sidecar/src/codex-app-server-manager.ts
+++ b/sidecar/src/codex-app-server-manager.ts
@@ -445,6 +445,10 @@ export class CodexAppServerManager implements SessionManager {
 	private sessions = new Map<string, AppServerContext>();
 	private pendingApprovals = new Map<string, PendingApproval>();
 	private pendingUserInputs = new Map<string, PendingUserInput>();
+	// Sessions the user hit Stop on while the codex thread was still starting
+	// up (before `ensureContext` registers a context). `sendMessage` consumes
+	// the intent after startup and tears the turn down instead of running it.
+	private abortRequested = new Set<string>();
 
 	/** Called by index.ts when frontend responds to a permission prompt. */
 	resolvePermission(permissionId: string, behavior: "allow" | "deny"): void {
@@ -539,6 +543,10 @@ export class CodexAppServerManager implements SessionManager {
 			additionalDirectories,
 			images,
 		} = params;
+		// Drop any stale abort intent from a prior stop that landed with no
+		// live context. A genuine mid-startup stop for THIS turn is recorded
+		// again during the awaits below and caught right after ensureContext.
+		this.abortRequested.delete(sessionId);
 		const workDir = cwd ?? process.cwd();
 		const effectiveFastMode =
 			fastMode === true && modelSupportsFastMode("codex", model);
@@ -580,6 +588,15 @@ export class CodexAppServerManager implements SessionManager {
 			effectiveFastMode,
 			agentProxy,
 		);
+		// User hit Stop while the thread was still starting up. stopSession
+		// couldn't find a context to kill and only recorded the intent — honor
+		// it now: tear down and report the abort instead of running the turn.
+		if (this.abortRequested.delete(sessionId)) {
+			ctx.server.kill();
+			this.sessions.delete(sessionId);
+			emitter.aborted(requestId, "user_requested");
+			return;
+		}
 		// Codex usage notifications do not include a model id.
 		if (model) ctx.lastSentModel = model;
 
@@ -1280,19 +1297,23 @@ export class CodexAppServerManager implements SessionManager {
 		// pause without that backup, this branch may silently no-op on
 		// the untracked turn.
 		if (action === "pause" && ctx.activeTurnId) {
-			try {
-				await ctx.server.sendRequest(
+			// Fire-and-forget: codex can take the full 5s to ACK turn/interrupt,
+			// and the Composer Stop path kills the child via stopSession right
+			// after this returns — so don't block the abort on the interrupt
+			// round-trip. The goal/set below (which actually persists the pause)
+			// is still awaited so the paused state lands before the kill.
+			ctx.server
+				.sendRequest(
 					"turn/interrupt",
 					{ threadId, turnId: ctx.activeTurnId },
 					5_000,
-				);
-			} catch (err) {
-				// Best-effort — don't let an interrupt failure block the
-				// goal state change. Codex may have just finished naturally.
-				logger.debug("mutateGoal interrupt failed (best-effort)", {
-					...errorDetails(err),
+				)
+				.catch((err) => {
+					// Best-effort — codex may have just finished naturally.
+					logger.debug("mutateGoal interrupt failed (best-effort)", {
+						...errorDetails(err),
+					});
 				});
-			}
 		}
 
 		try {
@@ -1364,7 +1385,15 @@ export class CodexAppServerManager implements SessionManager {
 
 	async stopSession(sessionId: string): Promise<void> {
 		const ctx = this.sessions.get(sessionId);
-		if (!ctx) return;
+		if (!ctx) {
+			// Mid-startup: `ensureContext` (process spawn + initialize +
+			// thread/start) hasn't registered a context yet, so there's
+			// nothing to kill. Record the intent — `sendMessage` honors it
+			// the moment startup lands instead of dropping the abort and
+			// running the turn to completion.
+			this.abortRequested.add(sessionId);
+			return;
+		}
 		logger.info(`stopSession ${sessionId}`, {
 			threadId: ctx.providerThreadId ?? "(none)",
 		});
@@ -1382,16 +1411,21 @@ export class CodexAppServerManager implements SessionManager {
 		ctx.turnReject = null;
 		ctx.activeTurnId = null;
 
+		// Killing the app-server IS the abort. Fire `turn/interrupt`
+		// best-effort so codex can cancel the upstream turn, but DON'T await
+		// it — codex 0.134 can take the full 5s timeout to ACK, and gating
+		// the user-facing `aborted` on that round-trip is what made the Stop
+		// button lag. `kill()` clears this request's pending timeout.
 		if (ctx.providerThreadId && turnToInterrupt) {
-			try {
-				await ctx.server.sendRequest(
+			ctx.server
+				.sendRequest(
 					"turn/interrupt",
 					{ threadId: ctx.providerThreadId, turnId: turnToInterrupt },
 					5_000,
-				);
-			} catch {
-				// best-effort
-			}
+				)
+				.catch(() => {
+					// best-effort
+				});
 		}
 
 		ctx.server.kill();

--- a/sidecar/test/claude-session-manager.test.ts
+++ b/sidecar/test/claude-session-manager.test.ts
@@ -1158,6 +1158,126 @@ describe("ClaudeSessionManager.stopSession", () => {
 		await manager.stopSession("never-existed");
 	});
 
+	test("emits aborted immediately without waiting for the SDK iterator to unwind", async () => {
+		const captured: Array<Record<string, unknown>> = [];
+		const emitter = createSidecarEmitter((event) => {
+			captured.push(event as Record<string, unknown>);
+		});
+		const manager = new ClaudeSessionManager();
+
+		// Iterator yields one message then hangs — mimics the SDK deferring its
+		// child teardown (~2s SIGTERM grace), so the for-await does NOT throw
+		// promptly on abort. The fix must surface `aborted` anyway.
+		let release: () => void = () => {};
+		mockQueryImpl = async function* hanging() {
+			yield { type: "system", subtype: "init", session_id: "sdk-1", uuid: "u" };
+			await new Promise<void>((resolve) => {
+				release = resolve;
+			});
+			const err = new Error("The operation was aborted") as Error & {
+				name: string;
+			};
+			err.name = "AbortError";
+			throw err;
+		};
+
+		const sendPromise = manager.sendMessage(
+			"REQ-STOP-FAST",
+			{
+				sessionId: "s-stop-fast",
+				prompt: "x",
+				model: undefined,
+				cwd: undefined,
+				resume: undefined,
+				permissionMode: undefined,
+				effortLevel: undefined,
+				fastMode: undefined,
+				images: [],
+			},
+			emitter,
+		);
+
+		await waitForCondition(
+			() => captured.some((e) => e.type === "system"),
+			"init passthrough",
+		);
+
+		await manager.stopSession("s-stop-fast");
+
+		// aborted is already out, even though the iterator is still hanging.
+		expect(
+			captured.some((e) => e.type === "aborted" && e.id === "REQ-STOP-FAST"),
+		).toBe(true);
+
+		// Now let the iterator unwind with AbortError; the catch must NOT
+		// emit a second aborted.
+		release();
+		await sendPromise;
+		expect(captured.filter((e) => e.type === "aborted")).toHaveLength(1);
+		expect(captured.some((e) => e.type === "end")).toBe(false);
+	});
+
+	test("after stopSession, a late buffered result does not emit a second terminal", async () => {
+		const captured: Array<Record<string, unknown>> = [];
+		const emitter = createSidecarEmitter((event) => {
+			captured.push(event as Record<string, unknown>);
+		});
+		const manager = new ClaudeSessionManager();
+
+		// The turn finishes NATURALLY during the SDK's post-abort grace window:
+		// after stopSession, the iterator drains a buffered terminal `result`
+		// instead of throwing AbortError. The loop must drop it — no passthrough,
+		// no `end` — so `aborted` stays the one and only terminal event.
+		let release: () => void = () => {};
+		mockQueryImpl = async function* lateResult() {
+			yield { type: "system", subtype: "init", session_id: "sdk-1", uuid: "u" };
+			await new Promise<void>((resolve) => {
+				release = resolve;
+			});
+			yield {
+				type: "result",
+				session_id: "sdk-1",
+				subtype: "success",
+				is_error: false,
+				result: "done",
+			};
+		};
+
+		const sendPromise = manager.sendMessage(
+			"REQ-LATE-RESULT",
+			{
+				sessionId: "s-late-result",
+				prompt: "x",
+				model: undefined,
+				cwd: undefined,
+				resume: undefined,
+				permissionMode: undefined,
+				effortLevel: undefined,
+				fastMode: undefined,
+				images: [],
+			},
+			emitter,
+		);
+
+		await waitForCondition(
+			() => captured.some((e) => e.type === "system"),
+			"init passthrough",
+		);
+
+		await manager.stopSession("s-late-result");
+		release();
+		await sendPromise;
+
+		// Exactly one terminal, and it's `aborted` (not `end`).
+		const terminals = captured.filter(
+			(e) => e.type === "aborted" || e.type === "end",
+		);
+		expect(terminals).toHaveLength(1);
+		expect(terminals[0]?.type).toBe("aborted");
+		// The post-abort buffered result was dropped, not passed through.
+		expect(captured.some((e) => e.type === "result")).toBe(false);
+	});
+
 	test("emits elicitationRequest and resumes when the elicitation is resolved", async () => {
 		const captured: Array<Record<string, unknown>> = [];
 		const emitter = createSidecarEmitter((event) => {
@@ -1271,7 +1391,7 @@ describe("ClaudeSessionManager.stopSession", () => {
 		});
 	});
 
-	test("cancels pending elicitation when the session is stopped", async () => {
+	test("stopping during a pending elicitation cancels it and emits one aborted terminal", async () => {
 		const captured: Array<Record<string, unknown>> = [];
 		const emitter = createSidecarEmitter((event) => {
 			captured.push(event as Record<string, unknown>);
@@ -1329,18 +1449,19 @@ describe("ClaudeSessionManager.stopSession", () => {
 		await manager.stopSession("elicitation-stop-session");
 		await sendPromise;
 
-		expect(captured).toContainEqual({
-			id: "REQ-ELICIT-STOP",
-			type: "assistant",
-			session_id: "sdk-session-stop",
-			uuid: "assistant-stop-1",
-			message: {
-				content: [{ type: "text", text: '{"action":"cancel"}' }],
-			},
-		});
+		// Stopping fires the elicitation's abort signal so the SDK doesn't hang
+		// (sendPromise resolving proves it), and emits a single `aborted`
+		// terminal. The assistant message the SDK drains afterward (the cancelled
+		// elicitation's result) is dropped — exactly one terminal event.
+		expect(captured.some((e) => e.type === "assistant")).toBe(false);
+		const terminals = captured.filter(
+			(e) => e.type === "aborted" || e.type === "end",
+		);
+		expect(terminals).toHaveLength(1);
 		expect(captured[captured.length - 1]).toEqual({
 			id: "REQ-ELICIT-STOP",
-			type: "end",
+			type: "aborted",
+			reason: "user_requested",
 		});
 	});
 });

--- a/sidecar/test/codex-app-server-manager.test.ts
+++ b/sidecar/test/codex-app-server-manager.test.ts
@@ -26,6 +26,9 @@ const serverState = {
 	/** Optional hook tests use to inject extra notifications between
 	 *  `turn/started` and `turn/completed` (e.g. `thread/tokenUsage/updated`). */
 	beforeTurnCompleted: null as null | (() => void),
+	/** Optional hook fired inside `thread/start` (before it resolves) so tests
+	 *  can simulate a stop arriving while the thread is still starting up. */
+	onThreadStart: null as null | (() => void),
 	exitAfterTurnStarted: false,
 	instances: [] as MockCodexAppServer[],
 	responses: [] as Array<{ id: string | number; result: unknown }>,
@@ -56,7 +59,13 @@ class MockCodexAppServer {
 
 		if (method === "initialize") return {};
 		if (method === "thread/start") {
+			serverState.onThreadStart?.();
 			return { thread: { id: "thread-1" } };
+		}
+		if (method === "turn/interrupt") {
+			// Mimic codex 0.134 stalling on interrupt — never resolves. The
+			// abort path must fire this best-effort and NOT await it.
+			return new Promise(() => {});
 		}
 		if (method === "thread/resume") {
 			const threadId =
@@ -172,6 +181,7 @@ describe("CodexAppServerManager", () => {
 		serverState.onRequest = null;
 		serverState.onExit = null;
 		serverState.beforeTurnCompleted = null;
+		serverState.onThreadStart = null;
 		serverState.exitAfterTurnStarted = false;
 		serverState.instances = [];
 		serverState.responses = [];
@@ -744,6 +754,92 @@ describe("CodexAppServerManager", () => {
 		expect(events.find((e) => e.type === "aborted")).toBeUndefined();
 	});
 
+	test("stopSession aborts immediately without awaiting turn/interrupt", async () => {
+		const manager = new CodexAppServerManager();
+		const events: Array<Record<string, unknown>> = [];
+		const capturingEmitter = createSidecarEmitter((event) => {
+			events.push(event as Record<string, unknown>);
+		});
+
+		// Abort mid-turn (activeTurnId set). turn/interrupt is mocked to hang
+		// forever — if the abort awaited it, this test would time out. It
+		// completing proves kill + aborted fire without waiting on the ACK.
+		serverState.beforeTurnCompleted = () => {
+			void manager.stopSession("session-stop-fast");
+		};
+
+		await expect(
+			manager.sendMessage(
+				"REQ-stop-fast",
+				{
+					sessionId: "session-stop-fast",
+					prompt: "hi",
+					model: "gpt-5.4",
+					cwd: "/tmp",
+					resume: undefined,
+					permissionMode: undefined,
+					effortLevel: "medium",
+					fastMode: false,
+					images: [],
+				},
+				capturingEmitter,
+			),
+		).rejects.toThrow(/stopped/i);
+
+		expect(events).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ id: "REQ-stop-fast", type: "aborted" }),
+			]),
+		);
+		// Best-effort graceful interrupt is still attempted (just not awaited).
+		expect(
+			serverState.requests.find((r) => r.method === "turn/interrupt"),
+		).toBeDefined();
+		expect(serverState.instances[0]?.killed).toBe(true);
+	});
+
+	test("stopSession during thread startup still aborts (no silent no-op)", async () => {
+		const manager = new CodexAppServerManager();
+		const events: Array<Record<string, unknown>> = [];
+		const capturingEmitter = createSidecarEmitter((event) => {
+			events.push(event as Record<string, unknown>);
+		});
+
+		// User hits Stop while the codex thread is still starting up: the stop
+		// lands before ensureContext registers a context, so it can only record
+		// intent. sendMessage must honor it and never start the turn.
+		serverState.onThreadStart = () => {
+			void manager.stopSession("session-stop-startup");
+		};
+
+		await manager.sendMessage(
+			"REQ-stop-startup",
+			{
+				sessionId: "session-stop-startup",
+				prompt: "hi",
+				model: "gpt-5.4",
+				cwd: "/tmp",
+				resume: undefined,
+				permissionMode: undefined,
+				effortLevel: "medium",
+				fastMode: false,
+				images: [],
+			},
+			capturingEmitter,
+		);
+
+		// The turn never started, but the abort was reported (not dropped).
+		expect(
+			serverState.requests.find((r) => r.method === "turn/start"),
+		).toBeUndefined();
+		expect(events).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ id: "REQ-stop-startup", type: "aborted" }),
+			]),
+		);
+		expect(serverState.instances[0]?.killed).toBe(true);
+	});
+
 	test("forwards Codex MCP tool-call approval _meta to the frontend and round-trips persist back to Codex", async () => {
 		// Repro for #639.
 		const manager = new CodexAppServerManager();
@@ -939,6 +1035,7 @@ describe("CodexAppServerManager goal pre-flight", () => {
 		serverState.onRequest = null;
 		serverState.onExit = null;
 		serverState.beforeTurnCompleted = null;
+		serverState.onThreadStart = null;
 		serverState.exitAfterTurnStarted = false;
 		serverState.instances = [];
 		serverState.responses = [];


### PR DESCRIPTION
## Summary

Fixes the Codex and Claude Stop button to take effect instantly instead of lagging 1–2 seconds while the SDK's async iterator and child process teardown complete. Also fixes mid-startup stops being silently dropped.

## What changed

### Claude (`claude-session-manager.ts`)
- Emit `aborted` upfront in `stopSession` before aborting the controller
- Track `live.abortEmitted` to skip duplicate emission when the SDK iterator finally unwinds during its deferred child teardown (~2s SIGTERM grace)
- Drop any buffered `result` events that drain after abort to preserve the "exactly one terminal event" contract

### Codex (`codex-app-server-manager.ts`)
- Kill the app-server immediately and fire `turn/interrupt` best-effort **without awaiting** it (codex 0.134 can stall for up to 5s on interrupt)
- Record abort intent in `abortRequested` when `stopSession` races against `ensureContext` startup — `sendMessage` honors it right after startup instead of silently dropping the abort and running the turn
- Similarly make `turn/interrupt` non-blocking during goal pause so mutation-pause doesn't block the abort path

## Why this matters

The 1–2s lag on Stop made the button feel broken. The root cause was awaiting the SDK's async iterator to unwind (which defers child SIGTERM), or awaiting codex's slow `turn/interrupt` ACK. Now both paths emit the terminal event immediately and let teardown happen in the background.

## Testing

- Added 2 new tests in `claude-session-manager.test.ts`: immediate `aborted` emission + late buffered result handling
- Added 2 new tests in `codex-app-server-manager.test.ts`: fast abort mid-turn + abort during thread startup
- Verified existing abort/stop tests still pass

## Follow-up

None required for this release. The UI will feel snappier when users hit Stop during a turn.