### PR TITLE
fix: ignore agent contexts in worktree changes

### DIFF
--- a/.changeset/fix-agent-contexts-ignore.md
+++ b/.changeset/fix-agent-contexts-ignore.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix the agent scratch directory so `.agent-contexts/` stays out of workspace Changes in new and existing worktree workspaces.

--- a/src-tauri/src/agents/system_prompt.rs
+++ b/src-tauri/src/agents/system_prompt.rs
@@ -144,7 +144,7 @@ pub fn build_helmor_system_prompt(ctx: &HelmorSystemPromptContext) -> String {
     }
 
     out.push_str(
-        "\nIf you need a scratch directory to leave files for other agents in this workspace (or for your own future sessions), use `<workspace_root>/.agent-contexts/`. It is gitignored at the worktree level, so anything you write there stays out of every diff.\n",
+        "\nIf you need a scratch directory to leave files for other agents in this workspace (or for your own future sessions), use `<workspace_root>/.agent-contexts/`. It is gitignored via the repo-local exclude file, so anything you write there stays out of every diff.\n",
     );
 
     let _ = write!(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -265,6 +265,14 @@ pub fn run() {
                 Err(e) => tracing::warn!("Failed to reconcile orphaned workspaces: {e:#}"),
             }
 
+            // Repair `.agent-contexts/` provisioning for existing worktree
+            // workspaces. This is best-effort because a missing scratch dir
+            // should never block the app from starting.
+            match workspace::agent_contexts::ensure_existing_worktree_contexts() {
+                Ok(_) => {}
+                Err(e) => tracing::warn!("Failed to repair .agent-contexts/ excludes: {e:#}"),
+            }
+
             // Clear rows stuck in `initializing` state past the cutoff —
             // happens when the app is force-quit mid-create (Phase 2 never
             // gets to flip the state to ready/setup_pending). Five minutes

--- a/src-tauri/src/workspace/agent_contexts.rs
+++ b/src-tauri/src/workspace/agent_contexts.rs
@@ -1,11 +1,11 @@
 //! `.agent-contexts/` — a per-workspace scratch directory agents can
 //! drop files into to coordinate across sessions or sub-tasks.
 //!
-//! The directory is **not** committed: we add it to the worktree's
-//! local exclude file (`<gitdir>/info/exclude`) so the rule lives next
-//! to the worktree itself and does **not** leak into the user's
-//! tracked `.gitignore`. The user's repo on disk has zero new lines
-//! after Helmor materialises a workspace — clean as it was.
+//! The directory is **not** committed: we add it to Git's local exclude
+//! file (`git rev-parse --git-path info/exclude`) so the rule does
+//! **not** leak into the user's tracked `.gitignore`. The user's repo
+//! on disk has zero new tracked lines after Helmor materialises a
+//! workspace — clean as it was.
 //!
 //! Both arms of `finalize_workspace_from_repo_impl` (FromBranch +
 //! UseBranch) call [`ensure_agent_contexts_in_worktree`] right after
@@ -17,22 +17,22 @@
 //!
 //! In a linked git worktree (which is what Helmor creates), the
 //! worktree's `.git` is a *file* whose first line reads
-//! `gitdir: <abs-path-to-main-repo>/.git/worktrees/<name>`. The
-//! per-worktree `info/exclude` lives **at that linked path**, not
-//! under the worktree's local `.git/`. [`resolve_worktree_git_dir`]
-//! handles both the linked-file form and the unusual "this is the
-//! main repo itself" directory form so the helper is correct under
-//! both layouts.
+//! `gitdir: <abs-path-to-main-repo>/.git/worktrees/<name>`. That path
+//! is **not** necessarily where Git reads `info/exclude` from. Ask Git
+//! for `--git-path info/exclude` and write exactly there so our rule
+//! matches `git check-ignore` and `git ls-files --exclude-standard`.
 
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 
+use crate::{db, git_ops};
+
 /// Subdirectory under the worktree root where agents can drop files
 /// that other agents (or the same agent in a later session) can read.
 pub const AGENT_CONTEXTS_DIR: &str = ".agent-contexts";
 
-/// The line we append to `<gitdir>/info/exclude`. Matches `git`'s
+/// The line we append to Git's local `info/exclude`. Matches `git`'s
 /// usual pathspec syntax — a leading slash anchors to the worktree
 /// root so we don't accidentally exclude any nested `.agent-contexts`
 /// folders the user might create later.
@@ -43,8 +43,8 @@ const EXCLUDE_RULE: &str = "/.agent-contexts/";
 const EXCLUDE_COMMENT: &str = "# Helmor: scratch space for agents to share files across sessions.";
 
 /// Materialise `.agent-contexts/` under `workspace_dir` and add it to
-/// the worktree's local exclude file. Best-effort: errors are returned
-/// so callers can log them, but callers should NOT abort workspace
+/// Git's local exclude file. Best-effort: errors are returned so
+/// callers can log them, but callers should NOT abort workspace
 /// creation on failure — agents will still work without the scratch
 /// dir, just without cross-session file sharing.
 pub fn ensure_agent_contexts_in_worktree(workspace_dir: &Path) -> Result<()> {
@@ -52,73 +52,111 @@ pub fn ensure_agent_contexts_in_worktree(workspace_dir: &Path) -> Result<()> {
     std::fs::create_dir_all(&contexts_dir)
         .with_context(|| format!("create agent-contexts dir at {}", contexts_dir.display()))?;
 
-    let git_dir = resolve_worktree_git_dir(workspace_dir)
-        .with_context(|| format!("resolve worktree git dir for {}", workspace_dir.display()))?;
-    append_worktree_local_exclude(&git_dir).with_context(|| {
-        format!(
-            "append agent-contexts rule to {}/info/exclude",
-            git_dir.display()
-        )
-    })?;
+    let exclude_path = resolve_git_exclude_path(workspace_dir)
+        .with_context(|| format!("resolve git exclude path for {}", workspace_dir.display()))?;
+    append_local_exclude(&exclude_path)
+        .with_context(|| format!("append agent-contexts rule to {}", exclude_path.display()))?;
     Ok(())
 }
 
-/// Resolve the path that owns `info/exclude` for this worktree.
-///
-/// - If `<workspace_dir>/.git` is a **directory**, this worktree is the
-///   main checkout: return that directory.
-/// - If `<workspace_dir>/.git` is a **file**, this worktree is a git
-///   linked worktree: read the file, extract the `gitdir: <path>` line
-///   (per git's worktree layout), and return that path.
-pub(crate) fn resolve_worktree_git_dir(workspace_dir: &Path) -> Result<PathBuf> {
-    let git_pointer = workspace_dir.join(".git");
-    let metadata = std::fs::metadata(&git_pointer)
-        .with_context(|| format!("stat {}", git_pointer.display()))?;
+/// Backfill existing operational worktree workspaces. New workspace
+/// creation calls [`ensure_agent_contexts_in_worktree`] directly; this
+/// repair path covers workspaces created before the correct exclude
+/// path logic shipped.
+pub fn ensure_existing_worktree_contexts() -> Result<usize> {
+    let connection = db::read_conn()?;
+    let mut stmt = connection.prepare(&format!(
+        "SELECT w.id, r.name, w.directory_name
+         FROM workspaces w
+         JOIN repos r ON r.id = w.repository_id
+         WHERE w.state {} AND COALESCE(w.mode, 'worktree') = 'worktree'",
+        crate::workspace_state::OPERATIONAL_FILTER
+    ))?;
+    let workspaces: Vec<(String, String, String)> = stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        })?
+        .filter_map(|row| row.ok())
+        .collect();
+    drop(stmt);
+    drop(connection);
 
-    if metadata.is_dir() {
-        return Ok(git_pointer);
+    let mut ensured = 0;
+    for (workspace_id, repo_name, directory_name) in workspaces {
+        let workspace_dir = match crate::data_dir::workspace_dir(&repo_name, &directory_name) {
+            Ok(path) => path,
+            Err(error) => {
+                tracing::warn!(
+                    workspace_id = %workspace_id,
+                    error = %format!("{error:#}"),
+                    "Failed to resolve workspace dir while repairing .agent-contexts/"
+                );
+                continue;
+            }
+        };
+        if !workspace_dir.is_dir() {
+            continue;
+        }
+        match ensure_agent_contexts_in_worktree(&workspace_dir) {
+            Ok(()) => ensured += 1,
+            Err(error) => {
+                tracing::warn!(
+                    workspace_id = %workspace_id,
+                    path = %workspace_dir.display(),
+                    error = %format!("{error:#}"),
+                    "Failed to repair .agent-contexts/ — workspace still usable"
+                );
+            }
+        }
     }
-    if !metadata.is_file() {
-        anyhow::bail!(
-            "{} is neither a file nor a directory — cannot locate worktree git dir",
-            git_pointer.display()
-        );
-    }
-
-    let raw = std::fs::read_to_string(&git_pointer)
-        .with_context(|| format!("read {}", git_pointer.display()))?;
-    let line = raw
-        .lines()
-        .find(|l| !l.trim().is_empty())
-        .with_context(|| {
-            format!(
-                "{} is empty — expected `gitdir: ...`",
-                git_pointer.display()
-            )
-        })?;
-    let path = line
-        .strip_prefix("gitdir:")
-        .map(|s| s.trim())
-        .with_context(|| {
-            format!(
-                "{} does not start with `gitdir:` — got {:?}",
-                git_pointer.display(),
-                line
-            )
-        })?;
-    Ok(PathBuf::from(path))
+    Ok(ensured)
 }
 
-/// Append our exclude rule to `<git_dir>/info/exclude`. Idempotent: if
+/// Resolve the exact `info/exclude` path Git will read for
+/// `workspace_dir`.
+pub(crate) fn resolve_git_exclude_path(workspace_dir: &Path) -> Result<PathBuf> {
+    let raw = git_ops::run_git(
+        [
+            "rev-parse",
+            "--path-format=absolute",
+            "--git-path",
+            "info/exclude",
+        ],
+        Some(workspace_dir),
+    )
+    .with_context(|| {
+        format!(
+            "run `git rev-parse --git-path info/exclude` in {}",
+            workspace_dir.display()
+        )
+    })?;
+    if raw.is_empty() {
+        anyhow::bail!(
+            "git returned an empty exclude path for {}",
+            workspace_dir.display()
+        );
+    }
+    Ok(PathBuf::from(raw))
+}
+
+/// Append our exclude rule to `exclude_path`. Idempotent: if
 /// the rule (or our exact comment) is already present, no second copy
 /// is written, so calling this repeatedly across workspace recreations
 /// doesn't litter the file.
-pub(crate) fn append_worktree_local_exclude(git_dir: &Path) -> Result<()> {
-    let info_dir = git_dir.join("info");
-    std::fs::create_dir_all(&info_dir).with_context(|| format!("create {}", info_dir.display()))?;
-    let exclude_path = info_dir.join("exclude");
+pub(crate) fn append_local_exclude(exclude_path: &Path) -> Result<()> {
+    let info_dir = exclude_path.parent().with_context(|| {
+        format!(
+            "exclude path has no parent directory: {}",
+            exclude_path.display()
+        )
+    })?;
+    std::fs::create_dir_all(info_dir).with_context(|| format!("create {}", info_dir.display()))?;
 
-    let existing = std::fs::read_to_string(&exclude_path).unwrap_or_default();
+    let existing = std::fs::read_to_string(exclude_path).unwrap_or_default();
     if existing.lines().any(|l| l.trim() == EXCLUDE_RULE) {
         // Already present — nothing to do. Idempotent across retries
         // and across re-creating a workspace at the same path.
@@ -133,7 +171,7 @@ pub(crate) fn append_worktree_local_exclude(git_dir: &Path) -> Result<()> {
     buffer.push('\n');
     buffer.push_str(EXCLUDE_RULE);
     buffer.push('\n');
-    std::fs::write(&exclude_path, buffer)
+    std::fs::write(exclude_path, buffer)
         .with_context(|| format!("write {}", exclude_path.display()))?;
     Ok(())
 }
@@ -142,44 +180,23 @@ pub(crate) fn append_worktree_local_exclude(git_dir: &Path) -> Result<()> {
 mod tests {
     use super::*;
 
-    /// `.git` is a directory (main-checkout case) → resolver returns
-    /// it directly.
-    #[test]
-    fn resolves_main_checkout_git_dir() {
-        let tmp = tempfile::tempdir().unwrap();
-        let git_dir = tmp.path().join(".git");
-        std::fs::create_dir_all(&git_dir).unwrap();
-
-        let resolved = resolve_worktree_git_dir(tmp.path()).unwrap();
-        assert_eq!(resolved, git_dir);
+    fn run(repo: &Path, args: &[&str]) {
+        git_ops::run_git(args, Some(repo)).unwrap_or_else(|error| {
+            panic!("git {:?} failed in {}: {error:#}", args, repo.display())
+        });
     }
 
-    /// `.git` is a file whose first line is `gitdir: …` (linked
-    /// worktree case) → resolver returns the gitdir target.
-    #[test]
-    fn resolves_linked_worktree_git_dir() {
-        let tmp = tempfile::tempdir().unwrap();
-        let target = tmp.path().join("main-repo/.git/worktrees/feature");
-        std::fs::create_dir_all(&target).unwrap();
-        std::fs::write(
-            tmp.path().join(".git"),
-            format!("gitdir: {}\n", target.display()),
-        )
-        .unwrap();
-
-        let resolved = resolve_worktree_git_dir(tmp.path()).unwrap();
-        assert_eq!(resolved, target);
-    }
-
-    /// `.git` file without `gitdir:` prefix → error mentions the
-    /// missing prefix so the caller can surface a useful message.
-    #[test]
-    fn rejects_git_pointer_without_gitdir_prefix() {
-        let tmp = tempfile::tempdir().unwrap();
-        std::fs::write(tmp.path().join(".git"), "not a real pointer\n").unwrap();
-
-        let err = resolve_worktree_git_dir(tmp.path()).unwrap_err();
-        assert!(format!("{err:#}").contains("gitdir"));
+    fn init_repo() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        run(dir.path(), &["init"]);
+        run(dir.path(), &["checkout", "-b", "main"]);
+        run(dir.path(), &["config", "user.email", "helmor@example.com"]);
+        run(dir.path(), &["config", "user.name", "Helmor Test"]);
+        run(dir.path(), &["config", "commit.gpgsign", "false"]);
+        std::fs::write(dir.path().join("file.txt"), "base\n").unwrap();
+        run(dir.path(), &["add", "file.txt"]);
+        run(dir.path(), &["commit", "-m", "initial"]);
+        dir
     }
 
     /// First call writes both comment + rule; second call is a no-op
@@ -188,16 +205,15 @@ mod tests {
     #[test]
     fn exclude_append_is_idempotent() {
         let tmp = tempfile::tempdir().unwrap();
-        let git_dir = tmp.path().join(".git");
-        std::fs::create_dir_all(&git_dir).unwrap();
+        let exclude_path = tmp.path().join(".git/info/exclude");
 
-        append_worktree_local_exclude(&git_dir).unwrap();
-        let after_first = std::fs::read_to_string(git_dir.join("info/exclude")).unwrap();
+        append_local_exclude(&exclude_path).unwrap();
+        let after_first = std::fs::read_to_string(&exclude_path).unwrap();
         assert!(after_first.contains(EXCLUDE_RULE));
         assert!(after_first.contains(EXCLUDE_COMMENT));
 
-        append_worktree_local_exclude(&git_dir).unwrap();
-        let after_second = std::fs::read_to_string(git_dir.join("info/exclude")).unwrap();
+        append_local_exclude(&exclude_path).unwrap();
+        let after_second = std::fs::read_to_string(&exclude_path).unwrap();
         assert_eq!(
             after_first, after_second,
             "second call must not change the file"
@@ -209,56 +225,90 @@ mod tests {
     #[test]
     fn exclude_append_preserves_existing_content() {
         let tmp = tempfile::tempdir().unwrap();
-        let info_dir = tmp.path().join(".git/info");
-        std::fs::create_dir_all(&info_dir).unwrap();
-        std::fs::write(info_dir.join("exclude"), "*.local\n").unwrap();
+        let exclude_path = tmp.path().join(".git/info/exclude");
+        std::fs::create_dir_all(exclude_path.parent().unwrap()).unwrap();
+        std::fs::write(&exclude_path, "*.local\n").unwrap();
 
-        append_worktree_local_exclude(&tmp.path().join(".git")).unwrap();
-        let final_content = std::fs::read_to_string(info_dir.join("exclude")).unwrap();
+        append_local_exclude(&exclude_path).unwrap();
+        let final_content = std::fs::read_to_string(&exclude_path).unwrap();
 
         assert!(final_content.starts_with("*.local\n"));
         assert!(final_content.contains(EXCLUDE_RULE));
     }
 
-    /// Full happy-path end-to-end: from a workspace dir with a fake
-    /// `.git` directory, `ensure_agent_contexts_in_worktree` should
-    /// create the contexts dir AND write the exclude rule.
+    /// Full happy-path end-to-end: from a real repo checkout,
+    /// `ensure_agent_contexts_in_worktree` should create the contexts
+    /// dir, write the exclude rule, and make Git ignore files under it.
     #[test]
     fn ensure_creates_dir_and_exclude_for_main_checkout() {
-        let tmp = tempfile::tempdir().unwrap();
-        let workspace = tmp.path();
-        std::fs::create_dir_all(workspace.join(".git")).unwrap();
+        let repo = init_repo();
+        let workspace = repo.path();
 
         ensure_agent_contexts_in_worktree(workspace).unwrap();
+        std::fs::write(workspace.join(".agent-contexts/probe.txt"), "probe\n").unwrap();
 
         assert!(workspace.join(AGENT_CONTEXTS_DIR).is_dir());
-        let exclude = std::fs::read_to_string(workspace.join(".git/info/exclude")).unwrap();
+        let exclude_path = resolve_git_exclude_path(workspace).unwrap();
+        let exclude = std::fs::read_to_string(&exclude_path).unwrap();
         assert!(exclude.contains(EXCLUDE_RULE));
-    }
-
-    /// End-to-end for the linked-worktree shape: `.git` is a file
-    /// pointing at an external gitdir, and the exclude lands there
-    /// (not under the worktree's own path).
-    #[test]
-    fn ensure_creates_dir_and_exclude_for_linked_worktree() {
-        let tmp = tempfile::tempdir().unwrap();
-        let workspace = tmp.path().join("workspace");
-        std::fs::create_dir_all(&workspace).unwrap();
-        let linked_gitdir = tmp.path().join("main-repo/.git/worktrees/feature");
-        std::fs::create_dir_all(&linked_gitdir).unwrap();
-        std::fs::write(
-            workspace.join(".git"),
-            format!("gitdir: {}\n", linked_gitdir.display()),
+        let ignored = git_ops::run_git(
+            ["check-ignore", "-v", ".agent-contexts/probe.txt"],
+            Some(workspace),
         )
         .unwrap();
+        assert!(ignored.contains(EXCLUDE_RULE));
+    }
+
+    /// End-to-end for a real linked worktree. This catches the bug
+    /// where writing to `.git/worktrees/<name>/info/exclude` looks
+    /// plausible but is not read by `git check-ignore` or
+    /// `git ls-files --others --exclude-standard`.
+    #[test]
+    fn ensure_creates_dir_and_exclude_for_linked_worktree() {
+        let repo = init_repo();
+        let worktree_root = tempfile::tempdir().unwrap();
+        let workspace = worktree_root.path().join("workspace");
+        let workspace_arg = workspace.display().to_string();
+        run(
+            repo.path(),
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "feature/agent-contexts",
+                workspace_arg.as_str(),
+                "HEAD",
+            ],
+        );
 
         ensure_agent_contexts_in_worktree(&workspace).unwrap();
+        std::fs::write(workspace.join(".agent-contexts/probe.txt"), "probe\n").unwrap();
 
         assert!(workspace.join(AGENT_CONTEXTS_DIR).is_dir());
-        let exclude = std::fs::read_to_string(linked_gitdir.join("info/exclude")).unwrap();
+        let exclude_path = resolve_git_exclude_path(&workspace).unwrap();
+        let exclude = std::fs::read_to_string(&exclude_path).unwrap();
         assert!(exclude.contains(EXCLUDE_RULE));
-        // The exclude file under the worktree's local `.git` (which
-        // for linked worktrees is a *file*, not a dir) must NOT exist.
-        assert!(!workspace.join(".git/info/exclude").exists());
+
+        let ignored = git_ops::run_git(
+            ["check-ignore", "-v", ".agent-contexts/probe.txt"],
+            Some(&workspace),
+        )
+        .unwrap();
+        assert!(ignored.contains(EXCLUDE_RULE));
+
+        let untracked = git_ops::run_git(
+            [
+                "ls-files",
+                "--others",
+                "--exclude-standard",
+                ".agent-contexts",
+            ],
+            Some(&workspace),
+        )
+        .unwrap();
+        assert!(
+            untracked.is_empty(),
+            ".agent-contexts should be hidden from Changes, got {untracked:?}"
+        );
     }
 }

--- a/src-tauri/src/workspace/files/tests/workspace_changes.rs
+++ b/src-tauri/src/workspace/files/tests/workspace_changes.rs
@@ -1,4 +1,8 @@
-use super::support::GitRepoHarness;
+use std::{fs, path::Path};
+
+use crate::{git_ops, workspace::agent_contexts::ensure_agent_contexts_in_worktree};
+
+use super::{list_workspace_changes, support::GitRepoHarness};
 
 #[test]
 fn classification_unstaged_modification() {
@@ -59,6 +63,67 @@ fn classification_untracked_file() {
     assert!(
         item.committed_status.is_none(),
         "untracked should NOT have committed_status: {item:?}"
+    );
+}
+
+#[test]
+fn agent_contexts_is_ignored_in_real_git_worktree_changes() {
+    let repo = GitRepoHarness::new();
+    let worktree_parent = tempfile::tempdir().unwrap();
+    let worktree_dir = worktree_parent.path().join("workspace");
+    let worktree_arg = worktree_dir.display().to_string();
+
+    git_ops::run_git(
+        [
+            "worktree",
+            "add",
+            "-b",
+            "feature/agent-contexts-ignore",
+            worktree_arg.as_str(),
+            "main",
+        ],
+        Some(Path::new(repo.path_str())),
+    )
+    .unwrap();
+    assert!(
+        worktree_dir.join(".git").is_file(),
+        "test must cover a real linked worktree"
+    );
+
+    ensure_agent_contexts_in_worktree(&worktree_dir).unwrap();
+    fs::write(worktree_dir.join(".agent-contexts/note.md"), "note\n").unwrap();
+    fs::write(worktree_dir.join("visible.txt"), "visible\n").unwrap();
+
+    let ignored = git_ops::run_git(
+        ["check-ignore", ".agent-contexts/note.md"],
+        Some(&worktree_dir),
+    );
+    assert!(ignored.is_ok(), "Git itself should ignore .agent-contexts");
+
+    let untracked = git_ops::run_git(
+        ["ls-files", "--others", "--exclude-standard"],
+        Some(&worktree_dir),
+    )
+    .unwrap();
+    assert!(
+        untracked.contains("visible.txt"),
+        "positive control should be untracked: {untracked:?}"
+    );
+    assert!(
+        !untracked.contains(".agent-contexts/"),
+        ".agent-contexts should be excluded by git: {untracked:?}"
+    );
+
+    let items = list_workspace_changes(worktree_dir.to_str().unwrap()).unwrap();
+    assert!(
+        items.iter().any(|item| item.path == "visible.txt"),
+        "positive control should appear in Changes: {items:?}"
+    );
+    assert!(
+        items
+            .iter()
+            .all(|item| !item.path.starts_with(".agent-contexts/")),
+        ".agent-contexts files must not appear in Changes: {items:?}"
     );
 }
 

--- a/src-tauri/src/workspace/lifecycle.rs
+++ b/src-tauri/src/workspace/lifecycle.rs
@@ -621,20 +621,7 @@ pub fn finalize_workspace_from_repo_impl(workspace_id: &str) -> Result<FinalizeW
             }
         }
 
-        // Scratch space for agents to share files across sessions. The
-        // directory lives at `<workspace>/.agent-contexts/` and the
-        // worktree-local git exclude entry keeps it out of every diff.
-        // Best-effort — a failure here doesn't block workspace creation
-        // (agents just lose cross-session file sharing for this WS).
-        if let Err(err) =
-            crate::workspace::agent_contexts::ensure_agent_contexts_in_worktree(&workspace_dir)
-        {
-            tracing::warn!(
-                workspace_id = %workspace_id,
-                error = %format!("{err:#}"),
-                "Failed to provision .agent-contexts/ — workspace still usable",
-            );
-        }
+        ensure_agent_contexts_best_effort(workspace_id, &workspace_dir);
 
         // Defer setup to the frontend inspector: if a script is configured AND
         // the user opted into auto-run, the workspace starts in "setup_pending"
@@ -772,6 +759,7 @@ pub fn move_local_workspace_to_worktree_impl(
             &head_commit,
         )?;
         created_worktree = true;
+        ensure_agent_contexts_best_effort(workspace_id, &workspace_dir);
 
         // 4. Apply tracked + index changes (if any).
         if let Some(sha) = stash_sha.as_deref() {
@@ -863,6 +851,23 @@ pub fn move_local_workspace_to_worktree_impl(
         branch: new_branch,
         state: record.state,
     })
+}
+
+fn ensure_agent_contexts_best_effort(workspace_id: &str, workspace_dir: &Path) {
+    // Scratch space for agents to share files across sessions. The
+    // directory lives at `<workspace>/.agent-contexts/`, and Git's
+    // local exclude file keeps it out of every diff. Best-effort — a
+    // failure here doesn't block workspace creation (agents just lose
+    // cross-session file sharing for this WS).
+    if let Err(error) =
+        crate::workspace::agent_contexts::ensure_agent_contexts_in_worktree(workspace_dir)
+    {
+        tracing::warn!(
+            workspace_id = %workspace_id,
+            error = %format!("{error:#}"),
+            "Failed to provision .agent-contexts/ — workspace still usable",
+        );
+    }
 }
 
 /// Legacy combined flow. Runs Phase 1 + Phase 2 back-to-back and returns


### PR DESCRIPTION
## What changed
- Resolve the Git local exclude path with `git rev-parse --git-path info/exclude` so `.agent-contexts/` is ignored in linked worktrees.
- Backfill existing operational worktree workspaces on app startup.
- Provision agent scratch contexts when moving local workspaces into worktrees.
- Add coverage for real linked worktrees and workspace changes.

## Why
Linked worktrees do not necessarily read excludes from the apparent worktree gitdir path. Using Git to resolve the exclude path keeps `.agent-contexts/` out of Changes for both new and existing workspaces.

## Tests
- Pre-commit ran `cargo fmt --manifest-path src-tauri/Cargo.toml --all`.
- Pre-commit ran `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`.

## Follow-up
None planned.