### PR TITLE
fix(sidecar): improve OpenCode session lifecycle and error handling

### DIFF
--- a/sidecar/src/opencode-server.ts
+++ b/sidecar/src/opencode-server.ts
@@ -88,6 +88,14 @@ export class OpencodeServer {
 	private handle: Promise<OpencodeServerHandle> | null = null;
 	private proxyUrl: string | null = null;
 
+	/**
+	 * @param onProcessExit Fired whenever a spawned server process exits
+	 *   (crash, kill, or restart). Lets the manager settle in-flight turns
+	 *   bound to a now-dead server instead of waiting on an SSE event that
+	 *   will never arrive.
+	 */
+	constructor(private readonly onProcessExit?: () => void) {}
+
 	/** Idempotent. Restarts if the proxy in `env` changed. Only called at turn
 	 *  start, so it never interrupts an in-flight stream. */
 	start(env: NodeJS.ProcessEnv): Promise<OpencodeServerHandle> {
@@ -200,6 +208,9 @@ export class OpencodeServer {
 				this.proc = null;
 				this.handle = null;
 			}
+			// Notify regardless of whether a newer proc replaced this one — turns
+			// bound to THIS (now-dead) server must be settled either way.
+			this.onProcessExit?.();
 		});
 
 		logger.info(`opencode server ready at ${url}`);

--- a/sidecar/src/opencode-session-manager.ts
+++ b/sidecar/src/opencode-session-manager.ts
@@ -42,7 +42,9 @@ interface SessionCtx {
 	activeEmitter: SidecarEmitter | null;
 	settle: TurnSettle | null;
 	aborted: boolean;
-	readonly abort: AbortController;
+	/** Mutable: replaced with a fresh controller when a stopped session is
+	 *  reused, so the next turn's pump subscribes with a live signal. */
+	abort: AbortController;
 	pumpStarted: boolean;
 	/** Last turn's model + effort variant, reused by `steer`. */
 	lastModel?: { providerID: string; modelID: string; variant?: string };
@@ -223,7 +225,9 @@ export function buildContextUsageMeta(input: {
 }
 
 export class OpencodeSessionManager implements SessionManager {
-	private readonly server = new OpencodeServer();
+	// The shared server's process death is a terminal signal for every
+	// in-flight turn bound to it — settle them so `await turnDone` can't hang.
+	private readonly server = new OpencodeServer(() => this.handleServerExit());
 	private readonly sessions = new Map<string, SessionCtx>();
 	private readonly byOpencodeId = new Map<string, SessionCtx>();
 	/** Stop pressed while sendMessage was still in startup (no ctx yet). */
@@ -507,6 +511,9 @@ export class OpencodeSessionManager implements SessionManager {
 
 	private ensureSessionPump(client: OpencodeClient, ctx: SessionCtx): void {
 		if (ctx.pumpStarted) return;
+		// A stopped session left `ctx.abort` aborted; swap in a fresh one so
+		// the reused turn's pump subscribes with a live signal.
+		if (ctx.abort.signal.aborted) ctx.abort = new AbortController();
 		ctx.pumpStarted = true;
 		void this.runSessionPump(client, ctx);
 	}
@@ -515,20 +522,46 @@ export class OpencodeSessionManager implements SessionManager {
 		client: OpencodeClient,
 		ctx: SessionCtx,
 	): Promise<void> {
+		// Capture THIS pump's controller — `ctx.abort` may be swapped out by a
+		// concurrent reuse, and we must check the signal we actually subscribed
+		// with, not whatever is current when the loop unwinds.
+		const abort = ctx.abort;
 		try {
 			const subscription = await client.event.subscribe(
 				{ directory: ctx.directory },
-				{ signal: ctx.abort.signal },
+				{ signal: abort.signal },
 			);
 			for await (const event of subscription.stream) {
 				this.handleEvent(ctx, event as OpencodeEvent);
 			}
+			// Clean exit (server closed the SSE) WITHOUT an intentional stop:
+			// the turn will never see `session.idle`, so settle it as an error
+			// instead of leaving `await turnDone` pending forever.
+			if (!abort.signal.aborted) {
+				ctx.settle?.reject(
+					new Error("opencode event stream ended before the turn finished"),
+				);
+			}
 		} catch (error) {
-			if (ctx.abort.signal.aborted) return;
+			if (abort.signal.aborted) return;
 			logger.error("opencode session pump failed", errorDetails(error));
 			ctx.settle?.reject(new Error("opencode event stream disconnected"));
 		} finally {
-			ctx.pumpStarted = false;
+			// Only clear the flag if we still own the current controller — a
+			// reuse may have already started a replacement pump.
+			if (ctx.abort === abort) ctx.pumpStarted = false;
+		}
+	}
+
+	/**
+	 * The shared opencode server process exited. Every session bound to it has
+	 * a dead SSE + dead provider state, so reject any in-flight turn rather
+	 * than let `await turnDone` hang. A later turn restarts the server (via
+	 * `server.start()`) and a fresh pump.
+	 */
+	private handleServerExit(): void {
+		for (const ctx of this.sessions.values()) {
+			ctx.settle?.reject(new Error("opencode server exited unexpectedly"));
 		}
 	}
 
@@ -946,16 +979,26 @@ export class OpencodeSessionManager implements SessionManager {
 		this.pendingAborts.delete(sessionId);
 		ctx.aborted = true;
 		this.clearPending(ctx);
-		try {
-			const handle = await this.server.start(process.env);
-			await handle.client.session.abort({
-				sessionID: ctx.openCodeSessionId,
-				directory: ctx.directory,
-			});
-		} catch (error) {
-			logger.debug("opencode abort failed", errorDetails(error));
-		}
+		// Unblock the local turn FIRST — never gate it behind the remote abort
+		// RPC, which can hang against a wedged server and strand `await
+		// turnDone` forever (the bug this fixes). Stop the pump too so we don't
+		// leak the SSE subscription; reuse swaps in a fresh controller.
 		ctx.settle?.resolve();
+		ctx.abort.abort();
+		ctx.pumpStarted = false;
+		// Best-effort remote abort, fire-and-forget: it tells opencode to stop
+		// server-side work but must not block (or fail) the local teardown.
+		void this.server
+			.start(process.env)
+			.then((handle) =>
+				handle.client.session.abort({
+					sessionID: ctx.openCodeSessionId,
+					directory: ctx.directory,
+				}),
+			)
+			.catch((error) =>
+				logger.debug("opencode abort failed", errorDetails(error)),
+			);
 	}
 
 	// Mid-turn steer via a second promptAsync on the busy session. RPC-first:


### PR DESCRIPTION
## Summary

Improves OpenCode session manager robustness by fixing several critical issues in the session lifecycle and error handling:

- Added `onProcessExit` callback to notify when the server process crashes or restarts, allowing in-flight turns to be settled immediately instead of hanging
- Fixed session pump reuse: replace the AbortController when a stopped session is reused so the next turn subscribes with a live signal
- Detect and handle unexpected SSE stream closures by settling in-flight turns as errors
- Made turn abort non-blocking: resolve local settlement immediately, then fire-and-forget the remote abort RPC to prevent hanging on wedged servers
- Overall: prevent `await turnDone` from hanging on dead connections or crashed OpenCode servers

## Changes

### opencode-server.ts
- Added `onProcessExit` callback parameter to constructor
- Call callback when process exits (crash, kill, or restart) to notify all bound sessions

### opencode-session-manager.ts
- Replace AbortController when reusing a stopped session
- Capture pump's controller to detect concurrent reuse
- Settle turns when event stream ends without intentional stop
- Add `handleServerExit()` to reject all in-flight turns when server crashes
- Refactor abort flow: resolve settlement first, make remote abort best-effort and non-blocking

## Testing

Run the full sidecar test suite:
```bash
cd sidecar && bun test
```

Also verify OpenCode functionality with a session:
```bash
bun run dev
```

Then send a few prompts to OpenCode and test stop/restart flows to ensure turns complete gracefully.