### PR TITLE
Fix: show optimistic message bubble before first thread fetch

### DIFF
--- a/.changeset/just-chat-bubble-loading.md
+++ b/.changeset/just-chat-bubble-loading.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix Just chat so your first message bubble shows immediately instead of the session flashing empty.

--- a/src/shell/controllers/use-start-surface-controller.ts
+++ b/src/shell/controllers/use-start-surface-controller.ts
@@ -20,12 +20,14 @@ import {
 	moveLocalWorkspaceToWorktree,
 	prewarmSlashCommandsForRepo,
 	type RepositoryCreateOption,
+	type ThreadMessageLike,
 	type WorkspaceBranchIntent,
 	type WorkspaceDetail,
 	type WorkspaceMode,
 } from "@/lib/api";
 import { extractError } from "@/lib/errors";
 import { helmorQueryKeys } from "@/lib/query-client";
+import { sessionThreadCacheKey } from "@/lib/session-thread-cache";
 import {
 	type AppSettings,
 	readRepoPreference,
@@ -547,6 +549,13 @@ export function useStartSurfaceController(
 					queryClient.setQueryData<WorkspaceDetail | null>(
 						helmorQueryKeys.workspaceDetail(workspaceId),
 						(existing) => existing ?? synthetic,
+					);
+					// Seed an empty thread so the panel's
+					// `messagesQuery.data === undefined` gate doesn't suppress the
+					// optimistic user bubble before the first DB fetch lands.
+					queryClient.setQueryData<ThreadMessageLike[]>(
+						sessionThreadCacheKey(sessionId),
+						(existing) => existing ?? [],
 					);
 				}
 


### PR DESCRIPTION
## Summary
When a user starts a new Just chat session, the first message bubble now shows immediately (optimistically) instead of waiting for the thread to be fetched from the database. This prevents the session from appearing empty when it first loads.

## What changed
- Seed an empty thread in the React Query cache when creating a new session
- This unblocks the chat panel's rendering logic, which was previously suppressed when `messagesQuery.data === undefined`
- Added import for `sessionThreadCacheKey` utility

## Why
Users saw a brief flash of an empty session before the thread messages loaded from the database. By seeding the cache with an empty array, the optimistic UI can show immediately while the first fetch is in-flight.

## Test notes
Verify that starting a new Just chat session shows the user's message bubble right away without a flash of emptiness.