### PR TITLE
fix(triage): make Smart triage resilient and honest on Slack

### DIFF
--- a/.changeset/slack-triage-resilience.md
+++ b/.changeset/slack-triage-resilience.md
@@ -1,0 +1,7 @@
+---
+"helmor": patch
+---
+
+Make Smart triage reliably pick up Slack messages:
+- Triage now retries transient Slack failures (DNS, connection, and 5xx errors) instead of dropping the whole fetch, so Slack channel mentions and DMs stop being silently missed.
+- The Triage settings panel now flags a Slack source as needing attention (with the failure reason) when its background fetch is failing, instead of always showing it as connected.

--- a/src-tauri/src/slack/api.rs
+++ b/src-tauri/src/slack/api.rs
@@ -163,6 +163,49 @@ fn cookie_header(creds: &SlackCreds) -> String {
 /// `http_runtime()` above — see that function's doc for why we don't
 /// reuse Tauri's runtime.
 fn call(creds: &SlackCreds, method: &str, params: &[(&str, &str)]) -> Result<Value> {
+    // Bounded retry for transient failures only: transport errors (DNS,
+    // connection-refused/reset, timeout) and HTTP 5xx. Auth errors, other
+    // 4xx, bad JSON and Slack `{ok:false}` codes are permanent and returned
+    // immediately. We don't yet honour Retry-After, so 429/`ratelimited`
+    // is treated as permanent rather than hammered.
+    const MAX_ATTEMPTS: u32 = 3;
+    let mut attempt: u32 = 0;
+    loop {
+        attempt += 1;
+        match call_once(creds, method, params) {
+            Ok(value) => return Ok(value),
+            Err(CallError::Retryable(error)) if attempt < MAX_ATTEMPTS => {
+                let delay = Duration::from_millis(200 * 2u64.pow(attempt - 1));
+                tracing::debug!(
+                    method = %method,
+                    attempt,
+                    delay_ms = delay.as_millis() as u64,
+                    error = %format!("{error:#}"),
+                    "slack api: transient error, retrying",
+                );
+                std::thread::sleep(delay);
+            }
+            Err(CallError::Retryable(error) | CallError::Fatal(error)) => return Err(error),
+        }
+    }
+}
+
+/// Retry classification for [`call_once`]. The inner `anyhow::Error` is
+/// returned to the caller unchanged (so `SlackApiError` downcasts such as
+/// [`is_invalid_auth`] still work); the variant only decides whether
+/// [`call`] retries.
+enum CallError {
+    Retryable(anyhow::Error),
+    Fatal(anyhow::Error),
+}
+
+/// One HTTP attempt. Urlencoded body + browser-shaped headers — see the
+/// module docs for why.
+fn call_once(
+    creds: &SlackCreds,
+    method: &str,
+    params: &[(&str, &str)],
+) -> std::result::Result<Value, CallError> {
     let url = format!("{SLACK_API_BASE}/{method}");
     let mut form: Vec<(&str, &str)> = Vec::with_capacity(params.len() + 1);
     form.push(("token", creds.xoxc.as_str()));
@@ -174,7 +217,7 @@ fn call(creds: &SlackCreds, method: &str, params: &[(&str, &str)]) -> Result<Val
     let client = client();
 
     let body: Value = http_runtime().block_on(async move {
-        let response = client
+        let response = match client
             .post(&url)
             .header("Cookie", cookie)
             // Origin pins the request to Slack's own SPA; without it
@@ -185,21 +228,32 @@ fn call(creds: &SlackCreds, method: &str, params: &[(&str, &str)]) -> Result<Val
             .form(&form)
             .send()
             .await
-            .with_context(|| format!("Failed to POST {method}"))?;
+        {
+            Ok(response) => response,
+            // Transport failure: exactly the transient class worth retrying.
+            Err(error) => {
+                return Err(CallError::Retryable(
+                    anyhow::Error::new(error).context(format!("Failed to POST {method}")),
+                ));
+            }
+        };
 
-        if !response.status().is_success() {
-            bail!(
-                "Slack API {} returned HTTP {}",
-                method,
-                response.status().as_u16()
-            );
+        let status = response.status();
+        if !status.is_success() {
+            let error = anyhow!("Slack API {method} returned HTTP {}", status.as_u16());
+            return if status.is_server_error() {
+                Err(CallError::Retryable(error))
+            } else {
+                Err(CallError::Fatal(error))
+            };
         }
 
-        let body: Value = response
-            .json()
-            .await
-            .with_context(|| format!("Failed to decode JSON from {method}"))?;
-        Ok::<Value, anyhow::Error>(body)
+        match response.json::<Value>().await {
+            Ok(body) => Ok(body),
+            Err(error) => Err(CallError::Fatal(
+                anyhow::Error::new(error).context(format!("Failed to decode JSON from {method}")),
+            )),
+        }
     })?;
 
     let ok = body.get("ok").and_then(Value::as_bool).unwrap_or(false);
@@ -210,11 +264,13 @@ fn call(creds: &SlackCreds, method: &str, params: &[(&str, &str)]) -> Result<Val
             .unwrap_or("unknown")
             .to_string();
         tracing::warn!(method = %method, error = %error, "Slack API call failed");
-        return Err(SlackApiError {
-            method: method.to_string(),
-            error,
-        }
-        .into());
+        return Err(CallError::Fatal(
+            SlackApiError {
+                method: method.to_string(),
+                error,
+            }
+            .into(),
+        ));
     }
 
     Ok(body)

--- a/src-tauri/src/slack/inbox.rs
+++ b/src-tauri/src/slack/inbox.rs
@@ -14,6 +14,7 @@ use anyhow::{bail, Result};
 
 use super::api::{self, ConversationRow, RawMessage, SearchMessagesPage, SearchSort, UserInfo};
 use super::credentials::{self, SlackCreds};
+use super::relevance;
 use super::types::{SlackInboxItem, SlackInboxItemKind, SlackInboxPage};
 
 const MAX_SNIPPET_CHARS: usize = 280;
@@ -38,15 +39,19 @@ pub fn list_inbox_items(
         .unwrap_or(1)
         .max(1);
 
-    // Mentions feed: `@<my_user_id>` is Slack's documented "mentions of
-    // me" query token. `from:me` would invert it. We deliberately don't
-    // request `has:reaction` etc. — keep the query minimal so Slack's
-    // search index responds fast.
-    let query = format!("<@{my_user_id}>");
+    // Mentions feed via the shared relevance layer (`@<my_user_id>` is
+    // Slack's documented "mentions of me" token). Auth failure propagates
+    // so the IPC layer can wipe the keychain + re-auth; a transient failure
+    // surfaces as an error here too, preserving the feed's "show an error,
+    // don't silently blank" behaviour.
+    let mentions = relevance::mentions(&creds, my_user_id, page, SearchSort::Timestamp)?;
+    if let Some(reason) = mentions.degraded {
+        bail!("{reason}");
+    }
     let SearchMessagesPage {
         matches,
         total_pages,
-    } = api::search_messages(&creds, &query, page, SearchSort::Timestamp)?;
+    } = mentions.value;
     let next_cursor = if page < total_pages {
         Some((page + 1).to_string())
     } else {
@@ -175,12 +180,12 @@ fn convert_search_match(
 /// is one connection, so this naturally stays under Slack's
 /// per-token burst threshold.
 fn unread_dm_snippets(team_id: &str, creds: &SlackCreds) -> Result<Vec<SlackInboxItem>> {
-    let dms = api::users_conversations_dms(creds)?;
+    // relevance::unread_dms already filters to unread_count_display > 0.
+    // Auth failure propagates; a transient failure degrades to an empty
+    // list (DM snippets are best-effort in the feed).
+    let dms = relevance::unread_dms(creds)?;
     let mut items = Vec::new();
-    for dm in dms {
-        if dm.unread_count_display == 0 {
-            continue;
-        }
+    for dm in dms.value {
         match snippet_for_dm(team_id, creds, &dm) {
             Ok(Some(item)) => items.push(item),
             Ok(None) => {}

--- a/src-tauri/src/slack/mod.rs
+++ b/src-tauri/src/slack/mod.rs
@@ -29,4 +29,5 @@ pub mod desktop_scrape;
 pub mod detail;
 pub mod files;
 pub mod inbox;
+pub mod relevance;
 pub mod types;

--- a/src-tauri/src/slack/relevance.rs
+++ b/src-tauri/src/slack/relevance.rs
@@ -1,0 +1,218 @@
+//! Shared, failure-aware "what's relevant to me right now" discovery for
+//! Slack. Both the inbox feed (`slack::inbox`) and the triage fetcher
+//! (`triage::fetcher::im::slack`) compose these primitives so the
+//! failure-handling policy + degradation reporting live in ONE place.
+//!
+//! The contract that fixes the original bug: a flaky underlying signal
+//! (`search.messages` 503s, transient network errors) returns a
+//! [`Outcome`] whose `value` is empty/partial AND whose `degraded`
+//! carries a human-readable reason — NEVER a silent empty. Callers must
+//! treat `degraded.is_some()` as "this is incomplete, surface it",
+//! distinct from a genuine empty result.
+//!
+//! This is also the seam a future `client.counts`/`client.boot`
+//! implementation swaps behind — consumers depend on these signatures,
+//! not on `search.messages`.
+
+use std::collections::BTreeSet;
+
+use anyhow::Result;
+use chrono::{Duration, Utc};
+
+use super::api::{self, ConversationRow, RawMessage, SearchMessagesPage, SearchSort};
+use super::credentials::SlackCreds;
+
+/// A discovery result that may be partial. `value` is always usable
+/// (possibly empty); `degraded` is `Some(reason)` when an underlying
+/// signal failed, so the caller can report incompleteness instead of
+/// silently treating "failed" as "nothing relevant".
+#[derive(Debug, Clone)]
+pub struct Outcome<T> {
+    pub value: T,
+    pub degraded: Option<String>,
+}
+
+impl<T> Outcome<T> {
+    fn ok(value: T) -> Self {
+        Self {
+            value,
+            degraded: None,
+        }
+    }
+
+    fn degraded(value: T, reason: impl Into<String>) -> Self {
+        Self {
+            value,
+            degraded: Some(reason.into()),
+        }
+    }
+}
+
+/// Classify an api error. Auth-fatal (`invalid_auth` / `not_authed` / …)
+/// → `Err`, so the caller can propagate it and trigger re-auth (the inbox
+/// IPC layer wipes the keychain + emits `SlackTokenInvalidated` on this).
+/// Anything else is transient → `Ok` with a degraded (empty/partial)
+/// outcome, so a flaky network/search index never looks like "auth gone".
+fn classify<T>(empty: T, error: anyhow::Error, what: &str) -> Result<Outcome<T>> {
+    if api::is_invalid_auth(&error) {
+        Err(error)
+    } else {
+        Ok(Outcome::degraded(
+            empty,
+            format!("{what} failed: {error:#}"),
+        ))
+    }
+}
+
+/// Mentions of `@me`, one page, caller-chosen sort. The inbox renders
+/// these as feed items; triage reads the channel envelopes to learn which
+/// channels mentioned it. Transient failure → empty page + degraded
+/// reason so a flaky search index never blanks the whole feed/queue;
+/// auth failure → `Err` for the caller to propagate.
+pub fn mentions(
+    creds: &SlackCreds,
+    my_user_id: &str,
+    page: u32,
+    sort: SearchSort,
+) -> Result<Outcome<SearchMessagesPage>> {
+    let query = format!("<@{my_user_id}>");
+    match api::search_messages(creds, &query, page, sort) {
+        Ok(page) => Ok(Outcome::ok(page)),
+        Err(error) => classify(
+            SearchMessagesPage {
+                matches: Vec::new(),
+                total_pages: 0,
+            },
+            error,
+            "mentions search",
+        ),
+    }
+}
+
+/// Channel ids I'm "involved" in over the cold-start window: channels I
+/// was @ed in OR posted in. Two `search.messages` queries; each failure
+/// degrades independently. DMs (discovered separately) are unaffected.
+pub fn involved_channels(
+    creds: &SlackCreds,
+    my_user_id: &str,
+    cold_start_days: i64,
+) -> Result<Outcome<BTreeSet<String>>> {
+    let after = (Utc::now() - Duration::days(cold_start_days))
+        .format("%Y-%m-%d")
+        .to_string();
+    let queries = [
+        ("mention", format!("<@{my_user_id}> after:{after}")),
+        ("from-me", format!("from:<@{my_user_id}> after:{after}")),
+    ];
+    let mut channels = BTreeSet::new();
+    let mut failures: Vec<String> = Vec::new();
+    for (label, query) in queries {
+        match api::search_messages(creds, &query, 1, SearchSort::Timestamp) {
+            Ok(page) => collect_channel_ids(&page.matches, &mut channels),
+            Err(error) => {
+                if api::is_invalid_auth(&error) {
+                    return Err(error);
+                }
+                failures.push(format!("{label}: {error:#}"));
+            }
+        }
+    }
+    if failures.is_empty() {
+        Ok(Outcome::ok(channels))
+    } else {
+        Ok(Outcome::degraded(
+            channels,
+            format!("channel discovery degraded ({})", failures.join("; ")),
+        ))
+    }
+}
+
+/// All conversations I'm a member of, filtered to `types` (Slack-side
+/// comma list: `im,mpim,public_channel,private_channel`). Unlike the old
+/// triage path, a failure is reported as degraded (empty) rather than
+/// silently skipping the whole workspace.
+pub fn member_conversations(
+    creds: &SlackCreds,
+    types: &str,
+    limit: u32,
+) -> Result<Outcome<Vec<ConversationRow>>> {
+    match api::users_conversations(creds, types, limit) {
+        Ok(rows) => Ok(Outcome::ok(rows)),
+        Err(error) => classify(Vec::new(), error, "users.conversations"),
+    }
+}
+
+/// Unread DM/MPIM conversations (`unread_count_display > 0`), for the
+/// inbox feed. Triage treats all DMs/MPIMs as candidates regardless of
+/// unread, so it uses [`member_conversations`] directly.
+pub fn unread_dms(creds: &SlackCreds) -> Result<Outcome<Vec<ConversationRow>>> {
+    match api::users_conversations_dms(creds) {
+        Ok(rows) => Ok(Outcome::ok(
+            rows.into_iter()
+                .filter(|d| d.unread_count_display > 0)
+                .collect(),
+        )),
+        Err(error) => classify(Vec::new(), error, "users.conversations (dms)"),
+    }
+}
+
+/// Union the channel ids carried in a batch of `search.messages` hits.
+fn collect_channel_ids(matches: &[RawMessage], into: &mut BTreeSet<String>) {
+    for hit in matches {
+        if let Some(channel) = hit.channel.as_ref() {
+            if !channel.id.is_empty() {
+                into.insert(channel.id.clone());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn match_in_channel(channel_id: &str) -> RawMessage {
+        serde_json::from_value(json!({
+            "ts": "1700000000.000100",
+            "channel": { "id": channel_id, "name": "eng" },
+        }))
+        .expect("valid RawMessage")
+    }
+
+    #[test]
+    fn collect_channel_ids_dedups_and_skips_empty() {
+        let matches = vec![
+            match_in_channel("C1"),
+            match_in_channel("C1"),
+            match_in_channel("C2"),
+            match_in_channel(""),
+        ];
+        let mut into = BTreeSet::new();
+        collect_channel_ids(&matches, &mut into);
+        assert_eq!(into.len(), 2);
+        assert!(into.contains("C1") && into.contains("C2"));
+    }
+
+    #[test]
+    fn outcome_degraded_carries_reason_with_usable_value() {
+        let o = Outcome::degraded(vec![1, 2], "boom");
+        assert_eq!(o.value, vec![1, 2]);
+        assert_eq!(o.degraded.as_deref(), Some("boom"));
+    }
+
+    #[test]
+    fn classify_propagates_auth_and_degrades_transient() {
+        use crate::slack::api::SlackApiError;
+        // Auth-fatal → Err so the caller can propagate + trigger re-auth.
+        let auth = anyhow::Error::from(SlackApiError {
+            method: "users.conversations".into(),
+            error: "invalid_auth".into(),
+        });
+        assert!(classify(Vec::<u8>::new(), auth, "x").is_err());
+        // Transient → Ok(degraded), never mistaken for auth loss.
+        let transient = anyhow::anyhow!("connection refused");
+        let out = classify(Vec::<u8>::new(), transient, "x").expect("transient is not fatal");
+        assert!(out.degraded.is_some());
+    }
+}

--- a/src-tauri/src/triage/fetcher/health.rs
+++ b/src-tauri/src/triage/fetcher/health.rs
@@ -1,0 +1,77 @@
+//! In-process, per-source fetch health for the Settings → Triage panel.
+//!
+//! Volatile by design: this is runtime state, cleared on restart (per the
+//! redesign decision — no DB table, no migration). Written by the fetcher
+//! scheduler ([`super::run_once`] + the IM backends), read by
+//! [`crate::triage::source_health`] to overlay real fetch outcomes on top
+//! of the static "is a workspace connected" check.
+//!
+//! Why this exists: before it, a fetch that failed silently produced zero
+//! candidates and the panel still reported "Connected · Watching N
+//! workspaces". Failures were invisible. Now they surface as `Degraded`.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+
+use chrono::{DateTime, Utc};
+
+#[derive(Debug, Clone, Default)]
+pub struct FetchHealth {
+    pub last_attempt_at: Option<DateTime<Utc>>,
+    pub last_success_at: Option<DateTime<Utc>>,
+    /// Set when the whole fetch tick failed (`fetch_once` returned `Err`).
+    /// Cleared on the next success.
+    pub last_error: Option<String>,
+    /// Set when a sub-signal degraded mid-tick (e.g. channel discovery
+    /// failed) but the tick still produced partial results. Reset at the
+    /// start of each attempt, so it always reflects the latest tick only.
+    pub last_degraded: Option<String>,
+    pub consecutive_failures: u32,
+    pub items_last: usize,
+}
+
+fn store() -> &'static Mutex<HashMap<String, FetchHealth>> {
+    static STORE: OnceLock<Mutex<HashMap<String, FetchHealth>>> = OnceLock::new();
+    STORE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Mark the start of a fetch attempt: stamps the time and clears the
+/// per-attempt degraded note so it can't leak across ticks.
+pub fn record_attempt(source: &str) {
+    let mut map = store().lock().expect("fetch-health poisoned");
+    let entry = map.entry(source.to_string()).or_default();
+    entry.last_attempt_at = Some(Utc::now());
+    entry.last_degraded = None;
+}
+
+/// A sub-signal degraded mid-tick but partial results still came through.
+/// Additive: does not clear a recorded success.
+pub fn record_degraded(source: &str, reason: impl Into<String>) {
+    let mut map = store().lock().expect("fetch-health poisoned");
+    let entry = map.entry(source.to_string()).or_default();
+    entry.last_degraded = Some(reason.into());
+}
+
+pub fn record_success(source: &str, items: usize) {
+    let mut map = store().lock().expect("fetch-health poisoned");
+    let entry = map.entry(source.to_string()).or_default();
+    entry.last_success_at = Some(Utc::now());
+    entry.last_error = None;
+    entry.consecutive_failures = 0;
+    entry.items_last = items;
+}
+
+pub fn record_failure(source: &str, reason: impl Into<String>) {
+    let mut map = store().lock().expect("fetch-health poisoned");
+    let entry = map.entry(source.to_string()).or_default();
+    entry.last_error = Some(reason.into());
+    entry.consecutive_failures = entry.consecutive_failures.saturating_add(1);
+}
+
+pub fn get(source: &str) -> Option<FetchHealth> {
+    store()
+        .lock()
+        .expect("fetch-health poisoned")
+        .get(source)
+        .cloned()
+}

--- a/src-tauri/src/triage/fetcher/im/slack.rs
+++ b/src-tauri/src/triage/fetcher/im/slack.rs
@@ -1,16 +1,15 @@
 //! Slack ImBackend. DMs/MPIMs unconditional; channels only when the user
 //! posted (`from:<@me>`) or was @ed (`<@me>`) within `COLD_START_DAYS`.
 
-use std::collections::BTreeSet;
-
 use anyhow::{Context, Result};
-use chrono::{DateTime, Duration, TimeZone, Utc};
+use chrono::{DateTime, TimeZone, Utc};
 use serde_json::json;
 
 use crate::models::slack_workspaces;
 use crate::slack::api::{self, ConversationRow, RawFile, RawMessage};
 use crate::slack::credentials::{self, SlackCreds};
 use crate::slack::files as slack_files;
+use crate::slack::relevance;
 use crate::slack::types::SlackWorkspace;
 use crate::triage::attachments;
 
@@ -43,29 +42,75 @@ impl ImBackend for SlackBackend {
                 None => continue,
             };
 
-            // Channel involvement signal (sent or @ed). Search failures degrade silently; DMs still flow.
-            let involved_channels = collect_involved_channels(ws, &creds);
-
-            let mut rows = match api::users_conversations(
+            // Channels I was @ed in or posted in. Auth failure → skip this
+            // workspace (token is invalid). A transient search failure →
+            // degraded (DMs below still flow), never silently swallowed.
+            let involved = match relevance::involved_channels(
                 &creds,
-                "im,mpim,public_channel,private_channel",
-                500,
+                &ws.my_user_id,
+                super::COLD_START_DAYS,
             ) {
-                Ok(r) => r,
+                Ok(outcome) => outcome,
                 Err(error) => {
                     tracing::warn!(
                         team_id = %ws.team_id,
                         error = %format!("{error:#}"),
-                        "slack backend: users.conversations failed",
+                        "slack backend: auth failure, skipping workspace",
+                    );
+                    crate::triage::fetcher::health::record_degraded(
+                        SOURCE,
+                        format!("auth failure: {error:#}"),
                     );
                     continue;
                 }
             };
+            if let Some(reason) = &involved.degraded {
+                tracing::warn!(
+                    team_id = %ws.team_id,
+                    reason = %reason,
+                    "slack backend: channel discovery degraded",
+                );
+                crate::triage::fetcher::health::record_degraded(SOURCE, reason.clone());
+            }
+
+            // Every conversation I'm a member of. A transient failure here
+            // used to skip the whole workspace silently; now it surfaces as
+            // degraded health and the tick processes whatever came back.
+            // Auth failure → skip this workspace.
+            let members = match relevance::member_conversations(
+                &creds,
+                "im,mpim,public_channel,private_channel",
+                500,
+            ) {
+                Ok(outcome) => outcome,
+                Err(error) => {
+                    tracing::warn!(
+                        team_id = %ws.team_id,
+                        error = %format!("{error:#}"),
+                        "slack backend: auth failure, skipping workspace",
+                    );
+                    crate::triage::fetcher::health::record_degraded(
+                        SOURCE,
+                        format!("auth failure: {error:#}"),
+                    );
+                    continue;
+                }
+            };
+            if let Some(reason) = &members.degraded {
+                tracing::warn!(
+                    team_id = %ws.team_id,
+                    reason = %reason,
+                    "slack backend: conversation listing degraded",
+                );
+                crate::triage::fetcher::health::record_degraded(SOURCE, reason.clone());
+            }
+
+            let mut rows = members.value;
             rows.retain(|c| {
                 if c.is_im || c.is_mpim {
                     true // DMs / group-DMs unconditional
                 } else {
-                    involved_channels.contains(&c.id)
+                    involved.value.contains(&c.id)
                 }
             });
             // DMs first; among channels the order doesn't really
@@ -178,38 +223,6 @@ fn stage_one(
         bytes,
         alt: file.title.clone().or_else(|| file.name.clone()),
     })
-}
-
-/// Two search.messages queries (mentions + from-me) → distinct channel ids.
-fn collect_involved_channels(ws: &SlackWorkspace, creds: &SlackCreds) -> BTreeSet<String> {
-    let after = (Utc::now() - Duration::days(super::COLD_START_DAYS))
-        .format("%Y-%m-%d")
-        .to_string();
-    let mention_query = format!("<@{my}> after:{after}", my = ws.my_user_id);
-    let sent_query = format!("from:<@{my}> after:{after}", my = ws.my_user_id);
-    let mut channels = BTreeSet::new();
-    for (label, q) in [("mention", mention_query), ("from-me", sent_query)] {
-        match api::search_messages(creds, &q, 1, api::SearchSort::Timestamp) {
-            Ok(page) => {
-                for hit in &page.matches {
-                    if let Some(ch) = hit.channel.as_ref() {
-                        if !ch.id.is_empty() {
-                            channels.insert(ch.id.clone());
-                        }
-                    }
-                }
-            }
-            Err(error) => {
-                tracing::warn!(
-                    team_id = %ws.team_id,
-                    kind = label,
-                    error = %format!("{error:#}"),
-                    "slack backend: search.messages failed; channels may be under-discovered",
-                );
-            }
-        }
-    }
-    channels
 }
 
 /// `ImConversation.id = <team_id>:<channel_id>`.

--- a/src-tauri/src/triage/fetcher/mod.rs
+++ b/src-tauri/src/triage/fetcher/mod.rs
@@ -4,6 +4,7 @@
 pub mod cache;
 pub mod github;
 pub mod gitlab;
+pub mod health;
 pub mod im;
 pub mod storage;
 
@@ -130,9 +131,11 @@ fn maybe_fire_triage_tick<R: TauriRuntime>(app: &AppHandle<R>) {
 pub fn run_once() {
     for fetcher in registered_fetchers() {
         let source = fetcher.source();
+        health::record_attempt(source);
         let started = Instant::now();
         match fetcher.fetch_once() {
             Ok(summary) => {
+                health::record_success(source, summary.source_parents_scanned);
                 tracing::info!(
                     source,
                     inserted = summary.inserted,
@@ -144,6 +147,7 @@ pub fn run_once() {
                 );
             }
             Err(error) => {
+                health::record_failure(source, format!("{error:#}"));
                 tracing::warn!(
                     source,
                     elapsed_ms = started.elapsed().as_millis() as u64,

--- a/src-tauri/src/triage/source_health.rs
+++ b/src-tauri/src/triage/source_health.rs
@@ -9,6 +9,7 @@ use tokio::time::timeout;
 
 use crate::models::repos;
 use crate::models::slack_workspaces;
+use crate::triage::fetcher::health::FetchHealth;
 
 const LARK_PROBE_TIMEOUT: Duration = Duration::from_secs(8);
 
@@ -22,6 +23,8 @@ pub enum SourceHealthState {
     NotAuthed,
     /// Auth OK but no repos/workspaces to fetch from.
     NotConfigured,
+    /// Auth OK but the most recent fetch failed or returned partial data.
+    Degraded,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -105,7 +108,17 @@ async fn detect_lark() -> SourceHealth {
 
 fn detect_slack() -> SourceHealth {
     let workspaces = slack_workspaces::list_workspaces().unwrap_or_default();
-    if workspaces.is_empty() {
+    resolve_slack_health(
+        workspaces.len(),
+        crate::triage::fetcher::health::get("slack"),
+    )
+}
+
+/// Pure core: combine the static "is a workspace connected" signal with
+/// the runtime fetch-health overlay. Split out so it's unit-testable
+/// without touching the process-global health store.
+fn resolve_slack_health(n_workspaces: usize, health: Option<FetchHealth>) -> SourceHealth {
+    if n_workspaces == 0 {
         return SourceHealth {
             source: "slack",
             display_name: "Slack",
@@ -113,12 +126,47 @@ fn detect_slack() -> SourceHealth {
             detail: "No workspace connected".into(),
         };
     }
-    let n = workspaces.len();
+    // A hard failure on the most recent tick, or a partial degradation,
+    // overrides the otherwise-green "watching" status so the user sees it
+    // instead of the panel silently claiming everything is fine.
+    if let Some(h) = health {
+        if let Some(error) = h.last_error.as_deref() {
+            return SourceHealth {
+                source: "slack",
+                display_name: "Slack",
+                state: SourceHealthState::Degraded,
+                detail: format!("Last fetch failed: {}", short_reason(error)),
+            };
+        }
+        if let Some(degraded) = h.last_degraded.as_deref() {
+            return SourceHealth {
+                source: "slack",
+                display_name: "Slack",
+                state: SourceHealthState::Degraded,
+                detail: short_reason(degraded),
+            };
+        }
+    }
+    let n = n_workspaces;
     SourceHealth {
         source: "slack",
         display_name: "Slack",
         state: SourceHealthState::Ok,
         detail: format!("Watching {n} workspace{}", if n == 1 { "" } else { "s" }),
+    }
+}
+
+/// First line, trimmed and capped, so a multi-line anyhow chain stays a
+/// single readable row in the panel.
+fn short_reason(reason: &str) -> String {
+    let line = reason.lines().next().unwrap_or(reason).trim();
+    const MAX: usize = 140;
+    if line.chars().count() <= MAX {
+        line.to_string()
+    } else {
+        let mut out: String = line.chars().take(MAX).collect();
+        out.push('…');
+        out
     }
 }
 
@@ -161,5 +209,58 @@ fn detect_forge(source: &'static str, display_name: &'static str, auth_hint: &st
         display_name,
         state: SourceHealthState::Ok,
         detail: format!("Watching {n} repo{}", if n == 1 { "" } else { "s" }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_workspace_is_not_authed() {
+        let h = resolve_slack_health(0, None);
+        assert_eq!(h.state, SourceHealthState::NotAuthed);
+    }
+
+    #[test]
+    fn healthy_workspace_is_ok() {
+        let h = resolve_slack_health(2, None);
+        assert_eq!(h.state, SourceHealthState::Ok);
+        assert!(h.detail.contains("2 workspaces"));
+    }
+
+    #[test]
+    fn last_error_surfaces_as_degraded_single_line() {
+        let health = FetchHealth {
+            last_error: Some(
+                "users.conversations failed: connection refused\ntrailing noise".into(),
+            ),
+            ..Default::default()
+        };
+        let h = resolve_slack_health(1, Some(health));
+        assert_eq!(h.state, SourceHealthState::Degraded);
+        assert!(h.detail.starts_with("Last fetch failed:"));
+        assert!(!h.detail.contains('\n'));
+    }
+
+    #[test]
+    fn partial_degradation_surfaces_as_degraded() {
+        let health = FetchHealth {
+            last_degraded: Some("channel discovery degraded (mention: 503)".into()),
+            ..Default::default()
+        };
+        let h = resolve_slack_health(1, Some(health));
+        assert_eq!(h.state, SourceHealthState::Degraded);
+    }
+
+    #[test]
+    fn hard_error_takes_precedence_over_partial_degradation() {
+        let health = FetchHealth {
+            last_error: Some("boom".into()),
+            last_degraded: Some("partial".into()),
+            ..Default::default()
+        };
+        let h = resolve_slack_health(1, Some(health));
+        assert!(h.detail.starts_with("Last fetch failed:"));
     }
 }

--- a/src/features/settings/panels/triage.tsx
+++ b/src/features/settings/panels/triage.tsx
@@ -572,6 +572,12 @@ function stateBadge(state: TriageSourceHealthState): {
 				tone: "text-muted-foreground",
 				Icon: SettingsIcon,
 			};
+		case "degraded":
+			return {
+				label: "Attention",
+				tone: "text-amber-600 dark:text-amber-400",
+				Icon: AlertTriangle,
+			};
 		default:
 			return {
 				label: "Unknown",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2023,7 +2023,8 @@ export type TriageSourceHealthState =
 	| "ok"
 	| "notInstalled"
 	| "notAuthed"
-	| "notConfigured";
+	| "notConfigured"
+	| "degraded";
 
 export type TriageSourceHealth = {
 	source: string;


### PR DESCRIPTION
## What & why

Helmor's local-model **Smart triage** was not detecting Slack messages. The root cause was three compounding issues in the Slack fetch path:

1. **No resilience to transient network failures.** `slack::api::call` made a single HTTP attempt; the machine hit `Connection refused` / DNS failures / HTTP 503 against `slack.com/api` (clustered at app-launch / network-transition moments), and each blip dropped the whole fetch.
2. **Silent degradation.** A `users.conversations` failure skipped the *entire* workspace, and `search.messages` failures (channel discovery) were swallowed — so channel mentions never became triage candidates (prod DB: 0 channel candidates ever, only a few DMs vs 134 GitHub items).
3. **No observability.** Settings → Triage always showed "Connected · Watching N workspaces" regardless of whether fetching worked, so the failure was invisible for days.

## Changes

- **`slack::relevance`** (new): a shared, failure-aware discovery layer used by **both** the inbox feed and the triage fetcher. Primitives return `Outcome { value, degraded }` and distinguish auth-fatal errors (propagated, so the existing keychain-wipe / re-auth path still fires) from transient ones (degraded — never a silent empty). Removes the duplicated discovery logic between inbox and triage.
- **Retry/backoff** in `slack::api::call` (`call` + `call_once` + `CallError`): transient failures (transport errors + HTTP 5xx) retry up to 3× with bounded backoff; auth / other 4xx / bad JSON / Slack `{ok:false}` codes stay fatal and return the original error unchanged (so `is_invalid_auth` downcast still works).
- **Fetch-health observability**: triage records per-source attempt/success/failure/degraded (in-process), and `detect_slack` overlays it so the panel shows a `Degraded` "Attention" state with the failure reason instead of a green lie. New frontend `degraded` state + badge.

No changes to the message pipeline, persistence, or schema.

## Verification

- `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo test`: lib + integration green, incl. pipeline insta snapshots (zero drift). *Two pre-existing flaky tests in `workspace/scripts.rs` (untouched here; they fail only when run after the full suite due to a 5s subprocess-registration timeout, pass in isolation) are unrelated to this change.*
- `bun run typecheck`, `vitest` (1317), sidecar `bun test` (280), `biome`: all green.
- 11 new unit tests cover the auth-vs-transient classification and the health overlay.

## Follow-ups (not in this PR)

- Honor `Retry-After` for 429 / `ratelimited` (currently fatal, not retried).
- Worst-case latency on a persistently-failing endpoint rises to ~3× the request timeout.
- Optionally re-base the relevance signal on Slack's `client.counts` / `client.boot` if the new Degraded telemetry shows `search.messages` is the bottleneck.
