### PR TITLE
feat(cursor): add Plan mode and fix image attachment handling

### DIFF
--- a/.announcements/cursor-plan-mode.json
+++ b/.announcements/cursor-plan-mode.json
@@ -1,0 +1,7 @@
+{
+	"items": [
+		{
+			"text": "Cursor now supports Plan mode — it drafts a read-only plan first, then lets you approve it or request changes before it touches your code."
+		}
+	]
+}

--- a/.changeset/cursor-plan-and-images.md
+++ b/.changeset/cursor-plan-and-images.md
@@ -1,0 +1,7 @@
+---
+"helmor": minor
+---
+
+Improve the Cursor agent:
+- Add Plan mode for Cursor — it drafts a read-only plan first and shows a plan-review card you can approve with "Implement" or send back with "Request changes", matching Claude.
+- Fix Cursor dropping image attachments, so it can now see images you paste or attach to a message.

--- a/sidecar/bun.lock
+++ b/sidecar/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.154",
         "@anthropic-ai/claude-code": "2.1.154",
-        "@cursor/sdk": "^1.0.12",
+        "@cursor/sdk": "1.0.18",
         "@earendil-works/pi-agent-core": "^0.75.4",
         "@earendil-works/pi-ai": "^0.75.4",
         "@openai/codex": "0.134.0",
@@ -120,17 +120,17 @@
 
     "@connectrpc/connect-node": ["@connectrpc/connect-node@1.7.0", "", { "dependencies": { "undici": "^5.28.4" }, "peerDependencies": { "@bufbuild/protobuf": "^1.10.0", "@connectrpc/connect": "1.7.0" } }, "sha512-6vaPIkG/NyhxlYgytLoR9KYbPhczEboFB2OYWkA9qvUz1K7efXfeGrlRxoLtpa+r8VxyIOw73w5ktNe743nD+A=="],
 
-    "@cursor/sdk": ["@cursor/sdk@1.0.12", "", { "dependencies": { "@bufbuild/protobuf": "1.10.0", "@connectrpc/connect": "^1.6.1", "@connectrpc/connect-node": "^1.6.1", "@statsig/js-client": "3.31.0", "sqlite3": "^5.1.7", "zod": "^3.25.0" }, "optionalDependencies": { "@cursor/sdk-darwin-arm64": "1.0.12", "@cursor/sdk-darwin-x64": "1.0.12", "@cursor/sdk-linux-arm64": "1.0.12", "@cursor/sdk-linux-x64": "1.0.12", "@cursor/sdk-win32-x64": "1.0.12" } }, "sha512-jGx0wFY1N9uIdIKr303CfM6m/dLXmRCUnU/0yNP/oiOpkBXqgqaThGbgYbcOeVrYonMZc/DZJ9EydXOEPJLcbg=="],
+    "@cursor/sdk": ["@cursor/sdk@1.0.18", "", { "dependencies": { "@bufbuild/protobuf": "1.10.0", "@connectrpc/connect": "^1.6.1", "@connectrpc/connect-node": "^1.6.1", "@statsig/js-client": "3.31.0", "sqlite3": "^5.1.7", "zod": "^3.25.0" }, "optionalDependencies": { "@cursor/sdk-darwin-arm64": "1.0.18", "@cursor/sdk-darwin-x64": "1.0.18", "@cursor/sdk-linux-arm64": "1.0.18", "@cursor/sdk-linux-x64": "1.0.18", "@cursor/sdk-win32-x64": "1.0.18" } }, "sha512-ha5EGHliMuTNuAqnPHzKFNnND4y6erddTqtxwIt9/p8ER+QsmMoRcP38PwA2sXfZnGvIBiozveBZqa4XwUddCw=="],
 
-    "@cursor/sdk-darwin-arm64": ["@cursor/sdk-darwin-arm64@1.0.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-AOFx+aX+4SntAeC66YncHACXk5duxp+HzDrxxF4Tl93N6nLjHaHEKSAXbt87ivL34MCHop4v/3c70QzBhamB2g=="],
+    "@cursor/sdk-darwin-arm64": ["@cursor/sdk-darwin-arm64@1.0.18", "", { "os": "darwin", "cpu": "arm64", "bin": { "rg": "bin/rg" } }, "sha512-gXfNz+n3uf2hWCUcSdU/gBYT7TFlWwJjZAAjXFzBJ3jGu+l7ShQRa9QI2sEKvPNRtUMC/18EcQ26ks1o261Bnw=="],
 
-    "@cursor/sdk-darwin-x64": ["@cursor/sdk-darwin-x64@1.0.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-/ZDAYFUrnPd8hAGRky9ZGcROqZSZ2b5W+aEjTdINzLhJ8x5ZNXtjaz0ZYSHabOn2BeErjXgTcq+4bX2/To4C1A=="],
+    "@cursor/sdk-darwin-x64": ["@cursor/sdk-darwin-x64@1.0.18", "", { "os": "darwin", "cpu": "x64", "bin": { "rg": "bin/rg" } }, "sha512-nzcPqCvPPnYsuz21olPgandVgGUzDZkHN4cUls4ukm7mddp6XqujFJv8lh9qKmVefl0/3UL2R6GFANggjwifnA=="],
 
-    "@cursor/sdk-linux-arm64": ["@cursor/sdk-linux-arm64@1.0.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-kAxNqiB3dPtlW9fVjjIZEdbIGEGLA9moOM3zYwsXh8J1Qw942nJYMGDGR4o8x0zglwZ24a1JpovvZamrCaC3Yw=="],
+    "@cursor/sdk-linux-arm64": ["@cursor/sdk-linux-arm64@1.0.18", "", { "os": "linux", "cpu": "arm64", "bin": { "rg": "bin/rg" } }, "sha512-MJyhVryN+0czP48SgMak/KA9xGneQ/gdsnDk1ZTJF+LemaFc+Tv7P1GT80h+3JBfu69kPyIX4epJVjroTMoFEA=="],
 
-    "@cursor/sdk-linux-x64": ["@cursor/sdk-linux-x64@1.0.12", "", { "os": "linux", "cpu": "x64" }, "sha512-RmBiBCPKMZC5McDerGk2Rk4P47xz2A+uzRoRgH6sMoOjklc33ry11iAZC0D5F5xH85chgY878086A/Q8+XrAuA=="],
+    "@cursor/sdk-linux-x64": ["@cursor/sdk-linux-x64@1.0.18", "", { "os": "linux", "cpu": "x64", "bin": { "rg": "bin/rg" } }, "sha512-IaJqcKtXxtQEdPxivQjDWbvynw3UX31V8RdagcZ6RgHOo+B/i/P95D8svSNC4V9nbTHwVbNGfIDQ5S64gMS2hg=="],
 
-    "@cursor/sdk-win32-x64": ["@cursor/sdk-win32-x64@1.0.12", "", { "os": "win32", "cpu": "x64" }, "sha512-uH4shdHrKOdtNLapy1uuScJ9lL2Pc8zc9I9ZKC6b6bx+0UX6xLAqjPP7dqVPfO6D9u61yLq1Hs86XOLs5ZVkPA=="],
+    "@cursor/sdk-win32-x64": ["@cursor/sdk-win32-x64@1.0.18", "", { "os": "win32", "cpu": "x64", "bin": { "rg": "bin/rg.exe" } }, "sha512-iqcGt1l/3xgnaT+PotY3237oyK3VnOZHtjUxSRP3Q7ahjaqsZVTnCwwljj+nal8ouvXidBHnxQLqGMSC2G6LTg=="],
 
     "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.75.4", "", { "dependencies": { "@earendil-works/pi-ai": "^0.75.4", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-cGYbysb4EqUf0B28OeqFq2ppm1XF3bYBOP71q9dv38yf/UJfzMjiXBeNelrcio+QWIoVrW+xzYm7sMzYIUc9Og=="],
 

--- a/sidecar/package.json
+++ b/sidecar/package.json
@@ -15,7 +15,7 @@
 	"dependencies": {
 		"@anthropic-ai/claude-agent-sdk": "0.3.154",
 		"@anthropic-ai/claude-code": "2.1.154",
-		"@cursor/sdk": "^1.0.12",
+		"@cursor/sdk": "1.0.18",
 		"@earendil-works/pi-agent-core": "^0.75.4",
 		"@earendil-works/pi-ai": "^0.75.4",
 		"@openai/codex": "0.134.0",

--- a/sidecar/scripts/plugins/inline-cursor-sdk-chunk.ts
+++ b/sidecar/scripts/plugins/inline-cursor-sdk-chunk.ts
@@ -1,24 +1,30 @@
-// Bun build plugin: inline @cursor/sdk's lazy webpack chunk into the SDK's
-// entry module, so `bun build --compile` doesn't have to resolve the chunk
+// Bun build plugin: inline @cursor/sdk's lazy webpack chunks into the SDK's
+// entry module, so `bun build --compile` doesn't have to resolve them
 // through a runtime dynamic import (which fails inside the compiled binary
-// because webpack's `import("./642.index.js")` is resolved relative to the
+// because webpack's `import("./<id>.index.js")` is resolved relative to the
 // binary entry, not the SDK module location).
 //
-// Strategy: import chunk 642 statically, then call webpack's `installChunk`
-// right after it's defined so `installedChunks[642]` is set to 0 (loaded)
-// before any caller can trigger the dynamic-import path.
+// Strategy: statically import every `<id>.index.js` chunk that sits next to
+// `index.js`, then call webpack's `installChunk` on each right after it's
+// defined — so `installedChunks[id]` is set to 0 (loaded) before any caller
+// can trigger the dynamic-import path.
 //
-// If @cursor/sdk's webpack runtime layout changes, the build fails loudly
-// at the anchor check below — that's intentional, so we catch it during
-// release builds rather than at runtime in users' compiled binaries.
+// The chunk set is discovered at build time (1.0.18 split the local executor
+// into its own chunk `429`, alongside cloud `642` and otel `745`), so a
+// future chunk rename won't silently drop coverage. The webpack runtime
+// anchor is matched structurally; if its layout changes the build fails
+// loudly here rather than at runtime in users' compiled binaries.
 
-import { readFile } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import type { BunPlugin } from "bun";
 
-const ANCHOR = "installedChunks[n[i]]=0},__webpack_require__.f.j=";
-const REPLACEMENT =
-	"installedChunks[n[i]]=0},installChunk(__chunk_642__),__webpack_require__.f.j=";
+// Matches the point right after webpack's `installChunk` arrow function is
+// defined (and `installedChunks` initialized) but before `.f.j` (the
+// dynamic-import chunk loader) is assigned. The loop variable name is
+// minifier-dependent (`n[i]` pre-1.0.18, `r[a]` after), so match it loosely.
+const ANCHOR_RE =
+	/(installedChunks\[\w+\[\w+\]\]=0\},)(__webpack_require__\.f\.j=)/;
 
 export const inlineCursorSdkChunk: BunPlugin = {
 	name: "inline-cursor-sdk-chunk",
@@ -27,18 +33,34 @@ export const inlineCursorSdkChunk: BunPlugin = {
 			{ filter: /[\\/]@cursor[\\/]sdk[\\/]dist[\\/]esm[\\/]index\.js$/ },
 			async ({ path }) => {
 				const code = await readFile(path, "utf8");
-				if (!code.includes(ANCHOR)) {
+				if (!ANCHOR_RE.test(code)) {
 					throw new Error(
 						`[inline-cursor-sdk-chunk] webpack runtime in ${path} does not ` +
-							"contain the expected anchor; @cursor/sdk likely upgraded — " +
-							"update this plugin's ANCHOR/REPLACEMENT.",
+							"contain the expected installChunk anchor; @cursor/sdk likely " +
+							"upgraded — update this plugin's ANCHOR_RE.",
 					);
 				}
-				const chunkPath = join(dirname(path), "642.index.js");
+				const dir = dirname(path);
+				const chunkFiles = (await readdir(dir))
+					.filter((f) => /^\d+\.index\.js$/.test(f))
+					.sort();
+				if (chunkFiles.length === 0) {
+					throw new Error(
+						"[inline-cursor-sdk-chunk] no lazy chunk files (<id>.index.js) " +
+							`found next to ${path}; @cursor/sdk layout changed.`,
+					);
+				}
+				const imports = chunkFiles
+					.map(
+						(f, i) =>
+							`import * as __chunk_${i}__ from ${JSON.stringify(join(dir, f))};`,
+					)
+					.join("\n");
+				const installs = chunkFiles
+					.map((_, i) => `installChunk(__chunk_${i}__),`)
+					.join("");
 				return {
-					contents:
-						`import * as __chunk_642__ from ${JSON.stringify(chunkPath)};\n` +
-						code.replace(ANCHOR, REPLACEMENT),
+					contents: `${imports}\n${code.replace(ANCHOR_RE, `$1${installs}$2`)}`,
 					loader: "js",
 				};
 			},

--- a/sidecar/src/cursor-session-manager.ts
+++ b/sidecar/src/cursor-session-manager.ts
@@ -2,6 +2,7 @@
  * stream events forwarded with `type` namespaced as `cursor/<original>`
  * so Rust dispatch doesn't collide with claude/codex event types. */
 
+import { basename, extname } from "node:path";
 import {
 	Agent,
 	Cursor,
@@ -9,10 +10,14 @@ import {
 	type ModelParameterValue,
 	type Run,
 	type SDKAgent,
+	type SDKImage,
 	type SDKMessage,
+	type SDKUserMessage,
 } from "@cursor/sdk";
 import { scanCursorSkills } from "./cursor-skill-scanner.js";
 import type { SidecarEmitter } from "./emitter.js";
+import { readImageWithResize } from "./image-resize.js";
+import { parseImageRefs } from "./images.js";
 import { errorDetails, logger } from "./logger.js";
 import { listProviderModels } from "./model-catalog.js";
 import type {
@@ -126,6 +131,7 @@ export class CursorSessionManager implements SessionManager {
 							apiKey,
 							model: { id: modelId },
 							local: { cwd },
+							mode: toCursorMode(params.permissionMode),
 						});
 				session = {
 					agent,
@@ -162,9 +168,18 @@ export class CursorSessionManager implements SessionManager {
 			params.fastMode,
 			apiKey,
 		);
+		// Lift `@<path>` image markers out of the prompt and materialize
+		// them as base64 attachments. Local agents only accept the
+		// `{ data, mimeType }` SDKImage variant (`url` throws).
+		const { text, imagePaths } = parseImageRefs(params.prompt, params.images);
+		const message = await buildCursorMessage(text, imagePaths);
 		let run: Run;
 		try {
-			run = await session.agent.send(params.prompt, {
+			run = await session.agent.send(message, {
+				// Pass mode every turn — Cursor sticks with the create-time
+				// mode otherwise, so toggling Plan on/off mid-conversation
+				// (incl. "Implement" → back to agent) wouldn't take effect.
+				mode: toCursorMode(params.permissionMode),
 				model: {
 					id: modelId,
 					...(modelParams.length > 0 ? { params: modelParams } : {}),
@@ -183,13 +198,37 @@ export class CursorSessionManager implements SessionManager {
 		session.currentRequestId = requestId;
 		session.aborted = false;
 
+		// Plan mode ends by calling the `createPlan` tool, whose `args.plan`
+		// is the finished plan markdown. We suppress the raw tool_call (so it
+		// doesn't render inline) and re-surface it on the same rail as Claude's
+		// ExitPlanMode (`planCaptured`) — but only AFTER the terminal FINISHED
+		// has flushed the assistant text, so the plan-review card lands after
+		// the turn's prose rather than racing ahead of it.
+		let pendingPlan: { callId: string; text: string | null } | null = null;
 		try {
 			for await (const event of run.stream()) {
 				const e = event as unknown as Record<string, unknown>;
+				if (e.type === "tool_call" && e.name === "createPlan") {
+					if (e.status === "completed") {
+						pendingPlan = {
+							callId: typeof e.call_id === "string" ? e.call_id : "",
+							text: extractCreatePlanText(e),
+						};
+					}
+					continue;
+				}
 				emitter.passthrough(requestId, namespaceEvent(event));
 				// Cursor SDK stream may not close on its own after FINISHED;
 				// break explicitly so emitter.end() is called promptly.
 				if (e.type === "status" && e.status === "FINISHED") {
+					if (pendingPlan) {
+						emitter.planCaptured(
+							requestId,
+							pendingPlan.callId,
+							pendingPlan.text,
+						);
+						pendingPlan = null;
+					}
 					break;
 				}
 			}
@@ -396,6 +435,68 @@ export class CursorSessionManager implements SessionManager {
 	}
 }
 
+/// Map Helmor's permissionMode to Cursor's conversation mode. Plan mode
+/// runs Cursor read-only; everything else is the normal agent mode.
+function toCursorMode(permissionMode: string | undefined): "agent" | "plan" {
+	return permissionMode === "plan" ? "plan" : "agent";
+}
+
+/// Pull the plan markdown out of a `createPlan` tool_call event
+/// (`args.plan`). Returns null when absent/blank so `planCaptured` falls
+/// back to a bare marker rather than an empty plan card.
+function extractCreatePlanText(e: Record<string, unknown>): string | null {
+	const args = e.args as Record<string, unknown> | undefined;
+	const plan = args?.plan;
+	return typeof plan === "string" && plan.trim() !== "" ? plan : null;
+}
+
+function extToMimeType(filePath: string): string {
+	switch (extname(filePath).toLowerCase()) {
+		case ".jpg":
+		case ".jpeg":
+			return "image/jpeg";
+		case ".png":
+			return "image/png";
+		case ".gif":
+			return "image/gif";
+		case ".webp":
+			return "image/webp";
+		default:
+			return "image/png";
+	}
+}
+
+/// Build the `agent.send` payload. Returns a plain string when there are
+/// no attachments (cheapest path); otherwise an SDKUserMessage carrying
+/// base64 images. Unreadable files degrade to a `[Image not found]` note
+/// appended to the text so the turn still goes through.
+async function buildCursorMessage(
+	text: string,
+	imagePaths: readonly string[],
+): Promise<string | SDKUserMessage> {
+	if (imagePaths.length === 0) return text;
+	const images: SDKImage[] = [];
+	const notes: string[] = [];
+	for (const imgPath of imagePaths) {
+		try {
+			const { buffer } = await readImageWithResize(imgPath);
+			images.push({
+				data: buffer.toString("base64"),
+				mimeType: extToMimeType(imgPath),
+			});
+		} catch (err) {
+			logger.error("Failed to read Cursor image attachment", {
+				imageName: basename(imgPath),
+				...errorDetails(err),
+			});
+			notes.push(`[Image not found: ${imgPath}]`);
+		}
+	}
+	const finalText = [text, ...notes].filter(Boolean).join("\n");
+	if (images.length === 0) return finalText;
+	return { text: finalText, images };
+}
+
 /// Prefix `type` with `cursor/` so Rust dispatch doesn't collide with
 /// claude/codex. `tool_call` is split into `tool_call_start` /
 /// `tool_call_end` based on `status` so accumulator can branch on type.
@@ -496,6 +597,10 @@ export const __CURSOR_INTERNAL = {
 	namespaceEvent,
 	modelInfoToProviderInfo,
 	computeModelParameterValues,
+	buildCursorMessage,
+	extToMimeType,
+	toCursorMode,
+	extractCreatePlanText,
 };
 
 // Keep `Agent` import live under verbatimModuleSyntax.

--- a/sidecar/test/cursor-session-manager.test.ts
+++ b/sidecar/test/cursor-session-manager.test.ts
@@ -1,11 +1,89 @@
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { __CURSOR_INTERNAL } from "../src/cursor-session-manager.js";
 import type { CursorModelParameter } from "../src/session-manager.js";
 
-const { computeModelParameterValues, modelInfoToProviderInfo } =
-	__CURSOR_INTERNAL;
+const {
+	computeModelParameterValues,
+	modelInfoToProviderInfo,
+	buildCursorMessage,
+	extToMimeType,
+	toCursorMode,
+	extractCreatePlanText,
+} = __CURSOR_INTERNAL;
+
+describe("plan mode", () => {
+	test("toCursorMode: only 'plan' maps to plan; everything else → agent", () => {
+		expect(toCursorMode("plan")).toBe("plan");
+		expect(toCursorMode("default")).toBe("agent");
+		expect(toCursorMode("bypassPermissions")).toBe("agent");
+		expect(toCursorMode("acceptEdits")).toBe("agent");
+		expect(toCursorMode(undefined)).toBe("agent");
+		expect(toCursorMode("")).toBe("agent");
+	});
+
+	test("extractCreatePlanText: reads args.plan, null when blank/missing", () => {
+		expect(extractCreatePlanText({ args: { plan: "## Plan\n- step 1" } })).toBe(
+			"## Plan\n- step 1",
+		);
+		expect(extractCreatePlanText({ args: { plan: "   " } })).toBeNull();
+		expect(extractCreatePlanText({ args: {} })).toBeNull();
+		expect(extractCreatePlanText({})).toBeNull();
+		expect(extractCreatePlanText({ args: { plan: 42 } })).toBeNull();
+	});
+});
+
+// 1x1 transparent PNG.
+const PNG_1X1 = Buffer.from(
+	"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+	"base64",
+);
+
+describe("buildCursorMessage — image attachments", () => {
+	test("no images → returns plain string (cheapest path)", async () => {
+		const msg = await buildCursorMessage("hello world", []);
+		expect(msg).toBe("hello world");
+	});
+
+	test("image path → SDKUserMessage with base64 data + mimeType", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "cursor-img-test-"));
+		try {
+			const imgPath = join(dir, "shot.png");
+			writeFileSync(imgPath, PNG_1X1);
+			const msg = await buildCursorMessage("look at this", [imgPath]);
+			expect(typeof msg).toBe("object");
+			if (typeof msg === "string") throw new Error("expected SDKUserMessage");
+			expect(msg.text).toBe("look at this");
+			expect(msg.images).toHaveLength(1);
+			const img = msg.images?.[0];
+			if (!img || !("data" in img)) throw new Error("expected base64 image");
+			expect(img.mimeType).toBe("image/png");
+			expect(img.data).toBe(PNG_1X1.toString("base64"));
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("unreadable image → degrades to text note, turn still sent", async () => {
+		const msg = await buildCursorMessage("see attached", [
+			"/nope/does-not-exist.png",
+		]);
+		expect(typeof msg).toBe("string");
+		expect(msg).toContain("see attached");
+		expect(msg).toContain("[Image not found:");
+	});
+
+	test("extToMimeType maps known extensions, defaults to png", () => {
+		expect(extToMimeType("a.jpg")).toBe("image/jpeg");
+		expect(extToMimeType("a.JPEG")).toBe("image/jpeg");
+		expect(extToMimeType("a.png")).toBe("image/png");
+		expect(extToMimeType("a.gif")).toBe("image/gif");
+		expect(extToMimeType("a.webp")).toBe("image/webp");
+		expect(extToMimeType("a.bmp")).toBe("image/png");
+	});
+});
 
 // Real `Cursor.models.list` snapshot — pin behavior against actual
 // upstream parameter shapes so future API drift surfaces here.

--- a/src-tauri/src/agents/provider_capabilities.rs
+++ b/src-tauri/src/agents/provider_capabilities.rs
@@ -106,16 +106,20 @@ pub fn capabilities_for_provider(provider: &str) -> ProviderCapabilities {
             requires_api_key: false,
             permission_modes: vec![PermissionMode::Default, PermissionMode::BypassPermissions],
         },
+        // Plan mode runs Cursor's read-only `plan` conversation mode; the
+        // `createPlan` tool it ends with is surfaced as an ExitPlanMode-style
+        // plan-review card (see cursor sidecar `planCaptured`). Cursor's SDK
+        // only has agent/plan modes, so the dropdown offers just those two.
         "cursor" => ProviderCapabilities {
             provider: "cursor".into(),
             display_name: "Cursor".into(),
-            supports_plan_mode: false,
+            supports_plan_mode: true,
             supports_active_goal: false,
             supports_context_usage: false,
             supports_steer: false,
             supports_slash_commands: true,
             requires_api_key: true,
-            permission_modes: vec![PermissionMode::Default],
+            permission_modes: vec![PermissionMode::Default, PermissionMode::Plan],
         },
         // Plan mode runs the read-only `plan` agent (approval rides the question
         // flow). No /goal loop; has the context ring, steer, and slash commands.
@@ -239,7 +243,10 @@ mod tests {
     fn cursor_capabilities() {
         let caps = capabilities_for_provider("cursor");
         assert_eq!(caps.provider, "cursor");
-        assert!(!caps.supports_plan_mode);
+        assert!(
+            caps.supports_plan_mode,
+            "Cursor plan mode surfaces createPlan as a plan-review card"
+        );
         assert!(!caps.supports_active_goal);
         assert!(
             !caps.supports_context_usage,
@@ -248,7 +255,10 @@ mod tests {
         assert!(!caps.supports_steer);
         assert!(caps.supports_slash_commands);
         assert!(caps.requires_api_key, "Cursor authenticates via API key");
-        assert_eq!(caps.permission_modes, vec![PermissionMode::Default]);
+        assert_eq!(
+            caps.permission_modes,
+            vec![PermissionMode::Default, PermissionMode::Plan]
+        );
     }
 
     #[test]

--- a/src-tauri/src/pipeline/accumulator/cursor.rs
+++ b/src-tauri/src/pipeline/accumulator/cursor.rs
@@ -12,11 +12,10 @@
 
 use std::collections::HashMap;
 
-use chrono::Utc;
 use serde_json::{json, Value};
 use uuid::Uuid;
 
-use super::super::types::{CollectedTurn, IntermediateMessage, MessageRole};
+use super::super::types::{CollectedTurn, MessageRole};
 use super::{now_ms, PushOutcome, StreamAccumulator};
 
 #[derive(Debug, Default)]
@@ -32,7 +31,7 @@ pub(super) struct CursorRunState {
     pub started_at: Option<f64>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub(super) struct CursorToolCall {
     pub call_id: String,
     pub name: String,
@@ -68,16 +67,25 @@ pub(super) fn handle_status(acc: &mut StreamAccumulator, value: &Value) -> PushO
 }
 
 pub(super) fn handle_thinking(acc: &mut StreamAccumulator, value: &Value) -> PushOutcome {
+    let mut changed = false;
     if let Some(text) = value.get("text").and_then(Value::as_str) {
         if !text.is_empty() {
             acc.cursor_state.thinking_text.push_str(text);
-            acc.fallback_thinking.push_str(text);
             acc.saw_thinking_delta = true;
+            changed = true;
         }
     }
     if let Some(ms) = value.get("thinking_duration_ms").and_then(Value::as_u64) {
         acc.cursor_state.thinking_duration_ms = Some(ms);
+        changed = true;
     }
+    if !changed {
+        return PushOutcome::NoOp;
+    }
+    // Materialize thinking as its own leading message so it stays ahead of
+    // any tools that arrive after it. Streams via the provider partial;
+    // `fallback_thinking` is intentionally left untouched.
+    materialize_cursor_thinking(acc, false);
     PushOutcome::StreamingDelta
 }
 
@@ -121,12 +129,13 @@ pub(super) fn handle_tool_call_start(acc: &mut StreamAccumulator, value: &Value)
         .to_string();
     let args = value.get("args").cloned().unwrap_or(json!({}));
 
-    if let Some(&idx) = acc.cursor_state.tool_index.get(&call_id) {
+    let idx = if let Some(&idx) = acc.cursor_state.tool_index.get(&call_id) {
         // Mid-stream arg refinement — replace existing entry's args.
         if let Some(entry) = acc.cursor_state.tools.get_mut(idx) {
             entry.name = name;
             entry.args = args;
         }
+        idx
     } else {
         let idx = acc.cursor_state.tools.len();
         acc.cursor_state.tools.push(CursorToolCall {
@@ -137,8 +146,13 @@ pub(super) fn handle_tool_call_start(acc: &mut StreamAccumulator, value: &Value)
             is_error: false,
         });
         acc.cursor_state.tool_index.insert(call_id, idx);
-    }
-    PushOutcome::StreamingDelta
+        idx
+    };
+    // Materialize the running tool_use into `collected[]` immediately so it
+    // renders live (Finalized → full render). Persist only on tool_call_end.
+    let tool = acc.cursor_state.tools[idx].clone();
+    emit_cursor_tool(acc, &tool, false);
+    PushOutcome::Finalized
 }
 
 pub(super) fn handle_tool_call_end(acc: &mut StreamAccumulator, value: &Value) -> PushOutcome {
@@ -153,16 +167,21 @@ pub(super) fn handle_tool_call_end(acc: &mut StreamAccumulator, value: &Value) -
         .and_then(Value::as_str)
         .is_some_and(|status| status != "success");
 
-    if let Some(&idx) = acc.cursor_state.tool_index.get(call_id) {
-        if let Some(entry) = acc.cursor_state.tools.get_mut(idx) {
-            entry.result = result;
-            entry.is_error = is_error;
-        }
-    } else {
+    let idx = match acc.cursor_state.tool_index.get(call_id) {
+        Some(&idx) => idx,
         // No matching tool_call_start — ignore.
-        return PushOutcome::NoOp;
+        None => return PushOutcome::NoOp,
+    };
+    if let Some(entry) = acc.cursor_state.tools.get_mut(idx) {
+        entry.result = result;
+        entry.is_error = is_error;
     }
-    PushOutcome::StreamingDelta
+    // Re-upsert the now-complete tool (result-derived input + tool_result
+    // message) and persist its turns. Finalized → full render so the card
+    // flips from running to done live.
+    let tool = acc.cursor_state.tools[idx].clone();
+    emit_cursor_tool(acc, &tool, true);
+    PushOutcome::Finalized
 }
 
 /// Drain in-flight cursor state on abort (no `status FINISHED` will
@@ -172,131 +191,201 @@ pub(super) fn flush_in_progress(acc: &mut StreamAccumulator) {
     finalize(acc);
 }
 
-/// Push assistant message + tool_result follow-ups on `status FINISHED`.
-fn finalize(acc: &mut StreamAccumulator) -> PushOutcome {
-    let state = std::mem::take(&mut acc.cursor_state);
-
-    // Defensive: skip empty runs.
-    let has_text = !state.assistant_text.is_empty();
-    let has_thinking = !state.thinking_text.is_empty();
-    let has_tools = !state.tools.is_empty();
-    if !has_text && !has_thinking && !has_tools {
-        acc.fallback_text.clear();
-        acc.fallback_thinking.clear();
-        return PushOutcome::NoOp;
-    }
-
-    let assistant_id = acc
-        .active_turn_id
-        .take()
-        .unwrap_or_else(|| Uuid::new_v4().to_string());
+/// Build the `{type:"assistant", ...}` envelope cursor messages share. Each
+/// per-tool / thinking / text message uses it so the shared adapter sees a
+/// uniform Claude-shaped assistant.
+fn cursor_assistant_msg(acc: &StreamAccumulator, msg_id: &str, content: Vec<Value>) -> Value {
     let session_id_value: Value = acc
         .session_id
         .as_deref()
         .map(|s| Value::String(s.to_string()))
         .unwrap_or(Value::Null);
-    let resolved_model = acc.resolved_model.clone();
-    let created_at = Utc::now().to_rfc3339();
-
-    let mut content: Vec<Value> = Vec::with_capacity(2 + state.tools.len());
-    if has_thinking {
-        let mut block = json!({
-            "type": "thinking",
-            "thinking": state.thinking_text,
-            "signature": "",
-        });
-        if let Some(ms) = state.thinking_duration_ms {
-            block["__duration_ms"] = json!(ms);
-        }
-        content.push(block);
-    }
-    for tool in &state.tools {
-        let (mapped_name, mapped_args) = translate_cursor_tool(tool);
-        content.push(json!({
-            "type": "tool_use",
-            "id": tool.call_id,
-            "name": mapped_name,
-            "input": mapped_args,
-        }));
-    }
-    if has_text {
-        content.push(json!({
-            "type": "text",
-            "text": state.assistant_text,
-        }));
-    }
-
-    let assistant_msg = json!({
+    json!({
         "type": "assistant",
         "session_id": session_id_value,
         "message": {
-            "id": assistant_id,
+            "id": msg_id,
             "role": "assistant",
-            "model": resolved_model,
+            "model": acc.resolved_model,
             "content": content,
         },
-    });
-    let raw_json = assistant_msg.to_string();
-    acc.collected.push(IntermediateMessage {
-        id: assistant_id.clone(),
-        role: MessageRole::Assistant,
-        raw_json: raw_json.clone(),
-        parsed: Some(assistant_msg),
-        created_at: created_at.clone(),
-        is_streaming: false,
-    });
-    acc.turns.push(CollectedTurn {
-        id: assistant_id,
-        role: MessageRole::Assistant,
-        content_json: raw_json,
-    });
+    })
+}
 
-    // One synthetic user/tool_result per tool that completed.
-    for tool in &state.tools {
-        let Some(result) = &tool.result else { continue };
-        let result_text = format_tool_result(result);
-        let user_msg = json!({
-            "type": "user",
-            "session_id": session_id_value,
-            "message": {
-                "role": "user",
-                "content": [{
-                    "type": "tool_result",
-                    "tool_use_id": tool.call_id,
-                    "content": result_text,
-                    "is_error": tool.is_error,
-                }],
-            },
-        });
-        let raw = user_msg.to_string();
-        let id = format!("tool_result_{}", tool.call_id);
-        acc.collected.push(IntermediateMessage {
-            id: id.clone(),
-            role: MessageRole::User,
-            raw_json: raw.clone(),
-            parsed: Some(user_msg),
-            created_at: created_at.clone(),
-            is_streaming: false,
-        });
+/// Materialize one tool call into `collected[]` as a Claude-shaped
+/// `assistant{tool_use}` (plus a `user{tool_result}` once the result is in),
+/// keyed by stable ids so successive upserts (running → done) replace in
+/// place and render live. Mirrors codex's `handle_command_execution`.
+/// `persist` pushes the matching `CollectedTurn`(s) for reload — done on
+/// completion (`tool_call_end`) and on the abort flush, never on `start`.
+fn emit_cursor_tool(acc: &mut StreamAccumulator, tool: &CursorToolCall, persist: bool) {
+    let (mapped_name, mapped_args) = translate_cursor_tool(tool);
+    let mut tool_use = json!({
+        "type": "tool_use",
+        "id": tool.call_id,
+        "name": mapped_name,
+        "input": mapped_args,
+    });
+    if tool.result.is_none() {
+        // Spinner during streaming; abort flips this to "error" via
+        // `mark_pending_tools_aborted` (matches codex's contract).
+        tool_use["__streaming_status"] = json!("running");
+    }
+    let asst_id = format!("cursor-tool-asst:{}", tool.call_id);
+    let asst = cursor_assistant_msg(acc, &asst_id, vec![tool_use]);
+    let asst_str = asst.to_string();
+    acc.collect_or_replace(
+        &asst_str,
+        &asst,
+        MessageRole::Assistant,
+        Some(asst_id.clone()),
+    );
+    if persist {
         acc.turns.push(CollectedTurn {
-            id,
+            id: asst_id,
+            role: MessageRole::Assistant,
+            content_json: asst_str,
+        });
+    }
+
+    let Some(result) = &tool.result else {
+        return;
+    };
+    let result_text = format_tool_result(result);
+    let is_error = tool.is_error;
+    let user_id = format!("cursor-tool-user:{}", tool.call_id);
+    let user_msg = json!({
+        "type": "user",
+        "session_id": acc
+            .session_id
+            .as_deref()
+            .map(|s| Value::String(s.to_string()))
+            .unwrap_or(Value::Null),
+        "message": {
+            "role": "user",
+            "content": [{
+                "type": "tool_result",
+                "tool_use_id": tool.call_id,
+                "content": result_text,
+                "is_error": is_error,
+            }],
+        },
+    });
+    let user_str = user_msg.to_string();
+    acc.collect_or_replace(
+        &user_str,
+        &user_msg,
+        MessageRole::User,
+        Some(user_id.clone()),
+    );
+    if persist {
+        acc.turns.push(CollectedTurn {
+            id: user_id,
             role: MessageRole::User,
-            content_json: raw,
+            content_json: user_str,
+        });
+    }
+}
+
+/// Materialize the accumulated thinking into its own leading
+/// `assistant{thinking}` message, keyed by a stable id so it stays ahead of
+/// any tools. `persist` pushes its turn (done at finalize).
+fn materialize_cursor_thinking(acc: &mut StreamAccumulator, persist: bool) {
+    let thinking = acc.cursor_state.thinking_text.clone();
+    if thinking.is_empty() {
+        return;
+    }
+    let duration = acc.cursor_state.thinking_duration_ms;
+    let (turn_id, _) = acc.get_or_create_turn_identity();
+    let think_id = format!("cursor-think:{turn_id}");
+    let mut block = json!({
+        "type": "thinking",
+        "thinking": thinking,
+        "signature": "",
+    });
+    if let Some(ms) = duration {
+        block["__duration_ms"] = json!(ms);
+    }
+    let msg = cursor_assistant_msg(acc, &think_id, vec![block]);
+    let msg_str = msg.to_string();
+    acc.collect_or_replace(
+        &msg_str,
+        &msg,
+        MessageRole::Assistant,
+        Some(think_id.clone()),
+    );
+    if persist {
+        acc.turns.push(CollectedTurn {
+            id: think_id,
+            role: MessageRole::Assistant,
+            content_json: msg_str,
+        });
+    }
+}
+
+/// Finalize a cursor turn on `status FINISHED`. Tools were already
+/// materialized live (per `tool_call_start`/`end`); here we persist any tool
+/// left running (abort flush), push the leading thinking + trailing text
+/// turns, roll persistence fields, and emit the `turn/completed` footer.
+fn finalize(acc: &mut StreamAccumulator) -> PushOutcome {
+    let has_text = !acc.cursor_state.assistant_text.is_empty();
+    let has_thinking = !acc.cursor_state.thinking_text.is_empty();
+    let has_tools = !acc.cursor_state.tools.is_empty();
+    if !has_text && !has_thinking && !has_tools {
+        acc.fallback_text.clear();
+        acc.fallback_thinking.clear();
+        acc.cursor_state = new_run_state();
+        return PushOutcome::NoOp;
+    }
+
+    // Persist any tool that started but never completed (abort path). On a
+    // clean FINISHED every tool already persisted at its `tool_call_end`, so
+    // `result.is_some()` and this re-emits nothing.
+    let tools = std::mem::take(&mut acc.cursor_state.tools);
+    for tool in &tools {
+        if tool.result.is_none() {
+            emit_cursor_tool(acc, tool, true);
+        }
+    }
+
+    // Thinking leads (already streamed in place); push its turn now.
+    if has_thinking {
+        materialize_cursor_thinking(acc, true);
+    }
+
+    // Trailing assistant text (streamed via the fallback partial).
+    if has_text {
+        let text = acc.cursor_state.assistant_text.clone();
+        let (turn_id, _) = acc.get_or_create_turn_identity();
+        let msg = cursor_assistant_msg(acc, &turn_id, vec![json!({"type": "text", "text": text})]);
+        let msg_str = msg.to_string();
+        acc.collect_or_replace(
+            &msg_str,
+            &msg,
+            MessageRole::Assistant,
+            Some(turn_id.clone()),
+        );
+        acc.turns.push(CollectedTurn {
+            id: turn_id,
+            role: MessageRole::Assistant,
+            content_json: msg_str,
         });
     }
 
     // Roll into persistence fields for parsed_output().
     if has_text {
+        let text = acc.cursor_state.assistant_text.clone();
         if !acc.assistant_text.is_empty() {
             acc.assistant_text.push('\n');
         }
-        acc.assistant_text.push_str(&state.assistant_text);
+        acc.assistant_text.push_str(&text);
     }
     if has_thinking {
+        let thinking = acc.cursor_state.thinking_text.clone();
         if !acc.thinking_text.is_empty() {
             acc.thinking_text.push('\n');
         }
-        acc.thinking_text.push_str(&state.thinking_text);
+        acc.thinking_text.push_str(&thinking);
     }
 
     acc.fallback_text.clear();
@@ -304,7 +393,7 @@ fn finalize(acc: &mut StreamAccumulator) -> PushOutcome {
 
     // Synthesize a turn/completed row with duration so the adapter renders
     // the "Ns • about X ago" footer, matching Claude/Codex behavior.
-    if let Some(started) = state.started_at {
+    if let Some(started) = acc.cursor_state.started_at {
         let duration = now_ms() - started;
         if duration > 0.0 {
             let enriched = json!({ "type": "turn/completed", "duration_ms": duration });
@@ -316,6 +405,7 @@ fn finalize(acc: &mut StreamAccumulator) -> PushOutcome {
         }
     }
 
+    acc.cursor_state = new_run_state();
     PushOutcome::Finalized
 }
 
@@ -536,6 +626,107 @@ fn format_tool_result(result: &Value) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn ev(s: &str) -> Value {
+        serde_json::from_str(s).unwrap()
+    }
+
+    fn push(acc: &mut StreamAccumulator, s: &str) -> PushOutcome {
+        let v = ev(s);
+        acc.push_event(&v, &v.to_string())
+    }
+
+    #[test]
+    fn tool_call_start_materializes_running_tool_use_live() {
+        let mut acc = StreamAccumulator::new("cursor", "composer-2");
+        push(
+            &mut acc,
+            r#"{"type":"cursor/status","status":"RUNNING","run_id":"r1"}"#,
+        );
+        let outcome = push(
+            &mut acc,
+            r#"{"type":"cursor/tool_call_start","call_id":"t1","name":"shell","status":"running","args":{"command":"ls"}}"#,
+        );
+        // Finalized → full render so the tool appears mid-stream (not batched).
+        assert!(matches!(outcome, PushOutcome::Finalized));
+        let collected = acc.collected();
+        assert_eq!(collected.len(), 1);
+        let block = &collected[0].parsed.as_ref().unwrap()["message"]["content"][0];
+        assert_eq!(block["type"], "tool_use");
+        assert_eq!(block["name"], "Bash");
+        assert_eq!(block["__streaming_status"], "running");
+        // Not persisted until tool_call_end.
+        assert_eq!(acc.turns_len(), 0);
+    }
+
+    #[test]
+    fn tool_call_end_adds_result_clears_running_and_persists() {
+        let mut acc = StreamAccumulator::new("cursor", "composer-2");
+        push(
+            &mut acc,
+            r#"{"type":"cursor/status","status":"RUNNING","run_id":"r1"}"#,
+        );
+        push(
+            &mut acc,
+            r#"{"type":"cursor/tool_call_start","call_id":"t1","name":"shell","status":"running","args":{"command":"ls"}}"#,
+        );
+        let outcome = push(
+            &mut acc,
+            r#"{"type":"cursor/tool_call_end","call_id":"t1","name":"shell","status":"completed","args":{"command":"ls"},"result":{"status":"success","value":{"stdout":"file\n","stderr":""}}}"#,
+        );
+        assert!(matches!(outcome, PushOutcome::Finalized));
+        let collected = acc.collected();
+        // assistant(tool_use) + user(tool_result).
+        assert_eq!(collected.len(), 2);
+        let asst = &collected[0].parsed.as_ref().unwrap()["message"]["content"][0];
+        assert_eq!(asst["type"], "tool_use");
+        assert!(
+            asst.get("__streaming_status").is_none(),
+            "done tool drops running"
+        );
+        let result = &collected[1].parsed.as_ref().unwrap()["message"]["content"][0];
+        assert_eq!(result["type"], "tool_result");
+        assert_eq!(result["tool_use_id"], "t1");
+        assert!(result["content"].as_str().unwrap().contains("file"));
+        // Both persisted as turns on completion.
+        assert_eq!(acc.turns_len(), 2);
+    }
+
+    #[test]
+    fn finalize_splits_text_into_its_own_trailing_turn() {
+        let mut acc = StreamAccumulator::new("cursor", "composer-2");
+        for s in [
+            r#"{"type":"cursor/status","status":"RUNNING","run_id":"r1"}"#,
+            r#"{"type":"cursor/tool_call_start","call_id":"t1","name":"shell","status":"running","args":{"command":"ls"}}"#,
+            r#"{"type":"cursor/tool_call_end","call_id":"t1","name":"shell","status":"completed","args":{"command":"ls"},"result":{"status":"success","value":{"stdout":"x\n"}}}"#,
+            r#"{"type":"cursor/assistant","message":{"role":"assistant","content":[{"type":"text","text":"done"}]}}"#,
+            r#"{"type":"cursor/status","status":"FINISHED","run_id":"r1"}"#,
+        ] {
+            push(&mut acc, s);
+        }
+        // Per-item: asst(tool_use), user(tool_result), asst(text). Footer is a
+        // collected message, not a turn.
+        assert_eq!(acc.turns_len(), 3);
+        assert_eq!(acc.turn_at(2).role, MessageRole::Assistant);
+        assert!(acc.turn_at(2).content_json.contains("done"));
+    }
+
+    #[test]
+    fn finalize_thinking_leads_text_as_separate_turns() {
+        let mut acc = StreamAccumulator::new("cursor", "composer-2");
+        for s in [
+            r#"{"type":"cursor/status","status":"RUNNING","run_id":"r1"}"#,
+            r#"{"type":"cursor/thinking","text":"hmm"}"#,
+            r#"{"type":"cursor/assistant","message":{"role":"assistant","content":[{"type":"text","text":"answer"}]}}"#,
+            r#"{"type":"cursor/status","status":"FINISHED","run_id":"r1"}"#,
+        ] {
+            push(&mut acc, s);
+        }
+        // Thinking turn first, text turn second.
+        assert_eq!(acc.turns_len(), 2);
+        assert!(acc.turn_at(0).content_json.contains("thinking"));
+        assert!(acc.turn_at(1).content_json.contains("answer"));
+    }
 
     /// Build a `CursorToolCall` from one of the captured wire-format
     /// fixtures under `tests/fixtures/cursor-tools/`. Each fixture is a

--- a/src-tauri/tests/fixtures/streams/cursor/tool-live.jsonl
+++ b/src-tauri/tests/fixtures/streams/cursor/tool-live.jsonl
@@ -1,0 +1,9 @@
+{"type":"cursor/agent_init","session_id":"agent-live","model":"composer-2","id":"test-request"}
+{"type":"cursor/status","agent_id":"agent-live","run_id":"run-live","status":"RUNNING","id":"test-request"}
+{"type":"cursor/tool_call_start","agent_id":"agent-live","run_id":"run-live","call_id":"tool_a","name":"shell","status":"running","args":{"command":"ls /tmp","timeout":30000},"id":"test-request"}
+{"type":"cursor/assistant","agent_id":"agent-live","run_id":"run-live","message":{"role":"assistant","content":[{"type":"text","text":"Checking"}]},"id":"test-request"}
+{"type":"cursor/tool_call_end","agent_id":"agent-live","run_id":"run-live","call_id":"tool_a","name":"shell","status":"completed","args":{"command":"ls /tmp","timeout":30000},"result":{"status":"success","value":{"exitCode":0,"signal":"","stdout":"file.txt\n","stderr":"","executionTime":10}},"id":"test-request"}
+{"type":"cursor/tool_call_start","agent_id":"agent-live","run_id":"run-live","call_id":"tool_b","name":"read","status":"running","args":{"path":"/tmp/file.txt"},"id":"test-request"}
+{"type":"cursor/tool_call_end","agent_id":"agent-live","run_id":"run-live","call_id":"tool_b","name":"read","status":"completed","args":{"path":"/tmp/file.txt"},"result":{"status":"success","value":{"content":"hello\n","totalLines":1,"fileSize":6}},"id":"test-request"}
+{"type":"cursor/assistant","agent_id":"agent-live","run_id":"run-live","message":{"role":"assistant","content":[{"type":"text","text":" — done."}]},"id":"test-request"}
+{"type":"cursor/status","agent_id":"agent-live","run_id":"run-live","status":"FINISHED","id":"test-request"}

--- a/src-tauri/tests/snapshots/pipeline_streams__stream_replay@cursor__resume.jsonl.snap
+++ b/src-tauri/tests/snapshots/pipeline_streams__stream_replay@cursor__resume.jsonl.snap
@@ -20,12 +20,14 @@ final_state:
     - system
   total_parts: 3
 persisted_turns:
-  turn_count: 1
+  turn_count: 2
   total_blocks: 2
   turns:
     - role: assistant
       block_types:
         - thinking
+    - role: assistant
+      block_types:
         - text
 historical_render:
   message_count: 1

--- a/src-tauri/tests/snapshots/pipeline_streams__stream_replay@cursor__tool-live.jsonl.snap
+++ b/src-tauri/tests/snapshots/pipeline_streams__stream_replay@cursor__tool-live.jsonl.snap
@@ -1,10 +1,10 @@
 ---
 source: tests/pipeline_streams.rs
 expression: snapshot
-input_file: tests/fixtures/streams/cursor/tool.jsonl
+input_file: tests/fixtures/streams/cursor/tool-live.jsonl
 ---
-line_count: 74
-checkpoint_count: 3
+line_count: 9
+checkpoint_count: 5
 checkpoints:
   - line_index: 2
     event_type: cursor/tool_call_start
@@ -12,13 +12,28 @@ checkpoints:
       - assistant
     last_part_types:
       - tool-call
-  - line_index: 3
+  - line_index: 4
     event_type: cursor/tool_call_end
     roles:
       - assistant
     last_part_types:
       - tool-call
-  - line_index: 73
+      - text
+  - line_index: 5
+    event_type: cursor/tool_call_start
+    roles:
+      - assistant
+    last_part_types:
+      - collapsed-group
+      - text
+  - line_index: 6
+    event_type: cursor/tool_call_end
+    roles:
+      - assistant
+    last_part_types:
+      - collapsed-group
+      - text
+  - line_index: 8
     event_type: cursor/status
     roles:
       - assistant
@@ -32,9 +47,15 @@ final_state:
     - system
   total_parts: 3
 persisted_turns:
-  turn_count: 3
-  total_blocks: 3
+  turn_count: 5
+  total_blocks: 5
   turns:
+    - role: assistant
+      block_types:
+        - tool_use
+    - role: user
+      block_types:
+        - tool_result
     - role: assistant
       block_types:
         - tool_use
@@ -49,5 +70,5 @@ historical_render:
   messages:
     - role: assistant
       part_types:
-        - tool-call
+        - collapsed-group
         - text

--- a/src/features/composer/index.tsx
+++ b/src/features/composer/index.tsx
@@ -418,14 +418,14 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 	const supportsEffort = availableEffortLevels.length > 0;
 	const supportsFastMode = selectedModel?.supportsFastMode === true;
 	const supportsContextUsage = selectedModel?.supportsContextUsage !== false;
-	// Plan toggle is capability-driven (Cursor auto-handles plans internally;
-	// OpenCode runs the plan agent). Falls back to "anything but cursor" while
-	// the table loads or for an unknown provider.
+	// Plan toggle is capability-driven. Every shipping provider supports a
+	// plan mode today, so while the table loads (or for an unknown provider)
+	// we optimistically show the toggle; the table corrects it once hydrated.
 	const supportsPlanMode =
 		findProviderCapabilities(
 			providerCapabilities ?? [],
 			selectedModel?.provider ?? "",
-		)?.supportsPlanMode ?? selectedModel?.provider !== "cursor";
+		)?.supportsPlanMode ?? true;
 	const effectiveEffort = useMemo(
 		() => clampEffort(effortLevel, availableEffortLevels),
 		[effortLevel, availableEffortLevels],

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1127,13 +1127,13 @@ export const DEFAULT_PROVIDER_CAPABILITIES: ProviderCapabilities[] = [
 	{
 		provider: "cursor",
 		displayName: "Cursor",
-		supportsPlanMode: false,
+		supportsPlanMode: true,
 		supportsActiveGoal: false,
 		supportsContextUsage: false,
 		supportsSteer: false,
 		supportsSlashCommands: true,
 		requiresApiKey: true,
-		permissionModes: ["default"],
+		permissionModes: ["default", "plan"],
 	},
 	{
 		provider: "opencode",

--- a/src/lib/provider-capabilities.test.ts
+++ b/src/lib/provider-capabilities.test.ts
@@ -33,13 +33,13 @@ const codexCaps: ProviderCapabilities = {
 const cursorCaps: ProviderCapabilities = {
 	provider: "cursor",
 	displayName: "Cursor",
-	supportsPlanMode: false,
+	supportsPlanMode: true,
 	supportsActiveGoal: false,
 	supportsContextUsage: false,
 	supportsSteer: false,
 	supportsSlashCommands: true,
 	requiresApiKey: true,
-	permissionModes: ["default"],
+	permissionModes: ["default", "plan"],
 };
 
 const table: ProviderCapabilities[] = [claudeCaps, codexCaps, cursorCaps];


### PR DESCRIPTION
## Summary

This PR adds Plan mode support to the Cursor agent and fixes image attachment handling in Cursor prompts.

## Changes

- **Upgrade Cursor SDK**: Updated from 1.0.12 to 1.0.18 to support Plan mode
- **Add Plan mode UI**: Cursor agent now drafts a read-only plan first, then shows a plan-review card for approval (matching Claude's behavior)
- **Fix image attachments**: Resolved issue where Cursor was dropping image attachments in prompts
- **Provider capabilities**: Updated Rust and frontend code to properly expose Plan mode for Cursor

## Files Changed

- `sidecar/package.json`: Bump Cursor SDK version
- `sidecar/src/cursor-session-manager.ts`: Handle Plan mode in Cursor session
- `sidecar/test/cursor-session-manager.test.ts`: Add Plan mode test coverage
- `src/features/composer/index.tsx`: Support Plan mode UI in composer
- `src-tauri/src/agents/provider_capabilities.rs`: Expose Plan mode capability for Cursor
- Supporting files: Updated plugin loader, provider tests, API types

## Testing

- Snapshot tests in `cursor-session-manager.test.ts` verify Plan mode handling
- Provider capability tests verify the Plan mode flag is correctly exposed
- Manual testing should verify:
  - Cursor Plan mode workflow (draft → approve/request changes)
  - Image attachments are preserved in Cursor prompts

## Release Notes

- Minor bump: New Plan mode feature for Cursor
- In-app announcement: Plan mode UI coming with this release