### PR TITLE
fix(triage): restart the local LLM when it stops mid-session

### DIFF
--- a/.changeset/triage-restart-local-llm.md
+++ b/.changeset/triage-restart-local-llm.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Smart triage now restarts the local model if it stopped mid-session, instead of silently producing no tasks until you relaunch the app. Previously, when the bundled local LLM crashed or its health-check gave up, every triage tick failed with "Local LLM is not running" — so freshly-indexed Slack/GitHub/etc. activity never got turned into tasks until the app was restarted.

--- a/src-tauri/src/triage/scheduler.rs
+++ b/src-tauri/src/triage/scheduler.rs
@@ -146,8 +146,24 @@ fn execute_tick<R: Runtime>(
     tick_id: &str,
 ) -> Result<ExecuteOk> {
     let repos = list_repos_payload()?;
-    let endpoint = app
-        .state::<crate::local_llm::Manager>()
+    let manager = app.state::<crate::local_llm::Manager>();
+    // The local LLM can die mid-session (a crash, or a transient connect
+    // blip that trips the healthcheck — it then exits and nothing restarts
+    // the server until the next app launch). That silently wedges triage:
+    // every tick fails the endpoint check below forever. If the model is
+    // enabled but not currently serving, (re)start it here so the next tick
+    // can classify instead of failing indefinitely. `start()` early-returns
+    // when a healthy server is already tracked, so this is a no-op on the
+    // happy path.
+    if manager.endpoint().is_none() && crate::local_llm::load_settings().enabled {
+        if let Err(error) = manager.start() {
+            tracing::warn!(
+                error = %format!("{error:#}"),
+                "triage: local LLM not serving and restart attempt failed",
+            );
+        }
+    }
+    let endpoint = manager
         .endpoint()
         .ok_or_else(|| anyhow!("Local LLM is not running"))?;
     let store = app.state::<ActiveStatusStore>();


### PR DESCRIPTION
## What & why

Follow-up to #701 (Slack channel/thread @-mention indexing). After #701 shipped, Slack channel mentions **are** now indexed (confirmed in prod logs: ~50 mentions/tick incl. thread mentions), but **no tasks were created from them**. The prod logs show the indexing is fine — the failure is downstream, in the triage → local-LLM step:

- Every triage tick ended with `triage: auto-fire after fetch failed { error: "Local LLM is not running" }`.
- The bundled `llama-server` had died mid-session; the manager's healthcheck logged `Local LLM healthcheck: server gone, exiting` and **exited without restarting it**. Nothing re-spawns the model at runtime — the boot autostart thread is one-shot — so triage stayed wedged until the next app launch.
- (Ironically, a healthy `llama-server` was still listening as an orphan, but the manager had stopped tracking it — it only gets re-adopted/reaped on the next launch.)

So `Manager::endpoint()` returned `None` on every tick → `execute_tick` bailed with "Local LLM is not running" → the freshly-indexed candidates were never classified.

## Fix

`execute_tick` now (re)starts the model when it is **enabled but not currently serving**, reusing `Manager::start()` (which early-returns when a healthy server is already tracked — a no-op on the happy path). Triage self-heals on the next tick instead of staying stuck until relaunch.

```rust
if manager.endpoint().is_none() && crate::local_llm::load_settings().enabled {
    if let Err(error) = manager.start() { /* warn */ }
}
```

## Scope / risk

- Triage-only, ~20 lines. No change to the `local_llm` manager itself.
- Respects the `enabled` setting (won't force-start a model the user disabled).
- `start()` is serialized + idempotent; the restart only fires while the model is down, bounded to once per ~5-min tick.

## Verification

- `cargo clippy --all-targets -- -D warnings`: clean.
- Root cause confirmed from prod logs (channel-indexed events carrying mentions, alongside repeated `Local LLM is not running` auto-fire failures while a healthy orphan `llama-server` was actually running).
- Not yet live-verified end-to-end — reproducing a mid-session model death + a triage tick inside a build isn't practical here; the change is a guarded reuse of the existing, exercised `start()` path.

## Follow-up (deeper, not in this PR)

The root robustness gap lives in `local_llm`: the healthcheck exits permanently on the first connect-refused and nothing supervises a restart. A proper fix would have the manager itself re-spawn (or re-adopt the healthy orphan) rather than relying on consumers to re-ensure. Worth a dedicated follow-up.
