### PR TITLE
fix(composer): plan keyboard shortcut exits to bypassPermissions, not default (#733)

### DIFF
--- a/.changeset/plan-toggle-permission-mode.md
+++ b/.changeset/plan-toggle-permission-mode.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix the plan-mode keyboard shortcut so leaving plan mode returns to full-access mode (matching the Plan button), instead of switching to a mode that re-prompted for tool and MCP approvals.

--- a/src/features/composer/index.test.tsx
+++ b/src/features/composer/index.test.tsx
@@ -1588,4 +1588,48 @@ describe("WorkspaceComposer", () => {
 		await userEvent.click(planButton);
 		expect(onChangePermissionMode).toHaveBeenCalledWith("bypassPermissions");
 	});
+
+	it("plan keyboard shortcut exits plan into bypassPermissions (matches the button), not default (#733)", () => {
+		const queryClient = createHelmorQueryClient();
+		const onChangePermissionMode = vi.fn();
+
+		const { container } = render(
+			<QueryClientProvider client={queryClient}>
+				<WorkspaceComposer
+					contextKey="session:session-1"
+					onSubmit={vi.fn()}
+					disabled={false}
+					submitDisabled={false}
+					sending={false}
+					selectedModelId="opus-1m"
+					modelSections={MODEL_SECTIONS}
+					onSelectModel={vi.fn()}
+					provider="codex"
+					effortLevel="high"
+					onSelectEffort={vi.fn()}
+					permissionMode="plan"
+					onChangePermissionMode={onChangePermissionMode}
+					togglePlanShortcut="Mod+Shift+P"
+					focusScope="workspace-composer"
+					restoreImages={[]}
+					restoreFiles={[]}
+					restoreCustomTags={[]}
+				/>
+			</QueryClientProvider>,
+		);
+
+		const root = container.querySelector(
+			'[data-focus-scope="workspace-composer"]',
+		);
+		expect(root).not.toBeNull();
+		fireEvent.keyDown(root as Element, {
+			code: "KeyP",
+			key: "p",
+			metaKey: true,
+			shiftKey: true,
+		});
+
+		expect(onChangePermissionMode).toHaveBeenCalledWith("bypassPermissions");
+		expect(onChangePermissionMode).not.toHaveBeenCalledWith("default");
+	});
 });

--- a/src/features/composer/index.tsx
+++ b/src/features/composer/index.tsx
@@ -695,7 +695,12 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 			) {
 				event.preventDefault();
 				event.stopPropagation();
-				onChangePermissionMode(permissionMode === "plan" ? "default" : "plan");
+				// Exit plan into bypassPermissions, matching the Plan button and
+				// handlePlanImplement. "default" left Codex prompting for MCP
+				// tool calls despite full-access sandbox (#733).
+				onChangePermissionMode(
+					permissionMode === "plan" ? "bypassPermissions" : "plan",
+				);
 			}
 		},
 		[


### PR DESCRIPTION
## Summary

Fixed the plan mode toggle keyboard shortcut (Mod+Shift+P) to exit into `bypassPermissions` instead of `default` permission mode.

## What changed

- When exiting plan mode via keyboard shortcut, now transitions to `bypassPermissions` to match the Plan button behavior
- This prevents Codex from prompting for MCP tool calls despite being in full-access sandbox mode
- Added test case to verify the keyboard shortcut behavior explicitly

## Test notes

- All existing tests pass
- New test `plan keyboard shortcut exits plan into bypassPermissions (matches the button), not default (#733)` verifies the fix
- Manual testing: Mod+Shift+P in plan mode now correctly exits to bypassPermissions mode