### PR TITLE
fix(slack): surface channel thread @-mentions in triage + Context, gate fetch on opt-in

### DIFF
--- a/.changeset/slack-triage-thread-mentions.md
+++ b/.changeset/slack-triage-thread-mentions.md
@@ -1,0 +1,7 @@
+---
+"helmor": patch
+---
+
+Make Smart triage reliably pick up Slack channel @-mentions, and stop background fetching entirely for users who haven't enabled it:
+- Triage now indexes the channels you were @-mentioned in — including mentions inside threads (the full thread is pulled in for context) and channels you aren't a member of. Previously thread mentions were silently dropped and channels were crowded out by your DMs, so those tasks never surfaced.
+- When Smart triage is turned off, Helmor no longer runs any background Slack/GitHub/GitLab/Lark fetches, so people who don't use the feature incur zero background activity.

--- a/.changeset/slack-triage-thread-mentions.md
+++ b/.changeset/slack-triage-thread-mentions.md
@@ -5,3 +5,4 @@
 Make Smart triage reliably pick up Slack channel @-mentions, and stop background fetching entirely for users who haven't enabled it:
 - Triage now indexes the channels you were @-mentioned in — including mentions inside threads (the full thread is pulled in for context) and channels you aren't a member of. Previously thread mentions were silently dropped and channels were crowded out by your DMs, so those tasks never surfaced.
 - When Smart triage is turned off, Helmor no longer runs any background Slack/GitHub/GitLab/Lark fetches, so people who don't use the feature incur zero background activity.
+- In the Context Slack inbox, opening an @-mention that was posted inside a thread now shows the full thread (tagged with a `Thread` badge), instead of only the surrounding channel messages.

--- a/src-tauri/src/slack/detail.rs
+++ b/src-tauri/src/slack/detail.rs
@@ -1,12 +1,11 @@
 //! Build the detail view for a single Slack inbox item.
 //!
-//! Two modes:
-//!   1. `thread_ts` is set → `conversations.replies` returns the full
-//!      thread including the root message. We render the whole tree.
-//!   2. `thread_ts` is None → `conversations.history` with the message's
-//!      `ts` as `latest`+`inclusive` gives a small context window around
-//!      a single DM / channel message. Better than showing the message
-//!      naked.
+//! The client sends `thread_ts=None` and lets the backend resolve it from
+//! the anchor `ts` (see [`resolve_thread`]):
+//!   - the anchor belongs to a thread (as the root OR a reply) → render the
+//!     whole thread via `conversations.replies`;
+//!   - otherwise it's a standalone message → a small `conversations.history`
+//!     context window around it, rather than showing the message naked.
 
 use anyhow::{bail, Context, Result};
 
@@ -31,18 +30,12 @@ pub fn get_thread_detail(
             true,
         )
     } else {
-        // The client always sends thread_ts=None and lets us decide (it
-        // can't know it). A root @-mention frequently grows a thread that
-        // search.messages never re-surfaces (the replies don't mention
-        // you), so probe the anchor's own thread first: conversations.replies
-        // returns the root + every reply when one exists, or just the single
-        // message otherwise. `len > 1` ⇒ it IS a thread → show the whole
-        // conversation that grew under the mention.
-        match api::conversations_replies(&creds, channel_id, anchor_ts) {
-            Ok(replies) if replies.len() > 1 => (replies, true),
-            _ => {
-                // Standalone message (or an unreachable thread): a small
-                // channel-history context window, newest-first → oldest-first.
+        // The client sends thread_ts=None and lets us resolve it from the
+        // anchor (see `resolve_thread`). A genuine standalone message has no
+        // thread → fall back to a small channel-history context window.
+        match resolve_thread(&creds, channel_id, anchor_ts) {
+            Some(thread) => (thread, true),
+            None => {
                 let mut messages = api::conversations_history(&creds, channel_id, None, 20)
                     .context("Failed to fetch channel history for detail view")?;
                 messages.reverse();
@@ -71,6 +64,33 @@ pub fn get_thread_detail(
         messages,
         permalink,
     })
+}
+
+/// Resolve the full thread an `anchor_ts` belongs to, or `None` when the
+/// anchor is a standalone (non-threaded) message.
+///
+/// `conversations.replies(anchor)` behaves differently by anchor kind:
+///   • root  → returns the entire thread (root + every reply).
+///   • reply → returns ONLY that single message (the web/xoxc API does not
+///     expand a thread from a reply's ts), but the returned message carries
+///     `thread_ts` pointing at the real root. We then re-fetch the root to
+///     pull in the whole thread the @-mention lives in.
+fn resolve_thread(
+    creds: &SlackCreds,
+    channel_id: &str,
+    anchor_ts: &str,
+) -> Option<Vec<RawMessage>> {
+    let first = api::conversations_replies(creds, channel_id, anchor_ts).ok()?;
+    if first.len() > 1 {
+        return Some(first); // anchor was the thread root
+    }
+    // Single message: a reply points at its real root via `thread_ts`.
+    let root = first.first()?.thread_ts.as_deref()?;
+    if root == anchor_ts {
+        return None; // a root with no replies → standalone message
+    }
+    let thread = api::conversations_replies(creds, channel_id, root).ok()?;
+    (thread.len() > 1).then_some(thread)
 }
 
 fn convert_message(team_id: &str, creds: &SlackCreds, raw: RawMessage) -> SlackMessage {

--- a/src-tauri/src/slack/detail.rs
+++ b/src-tauri/src/slack/detail.rs
@@ -31,14 +31,24 @@ pub fn get_thread_detail(
             true,
         )
     } else {
-        // Single-message preview: grab the last ~20 of channel history
-        // and flip newest-first → oldest-first for rendering. v1 takes
-        // the simple "last 20" slice — perfect-anchor centering can
-        // wait until we hear the UX demand it.
-        let mut messages = api::conversations_history(&creds, channel_id, None, 20)
-            .context("Failed to fetch channel history for detail view")?;
-        messages.reverse();
-        (messages, false)
+        // The client always sends thread_ts=None and lets us decide (it
+        // can't know it). A root @-mention frequently grows a thread that
+        // search.messages never re-surfaces (the replies don't mention
+        // you), so probe the anchor's own thread first: conversations.replies
+        // returns the root + every reply when one exists, or just the single
+        // message otherwise. `len > 1` ⇒ it IS a thread → show the whole
+        // conversation that grew under the mention.
+        match api::conversations_replies(&creds, channel_id, anchor_ts) {
+            Ok(replies) if replies.len() > 1 => (replies, true),
+            _ => {
+                // Standalone message (or an unreachable thread): a small
+                // channel-history context window, newest-first → oldest-first.
+                let mut messages = api::conversations_history(&creds, channel_id, None, 20)
+                    .context("Failed to fetch channel history for detail view")?;
+                messages.reverse();
+                (messages, false)
+            }
+        }
     };
 
     let channel_label =

--- a/src-tauri/src/slack/relevance.rs
+++ b/src-tauri/src/slack/relevance.rs
@@ -127,6 +127,61 @@ pub fn involved_channels(
     }
 }
 
+/// One involvement hit from `search.messages`. `is_mention` distinguishes the
+/// `<@me>` query (a real mention of me — an anchor candidate) from the
+/// `from:<@me>` query (my own post — context, not an anchor).
+#[derive(Debug, Clone)]
+pub struct MentionHit {
+    pub channel_id: String,
+    pub ts: String,
+    pub thread_ts: Option<String>,
+    pub text: String,
+    pub is_mention: bool,
+}
+
+/// Like [`involved_channels`] but returns the matched hits (ts / thread_ts /
+/// text), not just channel ids — so triage can expand the exact thread and
+/// guarantee the mention surfaces, instead of discarding the hits and
+/// re-fetching the channel timeline (which omits thread replies). Same two
+/// queries, same degraded/auth contract.
+pub fn involved_channel_hits(
+    creds: &SlackCreds,
+    my_user_id: &str,
+    cold_start_days: i64,
+) -> Result<Outcome<Vec<MentionHit>>> {
+    let after = (Utc::now() - Duration::days(cold_start_days))
+        .format("%Y-%m-%d")
+        .to_string();
+    let mut hits: Vec<MentionHit> = Vec::new();
+    let mut failures: Vec<String> = Vec::new();
+    for (label, query, is_mention) in [
+        ("mention", format!("<@{my_user_id}> after:{after}"), true),
+        (
+            "from-me",
+            format!("from:<@{my_user_id}> after:{after}"),
+            false,
+        ),
+    ] {
+        match api::search_messages(creds, &query, 1, SearchSort::Timestamp) {
+            Ok(page) => collect_hits(&page.matches, is_mention, &mut hits),
+            Err(error) => {
+                if api::is_invalid_auth(&error) {
+                    return Err(error);
+                }
+                failures.push(format!("{label}: {error:#}"));
+            }
+        }
+    }
+    if failures.is_empty() {
+        Ok(Outcome::ok(hits))
+    } else {
+        Ok(Outcome::degraded(
+            hits,
+            format!("channel discovery degraded ({})", failures.join("; ")),
+        ))
+    }
+}
+
 /// All conversations I'm a member of, filtered to `types` (Slack-side
 /// comma list: `im,mpim,public_channel,private_channel`). Unlike the old
 /// triage path, a failure is reported as degraded (empty) rather than
@@ -167,6 +222,24 @@ fn collect_channel_ids(matches: &[RawMessage], into: &mut BTreeSet<String>) {
     }
 }
 
+fn collect_hits(matches: &[RawMessage], is_mention: bool, into: &mut Vec<MentionHit>) {
+    for hit in matches {
+        let Some(channel) = hit.channel.as_ref() else {
+            continue;
+        };
+        if channel.id.is_empty() || hit.ts.is_empty() {
+            continue;
+        }
+        into.push(MentionHit {
+            channel_id: channel.id.clone(),
+            ts: hit.ts.clone(),
+            thread_ts: hit.thread_ts.clone(),
+            text: api::extract_display_text(hit),
+            is_mention,
+        });
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -192,6 +265,24 @@ mod tests {
         collect_channel_ids(&matches, &mut into);
         assert_eq!(into.len(), 2);
         assert!(into.contains("C1") && into.contains("C2"));
+    }
+
+    #[test]
+    fn collect_hits_captures_ts_thread_and_mention_flag() {
+        let raw: RawMessage = serde_json::from_value(json!({
+            "ts": "1700000000.000500",
+            "thread_ts": "1700000000.000100",
+            "text": "hi <@U_me>",
+            "channel": { "id": "C9", "name": "eng" },
+        }))
+        .expect("valid RawMessage");
+        let mut into = Vec::new();
+        collect_hits(&[raw], true, &mut into);
+        assert_eq!(into.len(), 1);
+        assert_eq!(into[0].channel_id, "C9");
+        assert_eq!(into[0].ts, "1700000000.000500");
+        assert_eq!(into[0].thread_ts.as_deref(), Some("1700000000.000100"));
+        assert!(into[0].is_mention);
     }
 
     #[test]

--- a/src-tauri/src/slack/relevance.rs
+++ b/src-tauri/src/slack/relevance.rs
@@ -14,8 +14,6 @@
 //! implementation swaps behind — consumers depend on these signatures,
 //! not on `search.messages`.
 
-use std::collections::BTreeSet;
-
 use anyhow::Result;
 use chrono::{Duration, Utc};
 
@@ -86,44 +84,6 @@ pub fn mentions(
             error,
             "mentions search",
         ),
-    }
-}
-
-/// Channel ids I'm "involved" in over the cold-start window: channels I
-/// was @ed in OR posted in. Two `search.messages` queries; each failure
-/// degrades independently. DMs (discovered separately) are unaffected.
-pub fn involved_channels(
-    creds: &SlackCreds,
-    my_user_id: &str,
-    cold_start_days: i64,
-) -> Result<Outcome<BTreeSet<String>>> {
-    let after = (Utc::now() - Duration::days(cold_start_days))
-        .format("%Y-%m-%d")
-        .to_string();
-    let queries = [
-        ("mention", format!("<@{my_user_id}> after:{after}")),
-        ("from-me", format!("from:<@{my_user_id}> after:{after}")),
-    ];
-    let mut channels = BTreeSet::new();
-    let mut failures: Vec<String> = Vec::new();
-    for (label, query) in queries {
-        match api::search_messages(creds, &query, 1, SearchSort::Timestamp) {
-            Ok(page) => collect_channel_ids(&page.matches, &mut channels),
-            Err(error) => {
-                if api::is_invalid_auth(&error) {
-                    return Err(error);
-                }
-                failures.push(format!("{label}: {error:#}"));
-            }
-        }
-    }
-    if failures.is_empty() {
-        Ok(Outcome::ok(channels))
-    } else {
-        Ok(Outcome::degraded(
-            channels,
-            format!("channel discovery degraded ({})", failures.join("; ")),
-        ))
     }
 }
 
@@ -211,17 +171,6 @@ pub fn unread_dms(creds: &SlackCreds) -> Result<Outcome<Vec<ConversationRow>>> {
     }
 }
 
-/// Union the channel ids carried in a batch of `search.messages` hits.
-fn collect_channel_ids(matches: &[RawMessage], into: &mut BTreeSet<String>) {
-    for hit in matches {
-        if let Some(channel) = hit.channel.as_ref() {
-            if !channel.id.is_empty() {
-                into.insert(channel.id.clone());
-            }
-        }
-    }
-}
-
 fn collect_hits(matches: &[RawMessage], is_mention: bool, into: &mut Vec<MentionHit>) {
     for hit in matches {
         let Some(channel) = hit.channel.as_ref() else {
@@ -244,28 +193,6 @@ fn collect_hits(matches: &[RawMessage], is_mention: bool, into: &mut Vec<Mention
 mod tests {
     use super::*;
     use serde_json::json;
-
-    fn match_in_channel(channel_id: &str) -> RawMessage {
-        serde_json::from_value(json!({
-            "ts": "1700000000.000100",
-            "channel": { "id": channel_id, "name": "eng" },
-        }))
-        .expect("valid RawMessage")
-    }
-
-    #[test]
-    fn collect_channel_ids_dedups_and_skips_empty() {
-        let matches = vec![
-            match_in_channel("C1"),
-            match_in_channel("C1"),
-            match_in_channel("C2"),
-            match_in_channel(""),
-        ];
-        let mut into = BTreeSet::new();
-        collect_channel_ids(&matches, &mut into);
-        assert_eq!(into.len(), 2);
-        assert!(into.contains("C1") && into.contains("C2"));
-    }
 
     #[test]
     fn collect_hits_captures_ts_thread_and_mention_flag() {

--- a/src-tauri/src/triage/fetcher/im/mod.rs
+++ b/src-tauri/src/triage/fetcher/im/mod.rs
@@ -71,6 +71,18 @@ pub trait ImBackend: Send + Sync {
     fn trim_window(&self, conv: &ImConversation, messages: &mut Vec<ImMessage>) {
         default_trim_window(messages, self, conv);
     }
+
+    /// Render the full candidate payload. Default = the flat chronological
+    /// chat stream. Slack overrides for channels to add the `your_mentions`
+    /// header + per-mention markers without changing the per-message format.
+    fn render_payload(
+        &self,
+        conv: &ImConversation,
+        messages: &[ImMessage],
+        proposed_anchors: &[String],
+    ) -> String {
+        render_chat_payload(self, conv, messages, proposed_anchors)
+    }
 }
 
 /// Generic fetcher wrapping a single [`ImBackend`]. One per platform.
@@ -92,9 +104,16 @@ impl<B: ImBackend + 'static> Fetcher for ImFetcher<B> {
             return Ok(FetchSummary::default());
         }
         let conversations = match self.0.discover_conversations(MAX_CONVERSATIONS_PER_TICK) {
-            Ok(mut conv) => {
-                conv.truncate(MAX_CONVERSATIONS_PER_TICK);
-                conv
+            Ok(conv) => {
+                // Cap the DM/MPIM firehose only; involved channels (few,
+                // high-signal) are processed in full so a large DM list can
+                // never crowd out a channel @-mention.
+                let (mut dms, channels): (Vec<_>, Vec<_>) = conv.into_iter().partition(|c| {
+                    matches!(c.kind, ImConversationKind::Dm | ImConversationKind::GroupDm)
+                });
+                dms.truncate(MAX_CONVERSATIONS_PER_TICK);
+                dms.extend(channels);
+                dms
             }
             Err(error) => {
                 tracing::warn!(
@@ -170,7 +189,7 @@ fn ingest_conversation<B: ImBackend + ?Sized>(
 
     let newest_ts = ordered.last().expect("non-empty").timestamp;
     let proposed_anchors = storage::proposed_anchors_for_chat(source, &conv.id)?;
-    let payload = render_chat_payload(backend, conv, &ordered, &proposed_anchors);
+    let payload = backend.render_payload(conv, &ordered, &proposed_anchors);
     let payload_path = build_payload_path(source, &conv.id);
     let payload_bytes = cache::write_payload(&payload_path, &payload)?;
     write_attachments_sidecar(source, &conv.id, &ordered)?;

--- a/src-tauri/src/triage/fetcher/im/mod.rs
+++ b/src-tauri/src/triage/fetcher/im/mod.rs
@@ -63,6 +63,14 @@ pub trait ImBackend: Send + Sync {
     fn render_message_block(&self, conv: &ImConversation, msg: &ImMessage) -> String {
         default_message_block(conv, msg)
     }
+
+    /// Trim the merged window to the byte/message/time budget. Default is
+    /// oldest-first (time floor → message cap → byte cap). Backends that must
+    /// protect specific messages (e.g. Slack mention threads, which may be
+    /// older than the time floor) override this.
+    fn trim_window(&self, conv: &ImConversation, messages: &mut Vec<ImMessage>) {
+        default_trim_window(messages, self, conv);
+    }
 }
 
 /// Generic fetcher wrapping a single [`ImBackend`]. One per platform.
@@ -153,7 +161,7 @@ fn ingest_conversation<B: ImBackend + ?Sized>(
     // Chronological order (oldest first) + window trimming.
     let mut ordered: Vec<ImMessage> = merged_index.into_values().collect();
     ordered.sort_by_key(|m| m.timestamp);
-    trim_window(&mut ordered, backend, conv);
+    backend.trim_window(conv, &mut ordered);
 
     if ordered.is_empty() {
         // Cold start with empty chat — skip cursor write too.
@@ -233,8 +241,10 @@ fn load_existing_messages(existing: Option<&storage::CandidateRow>) -> BTreeMap<
     parse_chat_payload(&raw)
 }
 
-/// Trim window: time floor → message cap → byte cap.
-fn trim_window<B: ImBackend + ?Sized>(
+/// Default window trim: time floor → message cap → byte cap, oldest-first.
+/// Backs `ImBackend::trim_window`'s default; backends may override to protect
+/// specific messages.
+pub(super) fn default_trim_window<B: ImBackend + ?Sized>(
     messages: &mut Vec<ImMessage>,
     backend: &B,
     conv: &ImConversation,
@@ -664,7 +674,7 @@ mod tests {
                 raw: Value::Null,
             },
         ];
-        trim_window(&mut messages, &B, &conv);
+        default_trim_window(&mut messages, &B, &conv);
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].id, "fresh");
     }

--- a/src-tauri/src/triage/fetcher/im/slack.rs
+++ b/src-tauri/src/triage/fetcher/im/slack.rs
@@ -280,11 +280,21 @@ impl ImBackend for SlackBackend {
         }
         // Force-inject any mention the replies page truncated away or that
         // lives in an inaccessible channel — guarantees the mention is present.
+        let mut forced = 0usize;
         for hit in &ch_hits.hits {
             if hit.is_mention && seen.insert(hit.ts.clone()) {
                 messages.push(force_inject_message(hit));
+                forced += 1;
             }
         }
+        tracing::info!(
+            conv_id = %conv.id,
+            threads_expanded = ch_hits.thread_seeds.len(),
+            mentions = ch_hits.hits.iter().filter(|h| h.is_mention).count(),
+            force_injected = forced,
+            messages = messages.len(),
+            "slack triage: channel indexed",
+        );
         Ok(messages)
     }
 

--- a/src-tauri/src/triage/fetcher/im/slack.rs
+++ b/src-tauri/src/triage/fetcher/im/slack.rs
@@ -1,24 +1,101 @@
-//! Slack ImBackend. DMs/MPIMs unconditional; channels only when the user
-//! posted (`from:<@me>`) or was @ed (`<@me>`) within `COLD_START_DAYS`.
+//! Slack ImBackend. DMs/MPIMs unconditional; channels where the user was
+//! @ed or posted within `COLD_START_DAYS`.
+//!
+//! Channels are **surface-aware**: instead of discarding the search hits and
+//! re-fetching the channel timeline (which omits thread replies — the bug
+//! this replaces), we keep the hits, expand the exact @-ed thread via
+//! `conversations.replies`, and always surface the mention message. The DM
+//! path is unchanged (a plain `conversations.history` window).
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::sync::Mutex;
 
 use anyhow::{Context, Result};
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{DateTime, Duration, TimeZone, Utc};
 use serde_json::json;
 
 use crate::models::slack_workspaces;
 use crate::slack::api::{self, ConversationRow, RawFile, RawMessage};
 use crate::slack::credentials::{self, SlackCreds};
 use crate::slack::files as slack_files;
-use crate::slack::relevance;
+use crate::slack::relevance::{self, MentionHit};
 use crate::slack::types::SlackWorkspace;
 use crate::triage::attachments;
 
 use super::types::{ImAttachment, ImConversation, ImConversationKind, ImMessage};
-use super::ImBackend;
+use super::{
+    default_message_block, default_trim_window, render_chat_payload, ImBackend, WINDOW_DAYS,
+    WINDOW_MAX_BYTES, WINDOW_MAX_MESSAGES,
+};
 
 const SOURCE: &str = "slack";
 
-pub struct SlackBackend;
+/// Per-tick discovery output for one involved channel. Populated by
+/// `discover_conversations`, consumed by `fetch_messages` / `render_payload` /
+/// `trim_window` within the SAME tick (same `&self`).
+#[derive(Default, Clone)]
+struct ChannelHits {
+    /// `thread_ts` values to expand fully via `conversations.replies`.
+    thread_seeds: BTreeSet<String>,
+    /// The matched hits — used to force-inject a mention the replies page
+    /// truncated away (or an inaccessible channel), and to mark anchors.
+    hits: Vec<MentionHit>,
+}
+
+/// Slack triage backend. Holds the current tick's per-channel discovery hits
+/// so the channel fetch/render/trim path can expand the right threads and
+/// protect the mention. `Mutex` (not `RefCell`) because `ImBackend: Send+Sync`.
+#[derive(Default)]
+pub struct SlackBackend {
+    hits: Mutex<HashMap<String, ChannelHits>>,
+}
+
+impl SlackBackend {
+    /// Mention anchors for a channel = `is_mention` hit ts that are actually
+    /// present in `messages` (so every anchor is a real `ImMessage.id`).
+    fn channel_anchors(&self, conv_id: &str, messages: &[ImMessage]) -> Vec<String> {
+        let present: BTreeSet<&str> = messages.iter().map(|m| m.id.as_str()).collect();
+        let map = self.hits.lock().expect("slack hits poisoned");
+        let Some(ch) = map.get(conv_id) else {
+            return Vec::new();
+        };
+        let mut anchors: Vec<String> = ch
+            .hits
+            .iter()
+            .filter(|h| h.is_mention && present.contains(h.ts.as_str()))
+            .map(|h| h.ts.clone())
+            .collect();
+        anchors.sort();
+        anchors.dedup();
+        anchors
+    }
+
+    /// Protected ts = mention anchors ∪ every message belonging to a seeded
+    /// thread, so the whole @-ed thread survives trimming even if older than
+    /// the time floor.
+    fn channel_protected(&self, conv_id: &str, messages: &[ImMessage]) -> BTreeSet<String> {
+        let map = self.hits.lock().expect("slack hits poisoned");
+        let Some(ch) = map.get(conv_id) else {
+            return BTreeSet::new();
+        };
+        let mut protected: BTreeSet<String> = ch
+            .hits
+            .iter()
+            .filter(|h| h.is_mention)
+            .map(|h| h.ts.clone())
+            .collect();
+        for m in messages {
+            let in_seeded_thread = message_thread_ts(m)
+                .map(|t| ch.thread_seeds.contains(&t))
+                .unwrap_or(false)
+                || ch.thread_seeds.contains(&m.id);
+            if in_seeded_thread {
+                protected.insert(m.id.clone());
+            }
+        }
+        protected
+    }
+}
 
 impl ImBackend for SlackBackend {
     fn source(&self) -> &'static str {
@@ -36,16 +113,16 @@ impl ImBackend for SlackBackend {
     fn discover_conversations(&self, _limit: usize) -> Result<Vec<ImConversation>> {
         let workspaces = slack_workspaces::list_workspaces()?;
         let mut out: Vec<ImConversation> = Vec::new();
+        self.hits.lock().expect("slack hits poisoned").clear();
         for ws in &workspaces {
             let creds = match credentials::load_credentials(&ws.team_id)? {
                 Some(c) => c,
                 None => continue,
             };
 
-            // Channels I was @ed in or posted in. Auth failure → skip this
-            // workspace (token is invalid). A transient search failure →
-            // degraded (DMs below still flow), never silently swallowed.
-            let involved = match relevance::involved_channels(
+            // Which channels mentioned me / I posted in, WITH the messages.
+            // Auth failure → skip this workspace; transient → degraded.
+            let involved = match relevance::involved_channel_hits(
                 &creds,
                 &ws.my_user_id,
                 super::COLD_START_DAYS,
@@ -73,10 +150,18 @@ impl ImBackend for SlackBackend {
                 crate::triage::fetcher::health::record_degraded(SOURCE, reason.clone());
             }
 
-            // Every conversation I'm a member of. A transient failure here
-            // used to skip the whole workspace silently; now it surfaces as
-            // degraded health and the tick processes whatever came back.
-            // Auth failure → skip this workspace.
+            // Group hits by channel id.
+            let mut by_channel: BTreeMap<String, ChannelHits> = BTreeMap::new();
+            for hit in involved.value {
+                let entry = by_channel.entry(hit.channel_id.clone()).or_default();
+                if let Some(t) = &hit.thread_ts {
+                    entry.thread_seeds.insert(t.clone());
+                }
+                entry.hits.push(hit);
+            }
+
+            // Every conversation I'm a member of (DMs/MPIMs + channels). A
+            // transient failure surfaces as degraded health; auth → skip ws.
             let members = match relevance::member_conversations(
                 &creds,
                 "im,mpim,public_channel,private_channel",
@@ -105,23 +190,32 @@ impl ImBackend for SlackBackend {
                 crate::triage::fetcher::health::record_degraded(SOURCE, reason.clone());
             }
 
-            let mut rows = members.value;
-            rows.retain(|c| {
-                if c.is_im || c.is_mpim {
-                    true // DMs / group-DMs unconditional
-                } else {
-                    involved.value.contains(&c.id)
+            let member_by_id: HashMap<&str, &ConversationRow> =
+                members.value.iter().map(|c| (c.id.as_str(), c)).collect();
+
+            // DMs / group-DMs: unconditional, verbatim history path.
+            for row in &members.value {
+                if row.is_im || row.is_mpim {
+                    out.push(to_im_conversation(ws, row));
                 }
-            });
-            // DMs first; among channels the order doesn't really
-            // matter (the generic layer truncates to a cap anyway).
-            rows.sort_by(|a, b| {
-                let dm_a = (a.is_im || a.is_mpim) as u8;
-                let dm_b = (b.is_im || b.is_mpim) as u8;
-                dm_b.cmp(&dm_a)
-            });
-            for row in rows {
-                out.push(to_im_conversation(ws, &row));
+            }
+
+            // Involved channels (incl. ones I'm not a member of — Q1). Store
+            // the hits keyed by conv.id for the surface-aware fetch/render/trim.
+            let mut map = self.hits.lock().expect("slack hits poisoned");
+            for (channel_id, ch_hits) in by_channel {
+                // A `<@me>` in a DM shows up here too — already covered above.
+                if let Some(row) = member_by_id.get(channel_id.as_str()) {
+                    if row.is_im || row.is_mpim {
+                        continue;
+                    }
+                }
+                let conv = match member_by_id.get(channel_id.as_str()) {
+                    Some(row) => to_im_conversation(ws, row),
+                    None => synthesize_channel_conv(ws, &channel_id, &creds),
+                };
+                map.insert(conv.id.clone(), ch_hits);
+                out.push(conv);
             }
         }
         Ok(out)
@@ -139,22 +233,259 @@ impl ImBackend for SlackBackend {
             None => return Ok(Vec::new()),
         };
         let channel_id = parse_channel_id(&conv.id);
-        let oldest = since.map(|dt| format!("{}.000000", dt.timestamp()));
-        let raws = api::conversations_history(
-            &creds,
-            channel_id,
-            oldest.as_deref(),
-            limit.min(u32::MAX as usize) as u32,
-        )
-        .with_context(|| format!("slack conversations.history {channel_id}"))?;
-        let mut messages = Vec::with_capacity(raws.len());
-        for raw in raws {
-            if let Some(mut m) = to_im_message(team_id, &creds, &raw) {
-                m.attachments = download_image_attachments(&conv.id, &raw);
-                messages.push(m);
+        let mut messages = fetch_history(&creds, team_id, channel_id, &conv.id, since, limit)?;
+
+        // DM / group-DM: the history window is the whole story.
+        if matches!(
+            conv.kind,
+            ImConversationKind::Dm | ImConversationKind::GroupDm
+        ) {
+            return Ok(messages);
+        }
+
+        // Channel: expand each @-ed thread fully, then guarantee the mention.
+        let ch_hits = self
+            .hits
+            .lock()
+            .expect("slack hits poisoned")
+            .get(&conv.id)
+            .cloned()
+            .unwrap_or_default();
+        let mut seen: BTreeSet<String> = messages.iter().map(|m| m.id.clone()).collect();
+        for thread_ts in &ch_hits.thread_seeds {
+            match api::conversations_replies(&creds, channel_id, thread_ts) {
+                Ok(raws) => {
+                    for raw in raws {
+                        if raw.ts.is_empty() || !seen.insert(raw.ts.clone()) {
+                            continue;
+                        }
+                        if let Some(mut m) = to_im_message(team_id, &creds, &raw) {
+                            m.attachments = download_image_attachments(&conv.id, &raw);
+                            messages.push(m);
+                        }
+                    }
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        conv_id = %conv.id,
+                        error = %format!("{error:#}"),
+                        "slack backend: thread replies fetch failed",
+                    );
+                    crate::triage::fetcher::health::record_degraded(
+                        SOURCE,
+                        format!("thread replies failed: {error:#}"),
+                    );
+                }
+            }
+        }
+        // Force-inject any mention the replies page truncated away or that
+        // lives in an inaccessible channel — guarantees the mention is present.
+        for hit in &ch_hits.hits {
+            if hit.is_mention && seen.insert(hit.ts.clone()) {
+                messages.push(force_inject_message(hit));
             }
         }
         Ok(messages)
+    }
+
+    fn render_payload(
+        &self,
+        conv: &ImConversation,
+        messages: &[ImMessage],
+        proposed_anchors: &[String],
+    ) -> String {
+        if matches!(
+            conv.kind,
+            ImConversationKind::Dm | ImConversationKind::GroupDm
+        ) {
+            return render_chat_payload(self, conv, messages, proposed_anchors);
+        }
+        let anchors = self.channel_anchors(&conv.id, messages);
+        build_channel_payload(conv, messages, &anchors, proposed_anchors)
+    }
+
+    fn trim_window(&self, conv: &ImConversation, messages: &mut Vec<ImMessage>) {
+        if matches!(
+            conv.kind,
+            ImConversationKind::Dm | ImConversationKind::GroupDm
+        ) {
+            default_trim_window(messages, self, conv);
+            return;
+        }
+        let protected = self.channel_protected(&conv.id, messages);
+        protected_trim(messages, self, conv, &protected);
+    }
+}
+
+/// `conversations.history` window → resolved [`ImMessage`]s with attachments.
+/// Shared by the DM path and the channel base window.
+fn fetch_history(
+    creds: &SlackCreds,
+    team_id: &str,
+    channel_id: &str,
+    conv_id: &str,
+    since: Option<DateTime<Utc>>,
+    limit: usize,
+) -> Result<Vec<ImMessage>> {
+    let oldest = since.map(|dt| format!("{}.000000", dt.timestamp()));
+    let raws = api::conversations_history(
+        creds,
+        channel_id,
+        oldest.as_deref(),
+        limit.min(u32::MAX as usize) as u32,
+    )
+    .with_context(|| format!("slack conversations.history {channel_id}"))?;
+    let mut messages = Vec::with_capacity(raws.len());
+    for raw in raws {
+        if let Some(mut m) = to_im_message(team_id, creds, &raw) {
+            m.attachments = download_image_attachments(conv_id, &raw);
+            messages.push(m);
+        }
+    }
+    Ok(messages)
+}
+
+/// Minimal [`ImMessage`] built from a retained search hit, for when a thread
+/// truncated the mention past the replies page or the channel is inaccessible.
+fn force_inject_message(hit: &MentionHit) -> ImMessage {
+    let timestamp = ts_string_to_utc(&hit.ts).unwrap_or_else(Utc::now);
+    ImMessage {
+        id: hit.ts.clone(),
+        timestamp,
+        sender: None,
+        text: hit.text.clone(),
+        external_url: None,
+        deleted: false,
+        attachments: Vec::new(),
+        raw: json!({ "thread_ts": hit.thread_ts }),
+    }
+}
+
+/// Read the `thread_ts` stashed on an [`ImMessage`] by [`to_im_message`].
+fn message_thread_ts(m: &ImMessage) -> Option<String> {
+    m.raw
+        .get("thread_ts")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+}
+
+/// Non-member channel (e.g. @-ed then removed, or a public channel not
+/// joined). Best-effort name resolution; defaults to a public-channel kind.
+fn synthesize_channel_conv(
+    ws: &SlackWorkspace,
+    channel_id: &str,
+    creds: &SlackCreds,
+) -> ImConversation {
+    let label = api::conversations_info(creds, channel_id)
+        .ok()
+        .unwrap_or_else(|| format!("#{channel_id}"));
+    ImConversation {
+        id: format!("{}:{}", ws.team_id, channel_id),
+        label: Some(label),
+        kind: ImConversationKind::Channel,
+        raw: json!({ "team_id": ws.team_id, "channel_id": channel_id }),
+    }
+}
+
+/// Pure channel payload: the flat chat stream (per-message blocks stay
+/// byte-compatible with [`default_message_block`] so the reload parser still
+/// recovers them) + a `your_mentions` header + a parser-ignored `- ↳ mention`
+/// marker on each anchor. No `## ` banners — the `read_candidate` `tail`
+/// consumer splits on `\n## ` and would miscount them.
+fn build_channel_payload(
+    conv: &ImConversation,
+    messages: &[ImMessage],
+    your_mentions: &[String],
+    proposed_anchors: &[String],
+) -> String {
+    let mut out = String::new();
+    let label = conv.label.as_deref().unwrap_or(&conv.id);
+    out.push_str(&format!("# slack chat — {label}\n\n"));
+    out.push_str(&format!("- conversation_id: {}\n", conv.id));
+    out.push_str(&format!("- kind: {}\n", conv.kind.as_source_kind()));
+    out.push_str(&format!(
+        "- window: last {WINDOW_DAYS} days, {} messages\n",
+        messages.len()
+    ));
+    if !your_mentions.is_empty() {
+        out.push_str(&format!(
+            "- your_mentions: {}  (messages that @-mention you — anchor a task on one)\n",
+            your_mentions.join(", ")
+        ));
+    }
+    if !proposed_anchors.is_empty() {
+        out.push_str("- last_proposed_anchors: ");
+        out.push_str(&proposed_anchors.join(", "));
+        out.push('\n');
+        out.push_str("  (the LLM has already created workspaces for these anchors — skip them)\n");
+    }
+    out.push_str("\n---\n\n");
+    let mention_set: BTreeSet<&str> = your_mentions.iter().map(String::as_str).collect();
+    for m in messages {
+        let block = default_message_block(conv, m);
+        if mention_set.contains(m.id.as_str()) {
+            // Inject the marker after the `## …` header line; the parser skips
+            // the bulleted-meta region, so the block stays round-trippable.
+            match block.split_once('\n') {
+                Some((head, rest)) => {
+                    out.push_str(head);
+                    out.push_str("\n- ↳ mention\n");
+                    out.push_str(rest);
+                }
+                None => out.push_str(&block),
+            }
+        } else {
+            out.push_str(&block);
+        }
+        for att in &m.attachments {
+            let alt = att.alt.as_deref().unwrap_or(&att.filename);
+            let mime = att
+                .mime_type
+                .as_deref()
+                .unwrap_or("application/octet-stream");
+            out.push_str(&format!(
+                "📎 attachment: {alt} ({mime}, {} bytes) — {}\n",
+                att.bytes,
+                att.local_path.display(),
+            ));
+        }
+        out.push('\n');
+    }
+    out
+}
+
+/// Like the default trim but never evicts a protected message (a mention or a
+/// message in an @-ed thread), even when older than the time floor.
+fn protected_trim<B: ImBackend + ?Sized>(
+    messages: &mut Vec<ImMessage>,
+    backend: &B,
+    conv: &ImConversation,
+    protected: &BTreeSet<String>,
+) {
+    let cutoff = Utc::now() - Duration::days(WINDOW_DAYS);
+    messages.retain(|m| protected.contains(&m.id) || m.timestamp >= cutoff);
+    while messages.len() > WINDOW_MAX_MESSAGES {
+        match messages.iter().position(|m| !protected.contains(&m.id)) {
+            Some(pos) => {
+                messages.remove(pos);
+            }
+            None => break,
+        }
+    }
+    loop {
+        let bytes: usize = messages
+            .iter()
+            .map(|m| backend.render_message_block(conv, m).len() + 1)
+            .sum();
+        if bytes <= WINDOW_MAX_BYTES {
+            break;
+        }
+        match messages.iter().position(|m| !protected.contains(&m.id)) {
+            Some(pos) => {
+                messages.remove(pos);
+            }
+            None => break,
+        }
     }
 }
 
@@ -346,26 +677,35 @@ mod tests {
         }
     }
 
+    fn msg(id: &str, ts_offset: i64, text: &str, thread_ts: Option<&str>) -> ImMessage {
+        ImMessage {
+            id: id.into(),
+            timestamp: Utc.with_ymd_and_hms(2026, 5, 26, 10, 0, 0).unwrap()
+                + Duration::seconds(ts_offset),
+            sender: Some("Alice".into()),
+            text: text.into(),
+            external_url: None,
+            deleted: false,
+            attachments: Vec::new(),
+            raw: json!({ "thread_ts": thread_ts }),
+        }
+    }
+
+    fn channel_conv() -> ImConversation {
+        ImConversation {
+            id: "T0:C1".into(),
+            label: Some("#eng".into()),
+            kind: ImConversationKind::Channel,
+            raw: json!({}),
+        }
+    }
+
     #[test]
     fn maps_dm_to_kind_dm_with_label() {
         let conv = to_im_conversation(&ws(), &row("D1", "alice", true, false, false, 0));
         assert_eq!(conv.kind, ImConversationKind::Dm);
         assert_eq!(conv.label.as_deref(), Some("DM · alice"));
         assert_eq!(conv.id, "T0:D1");
-    }
-
-    #[test]
-    fn maps_private_channel_to_kind_private_channel() {
-        let conv = to_im_conversation(&ws(), &row("C1", "leads", false, false, true, 1));
-        assert_eq!(conv.kind, ImConversationKind::PrivateChannel);
-        assert_eq!(conv.label.as_deref(), Some("#leads"));
-    }
-
-    #[test]
-    fn maps_mpim_to_kind_group_dm() {
-        let conv = to_im_conversation(&ws(), &row("MP1", "trio", false, true, false, 0));
-        assert_eq!(conv.kind, ImConversationKind::GroupDm);
-        assert_eq!(conv.label.as_deref(), Some("DM · trio"));
     }
 
     #[test]
@@ -380,5 +720,80 @@ mod tests {
     fn ts_round_trip() {
         let dt = ts_string_to_utc("1735000000.123456").unwrap();
         assert_eq!(dt.timestamp(), 1735000000);
+    }
+
+    #[test]
+    fn channel_payload_marks_mentions_and_lists_them_in_header() {
+        let conv = channel_conv();
+        let messages = vec![
+            msg("100.1", 0, "morning all", None),
+            msg("100.2", 60, "hey <@U_me> can you own SOC II?", None),
+        ];
+        let payload = build_channel_payload(&conv, &messages, &["100.2".into()], &[]);
+        assert!(payload.contains("- your_mentions: 100.2"));
+        // The mention block carries the marker; the other does not.
+        assert!(payload.contains("· id:100.2\n- ↳ mention\n"));
+        assert!(payload.contains("· id:100.1\n```"));
+        // No decorative `## ` banner — only real message blocks start with `## `.
+        for line in payload.lines().filter(|l| l.starts_with("## ")) {
+            assert!(line.contains("· id:"), "stray ## banner: {line}");
+        }
+    }
+
+    #[test]
+    fn protected_trim_keeps_old_mention_thread_over_time_floor() {
+        struct B;
+        impl ImBackend for B {
+            fn source(&self) -> &'static str {
+                SOURCE
+            }
+            fn preflight(&self) -> Result<()> {
+                Ok(())
+            }
+            fn discover_conversations(&self, _: usize) -> Result<Vec<ImConversation>> {
+                Ok(vec![])
+            }
+            fn fetch_messages(
+                &self,
+                _: &ImConversation,
+                _: Option<DateTime<Utc>>,
+                _: usize,
+            ) -> Result<Vec<ImMessage>> {
+                Ok(vec![])
+            }
+        }
+        let conv = channel_conv();
+        // An old protected thread root + a recent unprotected message.
+        let old_root = ImMessage {
+            timestamp: Utc::now() - Duration::days(WINDOW_DAYS + 5),
+            ..msg("root", 0, "old @-ed thread root", None)
+        };
+        let recent = ImMessage {
+            timestamp: Utc::now() - Duration::hours(1),
+            ..msg("recent", 0, "fresh chatter", None)
+        };
+        let mut messages = vec![old_root, recent];
+        let protected: BTreeSet<String> = ["root".to_string()].into_iter().collect();
+        protected_trim(&mut messages, &B, &conv, &protected);
+        assert!(
+            messages.iter().any(|m| m.id == "root"),
+            "old protected root must survive the time floor",
+        );
+        assert!(messages.iter().any(|m| m.id == "recent"));
+    }
+
+    #[test]
+    fn force_inject_builds_message_from_hit() {
+        let hit = MentionHit {
+            channel_id: "C1".into(),
+            ts: "1735000000.000900".into(),
+            thread_ts: Some("1735000000.000100".into()),
+            text: "<@U_me> ping".into(),
+            is_mention: true,
+        };
+        let m = force_inject_message(&hit);
+        assert_eq!(m.id, "1735000000.000900");
+        assert_eq!(m.text, "<@U_me> ping");
+        assert_eq!(message_thread_ts(&m).as_deref(), Some("1735000000.000100"));
     }
 }

--- a/src-tauri/src/triage/fetcher/mod.rs
+++ b/src-tauri/src/triage/fetcher/mod.rs
@@ -185,7 +185,7 @@ fn registered_fetchers() -> Vec<Box<dyn Fetcher>> {
     vec![
         Box::new(github::GithubFetcher),
         Box::new(gitlab::GitlabFetcher),
-        Box::new(im::ImFetcher(im::slack::SlackBackend)),
+        Box::new(im::ImFetcher(im::slack::SlackBackend::default())),
         Box::new(im::ImFetcher(im::lark::LarkBackend)),
     ]
 }

--- a/src-tauri/src/triage/fetcher/mod.rs
+++ b/src-tauri/src/triage/fetcher/mod.rs
@@ -127,8 +127,30 @@ fn maybe_fire_triage_tick<R: TauriRuntime>(app: &AppHandle<R>) {
     }
 }
 
+/// The triage fetch path is opt-in. Pure predicate so it is unit-testable
+/// without standing up the scheduler thread.
+pub(crate) fn should_fetch(cfg: &crate::triage::TriageConfig) -> bool {
+    cfg.enabled
+}
+
 /// Run every registered fetcher once. Logs per-provider summary.
+///
+/// Opt-in gate: when Smart triage is disabled, skip the ENTIRE fetch path
+/// (all of GitHub/GitLab/Slack/Lark) so users who never enabled triage incur
+/// zero background fetch traffic. Gated on `enabled` (not `auto_run`) so a
+/// manual "Run now" still finds a warm queue.
 pub fn run_once() {
+    match crate::triage::load_config() {
+        Ok(cfg) if should_fetch(&cfg) => {}
+        Ok(_) => return,
+        Err(error) => {
+            tracing::warn!(
+                error = %format!("{error:#}"),
+                "triage fetcher: load_config failed, skipping tick",
+            );
+            return;
+        }
+    }
     for fetcher in registered_fetchers() {
         let source = fetcher.source();
         health::record_attempt(source);
@@ -166,4 +188,18 @@ fn registered_fetchers() -> Vec<Box<dyn Fetcher>> {
         Box::new(im::ImFetcher(im::slack::SlackBackend)),
         Box::new(im::ImFetcher(im::lark::LarkBackend)),
     ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_fetch;
+    use crate::triage::TriageConfig;
+
+    #[test]
+    fn fetch_is_gated_on_enabled() {
+        let mut cfg = TriageConfig::default();
+        assert!(!should_fetch(&cfg), "default (disabled) must not fetch");
+        cfg.enabled = true;
+        assert!(should_fetch(&cfg), "enabled must fetch");
+    }
 }

--- a/src/features/source-detail/slack/thread-view.tsx
+++ b/src/features/source-detail/slack/thread-view.tsx
@@ -3,6 +3,7 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import { Clock3, ExternalLink } from "lucide-react";
 import { AppendContextButton } from "@/components/append-context-button";
 import { HelmorLogoAnimated } from "@/components/helmor-logo-animated";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
 	Tooltip,
@@ -84,6 +85,11 @@ export function SlackThreadView({
 							/>
 							{headerLabel}
 						</span>
+						{detail?.isThread ? (
+							<Badge variant="secondary" className="h-[18px] px-1.5">
+								Thread
+							</Badge>
+						) : null}
 						<span className="text-muted-foreground/70">·</span>
 						<span className="font-normal text-muted-foreground/70">
 							{workspaceLabel}


### PR DESCRIPTION
## What & why

Follow-up to #697. That PR made the Slack triage fetch *resilient + observable*, and verifying it live surfaced two structural gaps in how channel @-mentions — especially **mentions inside threads** — were handled.

**1. Triage dropped thread mentions and starved channels.** Triage discovered channel @-mentions via `search.messages` but then **discarded the matched messages and re-fetched the channel via `conversations.history`** — which (a) omits thread replies, so thread @-mentions were silently dropped, and (b) made channels compete with DMs for a per-tick cap, so a user with many DMs never got their channels indexed. Confirmed live (91 DMs → 0 channels indexed; `#marketing-discussion` ingested but the actual thread mention absent).

**2. The Context inbox couldn't show a threaded mention.** Opening a Slack @-mention posted *inside a thread* showed only a flat channel-history window, never the thread it lived in — because `conversations.replies(anchor_ts)` on the xoxc web API returns only the single message when the anchor is a reply (not the thread root). Confirmed live against real Slack.

Also closes a fetcher-wide isolation hole: the background fetcher ran **unconditionally** (only the LLM tick was gated), so every user — even those who never enabled Smart triage — was running background GitHub/GitLab/Slack/Lark scans.

Full design + adversarial review notes: `.agent-contexts/slack-mention-indexing-design.md` (not committed).

## Changes

**Triage fetch**
- **Opt-in gate (isolation):** `run_once` returns early unless triage is enabled, so non-users incur zero background fetch traffic across all four sources.
- **Surface-aware channel indexing:** `relevance::involved_channel_hits` keeps the matched messages (ts/thread_ts/text). The Slack backend, per involved channel, expands each @-ed thread via `conversations.replies`, force-injects the mention if a >200-reply thread truncates it (or the channel is inaccessible), and includes channels you were @-ed in but aren't a member of.
- **Cap fix:** only the DM/MPIM firehose is capped now; involved channels (few, high-signal) are processed in full.
- **Payload:** flat chronological stream + a `your_mentions:` header + a parser-ignored `- ↳ mention` marker — **no `## ` banners**, so `read_candidate`'s `tail` consumer isn't broken and the per-message blocks stay reload-round-trippable.
- **Protected trimming:** a new `ImBackend::trim_window` hook lets Slack protect the mention + its thread from the byte/message/time-floor trim (Lark/DM keep the default).

**Context detail view** (`slack::detail`)
- **Full-thread resolution:** `resolve_thread` probes `conversations.replies(anchor)`; when the anchor comes back as a lone reply, it reads the message's `thread_ts` (the real root) and re-fetches `conversations.replies(root)` to pull the whole thread. Standalone messages still get the channel context window. Fixes thread @-mentions that previously opened as a flat channel window.
- **Thread badge:** the detail header shows a `Thread` badge when the resolved view is a thread.

DM/MPIM path, candidate ids, cursors, and the inbox **feed** (`slack::inbox`) are unchanged.

## Modularity / isolation

The triage logic lives in the triage Slack backend; the inbox feed (`slack::inbox`) is untouched. The Context detail view (`slack::detail`) gains thread resolution + a badge but is purely additive — standalone messages behave exactly as before. Non-triage users: zero background activity. Source Health stays honest (the panel only renders when triage is on).

## Verification

- `cargo clippy --all-targets -- -D warnings`: clean.
- slack/triage unit tests pass, incl. locks on the regression class: mention block present + marked, **no stray `## ` banner**, old mention-thread survives the time floor, force-inject from a truncated/inaccessible thread, auth-vs-transient classification.
- Pipeline snapshot integration tests (scenarios/fixtures/streams): zero drift.
- Live dev-build verification against real Slack — both the triage channel thread-mention indexing **and** the Context full-thread + `Thread` badge behavior. See PR comments (incl. the reply→root resolution table).

## Follow-ups (noted, not in this PR)

- Physically split `triage/fetcher/im/slack.rs` into `slack/{mod,channel}.rs` (it now exceeds the 300-line guideline); kept as one clearly-sectioned file here for review locality.
- `ChannelApi` seam for a dedicated fetch-routing unit test; honor `Retry-After` for 429.
