### PR TITLE
fix: allow first turn to dispatch after workspace navigation

### DIFF
--- a/.changeset/swift-foxes-whisper.md
+++ b/.changeset/swift-foxes-whisper.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix a task started from the start page never actually running — while still showing as working in the sidebar — when you immediately switch to another workspace before it finishes setting up.

--- a/src/features/conversation/hooks/use-streaming.ts
+++ b/src/features/conversation/hooks/use-streaming.ts
@@ -649,12 +649,17 @@ export function useConversationStreaming({
 				sessionId: string;
 				workspaceId: string | null;
 				contextKey: string;
+				// Pin the target repo for the preference prefix; absent → use
+				// the displayed repo.
+				repoId?: string | null;
 			},
 		) => {
 			const isOverride = override !== undefined;
 			const targetSessionId = override?.sessionId ?? displayedSessionId;
 			const targetWorkspaceId = override?.workspaceId ?? displayedWorkspaceId;
 			const targetContextKey = override?.contextKey ?? composerContextKey;
+			const targetRepoId =
+				override && "repoId" in override ? override.repoId : repoId;
 
 			const trimmedPrompt = prompt.trim();
 			// `selectionPending` is a UI-only guard (user clicked a session
@@ -829,7 +834,9 @@ export function useConversationStreaming({
 			const isFirstUserMessage =
 				(currentThread ?? []).every((message) => message.role !== "user") &&
 				(currentTitle == null || currentTitle === "Untitled");
-			const repoPreferences = repoId ? await loadRepoPreferences(repoId) : null;
+			const repoPreferences = targetRepoId
+				? await loadRepoPreferences(targetRepoId)
+				: null;
 			// The general-preference preamble is prepended ONLY on the wire
 			// to the agent (Rust side stitches it onto `prompt_prefix`).
 			// `trimmedPrompt` is what the user typed — that's what we
@@ -1000,9 +1007,9 @@ export function useConversationStreaming({
 					error,
 					"Failed to send message.",
 				);
-				if (isRecoverableByPurge(code) && displayedWorkspaceId) {
+				if (isRecoverableByPurge(code) && targetWorkspaceId) {
 					showWorkspaceBrokenToast({
-						workspaceId: displayedWorkspaceId,
+						workspaceId: targetWorkspaceId,
 						pushToast,
 						queryClient,
 					});

--- a/src/features/conversation/index.test.tsx
+++ b/src/features/conversation/index.test.tsx
@@ -68,6 +68,9 @@ function renderContainer(
 		busySessionIds?: Set<string>;
 		stoppableSessionIds?: Set<string>;
 		workspaceRootPath?: string | null;
+		displayedWorkspaceId?: string | null;
+		displayedSessionId?: string | null;
+		pendingRepoId?: string | null;
 	} = {},
 ) {
 	const queryClient = new QueryClient({
@@ -78,9 +81,9 @@ function renderContainer(
 		<QueryClientProvider client={queryClient}>
 			<WorkspaceConversationContainer
 				selectedWorkspaceId="workspace-1"
-				displayedWorkspaceId="workspace-1"
+				displayedWorkspaceId={options.displayedWorkspaceId ?? "workspace-1"}
 				selectedSessionId="session-1"
-				displayedSessionId="session-1"
+				displayedSessionId={options.displayedSessionId ?? "session-1"}
 				repoId="repo-1"
 				activeStreams={[]}
 				onSelectSession={vi.fn()}
@@ -91,6 +94,9 @@ function renderContainer(
 					sessionId: "session-1",
 					payload: pendingPayload,
 					finalized: options.finalized ?? true,
+					...(options.pendingRepoId !== undefined
+						? { repoId: options.pendingRepoId }
+						: {}),
 				}}
 				onPendingCreatedWorkspaceSubmitConsumed={onConsumed}
 				busySessionIds={options.busySessionIds}
@@ -143,6 +149,73 @@ describe("WorkspaceConversationContainer", () => {
 			);
 		});
 		expect(onConsumed).toHaveBeenCalledWith("pending-1");
+	});
+
+	it("dispatches even after the user navigated to another workspace before finalize", async () => {
+		// Regression: dispatch was gated on the pending target matching the
+		// displayed workspace, so switching away during finalize stranded the
+		// first turn. It must fire regardless of focus.
+		const onConsumed = vi.fn();
+		const pendingPayload: ComposerSubmitPayload = {
+			prompt: "Build this now",
+			imagePaths: [],
+			filePaths: [],
+			customTags: [],
+			model: MODEL,
+			workingDirectory: "/tmp/new-workspace",
+			effortLevel: "high",
+			permissionMode: "default",
+			fastMode: false,
+		};
+
+		renderContainer(pendingPayload, onConsumed, {
+			displayedWorkspaceId: "workspace-2",
+			displayedSessionId: "session-2",
+		});
+
+		await waitFor(() => {
+			expect(streamingMocks.handleComposerSubmit).toHaveBeenCalledWith(
+				pendingPayload,
+				{
+					sessionId: "session-1",
+					workspaceId: "workspace-1",
+					contextKey: "session:session-1",
+				},
+			);
+		});
+		expect(onConsumed).toHaveBeenCalledWith("pending-1");
+	});
+
+	it("forwards the pending repoId into the override", async () => {
+		const pendingPayload: ComposerSubmitPayload = {
+			prompt: "Build this now",
+			imagePaths: [],
+			filePaths: [],
+			customTags: [],
+			model: MODEL,
+			workingDirectory: "/tmp/new-workspace",
+			effortLevel: "high",
+			permissionMode: "default",
+			fastMode: false,
+		};
+
+		renderContainer(pendingPayload, vi.fn(), {
+			displayedWorkspaceId: "workspace-2",
+			displayedSessionId: "session-2",
+			pendingRepoId: "repo-new",
+		});
+
+		await waitFor(() => {
+			expect(streamingMocks.handleComposerSubmit).toHaveBeenCalledWith(
+				pendingPayload,
+				{
+					sessionId: "session-1",
+					workspaceId: "workspace-1",
+					contextKey: "session:session-1",
+					repoId: "repo-new",
+				},
+			);
+		});
 	});
 
 	it("uses payload.workingDirectory verbatim even when workspaceRootPath is null", async () => {

--- a/src/features/conversation/index.tsx
+++ b/src/features/conversation/index.tsx
@@ -67,6 +67,9 @@ export type PendingCreatedWorkspaceSubmit = {
 	id: string;
 	workspaceId: string;
 	sessionId: string;
+	/** New workspace's repo, forwarded into the first-turn send so the
+	 *  preference prefix stays correct even after navigating away. */
+	repoId?: string | null;
 	payload: ComposerSubmitPayload;
 	/** False until `await finalizePromise` resolves. The optimistic user
 	 *  bubble is rendered as soon as the pending submit is queued, but the
@@ -489,16 +492,10 @@ export const WorkspaceConversationContainer = memo(
 				dispatchedCreatedWorkspaceSubmitRef.current = null;
 				return;
 			}
-			if (
-				pendingCreatedWorkspaceSubmit.workspaceId !== displayedWorkspaceId ||
-				pendingCreatedWorkspaceSubmit.sessionId !== displayedSessionId
-			) {
-				return;
-			}
-			// Hold off until the App-level handler has awaited finalize. The
-			// backend has already written `state=ready` / `setup_pending` by
-			// the time `finalized` flips true — no React Query round-trip
-			// needed before firing the submit.
+			// Not gated on the displayed workspace: the send targets the
+			// pending session via `override`, so it must fire even if the user
+			// navigated away during finalize. Wait for `finalized` though —
+			// the backend row is operational only once it flips true.
 			if (!pendingCreatedWorkspaceSubmit.finalized) {
 				return;
 			}
@@ -523,14 +520,15 @@ export const WorkspaceConversationContainer = memo(
 						pendingCreatedWorkspaceSubmit.workspaceId,
 						pendingCreatedWorkspaceSubmit.sessionId,
 					),
+					...(pendingCreatedWorkspaceSubmit.repoId !== undefined
+						? { repoId: pendingCreatedWorkspaceSubmit.repoId }
+						: {}),
 				});
 				onPendingCreatedWorkspaceSubmitConsumed?.(
 					pendingCreatedWorkspaceSubmit.id,
 				);
 			})();
 		}, [
-			displayedSessionId,
-			displayedWorkspaceId,
 			handleComposerSubmit,
 			onPendingCreatedWorkspaceSubmitConsumed,
 			pendingCreatedWorkspaceSubmit,

--- a/src/shell/controllers/use-start-surface-controller.ts
+++ b/src/shell/controllers/use-start-surface-controller.ts
@@ -573,6 +573,8 @@ export function useStartSurfaceController(
 						id: pendingId,
 						workspaceId: outcome.workspaceId,
 						sessionId: outcome.sessionId,
+						// Pin the new workspace's repo (chat mode has none).
+						repoId: startRepository?.id ?? null,
 						// Local mode already has the cwd; worktree mode patches it
 						// onto the payload below once finalize materialises the
 						// worktree dir. Either way the payload is the single source


### PR DESCRIPTION
## Summary

When a task is started from the start surface and the user navigates to another workspace before the setup completes, the first message dispatch was getting blocked. The task would show as working in the sidebar but never actually run.

## Root Cause

The pending workspace submit dispatch was gated on the displayed workspace matching the pending workspace ID. When a user navigated away during finalization, this condition failed and the dispatch was dropped.

## Changes

1. **Remove workspace-mismatch gating** in `WorkspaceConversationContainer`: The dispatch should fire regardless of which workspace is currently displayed, since it targets the pending session via `override`.

2. **Pin repo preference** via `repoId` in the override: Ensures the correct preference prefix is loaded even after navigation. New workspace creation passes the repo ID through the pending submit.

3. **Add test coverage**:
   - Regression test for workspace navigation during finalize
   - Test for `repoId` forwarding in pending submit

## Test Plan

- [x] Tests pass: `bun run test:frontend`
- [x] Manual: Create task from start surface → switch workspace immediately → verify task runs with correct preferences