### PR TITLE
fix(navigation): keep sidebar drag previews aligned

### DIFF
--- a/.changeset/neat-drag-ghosts.md
+++ b/.changeset/neat-drag-ghosts.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix sidebar drag previews so they stay aligned with the pointer while workspaces or repository groups move through the list.

--- a/src/features/navigation/dnd/drag-ghosts.tsx
+++ b/src/features/navigation/dnd/drag-ghosts.tsx
@@ -1,3 +1,4 @@
+import { createPortal } from "react-dom";
 import type { WorkspaceRow } from "@/lib/api";
 import { WorkspaceAvatar } from "../avatar";
 import { WorkspaceRowItem } from "../row-item";
@@ -31,7 +32,7 @@ export function WorkspaceDragGhost({
 }: WorkspaceDragGhostProps) {
 	const stackCount =
 		stackRows && stackRows.length > 1 ? stackRows.length : null;
-	return (
+	return createPortal(
 		<div
 			className="pointer-events-none fixed z-50"
 			style={{
@@ -57,7 +58,8 @@ export function WorkspaceDragGhost({
 					</span>
 				) : null}
 			</div>
-		</div>
+		</div>,
+		document.body,
 	);
 }
 
@@ -82,7 +84,7 @@ export function RepoDragGhost({
 }: RepoDragGhostProps) {
 	// Re-use the sidebar's native header + row look; one outer opacity
 	// fades the whole stack so it reads as "same group, lifted off".
-	return (
+	return createPortal(
 		<div
 			className="pointer-events-none fixed z-50 opacity-60"
 			style={{
@@ -113,6 +115,7 @@ export function RepoDragGhost({
 					/>
 				</div>
 			))}
-		</div>
+		</div>,
+		document.body,
 	);
 }


### PR DESCRIPTION
## Summary
- Render sidebar workspace and repo drag previews through `document.body`.
- Add a patch changeset for the user-visible drag preview alignment fix.

## Why
The sidebar list uses virtualization and transformed DOM nodes, which can interfere with fixed-position drag previews when they render inside the sidebar tree. Portaling the preview to `document.body` keeps its viewport-based coordinates aligned with the pointer.

## Validation
- `bun run typecheck`
- `bunx biome check src/features/navigation/dnd/drag-ghosts.tsx .changeset/neat-drag-ghosts.md --config-path=./biome.json`