### PR TITLE
Fix ellipsis placeholders for empty text blocks and omitted thinking

### DIFF
--- a/.changeset/silent-ellipsis-vanish.md
+++ b/.changeset/silent-ellipsis-vanish.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Before Claude starts replying, show a single "Thinking…" indicator instead of placeholder dots ("...") — collapsing the duplicate rows that appeared after the recent SDK update and filling the blank pause while Claude thinks when Thinking Display is set to Omitted.

--- a/src-tauri/src/pipeline/accumulator/mod.rs
+++ b/src-tauri/src/pipeline/accumulator/mod.rs
@@ -551,9 +551,7 @@ impl StreamAccumulator {
     ) -> Option<IntermediateMessage> {
         if !self.blocks.is_empty() {
             let (partial_id, created_at) = self.get_or_create_turn_identity();
-            Some(streaming::build_partial_from_blocks(
-                self, session_id, partial_id, created_at,
-            ))
+            streaming::build_partial_from_blocks(self, session_id, partial_id, created_at)
         } else {
             let text = self.fallback_text.trim();
             let thinking = self.fallback_thinking.trim();

--- a/src-tauri/src/pipeline/accumulator/streaming.rs
+++ b/src-tauri/src/pipeline/accumulator/streaming.rs
@@ -317,36 +317,34 @@ pub(super) fn build_partial_from_blocks(
     _session_id: &str,
     partial_id: String,
     created_at: String,
-) -> IntermediateMessage {
+) -> Option<IntermediateMessage> {
     let mut content_blocks = Vec::new();
     for block in acc.blocks.values() {
         match block {
             StreamingBlock::Text { id, text } => {
-                let display = if text.is_empty() {
-                    "..."
-                } else {
-                    text.as_str()
-                };
-                content_blocks.push(serde_json::json!({
-                    "type": "text",
-                    "text": display,
-                    "__part_id": id,
-                }));
-            }
-            StreamingBlock::Thinking { id, text, .. } => {
-                // Partials only fire while the block is still live —
-                // `handle_assistant` clears `self.blocks` once the SDK
-                // finalizes the turn. So "still streaming" is the only
-                // state this path ever emits. Duration is stamped later
-                // by `handle_assistant` from each block's `started_at_ms`.
+                // Empty text block renders nothing — no "..." placeholder.
                 if !text.is_empty() {
                     content_blocks.push(serde_json::json!({
-                        "type": "thinking",
-                        "thinking": text,
-                        "__is_streaming": true,
+                        "type": "text",
+                        "text": text,
                         "__part_id": id,
                     }));
                 }
+            }
+            StreamingBlock::Thinking { id, text, .. } => {
+                // Emit the thinking block even with empty text. With Thinking
+                // Display = omitted the deltas carry no text, so the block
+                // stays empty for the whole (possibly 60s+) thinking phase —
+                // an empty thinking block is what drives the frontend's
+                // content-less "Thinking…" chip. Skipping it would leave the
+                // bubble blank until the answer text arrives. Duration is
+                // stamped later by `handle_assistant` from `started_at_ms`.
+                content_blocks.push(serde_json::json!({
+                    "type": "thinking",
+                    "thinking": text,
+                    "__is_streaming": true,
+                    "__part_id": id,
+                }));
             }
             StreamingBlock::ToolUse {
                 tool_use_id,
@@ -372,8 +370,10 @@ pub(super) fn build_partial_from_blocks(
         }
     }
 
+    // No renderable content yet (e.g. only empty text blocks while the
+    // SDK warms up) — emit nothing so the thread shows no placeholder.
     if content_blocks.is_empty() {
-        content_blocks.push(serde_json::json!({"type": "text", "text": "..."}));
+        return None;
     }
 
     let parsed = serde_json::json!({
@@ -386,14 +386,14 @@ pub(super) fn build_partial_from_blocks(
         "__streaming": true,
     });
 
-    IntermediateMessage {
+    Some(IntermediateMessage {
         id: partial_id,
         role: MessageRole::Assistant,
         raw_json: serde_json::to_string(&parsed).unwrap_or_default(),
         parsed: Some(parsed),
         created_at,
         is_streaming: true,
-    }
+    })
 }
 
 pub(super) fn build_materialized_partial_from_blocks(
@@ -419,21 +419,21 @@ pub(super) fn build_materialized_partial_from_blocks(
                 started_at_ms,
                 ..
             } => {
-                if !text.is_empty() {
-                    let duration = now_ms().saturating_sub(*started_at_ms);
-                    // Materialized partials go to `collected[]` on the
-                    // abort path. Stamp `__is_streaming: false` so the
-                    // frontend treats them the same as `handle_assistant`
-                    // output — open + "Thought for Ns". `materialize_partial`
-                    // strips it before persisting (see `strip_is_streaming_markers`).
-                    content_blocks.push(serde_json::json!({
-                        "type": "thinking",
-                        "thinking": text,
-                        "__part_id": id,
-                        "__duration_ms": duration,
-                        "__is_streaming": false,
-                    }));
-                }
+                let duration = now_ms().saturating_sub(*started_at_ms);
+                // Materialized partials go to `collected[]` on the abort
+                // path. Emit even when empty so an aborted omitted-thinking
+                // turn keeps its "Thought for Ns" chip instead of vanishing.
+                // Stamp `__is_streaming: false` so the frontend treats it the
+                // same as `handle_assistant` output — open + "Thought for Ns".
+                // `materialize_partial` strips it before persisting (see
+                // `strip_is_streaming_markers`).
+                content_blocks.push(serde_json::json!({
+                    "type": "thinking",
+                    "thinking": text,
+                    "__part_id": id,
+                    "__duration_ms": duration,
+                    "__is_streaming": false,
+                }));
             }
             StreamingBlock::ToolUse {
                 tool_use_id,
@@ -488,41 +488,38 @@ pub(super) fn build_partial_fallback(
 ) -> IntermediateMessage {
     let text = acc.fallback_text.trim();
     let thinking = acc.fallback_thinking.trim();
-    let display_text = if text.is_empty() { "..." } else { text };
 
-    let thinking_part_id = format!("{partial_id}:blk:0");
-    let text_part_id = if thinking.is_empty() {
-        format!("{partial_id}:blk:0")
-    } else {
-        format!("{partial_id}:blk:1")
-    };
+    // Only emit parts that actually have content — empty text never
+    // renders a "..." placeholder. The caller (`build_partial`) only
+    // reaches this path when text or thinking is non-empty, so the
+    // resulting content is never empty.
+    let mut content = Vec::new();
+    let mut idx = 0;
+    if !thinking.is_empty() {
+        content.push(serde_json::json!({
+            "type": "thinking",
+            "thinking": thinking,
+            "__part_id": format!("{partial_id}:blk:{idx}"),
+        }));
+        idx += 1;
+    }
+    if !text.is_empty() {
+        content.push(serde_json::json!({
+            "type": "text",
+            "text": text,
+            "__part_id": format!("{partial_id}:blk:{idx}"),
+        }));
+    }
 
-    let parsed = if !thinking.is_empty() {
-        serde_json::json!({
-            "type": "assistant",
-            "message": {
-                "type": "message",
-                "role": "assistant",
-                "content": [
-                    {"type": "thinking", "thinking": thinking, "__part_id": thinking_part_id},
-                    {"type": "text", "text": display_text, "__part_id": text_part_id},
-                ],
-            },
-            "__streaming": true,
-        })
-    } else {
-        serde_json::json!({
-            "type": "assistant",
-            "message": {
-                "type": "message",
-                "role": "assistant",
-                "content": [
-                    {"type": "text", "text": display_text, "__part_id": text_part_id},
-                ],
-            },
-            "__streaming": true,
-        })
-    };
+    let parsed = serde_json::json!({
+        "type": "assistant",
+        "message": {
+            "type": "message",
+            "role": "assistant",
+            "content": content,
+        },
+        "__streaming": true,
+    });
 
     IntermediateMessage {
         id: partial_id,

--- a/src-tauri/tests/pipeline_scenarios.rs
+++ b/src-tauri/tests/pipeline_scenarios.rs
@@ -685,6 +685,154 @@ fn stream_thinking_lifecycle_end_to_end() {
 }
 
 #[test]
+fn stream_empty_text_blocks_emit_no_placeholder() {
+    // Newer Claude SDKs can open more than one text content block before
+    // any `text_delta` (or finalized `assistant` event) arrives, so two
+    // empty `StreamingBlock::Text` entries coexist in `acc.blocks`. The
+    // partial builder must NOT render a "..." placeholder per empty block
+    // (which produced the duplicate "..." rows users saw) — empty blocks
+    // emit nothing, and only real text ever reaches the thread.
+    let events = vec![
+        json!({
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "text", "text": ""},
+            },
+            "session_id": "session-1",
+        }),
+        // Second empty text block opens — both are now live with no deltas.
+        json!({
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_start",
+                "index": 1,
+                "content_block": {"type": "text", "text": ""},
+            },
+            "session_id": "session-1",
+        }),
+        // First real text lands in block 1. Block 0 is still empty and must
+        // stay invisible — no leading "..." above the answer.
+        json!({
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "index": 1,
+                "delta": {"type": "text_delta", "text": "Hello."},
+            },
+            "session_id": "session-1",
+        }),
+        json!({
+            "type": "assistant",
+            "message": {
+                "id": "msg_1",
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Hello."}],
+            },
+            "session_id": "session-1",
+        }),
+    ];
+
+    let fingerprint = replay_stream_events("claude", &events);
+    assert_yaml_snapshot!(normalize_stream_fingerprint(&fingerprint));
+}
+
+#[test]
+fn stream_omitted_thinking_shows_thinking_chip() {
+    // Thinking Display = omitted: the SDK opens a `thinking` block and
+    // streams `thinking_delta`s whose text is ALWAYS empty (the content is
+    // redacted server-side), often for 60s+, before any answer text. The
+    // partial builder must surface the empty thinking block as a streaming
+    // reasoning part so the frontend shows its content-less "Thinking…" chip
+    // for the whole phase — NOT skip it (blank bubble) and NOT a "..."
+    // placeholder. Mirrors the real stream captured from Claude.
+    let events = vec![
+        json!({
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "thinking", "thinking": "", "signature": ""},
+            },
+            "session_id": "session-1",
+        }),
+        // Redacted thinking: delta text is empty but the block is live.
+        json!({
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "thinking_delta", "thinking": ""},
+            },
+            "session_id": "session-1",
+        }),
+        json!({
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "signature_delta", "signature": "sig"},
+            },
+            "session_id": "session-1",
+        }),
+        // Finalized thinking block — still empty text, carries the signature.
+        json!({
+            "type": "assistant",
+            "message": {
+                "id": "msg_1",
+                "role": "assistant",
+                "content": [{"type": "thinking", "thinking": "", "signature": "sig"}],
+            },
+            "session_id": "session-1",
+        }),
+        json!({
+            "type": "stream_event",
+            "event": {"type": "content_block_stop", "index": 0},
+            "session_id": "session-1",
+        }),
+        json!({
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_start",
+                "index": 1,
+                "content_block": {"type": "text", "text": ""},
+            },
+            "session_id": "session-1",
+        }),
+        json!({
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "index": 1,
+                "delta": {"type": "text_delta", "text": "Answer."},
+            },
+            "session_id": "session-1",
+        }),
+        json!({
+            "type": "assistant",
+            "message": {
+                "id": "msg_1",
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "", "signature": "sig"},
+                    {"type": "text", "text": "Answer."},
+                ],
+            },
+            "session_id": "session-1",
+        }),
+        json!({
+            "type": "stream_event",
+            "event": {"type": "content_block_stop", "index": 1},
+            "session_id": "session-1",
+        }),
+    ];
+
+    let fingerprint = replay_stream_events("claude", &events);
+    assert_yaml_snapshot!(normalize_stream_fingerprint(&fingerprint));
+}
+
+#[test]
 fn asst_server_tool_use() {
     let msgs = vec![assistant_json(
         "a1",

--- a/src-tauri/tests/snapshots/pipeline_scenarios__stream_empty_text_blocks_emit_no_placeholder.snap
+++ b/src-tauri/tests/snapshots/pipeline_scenarios__stream_empty_text_blocks_emit_no_placeholder.snap
@@ -1,0 +1,42 @@
+---
+source: tests/pipeline_scenarios.rs
+expression: normalize_stream_fingerprint(&fingerprint)
+---
+emissions:
+  - kind: partial
+    line_index: 2
+    event_type: stream_event
+    message:
+      role: assistant
+      id: msg-1
+      content:
+        - type: text
+          text: Hello.
+      streaming: true
+  - kind: full
+    line_index: 3
+    event_type: assistant
+    messages:
+      - role: assistant
+        id: msg-1
+        content:
+          - type: text
+            text: Hello.
+        streaming: ~
+final_render:
+  - role: assistant
+    id: msg-1
+    content:
+      - type: text
+        text: Hello.
+    streaming: ~
+persisted_turn_blocks:
+  - - type: text
+      has_duration_ms: false
+historical_render:
+  - role: assistant
+    id: msg-2
+    content:
+      - type: text
+        text: Hello.
+    streaming: ~

--- a/src-tauri/tests/snapshots/pipeline_scenarios__stream_omitted_thinking_shows_thinking_chip.snap
+++ b/src-tauri/tests/snapshots/pipeline_scenarios__stream_omitted_thinking_shows_thinking_chip.snap
@@ -23,7 +23,7 @@ emissions:
       id: msg-1
       content:
         - type: reasoning
-          text_preview: Quick thought.
+          text_preview: ""
           streaming: true
           has_duration: false
       streaming: true
@@ -35,7 +35,7 @@ emissions:
       id: msg-1
       content:
         - type: reasoning
-          text_preview: Quick thought.
+          text_preview: ""
           streaming: true
           has_duration: false
       streaming: true
@@ -47,7 +47,7 @@ emissions:
         id: msg-1
         content:
           - type: reasoning
-            text_preview: Quick thought.
+            text_preview: ""
             streaming: false
             has_duration: true
         streaming: ~
@@ -59,7 +59,7 @@ emissions:
       id: msg-1
       content:
         - type: text
-          text: Done.
+          text: Answer.
       streaming: true
   - kind: full
     line_index: 7
@@ -69,22 +69,22 @@ emissions:
         id: msg-1
         content:
           - type: reasoning
-            text_preview: Quick thought.
+            text_preview: ""
             streaming: false
             has_duration: true
           - type: text
-            text: Done.
+            text: Answer.
         streaming: ~
 final_render:
   - role: assistant
     id: msg-1
     content:
       - type: reasoning
-        text_preview: Quick thought.
+        text_preview: ""
         streaming: false
         has_duration: true
       - type: text
-        text: Done.
+        text: Answer.
     streaming: ~
 persisted_turn_blocks:
   - - type: thinking
@@ -96,9 +96,9 @@ historical_render:
     id: msg-2
     content:
       - type: reasoning
-        text_preview: Quick thought.
+        text_preview: ""
         streaming: ~
         has_duration: true
       - type: text
-        text: Done.
+        text: Answer.
     streaming: ~

--- a/src-tauri/tests/snapshots/pipeline_streams__stream_replay@claude__task-plan.jsonl.snap
+++ b/src-tauri/tests/snapshots/pipeline_streams__stream_replay@claude__task-plan.jsonl.snap
@@ -23,7 +23,7 @@ checkpoints:
     roles:
       - assistant
     last_part_types:
-      - text
+      - reasoning
   - line_index: 8
     event_type: assistant
     roles:
@@ -57,8 +57,8 @@ checkpoints:
       - assistant
     last_part_types:
       - reasoning
+      - reasoning
       - tool-call
-      - text
   - line_index: 25
     event_type: system
     roles:

--- a/src/features/conversation/streaming-tail-collapse.test.ts
+++ b/src/features/conversation/streaming-tail-collapse.test.ts
@@ -142,4 +142,58 @@ describe("stabilizeStreamingMessages", () => {
 		expect(messages[0]?.content[0]?.type).toBe("tool-call");
 		expect(messages[0]?.content[1]?.type).toBe("tool-call");
 	});
+
+	it("dedupes one thinking block that surfaces in both the base snapshot and the pending partial", () => {
+		// Omitted-thinking reproduction: a `system thinking_tokens` full render
+		// (base) and the next streaming partial each carry the same reasoning
+		// block (same `__part_id`, empty text). Must render ONE "Thinking…" chip.
+		const reasoning = {
+			type: "reasoning" as const,
+			id: "turn-1:blk:0",
+			text: "",
+			streaming: true,
+		};
+		const messages = stabilizeStreamingMessages([
+			assistant("a1", [{ ...reasoning }], true),
+			assistant("a2", [{ ...reasoning }], true),
+		]);
+
+		expect(messages).toHaveLength(1);
+		expect(messages[0]?.content).toHaveLength(1);
+		expect(messages[0]?.content[0]?.type).toBe("reasoning");
+	});
+
+	it("keeps distinct thinking blocks with different ids", () => {
+		const messages = stabilizeStreamingMessages([
+			assistant(
+				"a1",
+				[
+					{
+						type: "reasoning",
+						id: "turn-1:blk:0",
+						text: "First.",
+						streaming: false,
+					},
+				],
+				true,
+			),
+			assistant(
+				"a2",
+				[
+					{
+						type: "reasoning",
+						id: "turn-1:blk:2",
+						text: "Second.",
+						streaming: true,
+					},
+				],
+				true,
+			),
+		]);
+
+		expect(messages).toHaveLength(1);
+		expect(messages[0]?.content).toHaveLength(2);
+		expect(messages[0]?.content[0]?.type).toBe("reasoning");
+		expect(messages[0]?.content[1]?.type).toBe("reasoning");
+	});
 });

--- a/src/features/conversation/streaming-tail-collapse.ts
+++ b/src/features/conversation/streaming-tail-collapse.ts
@@ -192,6 +192,14 @@ function collapseAssistantParts(
 ): ExtendedMessagePart[] {
 	const result: ExtendedMessagePart[] = [];
 	const currentGroup: ToolCallPart[] = [];
+	// A streaming turn's thinking block surfaces in BOTH the stable base
+	// snapshot and the pending partial when this run is merged — every
+	// `system thinking_tokens` event triggers a full render that races the
+	// streaming partial, so the same reasoning lands twice. Both copies share
+	// the same `__part_id`, so dedupe by id (the same block index is never two
+	// different thoughts). Without this, omitted-thinking turns — where the
+	// reasoning text stays empty the whole time — render two "Thinking…" rows.
+	const reasoningIndexById = new Map<string, number>();
 
 	const flushGroup = () => {
 		if (currentGroup.length === 0) {
@@ -218,7 +226,15 @@ function collapseAssistantParts(
 			continue;
 		}
 		if (part.type === "reasoning") {
-			result.push(part);
+			const seenIdx = reasoningIndexById.get(part.id);
+			if (seenIdx !== undefined) {
+				// Same logical block already shown — keep the latest copy so
+				// newer duration / content wins.
+				result[seenIdx] = part;
+			} else {
+				reasoningIndexById.set(part.id, result.length);
+				result.push(part);
+			}
 			continue;
 		}
 		flushGroup();


### PR DESCRIPTION
## Summary
Fixes the issue where empty text blocks rendered as "..." placeholders and omitted-thinking turns showed duplicate or missing indicators.

## Changes
- Remove "..." placeholder rendering when text/thinking blocks are empty
- Surface empty thinking blocks in streaming partials to show "Thinking…" chip during omitted-thinking mode  
- Deduplicate reasoning blocks that appear in both stable base snapshot and pending partial from the SDK
- Return `Option<IntermediateMessage>` from `build_partial_from_blocks` to skip rendering when no renderable content exists
- Stabilize streaming tail collapse to prevent duplicate thinking indicators
- Add comprehensive tests for empty text block and omitted thinking scenarios

## Problem
After a recent Claude SDK update, the message streaming pipeline would render multiple "..." placeholder rows while the message was still being composed. Additionally, when Thinking Display is set to Omitted, the thinking blocks were either missing (blank bubble) or appearing as duplicates instead of a single "Thinking…" indicator.

## Solution
- Empty text blocks are now skipped entirely (no placeholder)
- Empty thinking blocks are still emitted as streaming partials (preserving the "Thinking…" UI state during the thinking phase)
- Deduplication logic in the tail collapse prevents the same reasoning block from appearing twice when it surfaces in both the base snapshot and pending partial

## Test Coverage
- `stream_empty_text_blocks_emit_no_placeholder` - validates that multiple empty text blocks don't produce placeholder output
- `stream_omitted_thinking_shows_thinking_chip` - validates that omitted thinking displays as a single "Thinking…" indicator

## Related Issue
Fixes the duplicate ellipsis rows and blank bubble issues that appeared after SDK update.