### PR TITLE
feat(opencode): support plan review mode

### DIFF
--- a/.changeset/opencode-plan-review.md
+++ b/.changeset/opencode-plan-review.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Bring Helmor's plan review flow to OpenCode — plan mode now drafts a read-only plan you can Implement or request changes on, just like Claude and Codex.

--- a/sidecar/src/opencode-session-manager.test.ts
+++ b/sidecar/src/opencode-session-manager.test.ts
@@ -1,14 +1,20 @@
 import { describe, expect, test } from "bun:test";
 import {
+	assemblePlanText,
 	buildContextUsageMeta,
 	buildImageParts,
 	buildPermissionRules,
 	buildPromptParts,
+	capturePlanPart,
 	extractTitleText,
 	flattenOpencodeModels,
 	mapQuestionAnswers,
+	newPlanCapture,
+	notePlanMessage,
 	parseModelSlug,
 	parseSlashCommand,
+	planMessageId,
+	resetPlanCapture,
 } from "./opencode-session-manager.js";
 
 describe("parseSlashCommand", () => {
@@ -197,6 +203,13 @@ describe("buildPermissionRules", () => {
 		);
 	});
 
+	test("plan mode is allow-all (matches t3code; plan agent blocks edits, reads don't prompt)", () => {
+		// No ask-all fallthrough — that was the bug (reads prompting in plan mode).
+		expect(buildPermissionRules("plan")).toEqual([
+			{ permission: "*", pattern: "*", action: "allow" },
+		]);
+	});
+
 	test("acceptEdits adds an edit allow on top of ask-all", () => {
 		const rules = buildPermissionRules("acceptEdits");
 		expect(rules).toHaveLength(3);
@@ -249,6 +262,112 @@ describe("mapQuestionAnswers", () => {
 
 	test("returns empty arrays when content is missing", () => {
 		expect(mapQuestionAnswers(questions, undefined)).toEqual([[], []]);
+	});
+});
+
+describe("plan capture (opencode plan mode → plan-review card)", () => {
+	const textUpdated = (messageID: string, id: string, text: string) => ({
+		type: "message.part.updated",
+		properties: { part: { type: "text", id, messageID, text } },
+	});
+
+	test("captures assistant text snapshots, latest snapshot wins per part", () => {
+		const cap = newPlanCapture();
+		notePlanMessage(cap, { role: "assistant", id: "m1" });
+		// Streamed snapshots for the same part — final one is authoritative.
+		expect(capturePlanPart(cap, textUpdated("m1", "p1", "## Pla"))).toBe(true);
+		expect(
+			capturePlanPart(cap, textUpdated("m1", "p1", "## Plan\n- step")),
+		).toBe(true);
+		expect(assemblePlanText(cap)).toBe("## Plan\n- step");
+		expect(planMessageId(cap)).toBe("m1");
+	});
+
+	test("captures text that arrives BEFORE its role event (the race)", () => {
+		const cap = newPlanCapture();
+		// opencode emits the text part first; role (message.updated) lands later.
+		expect(capturePlanPart(cap, textUpdated("m1", "p1", "the plan"))).toBe(
+			true,
+		);
+		// Before the role is known, the split is undecided → nothing assembled yet.
+		expect(assemblePlanText(cap)).toBe("");
+		// Role arrives at/by idle → the captured text is now attributed correctly.
+		notePlanMessage(cap, { role: "assistant", id: "m1" });
+		expect(assemblePlanText(cap)).toBe("the plan");
+		expect(planMessageId(cap)).toBe("m1");
+	});
+
+	test("joins multiple text parts in arrival order", () => {
+		const cap = newPlanCapture();
+		notePlanMessage(cap, { role: "assistant", id: "m1" });
+		capturePlanPart(cap, textUpdated("m1", "p1", "intro"));
+		capturePlanPart(cap, textUpdated("m1", "p2", "the plan"));
+		expect(assemblePlanText(cap)).toBe("intro\n\nthe plan");
+	});
+
+	test("drops all deltas (suppressed so partial prose never leaks)", () => {
+		const cap = newPlanCapture();
+		expect(
+			capturePlanPart(cap, {
+				type: "message.part.delta",
+				properties: { partID: "p1", field: "text", delta: "abc" },
+			}),
+		).toBe(true);
+		// Delta content is NOT captured — only full-text snapshots are.
+		expect(assemblePlanText(cap)).toBe("");
+	});
+
+	test("suppresses the user-prompt echo but excludes it from the plan", () => {
+		const cap = newPlanCapture();
+		notePlanMessage(cap, { role: "user", id: "u1" });
+		notePlanMessage(cap, { role: "assistant", id: "m1" });
+		// User echo text is suppressed (true) — the accumulator drops it anyway —
+		// but it must NOT end up in the plan.
+		expect(capturePlanPart(cap, textUpdated("u1", "pu", "my request"))).toBe(
+			true,
+		);
+		expect(capturePlanPart(cap, textUpdated("m1", "p1", "the plan"))).toBe(
+			true,
+		);
+		expect(assemblePlanText(cap)).toBe("the plan");
+		expect(planMessageId(cap)).toBe("m1");
+	});
+
+	test("passes through non-text parts and lifecycle events", () => {
+		const cap = newPlanCapture();
+		notePlanMessage(cap, { role: "assistant", id: "m1" });
+		expect(
+			capturePlanPart(cap, {
+				type: "message.part.updated",
+				properties: { part: { type: "tool", id: "t1", messageID: "m1" } },
+			}),
+		).toBe(false);
+		expect(
+			capturePlanPart(cap, {
+				type: "message.part.updated",
+				properties: { part: { type: "reasoning", id: "r1", messageID: "m1" } },
+			}),
+		).toBe(false);
+		expect(capturePlanPart(cap, { type: "session.idle" })).toBe(false);
+	});
+
+	test("notePlanMessage records both user and assistant roles", () => {
+		const cap = newPlanCapture();
+		notePlanMessage(cap, { role: "user", id: "u1" });
+		notePlanMessage(cap, { role: "assistant", id: "m1" });
+		notePlanMessage(cap, undefined);
+		expect(cap.roleByMessageId.get("u1")).toBe("user");
+		expect(cap.roleByMessageId.get("m1")).toBe("assistant");
+	});
+
+	test("resetPlanCapture clears state between turns", () => {
+		const cap = newPlanCapture();
+		notePlanMessage(cap, { role: "assistant", id: "m1" });
+		capturePlanPart(cap, textUpdated("m1", "p1", "old plan"));
+		resetPlanCapture(cap);
+		expect(assemblePlanText(cap)).toBe("");
+		expect(planMessageId(cap)).toBeNull();
+		expect(cap.roleByMessageId.size).toBe(0);
 	});
 });
 

--- a/sidecar/src/opencode-session-manager.ts
+++ b/sidecar/src/opencode-session-manager.ts
@@ -47,6 +47,9 @@ interface SessionCtx {
 	 *  reused, so the next turn's pump subscribes with a live signal. */
 	abort: AbortController;
 	pumpStarted: boolean;
+	/** Client the live pump subscribed with. On `opencode serve` respawn a turn
+	 *  gets a new client; we rebind the pump when this no longer matches it. */
+	pumpClient?: OpencodeClient;
 	/** Last turn's model + effort variant, reused by `steer`. */
 	lastModel?: { providerID: string; modelID: string; variant?: string };
 	contextTokens: number;
@@ -59,6 +62,11 @@ interface SessionCtx {
 	};
 	/** childSessionId → parent `task` tool callID (subagent nesting). */
 	readonly subtaskParents: Map<string, string>;
+	/** This turn runs opencode's read-only `plan` agent — no ExitPlanMode signal,
+	 *  so we capture the assistant text and re-surface it as a plan-review card. */
+	planMode: boolean;
+	/** Per-turn plan text capture (reset at turn start). */
+	readonly planCapture: PlanCapture;
 }
 
 interface OpencodeProviderList {
@@ -105,6 +113,88 @@ export function flattenOpencodeModels(
 		}
 	}
 	return out.sort((a, b) => a.label.localeCompare(b.label));
+}
+
+// ── Plan-mode capture ────────────────────────────────────────────────────────
+// opencode's `plan` agent has no ExitPlanMode signal — the plan is just streamed
+// assistant text. Capture it and re-emit as `planCaptured` (Claude/Cursor's rail)
+// for the plan-review card, suppressing the now-duplicate prose from the stream.
+
+export interface PlanCapture {
+	/** messageID → role. opencode can emit a part before its role event, so the
+	 *  assistant-vs-user split is resolved at idle, not at part-arrival time. */
+	readonly roleByMessageId: Map<string, string>;
+	/** partID → text snapshot + owning messageID; insertion order = read order. */
+	readonly text: Map<string, { messageId: string; text: string }>;
+}
+
+export function newPlanCapture(): PlanCapture {
+	return { roleByMessageId: new Map(), text: new Map() };
+}
+
+export function resetPlanCapture(capture: PlanCapture): void {
+	capture.roleByMessageId.clear();
+	capture.text.clear();
+}
+
+/** Record a message's role (user or assistant) for the idle-time split. */
+export function notePlanMessage(
+	capture: PlanCapture,
+	info: { role?: string; id?: string } | undefined,
+): void {
+	if (typeof info?.id === "string" && typeof info.role === "string") {
+		capture.roleByMessageId.set(info.id, info.role);
+	}
+}
+
+/** Suppress all token deltas + text snapshots in plan mode (the user echo is
+ *  dropped by the accumulator anyway) and capture them. The assistant/user split
+ *  is deferred to assemblePlanText. Returns true when the event is consumed. */
+export function capturePlanPart(
+	capture: PlanCapture,
+	event: { type: string; properties?: Record<string, unknown> },
+): boolean {
+	// Drop token deltas; the later full-text snapshot is authoritative.
+	if (event.type === "message.part.delta") return true;
+	if (event.type !== "message.part.updated") return false;
+	const part = (
+		event.properties as
+			| {
+					part?: {
+						type?: string;
+						id?: string;
+						messageID?: string;
+						text?: string;
+					};
+			  }
+			| undefined
+	)?.part;
+	if (part?.type !== "text") return false;
+	if (typeof part.id === "string" && typeof part.messageID === "string") {
+		capture.text.set(part.id, {
+			messageId: part.messageID,
+			text: typeof part.text === "string" ? part.text : "",
+		});
+	}
+	return true;
+}
+
+/** Concatenate captured assistant text in arrival order (user echo excluded). */
+export function assemblePlanText(capture: PlanCapture): string {
+	const out: string[] = [];
+	for (const { messageId, text } of capture.text.values()) {
+		if (capture.roleByMessageId.get(messageId) === "assistant") out.push(text);
+	}
+	return out.join("\n\n").trim();
+}
+
+/** First assistant message id with plan text — seeds the synthetic tool-use id. */
+export function planMessageId(capture: PlanCapture): string | null {
+	for (const { messageId } of capture.text.values()) {
+		if (capture.roleByMessageId.get(messageId) === "assistant")
+			return messageId;
+	}
+	return null;
 }
 
 const IMAGE_MIME_BY_EXT: Record<string, string> = {
@@ -178,7 +268,12 @@ const OPENCODE_PERMISSION_PREFIX = "opencode-";
 export function buildPermissionRules(
 	mode: string | undefined,
 ): PermissionRuleset {
-	if (mode === "bypassPermissions" || mode === "dontAsk" || mode === "auto") {
+	if (
+		mode === "bypassPermissions" ||
+		mode === "dontAsk" ||
+		mode === "auto" ||
+		mode === "plan"
+	) {
 		return [{ permission: "*", pattern: "*", action: "allow" }];
 	}
 	const rules: PermissionRuleset = [
@@ -390,6 +485,8 @@ export class OpencodeSessionManager implements SessionManager {
 				abort: new AbortController(),
 				pumpStarted: false,
 				subtaskParents: new Map(),
+				planMode: false,
+				planCapture: newPlanCapture(),
 				contextTokens: 0,
 				contextParts: {
 					input: 0,
@@ -421,7 +518,22 @@ export class OpencodeSessionManager implements SessionManager {
 		ctx.activeRequestId = requestId;
 		ctx.activeEmitter = emitter;
 		ctx.aborted = false;
+		ctx.planMode = params.permissionMode === "plan";
+		resetPlanCapture(ctx.planCapture);
 		this.ensureSessionPump(client, ctx);
+
+		// opencode pins permission rules at session.create; re-apply every turn so a
+		// mode switch (plan → bypassPermissions on Implement) takes effect on a
+		// reused/resumed session instead of still prompting per tool call.
+		try {
+			await client.session.update({
+				sessionID: ctx.openCodeSessionId,
+				directory,
+				permission: buildPermissionRules(params.permissionMode),
+			});
+		} catch (error) {
+			logger.debug("opencode permission update failed", errorDetails(error));
+		}
 
 		const turnDone = new Promise<void>((resolve, reject) => {
 			ctx!.settle = { resolve, reject };
@@ -432,9 +544,9 @@ export class OpencodeSessionManager implements SessionManager {
 		const effort = params.effortLevel?.trim();
 		if (model && effort) model.variant = effort;
 		if (model) ctx.lastModel = model;
-		// Plan mode runs opencode's read-only `plan` agent; it ends by calling
-		// `plan_exit`, which asks (via the question flow) to switch to `build`.
-		const planAgent = params.permissionMode === "plan" ? "plan" : undefined;
+		// Plan mode runs opencode's read-only `plan` agent; its text is captured at
+		// idle and re-surfaced as a plan-review card (see ctx.planMode below).
+		const planAgent = ctx.planMode ? "plan" : undefined;
 		// `/compact` uses session.summarize (V2 compact is still a 503 stub in
 		// 1.16.x); it BLOCKS until idle and requires providerID/modelID.
 		const isCompact = params.prompt.trim() === "/compact";
@@ -513,6 +625,17 @@ export class OpencodeSessionManager implements SessionManager {
 			emitter.aborted(requestId, "user_requested");
 		} else if (turnError) {
 			emitter.error(requestId, `opencode: ${turnError.message}`);
+		} else if (ctx.planMode) {
+			// Re-surface the captured plan as a plan-review card (lands after the
+			// turn's prose, before `end`) so the Implement / Request-Changes CTA shows.
+			const planText = assemblePlanText(ctx.planCapture);
+			if (planText) {
+				emitter.planCaptured(
+					requestId,
+					`opencode-plan-${planMessageId(ctx.planCapture) ?? requestId}`,
+					planText,
+				);
+			}
 		}
 		// Emit BEFORE `end`: Rust's stream loop breaks on the terminal event.
 		await this.emitContextUsage(ctx, requestId, emitter);
@@ -520,11 +643,18 @@ export class OpencodeSessionManager implements SessionManager {
 	}
 
 	private ensureSessionPump(client: OpencodeClient, ctx: SessionCtx): void {
-		if (ctx.pumpStarted) return;
-		// A stopped session left `ctx.abort` aborted; swap in a fresh one so
-		// the reused turn's pump subscribes with a live signal.
+		// Already pumping on the SAME server → reuse it.
+		if (ctx.pumpStarted && ctx.pumpClient === client) return;
+		// Server respawned → new client; tear down the old pump (dead socket) first.
+		if (ctx.pumpStarted && ctx.pumpClient !== client) {
+			ctx.abort.abort();
+			ctx.pumpStarted = false;
+		}
+		// A stopped/torn-down session left `ctx.abort` aborted; swap in a fresh one
+		// so the reused turn's pump subscribes with a live signal.
 		if (ctx.abort.signal.aborted) ctx.abort = new AbortController();
 		ctx.pumpStarted = true;
+		ctx.pumpClient = client;
 		void this.runSessionPump(client, ctx);
 	}
 
@@ -572,6 +702,10 @@ export class OpencodeSessionManager implements SessionManager {
 	private handleServerExit(): void {
 		for (const ctx of this.sessions.values()) {
 			ctx.settle?.reject(new Error("opencode server exited unexpectedly"));
+			// Tear down the pump bound to the dead server (its SSE may hang, leaving
+			// `pumpStarted` stuck true); the next turn rebinds to the respawned one.
+			ctx.abort.abort();
+			ctx.pumpStarted = false;
 		}
 	}
 
@@ -599,8 +733,11 @@ export class OpencodeSessionManager implements SessionManager {
 		// Track context size for the usage ring (input+output+reasoning+cache).
 		if (event.type === "message.updated") {
 			const info = (
-				event.properties as { info?: OpencodeMessageInfo } | undefined
+				event.properties as
+					| { info?: OpencodeMessageInfo & { id?: string } }
+					| undefined
 			)?.info;
+			if (ctx.planMode) notePlanMessage(ctx.planCapture, info);
 			const t = info?.tokens;
 			if (info?.role === "assistant" && t && (t.output ?? 0) > 0) {
 				ctx.contextParts = {
@@ -635,6 +772,11 @@ export class OpencodeSessionManager implements SessionManager {
 			default:
 				break;
 		}
+
+		// Plan mode: capture the plan text and drop it from the live stream so it
+		// re-surfaces once as a plan-review card (planCaptured at idle) rather than
+		// duplicated as prose. Lifecycle events (session.idle) fall through.
+		if (ctx.planMode && capturePlanPart(ctx.planCapture, event)) return;
 
 		// Verbatim passthrough, namespaced. Skip `session.next.*`: it's the
 		// redundant raw form of the `message.part.*` the accumulator consumes.


### PR DESCRIPTION
## Summary
Implement plan mode for OpenCode that captures the read-only plan agent's text output and re-surfaces it as a plan-review card, enabling Implement and Request-Changes CTAs just like Claude and Codex.

## What Changed
- **Plan capture infrastructure**: New `PlanCapture` interface and utilities (`newPlanCapture`, `resetPlanCapture`, `notePlanMessage`, `capturePlanPart`, `assemblePlanText`, `planMessageId`) to collect plan text snapshots
- **Plan mode handling**: Added `plan` to the permission rules allow-all list and plan mode context tracking
- **Session pump rebinding**: Fixed pump lifecycle to properly tear down and rebind when the OpenCode server respawns (on a new client connection)
- **Event filtering**: Plan mode now suppresses streamed plan text from the live event stream (including token deltas and user-echo prose) so it re-surfaces cleanly as a plan-review card at idle
- **Comprehensive tests**: Added 8 new test cases covering plan capture edge cases (role-race, multiple parts, delta suppression, user-echo filtering)

## Why
Brings feature parity with Claude Code and Codex: users can now run OpenCode in plan mode, review the draft plan, and either proceed with implementation or request changes—all within a unified interface.

## Test Notes
- All existing tests pass
- New tests cover: part capture, role-message race, part concatenation, delta suppression, user-echo handling, lifecycle events, multi-role messages, and state reset
- Manual testing should verify plan-review card surfaces on idle (after `session.idle` event) and CTA buttons integrate properly