### PR TITLE
fix(composer): show description in OpenCode tool-approval cards

### DIFF
--- a/.changeset/spotty-rooms-approve.md
+++ b/.changeset/spotty-rooms-approve.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix OpenCode tool-approval cards showing an empty `{}` instead of the file or resource being approved, so read/skill/todo/shell approvals now display what the tool is about to act on.

--- a/src/features/composer/permission-panel.tsx
+++ b/src/features/composer/permission-panel.tsx
@@ -35,6 +35,7 @@ export function PermissionPanel({
 		<ToolApprovalCard
 			toolName={permission.toolName}
 			toolInput={permission.toolInput}
+			description={permission.description}
 			disabled={disabled}
 			onResponse={handleResponse}
 		/>

--- a/src/features/composer/user-input-panel/generic-renderer.test.tsx
+++ b/src/features/composer/user-input-panel/generic-renderer.test.tsx
@@ -1,0 +1,53 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ToolApprovalCard } from "./generic-renderer";
+
+afterEach(cleanup);
+
+describe("ToolApprovalCard", () => {
+	it("renders the description as the body when toolInput is empty (OpenCode read/skill/todo/shell)", () => {
+		render(
+			<ToolApprovalCard
+				toolName="read"
+				toolInput={{}}
+				description="src/index.ts"
+				onResponse={vi.fn()}
+			/>,
+		);
+		// Light + dark code blocks both carry the text, so use getAllByText.
+		expect(screen.getAllByText("src/index.ts").length).toBeGreaterThan(0);
+		// The empty-object `{}` must NOT be shown.
+		expect(screen.queryByText("{}")).toBeNull();
+	});
+
+	it("falls back to JSON when toolInput is empty and no description", () => {
+		render(
+			<ToolApprovalCard toolName="todo" toolInput={{}} onResponse={vi.fn()} />,
+		);
+		expect(screen.getAllByText("{}").length).toBeGreaterThan(0);
+	});
+
+	it("renders the bash command for shell-like tools", () => {
+		render(
+			<ToolApprovalCard
+				toolName="bash"
+				toolInput={{ command: "ls -la" }}
+				onResponse={vi.fn()}
+			/>,
+		);
+		expect(screen.getAllByText("ls -la").length).toBeGreaterThan(0);
+	});
+
+	it("renders the JSON input when toolInput has keys (ignores description fallback)", () => {
+		render(
+			<ToolApprovalCard
+				toolName="edit"
+				toolInput={{ filepath: "a.ts" }}
+				description="a.ts"
+				onResponse={vi.fn()}
+			/>,
+		);
+		// JSON form keeps the quoted key, distinct from the plain fallback.
+		expect(screen.getAllByText(/"filepath"/).length).toBeGreaterThan(0);
+	});
+});

--- a/src/features/composer/user-input-panel/generic-renderer.tsx
+++ b/src/features/composer/user-input-panel/generic-renderer.tsx
@@ -16,6 +16,9 @@ import { UserInputCard } from "./shared";
 export type ToolApprovalCardProps = {
 	toolName: string;
 	toolInput: Record<string, unknown>;
+	/** Fallback resource label when `toolInput` is empty (e.g. OpenCode's
+	 *  `patterns` — the file path / command being approved). */
+	description?: string | null;
 	disabled?: boolean;
 	onResponse: (behavior: "allow" | "deny") => void;
 };
@@ -35,6 +38,7 @@ function looksLikeCommand(
 function getCodePreview(
 	toolName: string,
 	toolInput: Record<string, unknown>,
+	description?: string | null,
 ): { code: string; language: string } {
 	const command = toolInput?.command;
 	if (
@@ -43,6 +47,13 @@ function getCodePreview(
 		looksLikeCommand(toolName, toolInput)
 	) {
 		return { code: command, language: "bash" };
+	}
+	// Some agents (OpenCode read/skill/todo/shell) send an empty input object
+	// and carry the target resource in `description` (its `patterns`). Show
+	// that instead of a useless `{}`.
+	if (toolInput == null || Object.keys(toolInput).length === 0) {
+		const fallback = description?.trim();
+		if (fallback) return { code: fallback, language: "text" };
 	}
 	return {
 		code: JSON.stringify(toolInput, null, 2),
@@ -53,12 +64,13 @@ function getCodePreview(
 export function ToolApprovalCard({
 	toolName,
 	toolInput,
+	description,
 	disabled,
 	onResponse,
 }: ToolApprovalCardProps) {
 	const preview = useMemo(
-		() => getCodePreview(toolName, toolInput),
-		[toolName, toolInput],
+		() => getCodePreview(toolName, toolInput, description),
+		[toolName, toolInput, description],
 	);
 
 	return (


### PR DESCRIPTION
## Summary
Display the fallback resource label (description field) when toolInput is empty, so read/skill/todo/shell approvals show what the tool is about to act on instead of an empty `{}` object.

## Changes
- Added `description` prop to `ToolApprovalCard` component
- Updated `getCodePreview()` to show description as fallback when toolInput is empty
- Added test coverage for the new functionality

## Why
OpenCode tools (read, skill, todo, shell) send approval requests with empty toolInput objects and carry the actual resource being approved in the `description` field. This fix ensures users see what they're actually approving instead of confusing empty JSON.