### PR TITLE
Fix: advance to neighbouring workspace when dismissing

### DIFF
--- a/.changeset/dismiss-workspace-advance-neighbour.md
+++ b/.changeset/dismiss-workspace-advance-neighbour.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix dismissing or archiving a workspace jumping to the start page instead of advancing to the next workspace in the same group.

--- a/src/features/navigation/hooks/use-controller.test.tsx
+++ b/src/features/navigation/hooks/use-controller.test.tsx
@@ -339,6 +339,42 @@ describe("useWorkspacesSidebarController archive flow", () => {
 		expect(pushWorkspaceToast).not.toHaveBeenCalled();
 	});
 
+	it("advances to the neighbour even when onOpenNewWorkspace is provided", async () => {
+		// Regression guard: production always passes onOpenNewWorkspace, so an
+		// archive that has a sibling must still advance to it rather than jump
+		// to the start page.
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false } },
+		});
+		const onSelectWorkspace = vi.fn();
+		const onOpenNewWorkspace = vi.fn();
+		const pushWorkspaceToast = vi.fn();
+
+		const { result } = renderHook(
+			() =>
+				useWorkspacesSidebarController({
+					selectedWorkspaceId: "ws-1",
+					onSelectWorkspace,
+					onOpenNewWorkspace,
+					pushWorkspaceToast,
+				}),
+			{ wrapper: createWrapper(queryClient) },
+		);
+
+		await waitFor(() => {
+			expect(result.current.groups[0]?.rows).toHaveLength(2);
+		});
+
+		act(() => {
+			result.current.handleArchiveWorkspace("ws-1");
+		});
+
+		await waitFor(() => {
+			expect(onSelectWorkspace).toHaveBeenCalledWith("ws-2");
+		});
+		expect(onOpenNewWorkspace).not.toHaveBeenCalled();
+	});
+
 	it("consecutive archives advance to the next sidebar row instead of jumping to archived", async () => {
 		const queryClient = new QueryClient({
 			defaultOptions: { queries: { retry: false } },

--- a/src/features/navigation/hooks/use-controller.ts
+++ b/src/features/navigation/hooks/use-controller.ts
@@ -1514,20 +1514,23 @@ export function useWorkspacesSidebarController({
 				const shouldNavigate =
 					!selectedWorkspaceId || selectedWorkspaceId === workspaceId;
 				if (shouldNavigate) {
-					if (onOpenNewWorkspace) {
+					// Advance to the neighbour in the same group (then next group,
+					// then archived) — same as delete. Only fall back to the start
+					// page when nothing is left to select.
+					const nextWorkspaceId = findReplacementWorkspaceIdAfterRemoval({
+						currentGroups: groups,
+						currentArchivedRows: archivedRows,
+						nextGroups: optimisticVisual.groups,
+						nextArchivedRows: optimisticVisual.archivedRows,
+						removedWorkspaceId: workspaceId,
+					});
+					if (nextWorkspaceId) {
+						prefetchWorkspace(nextWorkspaceId);
+						onSelectWorkspace(nextWorkspaceId);
+					} else if (onOpenNewWorkspace) {
 						onOpenNewWorkspace();
 					} else {
-						const nextWorkspaceId = findReplacementWorkspaceIdAfterRemoval({
-							currentGroups: groups,
-							currentArchivedRows: archivedRows,
-							nextGroups: optimisticVisual.groups,
-							nextArchivedRows: optimisticVisual.archivedRows,
-							removedWorkspaceId: workspaceId,
-						});
-						if (nextWorkspaceId) {
-							prefetchWorkspace(nextWorkspaceId);
-						}
-						onSelectWorkspace(nextWorkspaceId);
+						onSelectWorkspace(null);
 					}
 				}
 


### PR DESCRIPTION
## Summary

Fixed a regression where dismissing or archiving a workspace would jump to the start page instead of advancing to the next workspace in the same group.

## Changes

- Reordered the navigation logic in `useWorkspacesSidebarController` to prioritize finding a replacement workspace before falling back to `onOpenNewWorkspace()`
- Updated the fallback cascade: find neighbour → call `onOpenNewWorkspace()` → select start page (null)
- Added regression test to ensure this behavior is preserved even when `onOpenNewWorkspace` is provided

## Testing

The new test `advances to the neighbour even when onOpenNewWorkspace is provided` verifies that archiving a workspace with a sibling correctly advances to that sibling rather than invoking the "new workspace" callback.

## Related

Fixes dismissal/archive regression where workspace selection incorrectly favored opening a new workspace over advancing to an existing neighbour.