### PR TITLE
fix(composer): restore cursor visibility after clearing history

### DIFF
--- a/src/features/composer/editor/plugins/history-recall-plugin.tsx
+++ b/src/features/composer/editor/plugins/history-recall-plugin.tsx
@@ -223,6 +223,9 @@ export function HistoryRecallPlugin({ getHistory, scopeKey }: Props) {
 			editor.update(
 				() => {
 					$setEditorContent("", [], [], []);
+					// Re-place the caret — rebuilding the root drops the selection,
+					// which leaves the composer with no visible cursor.
+					$getRoot().selectEnd();
 				},
 				{ tag: HISTORY_RECALL_RESTORE_TAG },
 			);


### PR DESCRIPTION
## Summary

Fixes the missing cursor in the composer when history is recalled and the editor is cleared. The root rebuild operation in the Lexical editor drops the selection state, which leaves the composer without a visible cursor until the user types or interacts with the editor.

## Changes

- Re-place the caret at the end of the content after clearing the editor via `$getRoot().selectEnd()`
- Added clarifying comment explaining the cursor visibility issue

## Test plan

- Recall a history entry in the composer
- Verify the cursor is visibly placed in the (now-empty) editor
- Verify typing immediately after recall works as expected