### PR TITLE
feat: stacked PR support

### DIFF
--- a/.agents/skills/helmor-cli/SKILL.md
+++ b/.agents/skills/helmor-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: helmor-cli
-description: Use the Helmor CLI to remote-control Helmor from the terminal. Use when the user asks to inspect Helmor data/settings, manage repositories/workspaces/sessions/files, send prompts to agents, list models, use GitHub integration, inspect scripts, migrate from Conductor, run Helmor as an MCP server, generate shell completions, quit a running app, check/install/update the Helmor CLI beta, install/update Helmor skills through the beta app flow, or needs the Helmor command reference. Also plan and build a large change as a stack of dependent PRs (`/helmor-cli stack`) and re-sync a stack after lower layers change or merge (`/helmor-cli restack`).
+description: Use the Helmor CLI to remote-control Helmor from the terminal. Use when the user asks to inspect Helmor data/settings, manage repositories/workspaces/sessions/files, send prompts to agents, list models, use GitHub integration, inspect scripts, migrate from Conductor, run Helmor as an MCP server, generate shell completions, quit a running app, check/install/update the Helmor CLI beta, install/update Helmor skills through the beta app flow, or needs the Helmor command reference. Also plan and build a large change as a stack of dependent PRs (`/helmor-cli stack`), split a change you've already written into a stack (`/helmor-cli break`), and re-sync a stack after lower layers change or merge (`/helmor-cli restack`).
 ---
 
 # Helmor CLI
@@ -13,6 +13,7 @@ Route by the first word after `/helmor-cli`:
 
 - `restack` — re-sync a PR stack after a lower layer changed or merged. Follow `references/restack.md`. (This is what the composer's **Restack** button sends.)
 - `stack` — plan and build a large change as a stack of dependent PRs. Follow `references/stacked-pr.md`.
+- `break` — split the change you've ALREADY written in the current workspace into a stack of smaller dependent PRs, confirming the slicing granularity with the user first. Follow `references/break.md`.
 - Anything else (or no argument) — an ordinary Helmor CLI task; use the binary-name guidance and command reference below.
 
 ## Binary Name (Release vs Dev)

--- a/.agents/skills/helmor-cli/SKILL.md
+++ b/.agents/skills/helmor-cli/SKILL.md
@@ -1,11 +1,19 @@
 ---
 name: helmor-cli
-description: Use the Helmor CLI to remote-control Helmor from the terminal. Use when the user asks to inspect Helmor data/settings, manage repositories/workspaces/sessions/files, send prompts to agents, list models, use GitHub integration, inspect scripts, migrate from Conductor, run Helmor as an MCP server, generate shell completions, quit a running app, check/install/update the Helmor CLI beta, install/update Helmor skills through the beta app flow, or needs the Helmor command reference.
+description: Use the Helmor CLI to remote-control Helmor from the terminal. Use when the user asks to inspect Helmor data/settings, manage repositories/workspaces/sessions/files, send prompts to agents, list models, use GitHub integration, inspect scripts, migrate from Conductor, run Helmor as an MCP server, generate shell completions, quit a running app, check/install/update the Helmor CLI beta, install/update Helmor skills through the beta app flow, or needs the Helmor command reference. Also plan and build a large change as a stack of dependent PRs (`/helmor-cli stack`) and re-sync a stack after lower layers change or merge (`/helmor-cli restack`).
 ---
 
 # Helmor CLI
 
 Use this skill to guide simple terminal-first Helmor workflows. Keep the answer practical: prefer one or two concrete commands over a long CLI tutorial.
+
+## Command Routing
+
+Route by the first word after `/helmor-cli`:
+
+- `restack` — re-sync a PR stack after a lower layer changed or merged. Follow `references/restack.md`. (This is what the composer's **Restack** button sends.)
+- `stack` — plan and build a large change as a stack of dependent PRs. Follow `references/stacked-pr.md`.
+- Anything else (or no argument) — an ordinary Helmor CLI task; use the binary-name guidance and command reference below.
 
 ## Binary Name (Release vs Dev)
 

--- a/.agents/skills/helmor-cli/references/break.md
+++ b/.agents/skills/helmor-cli/references/break.md
@@ -6,8 +6,16 @@ it into a stack of small, dependent PRs — **confirming the slicing granularity
 with the user** before committing to anything. The output is the normal stack:
 one workspace + PR per slice, nested in the sidebar.
 
-**Input**: the current workspace's full diff vs its base branch. If the working
-tree is dirty, commit a WIP snapshot first so there's a stable diff to slice.
+**Input**: the current workspace's full diff vs its base branch. The current
+workspace becomes the stack's **root**, so capture a recovery ref before you
+rewrite anything:
+```bash
+git commit -am "WIP: snapshot before break"   # only if the working tree is dirty
+ORIG=$(git rev-parse HEAD)                      # the full change you're slicing
+git branch helmor/break-backup "$ORIG"          # named recovery point
+```
+Source every slice below from `$ORIG` (not the branch name) — once the root is
+reset, the branch no longer points at the full change.
 
 ## Workflow
 
@@ -39,22 +47,34 @@ single file whose changes span concerns (e.g. `utils.ts` with both schema and UI
 helpers): keep it whole in one slice, or flag it for a manual hunk-level split
 (out of scope for v1 — see Limits).
 
-### 4. Materialize the stack (bottom-up)
+### 4. Materialize the stack (bottom-up) — your current workspace becomes the root
+The workspace you're in becomes the **bottom** layer; only the higher layers are
+new workspaces. No throwaway launchpad, nothing to delete afterward.
+
 For each slice K, from the bottom up:
 
-1. Create its workspace:
-   - bottom slice: `helmor workspace new --repo <repo>`
-   - every higher slice: `helmor workspace new --parent <slice K-1 workspace>`
+1. Get the layer's workspace:
+   - **bottom slice (root) = your current workspace** — reset it onto the base and
+     rebuild it as slice 1 only:
+     ```bash
+     git reset --hard <base>                  # e.g. origin/main — the slicing base
+     git checkout "$ORIG" -- <slice-1 added/modified files>
+     git rm <slice-1 deleted files>           # if any
+     git commit -m "<slice 1 title>"
+     ```
+   - **every higher slice**: `helmor workspace new --parent <slice K-1 workspace>`
+     (the first higher layer's `--parent` is your current workspace).
 2. Apply **only slice K's files** onto that layer (it already contains slices
-   1..K-1 because it forked off the layer below):
-   - added / modified files: `git checkout <original-branch> -- <files>`
+   1..K-1 because it forked off the layer below), sourcing from `$ORIG`:
+   - added / modified files: `git checkout "$ORIG" -- <files>`
    - deleted files: `git rm <files>`
    - then commit with the slice title.
 
-   Drive each layer with a focused dispatch so it works inside its own worktree:
+   Drive each higher layer with a focused dispatch so it works inside its own
+   worktree (pass `$ORIG`'s SHA explicitly; `helmor/break-backup` resolves it too):
    ```bash
-   helmor send --workspace <id> --plan "Apply ONLY these files from branch <original>: <list>. \
-   Added/modified: git checkout <original> -- <files>. Deleted: git rm <files>. \
+   helmor send --workspace <id> --plan "Apply ONLY these files from <ORIG-sha>: <list>. \
+   Added/modified: git checkout <ORIG-sha> -- <files>. Deleted: git rm <files>. \
    Commit as '<title>'. Do not touch anything else."
    ```
 
@@ -64,16 +84,18 @@ original change exactly.
 ### 5. Verify lossless
 The stack must reproduce the original exactly:
 ```bash
-git diff <original-branch> <top-layer-branch>
+git diff "$ORIG" <top-layer-branch>
 ```
 **This must be empty.** Empty = the top of the stack has the same tree as the
-original → nothing was dropped or duplicated. If it is not empty, report the
-difference and STOP — the slicing missed or double-counted something.
+original → nothing was dropped or duplicated. If it is **not** empty, STOP and
+report the difference — and restore the root with `git reset --hard helmor/break-backup`.
 
 ### 6. Hand off
-You now have N stacked workspaces (`helmor workspace stack <top>` shows the
-chain; the sidebar nests them). Open PRs bottom-up. The **original workspace is
-left untouched** — archive it once you've confirmed the split is faithful.
+Your current workspace is now the stack's **root**; the higher layers are the
+only new workspaces (`helmor workspace stack <top>` shows the chain; the sidebar
+nests them). Open PRs bottom-up. Consider retitling the root to its slice-1
+title. Once you've confirmed the split is faithful, the recovery branch is yours
+to keep or drop (`git branch -D helmor/break-backup`).
 
 ## Limits (v1)
 - **File-level slices only**: a file goes wholesale into one slice. Splitting a
@@ -81,4 +103,8 @@ left untouched** — archive it once you've confirmed the split is faithful.
   such files in step 3 and keep them in one slice.
 - Slices must **partition** all changed files; the step-5 lossless check
   enforces it.
-- **Non-destructive**: never delete or rewrite the original workspace's branch.
+- **Root = your current workspace**: its branch is rewritten in place to become
+  slice 1. The full change stays recoverable at `helmor/break-backup` (and is
+  reproduced at the stack tip + checked in step 5), so it's safe — but unlike a
+  fresh-stack build, the starting branch *is* rewritten. Higher layers are new
+  workspaces.

--- a/.agents/skills/helmor-cli/references/break.md
+++ b/.agents/skills/helmor-cli/references/break.md
@@ -1,0 +1,84 @@
+# `/helmor-cli break` — split an existing change into a stack
+
+`break` is the mirror of `stack`: instead of planning a stack from scratch, it
+takes the change you've **already written** in the current workspace and carves
+it into a stack of small, dependent PRs — **confirming the slicing granularity
+with the user** before committing to anything. The output is the normal stack:
+one workspace + PR per slice, nested in the sidebar.
+
+**Input**: the current workspace's full diff vs its base branch. If the working
+tree is dirty, commit a WIP snapshot first so there's a stable diff to slice.
+
+## Workflow
+
+### 1. Analyze the diff
+```bash
+git diff --name-status <base>...
+```
+(`<base>` is the workspace's target branch, e.g. `origin/main` — the system
+prompt tells you which.) Read the changed files and their add/modify/delete
+status, and group them by concern (schema/data, backend/API, UI, tests, docs…).
+
+### 2. Propose a slicing
+Build a **dependency-ordered** list of slices (bottom depends on nothing new;
+top depends on everything below), e.g. `db → api → ui`. For each slice give: a
+title, the files it contains, and the one-line reason it depends on the slice
+below. Show the full proposal.
+
+### 3. Confirm granularity WITH the user — the point of `break`
+Do NOT auto-split. Present the proposal and let the user steer the granularity
+with structured choices:
+- **Approve** as-is.
+- **Coarser** — merge two adjacent slices.
+- **Finer** — split a slice (e.g. pull tests into their own layer).
+- **Move a file** — reassign a file to a different slice.
+- **Reorder** — fix the dependency order.
+
+Loop until the user approves. Also **proactively ask** about ambiguous files — a
+single file whose changes span concerns (e.g. `utils.ts` with both schema and UI
+helpers): keep it whole in one slice, or flag it for a manual hunk-level split
+(out of scope for v1 — see Limits).
+
+### 4. Materialize the stack (bottom-up)
+For each slice K, from the bottom up:
+
+1. Create its workspace:
+   - bottom slice: `helmor workspace new --repo <repo>`
+   - every higher slice: `helmor workspace new --parent <slice K-1 workspace>`
+2. Apply **only slice K's files** onto that layer (it already contains slices
+   1..K-1 because it forked off the layer below):
+   - added / modified files: `git checkout <original-branch> -- <files>`
+   - deleted files: `git rm <files>`
+   - then commit with the slice title.
+
+   Drive each layer with a focused dispatch so it works inside its own worktree:
+   ```bash
+   helmor send --workspace <id> --plan "Apply ONLY these files from branch <original>: <list>. \
+   Added/modified: git checkout <original> -- <files>. Deleted: git rm <files>. \
+   Commit as '<title>'. Do not touch anything else."
+   ```
+
+Result: layer K = base + slices 1..K (cumulative); the top layer reproduces the
+original change exactly.
+
+### 5. Verify lossless
+The stack must reproduce the original exactly:
+```bash
+git diff <original-branch> <top-layer-branch>
+```
+**This must be empty.** Empty = the top of the stack has the same tree as the
+original → nothing was dropped or duplicated. If it is not empty, report the
+difference and STOP — the slicing missed or double-counted something.
+
+### 6. Hand off
+You now have N stacked workspaces (`helmor workspace stack <top>` shows the
+chain; the sidebar nests them). Open PRs bottom-up. The **original workspace is
+left untouched** — archive it once you've confirmed the split is faithful.
+
+## Limits (v1)
+- **File-level slices only**: a file goes wholesale into one slice. Splitting a
+  single file's changes across slices (hunk-level) isn't supported yet — flag
+  such files in step 3 and keep them in one slice.
+- Slices must **partition** all changed files; the step-5 lossless check
+  enforces it.
+- **Non-destructive**: never delete or rewrite the original workspace's branch.

--- a/.agents/skills/helmor-cli/references/restack.md
+++ b/.agents/skills/helmor-cli/references/restack.md
@@ -1,0 +1,30 @@
+# `/helmor-cli restack` — re-sync a PR stack after lower layers changed
+
+Restack propagates changes **up** a stack: after a lower layer gets new commits (or merges), every layer above it is out of date and must pull the new base. This is the "brain" behind the composer's **Restack** button (it appears on a stack tip and sends `/helmor-cli restack`).
+
+In Helmor each layer's target branch is its parent's branch, so restacking = syncing each layer with its parent, **bottom-up**. v1 is **merge-based** — no rebase, no force-push — matching `helmor workspace sync`.
+
+## Workflow
+
+### 1. Map the stack
+Run `helmor workspace stack <current-workspace-ref>` (add `--json` to parse) to see the full chain root → tip: each layer's branch, target, PR, and status. You're typically invoked from the tip.
+
+### 2. Sync bottom-up
+Walk the chain from the **bottom up** (skip the root — its base is `main`, not another layer). For each layer in order:
+
+1. If the layer below has local commits the child still needs on its remote, push it first: `helmor workspace push <lower-ref>`.
+2. Pull the parent's latest into this layer: `helmor workspace sync <this-ref>` — merges this layer's target (its parent's branch) in.
+
+`sync` reports an outcome: `Updated`, `AlreadyUpToDate`, `Conflict`, or `StashPopConflict`.
+
+### 3. Stop on conflict
+If any `sync` reports a conflict, **STOP**. Tell the user which layer conflicted and the files involved — do **not** try to auto-resolve. Let them resolve in that workspace, then re-run `/helmor-cli restack`.
+
+### 4. Report
+Summarize per layer (synced / already up to date / conflicted) and name the next layer to review.
+
+## Notes
+- Restack is **manual** for now (the button or this command). Automatic restack-on-merge is a planned Helmor feature.
+- Never rebase or force-push in v1 — stay merge-based via `helmor workspace sync`.
+- When the bottom PR merges into `main`, the next layer should re-target `main` before syncing: `helmor workspace target-branch set <ref> main`, then `helmor workspace sync <ref>`.
+- Stop for the user before any risky git operation (dirty worktrees, multi-branch pushes, conflict resolution).

--- a/.agents/skills/helmor-cli/references/stack-spec.md
+++ b/.agents/skills/helmor-cli/references/stack-spec.md
@@ -1,0 +1,72 @@
+# Stack spec — format & canonical diagram
+
+The `stacked-pr` skill renders its diagram from a JSON **stack spec** via
+`scripts/render_stack.py`. The renderer derives all column widths from the
+data, so every stack comes out in the same shape. Do not hand-draw the
+diagram — always render through the script so output is byte-for-byte
+consistent.
+
+## Spec shape
+
+Layers are ordered **tip → root** — the newest PR (top of the stack) first,
+the base-most PR last.
+
+```json
+{
+  "name": "dark-mode",
+  "repo": "helmor/uranus",
+  "base": "main",
+  "layers": [
+    {"pr": "483", "title": "feat: dark mode toggle",  "state": "draft",  "ws": "dark-mode-ui"},
+    {"pr": "482", "title": "feat: persist theme pref", "state": "open",   "ws": "dark-mode-api"},
+    {"pr": "481", "title": "feat: add theme column",   "state": "merged", "ws": "dark-mode-schema"}
+  ]
+}
+```
+
+| Field        | Meaning |
+| ------------ | ------- |
+| `name`       | Short stack name (e.g. the feature). |
+| `repo`       | `owner/name` slug, shown in the header. |
+| `base`       | The branch the bottom of the stack targets (usually `main`). |
+| `layers[]`   | Ordered tip → root. |
+| `layers[].pr`    | PR number as a string. Empty/omitted = no PR opened yet (lazy growth) → renders as `—`. |
+| `layers[].title` | The PR / commit title. |
+| `layers[].state` | One of `merged` · `open` · `draft` · `closed` · `none`. |
+| `layers[].ws`    | The Helmor workspace (directory) name for this layer. |
+
+The `base ◂` pointer for each layer is **derived**: it points at the PR of the
+layer immediately below, and the bottom layer points at `base`. The `← HEAD`
+marker is always on `layers[0]` (the tip).
+
+## State glyphs (legend)
+
+| Glyph | State |
+| ----- | ----- |
+| `✓`   | merged |
+| `◉`   | open or draft (has a live PR) |
+| `✕`   | closed |
+| `○`   | no PR opened yet |
+
+## Canonical output (style A)
+
+Running the spec above produces exactly:
+
+```text
+stack: dark-mode · helmor/uranus · 3 PRs
+
+◉ #483  feat: dark mode toggle      draft    ← HEAD
+│  └ ws: dark-mode-ui      base ◂ #482
+│
+◉ #482  feat: persist theme pref    open
+│  └ ws: dark-mode-api     base ◂ #481
+│
+✓ #481  feat: add theme column      merged
+│  └ ws: dark-mode-schema  base ◂ main
+┴ main
+```
+
+Read it top-down: the tip (`#483`, newest) is on top and sorts into the
+sidebar normally; each lower PR is the base of the one above it; `main` is the
+stack's foundation at the bottom. This is the textual twin of how the Helmor
+sidebar groups the stack's workspaces.

--- a/.agents/skills/helmor-cli/references/stacked-pr.md
+++ b/.agents/skills/helmor-cli/references/stacked-pr.md
@@ -1,0 +1,50 @@
+# `/helmor-cli stack` — plan & build a stacked PR
+
+Turn a large change into a **stack of small, dependent PRs** — each PR builds on the one below instead of all branching from `main`. This keeps every PR small and reviewable while you keep moving, without waiting for the previous one to merge.
+
+In Helmor a stack is a **chain of workspaces**: one workspace = one branch = one PR, linked by `parentWorkspaceId`. The sidebar groups a stack's workspaces together (tip on top, base at the bottom); `gh pr create --base` automatically targets the parent branch.
+
+## Workflow
+
+### 1. Investigate prior art FIRST
+Before proposing a stack, check whether related work already exists, so you **extend** it instead of duplicating it.
+
+- `helmor workspace list --json` — scan open workspaces for related branches or an in-flight stack (rows in the same repo, or already linked by a parent).
+- `helmor workspace stack <ref>` — if a candidate is already stacked, see its whole chain.
+- `helmor workspace show <ref>` — inspect a candidate's branch, target, and PR.
+- `gh pr list` / search the repo — find related open PRs and code.
+
+Report what you found in one line, e.g. *"you already have open PR #481 adding the schema column — the stack can start on top of it"* — that beats starting from scratch.
+
+### 2. Decompose into an ordered stack
+Break the task into the **smallest sequence of PRs where each depends only on the ones below it**. Order bottom-up by dependency, e.g. data/schema → backend → UI. For each layer, state the one-line reason it depends on the layer below.
+
+### 3. Render the plan — always, deterministically
+Always render through the bundled script so the diagram is byte-for-byte identical every time — **never hand-draw the ASCII**. Two sources, one renderer:
+
+- **From a stack that already exists** (workspaces are created): pipe the live data straight through —
+  ```bash
+  helmor workspace stack <ref> --json | python3 scripts/render_stack.py -
+  ```
+- **From a plan you're proposing** (nothing created yet): build a JSON stack spec (see `references/stack-spec.md`, layers ordered tip → root) and render it —
+  ```bash
+  python3 scripts/render_stack.py /path/to/spec.json
+  ```
+
+(Sanity-check the renderer any time with `python3 scripts/render_stack.py --selfcheck`.) Show the rendered stack to the user before creating anything.
+
+### 4. Grow the stack lazily — one layer at a time
+Do **not** create every workspace up front (you'll guess the decomposition wrong before you've learned anything). Create the **bottom** layer, build it, then grow upward as each layer stabilizes:
+
+- **Bottom of the stack** (base = repo default): `helmor workspace new --repo <repo>`
+- **Each higher layer** (forks off the layer below; its PR targets the parent): `helmor workspace new --parent <lower-workspace-ref>`
+
+`--parent` records `parentWorkspaceId` **and** materializes the child's target branch to the parent's branch — so the sidebar nests the stack and `gh pr create --base` targets the parent with no extra steps. The child forks off the parent's branch tip (published `origin/<branch>` if pushed, else the local tip), so you can stack before pushing.
+
+### 5. Ship bottom-up
+Ship and merge the **bottom** PR first. After a lower layer changes or merges, re-sync the layers above it with `/helmor-cli restack` (see `references/restack.md`).
+
+## Notes
+- Keep each PR small and independently reviewable — that's the whole point of stacking.
+- The diagram from step 3 is the **textual twin** of the sidebar's stack grouping — same order (tip on top, base at the bottom). Keep them consistent by always rendering through the script.
+- A stack is single-repo: every layer lives in the same repository as its parent.

--- a/.agents/skills/helmor-cli/references/stacked-pr.md
+++ b/.agents/skills/helmor-cli/references/stacked-pr.md
@@ -36,8 +36,8 @@ Always render through the bundled script so the diagram is byte-for-byte identic
 ### 4. Grow the stack lazily — one layer at a time
 Do **not** create every workspace up front (you'll guess the decomposition wrong before you've learned anything). Create the **bottom** layer, build it, then grow upward as each layer stabilizes:
 
-- **Bottom of the stack** (base = repo default): `helmor workspace new --repo <repo>`
-- **Each higher layer** (forks off the layer below; its PR targets the parent): `helmor workspace new --parent <lower-workspace-ref>`
+- **Bottom of the stack** = **your current workspace** (the one you're running in). It already targets the repo's default branch, so build the first layer's change directly here — do NOT spin up a separate `--repo` workspace for the base. The workspace you started from becomes the stack's root, instead of being left behind as an empty launchpad to delete later.
+- **Each higher layer** (forks off the layer below; its PR targets the parent): `helmor workspace new --parent <lower-workspace-ref>` — the first higher layer's `<lower-workspace-ref>` is your current workspace.
 
 `--parent` records `parentWorkspaceId` **and** materializes the child's target branch to the parent's branch — so the sidebar nests the stack and `gh pr create --base` targets the parent with no extra steps. The child forks off the parent's branch tip (published `origin/<branch>` if pushed, else the local tip), so you can stack before pushing.
 

--- a/.agents/skills/helmor-cli/scripts/render_stack.py
+++ b/.agents/skills/helmor-cli/scripts/render_stack.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Deterministic renderer for the Helmor stacked-PR diagram (canonical style A).
+
+The stacked-pr skill builds a JSON "stack spec" and pipes it through this
+script so the diagram is byte-for-byte identical every time — never hand-drawn
+by the model. Column widths are derived from the data, so any stack renders in
+the same shape.
+
+Usage:
+    python3 render_stack.py spec.json      # render a spec file
+    python3 render_stack.py -              # render a spec from stdin
+    python3 render_stack.py --selfcheck    # verify the canonical sample
+
+Spec shape (layers ordered tip -> root, i.e. newest PR first):
+    {
+      "name": "dark-mode",
+      "repo": "helmor/uranus",
+      "base": "main",
+      "layers": [
+        {"pr": "483", "title": "feat: dark mode toggle",  "state": "draft",  "ws": "dark-mode-ui"},
+        {"pr": "482", "title": "feat: persist theme pref", "state": "open",   "ws": "dark-mode-api"},
+        {"pr": "481", "title": "feat: add theme column",   "state": "merged", "ws": "dark-mode-schema"}
+      ]
+    }
+
+`pr` may be empty for a layer whose PR hasn't been opened yet (lazy growth).
+"""
+
+import json
+import sys
+
+# State glyph legend (matches the locked canonical style A):
+#   ✓ merged   ◉ open / draft (has a live PR)   ✕ closed   ○ no PR yet
+GLYPH = {
+    "merged": "✓",
+    "open": "◉",
+    "draft": "◉",
+    "closed": "✕",
+    "none": "○",
+    "": "○",
+}
+
+
+def render(spec):
+    layers = spec.get("layers", [])
+    base = str(spec.get("base", "main"))
+    name = str(spec.get("name", "stack"))
+    repo = str(spec.get("repo", ""))
+    n = len(layers)
+
+    def pr_str(layer):
+        pr = str(layer.get("pr") or "")
+        return ("#" + pr) if pr else "—"
+
+    prw = max((len(pr_str(l)) for l in layers), default=2)
+    titlew = max((len(str(l.get("title", ""))) for l in layers), default=0) + 4
+    wsw = max((len(str(l.get("ws", ""))) for l in layers), default=0) + 2
+
+    lines = []
+    header = f"stack: {name}"
+    meta = " · ".join(
+        part for part in (repo, f"{n} PR" + ("s" if n != 1 else "")) if part
+    )
+    if meta:
+        header += " · " + meta
+    lines.append(header)
+    lines.append("")
+
+    for i, layer in enumerate(layers):
+        glyph = GLYPH.get(str(layer.get("state", "none")), "○")
+        title = str(layer.get("title", ""))
+        state = str(layer.get("state", ""))
+        main = f"{glyph} {pr_str(layer):<{prw}}  {title:<{titlew}}{state}"
+        if i == 0:
+            main += "    ← HEAD"
+        lines.append(main)
+
+        ws = str(layer.get("ws", ""))
+        if i + 1 < n:
+            lower = layers[i + 1]
+            lower_pr = str(lower.get("pr") or "")
+            base_ref = ("#" + lower_pr) if lower_pr else str(lower.get("ws") or "—")
+        else:
+            base_ref = base
+        lines.append(f"│  └ ws: {ws:<{wsw}}base ◂ {base_ref}")
+        if i < n - 1:
+            lines.append("│")
+
+    lines.append(f"┴ {base}")
+    return "\n".join(lines)
+
+
+SELF_CHECK_SPEC = {
+    "name": "dark-mode",
+    "repo": "helmor/uranus",
+    "base": "main",
+    "layers": [
+        {"pr": "483", "title": "feat: dark mode toggle", "state": "draft", "ws": "dark-mode-ui"},
+        {"pr": "482", "title": "feat: persist theme pref", "state": "open", "ws": "dark-mode-api"},
+        {"pr": "481", "title": "feat: add theme column", "state": "merged", "ws": "dark-mode-schema"},
+    ],
+}
+
+SELF_CHECK_EXPECTED = "\n".join(
+    [
+        "stack: dark-mode · helmor/uranus · 3 PRs",
+        "",
+        "◉ #483  feat: dark mode toggle      draft    ← HEAD",
+        "│  └ ws: dark-mode-ui      base ◂ #482",
+        "│",
+        "◉ #482  feat: persist theme pref    open",
+        "│  └ ws: dark-mode-api     base ◂ #481",
+        "│",
+        "✓ #481  feat: add theme column      merged",
+        "│  └ ws: dark-mode-schema  base ◂ main",
+        "┴ main",
+    ]
+)
+
+
+def selfcheck():
+    got = render(SELF_CHECK_SPEC)
+    if got == SELF_CHECK_EXPECTED:
+        print("render_stack selfcheck OK")
+        return 0
+    print("render_stack selfcheck FAILED\n", file=sys.stderr)
+    print("--- expected ---", file=sys.stderr)
+    print(SELF_CHECK_EXPECTED, file=sys.stderr)
+    print("--- got ---", file=sys.stderr)
+    print(got, file=sys.stderr)
+    return 1
+
+
+def main(argv):
+    if len(argv) < 2:
+        print(__doc__)
+        return 2
+    arg = argv[1]
+    if arg == "--selfcheck":
+        return selfcheck()
+    raw = sys.stdin.read() if arg == "-" else open(arg, encoding="utf-8").read()
+    print(render(json.loads(raw)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.announcements/stacked-prs.json
+++ b/.announcements/stacked-prs.json
@@ -1,0 +1,7 @@
+{
+	"items": [
+		{
+			"text": "You can now build stacked PRs — a chain of small, dependent PRs. Plan one with /helmor-cli stack, or split a change you've already written with /helmor-cli break; the sidebar groups each stack together."
+		}
+	]
+}

--- a/.changeset/stacked-pr-support.md
+++ b/.changeset/stacked-pr-support.md
@@ -1,0 +1,8 @@
+---
+"helmor": minor
+---
+
+Add stacked PR support — work on a chain of small, dependent PRs instead of one big branch:
+- `/helmor-cli stack` plans a large change as a stack of dependent PRs, and `/helmor-cli break` splits a change you've already written into one. Each layer is its own workspace and PR, and the workspace you start from becomes the stack's base.
+- `/helmor-cli restack` re-syncs the layers above after a lower one changes or merges.
+- The sidebar groups a stack's workspaces together, and each layer's header points at the workspace it builds on.

--- a/docs/cli-and-mcp.md
+++ b/docs/cli-and-mcp.md
@@ -35,6 +35,7 @@ helmor repo add /path/to/repo
 helmor workspace list
 helmor workspace show helmor/earth            # human-readable ref
 helmor workspace new --repo helmor
+helmor workspace stack helmor/earth           # show PR stack for a workspace
 helmor session list --workspace helmor/earth
 helmor session new --workspace helmor/earth
 helmor send --workspace helmor/earth "Refactor the auth module"
@@ -70,6 +71,65 @@ Run `helmor mcp` (or `helmor-dev mcp` in debug) to start a stdio MCP server impl
 | `helmor_session_list` | List sessions |
 | `helmor_session_create` | Create session |
 | `helmor_send` | Send prompt to AI agent |
+
+## Agent Commands
+
+Helmor agents understand special commands you can send through `helmor send` or directly in the UI:
+
+### Stacked PR Workflow
+
+Helmor supports building a large change as a **stack of small, dependent PRs** — one workspace = one branch = one PR, linked by `parentWorkspaceId`. Each PR builds on the one below instead of all branching from `main`, keeping every PR small and reviewable while you keep moving.
+
+The agent provides three commands for stacked PR workflows:
+
+- **`/helmor-cli stack`** — Plan and build a large change as a stack of dependent PRs, built one layer at a time. The workspace you start from becomes the stack's base (no throwaway launchpad).
+- **`/helmor-cli break`** — Split a change you've *already written* into a stack, confirming the slicing granularity with you first. The starting workspace becomes the root.
+- **`/helmor-cli restack`** — Re-sync a stack after a lower layer changes or merges. Also triggered by the composer's **Restack** button.
+
+**Stack structure:**
+- Each layer is a workspace with its own branch
+- The sidebar groups stack workspaces together (tip on top → base at bottom) with connector lines
+- A stacked workspace's panel header shows a clickable parent-workspace chip instead of a raw target-branch name
+- `helmor workspace stack <ref>` displays the full PR stack chain
+
+## CLI Commands
+
+### Workspace Commands
+
+#### helmor workspace stack <ref>
+
+Display a workspace's PR stack — shows the whole chain of dependent workspaces from root to tip.
+
+Options:
+- `--json` — Output machine-readable JSON format matching the render_stack.py input spec
+
+Example:
+```bash
+helmor workspace stack helmor/earth
+helmor workspace stack helmor/earth --json | python3 scripts/render_stack.py -
+```
+
+#### helmor workspace new
+
+Create a new workspace, either from a repository or as a stacked workspace on top of an existing workspace.
+
+Syntax:
+```bash
+helmor workspace new [--repo <repo>] [--parent <workspace>]
+```
+
+Either `--repo` OR `--parent` is required:
+- **`--repo <repo>`** — Create a workspace from a repository (for starting fresh)
+- **`--parent <workspace-ref>`** — Create a stacked workspace that builds on top of an existing workspace (for stacked PRs). Records the parent workspace ID and sets the child's target branch to the parent's branch.
+
+Examples:
+```bash
+# Start fresh from a repository
+helmor workspace new --repo helmor
+
+# Create a stacked workspace for dependent PRs
+helmor workspace new --parent helmor/earth
+```
 
 ### Register with Claude Code
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
 	"scripts": {
 		"changeset": "changeset",
 		"dev": "bun run dev:prepare && tauri dev",
-		"dev:prepare": "cd sidecar && bun run dev:prepare",
+		"dev:prepare": "bun run dev:prepare:sidecar && bun run dev:prepare:cli",
+		"dev:prepare:sidecar": "cd sidecar && bun run dev:prepare",
+		"dev:prepare:cli": "node scripts/stage-dev-cli.mjs",
 		"dev:analyze": "bun run dev:prepare && VITE_HELMOR_PERF_HUD=1 tauri dev",
 		"build": "tsc && vite build",
 		"preview": "vite preview",

--- a/scripts/stage-dev-cli.mjs
+++ b/scripts/stage-dev-cli.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * Dev-only CLI staging.
+ *
+ * `tauri dev`'s `beforeDevCommand` is just Vite — unlike `tauri build` it never
+ * runs `prepare-sidecar.mjs`, so nothing stages the companion `helmor-cli`.
+ * Without this step `build.rs`'s `externalBin` placeholder (`#!/bin/sh; exit 0`)
+ * is what Tauri copies to `target/debug/helmor-cli`: the dev CLI then runs,
+ * prints nothing, and any agent told to drive `helmor` from the terminal
+ * silently gets no output (e.g. `helmor workspace stack` can't run at all).
+ *
+ * This builds the debug `helmor-cli` and stages it as the target-suffixed
+ * external bin Tauri ingests, so the dev build lands a REAL CLI at
+ * `target/debug/helmor-cli`. Combined with the app's startup symlink self-heal,
+ * a plain `bun run dev` restart fixes the dev CLI instead of a manual rebuild.
+ */
+import { execFileSync, execSync } from "node:child_process";
+import { copyFileSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const srcTauriDir = resolve(repoRoot, "src-tauri");
+const bundledBinDir = resolve(srcTauriDir, "target", "bundled");
+const cliName = process.platform === "win32" ? "helmor-cli.exe" : "helmor-cli";
+
+function detectTargetTriple() {
+	for (const key of [
+		"TAURI_TARGET_TRIPLE",
+		"TAURI_ENV_TARGET_TRIPLE",
+		"CARGO_BUILD_TARGET",
+	]) {
+		const override = process.env[key]?.trim();
+		if (override) {
+			return override;
+		}
+	}
+	const triple = execSync("rustc --print host-tuple", {
+		encoding: "utf8",
+	}).trim();
+	if (!triple) {
+		throw new Error("`rustc --print host-tuple` returned empty output");
+	}
+	return triple;
+}
+
+const triple = detectTargetTriple();
+const builtCli = resolve(srcTauriDir, "target", "debug", cliName);
+const stagedCli = resolve(bundledBinDir, `helmor-cli-${triple}`);
+
+// Force cargo to re-link the top-level binary even when the compile is cached:
+// the stale artifact sitting here is `build.rs`'s no-op shell placeholder, and
+// it must not survive as the "built" CLI.
+rmSync(builtCli, { force: true });
+
+console.log("[stage-dev-cli] building debug helmor-cli…");
+execFileSync(
+	"cargo",
+	[
+		"build",
+		"--manifest-path",
+		resolve(srcTauriDir, "Cargo.toml"),
+		"--bin",
+		"helmor-cli",
+	],
+	{ stdio: "inherit" },
+);
+
+// Guard: if the placeholder somehow survived the build, fail loudly rather than
+// stage a silent no-op CLI.
+const head = readFileSync(builtCli).subarray(0, 16).toString("latin1");
+if (head.startsWith("#!/bin/sh")) {
+	throw new Error(
+		`[stage-dev-cli] ${builtCli} is still the build.rs placeholder after build`,
+	);
+}
+
+mkdirSync(bundledBinDir, { recursive: true });
+copyFileSync(builtCli, stagedCli);
+console.log(`[stage-dev-cli] staged ${builtCli} → ${stagedCli}`);

--- a/src-tauri/src/agents/queries.rs
+++ b/src-tauri/src/agents/queries.rs
@@ -458,13 +458,10 @@ pub async fn generate_session_title(
                     };
 
                     if fs_rename_ok {
-                        let write_result = crate::models::db::write_conn().and_then(|conn| {
-                            conn.execute(
-                                "UPDATE workspaces SET branch = ?1 WHERE id = ?2",
-                                (&new_branch, &workspace_id),
-                            )
-                            .map_err(|e| anyhow::anyhow!(e))
-                        });
+                        let write_result = crate::models::workspaces::update_workspace_branch(
+                            &workspace_id,
+                            &new_branch,
+                        );
                         if let Err(error) = write_result {
                             tracing::error!(workspace_id = %workspace_id, "DB UPDATE workspaces.branch failed: {error:#}");
                             if fs_rename_attempted {

--- a/src-tauri/src/agents/streaming/mod.rs
+++ b/src-tauri/src/agents/streaming/mod.rs
@@ -1439,6 +1439,23 @@ pub(crate) fn build_helmor_system_prompt_for_workspace(
     let linked_directories =
         crate::agents::streaming::lookup_workspace_linked_directories(helmor_session_id);
 
+    // Stacked-PR awareness: when this workspace is part of a multi-layer stack,
+    // surface a lightweight pointer so the agent self-locates and fetches the
+    // rest with `helmor workspace stack`. Best-effort — failures just elide it.
+    let stack = crate::models::workspaces::load_workspace_stack(workspace_id)
+        .ok()
+        .filter(|chain| chain.len() > 1)
+        .and_then(|chain| {
+            let index = chain.iter().position(|layer| layer.id == workspace_id)?;
+            Some(crate::agents::system_prompt::StackContext {
+                position: index + 1,
+                total: chain.len(),
+                parent_branch: index
+                    .checked_sub(1)
+                    .and_then(|below| chain[below].branch.clone()),
+            })
+        });
+
     let ctx = HelmorSystemPromptContext {
         workspace_label,
         workspace_root_path: working_directory.display().to_string(),
@@ -1446,6 +1463,7 @@ pub(crate) fn build_helmor_system_prompt_for_workspace(
         base_branch,
         linked_directories,
         cli_command_name,
+        stack,
     };
     Some(build_helmor_system_prompt(&ctx))
 }

--- a/src-tauri/src/agents/system_prompt.rs
+++ b/src-tauri/src/agents/system_prompt.rs
@@ -83,6 +83,23 @@ pub struct HelmorSystemPromptContext {
     /// `--version` etc.) because we already know it exists — it's the
     /// process the agent is talking to.
     pub cli_command_name: String,
+    /// Stacked-PR awareness for this workspace. `Some` only when the workspace
+    /// belongs to a multi-layer stack; drives the stack block in the preamble.
+    /// Computed by the caller (it needs DB access to walk the chain).
+    pub stack: Option<StackContext>,
+}
+
+/// Lightweight stacked-PR context injected into the workspace preamble so the
+/// agent knows its place in the stack and fetches the rest itself.
+#[derive(Debug, Clone)]
+pub struct StackContext {
+    /// 1-based position from the bottom of the stack (root = 1).
+    pub position: usize,
+    /// Total number of layers in the stack.
+    pub total: usize,
+    /// Branch this layer is stacked on (its parent's branch); `None` for the
+    /// bottom layer, whose base is the repo default.
+    pub parent_branch: Option<String>,
 }
 
 /// Context the chat-mode prompt template consumes. Chat sessions are
@@ -129,6 +146,22 @@ pub fn build_helmor_system_prompt(ctx: &HelmorSystemPromptContext) -> String {
                 "Target branch for this workspace is not configured — ask the user before opening a PR.\n",
             );
         }
+    }
+
+    if let Some(stack) = &ctx.stack {
+        let _ = write!(
+            out,
+            "\nStacked PR: this workspace is layer {} of {} in a PR stack",
+            stack.position, stack.total,
+        );
+        if let Some(parent) = stack.parent_branch.as_deref() {
+            let _ = write!(out, " (stacked on `{parent}`)");
+        }
+        let _ = writeln!(
+            out,
+            ". The layers below you are already in your branch — implement only THIS layer's slice, not the lower layers (already done) or the layer above (another agent's). Run `{cli} workspace stack` for the full chain; after a lower layer changes or merges, run `/helmor-cli restack` to re-sync the stack.",
+            cli = ctx.cli_command_name,
+        );
     }
 
     if !ctx.linked_directories.is_empty() {
@@ -208,6 +241,7 @@ mod tests {
             base_branch: Some("main".to_string()),
             linked_directories: Vec::new(),
             cli_command_name: "helmor".to_string(),
+            stack: None,
         }
     }
 
@@ -253,6 +287,31 @@ mod tests {
     fn linked_directories_paragraph_is_elided_when_list_empty() {
         let prompt = build_helmor_system_prompt(&ctx_with_defaults());
         assert!(!prompt.contains("linked directories"));
+    }
+
+    /// A multi-layer stack injects the stack-awareness block: position, base
+    /// pointer, and the fetch-it-yourself pointers.
+    #[test]
+    fn stacked_workspace_injects_stack_block() {
+        let mut ctx = ctx_with_defaults();
+        ctx.stack = Some(StackContext {
+            position: 2,
+            total: 3,
+            parent_branch: Some("demo/theme-schema".to_string()),
+        });
+        let prompt = build_helmor_system_prompt(&ctx);
+        assert!(prompt.contains("layer 2 of 3"));
+        assert!(prompt.contains("`demo/theme-schema`"));
+        assert!(prompt.contains("workspace stack"));
+        assert!(prompt.contains("/helmor-cli restack"));
+    }
+
+    /// A non-stacked workspace gets no stack block at all.
+    #[test]
+    fn non_stacked_workspace_has_no_stack_block() {
+        let prompt = build_helmor_system_prompt(&ctx_with_defaults());
+        assert!(!prompt.contains("Stacked PR:"));
+        assert!(!prompt.contains("/helmor-cli restack"));
     }
 
     /// Non-empty list → the paragraph appears with each entry on its

--- a/src-tauri/src/cli/args.rs
+++ b/src-tauri/src/cli/args.rs
@@ -344,12 +344,23 @@ pub enum WorkspaceAction {
         #[arg(name = "ref")]
         workspace_ref: String,
     },
+    /// Show a workspace's PR stack (root → tip). `--json` emits a spec you can
+    /// pipe to the stacked-pr renderer.
+    Stack {
+        #[arg(name = "ref")]
+        workspace_ref: String,
+    },
     /// Create a new workspace for an existing repository.
     #[command(after_help = EXAMPLES_WORKSPACE_NEW)]
     New {
-        /// Repo name or UUID.
+        /// Repo name or UUID. Required unless `--parent` is given.
         #[arg(long)]
-        repo: String,
+        repo: Option<String>,
+        /// Stack the new workspace on top of an existing one (stacked PRs):
+        /// its branch forks off the parent's branch and its PR targets the
+        /// parent's branch. The repo is taken from the parent.
+        #[arg(long)]
+        parent: Option<String>,
     },
     /// Permanently delete a workspace (DB rows + git worktree + files).
     Delete {

--- a/src-tauri/src/cli/workspace.rs
+++ b/src-tauri/src/cli/workspace.rs
@@ -34,7 +34,8 @@ pub fn dispatch(action: &WorkspaceAction, cli: &Cli) -> Result<()> {
             cli,
         ),
         WorkspaceAction::Show { workspace_ref } => show(workspace_ref, cli),
-        WorkspaceAction::New { repo } => new(repo, cli),
+        WorkspaceAction::Stack { workspace_ref } => stack(workspace_ref, cli),
+        WorkspaceAction::New { repo, parent } => new(repo.as_deref(), parent.as_deref(), cli),
         WorkspaceAction::Delete { workspace_ref } => delete(workspace_ref, cli),
         WorkspaceAction::Archive { workspace_ref } => archive(workspace_ref, cli),
         WorkspaceAction::Restore {
@@ -268,9 +269,108 @@ fn show(workspace_ref: &str, cli: &Cli) -> Result<()> {
     })
 }
 
-fn new(repo_ref: &str, cli: &Cli) -> Result<()> {
-    let repo_id = service::resolve_repo_ref(repo_ref)?;
-    let response = service::create_workspace_from_repo_impl(&repo_id)?;
+#[derive(serde::Serialize)]
+struct StackSpecLayer {
+    pr: String,
+    title: String,
+    state: String,
+    ws: String,
+}
+
+/// JSON shape matching the stacked-pr renderer's input (layers tip → root),
+/// so `helmor workspace stack <ws> --json | render_stack.py -` draws the
+/// canonical diagram with no second source of truth.
+#[derive(serde::Serialize)]
+struct StackSpec {
+    name: String,
+    repo: String,
+    base: String,
+    layers: Vec<StackSpecLayer>,
+}
+
+/// Build the render spec from a root→tip stack chain. `None` for an empty
+/// chain (workspace not found). Pure — unit-tested below.
+fn build_stack_spec(chain: &[workspace_models::StackLayer]) -> Option<StackSpec> {
+    let root = chain.first()?;
+    Some(StackSpec {
+        name: root.directory_name.clone(),
+        repo: root.repo_name.clone(),
+        base: root
+            .intended_target_branch
+            .clone()
+            .unwrap_or_else(|| "main".to_string()),
+        layers: chain
+            .iter()
+            .rev() // tip → root, matching the render spec
+            .map(|layer| StackSpecLayer {
+                pr: layer
+                    .pr_url
+                    .as_deref()
+                    .and_then(|url| url.rsplit('/').next())
+                    .filter(|segment| !segment.is_empty())
+                    .unwrap_or_default()
+                    .to_string(),
+                title: layer
+                    .title
+                    .clone()
+                    .unwrap_or_else(|| layer.directory_name.clone()),
+                state: layer.pr_sync_state.as_str().to_string(),
+                ws: layer.directory_name.clone(),
+            })
+            .collect(),
+    })
+}
+
+fn stack(workspace_ref: &str, cli: &Cli) -> Result<()> {
+    let id = service::resolve_workspace_ref(workspace_ref)?;
+    let chain = workspace_models::load_workspace_stack(&id)?; // root → tip
+    let Some(spec) = build_stack_spec(&chain) else {
+        bail!("Workspace not found: {workspace_ref}");
+    };
+
+    output::print(cli, &spec, |s| {
+        let mut out = format!(
+            "stack: {} · {} · {} PR{}\n",
+            s.name,
+            s.repo,
+            s.layers.len(),
+            if s.layers.len() == 1 { "" } else { "s" },
+        );
+        for (index, layer) in s.layers.iter().enumerate() {
+            let pr = if layer.pr.is_empty() {
+                "—".to_string()
+            } else {
+                format!("#{}", layer.pr)
+            };
+            let head = if index == 0 { "    ← HEAD" } else { "" };
+            out.push_str(&format!(
+                "  {pr}  {ws}  [{state}]  {title}{head}\n",
+                ws = layer.ws,
+                state = layer.state,
+                title = layer.title,
+            ));
+        }
+        out.push_str(&format!("  └ base: {}", s.base));
+        out
+    })
+}
+
+fn new(repo: Option<&str>, parent: Option<&str>, cli: &Cli) -> Result<()> {
+    let response = match parent {
+        Some(parent_ref) => {
+            let parent_id = service::resolve_workspace_ref(parent_ref)?;
+            service::create_stacked_workspace_impl(&parent_id)?
+        }
+        None => {
+            let repo_ref = repo.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Provide --repo <repo> or --parent <workspace> to create a workspace"
+                )
+            })?;
+            let repo_id = service::resolve_repo_ref(repo_ref)?;
+            service::create_workspace_from_repo_impl(&repo_id)?
+        }
+    };
     notify_ui_events([
         UiMutationEvent::WorkspaceListChanged,
         UiMutationEvent::WorkspaceChanged {
@@ -622,5 +722,65 @@ mod tests {
         for (cli_action, shared_action) in cases {
             assert_eq!(WorkspaceShipActionKind::from(cli_action), shared_action);
         }
+    }
+
+    #[test]
+    fn build_stack_spec_orders_tip_to_root_and_parses_pr() {
+        use crate::workspace_pr_sync::PrSyncState;
+        use crate::workspace_status::WorkspaceStatus;
+
+        let layer =
+            |id: &str, ws: &str, parent: Option<&str>, pr_url: Option<&str>, state: PrSyncState| {
+                workspace_models::StackLayer {
+                    id: id.to_string(),
+                    repo_name: "helmor".to_string(),
+                    directory_name: ws.to_string(),
+                    title: None,
+                    branch: Some(format!("demo/{ws}")),
+                    intended_target_branch: Some("main".to_string()),
+                    pr_sync_state: state,
+                    pr_url: pr_url.map(str::to_string),
+                    status: WorkspaceStatus::InProgress,
+                    parent_workspace_id: parent.map(str::to_string),
+                }
+            };
+
+        // chain is root -> tip
+        let chain = vec![
+            layer(
+                "a",
+                "theme-schema",
+                None,
+                Some("https://github.com/o/r/pull/481"),
+                PrSyncState::Merged,
+            ),
+            layer(
+                "b",
+                "theme-api",
+                Some("a"),
+                Some("https://github.com/o/r/pull/482"),
+                PrSyncState::Open,
+            ),
+            layer("c", "theme-ui", Some("b"), None, PrSyncState::None),
+        ];
+        let spec = build_stack_spec(&chain).expect("non-empty chain");
+
+        assert_eq!(spec.name, "theme-schema");
+        assert_eq!(spec.repo, "helmor");
+        assert_eq!(spec.base, "main");
+        // Rendered tip -> root.
+        let ws: Vec<&str> = spec.layers.iter().map(|layer| layer.ws.as_str()).collect();
+        assert_eq!(ws, vec!["theme-ui", "theme-api", "theme-schema"]);
+        // Tip has no PR yet; title falls back to the directory name.
+        assert_eq!(spec.layers[0].pr, "");
+        assert_eq!(spec.layers[0].state, "none");
+        assert_eq!(spec.layers[0].title, "theme-ui");
+        // PR number parsed from the URL tail; state from pr_sync_state.
+        assert_eq!(spec.layers[1].pr, "482");
+        assert_eq!(spec.layers[1].state, "open");
+        assert_eq!(spec.layers[2].pr, "481");
+        assert_eq!(spec.layers[2].state, "merged");
+
+        assert!(build_stack_spec(&[]).is_none());
     }
 }

--- a/src-tauri/src/commands/system_commands.rs
+++ b/src-tauri/src/commands/system_commands.rs
@@ -718,11 +718,32 @@ fn try_install_cli_silent_at(
     }
 }
 
-fn try_install_cli_silent() -> anyhow::Result<()> {
-    let source = std::env::current_exe().context("Cannot determine app executable path")?;
-    let cli_binary = bundled_cli_binary(&source)?;
-    let install_path = cli_install_target();
-    try_install_cli_silent_at(&cli_binary, &install_path)
+/// Verify the managed CLI symlink and silently re-point it if it is stale
+/// or missing. Returns the silent-install error (if any) for the panel.
+///
+/// This runs on EVERY components check — never gated by the per-version
+/// cache — because the symlink is cheap to fix (a stat + an unprivileged
+/// symlink rewrite) and can go stale WITHIN a single version whenever the
+/// dev build switches worktrees. Caching it behind the version key is
+/// exactly what used to leave a dangling `/usr/local/bin/helmor-dev`
+/// pointing at a worktree whose binary was rebuilt or removed.
+fn check_and_heal_cli_symlink(
+    install_path: &std::path::Path,
+    bundled_cli: &std::path::Path,
+) -> Option<String> {
+    match classify_cli_install(install_path, bundled_cli) {
+        CliInstallState::Managed => None,
+        CliInstallState::Missing | CliInstallState::Stale => {
+            match try_install_cli_silent_at(bundled_cli, install_path) {
+                Ok(()) => None,
+                Err(error) => {
+                    let msg = format!("{error:#}");
+                    tracing::info!(error = %msg, "Components check: silent CLI install deferred to user");
+                    Some(msg)
+                }
+            }
+        }
+    }
 }
 
 /// One pass of the silent startup check. Returns the post-check snapshot
@@ -731,55 +752,37 @@ fn try_install_cli_silent() -> anyhow::Result<()> {
 fn run_components_check_inner(force: bool) -> ComponentsUpdateCheck {
     let current_version = env!("CARGO_PKG_VERSION").to_string();
 
-    // Cache hit — skip everything. The panel still re-reads errors so
-    // a "Re-check" that clears the cache key (via `force`) shows fresh.
+    // --- CLI half: ALWAYS run, BEFORE the per-version cache gate ---------
+    // Self-heal the managed CLI symlink on every launch (see
+    // `check_and_heal_cli_symlink`): it can go stale within a single
+    // version when the dev build switches worktrees, and re-pointing it is
+    // cheap and (on a user-writable install dir) needs no sudo, so a plain
+    // restart fixes it instead of forcing a manual `ln -sfn`.
+    let install_path = cli_install_target();
+    let cli_error: Option<String> = match std::env::current_exe()
+        .context("Cannot determine app executable path")
+        .and_then(|exe| bundled_cli_binary(&exe))
+    {
+        Ok(cli_binary) => check_and_heal_cli_symlink(&install_path, &cli_binary),
+        Err(error) => {
+            tracing::warn!(error = %format!("{error:#}"), "Components check: bundled CLI lookup failed");
+            None
+        }
+    };
+    persist_error(UPDATE_CHECK_CLI_ERROR_KEY, cli_error.as_deref());
+
+    // --- Skills install is expensive (`npx skills add`): gate it behind
+    // the per-version cache. The CLI half above is independent of this.
     if !force {
         if let Ok(Some(last)) =
             crate::models::settings::load_setting_value(LAST_UPDATE_CHECK_VERSION_KEY)
         {
             if last == current_version {
-                return read_components_update_check().unwrap_or_else(|error| {
-                    tracing::warn!(
-                        error = %format!("{error:#}"),
-                        "Failed to read components-check cache; returning empty snapshot",
-                    );
-                    empty_components_check(current_version.clone())
-                });
+                return read_components_update_check()
+                    .unwrap_or_else(|_| empty_components_check(current_version));
             }
         }
     }
-
-    // --- CLI half --------------------------------------------------------
-    let install_path = cli_install_target();
-    let source = match std::env::current_exe() {
-        Ok(path) => path,
-        Err(error) => {
-            tracing::warn!(error = %error, "Components check: current_exe failed");
-            return read_components_update_check()
-                .unwrap_or_else(|_| empty_components_check(current_version));
-        }
-    };
-    let cli_binary = match bundled_cli_binary(&source) {
-        Ok(path) => path,
-        Err(error) => {
-            tracing::warn!(error = %format!("{error:#}"), "Components check: bundled CLI lookup failed");
-            return read_components_update_check()
-                .unwrap_or_else(|_| empty_components_check(current_version));
-        }
-    };
-
-    let cli_state = classify_cli_install(&install_path, &cli_binary);
-    let cli_error: Option<String> = match cli_state {
-        CliInstallState::Managed => None,
-        CliInstallState::Missing | CliInstallState::Stale => match try_install_cli_silent() {
-            Ok(()) => None,
-            Err(error) => {
-                let msg = format!("{error:#}");
-                tracing::info!(error = %msg, "Components check: silent CLI install deferred to user");
-                Some(msg)
-            }
-        },
-    };
 
     // --- Skills half -----------------------------------------------------
     //
@@ -806,17 +809,13 @@ fn run_components_check_inner(force: bool) -> ComponentsUpdateCheck {
             }
         }
     };
-
-    // Persist error state unconditionally so the panel reflects reality.
-    persist_error(UPDATE_CHECK_CLI_ERROR_KEY, cli_error.as_deref());
     persist_error(UPDATE_CHECK_SKILLS_ERROR_KEY, skills_error.as_deref());
 
-    // Only advance the cache key if neither half left a real error
-    // behind. This way a transient skills failure (no network, npx not
-    // on PATH yet) auto-retries on the next launch, while a steady
-    // state ("CLI needs sudo, you have to click Retry") still only
-    // checks once per upgrade.
-    if cli_error.is_none() && skills_error.is_none() {
+    // Advance the cache key (which gates the expensive skills install) only
+    // when the skills half is clean — a transient failure (no network, npx
+    // not on PATH yet) auto-retries on the next launch. The CLI half is
+    // independent and always runs, so it no longer gates this key.
+    if skills_error.is_none() {
         if let Err(error) = crate::models::settings::upsert_setting_value(
             LAST_UPDATE_CHECK_VERSION_KEY,
             &current_version,
@@ -1962,6 +1961,39 @@ mod tests {
 
         install_cli_symlink(&bundled_cli, &install_path).unwrap();
 
+        assert_eq!(
+            classify_cli_install(&install_path, &bundled_cli),
+            CliInstallState::Managed
+        );
+    }
+
+    #[test]
+    fn check_and_heal_cli_symlink_repoints_a_stale_link() {
+        let tmp = tempdir().unwrap();
+        let bundled_cli = tmp.path().join("Helmor.app/Contents/MacOS/helmor-cli");
+        let old_cli = tmp.path().join("old-worktree/helmor-cli");
+        let install_path = tmp.path().join("usr/local/bin/helmor-dev");
+        fs::create_dir_all(bundled_cli.parent().unwrap()).unwrap();
+        fs::create_dir_all(old_cli.parent().unwrap()).unwrap();
+        fs::create_dir_all(install_path.parent().unwrap()).unwrap();
+        fs::write(&bundled_cli, "#!/bin/sh\n").unwrap();
+        fs::write(&old_cli, "#!/bin/sh\n").unwrap();
+
+        // Reproduce the dev-CLI breakage: the managed symlink points at a
+        // different worktree's binary, so it reads as Stale.
+        std::os::unix::fs::symlink(&old_cli, &install_path).unwrap();
+        assert_eq!(
+            classify_cli_install(&install_path, &bundled_cli),
+            CliInstallState::Stale
+        );
+
+        // The plain (un-forced) heal a restart triggers re-points it with no
+        // error and no sudo — the whole point of moving this out of the
+        // per-version cache gate.
+        assert_eq!(
+            check_and_heal_cli_symlink(&install_path, &bundled_cli),
+            None
+        );
         assert_eq!(
             classify_cli_install(&install_path, &bundled_cli),
             CliInstallState::Managed

--- a/src-tauri/src/commands/tests/workspace_creation.rs
+++ b/src-tauri/src/commands/tests/workspace_creation.rs
@@ -4,6 +4,139 @@ use crate::workspace_state::{WorkspaceBranchIntent, WorkspaceMode, WorkspaceStat
 use crate::workspace_status::WorkspaceStatus;
 
 #[test]
+fn create_stacked_workspace_links_parent_and_targets_parent_branch() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let harness = CreateTestHarness::new();
+
+    // Bottom of the stack: a normal workspace off the repo default.
+    let parent = workspaces::create_workspace_from_repo_impl(&harness.repo_id).unwrap();
+    // Layer 2: stacked on the parent.
+    let child = workspaces::create_stacked_workspace_impl(&parent.created_workspace_id).unwrap();
+
+    assert_eq!(child.created_state, WorkspaceState::Ready);
+    // Child got its own fresh branch, distinct from the parent's.
+    assert_ne!(child.branch, parent.branch);
+
+    let connection = Connection::open(harness.db_path()).unwrap();
+    let (parent_id, intended_target, init_parent): (
+        Option<String>,
+        Option<String>,
+        Option<String>,
+    ) = connection
+        .query_row(
+            r#"
+            SELECT parent_workspace_id, intended_target_branch,
+              initialization_parent_branch
+            FROM workspaces WHERE id = ?1
+            "#,
+            [&child.created_workspace_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
+
+    // Stack link recorded.
+    assert_eq!(
+        parent_id.as_deref(),
+        Some(parent.created_workspace_id.as_str())
+    );
+    // Dual-write invariant: the child's base IS the parent's branch, so
+    // `gh pr create --base` targets the parent (no ship-path change needed).
+    assert_eq!(intended_target.as_deref(), Some(parent.branch.as_str()));
+    assert_eq!(init_parent.as_deref(), Some(parent.branch.as_str()));
+}
+
+#[test]
+fn stack_deletion_constraint_tip_free_root_pops_middle_blocked() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let harness = CreateTestHarness::new();
+
+    // root -> mid -> tip
+    let root = workspaces::create_workspace_from_repo_impl(&harness.repo_id).unwrap();
+    let mid = workspaces::create_stacked_workspace_impl(&root.created_workspace_id).unwrap();
+    let tip = workspaces::create_stacked_workspace_impl(&mid.created_workspace_id).unwrap();
+
+    // Middle layer (live parent below + children above): blocked.
+    let err = workspaces::permanently_delete_workspace(&mid.created_workspace_id).unwrap_err();
+    assert!(
+        err.to_string().to_lowercase().contains("middle"),
+        "expected a middle-layer block, got: {err}"
+    );
+
+    // Tip (has parent, no children): free delete.
+    workspaces::permanently_delete_workspace(&tip.created_workspace_id).unwrap();
+
+    // Root (no parent, has children = `mid` now that the tip is gone): pop the
+    // bottom — `mid` becomes a new root targeting the repo default.
+    workspaces::permanently_delete_workspace(&root.created_workspace_id).unwrap();
+
+    let connection = Connection::open(harness.db_path()).unwrap();
+    let (parent, target): (Option<String>, Option<String>) = connection
+        .query_row(
+            "SELECT parent_workspace_id, intended_target_branch FROM workspaces WHERE id = ?1",
+            [&mid.created_workspace_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(
+        parent, None,
+        "mid should be detached to a root after root pop"
+    );
+    let default_branch: String = connection
+        .query_row(
+            "SELECT default_branch FROM repos WHERE id = ?1",
+            [&harness.repo_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(target.as_deref(), Some(default_branch.as_str()));
+}
+
+#[test]
+fn load_workspace_stack_returns_root_to_tip_chain() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let harness = CreateTestHarness::new();
+
+    // Build a 3-layer stack: root -> mid -> tip.
+    let root = workspaces::create_workspace_from_repo_impl(&harness.repo_id).unwrap();
+    let mid = workspaces::create_stacked_workspace_impl(&root.created_workspace_id).unwrap();
+    let tip = workspaces::create_stacked_workspace_impl(&mid.created_workspace_id).unwrap();
+
+    // From the MIDDLE layer: walks up to root AND down to tip, ordered root→tip.
+    let chain = crate::models::workspaces::load_workspace_stack(&mid.created_workspace_id).unwrap();
+    let ids: Vec<&str> = chain.iter().map(|layer| layer.id.as_str()).collect();
+    assert_eq!(
+        ids,
+        vec![
+            root.created_workspace_id.as_str(),
+            mid.created_workspace_id.as_str(),
+            tip.created_workspace_id.as_str(),
+        ],
+        "stack should be ordered root -> tip regardless of entry layer"
+    );
+    assert_eq!(
+        chain[1].parent_workspace_id.as_deref(),
+        Some(root.created_workspace_id.as_str())
+    );
+    assert_eq!(
+        chain[2].parent_workspace_id.as_deref(),
+        Some(mid.created_workspace_id.as_str())
+    );
+
+    // A standalone (non-stacked) workspace returns just itself.
+    let solo = workspaces::create_workspace_from_repo_impl(&harness.repo_id).unwrap();
+    let solo_chain =
+        crate::models::workspaces::load_workspace_stack(&solo.created_workspace_id).unwrap();
+    assert_eq!(solo_chain.len(), 1);
+    assert_eq!(solo_chain[0].id, solo.created_workspace_id);
+}
+
+#[test]
 fn create_workspace_from_repo_creates_ready_workspace_and_initial_session() {
     let _guard = TEST_LOCK
         .lock()

--- a/src-tauri/src/models/workspaces.rs
+++ b/src-tauri/src/models/workspaces.rs
@@ -765,6 +765,39 @@ pub(crate) fn set_workspace_parent_id(
     Ok(())
 }
 
+/// Rename a workspace's own branch AND cascade the new name to every direct
+/// stacked child whose `intended_target_branch` tracks it.
+///
+/// `intended_target_branch` is a denormalized cache of the parent's branch
+/// (materialized when the child is stacked). Without this cascade a child's
+/// target goes stale the moment the parent's branch changes — via the header
+/// rename, or the LLM branch regeneration after the first message. One level
+/// suffices: each child targets only its DIRECT parent's branch.
+///
+/// Both UPDATEs run in one transaction so a child is never left pointing at a
+/// branch its parent no longer has.
+pub(crate) fn update_workspace_branch(workspace_id: &str, new_branch: &str) -> Result<()> {
+    let mut connection = db::write_conn()?;
+    let tx = connection.transaction()?;
+    let updated = tx
+        .execute(
+            "UPDATE workspaces SET branch = ?1 WHERE id = ?2",
+            (new_branch, workspace_id),
+        )
+        .context("Failed to update workspace branch")?;
+    if updated != 1 {
+        bail!("Cannot update branch for workspace {workspace_id}: row not found");
+    }
+    tx.execute(
+        "UPDATE workspaces SET intended_target_branch = ?1 WHERE parent_workspace_id = ?2",
+        (new_branch, workspace_id),
+    )
+    .context("Failed to cascade branch rename to stacked children")?;
+    tx.commit()
+        .context("Failed to commit workspace branch update")?;
+    Ok(())
+}
+
 /// One layer of a PR stack, ordered root → tip by [`load_workspace_stack`].
 #[derive(Debug, Clone)]
 pub struct StackLayer {

--- a/src-tauri/src/models/workspaces.rs
+++ b/src-tauri/src/models/workspaces.rs
@@ -1,3 +1,5 @@
+use std::collections::{HashMap, HashSet};
+
 use anyhow::{bail, Context, Result};
 use rusqlite::Row;
 
@@ -81,6 +83,10 @@ pub struct WorkspaceRecord {
     /// Originating triage platform for ai_triage workspaces ("github",
     /// "gitlab", "slack", "lark"). `None` for manual workspaces.
     pub triage_source_type: Option<String>,
+    /// Stacked PRs: `workspaces.id` of the layer below this one (its base).
+    /// `None` = bottom of stack (base is the repo default) or a non-stacked
+    /// workspace. FK-by-convention; integrity enforced in the write layer.
+    pub parent_workspace_id: Option<String>,
 }
 
 pub const WORKSPACE_RECORD_SQL: &str = r#"
@@ -192,7 +198,8 @@ pub const WORKSPACE_RECORD_SQL: &str = r#"
       w.active_run_action_id,
       COALESCE(w.kind, 'manual') AS kind,
       COALESCE(w.ai_priming_consumed, 0) AS ai_priming_consumed,
-      w.triage_source_type
+      w.triage_source_type,
+      w.parent_workspace_id
     FROM workspaces w
     JOIN repos r ON r.id = w.repository_id
     LEFT JOIN sessions s ON s.id = w.active_session_id
@@ -734,7 +741,142 @@ fn workspace_record_from_row(row: &Row<'_>) -> rusqlite::Result<WorkspaceRecord>
         kind: row.get(41)?,
         ai_priming_consumed: row.get::<_, i64>(42)? != 0,
         triage_source_type: row.get(43)?,
+        parent_workspace_id: row.get(44)?,
     })
+}
+
+/// Set (or clear) the stacked-PR parent link for a workspace. `Some(id)`
+/// records that this workspace stacks on `id` (its base); `None` clears it.
+/// Drives sidebar nesting and the future restack cascade.
+pub(crate) fn set_workspace_parent_id(
+    workspace_id: &str,
+    parent_workspace_id: Option<&str>,
+) -> Result<()> {
+    let connection = db::write_conn()?;
+    let updated = connection
+        .execute(
+            "UPDATE workspaces SET parent_workspace_id = ?1, updated_at = datetime('now') WHERE id = ?2",
+            (parent_workspace_id, workspace_id),
+        )
+        .context("Failed to update workspace parent_workspace_id")?;
+    if updated != 1 {
+        bail!("Cannot set parent for workspace {workspace_id}: row not found");
+    }
+    Ok(())
+}
+
+/// One layer of a PR stack, ordered root → tip by [`load_workspace_stack`].
+#[derive(Debug, Clone)]
+pub struct StackLayer {
+    pub id: String,
+    pub repo_name: String,
+    pub directory_name: String,
+    /// Display title (primary session title); the presentation layer falls
+    /// back to `directory_name` when this is `None`.
+    pub title: Option<String>,
+    pub branch: Option<String>,
+    pub intended_target_branch: Option<String>,
+    pub pr_sync_state: PrSyncState,
+    pub pr_url: Option<String>,
+    pub status: WorkspaceStatus,
+    pub parent_workspace_id: Option<String>,
+}
+
+fn record_to_stack_layer(record: &WorkspaceRecord) -> StackLayer {
+    StackLayer {
+        id: record.id.clone(),
+        repo_name: record.repo_name.clone(),
+        directory_name: record.directory_name.clone(),
+        title: record.primary_session_title.clone(),
+        branch: record.branch.clone(),
+        intended_target_branch: record.intended_target_branch.clone(),
+        pr_sync_state: record.pr_sync_state,
+        pr_url: record.pr_url.clone(),
+        status: record.status,
+        parent_workspace_id: record.parent_workspace_id.clone(),
+    }
+}
+
+/// Cheap check: does any workspace point at `workspace_id` as its stack parent?
+fn has_stack_children(workspace_id: &str) -> Result<bool> {
+    let connection = db::read_conn()?;
+    let exists: bool = connection
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM workspaces WHERE parent_workspace_id = ?1)",
+            [workspace_id],
+            |row| row.get(0),
+        )
+        .context("Failed to check stack children")?;
+    Ok(exists)
+}
+
+/// Load the ordered PR-stack chain (root → tip) that `workspace_id` belongs to.
+///
+/// A non-stacked workspace (no parent, no children) returns a single-element
+/// vec containing itself. A stack never spans repos, so the walk is restricted
+/// to the workspace's own repo. Defensive against dangling parent ids and
+/// cycles; on a fork (a layer with multiple children) it follows the
+/// earliest-created child deterministically.
+pub fn load_workspace_stack(workspace_id: &str) -> Result<Vec<StackLayer>> {
+    let Some(start) = load_workspace_record_by_id(workspace_id)? else {
+        return Ok(Vec::new());
+    };
+    // Fast path: no parent and no children → not stacked. Skip the repo scan
+    // (this runs on every message send for the common non-stacked workspace).
+    if start.parent_workspace_id.is_none() && !has_stack_children(&start.id)? {
+        return Ok(vec![record_to_stack_layer(&start)]);
+    }
+    let repo_id = start.repo_id.clone();
+
+    let by_id: HashMap<String, WorkspaceRecord> = load_workspace_records()?
+        .into_iter()
+        .filter(|record| record.repo_id == repo_id)
+        .map(|record| (record.id.clone(), record))
+        .collect();
+
+    let mut seen: HashSet<String> = HashSet::new();
+
+    // Walk up from `start` to the root (topmost visible ancestor), then
+    // reverse so the chain reads root → start.
+    let mut chain: Vec<String> = Vec::new();
+    let mut cursor = Some(start.id.clone());
+    while let Some(id) = cursor {
+        if !seen.insert(id.clone()) {
+            break; // cycle guard
+        }
+        cursor = by_id
+            .get(&id)
+            .and_then(|record| record.parent_workspace_id.clone())
+            .filter(|parent| by_id.contains_key(parent));
+        chain.push(id);
+    }
+    chain.reverse();
+
+    // Walk down from `start` following the earliest-created child each step.
+    let child_of = |parent_id: &str| -> Option<&WorkspaceRecord> {
+        by_id
+            .values()
+            .filter(|record| record.parent_workspace_id.as_deref() == Some(parent_id))
+            .min_by(|a, b| {
+                a.created_at
+                    .cmp(&b.created_at)
+                    .then_with(|| a.id.cmp(&b.id))
+            })
+    };
+    let mut cursor = child_of(&start.id).map(|record| record.id.clone());
+    while let Some(id) = cursor {
+        if !seen.insert(id.clone()) {
+            break; // cycle / already-seen guard
+        }
+        cursor = child_of(&id).map(|record| record.id.clone());
+        chain.push(id);
+    }
+
+    Ok(chain
+        .iter()
+        .filter_map(|id| by_id.get(id))
+        .map(record_to_stack_layer)
+        .collect())
 }
 
 /// Persist the user-picked active run-action id for a workspace. Passing

--- a/src-tauri/src/schema.rs
+++ b/src-tauri/src/schema.rs
@@ -494,6 +494,20 @@ fn run_migrations(connection: &Connection) -> Result<()> {
             .context("Failed to add pr_url column")?;
     }
 
+    // Migration: stacked PRs. `parent_workspace_id` links a workspace to the
+    // one below it in a PR stack (its base). NULL = bottom of stack or a
+    // non-stacked workspace. No SQL foreign key — consistent with
+    // `repository_id` (and SQLite can't ALTER ADD CONSTRAINT); integrity is
+    // enforced in the Rust write layer. No back-fill — existing rows are
+    // non-stacked.
+    if has_table(connection, "workspaces")
+        && !has_column(connection, "workspaces", "parent_workspace_id")
+    {
+        connection
+            .execute_batch("ALTER TABLE workspaces ADD COLUMN parent_workspace_id TEXT")
+            .context("Failed to add workspaces.parent_workspace_id column")?;
+    }
+
     let had_workspace_status =
         has_table(connection, "workspaces") && has_column(connection, "workspaces", "status");
     if has_table(connection, "workspaces") && !had_workspace_status {
@@ -1023,6 +1037,7 @@ CREATE TABLE IF NOT EXISTS workspaces (
     ai_priming_consumed INTEGER NOT NULL DEFAULT 0,
     triage_source_type TEXT,
     triage_source_ref TEXT,
+    parent_workspace_id TEXT,
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );

--- a/src-tauri/src/schema.rs
+++ b/src-tauri/src/schema.rs
@@ -167,6 +167,36 @@ pub fn ensure_schema(connection: &Connection) -> Result<()> {
 }
 
 /// Incremental migrations for schema changes to existing databases.
+/// Re-point every stacked child's `intended_target_branch` at its parent's
+/// current branch. Idempotent: only rows whose cached target differs from the
+/// parent's live branch are touched (dangling parents are skipped). Mirrors
+/// the write-layer cascade in `models::workspaces::update_workspace_branch`
+/// so rows that predate it self-heal on startup.
+fn backfill_stacked_target_branches(connection: &Connection) -> Result<()> {
+    if !has_table(connection, "workspaces")
+        || !has_column(connection, "workspaces", "parent_workspace_id")
+        || !has_column(connection, "workspaces", "branch")
+        || !has_column(connection, "workspaces", "intended_target_branch")
+    {
+        return Ok(());
+    }
+    connection
+        .execute(
+            "UPDATE workspaces
+             SET intended_target_branch = (
+                 SELECT p.branch FROM workspaces p WHERE p.id = workspaces.parent_workspace_id
+             )
+             WHERE parent_workspace_id IS NOT NULL
+               AND (SELECT p.branch FROM workspaces p WHERE p.id = workspaces.parent_workspace_id) IS NOT NULL
+               AND intended_target_branch IS NOT (
+                   SELECT p.branch FROM workspaces p WHERE p.id = workspaces.parent_workspace_id
+               )",
+            [],
+        )
+        .context("Failed to re-point stacked target branches")?;
+    Ok(())
+}
+
 fn run_migrations(connection: &Connection) -> Result<()> {
     // Migration: rename claude_session_id → provider_session_id (supports any agent provider)
     let has_old_column: bool = connection
@@ -507,6 +537,14 @@ fn run_migrations(connection: &Connection) -> Result<()> {
             .execute_batch("ALTER TABLE workspaces ADD COLUMN parent_workspace_id TEXT")
             .context("Failed to add workspaces.parent_workspace_id column")?;
     }
+
+    // Stacked-PR invariant: a child's `intended_target_branch` caches its
+    // parent's branch. Re-assert it so rows that predate the write-layer
+    // cascade (or drifted when a parent was renamed before the cascade
+    // existed) self-heal. Idempotent + cheap — only mismatched linked
+    // children are touched.
+    backfill_stacked_target_branches(connection)
+        .context("Failed to backfill stacked-PR target branches")?;
 
     let had_workspace_status =
         has_table(connection, "workspaces") && has_column(connection, "workspaces", "status");
@@ -1232,6 +1270,87 @@ mod tests {
         ensure_schema(&connection).unwrap();
         // Call again — should not error
         ensure_schema(&connection).unwrap();
+    }
+
+    fn insert_ws(
+        connection: &Connection,
+        id: &str,
+        branch: &str,
+        target: Option<&str>,
+        parent: Option<&str>,
+    ) {
+        connection
+            .execute(
+                "INSERT INTO workspaces (id, repository_id, directory_name, state, status, branch, intended_target_branch, parent_workspace_id, display_order)
+                 VALUES (?1, 'repo', ?1, 'ready', 'in-progress', ?2, ?3, ?4, 0)",
+                rusqlite::params![id, branch, target, parent],
+            )
+            .unwrap();
+    }
+
+    fn target_of(connection: &Connection, id: &str) -> Option<String> {
+        connection
+            .query_row(
+                "SELECT intended_target_branch FROM workspaces WHERE id = ?1",
+                [id],
+                |r| r.get(0),
+            )
+            .unwrap()
+    }
+
+    #[test]
+    fn backfill_repoints_stale_child_targets_at_parent_branch() {
+        let (connection, _dir) = open_test_db();
+        ensure_schema(&connection).unwrap();
+
+        // child's target is a stale snapshot of the parent's old branch name.
+        insert_ws(&connection, "root", "feat/root", Some("main"), None);
+        insert_ws(
+            &connection,
+            "child",
+            "feat/child",
+            Some("feat/root-OLD"),
+            Some("root"),
+        );
+        insert_ws(&connection, "solo", "feat/solo", Some("main"), None);
+
+        backfill_stacked_target_branches(&connection).unwrap();
+
+        // Child now tracks the parent's LIVE branch; root + non-stacked untouched.
+        assert_eq!(
+            target_of(&connection, "child").as_deref(),
+            Some("feat/root")
+        );
+        assert_eq!(target_of(&connection, "root").as_deref(), Some("main"));
+        assert_eq!(target_of(&connection, "solo").as_deref(), Some("main"));
+
+        // Idempotent: a second pass is a no-op.
+        backfill_stacked_target_branches(&connection).unwrap();
+        assert_eq!(
+            target_of(&connection, "child").as_deref(),
+            Some("feat/root")
+        );
+    }
+
+    #[test]
+    fn backfill_leaves_dangling_parent_targets_untouched() {
+        let (connection, _dir) = open_test_db();
+        ensure_schema(&connection).unwrap();
+        // parent id 'gone' does not exist — must NOT null out the target.
+        insert_ws(
+            &connection,
+            "orphan",
+            "feat/x",
+            Some("stale-base"),
+            Some("gone"),
+        );
+
+        backfill_stacked_target_branches(&connection).unwrap();
+
+        assert_eq!(
+            target_of(&connection, "orphan").as_deref(),
+            Some("stale-base")
+        );
     }
 
     #[test]

--- a/src-tauri/src/service.rs
+++ b/src-tauri/src/service.rs
@@ -26,7 +26,8 @@ pub use crate::models::workspaces::load_workspace_records;
 pub use crate::repos::{add_repository_from_local_path, list_repositories};
 pub use crate::sessions::{create_session, list_workspace_sessions};
 pub use crate::workspaces::{
-    create_workspace_from_repo_impl, get_workspace, list_workspace_groups,
+    create_stacked_workspace_impl, create_workspace_from_repo_impl, get_workspace,
+    list_workspace_groups,
 };
 
 /// Build [`DataInfo`] without needing a Tauri runtime.

--- a/src-tauri/src/workspace/branching.rs
+++ b/src-tauri/src/workspace/branching.rs
@@ -139,11 +139,7 @@ pub fn rename_workspace_branch(workspace_id: &str, new_branch: &str) -> Result<(
 
     git_ops::rename_branch(repo_root_path, old_branch, new_branch)?;
 
-    let connection = db::write_conn()?;
-    if let Err(db_err) = connection.execute(
-        "UPDATE workspaces SET branch = ?1 WHERE id = ?2",
-        (new_branch, workspace_id),
-    ) {
+    if let Err(db_err) = workspace_models::update_workspace_branch(workspace_id, new_branch) {
         if let Err(rb_err) = git_ops::rename_branch(repo_root_path, new_branch, old_branch) {
             tracing::error!(
                 old = old_branch,
@@ -151,7 +147,7 @@ pub fn rename_workspace_branch(workspace_id: &str, new_branch: &str) -> Result<(
                 "Rollback git branch -m failed: {rb_err:#}"
             );
         }
-        return Err(db_err).context("Failed to update branch name in database");
+        return Err(db_err.context("Failed to update branch name in database"));
     }
 
     Ok(())

--- a/src-tauri/src/workspace/helpers.rs
+++ b/src-tauri/src/workspace/helpers.rs
@@ -938,6 +938,7 @@ mod tests {
             kind: "manual".to_string(),
             ai_priming_consumed: false,
             triage_source_type: None,
+            parent_workspace_id: None,
         }
     }
 

--- a/src-tauri/src/workspace/lifecycle.rs
+++ b/src-tauri/src/workspace/lifecycle.rs
@@ -893,6 +893,57 @@ pub fn create_workspace_from_repo_impl(repo_id: &str) -> Result<CreateWorkspaceR
     })
 }
 
+/// Create a new workspace stacked on top of an existing one (stacked PRs).
+///
+/// The child's branch forks off the parent workspace's branch, and its
+/// `intended_target_branch` is materialized to the parent's branch (via the
+/// shared `FromBranch` prepare path) so `gh pr create --base` targets the
+/// parent with no ship-path change. `parent_workspace_id` records the stack
+/// link, which drives sidebar nesting and the future restack cascade.
+///
+/// One-shot (prepare + finalize), mirroring `create_workspace_from_repo_impl`.
+/// The repo is taken from the parent. Finalize forks the worktree off the
+/// parent branch's published tip (`origin/<branch>`) when available, falling
+/// back to the local branch for a not-yet-pushed parent.
+pub fn create_stacked_workspace_impl(parent_workspace_id: &str) -> Result<CreateWorkspaceResponse> {
+    let parent = workspace_models::load_workspace_record_by_id(parent_workspace_id)?
+        .with_context(|| format!("Parent workspace not found: {parent_workspace_id}"))?;
+    if !parent.state.is_operational() {
+        bail!(
+            "Cannot stack on workspace {parent_workspace_id}: it is {} (archived or mid-creation)",
+            parent.state
+        );
+    }
+    let parent_branch = helpers::non_empty(&parent.branch)
+        .map(ToOwned::to_owned)
+        .with_context(|| {
+            format!("Parent workspace {parent_workspace_id} has no branch to stack on")
+        })?;
+
+    let prepared = prepare_workspace_from_repo_impl(
+        &parent.repo_id,
+        Some(&parent_branch),
+        WorkspaceBranchIntent::FromBranch,
+        WorkspaceStatus::default(),
+        None,
+    )?;
+
+    // Record the stack link before finalize so the row is fully shaped
+    // (and is cleaned up with the row if finalize fails).
+    workspace_models::set_workspace_parent_id(&prepared.workspace_id, Some(parent_workspace_id))?;
+
+    let finalized = finalize_workspace_from_repo_impl(&prepared.workspace_id)?;
+
+    Ok(CreateWorkspaceResponse {
+        created_workspace_id: prepared.workspace_id.clone(),
+        selected_workspace_id: prepared.workspace_id,
+        initial_session_id: prepared.initial_session_id,
+        created_state: finalized.final_state,
+        directory_name: prepared.directory_name,
+        branch: prepared.branch,
+    })
+}
+
 /// Remove workspace rows stuck in the `Initializing` state longer than the
 /// supplied cutoff. Called at app startup to clean up rows left behind when
 /// the process exited mid-finalize (e.g. the app was force-quit while the

--- a/src-tauri/src/workspace/workspaces.rs
+++ b/src-tauri/src/workspace/workspaces.rs
@@ -30,13 +30,13 @@ pub use super::branching::{
 };
 pub use super::lifecycle::{
     archive_workspace_impl, cleanup_orphaned_initializing_workspaces,
-    create_workspace_from_repo_impl, execute_archive_plan, finalize_workspace_from_repo_impl,
-    move_local_workspace_to_worktree_impl, prepare_archive_plan, prepare_chat_workspace_impl,
-    prepare_local_workspace_impl, prepare_workspace_from_repo_impl, restore_workspace_impl,
-    validate_archive_workspace, validate_restore_workspace, ArchivePreparedPlan,
-    ArchiveWorkspaceResponse, BranchRename, CreateWorkspaceResponse, FinalizeWorkspaceResponse,
-    MoveLocalToWorktreeResponse, PrepareWorkspaceResponse, RestoreWorkspaceResponse,
-    TargetBranchConflict, ValidateRestoreResponse,
+    create_stacked_workspace_impl, create_workspace_from_repo_impl, execute_archive_plan,
+    finalize_workspace_from_repo_impl, move_local_workspace_to_worktree_impl, prepare_archive_plan,
+    prepare_chat_workspace_impl, prepare_local_workspace_impl, prepare_workspace_from_repo_impl,
+    restore_workspace_impl, validate_archive_workspace, validate_restore_workspace,
+    ArchivePreparedPlan, ArchiveWorkspaceResponse, BranchRename, CreateWorkspaceResponse,
+    FinalizeWorkspaceResponse, MoveLocalToWorktreeResponse, PrepareWorkspaceResponse,
+    RestoreWorkspaceResponse, TargetBranchConflict, ValidateRestoreResponse,
 };
 
 #[derive(Debug, Clone, Serialize)]
@@ -85,6 +85,9 @@ pub struct WorkspaceSidebarRow {
     /// "slack", "lark"). `None` for manual workspaces. Drives the sidebar
     /// source-logo badge on AI-proposed rows.
     pub triage_source_type: Option<String>,
+    /// Stacked PRs: `id` of the workspace one layer below this in a PR stack
+    /// (its base). `None` for non-stacked rows. Drives sidebar stack grouping.
+    pub parent_workspace_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1304,6 +1307,7 @@ pub fn record_to_sidebar_row(record: WorkspaceRecord) -> WorkspaceSidebarRow {
         last_user_message_at: record.last_user_message_at,
         triage_priming_unconsumed: record.kind == "ai_triage" && !record.ai_priming_consumed,
         triage_source_type: record.triage_source_type,
+        parent_workspace_id: record.parent_workspace_id,
         kind: record.kind,
     }
 }
@@ -1519,6 +1523,40 @@ pub fn degrade_workspace_to_archived(workspace_id: &str) -> Result<bool> {
 pub fn permanently_delete_workspace(workspace_id: &str) -> Result<()> {
     let mut connection = db::write_conn()?;
 
+    // --- Stacked-PR deletion guard: tip free / root = pop-bottom / middle
+    // blocked. A middle layer (a live parent below AND layers stacked above)
+    // can't be deleted — it would leave an unrebaseable hole in the stack.
+    let (parent_id, default_branch): (Option<String>, Option<String>) = connection
+        .query_row(
+            "SELECT w.parent_workspace_id, r.default_branch
+               FROM workspaces w JOIN repos r ON r.id = w.repository_id WHERE w.id = ?1",
+            [workspace_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap_or((None, None));
+    let has_children: bool = connection
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM workspaces WHERE parent_workspace_id = ?1)",
+            [workspace_id],
+            |row| row.get(0),
+        )
+        .unwrap_or(false);
+    let has_live_parent = match parent_id.as_deref() {
+        Some(parent) => connection
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM workspaces WHERE id = ?1)",
+                [parent],
+                |row| row.get::<_, bool>(0),
+            )
+            .unwrap_or(false),
+        None => false,
+    };
+    if has_live_parent && has_children {
+        bail!(
+            "Cannot delete a middle layer of a PR stack — other workspaces are stacked on it. Delete from the top of the stack (the tip) downward, or restack first."
+        );
+    }
+
     // Load workspace info for filesystem cleanup. Skips the dir delete
     // step for local-mode rows (whose "dir" is the user's repo root).
     let record: Option<(
@@ -1566,6 +1604,21 @@ pub fn permanently_delete_workspace(workspace_id: &str) -> Result<()> {
 
     if deleted_rows != 1 {
         bail!("Workspace delete affected {deleted_rows} rows for {workspace_id}");
+    }
+
+    // Root pop: a deleted stack root's direct children become new roots
+    // targeting the repo default branch (they'll need a restack onto it).
+    if has_children {
+        transaction
+            .execute(
+                "UPDATE workspaces
+                   SET parent_workspace_id = NULL,
+                       intended_target_branch = ?2,
+                       updated_at = datetime('now')
+                 WHERE parent_workspace_id = ?1",
+                (workspace_id, default_branch.as_deref().unwrap_or("main")),
+            )
+            .context("Failed to reparent stack children after root delete")?;
     }
 
     transaction

--- a/src-tauri/src/workspace/workspaces.rs
+++ b/src-tauri/src/workspace/workspaces.rs
@@ -161,6 +161,10 @@ pub struct WorkspaceDetail {
     pub branch: Option<String>,
     pub initialization_parent_branch: Option<String>,
     pub intended_target_branch: Option<String>,
+    /// Stacked-PR parent link. When set, this workspace stacks on the
+    /// referenced workspace; the header renders a live "→ <parent title>"
+    /// chip instead of the raw target-branch picker.
+    pub parent_workspace_id: Option<String>,
     pub mode: WorkspaceMode,
     pub pinned_at: Option<String>,
     pub display_order: i64,
@@ -1398,6 +1402,7 @@ pub fn record_to_detail(record: WorkspaceRecord) -> WorkspaceDetail {
         mode: record.mode,
         initialization_parent_branch: record.initialization_parent_branch,
         intended_target_branch: record.intended_target_branch,
+        parent_workspace_id: record.parent_workspace_id,
         pinned_at: record.pinned_at,
         display_order: record.display_order,
         pr_title: record.pr_title,
@@ -1719,6 +1724,73 @@ mod tests {
             workspace_state(&env, "w-archived").as_deref(),
             Some("archived")
         );
+    }
+
+    #[test]
+    fn update_workspace_branch_cascades_to_stacked_children() {
+        let env = TestEnv::new("branch-cascade");
+        let conn = env.db_connection();
+        insert_repo(&conn, "r1", "demo", Some("origin"));
+        insert_workspace(
+            &conn,
+            &WorkspaceFixture {
+                id: "parent",
+                repo_id: "r1",
+                directory_name: "parent",
+                state: "ready",
+                branch: Some("feat/parent-old"),
+                intended_target_branch: Some("main"),
+            },
+        );
+        insert_workspace(
+            &conn,
+            &WorkspaceFixture {
+                id: "child",
+                repo_id: "r1",
+                directory_name: "child",
+                state: "ready",
+                branch: Some("feat/child"),
+                intended_target_branch: Some("feat/parent-old"),
+            },
+        );
+        insert_workspace(
+            &conn,
+            &WorkspaceFixture {
+                id: "solo",
+                repo_id: "r1",
+                directory_name: "solo",
+                state: "ready",
+                branch: Some("feat/solo"),
+                intended_target_branch: Some("main"),
+            },
+        );
+        conn.execute(
+            "UPDATE workspaces SET parent_workspace_id = 'parent' WHERE id = 'child'",
+            [],
+        )
+        .unwrap();
+
+        crate::models::workspaces::update_workspace_branch("parent", "feat/parent-new").unwrap();
+
+        let branch_of = |id: &str| -> String {
+            conn.query_row("SELECT branch FROM workspaces WHERE id = ?1", [id], |r| {
+                r.get(0)
+            })
+            .unwrap()
+        };
+        let target_of = |id: &str| -> Option<String> {
+            conn.query_row(
+                "SELECT intended_target_branch FROM workspaces WHERE id = ?1",
+                [id],
+                |r| r.get(0),
+            )
+            .unwrap()
+        };
+        // Parent's own branch is renamed; the child's cached target follows it,
+        // while an unrelated standalone workspace is left alone.
+        assert_eq!(branch_of("parent"), "feat/parent-new");
+        assert_eq!(target_of("child").as_deref(), Some("feat/parent-new"));
+        assert_eq!(target_of("solo").as_deref(), Some("main"));
     }
 
     #[test]

--- a/src-tauri/tests/schema_migrations.rs
+++ b/src-tauri/tests/schema_migrations.rs
@@ -50,6 +50,25 @@ fn workspaces_setup_completed_at_columns(
         .unwrap()
 }
 
+fn workspaces_parent_workspace_id_columns(
+    connection: &rusqlite::Connection,
+) -> Vec<(String, String, i64, Option<String>)> {
+    let mut statement = connection
+        .prepare(
+            "SELECT name, type, \"notnull\", dflt_value
+             FROM pragma_table_info('workspaces')
+             WHERE name = 'parent_workspace_id'",
+        )
+        .unwrap();
+    statement
+        .query_map([], |row| {
+            Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
+        })
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+}
+
 fn workspaces_port_columns(
     connection: &rusqlite::Connection,
 ) -> Vec<(String, String, i64, Option<String>)> {
@@ -272,6 +291,67 @@ fn workspaces_port_range_migration_adds_columns_when_missing() {
     assert_yaml_snapshot!(
         "workspaces_port_range_migration",
         workspaces_port_columns(&connection)
+    );
+}
+
+#[test]
+fn workspaces_parent_workspace_id_migration_adds_column_when_missing() {
+    let connection = rusqlite::Connection::open_in_memory().unwrap();
+    // Pre-existing workspaces table from before the stacked-PR parent link
+    // existed. Carry one row to prove the migration leaves legacy rows NULL
+    // (non-stacked) rather than back-filling.
+    connection
+        .execute_batch(
+            r#"
+            CREATE TABLE workspaces (
+                id TEXT PRIMARY KEY,
+                repository_id TEXT,
+                directory_name TEXT,
+                state TEXT DEFAULT 'active',
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+            INSERT INTO workspaces (id, repository_id, directory_name)
+            VALUES ('w1', 'r1', 'demo');
+            "#,
+        )
+        .unwrap();
+
+    schema::ensure_schema(&connection).unwrap();
+    // Idempotency: ALTER TABLE ADD COLUMN twice would error, so the guard
+    // must short-circuit on the second pass.
+    schema::ensure_schema(&connection).unwrap();
+
+    // Existing rows are non-stacked: the new link is NULL, not "".
+    let preserved: Option<String> = connection
+        .query_row(
+            "SELECT parent_workspace_id FROM workspaces WHERE id = 'w1'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(preserved.is_none());
+
+    // Round-trip: a stacked child stores and returns its parent's id.
+    connection
+        .execute(
+            "INSERT INTO workspaces (id, repository_id, directory_name, parent_workspace_id)
+             VALUES ('w2', 'r1', 'child', 'w1')",
+            [],
+        )
+        .unwrap();
+    let parent: Option<String> = connection
+        .query_row(
+            "SELECT parent_workspace_id FROM workspaces WHERE id = 'w2'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(parent.as_deref(), Some("w1"));
+
+    assert_yaml_snapshot!(
+        "workspaces_parent_workspace_id_migration",
+        workspaces_parent_workspace_id_columns(&connection)
     );
 }
 

--- a/src-tauri/tests/snapshots/schema_migrations__workspaces_parent_workspace_id_migration.snap
+++ b/src-tauri/tests/snapshots/schema_migrations__workspaces_parent_workspace_id_migration.snap
@@ -1,0 +1,8 @@
+---
+source: tests/schema_migrations.rs
+expression: workspaces_parent_workspace_id_columns(&connection)
+---
+- - parent_workspace_id
+  - TEXT
+  - 0
+  - ~

--- a/src/features/composer/composer-quick-actions.tsx
+++ b/src/features/composer/composer-quick-actions.tsx
@@ -1,0 +1,68 @@
+import { ListTree } from "lucide-react";
+import type { ComponentType } from "react";
+import { cn } from "@/lib/utils";
+
+export type ComposerQuickAction = {
+	id: string;
+	label: string;
+	/** Prompt sent verbatim when the tag is clicked — typically a slash
+	 *  command that triggers the matching skill (e.g. `/helmor-cli restack`). */
+	prompt: string;
+	icon?: ComponentType<{ className?: string; strokeWidth?: number }>;
+};
+
+// Default quick actions. Each tag fires a preset prompt on click — for now
+// just Restack, which kicks off the stacked-PR restack skill.
+const DEFAULT_QUICK_ACTIONS: ComposerQuickAction[] = [
+	{
+		id: "restack",
+		label: "Restack",
+		prompt: "/helmor-cli restack",
+		icon: ListTree,
+	},
+];
+
+type ComposerQuickActionsProps = {
+	actions?: ComposerQuickAction[];
+	onAction: (action: ComposerQuickAction) => void;
+	disabled?: boolean;
+};
+
+/**
+ * Row of one-click quick-action tags that sits above the composer. Clicking a
+ * tag dispatches its preset prompt. Rendered inside the composer's floating
+ * column so it stacks naturally with the other bars (queue, goal banner) and
+ * gets pushed up instead of overlapping them.
+ */
+export function ComposerQuickActions({
+	actions = DEFAULT_QUICK_ACTIONS,
+	onAction,
+	disabled,
+}: ComposerQuickActionsProps) {
+	if (actions.length === 0) return null;
+	return (
+		<div className="pointer-events-auto mb-1.5 flex w-full flex-wrap items-center justify-start gap-1.5 self-stretch pl-1">
+			{actions.map((action) => {
+				const Icon = action.icon;
+				return (
+					<button
+						key={action.id}
+						type="button"
+						disabled={disabled}
+						onClick={() => onAction(action)}
+						className={cn(
+							"inline-flex cursor-pointer items-center gap-1 rounded-md border border-border/50 bg-sidebar/90 px-2 py-1 text-small font-medium text-muted-foreground backdrop-blur transition-colors hover:border-border hover:bg-accent/60 hover:text-foreground",
+							disabled &&
+								"cursor-not-allowed opacity-50 hover:border-border/50 hover:bg-sidebar/90 hover:text-muted-foreground",
+						)}
+					>
+						{Icon ? (
+							<Icon className="size-3 shrink-0" strokeWidth={1.8} />
+						) : null}
+						<span>{action.label}</span>
+					</button>
+				);
+			})}
+		</div>
+	);
+}

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -326,18 +326,24 @@ export const WorkspaceComposerContainer = memo(
 		// workspace is a stack tip when it has a parent (is stacked on a layer
 		// below) AND no other workspace stacks on it. Reuses the cached sidebar
 		// workspace list.
-		const workspaceGroupsQuery = useQuery(workspaceGroupsQueryOptions());
-		const isStackTip = useMemo(() => {
-			if (!displayedWorkspaceId) return false;
-			const rows = (workspaceGroupsQuery.data ?? []).flatMap(
-				(group) => group.rows,
-			);
-			const current = rows.find((row) => row.id === displayedWorkspaceId);
-			if (!current?.parentWorkspaceId) return false;
-			return !rows.some(
-				(row) => row.parentWorkspaceId === displayedWorkspaceId,
-			);
-		}, [displayedWorkspaceId, workspaceGroupsQuery.data]);
+		// Narrow the cached sidebar workspace list down to the single boolean
+		// this composer needs, via `select`, so the query observer only
+		// re-renders when *that* flips — not on every workspace-list change
+		// (adds, status flips, reorders). Keeps non-stack composers free of
+		// churn-driven re-renders.
+		const isStackTip =
+			useQuery({
+				...workspaceGroupsQueryOptions(),
+				select: (groups) => {
+					if (!displayedWorkspaceId) return false;
+					const rows = groups.flatMap((group) => group.rows);
+					const current = rows.find((row) => row.id === displayedWorkspaceId);
+					if (!current?.parentWorkspaceId) return false;
+					return !rows.some(
+						(row) => row.parentWorkspaceId === displayedWorkspaceId,
+					);
+				},
+			}).data ?? false;
 		const workspaceDetailQuery = useQuery({
 			...workspaceDetailQueryOptions(displayedWorkspaceId ?? "__none__"),
 			enabled: Boolean(displayedWorkspaceId),

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -41,6 +41,7 @@ import {
 	slashCommandsQueryOptions,
 	workspaceCandidateDirectoriesQueryOptions,
 	workspaceDetailQueryOptions,
+	workspaceGroupsQueryOptions,
 	workspaceLinkedDirectoriesQueryOptions,
 	workspaceSessionsQueryOptions,
 } from "@/lib/query-client";
@@ -57,6 +58,10 @@ import {
 } from "@/lib/workspace-helpers";
 import { publishShellEvent } from "@/shell/event-bus";
 import { CodexGoalBanner } from "../panel/codex-goal-banner";
+import {
+	type ComposerQuickAction,
+	ComposerQuickActions,
+} from "./composer-quick-actions";
 import type { AddDirPickerEntry } from "./editor/add-dir/typeahead-plugin";
 import { WorkspaceComposer } from "./index";
 import {
@@ -317,6 +322,22 @@ export const WorkspaceComposerContainer = memo(
 			[settings.startSurfacePreferences, updateSettings],
 		);
 		const modelSectionsQuery = useQuery(agentModelSectionsQueryOptions());
+		// Stack-tip detection for the Restack quick action: the current
+		// workspace is a stack tip when it has a parent (is stacked on a layer
+		// below) AND no other workspace stacks on it. Reuses the cached sidebar
+		// workspace list.
+		const workspaceGroupsQuery = useQuery(workspaceGroupsQueryOptions());
+		const isStackTip = useMemo(() => {
+			if (!displayedWorkspaceId) return false;
+			const rows = (workspaceGroupsQuery.data ?? []).flatMap(
+				(group) => group.rows,
+			);
+			const current = rows.find((row) => row.id === displayedWorkspaceId);
+			if (!current?.parentWorkspaceId) return false;
+			return !rows.some(
+				(row) => row.parentWorkspaceId === displayedWorkspaceId,
+			);
+		}, [displayedWorkspaceId, workspaceGroupsQuery.data]);
 		const workspaceDetailQuery = useQuery({
 			...workspaceDetailQueryOptions(displayedWorkspaceId ?? "__none__"),
 			enabled: Boolean(displayedWorkspaceId),
@@ -901,6 +922,15 @@ export const WorkspaceComposerContainer = memo(
 			handleComposerSubmitInner("/goal resume", [], [], []);
 		}, [handleComposerSubmitInner]);
 
+		// Quick-action tag clicked above the composer — fire its preset prompt
+		// straight through the normal submit path (e.g. `/helmor-cli restack`).
+		const handleQuickAction = useCallback(
+			(action: ComposerQuickAction) => {
+				handleComposerSubmitInner(action.prompt, [], [], []);
+			},
+			[handleComposerSubmitInner],
+		);
+
 		// Track which queued prompt we've already dispatched so a re-render
 		// (e.g. due to query invalidation refreshing the session list) can't
 		// resubmit the same prompt twice before the parent clears the queue.
@@ -1093,6 +1123,12 @@ export const WorkspaceComposerContainer = memo(
 
 				<div className="relative z-10">
 					<div className="pointer-events-none absolute inset-x-0 bottom-[calc(100%-1px)] z-20 flex flex-col items-center gap-1.5">
+						{isStackTip ? (
+							<ComposerQuickActions
+								onAction={handleQuickAction}
+								disabled={composerUnavailable || sending}
+							/>
+						) : null}
 						<WorkflowProgressPanel
 							sessionId={displayedSessionId}
 							open={workflowsPanelOpen}

--- a/src/features/conversation/index.tsx
+++ b/src/features/conversation/index.tsx
@@ -85,6 +85,7 @@ export type WorkspaceConversationContainerProps = {
 	sessionSelectionHistory?: string[];
 	onSelectSession: (sessionId: string | null) => void;
 	onResolveDisplayedSession: (sessionId: string | null) => void;
+	onSelectWorkspace?: (workspaceId: string) => void;
 	onInteractionSessionsChange?: (
 		sessionWorkspaceMap: Map<string, string>,
 		interactionCounts: Map<string, number>,
@@ -180,6 +181,7 @@ export const WorkspaceConversationContainer = memo(
 		sessionSelectionHistory = [],
 		onSelectSession,
 		onResolveDisplayedSession,
+		onSelectWorkspace,
 		onInteractionSessionsChange,
 		activeStreams,
 		busySessionIds,
@@ -576,6 +578,7 @@ export const WorkspaceConversationContainer = memo(
 						modelSelections={composerModelSelections}
 						workspaceChangeRequest={workspaceChangeRequest}
 						onSelectSession={onSelectSession}
+						onSelectWorkspace={onSelectWorkspace}
 						onResolveDisplayedSession={onResolveDisplayedSession}
 						onQueuePendingPromptForSession={onQueuePendingPromptForSession}
 						onRequestCloseSession={onRequestCloseSession}

--- a/src/features/navigation/dnd/drag-ghosts.tsx
+++ b/src/features/navigation/dnd/drag-ghosts.tsx
@@ -15,6 +15,9 @@ type WorkspaceDragGhostProps = {
 	selected: boolean;
 	isSending?: boolean;
 	isInteractionRequired?: boolean;
+	/** Tip-first stack chain when dragging a stack tip. When it has >1 member
+	 *  the ghost shows a count badge (total PRs in the stack) on the right. */
+	stackRows?: WorkspaceRow[] | null;
 };
 
 export function WorkspaceDragGhost({
@@ -24,7 +27,10 @@ export function WorkspaceDragGhost({
 	selected,
 	isSending,
 	isInteractionRequired,
+	stackRows,
 }: WorkspaceDragGhostProps) {
+	const stackCount =
+		stackRows && stackRows.length > 1 ? stackRows.length : null;
 	return (
 		<div
 			className="pointer-events-none fixed z-50"
@@ -35,15 +41,22 @@ export function WorkspaceDragGhost({
 				width: dragState.width,
 			}}
 		>
-			<WorkspaceRowItem
-				row={row}
-				selected={selected}
-				isSending={isSending}
-				isInteractionRequired={isInteractionRequired}
-				dragPreview
-				hideRepoAvatar={hideRepoAvatar}
-				workspaceActionsDisabled
-			/>
+			<div className="relative">
+				<WorkspaceRowItem
+					row={row}
+					selected={selected}
+					isSending={isSending}
+					isInteractionRequired={isInteractionRequired}
+					dragPreview
+					hideRepoAvatar={hideRepoAvatar}
+					workspaceActionsDisabled
+				/>
+				{stackCount ? (
+					<span className="absolute right-0 top-1/2 flex h-4 min-w-4 -translate-y-1/2 items-center justify-center rounded-full bg-primary/70 px-1 text-nano font-semibold tabular-nums text-primary-foreground">
+						{stackCount}
+					</span>
+				) : null}
+			</div>
 		</div>
 	);
 }

--- a/src/features/navigation/index.tsx
+++ b/src/features/navigation/index.tsx
@@ -953,26 +953,49 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 					data-stack-tip-id={item.stackMeta?.tipId}
 				>
 					{item.stackMeta ? (
-						// Stack connector: a solid node dot per row, joined by a
-						// vertical line down the left gutter — tip connects only
-						// downward, root only upward, mid both ways.
+						// Stack connector: a node dot per row joined by vertical
+						// line segments that stop at the dot's edge (3px radius)
+						// rather than crossing it. Upper segment connects up
+						// (mid, root); lower segment connects down and extends 2px
+						// past the row to bridge the inter-row gap (ROW_HEIGHT =
+						// 30px row + 2px) so the line stays unbroken.
 						<>
-							<span
-								aria-hidden
-								className={cn(
-									// Downward segments (tip, mid) extend 2px past the
-									// row to bridge the inter-row gap (ROW_HEIGHT = 30px
-									// row + 2px) so the stack line stays unbroken.
-									"pointer-events-none absolute left-[3px] w-px -translate-x-1/2 bg-muted-foreground/20",
-									item.stackMeta.role === "tip" && "top-1/2 -bottom-0.5",
-									item.stackMeta.role === "root" && "top-0 bottom-1/2",
-									item.stackMeta.role === "mid" && "top-0 -bottom-0.5",
-								)}
-							/>
-							<span
-								aria-hidden
-								className="pointer-events-none absolute left-[3px] top-1/2 size-1.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-muted-foreground/40"
-							/>
+							{item.stackMeta.role !== "tip" ? (
+								<span
+									aria-hidden
+									className="pointer-events-none absolute left-[3px] top-0 bottom-[calc(50%_+_3px)] w-px -translate-x-1/2 bg-muted-foreground/20"
+								/>
+							) : null}
+							{item.stackMeta.role !== "root" ? (
+								<span
+									aria-hidden
+									className="pointer-events-none absolute left-[3px] top-[calc(50%_+_3px)] -bottom-0.5 w-px -translate-x-1/2 bg-muted-foreground/20"
+								/>
+							) : null}
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<span
+										className={cn(
+											// Base (root) layer gets a prominent solid dot
+											// (foreground = white in dark theme, black in
+											// light); other layers stay muted.
+											"pointer-events-auto absolute left-[3px] top-1/2 size-1.5 -translate-x-1/2 -translate-y-1/2 cursor-default rounded-full",
+											item.stackMeta.role === "root"
+												? "bg-foreground"
+												: "bg-muted-foreground/40",
+										)}
+									/>
+								</TooltipTrigger>
+								<TooltipContent side="left" sideOffset={6}>
+									{`${
+										item.stackMeta.role === "tip"
+											? "Stack tip"
+											: item.stackMeta.role === "root"
+												? "Stack base"
+												: "Stack"
+									} · ${item.stackMeta.depth + 1} of ${item.stackMeta.stackSize}`}
+								</TooltipContent>
+							</Tooltip>
 						</>
 					) : null}
 					<WorkspaceRowItem

--- a/src/features/navigation/index.tsx
+++ b/src/features/navigation/index.tsx
@@ -35,6 +35,7 @@ import {
 import { InlineShortcutDisplay } from "@/features/shortcuts/shortcut-display";
 import type {
 	RepositoryCreateOption,
+	StackRowMeta,
 	WorkspaceGroup,
 	WorkspaceRow,
 	WorkspaceStatus,
@@ -76,7 +77,15 @@ type VirtualItem =
 			group: WorkspaceGroup;
 			canCollapse: boolean;
 	  }
-	| { kind: "row"; groupId: string; row: WorkspaceRow; isArchived: boolean }
+	| {
+			kind: "row";
+			groupId: string;
+			row: WorkspaceRow;
+			isArchived: boolean;
+			/** Stacked-PR connector metadata for this row (from `nestStacks`),
+			 *  present only when the row belongs to a multi-member stack. */
+			stackMeta?: StackRowMeta;
+	  }
 	| {
 			kind: "drop-placeholder";
 			groupId: string;
@@ -303,6 +312,36 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 		}
 		return archivedRows.find((row) => row.id === activeDragWorkspaceId) ?? null;
 	}, [activeDragWorkspaceId, archivedRows, groups]);
+	// When the dragged row is a stack tip, collect its whole chain (tip-first,
+	// ordered by depth) so the drag ghost can render the stack as one pile
+	// that follows the tip — the stack moves as a unit.
+	const activeDragStackRows = useMemo(() => {
+		if (!activeDragWorkspaceId) return null;
+		for (const group of groups) {
+			const meta = group.stackMeta?.get(activeDragWorkspaceId);
+			if (!meta || meta.role !== "tip") continue;
+			const members = group.rows
+				.filter((row) => group.stackMeta?.get(row.id)?.tipId === meta.tipId)
+				.sort(
+					(a, b) =>
+						(group.stackMeta?.get(a.id)?.depth ?? 0) -
+						(group.stackMeta?.get(b.id)?.depth ?? 0),
+				);
+			return members.length > 1 ? members : null;
+		}
+		return null;
+	}, [activeDragWorkspaceId, groups]);
+	// Ids of the dragged stack's non-tip members. While the tip is dragging
+	// these rows are pulled OUT of the list (they collapse into the floating
+	// pile ghost) and restored — expanded — on drop.
+	const draggingStackMemberIds = useMemo(() => {
+		if (!activeDragStackRows) return null;
+		const ids = new Set<string>();
+		for (let i = 1; i < activeDragStackRows.length; i += 1) {
+			ids.add(activeDragStackRows[i].id);
+		}
+		return ids;
+	}, [activeDragStackRows]);
 	/** Group currently under repo-drag — rows feed the ghost. */
 	const repoDragGroup = useMemo(() => {
 		if (!activeRepoDragId) return null;
@@ -529,11 +568,17 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 					if (activeDragWorkspaceId === row.id) {
 						continue;
 					}
+					// Non-tip members of the dragging stack collapse into the
+					// floating pile ghost — skip them in the list.
+					if (draggingStackMemberIds?.has(row.id)) {
+						continue;
+					}
 					items.push({
 						kind: "row",
 						groupId: group.id,
 						row,
 						isArchived: false,
+						stackMeta: group.stackMeta?.get(row.id),
 					});
 				}
 			}
@@ -602,6 +647,7 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 		archivedRows,
 		sectionOpenState,
 		activeDragWorkspaceId,
+		draggingStackMemberIds,
 		dropTargetGroupId,
 		dropTargetBeforeWorkspaceId,
 		pinnedSlotReady,
@@ -898,12 +944,37 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 			// kind === "row"
 			return (
 				<div
-					className="pl-2"
+					className={cn("pl-2", item.stackMeta && "relative")}
 					data-workspace-drop-group-id={item.groupId}
 					data-workspace-dnd-row="true"
 					data-workspace-dnd-row-id={item.row.id}
 					data-workspace-dnd-group-id={item.groupId}
+					data-stack-role={item.stackMeta?.role}
+					data-stack-tip-id={item.stackMeta?.tipId}
 				>
+					{item.stackMeta ? (
+						// Stack connector: a solid node dot per row, joined by a
+						// vertical line down the left gutter — tip connects only
+						// downward, root only upward, mid both ways.
+						<>
+							<span
+								aria-hidden
+								className={cn(
+									// Downward segments (tip, mid) extend 2px past the
+									// row to bridge the inter-row gap (ROW_HEIGHT = 30px
+									// row + 2px) so the stack line stays unbroken.
+									"pointer-events-none absolute left-[3px] w-px -translate-x-1/2 bg-muted-foreground/20",
+									item.stackMeta.role === "tip" && "top-1/2 -bottom-0.5",
+									item.stackMeta.role === "root" && "top-0 bottom-1/2",
+									item.stackMeta.role === "mid" && "top-0 -bottom-0.5",
+								)}
+							/>
+							<span
+								aria-hidden
+								className="pointer-events-none absolute left-[3px] top-1/2 size-1.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-muted-foreground/40"
+							/>
+						</>
+					) : null}
 					<WorkspaceRowItem
 						row={item.row}
 						selected={selectedWorkspaceId === item.row.id}
@@ -924,7 +995,14 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 						onSetWorkspaceStatus={onSetWorkspaceStatus}
 						groupId={item.groupId}
 						onDragPointerDown={
-							dragReorderEnabled ? startDragGesture : undefined
+							// Stacked PRs move as a unit: only the tip (top row)
+							// initiates a drag — its stack members follow via
+							// `nestStacks` re-homing. Lock mid/root members so a
+							// single PR can't be torn out of the dependency chain.
+							dragReorderEnabled &&
+							(!item.stackMeta || item.stackMeta.role === "tip")
+								? startDragGesture
+								: undefined
 						}
 						disableHoverCard={isAnyDragging}
 						archivingWorkspaceIds={archivingWorkspaceIds}
@@ -1175,6 +1253,7 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 				<WorkspaceDragGhost
 					dragState={dragState}
 					row={activeDragRow}
+					stackRows={activeDragStackRows}
 					selected={selectedWorkspaceId === activeDragRow.id}
 					isSending={busyWorkspaceIds?.has(activeDragRow.id)}
 					isInteractionRequired={interactionRequiredWorkspaceIds?.has(

--- a/src/features/navigation/sidebar-projection.test.ts
+++ b/src/features/navigation/sidebar-projection.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
-import type { WorkspaceGroup, WorkspaceSummary } from "@/lib/api";
+import type { WorkspaceGroup, WorkspaceRow, WorkspaceSummary } from "@/lib/api";
 import {
 	applySidebarView,
+	nestStacks,
 	type PendingArchiveEntry,
 	type PendingCreationEntry,
 	projectSidebarLists,
@@ -506,6 +507,133 @@ describe("projectVisualSidebar", () => {
 		// for both groupings.
 		expect(repo.archivedRows.map((r) => r.id)).toEqual(["ws-a"]);
 		expect(status.archivedRows.map((r) => r.id)).toEqual(["ws-a"]);
+	});
+});
+
+describe("nestStacks", () => {
+	const mkRow = (id: string, parentWorkspaceId?: string): WorkspaceRow => ({
+		id,
+		title: id,
+		state: "ready",
+		status: "in-progress",
+		repoId: "repo-1",
+		repoName: "repo-one",
+		...(parentWorkspaceId ? { parentWorkspaceId } : {}),
+	});
+
+	it("hoists a stack's members contiguously under the tip, across status groups", () => {
+		// Stack tip `c` → `b` → root `a`, scattered across three status groups.
+		const groups: WorkspaceGroup[] = [
+			{ id: "done", label: "Done", tone: "done", rows: [mkRow("a")] },
+			{
+				id: "review",
+				label: "In review",
+				tone: "review",
+				rows: [mkRow("b", "a")],
+			},
+			{
+				id: "progress",
+				label: "In progress",
+				tone: "progress",
+				rows: [mkRow("c", "b")],
+			},
+		];
+		const result = nestStacks(groups);
+
+		// Tip keeps its group; the rest follow it in tip → root order.
+		const progress = result.find((g) => g.id === "progress");
+		expect(progress?.rows.map((r) => r.id)).toEqual(["c", "b", "a"]);
+		// Donor groups are emptied of the relocated members.
+		expect(result.find((g) => g.id === "done")?.rows).toEqual([]);
+		expect(result.find((g) => g.id === "review")?.rows).toEqual([]);
+		// Connector metadata lives on the tip's group.
+		expect(progress?.stackMeta?.get("c")).toEqual({
+			role: "tip",
+			depth: 0,
+			tipId: "c",
+		});
+		expect(progress?.stackMeta?.get("b")).toEqual({
+			role: "mid",
+			depth: 1,
+			tipId: "c",
+		});
+		expect(progress?.stackMeta?.get("a")).toEqual({
+			role: "root",
+			depth: 2,
+			tipId: "c",
+		});
+	});
+
+	it("leaves non-stacked rows untouched with no stackMeta", () => {
+		const groups: WorkspaceGroup[] = [
+			{
+				id: "progress",
+				label: "In progress",
+				tone: "progress",
+				rows: [mkRow("x"), mkRow("y")],
+			},
+		];
+		const result = nestStacks(groups);
+		expect(result[0]?.rows.map((r) => r.id)).toEqual(["x", "y"]);
+		expect(result[0]?.stackMeta).toBeUndefined();
+	});
+
+	it("ignores a parent link pointing outside the visible set (dangling)", () => {
+		const groups: WorkspaceGroup[] = [
+			{
+				id: "progress",
+				label: "In progress",
+				tone: "progress",
+				rows: [mkRow("child", "missing-parent")],
+			},
+		];
+		const result = nestStacks(groups);
+		expect(result[0]?.rows.map((r) => r.id)).toEqual(["child"]);
+		expect(result[0]?.stackMeta).toBeUndefined();
+	});
+
+	it("terminates on a parent cycle without duplicating rows", () => {
+		const groups: WorkspaceGroup[] = [
+			{
+				id: "progress",
+				label: "In progress",
+				tone: "progress",
+				rows: [mkRow("a", "b"), mkRow("b", "a")],
+			},
+		];
+		const result = nestStacks(groups);
+		expect([...(result[0]?.rows.map((r) => r.id) ?? [])].sort()).toEqual([
+			"a",
+			"b",
+		]);
+	});
+
+	it("keeps the stack contiguous through applySidebarView regardless of sort", () => {
+		// Two-member stack (tip `c2` → root `c1`) plus a standalone `z`.
+		const projected = {
+			groups: [
+				{
+					id: "progress",
+					label: "In progress",
+					tone: "progress" as const,
+					rows: [
+						{ ...mkRow("c1"), title: "alpha-root" },
+						{ ...mkRow("c2", "c1"), title: "mango-tip" },
+						{ ...mkRow("z"), title: "zebra" },
+					],
+				},
+			],
+			archivedRows: [],
+		};
+		const result = applySidebarView(projected, { sort: "createdAt" });
+		const ids = result.groups[0]?.rows.map((r) => r.id) ?? [];
+		// nestStacks runs after the sort: the root `c1` clings to its tip
+		// `c2` (immediately after), never standing alone.
+		const tipIndex = ids.indexOf("c2");
+		expect(tipIndex).toBeGreaterThanOrEqual(0);
+		expect(ids[tipIndex + 1]).toBe("c1");
+		// All rows survive exactly once.
+		expect([...ids].sort()).toEqual(["c1", "c2", "z"]);
 	});
 });
 

--- a/src/features/navigation/sidebar-projection.test.ts
+++ b/src/features/navigation/sidebar-projection.test.ts
@@ -550,16 +550,19 @@ describe("nestStacks", () => {
 		expect(progress?.stackMeta?.get("c")).toEqual({
 			role: "tip",
 			depth: 0,
+			stackSize: 3,
 			tipId: "c",
 		});
 		expect(progress?.stackMeta?.get("b")).toEqual({
 			role: "mid",
 			depth: 1,
+			stackSize: 3,
 			tipId: "c",
 		});
 		expect(progress?.stackMeta?.get("a")).toEqual({
 			role: "root",
 			depth: 2,
+			stackSize: 3,
 			tipId: "c",
 		});
 	});

--- a/src/features/navigation/sidebar-projection.ts
+++ b/src/features/navigation/sidebar-projection.ts
@@ -1,4 +1,9 @@
-import type { WorkspaceGroup, WorkspaceRow, WorkspaceSummary } from "@/lib/api";
+import type {
+	StackRowMeta,
+	WorkspaceGroup,
+	WorkspaceRow,
+	WorkspaceSummary,
+} from "@/lib/api";
 import type { SidebarGrouping, SidebarSort } from "@/lib/settings";
 import { summaryToArchivedRow } from "@/lib/workspace-helpers";
 
@@ -175,17 +180,98 @@ export function applySidebarView(
 		compareArchivedRowsByUpdatedAtDesc,
 	);
 
-	if (sort === "custom") {
-		return {
-			groups: filteredGroups,
-			archivedRows: sortedArchivedRows,
-		};
-	}
+	const orderedGroups =
+		sort === "custom"
+			? filteredGroups
+			: sortGroupsForView(filteredGroups, sort);
 
+	// Final step: group stacked-PR members so a stack renders contiguously
+	// under its tip. Runs here — the convergence point shared by BOTH the
+	// render path and the keyboard-nav path — so the two never desync, and
+	// AFTER sorting so the tip's already-sorted position anchors the stack.
 	return {
-		groups: sortGroupsForView(filteredGroups, sort),
+		groups: nestStacks(orderedGroups),
 		archivedRows: sortedArchivedRows,
 	};
+}
+
+/**
+ * Group stacked-PR workspaces so a stack's members render contiguously.
+ *
+ * A "stack" is a chain of workspaces linked by `parentWorkspaceId`. Only the
+ * TIP (the newest member — the one nobody else stacks on) keeps its natural
+ * sorted slot; every other member is pulled out of its own status / repo
+ * group and re-inserted immediately after the tip, in stack order
+ * (tip → … → root). Per-row connector metadata is recorded on the owning
+ * group's `stackMeta` so the row renderer can draw the stack-link affordance.
+ *
+ * Singletons and non-stacked rows are left exactly where they are — no
+ * behavior change for the common case. Defensive against dangling parent
+ * links, cycles, and forks (a shared ancestor is claimed by a single stack).
+ */
+export function nestStacks(groups: WorkspaceGroup[]): WorkspaceGroup[] {
+	const located = new Map<string, WorkspaceRow>();
+	for (const group of groups) {
+		for (const row of group.rows) located.set(row.id, row);
+	}
+
+	// Ids that are some visible row's parent → cannot themselves be a tip.
+	const visibleParentIds = new Set<string>();
+	for (const row of located.values()) {
+		const parent = row.parentWorkspaceId;
+		if (parent && located.has(parent)) visibleParentIds.add(parent);
+	}
+
+	// Build each stack from its tip downward (tip → … → root). `claimed`
+	// guards a shared ancestor (a fork) from landing in two stacks.
+	const chainsByTip = new Map<string, WorkspaceRow[]>();
+	const claimed = new Set<string>();
+	for (const tip of located.values()) {
+		const parent = tip.parentWorkspaceId;
+		const isTip =
+			!!parent && located.has(parent) && !visibleParentIds.has(tip.id);
+		if (!isTip) continue;
+		const chain: WorkspaceRow[] = [tip];
+		let cursor = located.get(parent as string);
+		while (cursor && cursor.id !== tip.id && !claimed.has(cursor.id)) {
+			claimed.add(cursor.id);
+			chain.push(cursor);
+			cursor = cursor.parentWorkspaceId
+				? located.get(cursor.parentWorkspaceId)
+				: undefined;
+		}
+		if (chain.length >= 2) chainsByTip.set(tip.id, chain);
+	}
+
+	if (chainsByTip.size === 0) return groups;
+
+	const relocated = new Set<string>();
+	for (const chain of chainsByTip.values()) {
+		for (let i = 1; i < chain.length; i += 1) relocated.add(chain[i].id);
+	}
+
+	return groups.map((group) => {
+		const stackMeta = new Map<string, StackRowMeta>();
+		const rows: WorkspaceRow[] = [];
+		for (const row of group.rows) {
+			if (relocated.has(row.id)) continue; // re-homed under its tip
+			rows.push(row);
+			const chain = chainsByTip.get(row.id);
+			if (!chain) continue;
+			chain.forEach((member, depth) => {
+				if (depth > 0) rows.push(member);
+				stackMeta.set(member.id, {
+					role:
+						depth === 0 ? "tip" : depth === chain.length - 1 ? "root" : "mid",
+					depth,
+					tipId: row.id,
+				});
+			});
+		}
+		return stackMeta.size > 0
+			? { ...group, rows, stackMeta }
+			: { ...group, rows };
+	});
 }
 
 function compareArchivedRowsByUpdatedAtDesc(

--- a/src/features/navigation/sidebar-projection.ts
+++ b/src/features/navigation/sidebar-projection.ts
@@ -264,6 +264,7 @@ export function nestStacks(groups: WorkspaceGroup[]): WorkspaceGroup[] {
 					role:
 						depth === 0 ? "tip" : depth === chain.length - 1 ? "root" : "mid",
 					depth,
+					stackSize: chain.length,
 					tipId: row.id,
 				});
 			});

--- a/src/features/panel/container.tsx
+++ b/src/features/panel/container.tsx
@@ -55,6 +55,7 @@ type WorkspacePanelContainerProps = {
 	modelSelections?: Record<string, string>;
 	workspaceChangeRequest?: ChangeRequestInfo | null;
 	onSelectSession: (sessionId: string | null) => void;
+	onSelectWorkspace?: (workspaceId: string) => void;
 	onResolveDisplayedSession: (sessionId: string | null) => void;
 	onQueuePendingPromptForSession?: (request: {
 		sessionId: string;
@@ -87,6 +88,7 @@ export const WorkspacePanelContainer = memo(function WorkspacePanelContainer({
 	modelSelections = {},
 	workspaceChangeRequest = null,
 	onSelectSession,
+	onSelectWorkspace,
 	onResolveDisplayedSession,
 	onQueuePendingPromptForSession,
 	onRequestCloseSession,
@@ -527,6 +529,11 @@ export const WorkspacePanelContainer = memo(function WorkspacePanelContainer({
 	const handleSelectSession = useCallback((sessionId: string) => {
 		onSelectSessionRef.current(sessionId);
 	}, []);
+	const onSelectWorkspaceRef = useRef(onSelectWorkspace);
+	onSelectWorkspaceRef.current = onSelectWorkspace;
+	const handleSelectWorkspace = useCallback((workspaceId: string) => {
+		onSelectWorkspaceRef.current?.(workspaceId);
+	}, []);
 	const handleSessionsChanged = useCallback(() => {
 		void invalidateSessionQueries();
 	}, [invalidateSessionQueries]);
@@ -650,6 +657,7 @@ export const WorkspacePanelContainer = memo(function WorkspacePanelContainer({
 			contextPreviewCard={contextPreviewCard}
 			contextPreviewActive={contextPreviewActive}
 			onSelectSession={handleSelectSession}
+			onSelectWorkspace={handleSelectWorkspace}
 			onSelectContextPreview={onSelectContextPreview}
 			onCloseContextPreview={onCloseContextPreview}
 			onPrefetchSession={handlePrefetchSession}

--- a/src/features/panel/header.tsx
+++ b/src/features/panel/header.tsx
@@ -60,6 +60,7 @@ import { initialsFor } from "@/lib/initials";
 import {
 	helmorQueryKeys,
 	workspaceAccountProfileQueryOptions,
+	workspaceDetailQueryOptions,
 	workspaceForgeActionStatusQueryOptions,
 } from "@/lib/query-client";
 import type { ContextCard } from "@/lib/sources/types";
@@ -97,6 +98,9 @@ type WorkspacePanelHeaderProps = {
 	onSessionRenamed?: (sessionId: string, title: string) => void;
 	onWorkspaceChanged?: () => void;
 	onRequestCloseSession?: (request: SessionCloseRequest) => void;
+	/** Navigate to another workspace by id (used by the stacked-PR parent
+	 *  chip). Wired from the shell's selection controller. */
+	onSelectWorkspace?: (workspaceId: string) => void;
 	newSessionShortcut?: string | null;
 };
 
@@ -128,6 +132,7 @@ export const WorkspacePanelHeader = memo(function WorkspacePanelHeader({
 	onSessionRenamed,
 	onWorkspaceChanged,
 	onRequestCloseSession,
+	onSelectWorkspace,
 	newSessionShortcut,
 }: WorkspacePanelHeaderProps) {
 	const branchTone = getWorkspaceBranchTone({
@@ -355,7 +360,15 @@ export const WorkspacePanelHeader = memo(function WorkspacePanelHeader({
 									</>
 								)}
 							</span>
-							{workspace?.intendedTargetBranch ? (
+							{workspace?.parentWorkspaceId ? (
+								<StackParentChip
+									parentWorkspaceId={workspace.parentWorkspaceId}
+									fallbackBranch={workspace.intendedTargetBranch}
+									displayRemote={workspace.remote ?? "origin"}
+									archived={workspace.state === "archived"}
+									onSelectWorkspace={onSelectWorkspace}
+								/>
+							) : workspace?.intendedTargetBranch ? (
 								<>
 									<ArrowRight
 										className="relative top-px size-3 shrink-0 self-center text-muted-foreground"
@@ -867,6 +880,76 @@ function displayTooltipTitle(title: string): string {
 		.slice(0, SESSION_TITLE_TOOLTIP_MAX_CHARS - 3)
 		.join("")
 		.trimEnd()}...`;
+}
+
+// StackParentChip: for a stacked-PR child, replaces the target-branch picker
+// with a live "→ <parent workspace title>" chip that navigates to the parent.
+// The parent's title comes from its own (cached, auto-invalidated) detail
+// query, so renaming the parent updates this chip in place — and the click
+// never points at a stale branch string the way the raw target name could.
+function StackParentChip({
+	parentWorkspaceId,
+	fallbackBranch,
+	displayRemote,
+	archived,
+	onSelectWorkspace,
+}: {
+	parentWorkspaceId: string;
+	fallbackBranch?: string | null;
+	displayRemote: string;
+	archived: boolean;
+	onSelectWorkspace?: (workspaceId: string) => void;
+}) {
+	const parentQuery = useQuery(workspaceDetailQueryOptions(parentWorkspaceId));
+	const parent = parentQuery.data ?? null;
+	const label = parent?.title?.trim() || fallbackBranch || "base";
+	const branchHint = parent?.branch ?? fallbackBranch ?? null;
+	const chipInner = (
+		<>
+			<Layers className="size-3 shrink-0" strokeWidth={1.8} />
+			<span className="block min-w-0 truncate">{label}</span>
+		</>
+	);
+	return (
+		<>
+			<ArrowRight
+				className="relative top-px size-3 shrink-0 self-center text-muted-foreground"
+				strokeWidth={1.8}
+			/>
+			<Tooltip>
+				<TooltipTrigger asChild>
+					{archived ? (
+						<span className="inline-flex min-w-0 max-w-[200px] items-center gap-1 px-1 py-0.5 font-medium text-muted-foreground">
+							{chipInner}
+						</span>
+					) : (
+						<Button
+							type="button"
+							variant="ghost"
+							size="xs"
+							onClick={() => onSelectWorkspace?.(parentWorkspaceId)}
+							className="h-6 min-w-0 max-w-[200px] gap-1 rounded-md px-1.5 text-ui font-medium text-muted-foreground hover:text-foreground"
+						>
+							{chipInner}
+						</Button>
+					)}
+				</TooltipTrigger>
+				<TooltipContent
+					side="bottom"
+					sideOffset={4}
+					className="max-w-[260px] flex-col items-start rounded-md px-2 py-1.5 text-left text-mini leading-snug"
+				>
+					{branchHint ? (
+						<span className="block text-background/70">
+							Base branch {displayRemote}/{branchHint}
+						</span>
+					) : (
+						<span className="block text-background/70">Stacked on {label}</span>
+					)}
+				</TooltipContent>
+			</Tooltip>
+		</>
+	);
 }
 
 // BranchPicker: thin wrapper around shared BranchPickerPopover with header trigger styling.

--- a/src/features/panel/index.tsx
+++ b/src/features/panel/index.tsx
@@ -41,6 +41,7 @@ type WorkspacePanelProps = {
 	contextPreviewCard?: ContextCard | null;
 	contextPreviewActive?: boolean;
 	onSelectSession?: (sessionId: string) => void;
+	onSelectWorkspace?: (workspaceId: string) => void;
 	onSelectContextPreview?: () => void;
 	onCloseContextPreview?: () => void;
 	onPrefetchSession?: (sessionId: string) => void;
@@ -72,6 +73,7 @@ export const WorkspacePanel = memo(function WorkspacePanel({
 	contextPreviewCard = null,
 	contextPreviewActive = false,
 	onSelectSession,
+	onSelectWorkspace,
 	onSelectContextPreview,
 	onCloseContextPreview,
 	onPrefetchSession,
@@ -136,6 +138,7 @@ export const WorkspacePanel = memo(function WorkspacePanel({
 					headerActions={headerActions}
 					headerLeading={headerLeading}
 					onSelectSession={onSelectSession}
+					onSelectWorkspace={onSelectWorkspace}
 					onSelectContextPreview={onSelectContextPreview}
 					onCloseContextPreview={onCloseContextPreview}
 					onPrefetchSession={onPrefetchSession}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -133,6 +133,8 @@ export type StackRowMeta = {
 	role: "tip" | "mid" | "root";
 	/** 0 at the tip, increasing toward the base of the stack. */
 	depth: number;
+	/** Total number of members in this stack — used for the "k of N" tooltip. */
+	stackSize: number;
 	/** `id` of the stack's tip — the anchor every member is grouped under. */
 	tipId: string;
 };
@@ -385,6 +387,10 @@ export type WorkspaceDetail = {
 	branch?: string | null;
 	initializationParentBranch?: string | null;
 	intendedTargetBranch?: string | null;
+	/** Stacked-PR parent link. When set, the header renders a live
+	 * "→ <parent title>" chip (click to navigate) instead of the raw
+	 * target-branch picker. */
+	parentWorkspaceId?: string | null;
 	mode: WorkspaceMode;
 	pinnedAt?: string | null;
 	prTitle?: string | null;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -118,6 +118,23 @@ export type WorkspaceRow = {
 	 *  "slack" | "lark". Absent/null for manual workspaces. Drives the
 	 *  source-logo badge shown on AI-proposed sidebar rows. */
 	triageSourceType?: string | null;
+	/** Stacked PRs: `id` of the workspace one layer below this in a PR stack
+	 *  (its base). Absent/null for non-stacked rows. Drives sidebar stack
+	 *  grouping — the sidebar nests a stack's members under their tip. */
+	parentWorkspaceId?: string | null;
+};
+
+/** Per-row stacked-PR connector metadata, attached by the frontend
+ *  projection (`nestStacks`) — never sent by the backend. Lets the row
+ *  renderer draw the stack-link affordance. */
+export type StackRowMeta = {
+	/** `tip` = newest member (top of the stack, keeps its natural sort slot);
+	 *  `root` = base-most visible member; `mid` = in between. */
+	role: "tip" | "mid" | "root";
+	/** 0 at the tip, increasing toward the base of the stack. */
+	depth: number;
+	/** `id` of the stack's tip — the anchor every member is grouped under. */
+	tipId: string;
 };
 
 export type WorkspaceGroup = {
@@ -125,6 +142,10 @@ export type WorkspaceGroup = {
 	label: string;
 	tone: GroupTone;
 	rows: WorkspaceRow[];
+	/** Frontend-only projection annotation (populated by `nestStacks`, absent
+	 *  on backend payloads): stacked-PR connector metadata keyed by row id,
+	 *  present only for rows that belong to a multi-member stack. */
+	stackMeta?: ReadonlyMap<string, StackRowMeta>;
 };
 
 export type DataInfo = {

--- a/src/shell/components/workspace-pane-surface.tsx
+++ b/src/shell/components/workspace-pane-surface.tsx
@@ -207,6 +207,7 @@ export function WorkspacePaneSurface({
 							repoId={repoId}
 							sessionSelectionHistory={sessionSelectionHistory}
 							onSelectSession={onSelectSession}
+							onSelectWorkspace={selectionActions.selectWorkspace}
 							onResolveDisplayedSession={
 								selectionActions.resolveDisplayedSession
 							}


### PR DESCRIPTION
## What

Adds **stacked PR support** to Helmor — work on a chain of small, dependent PRs instead of one large branch.

### User-facing
- **`/helmor-cli stack`** — plan a large change as a stack of dependent PRs, built one layer at a time. The workspace you start from becomes the stack's base (no throwaway launchpad).
- **`/helmor-cli break`** — split a change you've *already written* into a stack, confirming the slicing granularity with you first; the starting workspace becomes the root.
- **`/helmor-cli restack`** — re-sync the layers above after a lower one changes or merges.
- **Sidebar** groups a stack's workspaces together (tip on top → base at the bottom) with connector lines and a per-node position tooltip.
- **Panel header** of a stacked workspace shows a live parent-workspace chip (click to open the parent) instead of a raw target-branch name.

### Under the hood
- `parent_workspace_id` links workspaces into a stack; `helmor workspace new --parent` materializes the child's target branch and nests it in the sidebar.
- Branch renames (manual + the post-first-message regeneration) now **cascade** to children's `intended_target_branch` via a single write helper, with an idempotent startup backfill for stacks that drifted before the cascade existed.
- `helmor workspace stack` CLI + stack-aware system-prompt priming.

### Also (dev-only, not user-facing)
- **dev CLI self-heal**: `bun run dev` now stages the real `helmor-cli`, and the startup check re-points the `/usr/local/bin/helmor-dev` symlink every launch — so a plain restart fixes a stale/stub dev CLI instead of a manual `ln -sfn`.

## Tests
- Rust: `cargo test --lib` (incl. new cascade + backfill unit tests) and `cargo test --tests` snapshots green; `clippy --all-targets -D warnings` clean.
- Frontend: `tsc` + biome clean; panel/conversation suites green.

A `minor` changeset + an in-app release announcement are included.