### PR TITLE
refactor(navigation): improve workspace switching responsiveness with visual preview selection

### DIFF
--- a/.changeset/quick-diffs-wait.md
+++ b/.changeset/quick-diffs-wait.md
@@ -2,4 +2,6 @@
 "helmor": patch
 ---
 
-Defer large workspace diff rendering after workspace switches, trim diff-row render overhead, and preserve the empty state after changes load.
+Improve workspace switching responsiveness in large workspaces:
+- Highlight the selected workspace in the sidebar before the workspace pane finishes loading.
+- Reduce Git diff panel rendering overhead and keep its empty state visible after changes load.

--- a/.changeset/quick-diffs-wait.md
+++ b/.changeset/quick-diffs-wait.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Defer large workspace diff rendering after workspace switches, trim diff-row render overhead, and preserve the empty state after changes load.

--- a/src/features/inspector/hooks/use-inspector.ts
+++ b/src/features/inspector/hooks/use-inspector.ts
@@ -59,6 +59,7 @@ const MIN_ACTIONS_BODY = 160;
 const MIN_TABS_BODY = 160;
 const DEFAULT_CHANGES_BODY = 240;
 const DEFAULT_TABS_BODY = 160;
+const CHANGES_QUERY_DEFER_FRAMES = 2;
 
 type ResizeState = {
 	pointerY: number;
@@ -391,16 +392,53 @@ export function useWorkspaceInspectorSidebar({
 		!!workspaceRootPath &&
 		workspaceState !== "initializing" &&
 		workspaceState !== "archived";
+	const changesQueryIdentity = `${workspaceRootPath ?? ""}\0${workspaceId ?? ""}\0${workspaceState ?? ""}`;
+	const [changesQueryReadyKey, setChangesQueryReadyKey] = useState<
+		string | null
+	>(null);
+	const changesQueryReady =
+		changesQueryEnabled && changesQueryReadyKey === changesQueryIdentity;
+	useEffect(() => {
+		setChangesQueryReadyKey(null);
+		if (!changesQueryEnabled) return;
+
+		const frameIds: number[] = [];
+		const schedule = (remainingFrames: number) => {
+			const frameId = window.requestAnimationFrame(() => {
+				if (remainingFrames <= 1) {
+					setChangesQueryReadyKey(changesQueryIdentity);
+					return;
+				}
+				schedule(remainingFrames - 1);
+			});
+			frameIds.push(frameId);
+		};
+
+		schedule(CHANGES_QUERY_DEFER_FRAMES);
+		return () => {
+			for (const frameId of frameIds) {
+				window.cancelAnimationFrame(frameId);
+			}
+		};
+	}, [changesQueryEnabled, changesQueryIdentity]);
 	const changesQuery = useQuery({
 		...workspaceChangesQueryOptions(workspaceRootPath ?? "", workspaceId),
-		enabled: changesQueryEnabled,
+		enabled: changesQueryEnabled && changesQueryReady,
 	});
-	const changes: InspectorFileItem[] = changesQuery.data ?? EMPTY_CHANGES;
+	const changes: InspectorFileItem[] = changesQueryReady
+		? (changesQuery.data ?? EMPTY_CHANGES)
+		: EMPTY_CHANGES;
+	const changesLoaded = changesQueryReady && changesQuery.data !== undefined;
 
 	const prevChangesRef = useRef<Map<string, string> | null>(null);
 	const prevRootPathRef = useRef(workspaceRootPath);
-	if (prevRootPathRef.current !== workspaceRootPath) {
+	const prevWorkspaceIdRef = useRef(workspaceId);
+	if (
+		prevRootPathRef.current !== workspaceRootPath ||
+		prevWorkspaceIdRef.current !== workspaceId
+	) {
 		prevRootPathRef.current = workspaceRootPath;
+		prevWorkspaceIdRef.current = workspaceId;
 		prevChangesRef.current = null;
 	}
 	const nextChangesSnapshot = useMemo(() => {
@@ -417,7 +455,7 @@ export function useWorkspaceInspectorSidebar({
 	}, [changes]);
 	const flashingPaths = useMemo(() => {
 		const previous = prevChangesRef.current;
-		if (previous === null) {
+		if (previous === null || !changesLoaded) {
 			return new Set<string>();
 		}
 
@@ -433,10 +471,11 @@ export function useWorkspaceInspectorSidebar({
 			}
 		}
 		return flashing;
-	}, [changes, nextChangesSnapshot]);
+	}, [changes, changesLoaded, nextChangesSnapshot]);
 	useEffect(() => {
+		if (!changesLoaded) return;
 		prevChangesRef.current = nextChangesSnapshot;
-	}, [nextChangesSnapshot]);
+	}, [changesLoaded, nextChangesSnapshot]);
 
 	const handleToggleTabs = useCallback(() => {
 		setTabsOpen((open) => !open);
@@ -602,6 +641,7 @@ export function useWorkspaceInspectorSidebar({
 		actionsRef,
 		activeTab,
 		changes,
+		changesLoaded,
 		changesRef,
 		containerRef,
 		flashingPaths,

--- a/src/features/inspector/hooks/use-inspector.ts
+++ b/src/features/inspector/hooks/use-inspector.ts
@@ -59,7 +59,6 @@ const MIN_ACTIONS_BODY = 160;
 const MIN_TABS_BODY = 160;
 const DEFAULT_CHANGES_BODY = 240;
 const DEFAULT_TABS_BODY = 160;
-const CHANGES_QUERY_DEFER_FRAMES = 2;
 
 type ResizeState = {
 	pointerY: number;
@@ -392,43 +391,12 @@ export function useWorkspaceInspectorSidebar({
 		!!workspaceRootPath &&
 		workspaceState !== "initializing" &&
 		workspaceState !== "archived";
-	const changesQueryIdentity = `${workspaceRootPath ?? ""}\0${workspaceId ?? ""}\0${workspaceState ?? ""}`;
-	const [changesQueryReadyKey, setChangesQueryReadyKey] = useState<
-		string | null
-	>(null);
-	const changesQueryReady =
-		changesQueryEnabled && changesQueryReadyKey === changesQueryIdentity;
-	useEffect(() => {
-		setChangesQueryReadyKey(null);
-		if (!changesQueryEnabled) return;
-
-		const frameIds: number[] = [];
-		const schedule = (remainingFrames: number) => {
-			const frameId = window.requestAnimationFrame(() => {
-				if (remainingFrames <= 1) {
-					setChangesQueryReadyKey(changesQueryIdentity);
-					return;
-				}
-				schedule(remainingFrames - 1);
-			});
-			frameIds.push(frameId);
-		};
-
-		schedule(CHANGES_QUERY_DEFER_FRAMES);
-		return () => {
-			for (const frameId of frameIds) {
-				window.cancelAnimationFrame(frameId);
-			}
-		};
-	}, [changesQueryEnabled, changesQueryIdentity]);
 	const changesQuery = useQuery({
 		...workspaceChangesQueryOptions(workspaceRootPath ?? "", workspaceId),
-		enabled: changesQueryEnabled && changesQueryReady,
+		enabled: changesQueryEnabled,
 	});
-	const changes: InspectorFileItem[] = changesQueryReady
-		? (changesQuery.data ?? EMPTY_CHANGES)
-		: EMPTY_CHANGES;
-	const changesLoaded = changesQueryReady && changesQuery.data !== undefined;
+	const changes: InspectorFileItem[] = changesQuery.data ?? EMPTY_CHANGES;
+	const changesLoaded = changesQueryEnabled && changesQuery.data !== undefined;
 
 	const prevChangesRef = useRef<Map<string, string> | null>(null);
 	const prevRootPathRef = useRef(workspaceRootPath);

--- a/src/features/inspector/index.test.tsx
+++ b/src/features/inspector/index.test.tsx
@@ -731,6 +731,17 @@ describe("WorkspaceInspectorSidebar Actions section", () => {
 		expect(screen.getByText("1m")).not.toHaveClass("pt-px");
 	});
 
+	it("shows an empty changes state after empty changes have loaded", async () => {
+		renderInspector();
+
+		expect(
+			screen.queryByText("No changes on this branch yet."),
+		).not.toBeInTheDocument();
+		expect(
+			await screen.findByText("No changes on this branch yet."),
+		).toBeInTheDocument();
+	});
+
 	it("renders link buttons only for remote items with urls", async () => {
 		const user = userEvent.setup();
 		apiMocks.loadWorkspaceForgeActionStatus.mockResolvedValue(

--- a/src/features/inspector/index.tsx
+++ b/src/features/inspector/index.tsx
@@ -154,6 +154,7 @@ export function WorkspaceInspectorSidebar({
 		actionsRef,
 		activeTab,
 		changes,
+		changesLoaded,
 		changesRef,
 		containerRef,
 		flashingPaths,
@@ -536,6 +537,7 @@ export function WorkspaceInspectorSidebar({
 				workspaceRemoteUrl={workspaceRemoteUrl ?? null}
 				workspaceTargetBranch={workspaceTargetBranch ?? null}
 				changes={changes}
+				changesLoaded={changesLoaded}
 				editorMode={editorMode}
 				activeEditor={activeEditor}
 				preferredEditor={preferredEditor}

--- a/src/features/inspector/sections/changes.tsx
+++ b/src/features/inspector/sections/changes.tsx
@@ -30,13 +30,7 @@ import {
 	ContextMenuSeparator,
 	ContextMenuTrigger,
 } from "@/components/ui/context-menu";
-import { NumberTicker } from "@/components/ui/number-ticker";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
-} from "@/components/ui/tooltip";
 import type {
 	CommitButtonState,
 	WorkspaceCommitButtonMode,
@@ -75,6 +69,30 @@ const STATUS_COLORS: Record<InspectorFileItem["status"], string> = {
 	D: "text-red-500",
 };
 
+const fileIconCache = new Map<string, string>();
+const folderIconCache = new Map<string, string>();
+const DIFF_ROW_RENDER_STYLE = {
+	contentVisibility: "auto",
+	containIntrinsicSize: "auto 20px",
+} as const;
+
+function getCachedFileIcon(name: string): string {
+	const cached = fileIconCache.get(name);
+	if (cached) return cached;
+	const icon = getMaterialFileIcon(name);
+	fileIconCache.set(name, icon);
+	return icon;
+}
+
+function getCachedFolderIcon(name: string, open: boolean): string {
+	const key = `${name}\0${open ? "1" : "0"}`;
+	const cached = folderIconCache.get(key);
+	if (cached) return cached;
+	const icon = getMaterialFolderIcon(name, open || undefined);
+	folderIconCache.set(key, icon);
+	return icon;
+}
+
 /** A change item already projected into a single area's line counts.
  * `insertions`/`deletions` are derived from the corresponding area
  * (staged / unstaged / committed) — never used elsewhere. */
@@ -90,6 +108,7 @@ type ChangesSectionProps = {
 	workspaceRemoteUrl: string | null;
 	workspaceTargetBranch: string | null;
 	changes: InspectorFileItem[];
+	changesLoaded: boolean;
 	editorMode: boolean;
 	activeEditor?: ActiveEditorTarget | null;
 	preferredEditor?: DetectedEditor | null;
@@ -114,6 +133,7 @@ function ChangesSectionImpl({
 	workspaceRemoteUrl,
 	workspaceTargetBranch,
 	changes,
+	changesLoaded,
 	editorMode,
 	activeEditor,
 	preferredEditor = null,
@@ -382,7 +402,7 @@ function ChangesSectionImpl({
 					/>
 				)}
 
-				{!hasChanges && (
+				{changesLoaded && !hasChanges && !branchSwitching && (
 					<div className="px-3 py-3 text-mini leading-5 text-muted-foreground">
 						No changes on this branch yet.
 					</div>
@@ -691,16 +711,20 @@ function buildTree(changes: ChangeRow[]) {
 	for (const change of changes) {
 		const parts = change.path.split("/");
 		let current = root;
+		let currentPath = "";
 		for (let index = 0; index < parts.length - 1; index += 1) {
 			const part = parts[index];
-			if (!current.children.has(part)) {
-				current.children.set(part, {
+			currentPath = currentPath ? `${currentPath}/${part}` : part;
+			let child = current.children.get(part);
+			if (!child) {
+				child = {
 					name: part,
-					path: parts.slice(0, index + 1).join("/"),
+					path: currentPath,
 					children: new Map(),
-				});
+				};
+				current.children.set(part, child);
 			}
-			current = current.children.get(part)!;
+			current = child;
 		}
 		current.children.set(change.name, {
 			name: change.name,
@@ -738,12 +762,12 @@ function ChangesTreeView({
 	workspaceBranch: string | null;
 	workspaceRemoteUrl: string | null;
 }) {
-	const tree = buildTree(changes);
+	const tree = useMemo(() => buildTree(changes), [changes]);
 	const [expanded, setExpanded] = useState<Set<string>>(
 		() => new Set(collectFolderPaths(tree)),
 	);
 
-	const toggle = (path: string) => {
+	const toggle = useCallback((path: string) => {
 		setExpanded((previous) => {
 			const next = new Set(previous);
 			if (next.has(path)) {
@@ -753,27 +777,33 @@ function ChangesTreeView({
 			}
 			return next;
 		});
-	};
+	}, []);
 
 	return (
-		<div className="py-0.5">
-			<TreeNodeList
-				nodes={tree.children}
-				expanded={expanded}
-				onToggle={toggle}
-				depth={0}
-				editorMode={editorMode}
-				activeEditorPath={activeEditorPath}
-				onOpenEditorFile={onOpenEditorFile}
-				onOpenExternalEditor={onOpenExternalEditor}
-				flashingPaths={flashingPaths}
-				action={action}
-				onStageAction={onStageAction}
-				onDiscard={onDiscard}
-				workspaceBranch={workspaceBranch}
-				workspaceRemoteUrl={workspaceRemoteUrl}
-			/>
-		</div>
+		<ChangesRowsContextMenu
+			changes={changes}
+			workspaceBranch={workspaceBranch}
+			workspaceRemoteUrl={workspaceRemoteUrl}
+		>
+			<div className="py-0.5">
+				<TreeNodeList
+					nodes={tree.children}
+					expanded={expanded}
+					onToggle={toggle}
+					depth={0}
+					editorMode={editorMode}
+					activeEditorPath={activeEditorPath}
+					onOpenEditorFile={onOpenEditorFile}
+					onOpenExternalEditor={onOpenExternalEditor}
+					flashingPaths={flashingPaths}
+					action={action}
+					onStageAction={onStageAction}
+					onDiscard={onDiscard}
+					workspaceBranch={workspaceBranch}
+					workspaceRemoteUrl={workspaceRemoteUrl}
+				/>
+			</div>
+		</ChangesRowsContextMenu>
 	);
 }
 
@@ -819,14 +849,18 @@ function TreeNodeList({
 	workspaceBranch: string | null;
 	workspaceRemoteUrl: string | null;
 }) {
-	const sorted = [...nodes.values()].sort((left, right) => {
-		const leftIsFolder = left.children.size > 0 && !left.file;
-		const rightIsFolder = right.children.size > 0 && !right.file;
-		if (leftIsFolder !== rightIsFolder) {
-			return leftIsFolder ? -1 : 1;
-		}
-		return left.name.localeCompare(right.name);
-	});
+	const sorted = useMemo(
+		() =>
+			[...nodes.values()].sort((left, right) => {
+				const leftIsFolder = left.children.size > 0 && !left.file;
+				const rightIsFolder = right.children.size > 0 && !right.file;
+				if (leftIsFolder !== rightIsFolder) {
+					return leftIsFolder ? -1 : 1;
+				}
+				return left.name.localeCompare(right.name);
+			}),
+		[nodes],
+	);
 
 	return (
 		<>
@@ -840,6 +874,7 @@ function TreeNodeList({
 							<div
 								className="flex cursor-interactive items-center gap-1 py-[1.5px] pr-2 text-muted-foreground transition-colors hover:bg-accent/60"
 								style={{
+									...DIFF_ROW_RENDER_STYLE,
 									paddingLeft: `${depth * 12 + 8}px`,
 								}}
 								onClick={() => onToggle(node.path)}
@@ -860,7 +895,7 @@ function TreeNodeList({
 									strokeWidth={1.8}
 								/>
 								<img
-									src={getMaterialFolderIcon(node.name, isOpen || undefined)}
+									src={getCachedFolderIcon(node.name, isOpen)}
 									alt=""
 									className="size-4 shrink-0"
 								/>
@@ -892,8 +927,9 @@ function TreeNodeList({
 				const selected = file?.absolutePath === activeEditorPath;
 				const isFlashing = !!file && flashingPaths.has(file.path);
 
-				const row = (
+				return (
 					<div
+						key={node.path}
 						className={cn(
 							"group/row flex cursor-interactive items-center gap-1 py-[1.5px] pr-2 text-muted-foreground transition-colors hover:bg-accent/60",
 							selected &&
@@ -902,8 +938,10 @@ function TreeNodeList({
 									: "bg-muted/60 text-foreground"),
 						)}
 						style={{
+							...DIFF_ROW_RENDER_STYLE,
 							paddingLeft: `${depth * 12 + 22}px`,
 						}}
+						data-change-path={file?.path}
 						role="treeitem"
 						tabIndex={0}
 						onClick={() =>
@@ -922,7 +960,7 @@ function TreeNodeList({
 						}}
 					>
 						<img
-							src={getMaterialFileIcon(node.name)}
+							src={getCachedFileIcon(node.name)}
 							alt=""
 							className="size-4 shrink-0"
 						/>
@@ -935,22 +973,6 @@ function TreeNodeList({
 								onStageAction={onStageAction}
 								onDiscard={onDiscard}
 							/>
-						)}
-					</div>
-				);
-
-				return (
-					<div key={node.path}>
-						{file ? (
-							<FileRowContextMenu
-								file={file}
-								workspaceBranch={workspaceBranch}
-								workspaceRemoteUrl={workspaceRemoteUrl}
-							>
-								{row}
-							</FileRowContextMenu>
-						) : (
-							row
 						)}
 					</div>
 				);
@@ -988,19 +1010,20 @@ function ChangesFlatView({
 	const hasDiscard = !!onDiscard;
 
 	return (
-		<div className="py-0.5">
-			{changes.map((change) => {
-				const canOpenExternalEditor = change.status !== "D";
-				const hasHoverAction = canOpenExternalEditor || hasStage || hasDiscard;
+		<ChangesRowsContextMenu
+			changes={changes}
+			workspaceBranch={workspaceBranch}
+			workspaceRemoteUrl={workspaceRemoteUrl}
+		>
+			<div className="py-0.5">
+				{changes.map((change) => {
+					const canOpenExternalEditor = change.status !== "D";
+					const hasHoverAction =
+						canOpenExternalEditor || hasStage || hasDiscard;
 
-				return (
-					<FileRowContextMenu
-						key={change.path}
-						file={change}
-						workspaceBranch={workspaceBranch}
-						workspaceRemoteUrl={workspaceRemoteUrl}
-					>
+					return (
 						<div
+							key={change.path}
 							className={cn(
 								"group/row flex cursor-interactive items-center gap-1.5 py-[1.5px] pl-2 pr-2 text-muted-foreground transition-colors hover:bg-accent/60",
 								change.absolutePath === activeEditorPath &&
@@ -1008,6 +1031,8 @@ function ChangesFlatView({
 										? "bg-accent text-foreground"
 										: "bg-muted/60 text-foreground"),
 							)}
+							style={DIFF_ROW_RENDER_STYLE}
+							data-change-path={change.path}
 							role="button"
 							tabIndex={0}
 							onClick={() =>
@@ -1025,7 +1050,7 @@ function ChangesFlatView({
 							}}
 						>
 							<img
-								src={getMaterialFileIcon(change.name)}
+								src={getCachedFileIcon(change.name)}
 								alt=""
 								className="size-4 shrink-0"
 							/>
@@ -1075,10 +1100,10 @@ function ChangesFlatView({
 								/>
 							)}
 						</div>
-					</FileRowContextMenu>
-				);
-			})}
-		</div>
+					);
+				})}
+			</div>
+		</ChangesRowsContextMenu>
 	);
 }
 
@@ -1153,22 +1178,19 @@ function RowHoverActions({
 	return (
 		<span className="ml-auto hidden items-center gap-0.5 group-hover/row:inline-flex">
 			{canOpenExternalEditor && (
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<RowIconButton
-							aria-label="Open in editor"
-							onClick={() => onOpenExternalEditor(absolutePath)}
-							className="text-muted-foreground hover:bg-accent/60 hover:text-foreground"
-						>
-							<ExternalLinkIcon className="size-3.5" strokeWidth={2} />
-						</RowIconButton>
-					</TooltipTrigger>
-					<TooltipContent side="top">Open in editor</TooltipContent>
-				</Tooltip>
+				<RowIconButton
+					aria-label="Open in editor"
+					title="Open in editor"
+					onClick={() => onOpenExternalEditor(absolutePath)}
+					className="text-muted-foreground hover:bg-accent/60 hover:text-foreground"
+				>
+					<ExternalLinkIcon className="size-3.5" strokeWidth={2} />
+				</RowIconButton>
 			)}
 			{onDiscard && (
 				<RowIconButton
 					aria-label="Discard file changes"
+					title="Discard file changes"
 					onClick={() => onDiscard(path)}
 					className="text-muted-foreground hover:bg-accent/60 hover:text-foreground"
 				>
@@ -1178,6 +1200,7 @@ function RowHoverActions({
 			{action && onStageAction && (
 				<RowIconButton
 					aria-label={action === "stage" ? "Stage file" : "Unstage file"}
+					title={action === "stage" ? "Stage file" : "Unstage file"}
 					onClick={() => onStageAction(path)}
 					className="text-muted-foreground hover:bg-accent/60 hover:text-foreground"
 				>
@@ -1198,12 +1221,14 @@ function RowIconButton({
 	children,
 	className,
 	"aria-label": ariaLabel,
+	title,
 }: {
 	onClick: () => void;
 	disabled?: boolean;
 	children: React.ReactNode;
 	className?: string;
 	"aria-label": string;
+	title?: string;
 }) {
 	return (
 		<Button
@@ -1211,6 +1236,7 @@ function RowIconButton({
 			variant="ghost"
 			size="icon-xs"
 			aria-label={ariaLabel}
+			title={title}
 			disabled={disabled}
 			onClick={(event) => {
 				event.stopPropagation();
@@ -1258,16 +1284,63 @@ async function copyToClipboard(value: string, label: string) {
 	}
 }
 
-function FileRowContextMenu({
-	file,
+function ChangesRowsContextMenu({
+	changes,
 	workspaceBranch,
 	workspaceRemoteUrl,
 	children,
 }: {
-	file: ChangeRow;
+	changes: ChangeRow[];
 	workspaceBranch: string | null;
 	workspaceRemoteUrl: string | null;
 	children: React.ReactNode;
+}) {
+	const [activeFile, setActiveFile] = useState<ChangeRow | null>(null);
+	const filesByPath = useMemo(
+		() => new Map(changes.map((change) => [change.path, change])),
+		[changes],
+	);
+	const handleContextMenu = useCallback(
+		(event: React.MouseEvent<HTMLElement>) => {
+			const target = event.target;
+			const row =
+				target instanceof Element
+					? target.closest<HTMLElement>("[data-change-path]")
+					: null;
+			const path = row?.dataset.changePath;
+			const file = path ? (filesByPath.get(path) ?? null) : null;
+			setActiveFile(file);
+			if (!file) {
+				event.preventDefault();
+			}
+		},
+		[filesByPath],
+	);
+
+	return (
+		<ContextMenu onOpenChange={(open) => !open && setActiveFile(null)}>
+			<ContextMenuTrigger asChild>
+				<div onContextMenu={handleContextMenu}>{children}</div>
+			</ContextMenuTrigger>
+			{activeFile && (
+				<FileRowContextMenuContent
+					file={activeFile}
+					workspaceBranch={workspaceBranch}
+					workspaceRemoteUrl={workspaceRemoteUrl}
+				/>
+			)}
+		</ContextMenu>
+	);
+}
+
+function FileRowContextMenuContent({
+	file,
+	workspaceBranch,
+	workspaceRemoteUrl,
+}: {
+	file: ChangeRow;
+	workspaceBranch: string | null;
+	workspaceRemoteUrl: string | null;
 }) {
 	const remoteFileUrl = useMemo(
 		() => buildRemoteFileUrl(workspaceRemoteUrl, workspaceBranch, file.path),
@@ -1298,31 +1371,25 @@ function FileRowContextMenu({
 	}, [remoteFileUrl]);
 
 	return (
-		<ContextMenu>
-			<ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
-			<ContextMenuContent className="min-w-52">
-				<ContextMenuItem onClick={() => void handleReveal()}>
-					<FolderOpenIcon />
-					<span>Reveal in Finder</span>
-				</ContextMenuItem>
-				<ContextMenuSeparator />
-				<ContextMenuItem onClick={handleCopyAbsolute}>
-					<CopyIcon />
-					<span>Copy Path</span>
-				</ContextMenuItem>
-				<ContextMenuItem onClick={handleCopyRelative}>
-					<CopyIcon />
-					<span>Copy Relative Path</span>
-				</ContextMenuItem>
-				<ContextMenuItem
-					onClick={handleCopyRemoteUrl}
-					disabled={!remoteFileUrl}
-				>
-					<LinkIcon />
-					<span>Copy Remote File URL</span>
-				</ContextMenuItem>
-			</ContextMenuContent>
-		</ContextMenu>
+		<ContextMenuContent className="min-w-52">
+			<ContextMenuItem onClick={() => void handleReveal()}>
+				<FolderOpenIcon />
+				<span>Reveal in Finder</span>
+			</ContextMenuItem>
+			<ContextMenuSeparator />
+			<ContextMenuItem onClick={handleCopyAbsolute}>
+				<CopyIcon />
+				<span>Copy Path</span>
+			</ContextMenuItem>
+			<ContextMenuItem onClick={handleCopyRelative}>
+				<CopyIcon />
+				<span>Copy Relative Path</span>
+			</ContextMenuItem>
+			<ContextMenuItem onClick={handleCopyRemoteUrl} disabled={!remoteFileUrl}>
+				<LinkIcon />
+				<span>Copy Remote File URL</span>
+			</ContextMenuItem>
+		</ContextMenuContent>
 	);
 }
 
@@ -1339,26 +1406,8 @@ function LineStats({
 
 	return (
 		<span className="flex shrink-0 items-center gap-1 text-micro tabular-nums">
-			{insertions > 0 && (
-				<span className="text-chart-2">
-					+
-					<NumberTicker
-						value={insertions}
-						animateOnMount={false}
-						className="text-chart-2"
-					/>
-				</span>
-			)}
-			{deletions > 0 && (
-				<span className="text-destructive">
-					−
-					<NumberTicker
-						value={deletions}
-						animateOnMount={false}
-						className="text-destructive"
-					/>
-				</span>
-			)}
+			{insertions > 0 && <span className="text-chart-2">+{insertions}</span>}
+			{deletions > 0 && <span className="text-destructive">−{deletions}</span>}
 		</span>
 	);
 }

--- a/src/features/navigation/container.test.tsx
+++ b/src/features/navigation/container.test.tsx
@@ -1,0 +1,150 @@
+import {
+	act,
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { WorkspaceGroup, WorkspaceRow } from "@/lib/api";
+import { WorkspacesSidebarContainer } from "./container";
+
+const useControllerMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./hooks/use-controller", () => ({
+	useWorkspacesSidebarController: useControllerMock,
+}));
+
+type ControllerArgs = {
+	onSelectWorkspace: (workspaceId: string | null) => void;
+};
+
+const workspaceRow: WorkspaceRow = {
+	id: "workspace-1",
+	title: "Workspace 1",
+	state: "ready",
+	hasUnread: false,
+};
+
+const workspaceGroups: WorkspaceGroup[] = [
+	{
+		id: "progress",
+		label: "In Progress",
+		tone: "progress",
+		rows: [
+			workspaceRow,
+			{
+				...workspaceRow,
+				id: "workspace-2",
+				title: "Workspace 2",
+			},
+		],
+	},
+];
+
+describe("WorkspacesSidebarContainer", () => {
+	const originalRequestAnimationFrame = window.requestAnimationFrame;
+	const originalCancelAnimationFrame = window.cancelAnimationFrame;
+
+	beforeEach(() => {
+		useControllerMock.mockImplementation((args: ControllerArgs) => ({
+			addingRepository: false,
+			archivingWorkspaceIds: new Set<string>(),
+			archivedRows: [],
+			availableRepositories: [],
+			creatingWorkspaceRepoId: null,
+			cloneDefaultDirectory: null,
+			groups: workspaceGroups,
+			sidebarGrouping: "status",
+			sidebarRepoFilterIds: [],
+			sidebarSort: "custom",
+			updateSettings: vi.fn(async () => {}),
+			handleAddRepository: vi.fn(async () => {}),
+			handleArchiveWorkspace: vi.fn(),
+			handleCloneFromUrl: vi.fn(async () => {}),
+			handleDeleteWorkspace: vi.fn(),
+			handleMarkWorkspaceUnread: vi.fn(),
+			handleMoveRepositoryInSidebar: vi.fn(),
+			handleMoveWorkspaceInSidebar: vi.fn(),
+			handleOpenCloneDialog: vi.fn(),
+			handleRestoreWorkspace: vi.fn(),
+			handleSelectWorkspace: (workspaceId: string) => {
+				args.onSelectWorkspace(workspaceId);
+			},
+			handleSetWorkspaceStatus: vi.fn(),
+			handleTogglePin: vi.fn(),
+			isCloneDialogOpen: false,
+			prefetchWorkspace: vi.fn(),
+			setIsCloneDialogOpen: vi.fn(),
+		}));
+	});
+
+	afterEach(() => {
+		cleanup();
+		vi.useRealTimers();
+		vi.clearAllMocks();
+		Object.defineProperty(window, "requestAnimationFrame", {
+			configurable: true,
+			value: originalRequestAnimationFrame,
+		});
+		Object.defineProperty(window, "cancelAnimationFrame", {
+			configurable: true,
+			value: originalCancelAnimationFrame,
+		});
+	});
+
+	it("defers external workspace selection until after the next frame", () => {
+		vi.useFakeTimers();
+		const onSelectWorkspace = vi.fn();
+		const frameCallbacks = new Map<number, FrameRequestCallback>();
+		let nextFrameId = 1;
+
+		Object.defineProperty(window, "requestAnimationFrame", {
+			configurable: true,
+			value: vi.fn((callback: FrameRequestCallback) => {
+				const id = nextFrameId;
+				nextFrameId += 1;
+				frameCallbacks.set(id, callback);
+				return id;
+			}),
+		});
+		Object.defineProperty(window, "cancelAnimationFrame", {
+			configurable: true,
+			value: vi.fn((id: number) => {
+				frameCallbacks.delete(id);
+			}),
+		});
+
+		render(
+			<TooltipProvider delayDuration={0}>
+				<WorkspacesSidebarContainer
+					selectedWorkspaceId="workspace-1"
+					onSelectWorkspace={onSelectWorkspace}
+					pushWorkspaceToast={vi.fn()}
+				/>
+			</TooltipProvider>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "Workspace 2" }));
+
+		expect(onSelectWorkspace).not.toHaveBeenCalled();
+		expect(frameCallbacks.size).toBe(1);
+
+		act(() => {
+			for (const [id, callback] of frameCallbacks) {
+				frameCallbacks.delete(id);
+				callback(performance.now());
+			}
+		});
+
+		expect(onSelectWorkspace).not.toHaveBeenCalled();
+
+		act(() => {
+			vi.runOnlyPendingTimers();
+		});
+
+		expect(onSelectWorkspace).toHaveBeenCalledTimes(1);
+		expect(onSelectWorkspace).toHaveBeenCalledWith("workspace-2");
+	});
+});

--- a/src/features/navigation/container.tsx
+++ b/src/features/navigation/container.tsx
@@ -1,4 +1,4 @@
-import { memo } from "react";
+import { memo, useCallback, useEffect, useRef } from "react";
 import { openWorkspaceInFinder } from "@/lib/api";
 import { extractError } from "@/lib/errors";
 import { useWorkspacesSidebarController } from "./hooks/use-controller";
@@ -44,6 +44,8 @@ export const WorkspacesSidebarContainer = memo(
 		onMoveLocalToWorktree,
 		pushWorkspaceToast,
 	}: WorkspacesSidebarContainerProps) {
+		const selectFrameRef = useRef<number | null>(null);
+		const selectTimeoutRef = useRef<number | null>(null);
 		const {
 			addingRepository,
 			archivingWorkspaceIds,
@@ -79,6 +81,35 @@ export const WorkspacesSidebarContainer = memo(
 			onAddRepositoryNeedsStart,
 			pushWorkspaceToast,
 		});
+		const cancelScheduledSelection = useCallback(() => {
+			if (selectFrameRef.current !== null) {
+				window.cancelAnimationFrame(selectFrameRef.current);
+				selectFrameRef.current = null;
+			}
+			if (selectTimeoutRef.current !== null) {
+				window.clearTimeout(selectTimeoutRef.current);
+				selectTimeoutRef.current = null;
+			}
+		}, []);
+		useEffect(() => cancelScheduledSelection, [cancelScheduledSelection]);
+		const handleDeferredSelectWorkspace = useCallback(
+			(workspaceId: string) => {
+				cancelScheduledSelection();
+				if (workspaceId === selectedWorkspaceId) {
+					handleSelectWorkspace(workspaceId);
+					return;
+				}
+				// Let the sidebar paint before the workspace pane does heavier work.
+				selectFrameRef.current = window.requestAnimationFrame(() => {
+					selectFrameRef.current = null;
+					selectTimeoutRef.current = window.setTimeout(() => {
+						selectTimeoutRef.current = null;
+						handleSelectWorkspace(workspaceId);
+					}, 0);
+				});
+			},
+			[cancelScheduledSelection, handleSelectWorkspace, selectedWorkspaceId],
+		);
 
 		return (
 			<WorkspacesSidebar
@@ -114,7 +145,7 @@ export const WorkspacesSidebarContainer = memo(
 				onCloneDialogOpenChange={setIsCloneDialogOpen}
 				cloneDefaultDirectory={cloneDefaultDirectory}
 				onSubmitClone={handleCloneFromUrl}
-				onSelectWorkspace={handleSelectWorkspace}
+				onSelectWorkspace={handleDeferredSelectWorkspace}
 				onPrefetchWorkspace={prefetchWorkspace}
 				onOpenNewWorkspace={onOpenNewWorkspace}
 				onCreateWorkspaceForRepo={onAddRepositoryNeedsStart}

--- a/src/features/navigation/index.test.tsx
+++ b/src/features/navigation/index.test.tsx
@@ -29,6 +29,22 @@ const workspaceGroups: WorkspaceGroup[] = [
 	},
 ];
 
+const twoWorkspaceGroups: WorkspaceGroup[] = [
+	{
+		id: "progress",
+		label: "In Progress",
+		tone: "progress",
+		rows: [
+			workspaceRow,
+			{
+				...workspaceRow,
+				id: "workspace-2",
+				title: "Workspace 2",
+			},
+		],
+	},
+];
+
 const repositoryOptions = [
 	{ id: "repo-alpha", name: "Alpha" },
 	{ id: "repo-beta", name: "Beta" },
@@ -131,6 +147,38 @@ describe("WorkspacesSidebar", () => {
 		);
 
 		expect(screen.getByLabelText("Unread")).toBeInTheDocument();
+	});
+
+	it("previews row selection on pointerdown before notifying the parent", () => {
+		const onSelectWorkspace = vi.fn();
+
+		render(
+			<TooltipProvider delayDuration={0}>
+				<WorkspacesSidebar
+					groups={twoWorkspaceGroups}
+					archivedRows={[]}
+					selectedWorkspaceId="workspace-1"
+					onSelectWorkspace={onSelectWorkspace}
+				/>
+			</TooltipProvider>,
+		);
+
+		const currentRow = screen.getByRole("button", { name: "Workspace 1" });
+		const nextRow = screen.getByRole("button", { name: "Workspace 2" });
+
+		expect(currentRow).toHaveClass("workspace-row-selected");
+		expect(nextRow).not.toHaveClass("workspace-row-selected");
+
+		fireEvent.pointerDown(nextRow, { button: 0, pointerId: 1 });
+
+		expect(currentRow).not.toHaveClass("workspace-row-selected");
+		expect(nextRow).toHaveClass("workspace-row-selected");
+		expect(onSelectWorkspace).not.toHaveBeenCalled();
+
+		fireEvent.click(nextRow);
+
+		expect(onSelectWorkspace).toHaveBeenCalledTimes(1);
+		expect(onSelectWorkspace).toHaveBeenCalledWith("workspace-2");
 	});
 
 	it("opens the workspace start page from the new workspace button", async () => {

--- a/src/features/navigation/index.tsx
+++ b/src/features/navigation/index.tsx
@@ -117,6 +117,10 @@ function getGroupGapSize(previousHasRows: boolean, nextHasRows: boolean) {
 	return previousHasRows && nextHasRows ? GROUP_GAP : EMPTY_GROUP_GAP;
 }
 
+function escapeAttributeSelectorValue(value: string) {
+	return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
@@ -219,6 +223,12 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 	const [isAddRepositoryMenuOpen, setIsAddRepositoryMenuOpen] = useState(false);
 	const [isSidebarViewPopoverOpen, setIsSidebarViewPopoverOpen] =
 		useState(false);
+	const [visualSelectedWorkspaceId, setVisualSelectedWorkspaceId] = useState(
+		selectedWorkspaceId ?? null,
+	);
+	const previewResetTimeoutRef = useRef<number | null>(null);
+	const selectedWorkspaceIdRef = useRef(selectedWorkspaceId ?? null);
+	selectedWorkspaceIdRef.current = selectedWorkspaceId ?? null;
 	const scrollContainerRef = useRef<HTMLDivElement>(null);
 	const dndPolicy = useMemo<WorkspaceDndPolicy>(
 		() =>
@@ -724,6 +734,61 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 	const createBusy = Boolean(creatingWorkspaceRepoId);
 	const addRepositoryBusy = Boolean(addingRepository);
 
+	const cancelPreviewReset = useCallback(() => {
+		if (previewResetTimeoutRef.current !== null) {
+			window.clearTimeout(previewResetTimeoutRef.current);
+			previewResetTimeoutRef.current = null;
+		}
+	}, []);
+	const applyImmediateSelectionClass = useCallback(
+		(workspaceId: string | null) => {
+			const root = scrollContainerRef.current;
+			if (!root) return;
+			for (const element of root.querySelectorAll(
+				"[data-workspace-row-body].workspace-row-selected",
+			)) {
+				element.classList.remove("workspace-row-selected");
+			}
+			if (!workspaceId) return;
+			const target = root.querySelector(
+				`[data-workspace-row-body][data-workspace-row-id="${escapeAttributeSelectorValue(workspaceId)}"]`,
+			);
+			target?.classList.add("workspace-row-selected");
+		},
+		[],
+	);
+	const showVisualSelection = useCallback(
+		(workspaceId: string | null) => {
+			applyImmediateSelectionClass(workspaceId);
+			setVisualSelectedWorkspaceId(workspaceId);
+		},
+		[applyImmediateSelectionClass],
+	);
+	useEffect(() => {
+		cancelPreviewReset();
+		setVisualSelectedWorkspaceId(selectedWorkspaceId ?? null);
+	}, [cancelPreviewReset, selectedWorkspaceId]);
+	useEffect(() => cancelPreviewReset, [cancelPreviewReset]);
+	const handlePreviewSelectWorkspace = useCallback(
+		(workspaceId: string) => {
+			cancelPreviewReset();
+			showVisualSelection(workspaceId);
+			previewResetTimeoutRef.current = window.setTimeout(() => {
+				previewResetTimeoutRef.current = null;
+				showVisualSelection(selectedWorkspaceIdRef.current);
+			}, 1200);
+		},
+		[cancelPreviewReset, showVisualSelection],
+	);
+	const handleSelectWorkspace = useCallback(
+		(workspaceId: string) => {
+			cancelPreviewReset();
+			showVisualSelection(workspaceId);
+			onSelectWorkspace?.(workspaceId);
+		},
+		[cancelPreviewReset, onSelectWorkspace, showVisualSelection],
+	);
+
 	useEffect(() => {
 		const handleOpenNewWorkspace = () => {
 			if (addRepositoryBusy || createBusy || workspaceActionsBusy) return;
@@ -1000,7 +1065,7 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 					) : null}
 					<WorkspaceRowItem
 						row={item.row}
-						selected={selectedWorkspaceId === item.row.id}
+						selected={visualSelectedWorkspaceId === item.row.id}
 						isSending={busyWorkspaceIds?.has(item.row.id)}
 						isInteractionRequired={interactionRequiredWorkspaceIds?.has(
 							item.row.id,
@@ -1008,7 +1073,8 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 						// Hide per-row avatar inside a real repo bucket — header
 						// already shows it. Pinned/backlog/archived keep theirs.
 						hideRepoAvatar={repoIdFromGroupId(item.groupId) !== null}
-						onSelect={onSelectWorkspace}
+						onSelect={handleSelectWorkspace}
+						onPreviewSelect={handlePreviewSelectWorkspace}
 						onPrefetch={onPrefetchWorkspace}
 						onArchiveWorkspace={onArchiveWorkspace}
 						onMoveLocalToWorktree={onMoveLocalToWorktree}
@@ -1048,11 +1114,12 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 			sectionOpenState,
 			sidebarGrouping,
 			toggleSection,
-			selectedWorkspaceId,
+			visualSelectedWorkspaceId,
 			busyWorkspaceIds,
 			interactionRequiredWorkspaceIds,
 			onCreateWorkspaceForRepo,
-			onSelectWorkspace,
+			handleSelectWorkspace,
+			handlePreviewSelectWorkspace,
 			onPrefetchWorkspace,
 			onArchiveWorkspace,
 			onMoveLocalToWorktree,
@@ -1277,7 +1344,7 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 					dragState={dragState}
 					row={activeDragRow}
 					stackRows={activeDragStackRows}
-					selected={selectedWorkspaceId === activeDragRow.id}
+					selected={visualSelectedWorkspaceId === activeDragRow.id}
 					isSending={busyWorkspaceIds?.has(activeDragRow.id)}
 					isInteractionRequired={interactionRequiredWorkspaceIds?.has(
 						activeDragRow.id,
@@ -1296,7 +1363,7 @@ export const WorkspacesSidebar = memo(function WorkspacesSidebar({
 					}
 					repoIconSrc={repoDragGroup.rows[0]?.repoIconSrc ?? null}
 					repoInitials={repoDragGroup.rows[0]?.repoInitials ?? null}
-					selectedWorkspaceId={selectedWorkspaceId}
+					selectedWorkspaceId={visualSelectedWorkspaceId}
 					busyWorkspaceIds={busyWorkspaceIds}
 					interactionRequiredWorkspaceIds={interactionRequiredWorkspaceIds}
 				/>

--- a/src/features/navigation/row-item.tsx
+++ b/src/features/navigation/row-item.tsx
@@ -88,6 +88,7 @@ export type WorkspaceRowItemProps = {
 	hideRepoAvatar?: boolean;
 	rowRef?: (element: HTMLDivElement | null) => void;
 	onSelect?: (workspaceId: string) => void;
+	onPreviewSelect?: (workspaceId: string) => void;
 	onPrefetch?: (workspaceId: string) => void;
 	onArchiveWorkspace?: (workspaceId: string) => void;
 	onMoveLocalToWorktree?: (workspaceId: string) => void;
@@ -150,6 +151,7 @@ export const WorkspaceRowItem = memo(
 		hideRepoAvatar = false,
 		rowRef,
 		onSelect,
+		onPreviewSelect,
 		onPrefetch,
 		onArchiveWorkspace,
 		onMoveLocalToWorktree,
@@ -317,6 +319,22 @@ export const WorkspaceRowItem = memo(
 				onPointerLeave={handleRowPointerLeave}
 				onPointerDown={(event) => {
 					cancelPendingPrefetch();
+					const target = event.target;
+					const inRowActions =
+						target instanceof Element
+							? target.closest("[data-workspace-row-actions]") !== null
+							: false;
+					if (
+						event.button === 0 &&
+						!dragPreview &&
+						!event.metaKey &&
+						!event.ctrlKey &&
+						!event.altKey &&
+						!event.shiftKey &&
+						!inRowActions
+					) {
+						onPreviewSelect?.(row.id);
+					}
 					if (onDragPointerDown && groupId) {
 						onDragPointerDown({ event, row, groupId, title: displayTitle });
 					}


### PR DESCRIPTION
## Summary
This change improves workspace switching responsiveness by providing immediate visual feedback and reducing rendering overhead:
- Preview workspace selection on pointerdown, letting the sidebar highlight the selected workspace before heavier pane operations complete
- Remove deferred diff query rendering in favor of immediate rendering that preserves empty state until data loads
- Add workspace row preview tests to verify selection timing

## Why
Large workspace switches had visible latency as users would click a workspace, but the sidebar wouldn't update until the workspace pane finished loading its diff and other metadata. Now users see the sidebar update immediately (on pointerdown), then the pane loads in the background.

## Testing
- New test verifies the visual selection preview behavior
- Existing tests continue to pass
- Manual testing: switch between workspaces in the sidebar, confirm the highlight updates immediately on click