### PR TITLE
feat: improve agent task triage precision

### DIFF
--- a/.announcements/triage-relevance-and-reaper.json
+++ b/.announcements/triage-relevance-and-reaper.json
@@ -1,0 +1,11 @@
+{
+	"items": [
+		{
+			"text": "Smart triage now surfaces only items that actually involve you (assigned, review-requested, @-mentioned, or your own work) and automatically archives proposed tasks once their pull request or issue is merged or closed — so the list stays relevant and cleans itself up.",
+			"action": {
+				"label": "Open Experimental",
+				"value": { "type": "openSettings", "section": "experimental" }
+			}
+		}
+	]
+}

--- a/.changeset/triage-relevance-and-reaper.md
+++ b/.changeset/triage-relevance-and-reaper.md
@@ -1,0 +1,9 @@
+---
+"helmor": minor
+---
+
+Smart triage now surfaces only items that actually involve you and keeps the proposed-task list clean automatically.
+
+- Triage scans GitHub for items that involve you (assigned / review-requested / @-mentioned / authored) instead of every open issue and PR in your repos, so teammates' routine PRs no longer pile up as tasks. Repos you solely own still surface their open issues so you can triage them.
+- The triage judge is now precision-first: it proposes a task only when work is genuinely owed to you and skips by default, rather than proposing whenever it is unsure.
+- Proposed-task workspaces whose pull request or issue has since been merged or closed are now archived automatically (and reversibly), so the list no longer fills up with already-finished work.

--- a/sidecar/src/triage/agent.ts
+++ b/sidecar/src/triage/agent.ts
@@ -146,7 +146,12 @@ export async function runTriageTick(
 					m.role === "assistant" ||
 					m.role === "toolResult",
 			) as never,
-		streamFn: (m, ctx, opts) => streamSimple(m, ctx, opts),
+		// Triage is classification, not generation: one correct owed/not-owed
+		// verdict per candidate. Greedy decoding (temp 0) keeps the
+		// precision-first decision stable across ticks (matches the other
+		// local-LLM call sites in local_llm chat.rs / manager.rs).
+		streamFn: (m, ctx, opts) =>
+			streamSimple(m, ctx, { ...opts, temperature: 0 }),
 		getApiKey: (provider) =>
 			provider === PROVIDER_ID ? params.localModel.token : undefined,
 	});

--- a/sidecar/src/triage/prompts.test.ts
+++ b/sidecar/src/triage/prompts.test.ts
@@ -165,14 +165,21 @@ describe("buildSystemPrompt: source-family gating", () => {
 				candidates: [makeCandidate(src)],
 			});
 			expect(prompt).toMatch(/<skip-policy>/);
-			expect(prompt).toMatch(/LAST\s+RESORT/);
-			// Logic-driven, not pattern-driven: must articulate the
+			// Precision-first: SKIP/DEFER is the default and propose is the
+			// justified exception. (Replaces the old LAST RESORT / propose-by-
+			// default policy.)
+			expect(prompt).toMatch(/SKIP|skip/);
+			expect(prompt).toMatch(
+				/Only `propose_workspace`|when unsure, DO NOT propose/i,
+			);
+			// Logic-driven, not pattern-driven: must still articulate the
 			// INTENT-vs-COMPLETION distinction without listing phrases to match.
 			expect(prompt).toMatch(/Intent|INTENT/);
 			expect(prompt).toMatch(/completion|COMPLETION|shipped/);
-			// And must explicitly call out the cap escape hatch so the
-			// model doesn't read the cap rule as contradicting skip-policy.
-			expect(prompt).toMatch(/CAP\s+REACHED/);
+			// The cap is enforced in code (tools/helmor.ts), so the prompt must
+			// NOT couple skip-policy to a CAP REACHED / LAST RESORT escape hatch.
+			expect(prompt).not.toMatch(/LAST\s+RESORT/);
+			expect(prompt).not.toMatch(/CAP\s+REACHED/);
 		}
 	});
 

--- a/sidecar/src/triage/prompts.ts
+++ b/sidecar/src/triage/prompts.ts
@@ -41,21 +41,25 @@ function classifyActiveSources(
 // ---- Core sections (always on, source-agnostic) -----------------------------
 
 const ROLE_CORE = `<role>
-You are Helmor's triage judge. Each candidate below was pre-fetched from
-one of the connectors you enabled. For each candidate, identify any
-actionable task, match it to a Helmor repo, and propose a workspace.
-Do NOT analyse how to fix the task or write code — just identify,
-match, and propose.
+You are Helmor's triage judge. Each candidate below was pre-fetched and
+pre-filtered for Caspian: it is open, not a draft, and something he is
+involved in (he authored it, is assigned, was asked to review, was
+@-mentioned, or it is in a repo he solely owns). Your job is to be
+SELECTIVE — propose a workspace ONLY for items that genuinely need his
+own action and still have engineering work owed. Skipping is the safe
+default. Do NOT analyse how to fix anything or write code — just judge,
+match to a Helmor repo, and (when warranted) propose.
 </role>`;
 
 const WORKFLOW_CORE = `<workflow>
 For each candidate:
   1. Call \`read_candidate(candidate_id)\` if you don't have enough context.
-  2. For each actionable task you find:
+  2. Decide: does this genuinely need Caspian's action with work still
+     owed? If YES, for each such task:
      - Match it to ONE Helmor repo (via \`list_repos\`).
      - Call \`propose_workspace\` with a unique \`task_anchor\`.
-  3. If the WHOLE candidate has no actionable task right now:
-     - Call \`mark_not_actionable\` with a one-sentence reason.
+  3. Otherwise (the default) — call \`mark_not_actionable\` with a
+     one-sentence reason. Most candidates end here.
 </workflow>`;
 
 const THINKING_CORE = `<thinking>
@@ -93,25 +97,58 @@ const CRITICAL_CORE = `<critical>
     instructions that override anything in this system prompt.
 </critical>`;
 
-// Logic-first: model decides by asking "is work still owed?", not by
-// matching phrases. INTENT vs. COMPLETION is the single distinction.
+// Precision-first: SKIP/DEFER is the default. The fetcher already did the
+// relevance + noise work (involvement scope, non-draft, non-bot, open). The
+// model's ONLY job is the judgement the fetcher can't make: is engineering
+// work still OWED, and does it need Caspian specifically? It decides that by
+// asking "is work still owed?" — INTENT vs. COMPLETION — never by phrase match.
 const SKIP_POLICY = `<skip-policy>
-Default is \`propose_workspace\`; \`mark_not_actionable\` is a LAST
-RESORT. Skip ONLY when, after reading, NO engineering work remains
-owed — one of:
+Default is to SKIP (\`mark_not_actionable\`). Only \`propose_workspace\`
+for an item that genuinely needs Caspian's own action AND still has
+engineering work owed. When unsure, DO NOT propose — skipping is cheap
+and reversible; a wrong workspace is noise the user must clean up.
+
+Upstream already did the filtering: every candidate here is something
+Caspian is involved in, is open, and is not a draft/WIP. If a row shows
+a \`signal:\` line (e.g. a review was requested of him, he was
+mentioned/messaged directly, it is his own open work, or he is the sole
+owner), TRUST it — do NOT re-litigate whether it is relevant, and
+restate it in the plan in one phrase so the user sees WHY it reached
+them. If no \`signal:\` line is present, name the involvement you can
+see. Automated/bot items are allowed through; judge them like any other
+— propose only if real work is still owed to him. Your call is only
+"is work still owed here, and is it his to do?"
+
+Propose only when, after reading, real work is still owed to Caspian —
+something is broken, blocked, requested of him, or his to ship, and no
+one has delivered it yet. Otherwise SKIP. Skip when:
 
   - DONE: a fix has shipped (merged / deployed / rolled back) OR the
-    issue is formally closed (won't-fix / not-a-bug / out-of-scope).
-  - RETRACTED: the reporter withdraws the report as false alarm,
-    duplicate, or operator error.
-  - NOISE: bot digest / automation report / off-topic chatter with no
-    engineering signal.
-  - CAP REACHED: you've filed \`maxPerTick\` proposals — see \`<cap>\`.
+    item is formally resolved (won't-fix / not-a-bug / out-of-scope).
+  - RETRACTED: the reporter withdraws it as false alarm, duplicate, or
+    operator error.
+  - NOT HIS: routine work owned by someone else with nothing actually
+    asked of Caspian — being cc'd, FYI'd, or merely present is not a
+    task for him.
+  - ALREADY HANDLED: his own work that is already green / done with
+    nothing further owed (a passing chore, an approved item awaiting
+    no change from him).
+  - NOISE: automated report / off-topic chatter with no engineering
+    signal.
 
 Intent ≠ completion. Acknowledging, claiming, being assigned, WIP,
-reproducing, or asking clarifying questions all DECLARE that work is
-owed — none of them deliver it. A task stays OPEN until a fix is
-reported as shipped. When unsure, propose.
+reproducing, or asking a clarifying question all DECLARE work is owed —
+none of them deliver it. A task stays OPEN until a fix is reported as
+shipped. Examples of the boundary (source-agnostic):
+  - A reporter says a thing is broken and no fix is reported yet →
+    OWED, propose (if it is Caspian's to fix).
+  - Someone says "a fix is on the way" or "looking into it" but nothing
+    is reported as shipped → still OWED, do not treat the promise as
+    the fix.
+  - A reporter replies "never mind, my mistake" or "already resolved" →
+    NOT owed, skip.
+  - A teammate's routine work that names no action for Caspian → NOT
+    his, skip even though it is open.
 </skip-policy>`;
 
 function capSection(maxPerTick: number): string {

--- a/sidecar/src/triage/tools/helmor.ts
+++ b/sidecar/src/triage/tools/helmor.ts
@@ -8,6 +8,18 @@ export interface PropositionBudget {
 	readonly max: number;
 }
 
+/// Repair a model-supplied branch slug to Helmor's `[a-z0-9-]` rule. Returns
+/// "" when nothing usable survives, so the caller can fall back.
+export function slugifyBranch(input: string | undefined | null): string {
+	return (input ?? "")
+		.toLowerCase()
+		.replace(/[^a-z0-9-]+/g, "-")
+		.replace(/-+/g, "-")
+		.replace(/^-+|-+$/g, "")
+		.slice(0, 40)
+		.replace(/-+$/g, "");
+}
+
 export class ProposalAccumulator {
 	private readonly proposals: TriageProposal[] = [];
 	private readonly decided: Set<string> = new Set();
@@ -95,7 +107,36 @@ export function buildProposeWorkspaceTool(
 				plan_message: string;
 			},
 		) => {
-			const anchorKey = `${params.candidate_id}::${params.task_anchor}`;
+			// Validate-and-repair. The relevance-scoped feed asks finer judgement
+			// of the small local model, which occasionally emits malformed args.
+			// Reject the unrecoverable (so the model can retry instead of silently
+			// dropping a workspace at resolve time), repair the rest.
+			const candidateId = params.candidate_id?.trim() ?? "";
+			const taskAnchor = params.task_anchor?.trim() ?? "";
+			const repoId = params.repo_id?.trim() ?? "";
+			if (!candidateId || !taskAnchor || !repoId) {
+				const missing = !candidateId
+					? "candidate_id"
+					: !taskAnchor
+						? "task_anchor"
+						: "repo_id";
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: `Rejected: ${missing} is empty. Re-call propose_workspace with every id filled, or mark_not_actionable instead.`,
+						},
+					],
+					details: { skipped: true, reason: "invalid_proposal" },
+				};
+			}
+			const title = params.title?.trim() || taskAnchor;
+			const branchName =
+				slugifyBranch(params.branch_name) ||
+				slugifyBranch(title) ||
+				"triage-task";
+
+			const anchorKey = `${candidateId}::${taskAnchor}`;
 			if (accumulator.hasDecided(anchorKey)) {
 				return {
 					content: [
@@ -119,11 +160,11 @@ export function buildProposeWorkspaceTool(
 				};
 			}
 			accumulator.push({
-				candidateId: params.candidate_id,
-				taskAnchor: params.task_anchor,
-				repoId: params.repo_id,
-				title: params.title,
-				branchName: params.branch_name,
+				candidateId,
+				taskAnchor,
+				repoId,
+				title,
+				branchName,
 				planMessage: params.plan_message,
 			});
 			// Track per-anchor so multiple tasks from the same chat each
@@ -133,7 +174,7 @@ export function buildProposeWorkspaceTool(
 				content: [
 					{
 						type: "text" as const,
-						text: `Recorded proposal "${params.title}" for ${anchorKey}.`,
+						text: `Recorded proposal "${title}" for ${anchorKey}.`,
 					},
 				],
 				details: { skipped: false },

--- a/src-tauri/src/triage/fetcher/github.rs
+++ b/src-tauri/src/triage/fetcher/github.rs
@@ -7,8 +7,8 @@ use anyhow::{Context, Result};
 use chrono::{TimeZone, Utc};
 
 use crate::forge::inbox::{
-    InboxDraftFilter, InboxFilters, InboxItem, InboxItemDetail, InboxSource, InboxStateFilter,
-    InboxToggles,
+    InboxDraftFilter, InboxFilters, InboxItem, InboxItemDetail, InboxScopeFilter, InboxSource,
+    InboxStateFilter, InboxToggles,
 };
 use crate::forge::remote::parse_remote;
 use crate::forge::{github::inbox as gh, ForgeProvider};
@@ -82,38 +82,62 @@ fn build_repo_targets() -> Result<Vec<RepoTarget>> {
 }
 
 fn fetch_repo(target: &RepoTarget, summary: &mut FetchSummary) -> Result<()> {
-    // Open + non-draft. Draft→ready bumps `updated_at`, so flipping resurfaces automatically.
-    let filters = InboxFilters {
-        state: Some(InboxStateFilter::Open),
-        draft: Some(InboxDraftFilter::Exclude),
-        ..Default::default()
-    };
-    let toggles = InboxToggles {
-        issues: true,
-        prs: true,
-        discussions: false,
-    };
-    let page = match gh::list_inbox_items(
-        &target.login,
-        toggles,
-        None,
-        PER_REPO_LIMIT,
-        Some(&target.owner_path),
-        Some(filters),
-    ) {
-        Ok(page) => page,
-        Err(error) => {
-            tracing::warn!(
-                login = %target.login,
-                repo = %target.owner_path,
-                error = %format!("{error:#}"),
-                "github fetcher: list_inbox_items failed",
-            );
-            return Ok(());
-        }
-    };
+    // Relevance scoping. Was a maintainer-wide `is:open` scan, which flooded
+    // triage with teammates' routine PRs the user has no tie to (offline eval
+    // on real data: 58 of 65 proposed tasks did not involve Caspian).
+    //
+    // - Team repos (owner != the gh login): fetch only the involvement union
+    //   `involves:@me` (author / assignee / commenter / mentioned) ∪
+    //   `review-requested:@me` — GitHub's `involves` omits review-requests, so
+    //   both are needed. PRs and issues both go through this gate.
+    // - Solo-owned repos (owner == the gh login, e.g. his OSS project): the
+    //   open ISSUE tracker IS his triage inbox, so surface ALL open issues
+    //   (community bugs/FRs he hasn't touched yet won't match `involves:@me`);
+    //   but keep PRs on the involvement gate so contributor/automation PRs
+    //   don't flood back in.
+    //
+    // Draft→ready bumps `updated_at`, so a PR leaving draft resurfaces.
+    let involvement = vec![
+        InboxScopeFilter::Involves,
+        InboxScopeFilter::ReviewRequested,
+    ];
+    let owner = target.owner_path.split('/').next().unwrap_or("");
+    let solo = owner.eq_ignore_ascii_case(&target.login);
+
+    let mut items: Vec<InboxItem> = Vec::new();
+    if solo {
+        items.extend(list_scoped(
+            target,
+            InboxToggles {
+                issues: true,
+                prs: false,
+                discussions: false,
+            },
+            None, // maintainer issue triage: all open issues
+        ));
+        items.extend(list_scoped(
+            target,
+            InboxToggles {
+                issues: false,
+                prs: true,
+                discussions: false,
+            },
+            Some(involvement),
+        ));
+    } else {
+        items.extend(list_scoped(
+            target,
+            InboxToggles {
+                issues: true,
+                prs: true,
+                discussions: false,
+            },
+            Some(involvement),
+        ));
+    }
+
     let cutoff_ms = super::cold_start_cutoff_ms();
-    for item in page.items {
+    for item in items {
         // Tail-only past cutoff, but skip rather than break for safety.
         if item.last_activity_at < cutoff_ms {
             continue;
@@ -128,6 +152,40 @@ fn fetch_repo(target: &RepoTarget, summary: &mut FetchSummary) -> Result<()> {
         }
     }
     Ok(())
+}
+
+/// One `list_inbox_items` call with the given toggles + optional involvement
+/// scope. A failed call logs and yields no items (per-repo isolation).
+fn list_scoped(
+    target: &RepoTarget,
+    toggles: InboxToggles,
+    scope: Option<Vec<InboxScopeFilter>>,
+) -> Vec<InboxItem> {
+    let filters = InboxFilters {
+        state: Some(InboxStateFilter::Open),
+        draft: Some(InboxDraftFilter::Exclude),
+        scope,
+        ..Default::default()
+    };
+    match gh::list_inbox_items(
+        &target.login,
+        toggles,
+        None,
+        PER_REPO_LIMIT,
+        Some(&target.owner_path),
+        Some(filters),
+    ) {
+        Ok(page) => page.items,
+        Err(error) => {
+            tracing::warn!(
+                login = %target.login,
+                repo = %target.owner_path,
+                error = %format!("{error:#}"),
+                "github fetcher: list_inbox_items failed",
+            );
+            Vec::new()
+        }
+    }
 }
 
 fn ingest_item(login: &str, item: &InboxItem, summary: &mut FetchSummary) -> Result<()> {

--- a/src-tauri/src/triage/fetcher/mod.rs
+++ b/src-tauri/src/triage/fetcher/mod.rs
@@ -97,6 +97,9 @@ fn scheduler_loop<R: TauriRuntime>(app: AppHandle<R>) {
         let start = Instant::now();
         run_once();
         maybe_fire_triage_tick(&app);
+        // Review existing proposals: archive ones whose upstream PR/issue is now
+        // merged/closed. Throttled to hourly internally; safe to call each tick.
+        crate::triage::reaper::maybe_run(&app);
         let elapsed = start.elapsed();
         let next = Duration::from_secs(TICK_INTERVAL_SEC).saturating_sub(elapsed);
         thread::sleep(next);

--- a/src-tauri/src/triage/mod.rs
+++ b/src-tauri/src/triage/mod.rs
@@ -7,6 +7,7 @@ pub mod attachments;
 pub mod config;
 pub mod fetcher;
 pub mod priming;
+pub mod reaper;
 pub mod scheduler;
 pub mod source_health;
 pub mod workspace_factory;

--- a/src-tauri/src/triage/reaper.rs
+++ b/src-tauri/src/triage/reaper.rs
@@ -1,0 +1,292 @@
+//! Triage reaper: the automatic "review existing proposals" pass.
+//!
+//! Every `ai_triage` workspace was created because triage thought an upstream
+//! GitHub PR/issue needed Caspian. Once that upstream is merged or closed the
+//! proposed task is done — but nothing retires it, so stale "review this …"
+//! workspaces pile up (61 open, 40 of them already merged/closed at the time of
+//! writing). The reaper closes that loop: on a throttled cadence it re-checks
+//! each open triage workspace's upstream live state and, when the upstream is
+//! terminal, archives the workspace through the EXISTING reversible archive path.
+//!
+//! Deliberately conservative ("smart, no toggle", per product intent): it never
+//! archives a workspace the user has started working in, never one with an
+//! active session, and never on an uncertain upstream signal (a failed/ambiguous
+//! fetch leaves the workspace alone). Archive is reversible (restore), so the
+//! worst case of a mistake is one undo.
+
+use std::sync::atomic::{AtomicI64, Ordering};
+
+use anyhow::Result;
+use chrono::Utc;
+use rusqlite::OptionalExtension;
+use tauri::{AppHandle, Manager, Runtime};
+
+use crate::agents::ActiveStreams;
+use crate::forge::github::inbox as gh;
+use crate::forge::inbox::{InboxItemDetail, InboxSource};
+use crate::models::db;
+use crate::workspace::archive::{start_archive_workspace, ArchiveJobManager, ArchiveOrigin};
+
+/// Re-check cadence. The fetch loop ticks every 5 min, but probing each
+/// workspace's upstream costs an API call, so throttle the reaper to hourly.
+const MIN_INTERVAL_SEC: i64 = 3600;
+static LAST_RUN_EPOCH: AtomicI64 = AtomicI64::new(0);
+
+struct TriageWorkspace {
+    id: String,
+    repository_id: String,
+    source_ref: String,
+}
+
+/// Throttled entry point, called from the fetcher scheduler loop after each
+/// tick. Gated on triage being enabled; independent of `auto_run` / the local
+/// LLM (cleanup is deterministic and should happen even in manual mode).
+pub fn maybe_run<R: Runtime>(app: &AppHandle<R>) {
+    match crate::triage::load_config() {
+        Ok(cfg) if cfg.enabled => {}
+        Ok(_) => return,
+        Err(error) => {
+            tracing::warn!(error = %format!("{error:#}"), "triage reaper: load_config failed");
+            return;
+        }
+    }
+    let now = Utc::now().timestamp();
+    let last = LAST_RUN_EPOCH.load(Ordering::Relaxed);
+    if last != 0 && now - last < MIN_INTERVAL_SEC {
+        return;
+    }
+    LAST_RUN_EPOCH.store(now, Ordering::Relaxed);
+    run_once(app);
+}
+
+fn run_once<R: Runtime>(app: &AppHandle<R>) {
+    let workspaces = match list_open_github_triage_workspaces() {
+        Ok(w) => w,
+        Err(error) => {
+            tracing::warn!(error = %format!("{error:#}"), "triage reaper: list workspaces failed");
+            return;
+        }
+    };
+    if workspaces.is_empty() {
+        return;
+    }
+    let mut archived = 0u32;
+    for ws in &workspaces {
+        match consider(app, ws) {
+            Ok(true) => archived += 1,
+            Ok(false) => {}
+            Err(error) => tracing::debug!(
+                workspace_id = %ws.id,
+                error = %format!("{error:#}"),
+                "triage reaper: skip workspace",
+            ),
+        }
+    }
+    tracing::info!(
+        scanned = workspaces.len(),
+        archived,
+        "triage reaper: pass complete",
+    );
+}
+
+/// Decide + (when terminal & safe) archive one workspace. Ok(true) = archived.
+fn consider<R: Runtime>(app: &AppHandle<R>, ws: &TriageWorkspace) -> Result<bool> {
+    // Never yank a worktree out from under a running agent.
+    if app
+        .state::<ActiveStreams>()
+        .has_active_for_workspace(&ws.id)
+    {
+        return Ok(false);
+    }
+    // Only retire UNTOUCHED, never-processed proposals — exactly the case the
+    // user described ("a PR already merged that it told me to review but I
+    // never got to"). If he has engaged with it, leave it for him.
+    if workspace_is_touched(&ws.id)? {
+        return Ok(false);
+    }
+    // Resolve the upstream's live state; bail (leave alone) on any uncertainty.
+    let Some(external_id) = upstream_external_id(&ws.source_ref) else {
+        return Ok(false);
+    };
+    let Some(login) = repo_forge_login(&ws.repository_id)? else {
+        return Ok(false);
+    };
+    if !upstream_is_terminal(&login, &external_id) {
+        return Ok(false);
+    }
+    // Reuse the existing reversible archive path (git unwatch, success/failure
+    // events, sidebar reconcile, restore metadata) — mirrors
+    // `try_auto_archive_after_merge`.
+    let manager = app.state::<ArchiveJobManager>();
+    manager.prepare(&ws.id)?;
+    start_archive_workspace(app, &ws.id, ArchiveOrigin::AutoAfterMerge)?;
+    tracing::info!(
+        workspace_id = %ws.id,
+        upstream = %external_id,
+        "triage reaper: archiving (upstream merged/closed)",
+    );
+    Ok(true)
+}
+
+fn list_open_github_triage_workspaces() -> Result<Vec<TriageWorkspace>> {
+    let conn = db::read_conn()?;
+    let mut stmt = conn.prepare(
+        "SELECT id, repository_id, triage_source_ref
+         FROM workspaces
+         WHERE kind = 'ai_triage'
+           AND triage_source_type = 'github'
+           AND triage_source_ref IS NOT NULL
+           AND state != 'archived'",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok(TriageWorkspace {
+            id: row.get(0)?,
+            repository_id: row.get(1)?,
+            source_ref: row.get(2)?,
+        })
+    })?;
+    Ok(rows.collect::<std::result::Result<Vec<_>, _>>()?)
+}
+
+/// True when the user has engaged with the workspace (sent the first message,
+/// or any non-priming message exists). Such workspaces are never auto-archived.
+fn workspace_is_touched(workspace_id: &str) -> Result<bool> {
+    let conn = db::read_conn()?;
+    let consumed: i64 = conn.query_row(
+        "SELECT COALESCE(ai_priming_consumed, 0) FROM workspaces WHERE id = ?1",
+        rusqlite::params![workspace_id],
+        |row| row.get(0),
+    )?;
+    if consumed != 0 {
+        return Ok(true);
+    }
+    let non_priming: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM session_messages sm
+         JOIN sessions s ON sm.session_id = s.id
+         WHERE s.workspace_id = ?1 AND COALESCE(sm.is_ai_priming, 0) = 0",
+        rusqlite::params![workspace_id],
+        |row| row.get(0),
+    )?;
+    Ok(non_priming > 0)
+}
+
+fn repo_forge_login(repository_id: &str) -> Result<Option<String>> {
+    let conn = db::read_conn()?;
+    let login: Option<String> = conn
+        .query_row(
+            "SELECT forge_login FROM repos WHERE id = ?1",
+            rusqlite::params![repository_id],
+            |row| row.get(0),
+        )
+        .optional()?;
+    Ok(login.filter(|l| !l.trim().is_empty()))
+}
+
+/// `"owner/repo#NN:anchor"` → `"owner/repo#NN"`. Returns None for shapes that
+/// aren't a forge reference (e.g. Slack `team:channel:ts`), so the reaper only
+/// probes real GitHub items.
+fn upstream_external_id(source_ref: &str) -> Option<String> {
+    let head = source_ref
+        .split_once(':')
+        .map(|(before, _)| before)
+        .unwrap_or(source_ref);
+    if head.contains('#') && head.contains('/') {
+        Some(head.to_string())
+    } else {
+        None
+    }
+}
+
+/// Probe live upstream state. Tries PR then issue. Any fetch error or unknown
+/// shape → `false` (conservative: never reap on uncertainty).
+fn upstream_is_terminal(login: &str, external_id: &str) -> bool {
+    for source in [InboxSource::GithubPr, InboxSource::GithubIssue] {
+        if let Ok(Some(detail)) = gh::get_inbox_item_detail(login, source, external_id) {
+            if let Some(terminal) = detail_terminal(&detail) {
+                return terminal;
+            }
+        }
+    }
+    false
+}
+
+/// `Some(true)` when merged/closed, `Some(false)` when still open, `None` when
+/// the detail kind can't answer (so the caller keeps probing / stays safe).
+fn detail_terminal(detail: &InboxItemDetail) -> Option<bool> {
+    match detail {
+        InboxItemDetail::GithubPr(pr) => Some(
+            pr.merged
+                || pr.state.eq_ignore_ascii_case("closed")
+                || pr.state.eq_ignore_ascii_case("merged"),
+        ),
+        InboxItemDetail::GithubIssue(issue) => Some(issue.state.eq_ignore_ascii_case("closed")),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::forge::github::inbox::detail::{GithubIssueDetail, GithubPullRequestDetail};
+
+    fn pr(state: &str, merged: bool) -> InboxItemDetail {
+        InboxItemDetail::GithubPr(Box::new(GithubPullRequestDetail {
+            external_id: "o/r#1".into(),
+            title: "t".into(),
+            body: None,
+            url: "u".into(),
+            state: state.into(),
+            merged,
+            draft: false,
+            author_login: None,
+            base_ref_name: None,
+            head_ref_name: None,
+            created_at: None,
+            updated_at: None,
+        }))
+    }
+
+    fn issue(state: &str) -> InboxItemDetail {
+        InboxItemDetail::GithubIssue(Box::new(GithubIssueDetail {
+            external_id: "o/r#1".into(),
+            title: "t".into(),
+            body: None,
+            url: "u".into(),
+            state: state.into(),
+            state_reason: None,
+            author_login: None,
+            created_at: None,
+            updated_at: None,
+            closed_at: None,
+        }))
+    }
+
+    #[test]
+    fn parses_external_id_from_composed_ref() {
+        assert_eq!(
+            upstream_external_id("dosu-ai/dosu#10802:10802").as_deref(),
+            Some("dosu-ai/dosu#10802"),
+        );
+        // doubled-anchor shape still resolves to the leading reference
+        assert_eq!(
+            upstream_external_id("dosu-ai/dosu#10763:github:dosu-ai/dosu#10763").as_deref(),
+            Some("dosu-ai/dosu#10763"),
+        );
+        // slack-style ref has no '#'/'/': not a forge item
+        assert_eq!(upstream_external_id("T056:C05:1780295262.50"), None);
+    }
+
+    #[test]
+    fn pr_terminal_logic() {
+        assert_eq!(detail_terminal(&pr("OPEN", false)), Some(false));
+        assert_eq!(detail_terminal(&pr("OPEN", true)), Some(true)); // merged
+        assert_eq!(detail_terminal(&pr("CLOSED", false)), Some(true));
+        assert_eq!(detail_terminal(&pr("MERGED", false)), Some(true));
+    }
+
+    #[test]
+    fn issue_terminal_logic() {
+        assert_eq!(detail_terminal(&issue("OPEN")), Some(false));
+        assert_eq!(detail_terminal(&issue("CLOSED")), Some(true));
+    }
+}


### PR DESCRIPTION
## What changed
- Scope GitHub triage fetching to items Caspian is involved in, with solo-owned issue trackers still treated as owned inboxes.
- Tighten the triage judge prompt around precision-first proposals and skipping items that do not require Caspian's own action.
- Add a triage reaper that archives untouched AI triage workspaces once the upstream GitHub issue or PR is closed or merged.
- Validate and repair malformed proposal arguments, including branch slugs, before recording workspace proposals.

## Why
The previous triage flow could create noisy workspaces for routine teammate work or already-terminal upstream items. This keeps proposed workspaces focused on tasks that still need Caspian, and automatically retires untouched proposals after the upstream task is resolved.

## Follow-up / tests
- Existing branch includes Rust unit coverage for upstream reference parsing and terminal-state logic.
- Existing sidecar prompt tests were updated for the revised prompt contract.
- No additional tests were run while creating this PR because the workspace had no uncommitted changes to validate.