### PR TITLE
fix: bound generated session titles

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "helmor",
@@ -60,6 +59,7 @@
         "react": "19.2.0",
         "react-dom": "19.2.0",
         "react-loading-skeleton": "^3.5.0",
+        "rehype-sanitize": "^6.0.0",
         "shadcn": "^4.1.2",
         "shiki": "^4.0.2",
         "simple-icons": "^16.17.0",

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
 		"react": "19.2.0",
 		"react-dom": "19.2.0",
 		"react-loading-skeleton": "^3.5.0",
+		"rehype-sanitize": "^6.0.0",
 		"shadcn": "^4.1.2",
 		"shiki": "^4.0.2",
 		"simple-icons": "^16.17.0",

--- a/sidecar/src/title.ts
+++ b/sidecar/src/title.ts
@@ -6,6 +6,8 @@
 
 export const TITLE_GENERATION_TIMEOUT_MS = 30_000;
 export const TITLE_GENERATION_FALLBACK_TIMEOUT_MS = 30_000;
+const MAX_GENERATED_TITLE_CHARS = 80;
+const TITLE_ELLIPSIS = "...";
 
 const DEFAULT_BRANCH_RENAME_PROMPT = `When you generate the branch name segment for a new chat:
 
@@ -83,6 +85,28 @@ export interface TitleGenerationDiagnosticsOptions {
 	readonly logError: TitleGenerationErrorLogger;
 }
 
+function truncateGeneratedTitle(title: string): string {
+	const chars = Array.from(title);
+	if (chars.length <= MAX_GENERATED_TITLE_CHARS) {
+		return title;
+	}
+	return `${chars
+		.slice(0, MAX_GENERATED_TITLE_CHARS - TITLE_ELLIPSIS.length)
+		.join("")
+		.trimEnd()}${TITLE_ELLIPSIS}`;
+}
+
+function normalizeGeneratedTitle(title: string): string {
+	const normalized = title
+		.trim()
+		.replace(QUOTE_STRIP_RE, "")
+		.trim()
+		.split(/\s+/)
+		.filter(Boolean)
+		.join(" ");
+	return truncateGeneratedTitle(normalized);
+}
+
 export function parseTitleAndBranch(raw: string): ParsedTitle {
 	let title = "";
 	let branch = "";
@@ -90,7 +114,7 @@ export function parseTitleAndBranch(raw: string): ParsedTitle {
 		const trimmed = line.trim();
 		const lower = trimmed.toLowerCase();
 		if (lower.startsWith("title:")) {
-			title = trimmed.slice(6).trim().replace(QUOTE_STRIP_RE, "").trim();
+			title = normalizeGeneratedTitle(trimmed.slice(6));
 		} else if (lower.startsWith("branch:")) {
 			branch = trimmed
 				.slice(7)
@@ -102,9 +126,9 @@ export function parseTitleAndBranch(raw: string): ParsedTitle {
 	}
 
 	// If structured parsing failed but the model returned *something*, fall
-	// back to using the raw text as the title (still better than empty).
+	// back to using a bounded normalized preview as the title.
 	if (!title && raw.trim()) {
-		title = raw.trim().replace(QUOTE_STRIP_RE, "").trim();
+		title = normalizeGeneratedTitle(raw);
 	}
 
 	return { title, branchName: branch || undefined };

--- a/sidecar/test/title.test.ts
+++ b/sidecar/test/title.test.ts
@@ -108,6 +108,23 @@ describe("parseTitleAndBranch", () => {
 		expect(parseTitleAndBranch(raw).title).toBe("Some unstructured reply");
 	});
 
+	test("bounds unstructured title fallback", () => {
+		const raw = `${"This is a very long unstructured title ".repeat(8)}
+that keeps going after a newline`;
+		const title = parseTitleAndBranch(raw).title;
+		expect(title.length).toBeLessThanOrEqual(80);
+		expect(title.endsWith("...")).toBe(true);
+	});
+
+	test("bounds long structured title", () => {
+		const raw = `title: ${"Repair tooltip overflow for extremely long session tab names ".repeat(4)}
+branch: tooltip-overflow`;
+		const result = parseTitleAndBranch(raw);
+		expect(result.title.length).toBeLessThanOrEqual(80);
+		expect(result.title.endsWith("...")).toBe(true);
+		expect(result.branchName).toBe("tooltip-overflow");
+	});
+
 	test("empty raw gives empty title and undefined branch", () => {
 		const result = parseTitleAndBranch("");
 		expect(result.title).toBe("");

--- a/src-tauri/src/local_llm/title.rs
+++ b/src-tauri/src/local_llm/title.rs
@@ -14,6 +14,8 @@ use anyhow::Result;
 use super::Manager;
 
 const TITLE_TIMEOUT: Duration = Duration::from_secs(15);
+const MAX_GENERATED_TITLE_CHARS: usize = 80;
+const TITLE_ELLIPSIS: &str = "...";
 
 const DEFAULT_BRANCH_RENAME_PROMPT: &str =
     "When you generate the branch name segment for a new chat:
@@ -119,18 +121,18 @@ fn parse_title_response(raw: &str) -> (String, Option<String>) {
         let trimmed = line.trim();
         let lower = trimmed.to_ascii_lowercase();
         if lower.starts_with("title:") {
-            title = strip_quotes(trimmed[6..].trim()).to_string();
+            title = normalize_generated_title(&trimmed[6..]);
         } else if lower.starts_with("branch:") {
             branch = sanitize_branch(trimmed[7..].trim());
         }
     }
     // Same fallback as the sidecar's `parseTitleAndBranch`: if structured
-    // parsing failed but the model returned something, use the whole raw
-    // body as the title.
+    // parsing failed but the model returned something, use a bounded
+    // normalized preview as the title.
     if title.is_empty() {
         let r = raw.trim();
         if !r.is_empty() {
-            title = strip_quotes(r).to_string();
+            title = normalize_generated_title(r);
         }
     }
     let branch_opt = if branch.is_empty() {
@@ -139,6 +141,34 @@ fn parse_title_response(raw: &str) -> (String, Option<String>) {
         Some(branch)
     };
     (title, branch_opt)
+}
+
+fn normalize_generated_title(raw: &str) -> String {
+    let stripped = strip_quotes(raw.trim());
+    let mut normalized = String::new();
+    for part in stripped.split_whitespace() {
+        if !normalized.is_empty() {
+            normalized.push(' ');
+        }
+        normalized.push_str(part);
+    }
+    truncate_generated_title(&normalized)
+}
+
+fn truncate_generated_title(title: &str) -> String {
+    if title.chars().count() <= MAX_GENERATED_TITLE_CHARS {
+        return title.to_string();
+    }
+
+    let mut truncated = title
+        .chars()
+        .take(MAX_GENERATED_TITLE_CHARS - TITLE_ELLIPSIS.len())
+        .collect::<String>();
+    while truncated.ends_with(char::is_whitespace) {
+        truncated.pop();
+    }
+    truncated.push_str(TITLE_ELLIPSIS);
+    truncated
 }
 
 fn strip_quotes(s: &str) -> &str {
@@ -220,6 +250,29 @@ mod tests {
         let raw = "Just a free-form title without label";
         let (title, _) = parse_title_response(raw);
         assert_eq!(title, "Just a free-form title without label");
+    }
+
+    #[test]
+    fn bounds_unstructured_title_fallback() {
+        let raw = format!(
+            "{}\nthat keeps going after a newline",
+            "This is a very long unstructured title ".repeat(8)
+        );
+        let (title, _) = parse_title_response(&raw);
+        assert!(title.chars().count() <= MAX_GENERATED_TITLE_CHARS);
+        assert!(title.ends_with(TITLE_ELLIPSIS));
+    }
+
+    #[test]
+    fn bounds_long_structured_title() {
+        let raw = format!(
+            "title: {}\nbranch: tooltip-overflow",
+            "Repair tooltip overflow for extremely long session tab names ".repeat(4)
+        );
+        let (title, branch) = parse_title_response(&raw);
+        assert!(title.chars().count() <= MAX_GENERATED_TITLE_CHARS);
+        assert!(title.ends_with(TITLE_ELLIPSIS));
+        assert_eq!(branch.as_deref(), Some("tooltip-overflow"));
     }
 
     #[test]

--- a/src/features/panel/header.tsx
+++ b/src/features/panel/header.tsx
@@ -99,6 +99,12 @@ type WorkspacePanelHeaderProps = {
 	newSessionShortcut?: string | null;
 };
 
+const SESSION_TITLE_TOOLTIP_MAX_CHARS = 240;
+const SESSION_TITLE_TOOLTIP_CLASS =
+	"pointer-events-none max-w-[22rem] whitespace-normal rounded-md px-2 py-1.5 text-left text-mini leading-snug";
+const SESSION_TITLE_TOOLTIP_TEXT_CLASS =
+	"block max-w-full whitespace-normal break-words [overflow-wrap:anywhere]";
+
 export const WorkspacePanelHeader = memo(function WorkspacePanelHeader({
 	workspace,
 	changeRequest = null,
@@ -539,9 +545,11 @@ export const WorkspacePanelHeader = memo(function WorkspacePanelHeader({
 											<TooltipContent
 												side="bottom"
 												sideOffset={4}
-												className="flex h-[22px] items-center rounded-md px-1.5 text-mini leading-none"
+												className={SESSION_TITLE_TOOLTIP_CLASS}
 											>
-												<span>{contextPreviewCard.title}</span>
+												<span className={SESSION_TITLE_TOOLTIP_TEXT_CLASS}>
+													{displayTooltipTitle(contextPreviewCard.title)}
+												</span>
 											</TooltipContent>
 										</Tooltip>
 									) : null}
@@ -636,7 +644,7 @@ export const WorkspacePanelHeader = memo(function WorkspacePanelHeader({
 															) : null}
 														</span>
 														{!isEditing ? (
-															<span className="pointer-events-none invisible absolute inset-y-0 right-0 flex items-center gap-0.5 pr-1 group-hover/tab:pointer-events-auto group-hover/tab:visible">
+															<span className="pointer-events-none invisible absolute inset-y-0 right-0 flex items-center gap-0.5 pr-1 group-hover/tab:pointer-events-auto group-hover/tab:visible group-focus-within/tab:pointer-events-auto group-focus-within/tab:visible">
 																<span
 																	role="button"
 																	aria-label="Rename session"
@@ -666,13 +674,19 @@ export const WorkspacePanelHeader = memo(function WorkspacePanelHeader({
 														) : null}
 													</TabsTrigger>
 												</TooltipTrigger>
-												<TooltipContent
-													side="bottom"
-													sideOffset={4}
-													className="flex h-[22px] items-center rounded-md px-1.5 text-mini leading-none"
-												>
-													<span>{displaySessionTitle(session)}</span>
-												</TooltipContent>
+												{!isEditing ? (
+													<TooltipContent
+														side="bottom"
+														sideOffset={4}
+														className={SESSION_TITLE_TOOLTIP_CLASS}
+													>
+														<span className={SESSION_TITLE_TOOLTIP_TEXT_CLASS}>
+															{displayTooltipTitle(
+																displaySessionTitle(session),
+															)}
+														</span>
+													</TooltipContent>
+												) : null}
 											</Tooltip>
 										);
 									})}
@@ -776,9 +790,11 @@ export const WorkspacePanelHeader = memo(function WorkspacePanelHeader({
 									<TooltipContent
 										side="left"
 										sideOffset={4}
-										className="flex h-[22px] items-center rounded-md px-1.5 text-mini leading-none"
+										className={SESSION_TITLE_TOOLTIP_CLASS}
 									>
-										<span>{displaySessionTitle(session)}</span>
+										<span className={SESSION_TITLE_TOOLTIP_TEXT_CLASS}>
+											{displayTooltipTitle(displaySessionTitle(session))}
+										</span>
 									</TooltipContent>
 								</Tooltip>
 							))
@@ -833,6 +849,18 @@ function displaySessionTitle(session: WorkspaceSessionSummary): string {
 		return session.title;
 	}
 	return "Untitled";
+}
+
+function displayTooltipTitle(title: string): string {
+	const normalized = title.trim().replace(/\s+/g, " ");
+	const chars = Array.from(normalized);
+	if (chars.length <= SESSION_TITLE_TOOLTIP_MAX_CHARS) {
+		return normalized;
+	}
+	return `${chars
+		.slice(0, SESSION_TITLE_TOOLTIP_MAX_CHARS - 3)
+		.join("")
+		.trimEnd()}...`;
 }
 
 // BranchPicker: thin wrapper around shared BranchPickerPopover with header trigger styling.

--- a/src/features/panel/index.test.tsx
+++ b/src/features/panel/index.test.tsx
@@ -15,6 +15,7 @@ import { createHelmorQueryClient, helmorQueryKeys } from "@/lib/query-client";
 const apiMocks = vi.hoisted(() => ({
 	createSession: vi.fn(),
 	hideSession: vi.fn(),
+	renameSession: vi.fn(),
 }));
 
 vi.mock("@/components/icons", () => ({
@@ -47,6 +48,7 @@ vi.mock("@/lib/api", async (importOriginal) => {
 		...actual,
 		createSession: apiMocks.createSession,
 		hideSession: apiMocks.hideSession,
+		renameSession: apiMocks.renameSession,
 	};
 });
 
@@ -105,8 +107,10 @@ describe("WorkspacePanel", () => {
 	beforeEach(() => {
 		apiMocks.createSession.mockReset();
 		apiMocks.hideSession.mockReset();
+		apiMocks.renameSession.mockReset();
 		apiMocks.createSession.mockResolvedValue({ sessionId: "session-new" });
 		apiMocks.hideSession.mockResolvedValue(undefined);
+		apiMocks.renameSession.mockResolvedValue(undefined);
 	});
 
 	afterEach(() => {
@@ -521,5 +525,56 @@ describe("WorkspacePanel", () => {
 		expect(session2Tab).toBeDefined();
 		expect(within(session1Tab!).getByTestId("codex-icon")).toBeInTheDocument();
 		expect(within(session2Tab!).getByTestId("claude-icon")).toBeInTheDocument();
+	});
+
+	it("keeps long session title tooltips bounded while rename remains reachable", async () => {
+		const user = userEvent.setup();
+		const longTitle = `处理 workspace tab 自动命名失败后产生的超长 hover tooltip 文本 ${"reallylongunbrokentoken".repeat(16)}`;
+		const sessions = [
+			{
+				...SESSIONS[0],
+				title: longTitle,
+			},
+		];
+
+		render(
+			<TooltipProvider delayDuration={0}>
+				<QueryClientProvider client={createHelmorQueryClient()}>
+					<WorkspacePanel
+						workspace={WORKSPACE}
+						sessions={sessions}
+						selectedSessionId="session-1"
+						sessionPanes={[]}
+						sending={false}
+					/>
+				</QueryClientProvider>
+			</TooltipProvider>,
+		);
+
+		const tab = screen.getByRole("tab", { name: /处理 workspace tab/ });
+		await user.hover(tab);
+
+		const tooltip = await screen.findByRole("tooltip");
+		const tooltipContent = document.querySelector(
+			'[data-slot="tooltip-content"]',
+		) as HTMLElement | null;
+		expect(tooltipContent).not.toBeNull();
+		expect(tooltipContent!).toHaveClass(
+			"max-w-[22rem]",
+			"whitespace-normal",
+			"leading-snug",
+		);
+		expect(tooltip.textContent?.length).toBeLessThanOrEqual(240);
+		expect(tooltip.textContent).toMatch(/\.\.\.$/);
+
+		const tooltipText = tooltip.querySelector("span");
+		expect(tooltipText).toHaveClass("whitespace-normal", "break-words");
+		expect(tooltipText?.className).toContain("[overflow-wrap:anywhere]");
+
+		await user.click(
+			within(tab).getByRole("button", { name: "Rename session" }),
+		);
+
+		expect(within(tab).getByDisplayValue(longTitle)).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
What changed
- Bounded generated session titles to 80 characters in both sidecar and local LLM parsing.
- Bounded session-title tooltips with wrapping/truncation while keeping rename controls reachable.
- Declared the direct `rehype-sanitize` dependency used by the streamdown loader.

Why it changed
- Overlong auto-generated session titles could create oversized hover tooltips and make tab controls difficult to use.
- The frontend imports `rehype-sanitize` directly, so it should be listed as an app dependency instead of relying on a transitive package.

Follow-up / test notes
- `bun x vitest run src/features/panel/index.test.tsx`
- `cd sidecar && bun test test/title.test.ts`
- `cd src-tauri && cargo test local_llm::title`
- Pre-commit hook passed Biome, cargo fmt, and cargo clippy.