### PR TITLE
feat(macos): add always-on-top menu & update mini-window shortcut

### DIFF
--- a/.announcements/mini-window-layout.json
+++ b/.announcements/mini-window-layout.json
@@ -1,7 +1,7 @@
 {
 	"items": [
 		{
-			"text": "Use Command+M or the header resize button to switch Helmor between desktop and mini window sizes."
+			"text": "Use Command+Control+M or the header resize button to switch Helmor between desktop and mini window sizes."
 		},
 		{
 			"text": "On narrow windows, the sidebars now peek in from the edges so the workspace stays full width."

--- a/.changeset/mini-window-layout.md
+++ b/.changeset/mini-window-layout.md
@@ -3,6 +3,6 @@
 ---
 
 Add a mini window layout for narrow workflows:
-- Add a resize control and Command+M shortcut for switching between desktop and mini window sizes.
+- Add a resize control and Command+Control+M shortcut for switching between desktop and mini window sizes.
 - Turn the sidebars into responsive edge drawers on narrow windows so the main workspace stays full width.
 - Move compact header actions into a More menu when the window is close to mobile size.

--- a/.changeset/window-always-on-top.md
+++ b/.changeset/window-always-on-top.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Add an Always on Top toggle in the Window menu to keep Helmor floating above other apps.

--- a/src-tauri/src/commands/system_commands.rs
+++ b/src-tauri/src/commands/system_commands.rs
@@ -1013,6 +1013,10 @@ pub fn enter_mini_window_mode(window: Window) -> CmdResult<()> {
     window
         .set_resizable(false)
         .context("Failed to disable mini window resizing")?;
+    // Resizing/centering drops the webview's keyboard focus on macOS, which
+    // kills the JS keydown listener until the user clicks back in. Re-focus
+    // so the toggle shortcut keeps working without a manual click.
+    let _ = window.set_focus();
 
     Ok(())
 }
@@ -1048,6 +1052,9 @@ pub fn exit_mini_window_mode(window: Window) -> CmdResult<()> {
             .set_resizable(true)
             .context("Failed to restore window resizing")?;
     }
+    // See enter_mini_window_mode: restore keyboard focus after resizing so the
+    // toggle shortcut stays live.
+    let _ = window.set_focus();
 
     Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -790,10 +790,13 @@ fn emit_quit_requested(app_handle: &tauri::AppHandle) {
 
 const HELMOR_QUIT_MENU_ID: &str = "helmor-quit";
 const HELMOR_CLOSE_CURRENT_SESSION_MENU_ID: &str = "helmor-close-current-session";
+const HELMOR_ALWAYS_ON_TOP_MENU_ID: &str = "helmor-always-on-top";
 
 #[cfg(target_os = "macos")]
 fn install_macos_menu(app: &tauri::AppHandle) -> tauri::Result<()> {
-    use tauri::menu::{AboutMetadataBuilder, MenuBuilder, MenuItemBuilder, SubmenuBuilder};
+    use tauri::menu::{
+        AboutMetadataBuilder, CheckMenuItemBuilder, MenuBuilder, MenuItemBuilder, SubmenuBuilder,
+    };
 
     let close_current_session_item = MenuItemBuilder::with_id(
         HELMOR_CLOSE_CURRENT_SESSION_MENU_ID,
@@ -801,6 +804,13 @@ fn install_macos_menu(app: &tauri::AppHandle) -> tauri::Result<()> {
     )
     .accelerator("Cmd+W")
     .build(app)?;
+
+    // Lets the user float the window above other apps. Decoupled from mini
+    // mode — purely a manual toggle, the check mark is the source of truth.
+    let always_on_top_item =
+        CheckMenuItemBuilder::with_id(HELMOR_ALWAYS_ON_TOP_MENU_ID, "Always on Top")
+            .checked(false)
+            .build(app)?;
 
     let quit_item = MenuItemBuilder::with_id(HELMOR_QUIT_MENU_ID, "Quit Helmor")
         .accelerator("Cmd+Q")
@@ -837,6 +847,7 @@ fn install_macos_menu(app: &tauri::AppHandle) -> tauri::Result<()> {
         .minimize()
         .maximize()
         .separator()
+        .item(&always_on_top_item)
         .item(&close_current_session_item)
         .build()?;
 
@@ -850,6 +861,16 @@ fn install_macos_menu(app: &tauri::AppHandle) -> tauri::Result<()> {
     app.on_menu_event(move |_, event| match event.id().0.as_str() {
         HELMOR_QUIT_MENU_ID => emit_quit_requested(&handle),
         HELMOR_CLOSE_CURRENT_SESSION_MENU_ID => emit_close_current_session_requested(&handle),
+        HELMOR_ALWAYS_ON_TOP_MENU_ID => {
+            // muda toggles the check mark before firing, so is_checked() is
+            // already the desired post-click state.
+            let checked = always_on_top_item.is_checked().unwrap_or(false);
+            if let Some(window) = handle.get_webview_window("main") {
+                if let Err(error) = window.set_always_on_top(checked) {
+                    tracing::warn!(error = %error, "Failed to set always-on-top from menu");
+                }
+            }
+        }
         _ => {}
     });
 

--- a/src/App.shortcuts.test.tsx
+++ b/src/App.shortcuts.test.tsx
@@ -759,7 +759,7 @@ describe("App global navigation shortcuts", () => {
 		await screen.findByRole("heading", { name: "Contexts" });
 	});
 
-	it("resizes the window on Command+M", async () => {
+	it("resizes the window on Command+Control+M", async () => {
 		const invokeMock = vi.mocked(invoke);
 		await renderAppReady();
 		invokeMock.mockClear();
@@ -768,6 +768,7 @@ describe("App global navigation shortcuts", () => {
 			key: "m",
 			code: "KeyM",
 			metaKey: true,
+			ctrlKey: true,
 		});
 
 		await waitFor(() => {
@@ -778,6 +779,7 @@ describe("App global navigation shortcuts", () => {
 			key: "m",
 			code: "KeyM",
 			metaKey: true,
+			ctrlKey: true,
 		});
 
 		await waitFor(() => {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -417,7 +417,7 @@ describe("App", () => {
 
 		const tooltip = await screen.findByRole("tooltip");
 		expect(tooltip).toHaveTextContent("Resize window");
-		expect(tooltip).toHaveTextContent("⌘M");
+		expect(tooltip).toHaveTextContent("⌘⌃M");
 	});
 
 	it("resizes the inspector sidebar and persists the width", async () => {

--- a/src/features/shortcuts/registry.ts
+++ b/src/features/shortcuts/registry.ts
@@ -221,7 +221,7 @@ export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
 		id: "window.miniMode.toggle",
 		title: "Toggle mini mode",
 		group: "System",
-		defaultHotkey: "Mod+M",
+		defaultHotkey: "Mod+Control+M",
 		scopes: ["app"],
 		editable: true,
 	},

--- a/src/shell/components/workspace-header-actions.tsx
+++ b/src/shell/components/workspace-header-actions.tsx
@@ -157,7 +157,7 @@ export function WorkspaceHeaderActions({
 				</div>
 			) : null}
 			<div className="flex -translate-x-px items-center gap-1">
-				<div className="max-[640px]:hidden">
+				<div className="flex items-center max-[640px]:hidden">
 					<ExportSessionImageButton sessionId={sessionId} />
 				</div>
 				<DropdownMenu>


### PR DESCRIPTION
## Summary

Add an Always on Top window menu toggle and update the mini window shortcut to avoid conflicts.

- Adds an **Always on Top** toggle in the Window menu to keep Helmor floating above other apps. Useful for reference windows while coding elsewhere.
- Changes mini window toggle shortcut from **Cmd+M** to **Cmd+Control+M** to avoid conflict with the system mute shortcut.
- Restores keyboard focus after mini window mode transitions so the toggle shortcut remains responsive without a manual click.

## Test plan

- [ ] Open Window menu and verify "Always on Top" appears with a checkbox
- [ ] Click "Always on Top" — window floats; uncheck to return normal stacking
- [ ] Press Cmd+Control+M to toggle mini window mode multiple times; verify keyboard shortcuts remain responsive
- [ ] Verify that regular Cmd+M (mute) can be used without triggering mini mode