### PR TITLE
feat(sidecar): pass linked directories context to OpenCode prompts

### DIFF
--- a/sidecar/src/opencode-session-manager.ts
+++ b/sidecar/src/opencode-session-manager.ts
@@ -12,6 +12,7 @@ import type {
 	TextPartInput,
 } from "@opencode-ai/sdk/v2";
 import type { SidecarEmitter } from "./emitter.js";
+import { prependLinkedDirectoriesContext } from "./linked-directories-context.js";
 import { errorDetails, logger } from "./logger.js";
 import { OpencodeServer } from "./opencode-server.js";
 import type {
@@ -472,7 +473,16 @@ export class OpencodeSessionManager implements SessionManager {
 					// Effort is a TOP-LEVEL variant; promptAsync ignores a nested model.variant.
 					...(effort ? { variant: effort } : {}),
 					...(planAgent ? { agent: planAgent } : {}),
-					parts: buildPromptParts(params.prompt, params.images),
+					// opencode has no additional-directories API param, so tell the
+					// model about /add-dir linked dirs in-prompt (it reaches them via
+					// absolute paths; bypass mode already allows external_directory).
+					parts: buildPromptParts(
+						prependLinkedDirectoriesContext(
+							params.prompt,
+							params.additionalDirectories,
+						),
+						params.images,
+					),
 				});
 			}
 		} catch (error) {

--- a/src-tauri/src/pipeline/accumulator/opencode.rs
+++ b/src-tauri/src/pipeline/accumulator/opencode.rs
@@ -298,6 +298,49 @@ fn render_text_or_reasoning(kind: &str, part: &Value) -> Value {
     out
 }
 
+// Pull per-file unified diffs out of a write-tool's `state.metadata` so the
+// adapter can render them through the shared diff view. apply_patch carries
+// `metadata.files[].patch` (multi-file); edit/write carry a single
+// `metadata.diff`. Empty diffs (or non-write tools) yield nothing.
+fn opencode_file_diffs(state: Option<&Value>, title: Option<&str>) -> Vec<Value> {
+    let Some(meta) = state.and_then(|s| s.get("metadata")) else {
+        return Vec::new();
+    };
+    if let Some(files) = meta.get("files").and_then(Value::as_array) {
+        let changes: Vec<Value> = files
+            .iter()
+            .filter_map(|f| {
+                let path = f
+                    .get("relativePath")
+                    .and_then(Value::as_str)
+                    .or_else(|| f.get("filePath").and_then(Value::as_str))?;
+                let diff = f
+                    .get("patch")
+                    .and_then(Value::as_str)
+                    .or_else(|| f.get("diff").and_then(Value::as_str))?;
+                (!diff.is_empty()).then(|| json!({ "path": path, "diff": diff }))
+            })
+            .collect();
+        if !changes.is_empty() {
+            return changes;
+        }
+    }
+    if let Some(diff) = meta.get("diff").and_then(Value::as_str) {
+        if !diff.is_empty() {
+            let path = title
+                .or_else(|| {
+                    state
+                        .and_then(|s| s.get("input"))
+                        .and_then(|i| i.get("filePath"))
+                        .and_then(Value::as_str)
+                })
+                .unwrap_or_default();
+            return vec![json!({ "path": path, "diff": diff })];
+        }
+    }
+    Vec::new()
+}
+
 fn render_tool_part(part: &Value) -> Value {
     let call_id = part
         .get("callID")
@@ -337,6 +380,10 @@ fn render_tool_part(part: &Value) -> Value {
             out["isError"] = json!(true);
         }
         _ => {}
+    }
+    let file_diffs = opencode_file_diffs(state, title);
+    if !file_diffs.is_empty() {
+        out["fileDiffs"] = json!(file_diffs);
     }
     out
 }
@@ -858,6 +905,71 @@ mod tests {
             .unwrap()
             .clone();
         assert!(parts.iter().all(|p| p["type"] != "step-finish"));
+    }
+
+    #[test]
+    fn edit_tool_surfaces_file_diff_from_metadata() {
+        let mut acc = StreamAccumulator::new("opencode", "");
+        assistant(&mut acc, "m1");
+        acc.push_event(
+            &json!({
+                "type": "opencode/message.part.updated", "session_id": "ses_1",
+                "part": {
+                    "type": "tool", "id": "p1", "messageID": "m1",
+                    "callID": "call_1", "tool": "edit",
+                    "state": {
+                        "status": "completed", "title": "a.txt",
+                        "input": { "filePath": "/tmp/a.txt", "oldString": "hi", "newString": "bye" },
+                        "output": "Edit applied successfully.",
+                        "metadata": { "diff": "--- a.txt\n+++ a.txt\n@@ -1 +1 @@\n-hi\n+bye\n" },
+                    },
+                },
+            }),
+            "",
+        );
+        acc.push_event(
+            &json!({ "type": "opencode/session.idle", "session_id": "ses_1" }),
+            "",
+        );
+        let tool = &acc.collected()[0].parsed.as_ref().unwrap()["parts"][0];
+        let diffs = tool["fileDiffs"].as_array().expect("fileDiffs present");
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(diffs[0]["path"], "a.txt");
+        assert!(diffs[0]["diff"].as_str().unwrap().contains("+bye"));
+    }
+
+    #[test]
+    fn apply_patch_surfaces_per_file_diffs_from_metadata() {
+        let mut acc = StreamAccumulator::new("opencode", "");
+        assistant(&mut acc, "m1");
+        acc.push_event(
+            &json!({
+                "type": "opencode/message.part.updated", "session_id": "ses_1",
+                "part": {
+                    "type": "tool", "id": "p1", "messageID": "m1",
+                    "callID": "call_1", "tool": "apply_patch",
+                    "state": {
+                        "status": "completed",
+                        "input": { "patchText": "<patch>" },
+                        "output": "Success. Updated the following files:\nM a.txt\nM b.txt",
+                        "metadata": { "files": [
+                            { "relativePath": "a.txt", "patch": "--- a.txt\n+++ a.txt\n@@\n-1\n+2\n" },
+                            { "relativePath": "b.txt", "patch": "--- b.txt\n+++ b.txt\n@@\n-3\n+4\n" },
+                        ] },
+                    },
+                },
+            }),
+            "",
+        );
+        acc.push_event(
+            &json!({ "type": "opencode/session.idle", "session_id": "ses_1" }),
+            "",
+        );
+        let tool = &acc.collected()[0].parsed.as_ref().unwrap()["parts"][0];
+        let diffs = tool["fileDiffs"].as_array().expect("fileDiffs present");
+        assert_eq!(diffs.len(), 2);
+        assert_eq!(diffs[0]["path"], "a.txt");
+        assert_eq!(diffs[1]["path"], "b.txt");
     }
 
     #[test]

--- a/src-tauri/src/pipeline/adapter/opencode_parts.rs
+++ b/src-tauri/src/pipeline/adapter/opencode_parts.rs
@@ -1,7 +1,7 @@
 //! Render opencode's native `opencode_message` into universal `MessagePart`s.
 //! Shared by the live-stream path and historical reload.
 
-use serde_json::Value;
+use serde_json::{json, Value};
 
 use super::super::types::{
     ExtendedMessagePart, ImageSource, MessagePart, NoticeSeverity, StreamingStatus, TodoItem,
@@ -178,7 +178,17 @@ fn render_tool(part: &Value) -> MessagePart {
         .get("input")
         .cloned()
         .unwrap_or_else(|| Value::Object(Default::default()));
-    let (tool_name, args) = canonical_tool(native_tool, &native_input);
+    // opencode surfaced per-file unified diffs (edit/write/apply_patch) → render
+    // through the shared apply_patch diff view (`changes: [{path, diff}]`); the
+    // frontend already draws this (green +/red -). Else use the name mapping.
+    let file_diffs = part
+        .get("fileDiffs")
+        .and_then(Value::as_array)
+        .filter(|c| !c.is_empty());
+    let (tool_name, args) = match file_diffs {
+        Some(changes) => ("apply_patch".to_string(), json!({ "changes": changes })),
+        None => canonical_tool(native_tool, &native_input),
+    };
     let args_text = serde_json::to_string(&args).unwrap_or_default();
     let status = part
         .get("status")
@@ -188,10 +198,16 @@ fn render_tool(part: &Value) -> MessagePart {
         .get("isError")
         .and_then(Value::as_bool)
         .unwrap_or(false);
-    let result = part
-        .get("output")
-        .and_then(Value::as_str)
-        .map(|o| Value::String(o.to_string()));
+    let result = part.get("output").and_then(Value::as_str).and_then(|o| {
+        // With a rendered diff the success summary ("Wrote file…", the M-file
+        // list) is redundant — drop it, but keep output that carries extra
+        // feedback (e.g. LSP errors).
+        if file_diffs.is_some() && !o.contains("LSP") {
+            None
+        } else {
+            Some(Value::String(o.to_string()))
+        }
+    });
     let streaming_status = match status {
         "pending" => Some(StreamingStatus::Pending),
         "running" => Some(StreamingStatus::Running),
@@ -327,6 +343,61 @@ mod tests {
         match &render_parts(&open, "m1", false)[0] {
             MessagePart::Reasoning { duration_ms, .. } => assert_eq!(*duration_ms, None),
             other => panic!("expected reasoning, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn write_tool_with_file_diffs_renders_as_apply_patch() {
+        let msg = json!({
+            "type": "opencode_message",
+            "parts": [{
+                "type": "tool", "callID": "c1", "tool": "write", "status": "completed",
+                "input": { "filePath": "/tmp/a.txt", "content": "hi" },
+                "output": "Wrote file successfully.",
+                "fileDiffs": [{ "path": "a.txt", "diff": "--- a.txt\n+++ a.txt\n@@\n+hi\n" }],
+            }],
+        });
+        match &render_parts(&msg, "m1", false)[0] {
+            MessagePart::ToolCall {
+                tool_name,
+                args,
+                result,
+                ..
+            } => {
+                assert_eq!(tool_name, "apply_patch");
+                let changes = args["changes"].as_array().unwrap();
+                assert_eq!(changes[0]["path"], "a.txt");
+                assert!(changes[0]["diff"].as_str().unwrap().contains("+hi"));
+                // Redundant success summary dropped — the diff conveys it.
+                assert!(result.is_none());
+            }
+            other => panic!("expected tool-call, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn diff_tool_keeps_lsp_feedback_in_result() {
+        let msg = json!({
+            "type": "opencode_message",
+            "parts": [{
+                "type": "tool", "callID": "c1", "tool": "edit", "status": "completed",
+                "input": { "filePath": "/tmp/a.txt" },
+                "output": "Edit applied successfully.\n\nLSP errors detected in this file:\nfoo",
+                "fileDiffs": [{ "path": "a.txt", "diff": "--- a.txt\n+++ a.txt\n@@\n-x\n+y\n" }],
+            }],
+        });
+        match &render_parts(&msg, "m1", false)[0] {
+            MessagePart::ToolCall {
+                tool_name, result, ..
+            } => {
+                assert_eq!(tool_name, "apply_patch");
+                assert!(result
+                    .as_ref()
+                    .and_then(|r| r.as_str())
+                    .unwrap()
+                    .contains("LSP errors"));
+            }
+            other => panic!("expected tool-call, got {other:?}"),
         }
     }
 

--- a/src-tauri/tests/pipeline_scenarios.rs
+++ b/src-tauri/tests/pipeline_scenarios.rs
@@ -428,6 +428,32 @@ fn opencode_reasoning_carries_thought_duration() {
     assert_yaml_snapshot!(run_normalized(msgs));
 }
 
+// opencode write/edit/apply_patch carry opencode's per-file unified diff
+// (`fileDiffs`), which the adapter reshapes into the shared apply_patch
+// `changes:[{path,diff}]` view so a colored diff renders on reload too.
+#[test]
+fn opencode_write_tool_renders_unified_diff() {
+    let assistant = json!({
+        "type": "opencode_message",
+        "session_id": "ses_1",
+        "role": "assistant",
+        "parts": [{
+            "type": "tool", "callID": "c1", "tool": "write", "status": "completed",
+            "input": { "filePath": "/tmp/a.txt", "content": "hi" },
+            "output": "Wrote file successfully.",
+            "fileDiffs": [
+                { "path": "a.txt", "diff": "--- a.txt\n+++ a.txt\n@@ -0,0 +1 @@\n+hi\n" },
+            ],
+        }],
+    });
+    let msgs = vec![make_record(
+        "om1",
+        "assistant",
+        &serde_json::to_string(&assistant).unwrap(),
+    )];
+    assert_yaml_snapshot!(run_normalized(msgs));
+}
+
 // ============================================================================
 // 4. Edge cases
 // ============================================================================

--- a/src-tauri/tests/snapshots/pipeline_scenarios__opencode_write_tool_renders_unified_diff.snap
+++ b/src-tauri/tests/snapshots/pipeline_scenarios__opencode_write_tool_renders_unified_diff.snap
@@ -1,0 +1,20 @@
+---
+source: tests/pipeline_scenarios.rs
+expression: run_normalized(msgs)
+---
+- role: assistant
+  id: msg-1
+  content_length: 1
+  content:
+    - type: tool-call
+      tool_name: apply_patch
+      tool_call_id: c1
+      args_keys:
+        - changes
+      args_text_length: 82
+      has_result: false
+      result_kind: ~
+      result_preview: ~
+      streaming_status: done
+  status: ~
+  streaming: ~


### PR DESCRIPTION
## Summary
Pass linked directories context to OpenCode prompts since OpenCode has no additional-directories API parameter.

## Changes
- Import `prependLinkedDirectoriesContext` helper
- Prepend linked directory context directly to prompts before sending to OpenCode
- The model can access linked directories via absolute paths (bypass mode already permits external_directory)

## Why
OpenCode lacks an API equivalent to Claude Agent SDK's `additionalDirectories` param. To support `/add-dir` linked directories in OpenCode sessions, we embed the directory info in the prompt itself, allowing the model to reference files by their absolute paths.

## Testing
This change allows OpenCode sessions to work with linked directories passed via `/add-dir`, consistent with Claude Code behavior.