### PR TITLE
Extract TruncatedToolList component for reusable collapsing UI

### DIFF
--- a/.changeset/lazy-otters-fold.md
+++ b/.changeset/lazy-otters-fold.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Collapsed tool-call groups now preview only their last few calls behind a "Show N more" toggle, so long runs of read-only commands no longer flood the message thread.

--- a/src/features/panel/message-components/tool-call.tsx
+++ b/src/features/panel/message-components/tool-call.tsx
@@ -2,7 +2,6 @@ import { getMaterialFileIcon } from "file-extension-icon-js";
 import {
 	AlertCircle,
 	Check,
-	ChevronDown,
 	FileText,
 	LoaderCircle,
 	Search,
@@ -14,8 +13,8 @@ import {
 	ReasoningContent,
 	ReasoningTrigger,
 } from "@/components/ai/reasoning";
-import { Button } from "@/components/ui/button";
 import {
+	type CollapsedGroupPart,
 	type ExtendedMessagePart,
 	partKey,
 	type ToolCallPart,
@@ -31,6 +30,7 @@ import {
 	isWorkflowPart,
 } from "./shared";
 import { getToolInfo } from "./tool-info";
+import { type TruncatedNoun, TruncatedToolList } from "./truncated-tool-list";
 
 // --- props & equality ---
 
@@ -484,7 +484,6 @@ const AgentChildrenBlock = memo(function AgentChildrenBlock({
 	isRunning,
 	parts,
 }: AgentChildrenBlockProps) {
-	const [expanded, setExpanded] = useState(false);
 	const isLive = isLiveStreamingStatus(streamingStatus);
 	const streaming = isLive || (!streamingStatus && !!isRunning);
 	const info = getToolInfo(toolName, toolArgs);
@@ -494,17 +493,6 @@ const AgentChildrenBlock = memo(function AgentChildrenBlock({
 		[parts],
 	);
 	const toolUseCount = toolCallParts.length;
-	const visibleParts: ExtendedMessagePart[] = expanded
-		? parts
-		: toolCallParts.slice(-AGENT_PREVIEW_STEPS);
-	const collapsedVisibleCount = Math.min(
-		toolCallParts.length,
-		AGENT_PREVIEW_STEPS,
-	);
-	const hiddenCount = parts.length - collapsedVisibleCount;
-	const hasMore =
-		toolCallParts.length >= AGENT_PREVIEW_STEPS && hiddenCount > 0;
-	const canToggle = hasMore;
 
 	return (
 		<div className="flex flex-col">
@@ -529,84 +517,66 @@ const AgentChildrenBlock = memo(function AgentChildrenBlock({
 				</span>
 			</div>
 
-			<div className="ml-5 flex flex-col gap-0.5 border-l border-border/30 pl-3 pt-1">
-				{canToggle ? (
-					<Button
-						type="button"
-						variant="ghost"
-						size="xs"
-						onClick={() => setExpanded((value) => !value)}
-						className="mb-0.5 h-auto items-center justify-start gap-1 px-0 text-mini text-muted-foreground/50 hover:bg-transparent hover:text-muted-foreground"
-					>
-						<ChevronDown
-							className={cn(
-								"size-3 transition-transform",
-								expanded && "rotate-180",
-							)}
-							strokeWidth={1.5}
-						/>
-						{expanded
-							? "Collapse"
-							: `Show ${hiddenCount} more step${hiddenCount > 1 ? "s" : ""}`}
-					</Button>
-				) : null}
-
-				<div className="flex flex-col gap-0.5">
-					{visibleParts.map((part) => {
-						const key = partKey(part);
-						if (isToolCallPart(part)) {
-							return (
-								<AssistantToolCall
-									key={key}
-									toolName={part.toolName ?? "unknown"}
-									args={part.args ?? {}}
-									result={part.result}
-									isError={part.isError}
-									compact={!expanded}
-									childParts={part.children}
-								/>
-							);
-						}
-						if (part.type === "text" && part.text) {
-							return (
-								<div
-									key={key}
-									className="text-ui leading-6 text-muted-foreground"
-								>
-									{part.text.slice(0, 300)}
-									{part.text.length > 300 ? "…" : ""}
-								</div>
-							);
-						}
-						if (part.type === "reasoning" && part.text) {
-							return (
-								<Reasoning key={key}>
-									<ReasoningTrigger />
-									<ReasoningContent>{part.text}</ReasoningContent>
-								</Reasoning>
-							);
-						}
-						if (isTodoListPart(part)) {
-							return <TodoList key={key} part={part} />;
-						}
-						if (isWorkflowPart(part)) {
-							return <WorkflowCard key={key} part={part} />;
-						}
-						return null;
-					})}
-				</div>
-			</div>
+			<TruncatedToolList
+				items={parts}
+				previewCount={AGENT_PREVIEW_STEPS}
+				previewFilter={(part) => part.type === "tool-call"}
+				getKey={partKey}
+				renderItem={(part, { expanded }) => {
+					if (isToolCallPart(part)) {
+						return (
+							<AssistantToolCall
+								toolName={part.toolName ?? "unknown"}
+								args={part.args ?? {}}
+								result={part.result}
+								isError={part.isError}
+								compact={!expanded}
+								childParts={part.children}
+							/>
+						);
+					}
+					if (part.type === "text" && part.text) {
+						return (
+							<div className="text-ui leading-6 text-muted-foreground">
+								{part.text.slice(0, 300)}
+								{part.text.length > 300 ? "…" : ""}
+							</div>
+						);
+					}
+					if (part.type === "reasoning" && part.text) {
+						return (
+							<Reasoning>
+								<ReasoningTrigger />
+								<ReasoningContent>{part.text}</ReasoningContent>
+							</Reasoning>
+						);
+					}
+					if (isTodoListPart(part)) {
+						return <TodoList part={part} />;
+					}
+					if (isWorkflowPart(part)) {
+						return <WorkflowCard part={part} />;
+					}
+					return null;
+				}}
+			/>
 		</div>
 	);
 }, agentChildrenBlockPropsEqual);
 
 // --- CollapsedToolGroup ---
 
-export function CollapsedToolGroup({
-	group,
-}: {
-	group: import("@/lib/api").CollapsedGroupPart;
-}) {
+const COLLAPSED_GROUP_NOUNS: Record<
+	CollapsedGroupPart["category"],
+	TruncatedNoun
+> = {
+	shell: { one: "command", other: "commands" },
+	search: { one: "search", other: "searches" },
+	read: { one: "file", other: "files" },
+	mixed: { one: "tool", other: "tools" },
+};
+
+export function CollapsedToolGroup({ group }: { group: CollapsedGroupPart }) {
 	const [open, setOpen] = useState(true);
 	const collapsedGroupIconClassName = "size-3.5 text-muted-foreground";
 
@@ -658,17 +628,19 @@ export function CollapsedToolGroup({
 				</span>
 			</summary>
 			{open ? (
-				<div className="ml-5 flex flex-col gap-0.5 border-l border-border/30 pl-3 pt-1">
-					{group.tools.map((tool) => (
+				<TruncatedToolList
+					items={group.tools}
+					getKey={(tool) => tool.toolCallId}
+					noun={COLLAPSED_GROUP_NOUNS[group.category]}
+					renderItem={(tool) => (
 						<AssistantToolCall
-							key={tool.toolCallId}
 							toolName={tool.toolName}
 							args={tool.args}
 							result={tool.result}
 							isError={tool.isError}
 						/>
-					))}
-				</div>
+					)}
+				/>
 			) : null}
 		</details>
 	);

--- a/src/features/panel/message-components/truncated-tool-list.test.tsx
+++ b/src/features/panel/message-components/truncated-tool-list.test.tsx
@@ -1,0 +1,147 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { TruncatedToolList } from "./truncated-tool-list";
+
+afterEach(() => cleanup());
+
+const getKey = (item: string) => item;
+const renderItem = (item: string) => <div>{item}</div>;
+
+describe("TruncatedToolList", () => {
+	it("renders all items and no toggle at or below the preview cap", () => {
+		render(
+			<TruncatedToolList
+				items={["a", "b", "c"]}
+				getKey={getKey}
+				renderItem={renderItem}
+			/>,
+		);
+		expect(screen.getByText("a")).toBeInTheDocument();
+		expect(screen.getByText("b")).toBeInTheDocument();
+		expect(screen.getByText("c")).toBeInTheDocument();
+		expect(screen.queryByRole("button")).not.toBeInTheDocument();
+	});
+
+	it("shows only the last previewCount items with a toggle when over the cap", () => {
+		render(
+			<TruncatedToolList
+				items={["a", "b", "c", "d", "e"]}
+				getKey={getKey}
+				renderItem={renderItem}
+			/>,
+		);
+		expect(screen.queryByText("a")).not.toBeInTheDocument();
+		expect(screen.queryByText("b")).not.toBeInTheDocument();
+		expect(screen.getByText("c")).toBeInTheDocument();
+		expect(screen.getByText("d")).toBeInTheDocument();
+		expect(screen.getByText("e")).toBeInTheDocument();
+		expect(screen.getByRole("button")).toHaveTextContent(/Show 2 more steps$/);
+	});
+
+	it("toggles between collapsed and expanded", () => {
+		render(
+			<TruncatedToolList
+				items={["a", "b", "c", "d", "e"]}
+				getKey={getKey}
+				renderItem={renderItem}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button"));
+		expect(screen.getByText("a")).toBeInTheDocument();
+		expect(screen.getByText("e")).toBeInTheDocument();
+		expect(screen.getByRole("button")).toHaveTextContent("Collapse");
+
+		fireEvent.click(screen.getByRole("button"));
+		expect(screen.queryByText("a")).not.toBeInTheDocument();
+		expect(screen.getByRole("button")).toHaveTextContent(/Show 2 more steps$/);
+	});
+
+	it("uses the singular noun for a single hidden item", () => {
+		render(
+			<TruncatedToolList
+				items={["a", "b", "c", "d"]}
+				getKey={getKey}
+				renderItem={renderItem}
+			/>,
+		);
+		expect(screen.getByRole("button")).toHaveTextContent(/Show 1 more step$/);
+	});
+
+	it("counts only filtered items toward the cap but expands to all", () => {
+		const items = [
+			{ id: "tool-1", kind: "tool" },
+			{ id: "text-1", kind: "text" },
+			{ id: "tool-2", kind: "tool" },
+			{ id: "tool-3", kind: "tool" },
+			{ id: "tool-4", kind: "tool" },
+		];
+		render(
+			<TruncatedToolList
+				items={items}
+				getKey={(i) => i.id}
+				previewFilter={(i) => i.kind === "tool"}
+				renderItem={(i) => <div>{i.id}</div>}
+			/>,
+		);
+		// Collapsed: last 3 of the 4 tool items; text + first tool hidden.
+		expect(screen.queryByText("text-1")).not.toBeInTheDocument();
+		expect(screen.queryByText("tool-1")).not.toBeInTheDocument();
+		expect(screen.getByText("tool-2")).toBeInTheDocument();
+		expect(screen.getByText("tool-3")).toBeInTheDocument();
+		expect(screen.getByText("tool-4")).toBeInTheDocument();
+		// hiddenCount = 5 total - min(4 tools, 3) = 2
+		expect(screen.getByRole("button")).toHaveTextContent(/Show 2 more steps$/);
+
+		fireEvent.click(screen.getByRole("button"));
+		expect(screen.getByText("text-1")).toBeInTheDocument();
+		expect(screen.getByText("tool-1")).toBeInTheDocument();
+	});
+
+	it("respects a custom previewCount and passes expanded to renderItem", () => {
+		render(
+			<TruncatedToolList
+				items={["a", "b", "c"]}
+				previewCount={1}
+				getKey={getKey}
+				renderItem={(item, { expanded }) => (
+					<div>{expanded ? `${item}-expanded` : item}</div>
+				)}
+			/>,
+		);
+		expect(screen.getByText("c")).toBeInTheDocument();
+		expect(screen.queryByText("a")).not.toBeInTheDocument();
+		expect(screen.getByRole("button")).toHaveTextContent(/Show 2 more steps$/);
+
+		fireEvent.click(screen.getByRole("button"));
+		expect(screen.getByText("a-expanded")).toBeInTheDocument();
+		expect(screen.getByText("c-expanded")).toBeInTheDocument();
+	});
+
+	it("uses a custom plural noun in the toggle label", () => {
+		render(
+			<TruncatedToolList
+				items={["a", "b", "c", "d", "e"]}
+				getKey={getKey}
+				renderItem={renderItem}
+				noun={{ one: "command", other: "commands" }}
+			/>,
+		);
+		expect(screen.getByRole("button")).toHaveTextContent(
+			/Show 2 more commands$/,
+		);
+	});
+
+	it("uses the custom singular noun for a single hidden item", () => {
+		render(
+			<TruncatedToolList
+				items={["a", "b", "c", "d"]}
+				getKey={getKey}
+				renderItem={renderItem}
+				noun={{ one: "command", other: "commands" }}
+			/>,
+		);
+		expect(screen.getByRole("button")).toHaveTextContent(
+			/Show 1 more command$/,
+		);
+	});
+});

--- a/src/features/panel/message-components/truncated-tool-list.tsx
+++ b/src/features/panel/message-components/truncated-tool-list.tsx
@@ -1,0 +1,73 @@
+import { ChevronDown } from "lucide-react";
+import { Fragment, type ReactNode, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export type TruncatedNoun = { one: string; other: string };
+
+const DEFAULT_PREVIEW_COUNT = 3;
+const DEFAULT_NOUN: TruncatedNoun = { one: "step", other: "steps" };
+
+const LIST_CLASS_NAME =
+	"ml-5 flex flex-col gap-0.5 border-l border-border/30 pl-3 pt-1";
+
+type TruncatedToolListProps<T> = {
+	items: T[];
+	getKey: (item: T) => string;
+	renderItem: (item: T, opts: { expanded: boolean }) => ReactNode;
+	/** Only items matching this count toward the preview cap. Defaults to all. */
+	previewFilter?: (item: T) => boolean;
+	previewCount?: number;
+	defaultExpanded?: boolean;
+	className?: string;
+	noun?: TruncatedNoun;
+};
+
+// Renders tool calls capped at `previewCount` with a "Show N more" toggle.
+// Shared by sub-agent children and collapsed read-only command groups.
+export function TruncatedToolList<T>({
+	items,
+	getKey,
+	renderItem,
+	previewFilter,
+	previewCount = DEFAULT_PREVIEW_COUNT,
+	defaultExpanded = false,
+	className,
+	noun = DEFAULT_NOUN,
+}: TruncatedToolListProps<T>) {
+	const [expanded, setExpanded] = useState(defaultExpanded);
+
+	const previewItems = previewFilter ? items.filter(previewFilter) : items;
+	const collapsedVisibleCount = Math.min(previewItems.length, previewCount);
+	const hiddenCount = items.length - collapsedVisibleCount;
+	const hasMore = previewItems.length >= previewCount && hiddenCount > 0;
+	const visible = expanded ? items : previewItems.slice(-previewCount);
+
+	return (
+		<div className={cn(LIST_CLASS_NAME, className)}>
+			{hasMore ? (
+				<Button
+					type="button"
+					variant="ghost"
+					size="xs"
+					onClick={() => setExpanded((value) => !value)}
+					className="mb-0.5 h-auto items-center justify-start gap-1 px-0 text-mini text-muted-foreground/50 hover:bg-transparent hover:text-muted-foreground"
+				>
+					<ChevronDown
+						className={cn(
+							"size-3 transition-transform",
+							expanded && "rotate-180",
+						)}
+						strokeWidth={1.5}
+					/>
+					{expanded
+						? "Collapse"
+						: `Show ${hiddenCount} more ${hiddenCount > 1 ? noun.other : noun.one}`}
+				</Button>
+			) : null}
+			{visible.map((item) => (
+				<Fragment key={getKey(item)}>{renderItem(item, { expanded })}</Fragment>
+			))}
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary

Extracted the expand/collapse toggle logic from `AgentChildrenBlock` and `CollapsedToolGroup` into a new reusable `TruncatedToolList` component. This reduces code duplication and ensures consistent truncation behavior across the message thread.

## What changed

- **New component:** `TruncatedToolList` handles the "Show N more" toggle and manages visible/hidden items state
- **Refactored:** `AgentChildrenBlock` now uses `TruncatedToolList` for cleaner rendering
- **Refactored:** `CollapsedToolGroup` now uses `TruncatedToolList` for consistent behavior
- **Removed:** Local state management (`expanded`, `canToggle`, `hiddenCount`) from both components

## Why

The expand/collapse pattern was duplicated across two places with subtle differences. Extracting it into a reusable component:
1. Reduces maintenance burden
2. Ensures consistent UX (same styling, same logic flow)
3. Makes it easier to adjust truncation behavior in one place

## Test plan

- [x] New tests in `truncated-tool-list.test.tsx`
- Existing snapshot tests should pass (no visual changes, same DOM structure)
- Manual: Long tool-call runs still collapse to preview, "Show N more" toggle works correctly