### PR TITLE
feat: add OpenCode agent type support and refactor provider resolution

### DIFF
--- a/src/features/panel/header.tsx
+++ b/src/features/panel/header.tsx
@@ -26,7 +26,12 @@ import { BranchPickerPopover } from "@/components/branch-picker";
 import { CachedAvatar } from "@/components/cached-avatar";
 import { TrafficLightSpacer } from "@/components/chrome/traffic-light-spacer";
 import { HelmorThinkingIndicator } from "@/components/helmor-thinking-indicator";
-import { ClaudeIcon, CursorIcon, OpenAIIcon } from "@/components/icons";
+import {
+	ClaudeIcon,
+	CursorIcon,
+	OpenAIIcon,
+	OpenCodeIcon,
+} from "@/components/icons";
 import { Button } from "@/components/ui/button";
 import {
 	DropdownMenu,
@@ -859,6 +864,9 @@ function SessionProviderIcon({
 	}
 	if (agentType === "cursor") {
 		return <CursorIcon className="size-3 shrink-0 text-muted-foreground" />;
+	}
+	if (agentType === "opencode") {
+		return <OpenCodeIcon className="size-3 shrink-0 text-muted-foreground" />;
 	}
 	return <ClaudeIcon className="size-3 shrink-0 text-muted-foreground" />;
 }

--- a/src/lib/workspace-helpers.test.ts
+++ b/src/lib/workspace-helpers.test.ts
@@ -788,7 +788,7 @@ describe("resolveSessionSelectedModelId", () => {
 });
 
 describe("resolveSessionDisplayProvider", () => {
-	it("maps the resolved model to the provider", () => {
+	it("uses the session's provider, ignoring the composer model selection", () => {
 		expect(
 			resolveSessionDisplayProvider({
 				session: {
@@ -802,22 +802,41 @@ describe("resolveSessionDisplayProvider", () => {
 				},
 				modelSections: MODEL_SECTIONS,
 			}),
-		).toBe("codex");
+		).toBe("claude");
 	});
 
-	it("falls back to persisted agent type when model resolution is unavailable", () => {
+	it("keeps the opencode icon regardless of the selected sub-provider model", () => {
 		expect(
 			resolveSessionDisplayProvider({
 				session: {
 					id: "session-2",
-					agentType: "claude",
+					agentType: "opencode",
 					model: null,
 					lastUserMessageAt: null,
 				},
-				modelSelections: {},
-				modelSections: [],
+				modelSelections: {
+					"session:session-2": "gpt-4o",
+				},
+				modelSections: MODEL_SECTIONS,
 			}),
-		).toBe("claude");
+		).toBe("opencode");
+	});
+
+	it("falls back to the selected model's provider when the session has no agent", () => {
+		expect(
+			resolveSessionDisplayProvider({
+				session: {
+					id: "session-3",
+					agentType: null,
+					model: null,
+					lastUserMessageAt: null,
+				},
+				modelSelections: {
+					"session:session-3": "gpt-4o",
+				},
+				modelSections: MODEL_SECTIONS,
+			}),
+		).toBe("codex");
 	});
 });
 

--- a/src/lib/workspace-helpers.ts
+++ b/src/lib/workspace-helpers.ts
@@ -734,32 +734,34 @@ export function resolveSessionDisplayProvider({
 	modelSections: AgentModelSection[];
 	settingsDefaultModelId?: string | null;
 }): AgentProvider | null {
+	// The Session Tab only has the four provider icons, so drive it from the
+	// session's agent — not the composer model (an opencode session can run many
+	// sub-provider models whose own logos aren't one of our four).
+	const agentProvider = agentTypeToProvider(session.agentType);
+	if (agentProvider) {
+		return agentProvider;
+	}
+	// New sessions without an assigned agent fall back to the selected model's
+	// provider so the icon still reflects what the next turn will use.
 	const selectedModelId = resolveSessionSelectedModelId({
 		session,
 		modelSelections,
 		modelSections,
 		settingsDefaultModelId,
 	});
-	const selectedProvider = findModelOption(
-		modelSections,
-		selectedModelId,
-	)?.provider;
-	if (selectedProvider) {
-		return selectedProvider;
+	return findModelOption(modelSections, selectedModelId)?.provider ?? null;
+}
+
+function agentTypeToProvider(agentType?: string | null): AgentProvider | null {
+	switch (agentType) {
+		case "claude":
+		case "codex":
+		case "cursor":
+		case "opencode":
+			return agentType;
+		default:
+			return null;
 	}
-	if (session.agentType === "codex") {
-		return "codex";
-	}
-	if (session.agentType === "claude") {
-		return "claude";
-	}
-	if (session.agentType === "cursor") {
-		return "cursor";
-	}
-	if (session.agentType === "opencode") {
-		return "opencode";
-	}
-	return null;
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR adds support for the OpenCode agent type in the session header UI and refactors the provider resolution logic for clearer behavior and maintainability.

## Changes

- **header.tsx**: Added `OpenCodeIcon` import and handler for OpenCode agent type in `SessionProviderIcon` component
- **workspace-helpers.ts**: Refactored `resolveSessionDisplayProvider` to:
  - Prioritize the session's `agentType` over the selected model (ensuring OpenCode sessions always show the OpenCode icon)
  - Extract agent-type-to-provider mapping into a dedicated `agentTypeToProvider` helper function
  - Fall back to the selected model's provider for new sessions without an assigned agent
- **workspace-helpers.test.ts**: Updated tests to reflect new behavior with clearer test descriptions

## Why

Previously, the provider resolution was mixing two concerns: displaying what agent is running the session vs. what model is currently selected in the composer. This change clarifies the semantics: the session tab icon drives from the agent type (what's actually running), and only falls back to the selected model when there's no active agent.

## Test notes

All existing tests pass. New test cases validate that:
1. OpenCode sessions keep their icon regardless of sub-provider model selection
2. Sessions with an agent type always use that agent's icon
3. New sessions without agents properly fall back to the selected model's provider