### PR TITLE
Add Gemma 4 12B to Local LLM installer

### DIFF
--- a/.announcements/agent-scratch-artifacts.json
+++ b/.announcements/agent-scratch-artifacts.json
@@ -1,0 +1,7 @@
+{
+	"items": [
+		{
+			"text": "Agents now keep research notes and other scratch artifacts out of workspace Changes."
+		}
+	]
+}

--- a/.announcements/gemma-4-local-model.json
+++ b/.announcements/gemma-4-local-model.json
@@ -1,0 +1,11 @@
+{
+	"items": [
+		{
+			"text": "Gemma 4 12B is now available in the Local LLM installer.",
+			"action": {
+				"label": "Open Experimental",
+				"value": { "type": "openSettings", "section": "experimental" }
+			}
+		}
+	]
+}

--- a/.changeset/clean-agent-scratch-files.md
+++ b/.changeset/clean-agent-scratch-files.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Tell agents to keep research notes and other scratch artifacts under `.agent-contexts/` so temporary files stay out of workspace Changes.

--- a/.changeset/fresh-gemma-model.md
+++ b/.changeset/fresh-gemma-model.md
@@ -1,0 +1,5 @@
+---
+"helmor": minor
+---
+
+Add Gemma 4 12B to the Local LLM installer so it can be downloaded and used by Helmor's local model features.

--- a/sidecar/scripts/stage-vendor.ts
+++ b/sidecar/scripts/stage-vendor.ts
@@ -89,13 +89,13 @@ const CLAUDE_CODE_SHA256: Readonly<
 // the upstream zip on first run; see DEV-fallback notes in
 // `downloadAndVerifyLlama`). Wipe sidecar/.bundle-cache when bumping
 // so the new archive isn't blocked by a wrong-sha cached copy.
-const LLAMA_VERSION = "b9294";
+const LLAMA_VERSION = "b9496";
 // Leave entries blank to skip strict verification during local dev —
 // stage-vendor will warn + trust HTTPS, print the computed sha, and
 // proceed. Fill these in (and commit) to lock the build in CI.
 const LLAMA_SHA256: Readonly<{ arm64: string; x64: string }> = {
-	arm64: "8cb59947211ac84f84a3afe6db83e6b8167ef24e70ca3dde199df48ff6591e44",
-	x64: "72ba8001fe1ec75ff6d5fd0fe5be244f25d4c560c2501abbcfcbbfbac6b2d1c1",
+	arm64: "f1eff7bb49590d80706b84e82e973a21f0bedb49560fbabfea2654756aa59dca",
+	x64: "0b415c8d366eabe9ab69fe7d8e79f29b63cc1baa33714967ca8a0c123ae75797",
 };
 
 // ---------------------------------------------------------------------------

--- a/src-tauri/src/agents/system_prompt.rs
+++ b/src-tauri/src/agents/system_prompt.rs
@@ -144,7 +144,13 @@ pub fn build_helmor_system_prompt(ctx: &HelmorSystemPromptContext) -> String {
     }
 
     out.push_str(
-        "\nIf you need a scratch directory to leave files for other agents in this workspace (or for your own future sessions), use `<workspace_root>/.agent-contexts/`. It is gitignored via the repo-local exclude file, so anything you write there stays out of every diff.\n",
+        "\nFor any agent-created temporary or supporting files that are not intended as product changes, use `<workspace_root>/.agent-contexts/<short-task-slug>/`. This includes web-research notes, plans, findings, downloaded snippets, screenshots, logs, intermediate reports, and files meant for other agents or future sessions.\n",
+    );
+    out.push_str(
+        "\nDo not create top-level scratch or research directories in the workspace root, such as `research_*`, `notes/`, `tmp/`, or `artifacts/`, unless the user explicitly asks for repo-tracked files there.\n",
+    );
+    out.push_str(
+        "\nBefore finalizing, run `git status --short`; move any accidental scratch artifacts outside `.agent-contexts/` into `.agent-contexts/`, or remove them if they are no longer needed. `.agent-contexts/` is gitignored via the repo-local exclude file, so anything you write there stays out of every diff.\n",
     );
 
     let _ = write!(
@@ -271,6 +277,9 @@ mod tests {
         let prompt = build_helmor_system_prompt(&ctx_with_defaults());
         assert!(prompt.contains(".agent-contexts/"));
         assert!(prompt.contains("gitignored"));
+        assert!(prompt.contains("web-research notes"));
+        assert!(prompt.contains("Do not create top-level scratch or research directories"));
+        assert!(prompt.contains("git status --short"));
     }
 
     /// The prompt points the agent at the CLI's own `--help` instead

--- a/src-tauri/src/local_llm/catalog.rs
+++ b/src-tauri/src/local_llm/catalog.rs
@@ -1,7 +1,7 @@
 //! Curated LLM catalog driving the Local LLM settings panel. The
 //! downloads manager (via `CatalogAssetProvider`) reads this list to
 //! know what to fetch / verify; the panel renders the entries as a
-//! dropdown of pickable Qwen variants.
+//! dropdown of pickable model variants.
 //!
 //! Adding an entry = append to `catalog()`. The unit tests in this
 //! file enforce uniqueness + RAM-tier ordering so accidental catalog
@@ -66,8 +66,8 @@ impl CatalogEntry {
     }
 }
 
-/// Curated catalog. Sorted by `recommended_for_gb` ascending. Every Qwen
-/// 3.5+ row also pulls the F16 mmproj from the same repo so llama-server
+/// Curated catalog. Sorted by `recommended_for_gb` ascending. Multimodal
+/// rows also pull a projector GGUF from the same repo so llama-server
 /// boots with vision enabled.
 pub fn catalog() -> Vec<CatalogEntry> {
     vec![
@@ -84,6 +84,20 @@ pub fn catalog() -> Vec<CatalogEntry> {
             kind: ModelKind::Llm,
             mmproj_file: Some("mmproj-F16.gguf".into()),
             mmproj_bytes: 672_423_616,
+        },
+        CatalogEntry {
+            id: "gemma4-12b-q4".into(),
+            repo: "unsloth/gemma-4-12b-it-GGUF".into(),
+            files: vec!["gemma-4-12b-it-Q4_K_M.gguf".into()],
+            label: "Gemma 4 12B".into(),
+            quant: "Q4_K_M".into(),
+            bytes: 7_121_860_000,
+            min_ram_gb: 16,
+            recommended_for_gb: 24,
+            blurb: "Latest Gemma 4 unified model — reasoning, coding, multimodal input.".into(),
+            kind: ModelKind::Llm,
+            mmproj_file: Some("mmproj-F16.gguf".into()),
+            mmproj_bytes: 122_031_680,
         },
         CatalogEntry {
             id: "qwen35-9b-q4".into(),


### PR DESCRIPTION
## Summary
- Add Gemma 4 12B Q4_K_M to the Local LLM catalog with its optional mmproj projector
- Upgrade bundled llama.cpp to b9496 for Gemma 4 12B runtime support
- Strengthen Helmor's agent context prompt so research notes and scratch artifacts stay under .agent-contexts/ instead of polluting workspace Changes
- Add Changesets and in-app announcement fragments for both user-visible changes

## Verification
- bun run typecheck
- cd src-tauri && cargo fmt --check
- cd src-tauri && cargo test local_llm::
- cd src-tauri && cargo test agents::system_prompt
- cd sidecar && bun run stage-vendor
- sidecar/dist/vendor/llama-cpp/llama-server --version
- jq empty .announcements/agent-scratch-artifacts.json
- pre-commit hook: biome, cargo fmt, cargo clippy -- -D warnings