### PR TITLE
Live session stream watching for companion clients

### DIFF
--- a/.changeset/companion-live-streaming-sync.md
+++ b/.changeset/companion-live-streaming-sync.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Conversations now stream live across paired devices, so a turn you start on the mobile companion (or another desktop window) appears on every open view in real time as the agent responds, instead of only showing up after a reload.

--- a/src-tauri/src/agents.rs
+++ b/src-tauri/src/agents.rs
@@ -33,7 +33,7 @@ pub use self::streaming::{
     abort_all_active_streams_blocking, bridge_aborted_event, bridge_done_event, bridge_error_event,
     bridge_permission_request_event, bridge_user_input_request_event, build_send_message_params,
     lookup_workspace_linked_directories, ActiveStreamSummary, ActiveStreams,
-    BuildSendMessageParamsInput,
+    BuildSendMessageParamsInput, SessionStreamHub,
 };
 
 use self::persistence::{
@@ -343,6 +343,36 @@ pub async fn list_active_streams(
     active_streams: tauri::State<'_, ActiveStreams>,
 ) -> CmdResult<Vec<ActiveStreamSummary>> {
     Ok(active_streams.snapshot_for_ui())
+}
+
+/// Attach a *watcher* to a session's live agent stream. The initiating client
+/// renders the turn from its own `send_agent_message_stream` channel; this lets
+/// ANY other connected client (a second desktop window, or the mobile
+/// companion over HTTP/NDJSON) mirror the same turn in real time. Events arrive
+/// on `on_event` exactly like the send path — the frontend feeds them through
+/// the same render pipeline. Symmetric across desktop and mobile.
+#[tauri::command]
+pub async fn subscribe_session_stream(
+    hub: tauri::State<'_, SessionStreamHub>,
+    session_id: String,
+    subscription_id: String,
+    on_event: Channel<AgentStreamEvent>,
+) -> CmdResult<()> {
+    hub.subscribe(session_id, subscription_id, on_event);
+    Ok(())
+}
+
+/// Detach a watcher previously attached via [`subscribe_session_stream`]. Over
+/// the companion HTTP bridge this is redundant (the SSE drop auto-unsubscribes)
+/// but native clients call it explicitly on teardown.
+#[tauri::command]
+pub async fn unsubscribe_session_stream(
+    hub: tauri::State<'_, SessionStreamHub>,
+    session_id: String,
+    subscription_id: String,
+) -> CmdResult<()> {
+    hub.unsubscribe(&session_id, &subscription_id);
+    Ok(())
 }
 
 #[tauri::command]

--- a/src-tauri/src/agents/streaming/actions.rs
+++ b/src-tauri/src/agents/streaming/actions.rs
@@ -114,6 +114,12 @@ pub(super) enum Action {
 pub(super) struct ApplyContext<'a> {
     pub on_event: &'a Channel<AgentStreamEvent>,
     pub app: &'a AppHandle,
+    /// Per-session fan-out to *watcher* clients (a second desktop window or
+    /// the mobile companion). The hot path is gated on a single atomic load,
+    /// so this costs nothing when nobody is watching.
+    pub hub: &'a super::stream_hub::SessionStreamHub,
+    /// Helmor session id this stream belongs to; `None` ⇒ no fan-out target.
+    pub session_id: Option<&'a str>,
 }
 
 /// Execute a single action against the runtime resources.
@@ -125,6 +131,13 @@ pub(super) struct ApplyContext<'a> {
 pub(super) fn apply_action(action: Action, ctx: &ApplyContext) {
     match action {
         Action::EmitToFrontend(event) => {
+            // Fan out to watcher clients FIRST (borrows `event`), then hand the
+            // owned event to the initiating client's direct channel. The hub
+            // early-outs on a single atomic load when nobody is watching, so
+            // the desktop-only path is unaffected.
+            if let Some(session_id) = ctx.session_id {
+                ctx.hub.publish(session_id, &event);
+            }
             // The legacy event loop also ignores send errors with
             // `let _ = on_event.send(...)`; matching that behavior keeps
             // this iteration a no-op-equivalent migration. The

--- a/src-tauri/src/agents/streaming/mod.rs
+++ b/src-tauri/src/agents/streaming/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod context_usage;
 mod params;
 mod session_id;
 mod state;
+mod stream_hub;
 mod workflow_persist;
 
 #[cfg(test)]
@@ -35,6 +36,7 @@ pub use params::{
     build_send_message_params, lookup_workspace_linked_directories, BuildSendMessageParamsInput,
 };
 use session_id::should_adopt_provider_session_id;
+pub use stream_hub::SessionStreamHub;
 
 use rusqlite::params;
 use serde_json::{json, Value};
@@ -346,9 +348,12 @@ pub(super) fn stream_via_sidecar(
         // are a snapshot at session-start; events that mutate them
         // (e.g., `permissionModeChanged`) mirror the change back into
         // the legacy local vars until those readers migrate too.
+        let stream_hub = app.state::<stream_hub::SessionStreamHub>();
         let apply_ctx = actions::ApplyContext {
             on_event: &on_event,
             app: &app,
+            hub: stream_hub.inner(),
+            session_id: hsid_copy.as_deref(),
         };
         let mut turn_session = state::TurnSession::new(state::TurnContext {
             provider: provider.clone(),

--- a/src-tauri/src/agents/streaming/stream_hub.rs
+++ b/src-tauri/src/agents/streaming/stream_hub.rs
@@ -1,0 +1,199 @@
+//! Per-session fan-out of live agent-stream events to *watchers*.
+//!
+//! The client that calls `send_agent_message_stream` renders the turn from
+//! its own per-invocation `Channel` (the direct, point-to-point path — left
+//! untouched). This hub is the SECOND path: any other connected client
+//! (a second desktop window, or the mobile companion over HTTP/NDJSON) can
+//! `subscribe_session_stream` and receive the SAME `AgentStreamEvent`s, so it
+//! mirrors the live turn in real time instead of only seeing it after reload.
+//!
+//! Demand-driven by design: `publish` is gated on a single relaxed atomic
+//! load, so a desktop with no watcher (the common case) pays only that load
+//! per event — no clone, no serialize, no lock. The expensive `event.clone()`
+//! happens only when at least one watcher is attached to that session.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
+
+use tauri::ipc::Channel;
+
+use crate::agents::AgentStreamEvent;
+
+struct Subscriber {
+    id: String,
+    channel: Channel<AgentStreamEvent>,
+}
+
+#[derive(Default)]
+struct SessionEntry {
+    subscribers: Vec<Subscriber>,
+    /// Last render-relevant event (`Update` / `StreamingPartial`), replayed to
+    /// a watcher that attaches mid-turn so it catches up immediately instead of
+    /// waiting for the next delta. Cleared on terminal events.
+    last_render: Option<AgentStreamEvent>,
+}
+
+/// Tauri-managed registry of session watchers. Shared by the native
+/// `subscribe_session_stream` command and the companion HTTP bridge — both go
+/// through the same instance, which is what makes mirroring symmetric across
+/// desktop and mobile.
+#[derive(Default)]
+pub struct SessionStreamHub {
+    inner: Mutex<HashMap<String, SessionEntry>>,
+    /// Total watcher count across all sessions. Lets `publish` early-out with a
+    /// single relaxed load when nobody is watching.
+    total: AtomicUsize,
+}
+
+impl SessionStreamHub {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Attach a watcher to `session_id`. Immediately replays the last
+    /// render-relevant event (if any) so a mid-turn joiner isn't blank until
+    /// the next delta.
+    pub fn subscribe(
+        &self,
+        session_id: String,
+        subscription_id: String,
+        channel: Channel<AgentStreamEvent>,
+    ) {
+        let mut map = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let entry = map.entry(session_id).or_default();
+        if let Some(event) = &entry.last_render {
+            let _ = channel.send(event.clone());
+        }
+        entry.subscribers.push(Subscriber {
+            id: subscription_id,
+            channel,
+        });
+        self.total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Detach a watcher. Drops the whole session entry (and its replay cache)
+    /// once the last watcher leaves, so no stale state lingers between turns.
+    pub fn unsubscribe(&self, session_id: &str, subscription_id: &str) {
+        let mut map = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(entry) = map.get_mut(session_id) {
+            let before = entry.subscribers.len();
+            entry.subscribers.retain(|s| s.id != subscription_id);
+            let removed = before - entry.subscribers.len();
+            if removed > 0 {
+                self.total.fetch_sub(removed, Ordering::Relaxed);
+            }
+            if entry.subscribers.is_empty() {
+                map.remove(session_id);
+            }
+        }
+    }
+
+    /// Cheap "is anyone watching anything" check — a single relaxed load.
+    /// Gates the streaming hot path so the no-watcher case is effectively free.
+    pub fn any_subscribers(&self) -> bool {
+        self.total.load(Ordering::Relaxed) > 0
+    }
+
+    /// Fan `event` out to every watcher of `session_id`. No-op (no clone, no
+    /// lock) when nobody is watching anywhere.
+    pub fn publish(&self, session_id: &str, event: &AgentStreamEvent) {
+        if !self.any_subscribers() {
+            return;
+        }
+        let mut map = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let Some(entry) = map.get_mut(session_id) else {
+            return;
+        };
+        match event {
+            AgentStreamEvent::Update { .. } | AgentStreamEvent::StreamingPartial { .. } => {
+                entry.last_render = Some(event.clone());
+            }
+            AgentStreamEvent::Done { .. }
+            | AgentStreamEvent::Aborted { .. }
+            | AgentStreamEvent::Error { .. } => {
+                entry.last_render = None;
+            }
+            _ => {}
+        }
+        let mut dropped = 0;
+        entry.subscribers.retain(|s| {
+            let ok = s.channel.send(event.clone()).is_ok();
+            if !ok {
+                dropped += 1;
+            }
+            ok
+        });
+        if dropped > 0 {
+            self.total.fetch_sub(dropped, Ordering::Relaxed);
+        }
+        if entry.subscribers.is_empty() {
+            map.remove(session_id);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn update_event(text: &str) -> AgentStreamEvent {
+        use crate::pipeline::types::{
+            ExtendedMessagePart, MessagePart, MessageRole, ThreadMessageLike,
+        };
+        AgentStreamEvent::Update {
+            messages: vec![ThreadMessageLike {
+                role: MessageRole::Assistant,
+                id: Some(text.to_string()),
+                created_at: None,
+                content: vec![ExtendedMessagePart::Basic(MessagePart::Text {
+                    id: text.to_string(),
+                    text: text.to_string(),
+                })],
+                status: None,
+                streaming: None,
+            }],
+        }
+    }
+
+    #[test]
+    fn idle_publish_is_noop_without_subscribers() {
+        let hub = SessionStreamHub::new();
+        assert!(!hub.any_subscribers());
+        // Must not panic / allocate a session entry when nobody is watching.
+        hub.publish("s1", &update_event("a"));
+        assert!(!hub.any_subscribers());
+    }
+
+    #[test]
+    fn unsubscribe_decrements_and_drops_entry() {
+        let hub = SessionStreamHub::new();
+        let channel = Channel::new(|_| Ok(()));
+        hub.subscribe("s1".into(), "sub1".into(), channel);
+        assert!(hub.any_subscribers());
+        hub.unsubscribe("s1", "sub1");
+        assert!(!hub.any_subscribers());
+        // Second unsubscribe is a harmless no-op.
+        hub.unsubscribe("s1", "sub1");
+        assert!(!hub.any_subscribers());
+    }
+
+    #[test]
+    fn replays_last_render_on_subscribe() {
+        let hub = SessionStreamHub::new();
+        // Prime a subscriber so publish caches the last render event.
+        let primer = Channel::new(|_| Ok(()));
+        hub.subscribe("s1".into(), "primer".into(), primer);
+        hub.publish("s1", &update_event("hello"));
+
+        // A late joiner should receive the cached event immediately.
+        let received = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let seen = received.clone();
+        let late = Channel::new(move |_| {
+            seen.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        });
+        hub.subscribe("s1".into(), "late".into(), late);
+        assert_eq!(received.load(Ordering::Relaxed), 1);
+    }
+}

--- a/src-tauri/src/companion/rpc.rs
+++ b/src-tauri/src/companion/rpc.rs
@@ -283,6 +283,20 @@ async fn dispatch(
             crate::commands::editor_commands::unstage_workspace_file(arg_string(&args, "workspaceRootPath")?, arg_string(&args, "relativePath")?).await?;
             Ok(Value::Null)
         }
+        // A watcher detaching. Deterministically drop the hub subscriber by id —
+        // do NOT rely on the `/rpc-stream` disconnect being detected (a half-open
+        // tunnel connection could otherwise keep a stale subscriber receiving
+        // fan-out). The browser also aborts the stream fetch (see `closeChannel`
+        // in ipc.ts); whichever lands first wins and the other no-ops.
+        "unsubscribe_session_stream" => {
+            crate::agents::unsubscribe_session_stream(
+                app.state::<crate::agents::SessionStreamHub>(),
+                arg_string(&args, "sessionId")?,
+                arg_string(&args, "subscriptionId")?,
+            )
+            .await?;
+            Ok(Value::Null)
+        }
         "update_app_settings" => {
             crate::commands::settings_commands::update_app_settings(app.state::<crate::sidecar::ManagedSidecar>(), arg_json(&args, "settingsMap")?).await?;
             Ok(Value::Null)

--- a/src-tauri/src/companion/stream.rs
+++ b/src-tauri/src/companion/stream.rs
@@ -16,7 +16,7 @@ use tauri::Manager;
 use tokio::sync::mpsc::UnboundedSender;
 
 use super::server::StreamStarter;
-use crate::agents::{self, AgentSendRequest, AgentStreamEvent};
+use crate::agents::{self, AgentSendRequest, AgentStreamEvent, SessionStreamHub};
 use crate::error::CommandError;
 use crate::sidecar::ManagedSidecar;
 use crate::ui_sync::{UiMutationEvent, UiSyncManager};
@@ -28,6 +28,7 @@ pub fn build_stream_starter(app: tauri::AppHandle) -> StreamStarter {
         move |command: &str, args: Value, tx: UnboundedSender<String>| match command {
             "send_agent_message_stream" => start_agent_stream(&app, args, tx),
             "subscribe_ui_mutations" => start_ui_subscription(&app, args, tx),
+            "subscribe_session_stream" => start_session_stream_subscription(&app, args, tx),
             other => Err(CommandError::from(anyhow::anyhow!(
                 "No companion stream for command: {other}"
             ))),
@@ -93,6 +94,39 @@ fn start_ui_subscription(
     tauri::async_runtime::spawn(async move {
         tx.closed().await;
         app.state::<UiSyncManager>().unsubscribe(&subscription_id);
+    });
+    Ok(())
+}
+
+/// Bridge `subscribe_session_stream` (a watcher attaching to another client's
+/// in-flight turn) onto the companion HTTP/NDJSON transport, reusing the same
+/// shared `SessionStreamHub`. Mirrors `start_ui_subscription`'s lifecycle: the
+/// SSE/NDJSON body drop auto-detaches the watcher.
+fn start_session_stream_subscription(
+    app: &tauri::AppHandle,
+    args: Value,
+    tx: UnboundedSender<String>,
+) -> Result<(), CommandError> {
+    let session_id = args
+        .get("sessionId")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| CommandError::from(anyhow::anyhow!("Missing sessionId")))?;
+    let subscription_id = args
+        .get("subscriptionId")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| CommandError::from(anyhow::anyhow!("Missing subscriptionId")))?;
+
+    let channel = ndjson_channel::<AgentStreamEvent>(tx.clone());
+    app.state::<SessionStreamHub>()
+        .subscribe(session_id.clone(), subscription_id.clone(), channel);
+
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        tx.closed().await;
+        app.state::<SessionStreamHub>()
+            .unsubscribe(&session_id, &subscription_id);
     });
     Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -176,6 +176,7 @@ pub fn run() {
     let app = builder
         .manage(sidecar::ManagedSidecar::new())
         .manage(agents::ActiveStreams::new())
+        .manage(agents::SessionStreamHub::new())
         .manage(agents::SlashCommandCache::new())
         .manage(workspace::archive::ArchiveJobManager::new())
         .manage(local_llm::Manager::default())
@@ -546,6 +547,8 @@ pub fn run() {
             agents::list_cursor_models,
             agents::list_provider_capabilities,
             agents::send_agent_message_stream,
+            agents::subscribe_session_stream,
+            agents::unsubscribe_session_stream,
             agents::stop_agent_stream,
             agents::list_active_streams,
             agents::steer_agent_stream,

--- a/src/features/conversation/hooks/use-watch-session-stream.ts
+++ b/src/features/conversation/hooks/use-watch-session-stream.ts
@@ -1,0 +1,205 @@
+/**
+ * Passive watcher for a session's live agent turn.
+ *
+ * The client that *sends* a message renders the turn from its own
+ * `startAgentMessageStream` channel (see `use-streaming.ts`). This hook is the
+ * mirror image: when the displayed session has an in-flight turn that THIS
+ * client did NOT start (driven by a second window, or by the phone via the
+ * mobile companion), it subscribes to the backend fan-out and feeds the same
+ * `update` / `streamingPartial` frames into the shared session-thread cache —
+ * so the desktop streams live instead of needing a reload.
+ *
+ * Read-only: permission / user-input prompts stay owned by the driving client.
+ * On turn end (or teardown) we reconcile to DB truth.
+ */
+
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect } from "react";
+import { useStreamingStore } from "@/features/conversation/state/streaming-store";
+import { stabilizeStreamingMessages } from "@/features/conversation/streaming-tail-collapse";
+import {
+	type ActiveStreamSummary,
+	type AgentStreamEvent,
+	subscribeSessionStream,
+	type ThreadMessageLike,
+} from "@/lib/api";
+import { sessionThreadMessagesQueryOptions } from "@/lib/query-client";
+import {
+	readSessionThread,
+	replaceStreamingTail,
+} from "@/lib/session-thread-cache";
+
+type Args = {
+	sessionId: string | null;
+	/** Backend-truth active-streams snapshot (App-owned). Tells us a turn is
+	 *  in flight for this session even though we didn't start it. */
+	activeStreams: readonly ActiveStreamSummary[];
+};
+
+type WatchAccumulator = {
+	baseMessages: ThreadMessageLike[];
+	pendingPartial: ThreadMessageLike | null;
+	needsFlush: boolean;
+	frameId: number | null;
+};
+
+export function useWatchSessionStream({ sessionId, activeStreams }: Args) {
+	const queryClient = useQueryClient();
+	const contextKey = sessionId ? `session:${sessionId}` : null;
+
+	// THIS client is the driver if it has a local active/sending session for
+	// this context (it called startAgentMessageStream itself). The driver
+	// already renders via its own channel — watching would double-render.
+	const isLocallyDriven = useStreamingStore((state) =>
+		contextKey
+			? Boolean(state.activeSessionByContext[contextKey]) ||
+				state.sendingContextKeys.has(contextKey)
+			: false,
+	);
+
+	const hasRemoteStream = sessionId
+		? activeStreams.some((stream) => stream.sessionId === sessionId)
+		: false;
+
+	const enabled = Boolean(sessionId) && hasRemoteStream && !isLocallyDriven;
+
+	useEffect(() => {
+		if (!enabled || !sessionId) return;
+		let disposed = false;
+		let unlisten: (() => void) | null = null;
+
+		const accumulator: WatchAccumulator = {
+			baseMessages: [],
+			pendingPartial: null,
+			needsFlush: false,
+			frameId: null,
+		};
+		// Gate rendering until the user prompt is guaranteed persisted. The
+		// backend writes the prompt row BEFORE the first sidecar event, so by
+		// the time any render frame arrives a DB refetch yields a thread whose
+		// last user message IS this turn's prompt — the splice boundary.
+		let boundaryReady = false;
+		let fetching = false;
+		const queued: AgentStreamEvent[] = [];
+
+		const refreshFromDb = () =>
+			queryClient
+				.fetchQuery({
+					...sessionThreadMessagesQueryOptions(sessionId),
+					staleTime: 0,
+				})
+				.catch(() => undefined);
+
+		const flush = () => {
+			accumulator.frameId = null;
+			if (!accumulator.needsFlush) return;
+			accumulator.needsFlush = false;
+
+			const base = readSessionThread(queryClient, sessionId) ?? [];
+			let boundary: ThreadMessageLike | undefined;
+			for (let i = base.length - 1; i >= 0; i--) {
+				const candidate = base[i];
+				if (candidate.role === "user" && candidate.id != null) {
+					boundary = candidate;
+					break;
+				}
+			}
+			if (!boundary?.id) return;
+
+			const rendered = accumulator.pendingPartial
+				? stabilizeStreamingMessages([
+						...accumulator.baseMessages,
+						accumulator.pendingPartial,
+					])
+				: accumulator.baseMessages;
+			replaceStreamingTail(queryClient, sessionId, boundary.id, [
+				boundary,
+				...rendered,
+			]);
+		};
+
+		const scheduleFlush = () => {
+			accumulator.needsFlush = true;
+			if (accumulator.frameId !== null) return;
+			accumulator.frameId = window.requestAnimationFrame(flush);
+		};
+
+		const handle = (event: AgentStreamEvent) => {
+			if (event.kind === "update") {
+				accumulator.baseMessages = event.messages;
+				accumulator.pendingPartial = null;
+				scheduleFlush();
+				return;
+			}
+			if (event.kind === "streamingPartial") {
+				accumulator.pendingPartial = event.message;
+				scheduleFlush();
+				return;
+			}
+			if (
+				event.kind === "done" ||
+				event.kind === "aborted" ||
+				event.kind === "error"
+			) {
+				if (accumulator.frameId !== null) {
+					window.cancelAnimationFrame(accumulator.frameId);
+					accumulator.frameId = null;
+				}
+				flush();
+				// Reconcile to canonical DB rows now the turn is finalized.
+				void refreshFromDb();
+			}
+			// permissionRequest / userInputRequest / planCaptured: ignored —
+			// the driving client owns interactive prompts.
+		};
+
+		const onEvent = (event: AgentStreamEvent) => {
+			if (disposed) return;
+			if (!boundaryReady) {
+				queued.push(event);
+				const isRender =
+					event.kind === "update" || event.kind === "streamingPartial";
+				if (isRender && !fetching) {
+					fetching = true;
+					void refreshFromDb().then(() => {
+						if (disposed) return;
+						boundaryReady = true;
+						const drain = queued.splice(0, queued.length);
+						for (const queuedEvent of drain) handle(queuedEvent);
+					});
+				}
+				return;
+			}
+			handle(event);
+		};
+
+		// Surface the user's prompt immediately — don't wait for the agent's
+		// first frame. The backend persists the prompt row at turn start, and
+		// we learn of the stream via `ActiveStreamsChanged` (which only fires
+		// after registration), so by the time this effect runs the prompt is
+		// in the DB. This is display-only: the overlay's splice boundary still
+		// waits for the first render frame's refetch (`boundaryReady`), so a
+		// rare prompt-not-yet-persisted race just falls back to that path
+		// rather than overlaying onto a stale boundary.
+		void refreshFromDb();
+
+		void subscribeSessionStream(sessionId, onEvent).then((cleanup) => {
+			if (disposed) {
+				cleanup();
+				return;
+			}
+			unlisten = cleanup;
+		});
+
+		return () => {
+			disposed = true;
+			if (accumulator.frameId !== null) {
+				window.cancelAnimationFrame(accumulator.frameId);
+			}
+			unlisten?.();
+			// On teardown (turn ended or navigated away), pull canonical DB
+			// state so a half-streamed snapshot never lingers.
+			void refreshFromDb();
+		};
+	}, [enabled, sessionId, queryClient]);
+}

--- a/src/features/conversation/index.tsx
+++ b/src/features/conversation/index.tsx
@@ -37,6 +37,7 @@ import {
 	type ComposerSubmitPayload,
 	useConversationStreaming,
 } from "./hooks/use-streaming";
+import { useWatchSessionStream } from "./hooks/use-watch-session-stream";
 
 export type { ComposerSubmitPayload } from "./hooks/use-streaming";
 
@@ -293,6 +294,11 @@ export const WorkspaceConversationContainer = memo(
 			onSessionCompleted,
 			onSessionAborted,
 		});
+
+		// Mirror live turns this client didn't start (driven by another window
+		// or the phone via the mobile companion) into the shared thread cache,
+		// so the desktop streams in real time instead of needing a reload.
+		useWatchSessionStream({ sessionId: displayedSessionId, activeStreams });
 
 		const queueItems = useSubmitQueueForSession(displayedSessionId);
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -4,7 +4,7 @@ import { type ErrorCode, extractError } from "./errors";
 // `invoke` / `Channel` / `listen` route through the transport shim so the same
 // frontend works in the desktop Tauri webview AND when served to a phone
 // browser by the companion server. See `src/lib/ipc.ts`.
-import { Channel, invoke, listen, type UnlistenFn } from "./ipc";
+import { Channel, closeChannel, invoke, listen, type UnlistenFn } from "./ipc";
 import { setSessionThreadPaginationState } from "./session-thread-pagination";
 
 export type GroupTone =
@@ -2356,6 +2356,7 @@ export async function subscribeUiMutations(
 	await invoke("subscribe_ui_mutations", { subscriptionId, onEvent });
 	return () => {
 		onEvent.onmessage = () => {};
+		closeChannel(onEvent);
 		void invoke("unsubscribe_ui_mutations", { subscriptionId });
 	};
 }
@@ -3698,6 +3699,37 @@ export async function stopAgentStream(
 	await invoke("stop_agent_stream", {
 		request: { sessionId, provider: provider ?? null },
 	});
+}
+
+/**
+ * Attach a read-only *watcher* to a session's live agent stream.
+ *
+ * The client that called `startAgentMessageStream` renders the turn from its
+ * own channel; this lets another client (a second window, or this same SPA
+ * served to a phone via the mobile companion) mirror the SAME turn live. The
+ * callback fires for every `AgentStreamEvent` the driver receives — feed them
+ * through the same render pipeline. Works identically over native Tauri and the
+ * companion HTTP/NDJSON transport. Returns an unlisten to detach.
+ */
+export async function subscribeSessionStream(
+	sessionId: string,
+	callback: (event: AgentStreamEvent) => void,
+): Promise<UnlistenFn> {
+	const subscriptionId = crypto.randomUUID();
+	const onEvent = new Channel<AgentStreamEvent>();
+	onEvent.onmessage = (event) => callback(event);
+	await invoke("subscribe_session_stream", {
+		sessionId,
+		subscriptionId,
+		onEvent,
+	});
+	return () => {
+		onEvent.onmessage = () => {};
+		// Abort the companion fetch so the server frees the watcher and the
+		// browser releases the connection slot (no-op on native Tauri).
+		closeChannel(onEvent);
+		void invoke("unsubscribe_session_stream", { sessionId, subscriptionId });
+	};
 }
 
 /** UI projection of a registered, in-flight agent stream. Mirror of

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -294,6 +294,29 @@ async function parseHttpError(res: Response): Promise<unknown> {
  */
 class CompanionChannel<T = unknown> {
 	onmessage: ((message: T) => void) | null = null;
+	/**
+	 * Aborts the underlying streaming `fetch`, if this channel was routed to a
+	 * `/rpc-stream` endpoint. Set by {@link companionInvoke}. Closing the fetch
+	 * is what tells the server the client disconnected (so it frees the
+	 * subscription) AND releases the browser's per-origin connection slot — a
+	 * long-lived stream that is never aborted leaks a connection, and once the
+	 * ~6-connection cap is hit new streams hang forever. Native Tauri channels
+	 * don't carry this; {@link closeChannel} no-ops on them.
+	 */
+	close: (() => void) | null = null;
+}
+
+/**
+ * Tear down a streaming subscription's transport. On a companion channel this
+ * aborts the underlying `fetch` (freeing the server subscription + the browser
+ * connection slot); on a native Tauri channel it's a no-op (the matching
+ * `unsubscribe_*` command owns native teardown). Call this from any `api.ts`
+ * unlisten that opened a long-lived stream.
+ */
+export function closeChannel(channel: unknown): void {
+	if (channel instanceof CompanionChannel) {
+		channel.close?.();
+	}
 }
 
 // Mirror Tauri's `Channel`, which is both a value (constructor) and a type.
@@ -360,6 +383,11 @@ async function companionInvoke<T>(cmd: string, args?: InvokeArgs): Promise<T> {
 					([, value]) => !(value instanceof CompanionChannel),
 				),
 			);
+			// Wire an AbortController so the subscription can close its fetch on
+			// teardown (see `closeChannel`). Without this, every stream leaks a
+			// connection until the per-origin cap stalls all new streams.
+			const controller = new AbortController();
+			(channel as CompanionChannel<unknown>).close = () => controller.abort();
 			// Tauri's invoke resolves immediately while the channel emits
 			// asynchronously — mirror that. Failures (e.g. a streaming endpoint
 			// not wired yet) degrade to "no events" rather than rejecting.
@@ -367,6 +395,7 @@ async function companionInvoke<T>(cmd: string, args?: InvokeArgs): Promise<T> {
 				cmd,
 				rest,
 				channel as CompanionChannel<unknown>,
+				controller.signal,
 			).catch(() => {});
 			return undefined as T;
 		}
@@ -404,6 +433,7 @@ async function companionStream(
 	cmd: string,
 	args: Record<string, unknown>,
 	channel: CompanionChannel<unknown>,
+	signal?: AbortSignal,
 ): Promise<void> {
 	const res = await fetch(
 		`${baseUrl()}/rpc-stream/${encodeURIComponent(cmd)}`,
@@ -411,6 +441,7 @@ async function companionStream(
 			method: "POST",
 			headers: jsonHeaders(),
 			body: JSON.stringify(args),
+			signal,
 		},
 	);
 	if (!res.ok || !res.body) throw await parseHttpError(res);


### PR DESCRIPTION
## Summary

Enable secondary windows and mobile companion clients to mirror in-flight agent streams in real time by subscribing to the initiating client's turn via a new `SessionStreamHub`. Watchers receive identical `AgentStreamEvent` callbacks and feed them through the existing render pipeline without the initiating client's overhead.

**Key design:** Hot path gated on a single atomic load, so desktop-only sessions pay zero cost.

## Changes

### Backend (Rust)
- **New `SessionStreamHub` module** (`src-tauri/src/agents/streaming/stream_hub.rs`): Holds per-session watchers and fans out events. Atomic "nobody is watching" check gates the dispatch.
- **New Tauri commands**: `subscribe_session_stream` and `unsubscribe_session_stream` for attaching/detaching watchers.
- **Action pipeline wiring**: `ApplyContext` now carries `hub` and `session_id`; `apply_action` fan-outs to watchers before sending to the initiating client's channel.
- **Companion RPC routing**: Stream subscription bridged onto the HTTP/NDJSON transport with deterministic subscriber teardown.

### Frontend (TypeScript/React)
- **New `subscribeSessionStream()` API** (`src/lib/api.ts`): Returns an unlisten to tear down the subscription.
- **New `useWatchSessionStream()` hook** (`src/features/conversation/hooks/use-watch-session-stream.ts`): Watches a session's live stream and updates the thread cache so the UI streams without a reload.
- **Connection slot management** (`src/lib/ipc.ts`): Added `closeChannel()` and `AbortController` to the companion HTTP stream lifecycle. Long-lived streams that never abort leak a browser connection slot; once the ~6-slot cap is hit, new streams hang. Proper teardown frees the slot.

## Why

The companion mobile app and multi-window desktop scenarios both need the secondary client to mirror the primary's in-flight turn. Without this, users see stale data until they reload. With the watcher pattern, all connected clients see the same live event stream.

## Test Plan

- [x] Pre-commit hook (Biome, Clippy, Cargo fmt) passes
- [x] Snapshot tests in `src-tauri/tests/` still pass (no accumulator/pipeline changes)
- [ ] **Manual**: Open two desktop windows, start an agent stream in one, confirm the second window's thread updates live
- [ ] **Manual**: Start an agent stream on desktop, confirm mobile companion mirrors it via HTTP
- [ ] **Manual**: Verify no connection slot leaks on mobile (check DevTools Network tab — old streams should close immediately on teardown)