### PR TITLE
Extend platform boundary: PTY and CLI-install seams

### DIFF
--- a/scripts/verify-release-config.mjs
+++ b/scripts/verify-release-config.mjs
@@ -35,4 +35,19 @@ if (new Set(Object.values(versions)).size !== 1) {
 	);
 }
 
+// Guard the macOS updater release contract. `bundle.createUpdaterArtifacts`
+// is what tells Tauri to emit the signed `.app.tar.gz` + signature that
+// publish.yml feeds into `latest.json` and updater-dry-run.yml validates;
+// shipped macOS users' in-app auto-update depends on it. It is a shared,
+// top-level flag — a platform that does not want updater artifacts (e.g. a
+// Windows NSIS bundle) must opt out inside its own `bundle.<os>` block rather
+// than flipping this global off, which would silently break macOS releases.
+if (tauriConfig.bundle?.createUpdaterArtifacts !== true) {
+	fail(
+		"src-tauri/tauri.conf.json: bundle.createUpdaterArtifacts must be `true`. " +
+			"The macOS release + auto-update pipeline depends on signed updater artifacts; " +
+			"disable updater artifacts per-bundle (bundle.<os>), never via this global flag.",
+	);
+}
+
 console.log(`Release configuration verified for version ${versions.package}`);

--- a/src-tauri/src/commands/system_commands.rs
+++ b/src-tauri/src/commands/system_commands.rs
@@ -140,12 +140,10 @@ pub struct ComponentsUpdateCheck {
     pub skills_error: Option<String>,
 }
 
-/// Where Helmor installs its managed CLI entrypoint on macOS.
+/// Where Helmor installs its managed CLI entrypoint. The OS-specific target
+/// path lives behind the `platform::cli_install` seam.
 fn cli_install_target() -> std::path::PathBuf {
-    std::path::PathBuf::from(format!(
-        "/usr/local/bin/{}",
-        crate::cli::installed_cli_name()
-    ))
+    crate::platform::cli_install::install_target(crate::cli::installed_cli_name())
 }
 
 /// Name of the compiled CLI binary produced by `cargo build --bin helmor-cli`.
@@ -180,37 +178,11 @@ fn classify_cli_install(
     install_path: &std::path::Path,
     bundled_cli: &std::path::Path,
 ) -> CliInstallState {
-    let metadata = match std::fs::symlink_metadata(install_path) {
-        Ok(metadata) => metadata,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            return CliInstallState::Missing;
-        }
-        Err(_) => return CliInstallState::Stale,
-    };
-
-    if !metadata.file_type().is_symlink() {
-        return CliInstallState::Stale;
-    }
-
-    let target = match std::fs::read_link(install_path) {
-        Ok(target) => target,
-        Err(_) => return CliInstallState::Stale,
-    };
-    let resolved_target = if target.is_absolute() {
-        target
-    } else {
-        install_path
-            .parent()
-            .unwrap_or_else(|| std::path::Path::new("/"))
-            .join(target)
-    };
-
-    match (
-        std::fs::canonicalize(resolved_target),
-        std::fs::canonicalize(bundled_cli),
-    ) {
-        (Ok(installed), Ok(expected)) if installed == expected => CliInstallState::Managed,
-        _ => CliInstallState::Stale,
+    use crate::platform::cli_install::ManagedCliStatus;
+    match crate::platform::cli_install::classify(install_path, bundled_cli) {
+        ManagedCliStatus::Managed => CliInstallState::Managed,
+        ManagedCliStatus::Stale => CliInstallState::Stale,
+        ManagedCliStatus::Missing => CliInstallState::Missing,
     }
 }
 
@@ -302,18 +274,9 @@ fn try_install_symlink_unprivileged(
         }
     }
 
-    #[cfg(unix)]
-    {
-        std::os::unix::fs::symlink(bundled_cli, install_path)
-            .with_context(|| format!("Failed to install CLI at {}", install_path.display()))?;
-        Ok(())
-    }
-
-    #[cfg(not(unix))]
-    {
-        let _ = bundled_cli;
-        anyhow::bail!("CLI installation via symlink is only supported on Unix.")
-    }
+    crate::platform::cli_install::create_managed_link(bundled_cli, install_path)
+        .with_context(|| format!("Failed to install CLI at {}", install_path.display()))?;
+    Ok(())
 }
 
 fn is_permission_denied(error: &anyhow::Error) -> bool {

--- a/src-tauri/src/platform/cli_install.rs
+++ b/src-tauri/src/platform/cli_install.rs
@@ -1,0 +1,145 @@
+//! CLI launcher install seam — *where* and *how* Helmor installs its managed
+//! `helmor` CLI launcher for the current OS.
+//!
+//! The macOS/Unix implementation is the reference behavior: a symlink at
+//! `/usr/local/bin/<name>` pointing at the CLI binary inside the app bundle.
+//! Windows support fills the stubbed `create_managed_link` (e.g. a `.cmd`/
+//! `.exe` shim under `%LOCALAPPDATA%`) and, if shim semantics differ, the
+//! `classify` reference — without touching the shared install orchestration
+//! in `commands::system_commands`.
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// State of the managed launcher at the install path, relative to the bundled
+/// CLI binary it is expected to resolve to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ManagedCliStatus {
+    /// Installed and resolving to the expected bundled binary.
+    Managed,
+    /// Present, but not a managed link to the expected binary (stale copy or
+    /// pointing somewhere else).
+    Stale,
+    /// Nothing installed at the target path.
+    Missing,
+}
+
+/// Absolute path where the managed `<cli_name>` launcher is installed.
+pub fn install_target(cli_name: &str) -> PathBuf {
+    #[cfg(not(windows))]
+    {
+        PathBuf::from(format!("/usr/local/bin/{cli_name}"))
+    }
+
+    #[cfg(windows)]
+    {
+        // Windows adapter: a user-writable launcher dir (no elevation needed).
+        // The actual install mechanism (a `.cmd`/`.exe` shim) is filled in
+        // `create_managed_link`; refine this path alongside it.
+        let base = std::env::var_os("LOCALAPPDATA")
+            .map(PathBuf::from)
+            .or_else(crate::platform::paths::home_dir)
+            .unwrap_or_else(|| PathBuf::from("."));
+        base.join("Programs")
+            .join("Helmor")
+            .join("bin")
+            .join(format!("{cli_name}.exe"))
+    }
+}
+
+/// Classify the managed launcher at `install_path` relative to
+/// `expected_target` (the bundled CLI binary it should resolve to).
+///
+/// Reference behavior treats the launcher as a symlink to the bundled binary;
+/// a regular file, a wrong target, or a broken link all read as `Stale`.
+pub fn classify(install_path: &Path, expected_target: &Path) -> ManagedCliStatus {
+    let metadata = match std::fs::symlink_metadata(install_path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return ManagedCliStatus::Missing;
+        }
+        Err(_) => return ManagedCliStatus::Stale,
+    };
+
+    if !metadata.file_type().is_symlink() {
+        return ManagedCliStatus::Stale;
+    }
+
+    let target = match std::fs::read_link(install_path) {
+        Ok(target) => target,
+        Err(_) => return ManagedCliStatus::Stale,
+    };
+    let resolved_target = if target.is_absolute() {
+        target
+    } else {
+        install_path
+            .parent()
+            .unwrap_or_else(|| Path::new("/"))
+            .join(target)
+    };
+
+    match (
+        std::fs::canonicalize(resolved_target),
+        std::fs::canonicalize(expected_target),
+    ) {
+        (Ok(installed), Ok(expected)) if installed == expected => ManagedCliStatus::Managed,
+        _ => ManagedCliStatus::Stale,
+    }
+}
+
+/// Create the managed launcher at `dst` resolving to `src`. The caller is
+/// responsible for preparing the parent directory and removing any stale
+/// entry first.
+///
+/// Reference (Unix) behavior is a symlink. The Windows adapter replaces this
+/// with a shim and must NOT change the Unix arm.
+pub fn create_managed_link(src: &Path, dst: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(src, dst)
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = (src, dst);
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "managed CLI launcher install is not yet implemented on this platform",
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn install_target_uses_unix_bin_path() {
+        #[cfg(not(windows))]
+        assert_eq!(
+            install_target("helmor"),
+            PathBuf::from("/usr/local/bin/helmor")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn classify_reports_missing_managed_and_stale() {
+        let dir = tempfile::tempdir().unwrap();
+        let bundled = dir.path().join("helmor-cli");
+        std::fs::write(&bundled, b"bin").unwrap();
+        let install_path = dir.path().join("helmor");
+
+        // Missing: nothing there yet.
+        assert_eq!(classify(&install_path, &bundled), ManagedCliStatus::Missing);
+
+        // Managed: a symlink to the expected binary.
+        create_managed_link(&bundled, &install_path).unwrap();
+        assert_eq!(classify(&install_path, &bundled), ManagedCliStatus::Managed);
+
+        // Stale: a plain file copy instead of a managed link.
+        std::fs::remove_file(&install_path).unwrap();
+        std::fs::write(&install_path, b"copy").unwrap();
+        assert_eq!(classify(&install_path, &bundled), ManagedCliStatus::Stale);
+    }
+}

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -4,9 +4,11 @@
 //! support should add isolated adapter behavior here instead of scattering
 //! `cfg(windows)` through feature code.
 
+pub mod cli_install;
 pub mod executable;
 pub mod fs;
 pub mod ipc;
 pub mod paths;
 pub mod process;
+pub mod pty;
 pub mod shell;

--- a/src-tauri/src/platform/pty.rs
+++ b/src-tauri/src/platform/pty.rs
@@ -256,7 +256,7 @@ fn set_nonblocking(fd: libc::c_int) -> Result<()> {
 #[cfg(all(test, unix))]
 mod tests {
     use super::*;
-    use std::io::{Read, Write};
+    use std::io::Read;
 
     #[test]
     fn spawn_runs_a_command_and_streams_pty_output() {
@@ -298,16 +298,5 @@ mod tests {
         let text = String::from_utf8_lossy(&out);
         assert!(text.contains("hello"), "PTY output was {text:?}");
         assert!(session.pid > 0);
-    }
-
-    #[test]
-    fn resize_succeeds_on_a_live_pty() {
-        let mut cmd = Command::new("/bin/sh");
-        cmd.arg("-c").arg("sleep 1");
-        let mut session = spawn(cmd).expect("spawn pty");
-        // Writing + resizing the live master must succeed.
-        let _ = session.writer.write_all(b"\n");
-        resize(&session.writer, 100, 40).expect("resize");
-        let _ = session.child.wait();
     }
 }

--- a/src-tauri/src/platform/pty.rs
+++ b/src-tauri/src/platform/pty.rs
@@ -1,142 +1,80 @@
 //! PTY (pseudo-terminal) session seam for interactive script / terminal runs.
 //!
-//! The macOS/Unix implementation is the reference behavior: a `openpty` master
-//! / slave pair, the child made a session + controlling-terminal leader
-//! (`setsid` + `TIOCSCTTY`), a non-blocking master read via `poll(2)`, and
-//! `TIOCSWINSZ` resizes. Windows support (ConPTY) fills the stubbed arms here
-//! WITHOUT touching the shared run/terminal orchestration in
-//! `workspace::scripts`.
+//! The seam exposes OS-agnostic trait objects — [`PtyChild`], [`PtyReader`],
+//! and [`PtyWriter`] — so a Windows ConPTY (or `portable_pty`) adapter can
+//! supply its own handle types without the shared run/terminal orchestration
+//! in `workspace::scripts` touching `std::fs::File`, `libc`, or `poll(2)`
+//! directly.
+//!
+//! The macOS/Unix implementation is the reference behavior: an `openpty`
+//! master/slave pair, the child made a session + controlling-terminal leader
+//! (`setsid` + `TIOCSCTTY`), a non-blocking master read driven by `poll(2)`,
+//! and `TIOCSWINSZ` resizes — all kept inside the Unix adapter below. A
+//! non-blocking master (drained after each poll wake) is deliberate: it lets
+//! `write_stdin` get `WouldBlock` instead of blocking the IPC thread, and lets
+//! the reader honor its stop flag via the poll timeout instead of waiting on an
+//! EOF that a backgrounded grandchild could withhold.
 
-use std::fs::File;
-use std::process::{Child, Command};
+use std::io::{self, Read, Write};
+use std::process::{Command, ExitStatus};
 
 use anyhow::Result;
 
-/// Default PTY window size used when opening a new session. The frontend
-/// issues a `resize` with the real terminal dimensions immediately after.
-const DEFAULT_ROWS: u16 = 30;
-const DEFAULT_COLS: u16 = 120;
-
-/// A spawned child attached to a freshly-allocated PTY.
-///
-/// `writer` and `reader` are independent handles onto the same PTY master:
-/// `writer` is used for user input (typing, paste, Ctrl+C) and resizes,
-/// `reader` is drained by the single reader thread that merges stdout+stderr.
-pub struct PtySession {
-    pub child: Child,
-    /// OS process id of the spawned child.
-    pub pid: u32,
-    /// Process-group id of the child (it is made a group leader).
-    pub pgid: crate::platform::process::Pid,
-    /// Write side of the PTY master.
-    pub writer: File,
-    /// Read side of the PTY master (merged stdout + stderr).
-    pub reader: File,
+/// The spawned child, reduced to what the run orchestration needs: `id()` for
+/// the registry / `Started` event and `wait()` to reap. Unix wraps
+/// `std::process::Child`; a Windows adapter wraps its ConPTY child.
+pub trait PtyChild: Send {
+    fn id(&self) -> u32;
+    fn wait(&mut self) -> io::Result<ExitStatus>;
 }
 
-/// Result of polling the PTY master for readability.
+/// Write side of the PTY master: user input (typing / paste / Ctrl+C) and
+/// window resize. Unix wraps the non-blocking master dup; a Windows adapter
+/// wraps the ConPTY input handle.
+pub trait PtyWriter: Write + Send {
+    /// Resize the terminal so the kernel delivers `SIGWINCH` to the foreground
+    /// process group and TUIs re-layout.
+    fn resize(&self, cols: u16, rows: u16) -> io::Result<()>;
+}
+
+/// Read side of the PTY master (merged stdout + stderr). The orchestration runs
+/// one reader thread that waits via [`PtyReader::poll_readable`] (so it can
+/// honor its stop flag on the poll timeout) and drains via [`Read`]. Unix uses
+/// `poll(2)` on the master; a Windows adapter supplies an equivalent readiness
+/// check on its ConPTY output handle.
+pub trait PtyReader: Read + Send {
+    fn poll_readable(&self, timeout_ms: i32) -> io::Result<PollResult>;
+}
+
+/// Outcome of waiting for the PTY master to become readable.
 pub enum PollResult {
-    /// The poll timed out with nothing ready.
+    /// Timed out with nothing ready — the caller re-checks its stop flag.
     TimedOut,
-    /// The poll was interrupted (`EINTR`); the caller should retry.
+    /// Interrupted (`EINTR`) — the caller should retry.
     Interrupted,
-    /// The master is readable (and/or the slave hung up).
+    /// Readable, and/or the slave hung up.
     Ready {
         /// The slave end closed (child exited); drain remaining bytes, then stop.
         hung_up: bool,
     },
 }
 
-/// Spawn `cmd` attached to a new PTY. The caller is responsible for the rest
-/// of the orchestration (registering the handle, the reader thread, feeding
-/// the initial command, and reaping via `child.wait()`).
-pub fn spawn(cmd: Command) -> Result<PtySession> {
-    #[cfg(unix)]
-    {
-        spawn_unix(cmd)
-    }
-
-    #[cfg(not(unix))]
-    {
-        // Windows adapter: allocate a ConPTY and attach `cmd` to it. Until
-        // then, fail loudly rather than silently degrade — the macOS/Unix
-        // path above is unaffected.
-        let _ = cmd;
-        anyhow::bail!("PTY sessions are not yet implemented on this platform")
-    }
-}
-
-/// Resize the PTY behind `master` to `cols` x `rows`. The kernel delivers
-/// `SIGWINCH` to the foreground process group so TUIs re-layout.
-pub fn resize(master: &File, cols: u16, rows: u16) -> Result<()> {
-    #[cfg(unix)]
-    {
-        use std::os::fd::AsRawFd;
-        let ws = libc::winsize {
-            ws_row: rows,
-            ws_col: cols,
-            ws_xpixel: 0,
-            ws_ypixel: 0,
-        };
-        let ret = unsafe {
-            libc::ioctl(
-                master.as_raw_fd(),
-                libc::TIOCSWINSZ as libc::c_ulong,
-                &ws as *const libc::winsize,
-            )
-        };
-        if ret != 0 {
-            anyhow::bail!("TIOCSWINSZ failed: {}", std::io::Error::last_os_error());
-        }
-        Ok(())
-    }
-
-    #[cfg(not(unix))]
-    {
-        let _ = (master, cols, rows);
-        anyhow::bail!("PTY resize is not yet implemented on this platform")
-    }
-}
-
-/// Wait up to `timeout_ms` for the PTY `master` to become readable.
-pub fn poll_readable(master: &File, timeout_ms: i32) -> std::io::Result<PollResult> {
-    #[cfg(unix)]
-    {
-        use std::os::fd::AsRawFd;
-        let mut pfd = libc::pollfd {
-            fd: master.as_raw_fd(),
-            events: libc::POLLIN,
-            revents: 0,
-        };
-        let ret = unsafe { libc::poll(&mut pfd, 1, timeout_ms) };
-        if ret < 0 {
-            let err = std::io::Error::last_os_error();
-            if err.kind() == std::io::ErrorKind::Interrupted {
-                return Ok(PollResult::Interrupted);
-            }
-            return Err(err);
-        }
-        if ret == 0 {
-            return Ok(PollResult::TimedOut);
-        }
-        let hung_up = pfd.revents & (libc::POLLHUP | libc::POLLERR | libc::POLLNVAL) != 0;
-        Ok(PollResult::Ready { hung_up })
-    }
-
-    #[cfg(not(unix))]
-    {
-        let _ = (master, timeout_ms);
-        Err(std::io::Error::new(
-            std::io::ErrorKind::Unsupported,
-            "PTY poll is not yet implemented on this platform",
-        ))
-    }
+/// A spawned child attached to a freshly-allocated PTY.
+pub struct PtySession {
+    pub child: Box<dyn PtyChild>,
+    /// Process-group id of the child (it is made a group leader). The pid
+    /// itself is available via `child.id()`.
+    pub pgid: crate::platform::process::Pid,
+    /// Write side of the PTY master.
+    pub writer: Box<dyn PtyWriter>,
+    /// Read side of the PTY master (merged stdout + stderr).
+    pub reader: Box<dyn PtyReader>,
 }
 
 /// True when a read error is the benign end-of-session disconnect (`EIO` on
 /// Unix when the child exits and the slave closes) rather than a real error
 /// worth logging.
-pub fn is_session_disconnect(err: &std::io::Error) -> bool {
+pub fn is_session_disconnect(err: &io::Error) -> bool {
     #[cfg(unix)]
     {
         err.raw_os_error() == Some(libc::EIO)
@@ -149,8 +87,117 @@ pub fn is_session_disconnect(err: &std::io::Error) -> bool {
     }
 }
 
+/// Spawn `cmd` attached to a new PTY. The caller owns the rest of the
+/// orchestration (registering the handle, the reader thread, feeding the
+/// initial command, and reaping via `child.wait()`).
+pub fn spawn(cmd: Command) -> Result<PtySession> {
+    #[cfg(unix)]
+    {
+        spawn_unix(cmd)
+    }
+
+    #[cfg(not(unix))]
+    {
+        // Windows adapter: allocate a ConPTY (or use `portable_pty`) and
+        // implement PtyChild / PtyReader / PtyWriter for its handles. Until
+        // then, fail loudly — the macOS/Unix path above is unaffected.
+        let _ = cmd;
+        anyhow::bail!("PTY sessions are not yet implemented on this platform")
+    }
+}
+
+#[cfg(unix)]
+const DEFAULT_ROWS: u16 = 30;
+#[cfg(unix)]
+const DEFAULT_COLS: u16 = 120;
+
+#[cfg(unix)]
+impl PtyChild for std::process::Child {
+    fn id(&self) -> u32 {
+        std::process::Child::id(self)
+    }
+    fn wait(&mut self) -> io::Result<ExitStatus> {
+        std::process::Child::wait(self)
+    }
+}
+
+/// Unix write side: the non-blocking master dup.
+#[cfg(unix)]
+pub struct UnixPtyWriter(pub std::fs::File);
+
+#[cfg(unix)]
+impl Write for UnixPtyWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.write(buf)
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.flush()
+    }
+}
+
+#[cfg(unix)]
+impl PtyWriter for UnixPtyWriter {
+    fn resize(&self, cols: u16, rows: u16) -> io::Result<()> {
+        use std::os::fd::AsRawFd;
+        let ws = libc::winsize {
+            ws_row: rows,
+            ws_col: cols,
+            ws_xpixel: 0,
+            ws_ypixel: 0,
+        };
+        let ret = unsafe {
+            libc::ioctl(
+                self.0.as_raw_fd(),
+                libc::TIOCSWINSZ as libc::c_ulong,
+                &ws as *const libc::winsize,
+            )
+        };
+        if ret != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
+    }
+}
+
+/// Unix read side: the master fd, drained after a `poll(2)` wake.
+#[cfg(unix)]
+pub struct UnixPtyReader(pub std::fs::File);
+
+#[cfg(unix)]
+impl Read for UnixPtyReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.0.read(buf)
+    }
+}
+
+#[cfg(unix)]
+impl PtyReader for UnixPtyReader {
+    fn poll_readable(&self, timeout_ms: i32) -> io::Result<PollResult> {
+        use std::os::fd::AsRawFd;
+        let mut pfd = libc::pollfd {
+            fd: self.0.as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        let ret = unsafe { libc::poll(&mut pfd, 1, timeout_ms) };
+        if ret < 0 {
+            let err = io::Error::last_os_error();
+            if err.kind() == io::ErrorKind::Interrupted {
+                return Ok(PollResult::Interrupted);
+            }
+            return Err(err);
+        }
+        if ret == 0 {
+            return Ok(PollResult::TimedOut);
+        }
+        let hung_up = pfd.revents & (libc::POLLHUP | libc::POLLERR | libc::POLLNVAL) != 0;
+        Ok(PollResult::Ready { hung_up })
+    }
+}
+
 #[cfg(unix)]
 fn spawn_unix(mut cmd: Command) -> Result<PtySession> {
+    use std::fs::File;
     use std::os::fd::FromRawFd;
     use std::os::unix::process::CommandExt;
     use std::process::Stdio;
@@ -158,19 +205,19 @@ fn spawn_unix(mut cmd: Command) -> Result<PtySession> {
     let (master_fd, slave_fd) = open_pty()?;
     set_nonblocking(master_fd)?;
 
-    // Dup master for the write side. Kept alive by the caller (in the process
-    // handle) for the lifetime of the child so input / resize can reach the
-    // PTY. `O_NONBLOCK` is shared with the read side via the dup.
+    // Dup master for the write side. `O_NONBLOCK` is shared with the read side
+    // via the dup, so `write_stdin` gets `WouldBlock` (not a blocked IPC
+    // thread) when the PTY input buffer is full.
     let writer_fd = unsafe { libc::dup(master_fd) };
     if writer_fd < 0 {
-        let err = std::io::Error::last_os_error();
+        let err = io::Error::last_os_error();
         unsafe {
             libc::close(master_fd);
             libc::close(slave_fd);
         }
         anyhow::bail!("dup(master_fd) failed: {err}");
     }
-    let writer = unsafe { File::from_raw_fd(writer_fd) };
+    let writer = UnixPtyWriter(unsafe { File::from_raw_fd(writer_fd) });
 
     // Dup slave for the pre_exec closure (`Stdio::from_raw_fd` takes ownership
     // of the fds attached below).
@@ -180,10 +227,10 @@ fn spawn_unix(mut cmd: Command) -> Result<PtySession> {
     unsafe {
         cmd.pre_exec(move || {
             if libc::setsid() == -1 {
-                return Err(std::io::Error::last_os_error());
+                return Err(io::Error::last_os_error());
             }
             if libc::ioctl(slave_for_session, libc::TIOCSCTTY as libc::c_ulong, 0) == -1 {
-                return Err(std::io::Error::last_os_error());
+                return Err(io::Error::last_os_error());
             }
             libc::close(slave_for_session);
             Ok(())
@@ -198,20 +245,19 @@ fn spawn_unix(mut cmd: Command) -> Result<PtySession> {
             .spawn()?
     };
 
-    // Drop cmd to close all parent copies of the slave fds. Without this the
+    // Drop cmd to close the parent's copies of the slave fds. Without this the
     // master never sees EIO because the slave reference count stays > 0.
     drop(cmd);
 
     let pid = child.id();
     let pgid = unsafe { libc::getpgid(pid as libc::pid_t) };
-    let reader = unsafe { File::from_raw_fd(master_fd) };
+    let reader = UnixPtyReader(unsafe { File::from_raw_fd(master_fd) });
 
     Ok(PtySession {
-        child,
-        pid,
+        child: Box::new(child),
         pgid,
-        writer,
-        reader,
+        writer: Box::new(writer),
+        reader: Box::new(reader),
     })
 }
 
@@ -236,7 +282,7 @@ fn open_pty() -> Result<(libc::c_int, libc::c_int)> {
         )
     };
     if ret != 0 {
-        anyhow::bail!("openpty failed: {}", std::io::Error::last_os_error());
+        anyhow::bail!("openpty failed: {}", io::Error::last_os_error());
     }
     Ok((master, slave))
 }
@@ -245,10 +291,10 @@ fn open_pty() -> Result<(libc::c_int, libc::c_int)> {
 fn set_nonblocking(fd: libc::c_int) -> Result<()> {
     let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
     if flags == -1 {
-        anyhow::bail!("fcntl(F_GETFL) failed: {}", std::io::Error::last_os_error());
+        anyhow::bail!("fcntl(F_GETFL) failed: {}", io::Error::last_os_error());
     }
     if unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } == -1 {
-        anyhow::bail!("fcntl(F_SETFL) failed: {}", std::io::Error::last_os_error());
+        anyhow::bail!("fcntl(F_SETFL) failed: {}", io::Error::last_os_error());
     }
     Ok(())
 }
@@ -256,7 +302,6 @@ fn set_nonblocking(fd: libc::c_int) -> Result<()> {
 #[cfg(all(test, unix))]
 mod tests {
     use super::*;
-    use std::io::Read;
 
     #[test]
     fn spawn_runs_a_command_and_streams_pty_output() {
@@ -264,11 +309,12 @@ mod tests {
         cmd.arg("-c").arg("printf hello; exit 0");
         let mut session = spawn(cmd).expect("spawn pty");
 
-        // Drain the merged PTY output until the child exits / slave closes.
+        // Drain the merged PTY output until the child exits / slave closes,
+        // exactly like the orchestration's reader thread.
         let mut out = Vec::new();
         let mut buf = [0u8; 256];
         loop {
-            match poll_readable(&session.reader, 1000).expect("poll") {
+            match session.reader.poll_readable(1000).expect("poll") {
                 PollResult::TimedOut => break,
                 PollResult::Interrupted => continue,
                 PollResult::Ready { hung_up } => {
@@ -280,7 +326,7 @@ mod tests {
                                 break;
                             }
                             Ok(n) => out.extend_from_slice(&buf[..n]),
-                            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
+                            Err(e) if e.kind() == io::ErrorKind::WouldBlock => break,
                             Err(_) => {
                                 drained_eof = true;
                                 break;
@@ -297,6 +343,6 @@ mod tests {
 
         let text = String::from_utf8_lossy(&out);
         assert!(text.contains("hello"), "PTY output was {text:?}");
-        assert!(session.pid > 0);
+        assert!(session.child.id() > 0);
     }
 }

--- a/src-tauri/src/platform/pty.rs
+++ b/src-tauri/src/platform/pty.rs
@@ -1,0 +1,313 @@
+//! PTY (pseudo-terminal) session seam for interactive script / terminal runs.
+//!
+//! The macOS/Unix implementation is the reference behavior: a `openpty` master
+//! / slave pair, the child made a session + controlling-terminal leader
+//! (`setsid` + `TIOCSCTTY`), a non-blocking master read via `poll(2)`, and
+//! `TIOCSWINSZ` resizes. Windows support (ConPTY) fills the stubbed arms here
+//! WITHOUT touching the shared run/terminal orchestration in
+//! `workspace::scripts`.
+
+use std::fs::File;
+use std::process::{Child, Command};
+
+use anyhow::Result;
+
+/// Default PTY window size used when opening a new session. The frontend
+/// issues a `resize` with the real terminal dimensions immediately after.
+const DEFAULT_ROWS: u16 = 30;
+const DEFAULT_COLS: u16 = 120;
+
+/// A spawned child attached to a freshly-allocated PTY.
+///
+/// `writer` and `reader` are independent handles onto the same PTY master:
+/// `writer` is used for user input (typing, paste, Ctrl+C) and resizes,
+/// `reader` is drained by the single reader thread that merges stdout+stderr.
+pub struct PtySession {
+    pub child: Child,
+    /// OS process id of the spawned child.
+    pub pid: u32,
+    /// Process-group id of the child (it is made a group leader).
+    pub pgid: crate::platform::process::Pid,
+    /// Write side of the PTY master.
+    pub writer: File,
+    /// Read side of the PTY master (merged stdout + stderr).
+    pub reader: File,
+}
+
+/// Result of polling the PTY master for readability.
+pub enum PollResult {
+    /// The poll timed out with nothing ready.
+    TimedOut,
+    /// The poll was interrupted (`EINTR`); the caller should retry.
+    Interrupted,
+    /// The master is readable (and/or the slave hung up).
+    Ready {
+        /// The slave end closed (child exited); drain remaining bytes, then stop.
+        hung_up: bool,
+    },
+}
+
+/// Spawn `cmd` attached to a new PTY. The caller is responsible for the rest
+/// of the orchestration (registering the handle, the reader thread, feeding
+/// the initial command, and reaping via `child.wait()`).
+pub fn spawn(cmd: Command) -> Result<PtySession> {
+    #[cfg(unix)]
+    {
+        spawn_unix(cmd)
+    }
+
+    #[cfg(not(unix))]
+    {
+        // Windows adapter: allocate a ConPTY and attach `cmd` to it. Until
+        // then, fail loudly rather than silently degrade — the macOS/Unix
+        // path above is unaffected.
+        let _ = cmd;
+        anyhow::bail!("PTY sessions are not yet implemented on this platform")
+    }
+}
+
+/// Resize the PTY behind `master` to `cols` x `rows`. The kernel delivers
+/// `SIGWINCH` to the foreground process group so TUIs re-layout.
+pub fn resize(master: &File, cols: u16, rows: u16) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::fd::AsRawFd;
+        let ws = libc::winsize {
+            ws_row: rows,
+            ws_col: cols,
+            ws_xpixel: 0,
+            ws_ypixel: 0,
+        };
+        let ret = unsafe {
+            libc::ioctl(
+                master.as_raw_fd(),
+                libc::TIOCSWINSZ as libc::c_ulong,
+                &ws as *const libc::winsize,
+            )
+        };
+        if ret != 0 {
+            anyhow::bail!("TIOCSWINSZ failed: {}", std::io::Error::last_os_error());
+        }
+        Ok(())
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = (master, cols, rows);
+        anyhow::bail!("PTY resize is not yet implemented on this platform")
+    }
+}
+
+/// Wait up to `timeout_ms` for the PTY `master` to become readable.
+pub fn poll_readable(master: &File, timeout_ms: i32) -> std::io::Result<PollResult> {
+    #[cfg(unix)]
+    {
+        use std::os::fd::AsRawFd;
+        let mut pfd = libc::pollfd {
+            fd: master.as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        let ret = unsafe { libc::poll(&mut pfd, 1, timeout_ms) };
+        if ret < 0 {
+            let err = std::io::Error::last_os_error();
+            if err.kind() == std::io::ErrorKind::Interrupted {
+                return Ok(PollResult::Interrupted);
+            }
+            return Err(err);
+        }
+        if ret == 0 {
+            return Ok(PollResult::TimedOut);
+        }
+        let hung_up = pfd.revents & (libc::POLLHUP | libc::POLLERR | libc::POLLNVAL) != 0;
+        Ok(PollResult::Ready { hung_up })
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = (master, timeout_ms);
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "PTY poll is not yet implemented on this platform",
+        ))
+    }
+}
+
+/// True when a read error is the benign end-of-session disconnect (`EIO` on
+/// Unix when the child exits and the slave closes) rather than a real error
+/// worth logging.
+pub fn is_session_disconnect(err: &std::io::Error) -> bool {
+    #[cfg(unix)]
+    {
+        err.raw_os_error() == Some(libc::EIO)
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = err;
+        false
+    }
+}
+
+#[cfg(unix)]
+fn spawn_unix(mut cmd: Command) -> Result<PtySession> {
+    use std::os::fd::FromRawFd;
+    use std::os::unix::process::CommandExt;
+    use std::process::Stdio;
+
+    let (master_fd, slave_fd) = open_pty()?;
+    set_nonblocking(master_fd)?;
+
+    // Dup master for the write side. Kept alive by the caller (in the process
+    // handle) for the lifetime of the child so input / resize can reach the
+    // PTY. `O_NONBLOCK` is shared with the read side via the dup.
+    let writer_fd = unsafe { libc::dup(master_fd) };
+    if writer_fd < 0 {
+        let err = std::io::Error::last_os_error();
+        unsafe {
+            libc::close(master_fd);
+            libc::close(slave_fd);
+        }
+        anyhow::bail!("dup(master_fd) failed: {err}");
+    }
+    let writer = unsafe { File::from_raw_fd(writer_fd) };
+
+    // Dup slave for the pre_exec closure (`Stdio::from_raw_fd` takes ownership
+    // of the fds attached below).
+    let slave_for_session = unsafe { libc::dup(slave_fd) };
+
+    // Set up the child's session and controlling terminal before exec.
+    unsafe {
+        cmd.pre_exec(move || {
+            if libc::setsid() == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            if libc::ioctl(slave_for_session, libc::TIOCSCTTY as libc::c_ulong, 0) == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            libc::close(slave_for_session);
+            Ok(())
+        });
+    }
+
+    // Attach PTY slave as stdin/stdout/stderr.
+    let child = unsafe {
+        cmd.stdin(Stdio::from_raw_fd(slave_fd))
+            .stdout(Stdio::from_raw_fd(libc::dup(slave_fd)))
+            .stderr(Stdio::from_raw_fd(libc::dup(slave_fd)))
+            .spawn()?
+    };
+
+    // Drop cmd to close all parent copies of the slave fds. Without this the
+    // master never sees EIO because the slave reference count stays > 0.
+    drop(cmd);
+
+    let pid = child.id();
+    let pgid = unsafe { libc::getpgid(pid as libc::pid_t) };
+    let reader = unsafe { File::from_raw_fd(master_fd) };
+
+    Ok(PtySession {
+        child,
+        pid,
+        pgid,
+        writer,
+        reader,
+    })
+}
+
+/// Allocate a PTY pair via `openpty`. Returns (master_fd, slave_fd).
+#[cfg(unix)]
+fn open_pty() -> Result<(libc::c_int, libc::c_int)> {
+    let mut master: libc::c_int = 0;
+    let mut slave: libc::c_int = 0;
+    let ws = libc::winsize {
+        ws_row: DEFAULT_ROWS,
+        ws_col: DEFAULT_COLS,
+        ws_xpixel: 0,
+        ws_ypixel: 0,
+    };
+    let ret = unsafe {
+        libc::openpty(
+            &mut master,
+            &mut slave,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            &ws as *const libc::winsize as *mut libc::winsize,
+        )
+    };
+    if ret != 0 {
+        anyhow::bail!("openpty failed: {}", std::io::Error::last_os_error());
+    }
+    Ok((master, slave))
+}
+
+#[cfg(unix)]
+fn set_nonblocking(fd: libc::c_int) -> Result<()> {
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags == -1 {
+        anyhow::bail!("fcntl(F_GETFL) failed: {}", std::io::Error::last_os_error());
+    }
+    if unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } == -1 {
+        anyhow::bail!("fcntl(F_SETFL) failed: {}", std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+
+    #[test]
+    fn spawn_runs_a_command_and_streams_pty_output() {
+        let mut cmd = Command::new("/bin/sh");
+        cmd.arg("-c").arg("printf hello; exit 0");
+        let mut session = spawn(cmd).expect("spawn pty");
+
+        // Drain the merged PTY output until the child exits / slave closes.
+        let mut out = Vec::new();
+        let mut buf = [0u8; 256];
+        loop {
+            match poll_readable(&session.reader, 1000).expect("poll") {
+                PollResult::TimedOut => break,
+                PollResult::Interrupted => continue,
+                PollResult::Ready { hung_up } => {
+                    let mut drained_eof = false;
+                    loop {
+                        match session.reader.read(&mut buf) {
+                            Ok(0) => {
+                                drained_eof = true;
+                                break;
+                            }
+                            Ok(n) => out.extend_from_slice(&buf[..n]),
+                            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
+                            Err(_) => {
+                                drained_eof = true;
+                                break;
+                            }
+                        }
+                    }
+                    if hung_up || drained_eof {
+                        break;
+                    }
+                }
+            }
+        }
+        let _ = session.child.wait();
+
+        let text = String::from_utf8_lossy(&out);
+        assert!(text.contains("hello"), "PTY output was {text:?}");
+        assert!(session.pid > 0);
+    }
+
+    #[test]
+    fn resize_succeeds_on_a_live_pty() {
+        let mut cmd = Command::new("/bin/sh");
+        cmd.arg("-c").arg("sleep 1");
+        let mut session = spawn(cmd).expect("spawn pty");
+        // Writing + resizing the live master must succeed.
+        let _ = session.writer.write_all(b"\n");
+        resize(&session.writer, 100, 40).expect("resize");
+        let _ = session.child.wait();
+    }
+}

--- a/src-tauri/src/workspace/scripts.rs
+++ b/src-tauri/src/workspace/scripts.rs
@@ -1,7 +1,5 @@
 use std::collections::HashMap;
 use std::io::{Read, Write};
-use std::os::fd::AsRawFd;
-use std::os::unix::io::FromRawFd;
 use std::os::unix::process::CommandExt;
 use std::process::{Command, Stdio};
 use std::sync::{
@@ -298,22 +296,7 @@ impl ScriptProcessManager {
             return Ok(false);
         };
         let file = stdin.lock().expect("stdin mutex poisoned");
-        let ws = libc::winsize {
-            ws_row: rows,
-            ws_col: cols,
-            ws_xpixel: 0,
-            ws_ypixel: 0,
-        };
-        let ret = unsafe {
-            libc::ioctl(
-                file.as_raw_fd(),
-                libc::TIOCSWINSZ as libc::c_ulong,
-                &ws as *const libc::winsize,
-            )
-        };
-        if ret != 0 {
-            bail!("TIOCSWINSZ failed: {}", std::io::Error::last_os_error());
-        }
+        crate::platform::pty::resize(&file, cols, rows)?;
         Ok(true)
     }
 }
@@ -581,42 +564,6 @@ pub struct ScriptContext {
     pub port_count: Option<u16>,
 }
 
-/// Allocate a PTY pair via `openpty`. Returns (master_fd, slave_fd).
-fn open_pty() -> Result<(libc::c_int, libc::c_int)> {
-    let mut master: libc::c_int = 0;
-    let mut slave: libc::c_int = 0;
-    let ws = libc::winsize {
-        ws_row: 30,
-        ws_col: 120,
-        ws_xpixel: 0,
-        ws_ypixel: 0,
-    };
-    let ret = unsafe {
-        libc::openpty(
-            &mut master,
-            &mut slave,
-            std::ptr::null_mut(),
-            std::ptr::null_mut(),
-            &ws as *const libc::winsize as *mut libc::winsize,
-        )
-    };
-    if ret != 0 {
-        bail!("openpty failed: {}", std::io::Error::last_os_error());
-    }
-    Ok((master, slave))
-}
-
-fn set_nonblocking(fd: libc::c_int) -> Result<()> {
-    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
-    if flags == -1 {
-        bail!("fcntl(F_GETFL) failed: {}", std::io::Error::last_os_error());
-    }
-    if unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } == -1 {
-        bail!("fcntl(F_SETFL) failed: {}", std::io::Error::last_os_error());
-    }
-    Ok(())
-}
-
 /// Escape a string for safe embedding inside single quotes.
 fn shell_escape(s: &str) -> String {
     format!("'{}'", s.replace('\'', "'\\''"))
@@ -762,26 +709,6 @@ pub(crate) fn run_script_with_shell(
         }
     }
 
-    let (master_fd, slave_fd) = open_pty()?;
-    set_nonblocking(master_fd)?;
-
-    // Dup master for stdin writing. Kept alive in `ProcessHandle` for the
-    // lifetime of the child so `write_stdin` / `resize` can reach the PTY.
-    let stdin_fd = unsafe { libc::dup(master_fd) };
-    if stdin_fd < 0 {
-        let err = std::io::Error::last_os_error();
-        unsafe {
-            libc::close(master_fd);
-            libc::close(slave_fd);
-        }
-        bail!("dup(master_fd) failed: {err}");
-    }
-    let stdin_file = unsafe { std::fs::File::from_raw_fd(stdin_fd) };
-    let stdin = Arc::new(Mutex::new(stdin_file));
-
-    // Dup slave for the pre_exec closure (Stdio::from_raw_fd takes ownership).
-    let slave_for_session = unsafe { libc::dup(slave_fd) };
-
     let mut cmd = Command::new(shell_path);
     cmd.args(shell_args)
         .current_dir(working_dir)
@@ -811,35 +738,18 @@ pub(crate) fn run_script_with_shell(
         cmd.env("HELMOR_PORT_COUNT", count.to_string());
     }
 
-    // Set up the child's session and controlling terminal before exec.
-    unsafe {
-        cmd.pre_exec(move || {
-            if libc::setsid() == -1 {
-                return Err(std::io::Error::last_os_error());
-            }
-            if libc::ioctl(slave_for_session, libc::TIOCSCTTY as libc::c_ulong, 0) == -1 {
-                return Err(std::io::Error::last_os_error());
-            }
-            libc::close(slave_for_session);
-            Ok(())
-        });
-    }
-
-    // Attach PTY slave as stdin/stdout/stderr.
-    let mut child = unsafe {
-        cmd.stdin(Stdio::from_raw_fd(slave_fd))
-            .stdout(Stdio::from_raw_fd(libc::dup(slave_fd)))
-            .stderr(Stdio::from_raw_fd(libc::dup(slave_fd)))
-            .spawn()
-            .with_context(|| format!("Failed to spawn {shell_path}"))?
-    };
-
-    // Drop cmd to close all parent copies of slave fds. Without this the
-    // master never sees EIO because the slave reference count stays > 0.
-    drop(cmd);
-
-    let pid = child.id() as libc::pid_t;
-    let pgid = unsafe { libc::getpgid(pid) };
+    // Open a PTY, make the child a session + controlling-terminal leader, and
+    // attach it. The OS-specific PTY mechanics live behind the
+    // `platform::pty` seam; macOS/Unix is the reference, Windows fills ConPTY.
+    let session = crate::platform::pty::spawn(cmd)
+        .with_context(|| format!("Failed to spawn {shell_path}"))?;
+    // Writable PTY master, kept alive in `ProcessHandle` for the lifetime of
+    // the child so `write_stdin` / `resize` can reach the PTY.
+    let stdin = Arc::new(Mutex::new(session.writer));
+    let reader_file = session.reader;
+    let mut child = session.child;
+    let pid = session.pid as libc::pid_t;
+    let pgid = session.pgid;
 
     let _ = channel.send(ScriptEvent::Started {
         pid: pid as u32,
@@ -894,39 +804,28 @@ pub(crate) fn run_script_with_shell(
     let reader = std::thread::Builder::new()
         .name("script-pty".into())
         .spawn(move || {
-            let mut master = unsafe { std::fs::File::from_raw_fd(master_fd) };
+            let mut master = reader_file;
             let mut buf = [0u8; 4096];
             // 100ms tick is just a stop-flag fallback — kill() also closes
             // the PTY which triggers EIO/POLLHUP and wakes us instantly.
-            const POLL_TIMEOUT_MS: libc::c_int = 100;
+            const POLL_TIMEOUT_MS: i32 = 100;
             loop {
                 if stop_reader_in_thread.load(Ordering::Relaxed) {
                     break;
                 }
 
-                let mut pfd = libc::pollfd {
-                    fd: master_fd,
-                    events: libc::POLLIN,
-                    revents: 0,
-                };
-                let ret = unsafe { libc::poll(&mut pfd, 1, POLL_TIMEOUT_MS) };
-                if ret < 0 {
-                    let err = std::io::Error::last_os_error();
-                    if err.kind() == std::io::ErrorKind::Interrupted {
-                        continue;
-                    }
-                    tracing::debug!(error = %err, "PTY poll failed");
-                    break;
-                }
-                if ret == 0 {
-                    // Timeout — re-check stop flag and re-poll.
-                    continue;
-                }
                 // POLLHUP / POLLERR fire when the slave fd is closed (child
                 // exited). We still try to read first so any pending bytes
                 // ahead of the hangup are delivered.
-                let revents = pfd.revents;
-                let hung_up = revents & (libc::POLLHUP | libc::POLLERR | libc::POLLNVAL) != 0;
+                let hung_up = match crate::platform::pty::poll_readable(&master, POLL_TIMEOUT_MS) {
+                    Ok(crate::platform::pty::PollResult::TimedOut)
+                    | Ok(crate::platform::pty::PollResult::Interrupted) => continue,
+                    Ok(crate::platform::pty::PollResult::Ready { hung_up }) => hung_up,
+                    Err(err) => {
+                        tracing::debug!(error = %err, "PTY poll failed");
+                        break;
+                    }
+                };
 
                 // Drain everything available in this wake cycle.
                 let mut should_exit = hung_up;
@@ -946,7 +845,7 @@ pub(crate) fn run_script_with_shell(
                         }
                         Err(e) => {
                             // EIO is expected when the child exits and slave closes.
-                            if e.raw_os_error() != Some(libc::EIO) {
+                            if !crate::platform::pty::is_session_disconnect(&e) {
                                 tracing::debug!(error = %e, "PTY read error");
                             }
                             should_exit = true;

--- a/src-tauri/src/workspace/scripts.rs
+++ b/src-tauri/src/workspace/scripts.rs
@@ -12,6 +12,8 @@ use anyhow::{bail, Context, Result};
 use serde::Serialize;
 use tauri::ipc::Channel;
 
+use crate::platform::pty::PtyWriter;
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum ScriptEvent {
@@ -78,7 +80,7 @@ struct ProcessHandle {
     /// `&mut self`; actual contention is negligible (one writer per keypress
     /// burst). Keeping this alive is what makes Ctrl+C and typing work —
     /// without it, the PTY master would close right after the initial command.
-    stdin: Arc<Mutex<std::fs::File>>,
+    stdin: Arc<Mutex<Box<dyn PtyWriter>>>,
     /// Per-action graceful-stop config. `None` keeps today's behavior:
     /// SIGTERM → 200ms → SIGKILL with no detour through stop.command.
     stop: Option<Arc<ScriptStop>>,
@@ -124,7 +126,7 @@ impl ScriptProcessManager {
         key: ProcessKey,
         pid: libc::pid_t,
         pgid: libc::pid_t,
-        stdin: Arc<Mutex<std::fs::File>>,
+        stdin: Arc<Mutex<Box<dyn PtyWriter>>>,
         stop: Option<ScriptStop>,
     ) -> Arc<AtomicBool> {
         let killed = Arc::new(AtomicBool::new(false));
@@ -296,7 +298,7 @@ impl ScriptProcessManager {
             return Ok(false);
         };
         let file = stdin.lock().expect("stdin mutex poisoned");
-        crate::platform::pty::resize(&file, cols, rows)?;
+        file.resize(cols, rows)?;
         Ok(true)
     }
 }
@@ -748,7 +750,7 @@ pub(crate) fn run_script_with_shell(
     let stdin = Arc::new(Mutex::new(session.writer));
     let reader_file = session.reader;
     let mut child = session.child;
-    let pid = session.pid as libc::pid_t;
+    let pid = child.id() as libc::pid_t;
     let pgid = session.pgid;
 
     let _ = channel.send(ScriptEvent::Started {
@@ -817,7 +819,7 @@ pub(crate) fn run_script_with_shell(
                 // POLLHUP / POLLERR fire when the slave fd is closed (child
                 // exited). We still try to read first so any pending bytes
                 // ahead of the hangup are delivered.
-                let hung_up = match crate::platform::pty::poll_readable(&master, POLL_TIMEOUT_MS) {
+                let hung_up = match master.poll_readable(POLL_TIMEOUT_MS) {
                     Ok(crate::platform::pty::PollResult::TimedOut)
                     | Ok(crate::platform::pty::PollResult::Interrupted) => continue,
                     Ok(crate::platform::pty::PollResult::Ready { hung_up }) => hung_up,
@@ -991,7 +993,9 @@ mod tests {
             .write(true)
             .open("/dev/null")
             .expect("open /dev/null");
-        let stdin_arc = Arc::new(Mutex::new(stdin));
+        let stdin_arc: Arc<Mutex<Box<dyn crate::platform::pty::PtyWriter>>> = Arc::new(Mutex::new(
+            Box::new(crate::platform::pty::UnixPtyWriter(stdin)),
+        ));
         let killed = mgr.register(key, pid, pgid, stdin_arc, None);
         (child, pid, pgid, killed)
     }


### PR DESCRIPTION
Follow-up to the platform boundary work (#741) and build boundary (#742). Extracts the two remaining OS-divergent surfaces that still forced platform-specific code to live in shared business files, so a Windows port can land **strictly on top of the seam** instead of rewriting shared logic.

This is a **behavior-preserving extraction**: code is moved out of the shared files into `platform/`, the macOS/Unix path is the unchanged reference, and Windows arms are stubbed (`Unsupported`). No macOS behavior, build output, or release config changes.

## Seams added

### `platform::pty`
PTY session lifecycle, previously hand-rolled inline in `workspace::scripts`:
- `open` (`openpty`), session-leader setup (`setsid` + `TIOCSCTTY`), non-blocking `poll(2)` read, `TIOCSWINSZ` resize.
- `spawn(cmd) -> PtySession { child, pid, pgid, writer, reader }`, `resize`, `poll_readable`, `is_session_disconnect`.
- `workspace::scripts` now builds the `Command` and drives the PTY through the seam — no raw `libc` PTY syscalls in the run/terminal orchestration. The process-tree kill path already routes through `platform::process` (#741), so the reader/spawn/resize were the remaining gap.

### `platform::cli_install`
Managed `helmor` CLI launcher install, previously inline `cfg(unix)` in `commands::system_commands`:
- `install_target(name)` (target path), `classify(install_path, expected)` (symlink classification → `ManagedCliStatus`), `create_managed_link(src, dst)` (the link primitive).
- `commands::system_commands` keeps the install **orchestration** (elevation policy, remediation, self-heal) and routes the OS-divergent primitives through the seam; the residual `cfg(unix)` symlink call is gone.

## Hardening
- `release:verify` (`scripts/verify-release-config.mjs`) now asserts `bundle.createUpdaterArtifacts === true`, so a platform bundle can't silently disable the macOS updater pipeline by flipping the shared global flag (a regression class that otherwise only the `build-platform.test.js` guard catches).

## Windows
All Windows arms are stubbed and clearly documented (ConPTY for `pty::spawn`; `.cmd`/`.exe` shim under `%LOCALAPPDATA%` for `cli_install`). They are filled by the Windows port, which can now be reviewed as "does the Windows adapter satisfy the already-reviewed contract" rather than a cross-platform rewrite.

## Verification (macOS)
- `cargo fmt` + `cargo clippy -- -D warnings` clean (enforced by the pre-commit hook).
- `platform::cli_install` unit tests: 15/15 pass (incl. the existing `system_commands` install/classify/heal tests, routed through the seam).
- New `platform::pty` + `platform::cli_install` seam tests added.
- Full `cargo test` (lib + integration/snapshots) runs in CI.