### PR TITLE
chore: retire deprecated Codex models and improve model catalog self-healing

### DIFF
--- a/.changeset/brisk-codex-retire.md
+++ b/.changeset/brisk-codex-retire.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Remove the GPT-5.3-Codex and GPT-5.2 Codex models from the model picker; any saved default, review, or action model that used one now falls back to an available model automatically.

--- a/sidecar/src/model-catalog.ts
+++ b/sidecar/src/model-catalog.ts
@@ -74,23 +74,9 @@ const MODEL_CATALOG: Record<Provider, readonly ProviderModelInfo[]> = {
 			supportsFastMode: true,
 		},
 		{
-			id: "gpt-5.3-codex",
-			label: "GPT-5.3-Codex",
-			cliModel: "gpt-5.3-codex",
-			effortLevels: CODEX_EFFORT_LEVELS,
-			supportsFastMode: true,
-		},
-		{
 			id: "gpt-5.3-codex-spark",
 			label: "GPT-5.3-Codex-Spark",
 			cliModel: "gpt-5.3-codex-spark",
-			effortLevels: CODEX_EFFORT_LEVELS,
-			supportsFastMode: true,
-		},
-		{
-			id: "gpt-5.2",
-			label: "GPT-5.2",
-			cliModel: "gpt-5.2",
 			effortLevels: CODEX_EFFORT_LEVELS,
 			supportsFastMode: true,
 		},
@@ -185,5 +171,5 @@ export function pickFastestCodexModel(): string {
 			best = { cliModel: m.cliModel, version, isMini };
 		}
 	}
-	return best?.cliModel ?? "gpt-5.2";
+	return best?.cliModel ?? "gpt-5.4-mini";
 }

--- a/sidecar/test/codex-app-server-manager.test.ts
+++ b/sidecar/test/codex-app-server-manager.test.ts
@@ -222,7 +222,7 @@ describe("CodexAppServerManager", () => {
 
 		const models = await manager.listModels();
 
-		expect(models).toHaveLength(6);
+		expect(models).toHaveLength(4);
 		expect(models).toEqual(
 			expect.arrayContaining([
 				expect.objectContaining({

--- a/src-tauri/src/agents/catalog.rs
+++ b/src-tauri/src/agents/catalog.rs
@@ -114,9 +114,7 @@ fn codex_section() -> AgentModelSection {
             codex_model("gpt-5.5", "GPT-5.5"),
             codex_model("gpt-5.4", "GPT-5.4"),
             codex_model("gpt-5.4-mini", "GPT-5.4-Mini"),
-            codex_model("gpt-5.3-codex", "GPT-5.3-Codex"),
             codex_model("gpt-5.3-codex-spark", "GPT-5.3-Codex-Spark"),
-            codex_model("gpt-5.2", "GPT-5.2"),
         ],
     }
 }
@@ -620,14 +618,7 @@ mod tests {
                 .iter()
                 .map(|model| model.id.as_str())
                 .collect::<Vec<_>>(),
-            vec![
-                "gpt-5.5",
-                "gpt-5.4",
-                "gpt-5.4-mini",
-                "gpt-5.3-codex",
-                "gpt-5.3-codex-spark",
-                "gpt-5.2",
-            ]
+            vec!["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex-spark",]
         );
         assert!(sections[1]
             .options
@@ -1271,10 +1262,10 @@ mod tests {
 
     #[test]
     fn provider_hint_disambiguates_overlapping_ids() {
-        // gpt-5.3-codex exists in both Codex and Cursor; the request's
-        // provider field is the tie-break. (Cursor's namespaced form
-        // would be `cursor-gpt-5.3-codex`, which obviates the hint —
-        // but bare ids may still arrive via legacy / external callers.)
+        // A bare `gpt-`-prefixed id routes to Codex by prefix, but a
+        // provider hint overrides that: the same id resolves to Cursor when
+        // hinted. (Cursor's namespaced form `cursor-gpt-5.3-codex` obviates
+        // the hint, but bare ids may still arrive via legacy / external callers.)
         let codex = resolve_model("gpt-5.3-codex", Some("codex"));
         assert_eq!(codex.provider, "codex");
         let cursor = resolve_model("gpt-5.3-codex", Some("cursor"));

--- a/src/shell/hooks/use-ensure-default-model.test.tsx
+++ b/src/shell/hooks/use-ensure-default-model.test.tsx
@@ -108,7 +108,7 @@ describe("useEnsureDefaultModel", () => {
 				{ id: "codex", label: "Codex", status: "unavailable", options: [] },
 			],
 			settingsOverrides: {
-				reviewModelId: "user-custom-review",
+				reviewModelId: "opus-1m",
 				reviewEffort: "low",
 				prFastMode: true,
 			},
@@ -120,6 +120,51 @@ describe("useEnsureDefaultModel", () => {
 			prModelId: "opus-1m",
 			prEffort: DEFAULT_SETTINGS.defaultEffort,
 			reviewFastMode: DEFAULT_SETTINGS.defaultFastMode,
+		});
+	});
+
+	it("unsets stale review/pr models that left the catalog", () => {
+		const { updateSettings } = renderUseEnsureDefaultModel({
+			defaultModelId: "opus-1m",
+			sections: [
+				{
+					id: "claude",
+					label: "Claude Code",
+					status: "ready",
+					options: [
+						{
+							id: "opus-1m",
+							provider: "claude",
+							label: "Opus",
+							cliModel: "opus-1m",
+						},
+					],
+				},
+				{
+					id: "codex",
+					label: "Codex",
+					status: "ready",
+					options: [
+						{
+							id: "gpt-5.5",
+							provider: "codex",
+							label: "GPT-5.5",
+							cliModel: "gpt-5.5",
+						},
+					],
+				},
+			],
+			settingsOverrides: {
+				reviewModelId: "gpt-5.2",
+				prModelId: "gpt-5.3-codex",
+			},
+		});
+
+		// Default is valid, so only the delisted review/pr picks are reset to
+		// null (→ fall back to the default at consumption time).
+		expect(updateSettings).toHaveBeenCalledWith({
+			reviewModelId: null,
+			prModelId: null,
 		});
 	});
 

--- a/src/shell/hooks/use-ensure-default-model.ts
+++ b/src/shell/hooks/use-ensure-default-model.ts
@@ -20,11 +20,11 @@ function isModelCatalogSettled(sections: AgentModelSection[]) {
 }
 
 /**
- * Invariant: once the model catalog is ready, `settings.defaultModelId` must
- * point to a model that exists in the catalog. If it doesn't (never set, or
- * the previously-picked model is gone), pick a reasonable default and write
- * it back. This is the single place that decides the initial default — every
- * other consumer reads `settings.defaultModelId` directly.
+ * Invariant: once the model catalog has settled, every stored model id must
+ * point to a model that still exists. `defaultModelId` is repaired to a
+ * sensible default; stale `review`/`pr` picks (e.g. a delisted model) are
+ * unset so they fall back to the default. No per-model migration needed —
+ * this self-heals on cold-start for any future delist.
  */
 export function useEnsureDefaultModel() {
 	const { settings, isLoaded, updateSettings } = useSettings();
@@ -34,44 +34,59 @@ export function useEnsureDefaultModel() {
 	useEffect(() => {
 		if (!isLoaded) return;
 		if (!sections || sections.length === 0) return;
+		const settled = isModelCatalogSettled(sections);
 		const allOptions = sections.flatMap((s) => s.options);
+		const patch: Partial<AppSettings> = {};
 
-		// Already valid — nothing to do.
-		if (
-			settings.defaultModelId &&
-			findModelOption(sections, settings.defaultModelId)
-		) {
-			return;
+		// Unset stale review/pr picks (non-null but gone from the catalog) so
+		// they fall back to the default. Only act once settled, so we don't
+		// confuse "delisted" with "still loading".
+		if (settled) {
+			if (
+				settings.reviewModelId &&
+				!findModelOption(sections, settings.reviewModelId)
+			) {
+				patch.reviewModelId = null;
+			}
+			if (
+				settings.prModelId &&
+				!findModelOption(sections, settings.prModelId)
+			) {
+				patch.prModelId = null;
+			}
 		}
 
-		// User previously saved a model but it's not in the catalog. Only
-		// repair it once every provider has reached a terminal state.
-		if (settings.defaultModelId && !isModelCatalogSettled(sections)) return;
+		const defaultValid =
+			!!settings.defaultModelId &&
+			!!findModelOption(sections, settings.defaultModelId);
 
-		// Never been set (null), or a previously-saved value is now definitively
-		// unavailable — pick a sensible available default.
-		const pick =
-			sections.find((s) => s.id === "claude")?.options[0]?.id ??
-			allOptions[0]?.id ??
-			null;
-		if (!pick) return;
+		// Repair the default when it's never been set, or was set but is now
+		// definitively gone (wait for every provider to settle first).
+		if (!defaultValid && (settled || !settings.defaultModelId)) {
+			const pick =
+				sections.find((s) => s.id === "claude")?.options[0]?.id ??
+				allOptions[0]?.id ??
+				null;
+			if (pick) {
+				patch.defaultModelId = pick;
+				// Materialize null review/pr fields alongside the default so a
+				// fresh install doesn't depend on the next cold-start migration.
+				if (settings.reviewModelId === null) patch.reviewModelId = pick;
+				if (settings.prModelId === null) patch.prModelId = pick;
+				if (settings.reviewEffort === null) {
+					patch.reviewEffort = settings.defaultEffort;
+				}
+				if (settings.prEffort === null) patch.prEffort = settings.defaultEffort;
+				if (settings.reviewFastMode === null) {
+					patch.reviewFastMode = settings.defaultFastMode;
+				}
+				if (settings.prFastMode === null) {
+					patch.prFastMode = settings.defaultFastMode;
+				}
+			}
+		}
 
-		// Materialize null review/pr fields alongside the default so a fresh
-		// install doesn't depend on the next cold-start migration.
-		const patch: Partial<AppSettings> = { defaultModelId: pick };
-		if (settings.reviewModelId === null) patch.reviewModelId = pick;
-		if (settings.prModelId === null) patch.prModelId = pick;
-		if (settings.reviewEffort === null) {
-			patch.reviewEffort = settings.defaultEffort;
-		}
-		if (settings.prEffort === null) patch.prEffort = settings.defaultEffort;
-		if (settings.reviewFastMode === null) {
-			patch.reviewFastMode = settings.defaultFastMode;
-		}
-		if (settings.prFastMode === null) {
-			patch.prFastMode = settings.defaultFastMode;
-		}
-		updateSettings(patch);
+		if (Object.keys(patch).length > 0) updateSettings(patch);
 	}, [
 		isLoaded,
 		sections,


### PR DESCRIPTION
## Summary

Remove two deprecated Codex models (`gpt-5.3-codex`, `gpt-5.2`) from the model catalog and improve the model selection self-healing logic.

## Changes

- **Model catalog cleanup**: Removed `gpt-5.3-codex` and `gpt-5.2` from the Codex section in both sidecar and Rust backend
- **Updated fallback default**: Changed the fallback for `pickFastestCodexModel()` from `gpt-5.2` to `gpt-5.4-mini`
- **Enhanced self-healing**: `useEnsureDefaultModel` now properly unsets stale `reviewModelId` and `prModelId` settings when they reference models that have left the catalog, allowing them to fall back to the default at consumption time
- **Test coverage**: Added test case to verify stale model IDs are cleared when they're no longer available

## Why

This cleanup removes deprecated models that are no longer actively supported, and the enhanced self-healing logic ensures that users with saved settings pointing to deleted models don't encounter errors — their review and PR model picks automatically reset to sensible defaults on cold-start.

## Testing

- Updated test expectations in `codex-app-server-manager.test.ts` (model count now 4 instead of 6)
- Added new test case in `use-ensure-default-model.test.tsx` to verify stale model cleanup
- Verified all pipeline snapshot tests still pass