### PR TITLE
Add platform abstraction boundary

### DIFF
--- a/src-tauri/src/agents/claude_project_files.rs
+++ b/src-tauri/src/agents/claude_project_files.rs
@@ -22,7 +22,7 @@ pub fn encode_project_dir(path: &Path) -> String {
 /// Resolve `~/.claude/projects` from `$HOME`. Returns `None` when HOME is
 /// unset or the directory does not exist (fresh install — nothing to do).
 fn claude_projects_root() -> Option<PathBuf> {
-    let home = std::env::var_os("HOME").map(PathBuf::from)?;
+    let home = crate::platform::paths::home_dir()?;
     let root = home.join(".claude").join("projects");
     if root.is_dir() {
         Some(root)

--- a/src-tauri/src/agents/opencode_config.rs
+++ b/src-tauri/src/agents/opencode_config.rs
@@ -53,8 +53,7 @@ fn config_dir() -> Result<PathBuf> {
             return Ok(PathBuf::from(xdg).join("opencode"));
         }
     }
-    let home = std::env::var_os("HOME").context("HOME is not set")?;
-    Ok(PathBuf::from(home).join(".config").join("opencode"))
+    crate::platform::paths::xdg_config_dir("opencode").context("HOME is not set")
 }
 
 // Precedence: `opencode.jsonc` > `opencode.json` > `config.json`; default to `opencode.jsonc`.

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -19,10 +19,7 @@ pub struct ApiKeyProvider {
 
 /// Resolve `~/.codex/config.toml`, honouring `$CODEX_HOME` if set.
 pub fn config_path() -> PathBuf {
-    std::env::var_os("CODEX_HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| home_dir().join(".codex"))
-        .join("config.toml")
+    crate::platform::paths::codex_home_dir().join("config.toml")
 }
 
 /// The provider currently selected by `model_provider`, if it declares an
@@ -79,12 +76,6 @@ pub fn declared_env_keys(config: &str) -> Vec<String> {
         }
     }
     keys
-}
-
-fn home_dir() -> PathBuf {
-    std::env::var_os("HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("/"))
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands/forge_commands.rs
+++ b/src-tauri/src/commands/forge_commands.rs
@@ -225,15 +225,9 @@ pub async fn spawn_forge_cli_auth_terminal(
 ) -> CmdResult<()> {
     let host = host.unwrap_or_else(|| "gitlab.com".to_string());
     let command = forge::forge_cli_auth_command(provider, Some(&host))?;
-    let working_dir = std::env::var("HOME")
-        .ok()
-        .filter(|home| !home.trim().is_empty())
-        .or_else(|| {
-            std::env::current_dir()
-                .ok()
-                .map(|path| path.display().to_string())
-        })
-        .unwrap_or_else(|| "/".to_string());
+    let working_dir = crate::platform::paths::home_dir_or_current_or_root()
+        .display()
+        .to_string();
     let context = ScriptContext {
         root_path: working_dir.clone(),
         workspace_path: None,
@@ -250,7 +244,7 @@ pub async fn spawn_forge_cli_auth_terminal(
         // input — written synchronously to the PTY master right after
         // the shell registers, so a frontend re-render-driven
         // cleanup→respawn can't drop the bytes.
-        let boot_input = format!("{command}; exit\n");
+        let boot_input = crate::platform::shell::boot_input(&command);
         if let Err(error) = crate::workspace::scripts::run_terminal_session(
             &mgr,
             FORGE_CLI_AUTH_REPO_ID,

--- a/src-tauri/src/commands/system_commands.rs
+++ b/src-tauri/src/commands/system_commands.rs
@@ -169,11 +169,11 @@ fn cli_install_remediation(cli_binary: &std::path::Path, install_path: &std::pat
 }
 
 fn shell_quote(path: &std::path::Path) -> String {
-    format!("'{}'", path.display().to_string().replace('\'', "'\\''"))
+    crate::platform::shell::quote_path(path)
 }
 
 fn shell_quote_arg(value: &str) -> String {
-    format!("'{}'", value.replace('\'', "'\\''"))
+    crate::platform::shell::quote_posix_arg(value)
 }
 
 fn classify_cli_install(
@@ -387,9 +387,7 @@ fn applescript_shell_arg(path: &std::path::Path) -> String {
 }
 
 fn home_dir() -> PathBuf {
-    std::env::var_os("HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("."))
+    crate::platform::paths::home_dir().unwrap_or_else(|| PathBuf::from("."))
 }
 
 fn claude_skills_dir() -> PathBuf {
@@ -614,7 +612,7 @@ pub async fn install_helmor_skills() -> CmdResult<HelmorSkillsStatus> {
             );
         }
 
-        let output = Command::new("npx")
+        let output = Command::new(crate::platform::executable::resolve_for_spawn("npx"))
             .args(helmor_skills_install_args(&agents))
             .output()
             .with_context(|| format!("Failed to start skills installer. Try:\n  {command}"))?;
@@ -847,7 +845,7 @@ fn run_components_check_inner(force: bool) -> ComponentsUpdateCheck {
 
 fn install_skills_silent(agents: &[&str]) -> anyhow::Result<()> {
     let command = helmor_skills_install_command(agents);
-    let output = Command::new("npx")
+    let output = Command::new(crate::platform::executable::resolve_for_spawn("npx"))
         .args(helmor_skills_install_args(agents))
         .output()
         .with_context(|| format!("Failed to start skills installer. Try:\n  {command}"))?;
@@ -1185,10 +1183,9 @@ pub async fn get_agent_versions() -> CmdResult<AgentVersions> {
 }
 
 fn agent_cli_version(provider: &str) -> Option<String> {
-    let output = std::process::Command::new(resolve_agent_binary(provider))
-        .arg("--version")
-        .output()
-        .ok()?;
+    let mut command = std::process::Command::new(resolve_agent_binary(provider));
+    crate::platform::process::configure_background_cli(&mut command);
+    let output = command.arg("--version").output().ok()?;
     if !output.status.success() {
         return None;
     }
@@ -1254,7 +1251,7 @@ fn resolve_agent_binary(provider: &str) -> PathBuf {
         "opencode" => bundled.opencode_bin,
         _ => None,
     };
-    bundled_path.unwrap_or_else(|| PathBuf::from(provider))
+    bundled_path.unwrap_or_else(|| crate::platform::executable::resolve_for_spawn(provider))
 }
 
 // Read from the sidecar-computed settings row, NOT `auth.json` (which misses env/config/Zen providers).
@@ -1284,10 +1281,9 @@ fn opencode_login_ready() -> bool {
 }
 
 fn claude_login_ready() -> bool {
-    match std::process::Command::new(resolve_agent_binary("claude"))
-        .args(["auth", "status"])
-        .output()
-    {
+    let mut command = std::process::Command::new(resolve_agent_binary("claude"));
+    crate::platform::process::configure_background_cli(&mut command);
+    match command.args(["auth", "status"]).output() {
         Ok(output) if output.status.success() => parse_claude_login_status(&output.stdout),
         Ok(output) => {
             // Claude exits non-zero when the user isn't authenticated —
@@ -1338,10 +1334,9 @@ fn codex_auth_status() -> CodexAuthStatus {
 }
 
 fn codex_login_ready() -> bool {
-    match std::process::Command::new(resolve_agent_binary("codex"))
-        .args(["login", "status"])
-        .output()
-    {
+    let mut command = std::process::Command::new(resolve_agent_binary("codex"));
+    crate::platform::process::configure_background_cli(&mut command);
+    match command.args(["login", "status"]).output() {
         Ok(output) if output.status.success() => {
             let stdout = String::from_utf8_lossy(&output.stdout);
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -1440,15 +1435,9 @@ pub async fn spawn_agent_login_terminal(
         let _ = window.set_focus();
     }
 
-    let working_dir = std::env::var("HOME")
-        .ok()
-        .filter(|home| !home.trim().is_empty())
-        .or_else(|| {
-            std::env::current_dir()
-                .ok()
-                .map(|path| path.display().to_string())
-        })
-        .unwrap_or_else(|| "/".to_string());
+    let working_dir = crate::platform::paths::home_dir_or_current_or_root()
+        .display()
+        .to_string();
     let context = ScriptContext {
         root_path: working_dir.clone(),
         workspace_path: None,
@@ -1470,7 +1459,7 @@ pub async fn spawn_agent_login_terminal(
         // input — written synchronously to the PTY master right after
         // the shell registers, so a frontend re-render-driven
         // cleanup→respawn can't drop the bytes.
-        let boot_input = format!("{command}; exit\n");
+        let boot_input = crate::platform::shell::boot_input(&command);
         if let Err(error) = crate::workspace::scripts::run_terminal_session(
             &mgr,
             AGENT_LOGIN_REPO_ID,

--- a/src-tauri/src/commands/triage_lark_cli_commands.rs
+++ b/src-tauri/src/commands/triage_lark_cli_commands.rs
@@ -53,15 +53,9 @@ pub async fn spawn_lark_cli_auth_terminal(
     instance_id: String,
     channel: Channel<ScriptEvent>,
 ) -> CmdResult<()> {
-    let working_dir = std::env::var("HOME")
-        .ok()
-        .filter(|home| !home.trim().is_empty())
-        .or_else(|| {
-            std::env::current_dir()
-                .ok()
-                .map(|path| path.display().to_string())
-        })
-        .unwrap_or_else(|| "/".to_string());
+    let working_dir = crate::platform::paths::home_dir_or_current_or_root()
+        .display()
+        .to_string();
     let context = ScriptContext {
         root_path: working_dir.clone(),
         workspace_path: None,
@@ -72,7 +66,7 @@ pub async fn spawn_lark_cli_auth_terminal(
     };
     let mgr = manager.inner().clone();
     let script_type = action.script_type(&instance_id);
-    let boot_input = format!("{}; exit\n", action.boot_command());
+    let boot_input = crate::platform::shell::boot_input(action.boot_command());
 
     tauri::async_runtime::spawn_blocking(move || {
         if let Err(error) = crate::workspace::scripts::run_terminal_session(

--- a/src-tauri/src/companion/tunnel.rs
+++ b/src-tauri/src/companion/tunnel.rs
@@ -220,9 +220,8 @@ fn spawn_and_await(
         .stdout(Stdio::null())
         .stderr(Stdio::piped());
 
-    // Own process group so a later SIGTERM reaches the whole tree.
-    use std::os::unix::process::CommandExt;
-    command.process_group(0);
+    // Own process tree so later termination reaches child processes.
+    crate::platform::process::configure_tree_root(&mut command);
 
     let mut child = command.spawn().with_context(|| {
         format!(
@@ -287,11 +286,14 @@ fn spawn_and_await(
 /// exited successfully.
 fn run_oneshot_interactive(args: &[String], timeout: Duration) -> Result<bool> {
     let bin = resolve_cloudflared();
-    let mut child = Command::new(&bin)
+    let mut command = Command::new(&bin);
+    command
         .args(args)
         .stdin(Stdio::null())
         .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
+        .stderr(Stdio::inherit());
+    crate::platform::process::configure_tree_root(&mut command);
+    let mut child = command
         .spawn()
         .with_context(|| format!("failed to spawn cloudflared ({})", bin.display()))?;
 
@@ -312,7 +314,7 @@ fn run_oneshot_interactive(args: &[String], timeout: Duration) -> Result<bool> {
 
 /// `~/.cloudflared`.
 fn cloudflared_home() -> Option<PathBuf> {
-    std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".cloudflared"))
+    crate::platform::paths::home_dir().map(|home| home.join(".cloudflared"))
 }
 
 /// Resolve the cloudflared binary: env override → bundled vendor copy → PATH.
@@ -364,11 +366,8 @@ fn parse_tunnel_uuid(text: &str) -> Option<String> {
 /// SIGTERM the child's process group, wait briefly, then SIGKILL. Mirrors the
 /// sidecar teardown ladder.
 fn kill_process_group(child: &mut Child) {
-    let pid = child.id() as libc::pid_t;
-    // SAFETY: negative PID targets the whole group spawned via process_group(0).
-    unsafe {
-        libc::kill(-pid, libc::SIGTERM);
-    }
+    let tree = crate::platform::process::ProcessTree::from_child_pid(child.id());
+    crate::platform::process::terminate_tree(tree);
     let deadline = Instant::now() + Duration::from_millis(2000);
     loop {
         if let Ok(Some(_)) = child.try_wait() {
@@ -379,9 +378,7 @@ fn kill_process_group(child: &mut Child) {
         }
         std::thread::sleep(Duration::from_millis(25));
     }
-    unsafe {
-        libc::kill(-pid, libc::SIGKILL);
-    }
+    crate::platform::process::kill_tree(tree);
     let _ = child.wait();
 }
 

--- a/src-tauri/src/data_dir.rs
+++ b/src-tauri/src/data_dir.rs
@@ -205,7 +205,7 @@ fn resolve_data_dir() -> Result<PathBuf> {
 }
 
 fn dirs_home() -> Option<PathBuf> {
-    std::env::var_os("HOME").map(PathBuf::from)
+    crate::platform::paths::home_dir()
 }
 
 /// Ensure all required subdirectories exist.

--- a/src-tauri/src/forge/cli_status.rs
+++ b/src-tauri/src/forge/cli_status.rs
@@ -54,17 +54,7 @@ fn bundled_program_token(program: &str) -> Result<String> {
 
 /// `'foo'\''bar'`-style single quoting safe for /bin/sh.
 fn shell_single_quote(value: &str) -> String {
-    let mut out = String::with_capacity(value.len() + 2);
-    out.push('\'');
-    for ch in value.chars() {
-        if ch == '\'' {
-            out.push_str("'\\''");
-        } else {
-            out.push(ch);
-        }
-    }
-    out.push('\'');
-    out
+    crate::platform::shell::quote_posix_arg(value)
 }
 
 pub(crate) fn labels_for(provider: ForgeProvider) -> ForgeLabels {

--- a/src-tauri/src/forge/command.rs
+++ b/src-tauri/src/forge/command.rs
@@ -134,7 +134,6 @@ where
     })
 }
 
-#[cfg(unix)]
 fn kill_process(child_pid: u32) {
     crate::platform::process::kill_tree(crate::platform::process::ProcessTree::from_child_pid(
         child_pid,

--- a/src-tauri/src/forge/command.rs
+++ b/src-tauri/src/forge/command.rs
@@ -95,11 +95,7 @@ where
         command.env(name, value);
     }
 
-    #[cfg(unix)]
-    {
-        use std::os::unix::process::CommandExt;
-        command.process_group(0);
-    }
+    crate::platform::process::configure_tree_root(&mut command);
 
     let child = command.spawn()?;
     let child_pid = child.id();
@@ -140,17 +136,9 @@ where
 
 #[cfg(unix)]
 fn kill_process(child_pid: u32) {
-    unsafe {
-        libc::kill(-(child_pid as libc::pid_t), libc::SIGKILL);
-    }
-}
-
-#[cfg(not(unix))]
-fn kill_process(child_pid: u32) {
-    let pid = child_pid.to_string();
-    let _ = Command::new("taskkill")
-        .args(["/PID", pid.as_str(), "/T", "/F"])
-        .status();
+    crate::platform::process::kill_tree(crate::platform::process::ProcessTree::from_child_pid(
+        child_pid,
+    ));
 }
 
 pub(crate) fn command_detail(output: &CommandOutput) -> String {

--- a/src-tauri/src/forge/gitlab/api.rs
+++ b/src-tauri/src/forge/gitlab/api.rs
@@ -157,19 +157,14 @@ fn xdg_glab_dir() -> Option<PathBuf> {
             return Some(PathBuf::from(value).join("glab-cli"));
         }
     }
-    let home = std::env::var_os("HOME")?;
-    let mut path = PathBuf::from(home);
-    path.push(".config");
-    path.push("glab-cli");
-    Some(path)
+    crate::platform::paths::xdg_config_dir("glab-cli")
 }
 
 fn macos_glab_dir() -> Option<PathBuf> {
     if !cfg!(target_os = "macos") {
         return None;
     }
-    let home = std::env::var_os("HOME")?;
-    let mut path = PathBuf::from(home);
+    let mut path = crate::platform::paths::home_dir()?;
     path.push("Library");
     path.push("Application Support");
     path.push("glab-cli");

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -127,9 +127,8 @@ where
 /// thread forever, eventually saturating Tokio's blocking pool and freezing
 /// the entire app.
 ///
-/// On timeout the child is killed via `SIGKILL` (Unix) — matching the
-/// existing pattern in `sidecar.rs::send_sigterm` — and a "git command
-/// timed out" error is returned to the caller.
+/// On timeout the child tree is killed and a "git command timed out" error is
+/// returned to the caller.
 pub fn run_git_with_timeout<I, S>(
     args: I,
     current_dir: Option<&Path>,
@@ -171,8 +170,7 @@ where
     );
     command.stdout(Stdio::piped());
     command.stderr(Stdio::piped());
-    use std::os::unix::process::CommandExt;
-    command.process_group(0);
+    crate::platform::process::configure_tree_root(&mut command);
 
     let child = command.spawn().context("Failed to spawn git")?;
     let child_pid = child.id();
@@ -202,18 +200,12 @@ where
             Err(anyhow::Error::from(io_err).context("Failed to wait for git"))
         }
         Err(mpsc::RecvTimeoutError::Timeout) => {
-            // Kill the child's entire process group so the waiter thread
+            // Kill the child's entire process tree so the waiter thread
             // observes the death and exits — otherwise we'd leak the OS
-            // thread until git decided to give up on its own. Using the
-            // negative PGID (== child PID because we set process_group(0)
-            // at spawn) ensures child processes like ssh are also killed.
-            //
-            // SAFETY: `child_pid` == PGID (we set process_group(0) at
-            // spawn). Negative PID targets the whole group. If the group
-            // has already exited, `libc::kill` returns ESRCH harmlessly.
-            unsafe {
-                libc::kill(-(child_pid as libc::pid_t), libc::SIGKILL);
-            }
+            // thread until git decided to give up on its own.
+            crate::platform::process::kill_tree(
+                crate::platform::process::ProcessTree::from_child_pid(child_pid),
+            );
             let _ = waiter.join();
             bail!(
                 "git command timed out after {timeout:?} (likely a stalled remote or credential prompt)"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -19,6 +19,7 @@ pub mod maintenance;
 pub mod mcp;
 pub mod models;
 pub mod pipeline;
+pub(crate) mod platform;
 pub mod rate_limits;
 pub mod schema;
 pub mod service;

--- a/src-tauri/src/platform/executable.rs
+++ b/src-tauri/src/platform/executable.rs
@@ -1,0 +1,97 @@
+//! Executable lookup helpers for process spawning.
+
+#[cfg(any(windows, test))]
+use std::path::Path;
+use std::path::PathBuf;
+
+pub fn resolve_for_spawn(program: &str) -> PathBuf {
+    resolve_on_path(program).unwrap_or_else(|| PathBuf::from(program))
+}
+
+pub fn resolve_on_path(program: &str) -> Option<PathBuf> {
+    #[cfg(windows)]
+    {
+        let path = std::env::var_os("PATH")?;
+        let pathext = std::env::var("PATHEXT").unwrap_or_else(|_| ".EXE;.CMD;.BAT".to_string());
+        return resolve_on_windows_path(
+            program,
+            std::env::split_paths(&path).collect::<Vec<_>>(),
+            &pathext,
+        );
+    }
+
+    #[cfg(not(windows))]
+    {
+        let _ = program;
+        None
+    }
+}
+
+#[cfg(any(windows, test))]
+fn resolve_on_windows_path(program: &str, dirs: Vec<PathBuf>, pathext: &str) -> Option<PathBuf> {
+    for dir in dirs {
+        for candidate in windows_candidates(&dir, program, pathext) {
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(any(windows, test))]
+fn windows_candidates(dir: &Path, program: &str, pathext: &str) -> Vec<PathBuf> {
+    let already_has_ext = Path::new(program).extension().is_some();
+    let mut candidates = Vec::new();
+    if already_has_ext {
+        candidates.push(dir.join(program));
+        return candidates;
+    }
+    for ext in pathext.split(';').filter(|ext| !ext.trim().is_empty()) {
+        candidates.push(dir.join(format!("{program}{}", ext.to_ascii_lowercase())));
+    }
+    candidates
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unix_spawn_resolution_preserves_bare_program_name() {
+        assert_eq!(
+            resolve_for_spawn("definitely-not-real"),
+            PathBuf::from("definitely-not-real")
+        );
+    }
+
+    #[test]
+    fn windows_candidates_honor_pathext_order() {
+        let candidates = windows_candidates(Path::new("C:\\bin"), "npx", ".EXE;.CMD;.BAT");
+        assert_eq!(
+            candidates,
+            vec![
+                PathBuf::from("C:\\bin").join("npx.exe"),
+                PathBuf::from("C:\\bin").join("npx.cmd"),
+                PathBuf::from("C:\\bin").join("npx.bat"),
+            ]
+        );
+    }
+
+    #[test]
+    fn windows_candidates_keep_explicit_extension() {
+        let candidates = windows_candidates(Path::new("C:\\bin"), "codex.cmd", ".EXE;.CMD");
+        assert_eq!(candidates, vec![PathBuf::from("C:\\bin").join("codex.cmd")]);
+    }
+
+    #[test]
+    fn windows_path_resolution_returns_first_existing_candidate() {
+        let dir = tempfile::tempdir().unwrap();
+        let cmd = dir.path().join("npx.cmd");
+        std::fs::write(&cmd, b"").unwrap();
+
+        let resolved = resolve_on_windows_path("npx", vec![dir.path().to_path_buf()], ".EXE;.CMD");
+
+        assert_eq!(resolved, Some(cmd));
+    }
+}

--- a/src-tauri/src/platform/fs.rs
+++ b/src-tauri/src/platform/fs.rs
@@ -1,0 +1,90 @@
+//! Filesystem operations whose semantics differ by platform.
+
+use std::io;
+use std::path::Path;
+
+pub fn symlink_to(original: &Path, link: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(original, link)
+    }
+
+    #[cfg(windows)]
+    {
+        let resolved = match link.parent() {
+            Some(parent) => parent.join(original),
+            None => original.to_path_buf(),
+        };
+        let target_is_dir = std::fs::metadata(&resolved)
+            .map(|metadata| metadata.is_dir())
+            .unwrap_or(false);
+        let result = if target_is_dir {
+            std::os::windows::fs::symlink_dir(original, link)
+        } else {
+            std::os::windows::fs::symlink_file(original, link)
+        };
+        match result {
+            Ok(()) => Ok(()),
+            Err(_) if target_is_dir => copy_dir_recursive(&resolved, link),
+            Err(_) => std::fs::copy(&resolved, link).map(|_| ()),
+        }
+    }
+}
+
+pub fn copy_symlink(source: &Path, destination: &Path) -> io::Result<()> {
+    if let Some(parent) = destination.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let link_target = std::fs::read_link(source)?;
+    symlink_to(&link_target, destination)
+}
+
+#[cfg(windows)]
+fn copy_dir_recursive(src: &Path, dst: &Path) -> io::Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir_recursive(&from, &to)?;
+        } else {
+            std::fs::copy(&from, &to)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn symlink_to_makes_target_readable() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src.txt");
+        std::fs::write(&src, b"hello").unwrap();
+        let dst = dir.path().join("dst.txt");
+
+        symlink_to(&src, &dst).unwrap();
+
+        assert_eq!(std::fs::read(&dst).unwrap(), b"hello");
+    }
+
+    #[test]
+    fn copy_symlink_preserves_relative_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target.txt");
+        std::fs::write(&target, b"data").unwrap();
+        let src_link = dir.path().join("src-link.txt");
+        let dst_link = dir.path().join("nested/dst-link.txt");
+        symlink_to(Path::new("../target.txt"), &src_link).unwrap();
+
+        copy_symlink(&src_link, &dst_link).unwrap();
+
+        assert_eq!(
+            std::fs::read_link(&dst_link).unwrap(),
+            Path::new("../target.txt")
+        );
+    }
+}

--- a/src-tauri/src/platform/ipc.rs
+++ b/src-tauri/src/platform/ipc.rs
@@ -1,0 +1,20 @@
+//! Local IPC socket boundary.
+
+use std::io;
+use std::path::Path;
+
+#[cfg(unix)]
+pub type LocalListener = std::os::unix::net::UnixListener;
+
+#[cfg(unix)]
+pub type LocalStream = std::os::unix::net::UnixStream;
+
+#[cfg(unix)]
+pub fn bind_listener(path: &Path) -> io::Result<LocalListener> {
+    LocalListener::bind(path)
+}
+
+#[cfg(unix)]
+pub fn connect(path: &Path) -> io::Result<LocalStream> {
+    LocalStream::connect(path)
+}

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -1,0 +1,12 @@
+//! Small platform boundary for OS-sensitive behavior.
+//!
+//! The macOS/Unix implementation is the reference behavior. Future Windows
+//! support should add isolated adapter behavior here instead of scattering
+//! `cfg(windows)` through feature code.
+
+pub mod executable;
+pub mod fs;
+pub mod ipc;
+pub mod paths;
+pub mod process;
+pub mod shell;

--- a/src-tauri/src/platform/paths.rs
+++ b/src-tauri/src/platform/paths.rs
@@ -1,0 +1,106 @@
+//! Cross-platform path resolution helpers.
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+pub fn home_dir() -> Option<PathBuf> {
+    home_dir_from_parts(
+        std::env::var_os("HOME"),
+        std::env::var_os("USERPROFILE"),
+        std::env::var_os("HOMEDRIVE"),
+        std::env::var_os("HOMEPATH"),
+    )
+}
+
+pub fn home_dir_or_root() -> PathBuf {
+    home_dir().unwrap_or_else(|| PathBuf::from("/"))
+}
+
+pub fn home_dir_or_current_or_root() -> PathBuf {
+    home_dir()
+        .or_else(|| std::env::current_dir().ok())
+        .unwrap_or_else(|| PathBuf::from("/"))
+}
+
+pub fn codex_home_dir() -> PathBuf {
+    std::env::var_os("CODEX_HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home_dir_or_root().join(".codex"))
+}
+
+pub fn xdg_config_dir(app_name: &str) -> Option<PathBuf> {
+    if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME").filter(|value| !value.is_empty()) {
+        return Some(PathBuf::from(xdg).join(app_name));
+    }
+    Some(home_dir()?.join(".config").join(app_name))
+}
+
+fn home_dir_from_parts(
+    home: Option<OsString>,
+    userprofile: Option<OsString>,
+    homedrive: Option<OsString>,
+    homepath: Option<OsString>,
+) -> Option<PathBuf> {
+    if let Some(home) = home.filter(|value| !value.is_empty()) {
+        return Some(PathBuf::from(home));
+    }
+
+    #[cfg(windows)]
+    {
+        windows_home_dir_from_parts(userprofile, homedrive, homepath)
+    }
+
+    #[cfg(not(windows))]
+    {
+        let _ = (userprofile, homedrive, homepath);
+        None
+    }
+}
+
+#[cfg(any(windows, test))]
+fn windows_home_dir_from_parts(
+    userprofile: Option<OsString>,
+    homedrive: Option<OsString>,
+    homepath: Option<OsString>,
+) -> Option<PathBuf> {
+    if let Some(profile) = userprofile.filter(|value| !value.is_empty()) {
+        return Some(PathBuf::from(profile));
+    }
+    let (Some(mut drive), Some(path)) = (homedrive, homepath) else {
+        return None;
+    };
+    if drive.is_empty() || path.is_empty() {
+        return None;
+    }
+    drive.push(path);
+    Some(PathBuf::from(drive))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn home_dir_prefers_home() {
+        let home = home_dir_from_parts(
+            Some("/Users/me".into()),
+            Some("C:\\Users\\me".into()),
+            None,
+            None,
+        );
+        assert_eq!(home, Some(PathBuf::from("/Users/me")));
+    }
+
+    #[test]
+    fn windows_home_dir_falls_back_to_userprofile() {
+        let home = windows_home_dir_from_parts(Some("C:\\Users\\me".into()), None, None);
+        assert_eq!(home, Some(PathBuf::from("C:\\Users\\me")));
+    }
+
+    #[test]
+    fn windows_home_dir_combines_drive_and_path() {
+        let home = windows_home_dir_from_parts(None, Some("C:".into()), Some("\\Users\\me".into()));
+        assert_eq!(home, Some(PathBuf::from("C:\\Users\\me")));
+    }
+}

--- a/src-tauri/src/platform/process.rs
+++ b/src-tauri/src/platform/process.rs
@@ -1,0 +1,246 @@
+//! Process spawning, liveness, and process-tree teardown.
+
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+#[cfg(unix)]
+pub type Pid = libc::pid_t;
+
+#[cfg(not(unix))]
+pub type Pid = u32;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProcessTree {
+    pub pid: Pid,
+    pub pgid: Pid,
+}
+
+impl ProcessTree {
+    pub fn new(pid: Pid, pgid: Pid) -> Self {
+        Self { pid, pgid }
+    }
+
+    pub fn from_child_pid(pid: u32) -> Self {
+        let pid = pid as Pid;
+        Self { pid, pgid: pid }
+    }
+}
+
+/// Configure a child as the root of a process tree.
+pub fn configure_tree_root(cmd: &mut Command) -> &mut Command {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        cmd.process_group(0);
+    }
+    configure_background_cli(cmd)
+}
+
+/// Configure a background CLI spawn so it cannot steal focus on platforms
+/// where console children are visible by default.
+pub fn configure_background_cli(cmd: &mut Command) -> &mut Command {
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    cmd
+}
+
+pub fn terminate_tree(tree: ProcessTree) {
+    #[cfg(unix)]
+    unsafe {
+        if can_signal_group(tree.pgid) {
+            libc::killpg(tree.pgid, libc::SIGTERM);
+        }
+        if tree.pid > 0 {
+            libc::kill(tree.pid, libc::SIGTERM);
+        }
+    }
+
+    #[cfg(windows)]
+    {
+        let _ = taskkill(tree.pid, false);
+    }
+}
+
+pub fn kill_tree(tree: ProcessTree) {
+    #[cfg(unix)]
+    unsafe {
+        if can_signal_group(tree.pgid) {
+            libc::killpg(tree.pgid, libc::SIGKILL);
+        }
+        if tree.pid > 0 {
+            libc::kill(tree.pid, libc::SIGKILL);
+        }
+    }
+
+    #[cfg(windows)]
+    {
+        let _ = taskkill(tree.pid, true);
+    }
+}
+
+pub fn pid_alive(pid: Pid) -> bool {
+    if pid <= 0 as Pid {
+        return false;
+    }
+
+    #[cfg(unix)]
+    unsafe {
+        if libc::kill(pid, 0) == 0 {
+            return true;
+        }
+        match std::io::Error::last_os_error().raw_os_error() {
+            Some(libc::ESRCH) => false,
+            Some(libc::EPERM) => true,
+            _ => true,
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        // Future Windows adapter should use a real process query. Returning
+        // false keeps today's non-Unix fallback conservative and isolated.
+        let _ = pid;
+        false
+    }
+}
+
+pub fn process_group_alive(pgid: Pid) -> bool {
+    #[cfg(unix)]
+    {
+        if pgid <= 0 {
+            return false;
+        }
+        let ret = unsafe { libc::killpg(pgid, 0) };
+        if ret == 0 {
+            return true;
+        }
+        match std::io::Error::last_os_error().raw_os_error() {
+            Some(libc::ESRCH) => false,
+            Some(libc::EPERM) => true,
+            _ => true,
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = pgid;
+        false
+    }
+}
+
+pub fn tree_gone(tree: ProcessTree) -> bool {
+    let pid_gone = !pid_alive(tree.pid);
+    let group_gone = !can_signal_group(tree.pgid) || !process_group_alive(tree.pgid);
+    pid_gone && group_gone
+}
+
+pub fn wait_for_tree_gone(tree: ProcessTree, timeout: Duration, poll: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if tree_gone(tree) {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(poll);
+    }
+}
+
+fn can_signal_group(pgid: Pid) -> bool {
+    #[cfg(unix)]
+    {
+        pgid > 0 && pgid != unsafe { libc::getpgrp() }
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = pgid;
+        false
+    }
+}
+
+#[cfg(windows)]
+fn taskkill(pid: Pid, force: bool) -> std::io::Result<std::process::ExitStatus> {
+    let pid = pid.to_string();
+    let mut cmd = Command::new("taskkill");
+    cmd.args(["/PID", pid.as_str(), "/T"]);
+    if force {
+        cmd.arg("/F");
+    }
+    configure_background_cli(&mut cmd);
+    cmd.status()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pid_alive_reports_current_process() {
+        assert!(pid_alive(std::process::id() as Pid));
+    }
+
+    #[test]
+    fn pid_alive_rejects_invalid_pids() {
+        assert!(!pid_alive(0 as Pid));
+        #[cfg(unix)]
+        assert!(!pid_alive(-1));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn kill_tree_reaches_background_children() {
+        use std::io::Write;
+        use std::os::unix::process::CommandExt;
+        use std::process::Stdio;
+
+        let mut pid_file = tempfile::NamedTempFile::new().unwrap();
+        let pid_path = pid_file.path().to_path_buf();
+        writeln!(pid_file, "pending").unwrap();
+
+        let mut command = Command::new("/bin/sh");
+        command
+            .arg("-c")
+            .arg(format!("sleep 30 & echo $! > {}; wait", pid_path.display()))
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        unsafe {
+            command.pre_exec(|| {
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+
+        let mut child = command.spawn().unwrap();
+        let pid = child.id() as Pid;
+        let pgid = unsafe { libc::getpgid(pid) };
+        let tree = ProcessTree::new(pid, pgid);
+
+        let deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            if let Ok(contents) = std::fs::read_to_string(&pid_path) {
+                if contents.trim().parse::<Pid>().is_ok() {
+                    break;
+                }
+            }
+            assert!(Instant::now() < deadline, "background pid was not written");
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        kill_tree(tree);
+        let _ = child.wait();
+
+        assert!(
+            wait_for_tree_gone(tree, Duration::from_secs(2), Duration::from_millis(10)),
+            "process tree should be gone"
+        );
+    }
+}

--- a/src-tauri/src/platform/shell.rs
+++ b/src-tauri/src/platform/shell.rs
@@ -1,0 +1,53 @@
+//! Shell command formatting for embedded auth/login terminals.
+
+use std::path::Path;
+
+pub fn quote_posix_arg(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+pub fn quote_path(path: &Path) -> String {
+    quote_posix_arg(&path.display().to_string())
+}
+
+pub fn format_boot_command(command: &str) -> String {
+    #[cfg(windows)]
+    {
+        format!("& {command}")
+    }
+
+    #[cfg(not(windows))]
+    {
+        command.to_string()
+    }
+}
+
+pub fn boot_input(command: &str) -> String {
+    format!("{}; exit\n", format_boot_command(command))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quote_posix_arg_wraps_plain_value() {
+        assert_eq!(
+            quote_posix_arg("/usr/local/bin/helmor"),
+            "'/usr/local/bin/helmor'"
+        );
+    }
+
+    #[test]
+    fn quote_posix_arg_escapes_single_quotes() {
+        assert_eq!(
+            quote_posix_arg("/Users/me/foo's app"),
+            "'/Users/me/foo'\\''s app'"
+        );
+    }
+
+    #[test]
+    fn boot_input_preserves_unix_command_shape() {
+        assert_eq!(boot_input("codex login"), "codex login; exit\n");
+    }
+}

--- a/src-tauri/src/rate_limits/claude/keychain.rs
+++ b/src-tauri/src/rate_limits/claude/keychain.rs
@@ -156,7 +156,6 @@ fn push_unique_account(accounts: &mut Vec<String>, account: String) {
 #[cfg(target_os = "macos")]
 fn read_via_security_cli(service: &str, account: Option<&str>) -> Option<Vec<u8>> {
     use std::io::Read;
-    use std::os::unix::process::CommandExt;
     use std::process::{Command, Stdio};
     use std::time::Instant;
 
@@ -177,14 +176,7 @@ fn read_via_security_cli(service: &str, account: Option<&str>) -> Option<Vec<u8>
 
     // SAFETY: `setpgid` is async-signal-safe, which is the only family
     // of calls allowed between fork and exec.
-    unsafe {
-        cmd.pre_exec(|| {
-            if libc::setpgid(0, 0) != 0 {
-                return Err(std::io::Error::last_os_error());
-            }
-            Ok(())
-        });
-    }
+    crate::platform::process::configure_tree_root(&mut cmd);
 
     let mut child = match cmd.spawn() {
         Ok(c) => c,
@@ -223,20 +215,11 @@ fn read_via_security_cli(service: &str, account: Option<&str>) -> Option<Vec<u8>
                     "/usr/bin/security read timed out after {:?}, killing process group",
                     SECURITY_CLI_TIMEOUT
                 );
-                // SAFETY: passing a negative pid to `kill` signals the
-                // whole process group rooted at `pgid`. `pgid` is the
-                // child we just `setpgid(0, 0)`'d, so the only members
-                // are `/usr/bin/security` and any subprocess it forked.
-                unsafe {
-                    libc::kill(-pgid, libc::SIGTERM);
-                }
+                let tree = crate::platform::process::ProcessTree::new(pgid, pgid);
+                crate::platform::process::terminate_tree(tree);
                 std::thread::sleep(SECURITY_CLI_SIGTERM_GRACE);
                 if matches!(child.try_wait(), Ok(None)) {
-                    // SAFETY: same as above. SIGKILL is the escalation
-                    // when the SIGTERM grace period didn't reap.
-                    unsafe {
-                        libc::kill(-pgid, libc::SIGKILL);
-                    }
+                    crate::platform::process::kill_tree(tree);
                     let _ = child.kill();
                 }
                 let _ = child.wait();

--- a/src-tauri/src/rate_limits/codex.rs
+++ b/src-tauri/src/rate_limits/codex.rs
@@ -85,22 +85,7 @@ impl CodexCredentials {
 }
 
 fn auth_file_path() -> PathBuf {
-    if let Ok(custom) = std::env::var("CODEX_HOME") {
-        let trimmed = custom.trim();
-        if !trimmed.is_empty() {
-            return PathBuf::from(trimmed).join("auth.json");
-        }
-    }
-    home_dir().join(".codex").join("auth.json")
-}
-
-fn home_dir() -> PathBuf {
-    if let Ok(home) = std::env::var("HOME") {
-        if !home.is_empty() {
-            return PathBuf::from(home);
-        }
-    }
-    PathBuf::from("/")
+    crate::platform::paths::codex_home_dir().join("auth.json")
 }
 
 fn load_credentials(path: &Path) -> Result<CodexCredentials> {

--- a/src-tauri/src/shell_env.rs
+++ b/src-tauri/src/shell_env.rs
@@ -230,16 +230,16 @@ mod unix {
         timeout: Duration,
     ) -> anyhow::Result<Vec<u8>> {
         use std::io::Read;
-        use std::os::unix::process::CommandExt;
 
-        let mut child = Command::new(program)
+        let mut command = Command::new(program);
+        command
             .args(args)
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::null())
-            // Start in its own process group so we can kill it
-            // without also signalling ourselves.
-            .process_group(0)
+            .stderr(std::process::Stdio::null());
+        crate::platform::process::configure_tree_root(&mut command);
+
+        let mut child = command
             .spawn()
             .map_err(|e| anyhow::anyhow!("spawn `{program}`: {e}"))?;
 
@@ -274,8 +274,9 @@ mod unix {
                 }
                 Ok(None) => {
                     if std::time::Instant::now() >= deadline {
-                        // Kill the process group, not just the shell.
-                        unsafe { libc::kill(-(pid as libc::pid_t), libc::SIGKILL) };
+                        crate::platform::process::kill_tree(
+                            crate::platform::process::ProcessTree::from_child_pid(pid),
+                        );
                         let _ = child.wait();
                         anyhow::bail!(
                             "login shell env capture timed out after {}s",

--- a/src-tauri/src/sidecar.rs
+++ b/src-tauri/src/sidecar.rs
@@ -148,7 +148,7 @@ impl SidecarProcess {
         let is_dev = sidecar_path.extension().is_some_and(|ext| ext == "ts");
 
         let mut cmd = if is_dev {
-            let mut c = Command::new("bun");
+            let mut c = Command::new(crate::platform::executable::resolve_for_spawn("bun"));
             c.arg("run").arg(&sidecar_path);
             // Anchor cwd to sidecar/ so Bun discovers `bunfig.toml` and
             // applies the preload that registers our build-time plugins
@@ -167,11 +167,9 @@ impl SidecarProcess {
             .stdout(Stdio::piped())
             .stderr(Stdio::inherit());
 
-        // Put the sidecar in its own process group so SIGTERM/SIGKILL
-        // reaches all child processes (Claude CLI, Codex CLI) instead
-        // of only hitting the Bun parent.
-        use std::os::unix::process::CommandExt;
-        cmd.process_group(0);
+        // Put the sidecar in its own process tree so termination reaches
+        // Claude/Codex/OpenCode children instead of only hitting Bun.
+        crate::platform::process::configure_tree_root(&mut cmd);
 
         // Pass log config to the sidecar process
         if let Ok(dir) = crate::data_dir::logs_dir() {
@@ -284,9 +282,9 @@ impl SidecarProcess {
     /// `ManagedSidecar::shutdown`. Kill the whole process group first so
     /// child CLIs don't get reparented to launchd as orphans.
     fn kill(&mut self) {
-        unsafe {
-            libc::kill(-(self.pid() as libc::pid_t), libc::SIGKILL);
-        }
+        crate::platform::process::kill_tree(crate::platform::process::ProcessTree::from_child_pid(
+            self.pid(),
+        ));
         let _ = self.child.kill();
         let _ = self.child.wait();
     }
@@ -313,11 +311,9 @@ impl SidecarProcess {
     /// (negative PID) ensures child CLIs spawned by Bun also receive the
     /// signal.
     fn send_sigterm(&self) {
-        // SAFETY: `pid()` is the live child's PID (== PGID since we set
-        // process_group(0) at spawn). Negative PID targets the whole group.
-        unsafe {
-            libc::kill(-(self.pid() as libc::pid_t), libc::SIGTERM);
-        }
+        crate::platform::process::terminate_tree(
+            crate::platform::process::ProcessTree::from_child_pid(self.pid()),
+        );
     }
 }
 

--- a/src-tauri/src/ui_sync/socket.rs
+++ b/src-tauri/src/ui_sync/socket.rs
@@ -20,7 +20,7 @@ pub fn start_listener<R: Runtime>(app: AppHandle<R>) -> Result<()> {
             let _ = std::fs::remove_file(&socket_path);
         }
 
-        let listener = std::os::unix::net::UnixListener::bind(&socket_path)
+        let listener = crate::platform::ipc::bind_listener(&socket_path)
             .with_context(|| format!("Failed to bind UI sync socket {}", socket_path.display()))?;
         listener
             .set_nonblocking(false)
@@ -79,7 +79,7 @@ pub fn notify_running_app(event: super::events::UiMutationEvent) -> Result<bool>
             return Ok(false);
         }
 
-        let mut stream = match std::os::unix::net::UnixStream::connect(&socket_path) {
+        let mut stream = match crate::platform::ipc::connect(&socket_path) {
             Ok(stream) => stream,
             Err(_) => return Ok(false),
         };
@@ -125,7 +125,7 @@ pub fn is_listener_running() -> bool {
             return false;
         }
 
-        std::os::unix::net::UnixStream::connect(socket_path).is_ok()
+        crate::platform::ipc::connect(&socket_path).is_ok()
     }
 
     #[cfg(not(unix))]

--- a/src-tauri/src/workspace/helpers.rs
+++ b/src-tauri/src/workspace/helpers.rs
@@ -400,20 +400,7 @@ pub fn copy_dir_all(source: &Path, destination: &Path) -> Result<()> {
 }
 
 pub fn copy_symlink(source: &Path, destination: &Path) -> Result<()> {
-    use std::os::unix::fs::symlink;
-
-    if let Some(parent) = destination.parent() {
-        fs::create_dir_all(parent).with_context(|| {
-            format!(
-                "Failed to create parent directory for symlink {}",
-                destination.display()
-            )
-        })?;
-    }
-
-    let link_target = fs::read_link(source)
-        .with_context(|| format!("Failed to read symlink {}", source.display()))?;
-    symlink(&link_target, destination).with_context(|| {
+    crate::platform::fs::copy_symlink(source, destination).with_context(|| {
         format!(
             "Failed to copy symlink {} to {}",
             source.display(),

--- a/src-tauri/src/workspace/runtime_registry.rs
+++ b/src-tauri/src/workspace/runtime_registry.rs
@@ -261,21 +261,7 @@ struct RawRuntimeRow {
 /// if it doesn't. We treat `EPERM` as alive too — it means the kernel
 /// has a process by that PID, even if we can't signal it.
 fn probe_pid_alive(pid: libc::pid_t) -> bool {
-    if pid <= 0 {
-        return false;
-    }
-    let ret = unsafe { libc::kill(pid, 0) };
-    if ret == 0 {
-        return true;
-    }
-    match std::io::Error::last_os_error().raw_os_error() {
-        Some(libc::ESRCH) => false,
-        // `EPERM` (process exists, signal not permitted) keeps us in
-        // the "maybe alive" camp — conservative classification matches
-        // the plan's "only auto-kill when ownership is proven" rule.
-        Some(libc::EPERM) => true,
-        _ => true,
-    }
+    crate::platform::process::pid_alive(pid)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/workspace/scripts.rs
+++ b/src-tauri/src/workspace/scripts.rs
@@ -325,66 +325,16 @@ impl ScriptProcessManager {
 /// for that group to disappear so a fast leader exit cannot leave descendants
 /// running after Stop returns.
 fn escalating_kill(pid: libc::pid_t, pgid: libc::pid_t) {
-    let current_pgrp = unsafe { libc::getpgrp() };
-    let can_signal_group = pgid > 0 && pgid != current_pgrp;
+    let tree = crate::platform::process::ProcessTree::new(pid, pgid);
+    crate::platform::process::terminate_tree(tree);
 
-    unsafe {
-        if can_signal_group {
-            libc::killpg(pgid, libc::SIGTERM);
-        }
-        libc::kill(pid, libc::SIGTERM);
-    }
-
-    if wait_for_processes_gone(pid, pgid, can_signal_group, PROCESS_TERM_TIMEOUT) {
+    if crate::platform::process::wait_for_tree_gone(tree, PROCESS_TERM_TIMEOUT, PTY_POLL_INTERVAL) {
         return;
     }
 
-    unsafe {
-        if can_signal_group {
-            libc::killpg(pgid, libc::SIGKILL);
-        }
-        libc::kill(pid, libc::SIGKILL);
-    }
-
-    let _ = wait_for_processes_gone(pid, pgid, can_signal_group, PROCESS_KILL_TIMEOUT);
-}
-
-fn wait_for_processes_gone(
-    pid: libc::pid_t,
-    pgid: libc::pid_t,
-    can_signal_group: bool,
-    timeout: Duration,
-) -> bool {
-    let deadline = Instant::now() + timeout;
-    loop {
-        let pid_gone = is_pid_gone(pid);
-        let group_gone = !can_signal_group || is_process_group_gone(pgid);
-        if pid_gone && group_gone {
-            return true;
-        }
-        if Instant::now() >= deadline {
-            return false;
-        }
-        std::thread::sleep(PTY_POLL_INTERVAL);
-    }
-}
-
-fn is_pid_gone(pid: libc::pid_t) -> bool {
-    let ret = unsafe { libc::kill(pid, 0) };
-    if ret == -1 {
-        let err = std::io::Error::last_os_error();
-        return err.raw_os_error() == Some(libc::ESRCH);
-    }
-    false
-}
-
-fn is_process_group_gone(pgid: libc::pid_t) -> bool {
-    let ret = unsafe { libc::killpg(pgid, 0) };
-    if ret == -1 {
-        let err = std::io::Error::last_os_error();
-        return err.raw_os_error() == Some(libc::ESRCH);
-    }
-    false
+    crate::platform::process::kill_tree(tree);
+    let _ =
+        crate::platform::process::wait_for_tree_gone(tree, PROCESS_KILL_TIMEOUT, PTY_POLL_INTERVAL);
 }
 
 /// SIGKILL any `stop.command` cleanup tree currently published in
@@ -395,10 +345,8 @@ fn is_process_group_gone(pgid: libc::pid_t) -> bool {
 /// the top of `graceful_kill`.
 fn kill_in_flight_stop_command(pgid_slot: &Mutex<Option<libc::pid_t>>) {
     let stop_pgid = *pgid_slot.lock().expect("stop_pgid mutex poisoned");
-    if let Some(pgid) = stop_pgid {
-        unsafe {
-            libc::killpg(pgid, libc::SIGKILL);
-        }
+    if let Some(pgid) = stop_pgid.filter(|pgid| *pgid > 0) {
+        crate::platform::process::kill_tree(crate::platform::process::ProcessTree::new(pgid, pgid));
     }
 }
 
@@ -532,12 +480,9 @@ fn run_stop_command(
                 // Don't leak the child + its reader threads on a
                 // try_wait failure — SIGKILL the pgid (or pid as
                 // fallback) and reap so the pipe ends close.
-                unsafe {
-                    if pgid > 0 {
-                        libc::killpg(pgid, libc::SIGKILL);
-                    }
-                    libc::kill(pid, libc::SIGKILL);
-                }
+                crate::platform::process::kill_tree(crate::platform::process::ProcessTree::new(
+                    pid, pgid,
+                ));
                 let _ = child.wait();
                 break StopOutcome::SpawnFailed(format!("try_wait failed: {e}"));
             }
@@ -1320,7 +1265,7 @@ mod tests {
         let mgr_c = mgr.clone();
         let key_c = key.clone();
         let tempdir = std::env::temp_dir().display().to_string();
-        let runner = std::thread::spawn(move || {
+        let mut runner = Some(std::thread::spawn(move || {
             run_script_with_shell(
                 &mgr_c,
                 &key_c.0,
@@ -1335,13 +1280,17 @@ mod tests {
                 None,
                 None,
             )
-        });
+        }));
 
         // Wait for run_script to register before we issue kill_all.
-        let deadline = Instant::now() + Duration::from_secs(5);
+        let deadline = Instant::now() + Duration::from_secs(15);
         loop {
             if mgr.processes.lock().unwrap().contains_key(&key) {
                 break;
+            }
+            if runner.as_ref().is_some_and(|runner| runner.is_finished()) {
+                let result = runner.take().unwrap().join().unwrap();
+                panic!("run_script exited before registration: {result:?}");
             }
             assert!(Instant::now() < deadline, "run_script never registered");
             std::thread::sleep(Duration::from_millis(10));
@@ -1352,7 +1301,7 @@ mod tests {
         // run_script's reaper must have unregistered + returned. If
         // kill_all held the map lock past the signal, the unregister
         // would have blocked and this join would hang.
-        let _ = runner.join().unwrap();
+        let _ = runner.unwrap().join().unwrap();
         // Real path is sub-second (PROCESS_TERM + PROCESS_KILL = 700ms
         // upper bound). 5s headroom for CI load; a real regression
         // (deadlock / missed signal) hangs indefinitely and still trips.


### PR DESCRIPTION
## Summary
- Add a small `src-tauri/src/platform/` boundary for process trees, path resolution, executable lookup, shell command bootstrapping, filesystem symlinks, and local IPC.
- Migrate existing macOS call sites onto that boundary without implementing full Windows support.
- Keep PTY internals, updater config, release packaging, lockfiles, and vendor staging untouched.

## Verification
- `bun run typecheck`
- `bun run test:rust`
- `cd src-tauri && cargo clippy --all-targets -- -D warnings`
- `cd src-tauri && cargo test --lib platform::`
- `cd src-tauri && cargo test graceful_kill -- --ignored`
- `git diff --check origin/main...HEAD`

Drafted with AI assistance.