### PR TITLE
Unify stop-turn handling across all session managers

### DIFF
--- a/.changeset/instant-first-turn-abort.md
+++ b/.changeset/instant-first-turn-abort.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix the Stop button lagging on the first message of a new Codex, Cursor, or OpenCode session — pressing Stop now cancels the turn instantly instead of waiting for the agent to finish starting up.

--- a/sidecar/src/active-turn-registry.ts
+++ b/sidecar/src/active-turn-registry.ts
@@ -1,0 +1,79 @@
+import type { SidecarEmitter } from "./emitter.js";
+
+/**
+ * Shared per-session active-turn tracking so every provider handles Stop
+ * identically — no per-provider abort logic.
+ *
+ * The problem this solves: a manager that registers its session only AFTER
+ * the (1-2s) first-turn startup (`ensureContext` / `Agent.create` /
+ * `server.start`) can't honor a Stop pressed during startup, so the abort
+ * lags until startup finishes.
+ *
+ * The fix (Claude's pattern, generalized): `sendMessage` calls `begin()`
+ * BEFORE any await, capturing the turn's `emitter` + `requestId`.
+ * `stopSession` then calls `requestStop()`, which emits the terminal
+ * `aborted` INSTANTLY and runs the provider's `teardown` — at any point,
+ * including mid-startup. The provider checks `isAbortRequested()` right
+ * after startup to skip running the turn, and the streaming loop reads it
+ * to avoid a duplicate terminal event.
+ */
+interface ActiveTurn {
+	requestId: string;
+	emitter: SidecarEmitter;
+	abortEmitted: boolean;
+	/** Provider-specific teardown (abort controller / kill server / cancel
+	 *  run). May be upgraded via `setTeardown` once a fuller handle exists. */
+	teardown: () => void;
+}
+
+export class ActiveTurnRegistry {
+	private readonly turns = new Map<string, ActiveTurn>();
+
+	/** Register a turn at `sendMessage` start, before any await. */
+	begin(
+		sessionId: string,
+		requestId: string,
+		emitter: SidecarEmitter,
+		teardown: () => void,
+	): void {
+		this.turns.set(sessionId, {
+			requestId,
+			emitter,
+			abortEmitted: false,
+			teardown,
+		});
+	}
+
+	/** Replace the teardown once a real handle exists (e.g. after the
+	 *  server/agent/run is live). No-op if the turn already ended. */
+	setTeardown(sessionId: string, teardown: () => void): void {
+		const turn = this.turns.get(sessionId);
+		if (turn) turn.teardown = teardown;
+	}
+
+	/** Stop the active turn: emit `aborted` now + run teardown. Idempotent;
+	 *  no-op if there's no live turn (`begin` not yet called / already ended). */
+	requestStop(sessionId: string): boolean {
+		const turn = this.turns.get(sessionId);
+		if (!turn || turn.abortEmitted) return false;
+		turn.abortEmitted = true;
+		turn.emitter.aborted(turn.requestId, "user_requested");
+		try {
+			turn.teardown();
+		} catch {
+			// best-effort — teardown must never throw past the stop
+		}
+		return true;
+	}
+
+	/** Whether Stop was requested for this turn. Providers gate the
+	 *  post-startup turn dispatch + the streaming loop's terminal emit on it. */
+	isAbortRequested(sessionId: string): boolean {
+		return this.turns.get(sessionId)?.abortEmitted ?? false;
+	}
+
+	/** Clear the turn once a terminal event has been emitted. */
+	end(sessionId: string): void {
+		this.turns.delete(sessionId);
+	}
+}

--- a/sidecar/src/claude-session-manager.ts
+++ b/sidecar/src/claude-session-manager.ts
@@ -15,6 +15,7 @@ import {
 	type SDKUserMessage,
 } from "@anthropic-ai/claude-agent-sdk";
 import { isAbortError, isQueryClosedTransient } from "./abort.js";
+import { ActiveTurnRegistry } from "./active-turn-registry.js";
 import { buildAgentProxyEnv } from "./agent-proxy.js";
 import { loadProjectMcpServers } from "./claude-project-mcp.js";
 import { buildClaudeRichMeta, buildClaudeStoredMeta } from "./context-usage.js";
@@ -163,10 +164,6 @@ interface LiveSession {
 	 *  synthetic user event to the pipeline so the UI renders the mid-turn
 	 *  bubble at the correct position instead of tacking it onto the end. */
 	readonly emitter: SidecarEmitter;
-	/** Set by `stopSession` once it has emitted `aborted` up front, so the
-	 *  for-await catch doesn't emit a duplicate when the SDK iterator finally
-	 *  unwinds (its child teardown defers SIGTERM by ~2s). */
-	abortEmitted?: boolean;
 }
 
 // Helmor models permission as a binary: `plan` (read-only) or full access.
@@ -320,6 +317,9 @@ async function buildUserMessageWithImages(
 
 export class ClaudeSessionManager implements SessionManager {
 	private readonly sessions = new Map<string, LiveSession>();
+	/** Shared Stop handling: instant `aborted` emit at any point (see
+	 *  ActiveTurnRegistry). Identical across all four providers. */
+	private readonly turns = new ActiveTurnRegistry();
 	private readonly pendingPermissions = new Map<
 		string,
 		(resolution: PermissionResolution) => void
@@ -384,6 +384,11 @@ export class ClaudeSessionManager implements SessionManager {
 			sourceRepoPath,
 		} = params;
 		const abortController = new AbortController();
+		// Register the turn before any await so a Stop during SDK startup
+		// emits `aborted` instantly + aborts the query.
+		this.turns.begin(sessionId, requestId, emitter, () =>
+			abortController.abort(),
+		);
 		const additionalDirectories = [...(params.additionalDirectories ?? [])];
 		logger.info(`[${requestId}] claude additionalDirectories resolved`, {
 			directories: additionalDirectories,
@@ -678,7 +683,7 @@ export class ClaudeSessionManager implements SessionManager {
 				// so the iterator can still drain buffered events — even a natural
 				// `result`. Drop them and return: passing them through or emitting
 				// `end` here would violate the "exactly one terminal event" contract.
-				if (live.abortEmitted) return;
+				if (this.turns.isAbortRequested(sessionId)) return;
 				logger.sdkEvent(requestId, message);
 				if (message.type === "rate_limit_event") {
 					lastRateLimitInfo = (
@@ -732,12 +737,13 @@ export class ClaudeSessionManager implements SessionManager {
 					return;
 				}
 			}
-			if (!live.abortEmitted) emitter.end(requestId);
+			if (!this.turns.isAbortRequested(sessionId)) emitter.end(requestId);
 		} catch (err) {
 			if (isAbortError(err)) {
 				// stopSession already emitted `aborted` up front (see below) —
 				// don't double-emit when the iterator finally unwinds.
-				if (!live.abortEmitted) emitter.aborted(requestId, "user_requested");
+				if (!this.turns.isAbortRequested(sessionId))
+					emitter.aborted(requestId, "user_requested");
 				return;
 			}
 			throw err;
@@ -758,6 +764,7 @@ export class ClaudeSessionManager implements SessionManager {
 			}
 			promptSource.close();
 			this.sessions.delete(sessionId);
+			this.turns.end(sessionId);
 			// Only cancel waiters belonging to THIS session — `pendingUserInputs`
 			// is manager-wide and other sessions may have parked AUQs / MCP
 			// elicitations on it.
@@ -1207,18 +1214,11 @@ export class ClaudeSessionManager implements SessionManager {
 	}
 
 	async stopSession(sessionId: string): Promise<void> {
-		const session = this.sessions.get(sessionId);
-		if (session) {
-			// Emit `aborted` now instead of waiting for the SDK's async iterator
-			// to unwind — its child teardown defers SIGTERM by ~2s, which is what
-			// made Claude's Stop button feel laggy (1–2s at any point in a turn).
-			// The abort controller still tears the query down in the background;
-			// the for-await catch skips the duplicate emit via `abortEmitted`.
-			session.abortEmitted = true;
-			session.abortController.abort();
-			session.emitter.aborted(session.requestId, "user_requested");
-			this.sessions.delete(sessionId);
-		}
+		// Instant `aborted` + abort the query (teardown) at any point in the
+		// turn, including SDK startup. The for-await/catch dedupe via the
+		// registry; the finally hard-closes the query in the background.
+		this.turns.requestStop(sessionId);
+		this.sessions.delete(sessionId);
 	}
 
 	async shutdown(): Promise<void> {

--- a/sidecar/src/codex-app-server-manager.ts
+++ b/sidecar/src/codex-app-server-manager.ts
@@ -11,6 +11,7 @@ import crypto from "node:crypto";
 import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
+import { ActiveTurnRegistry } from "./active-turn-registry.js";
 import type { AgentProxySettings } from "./agent-proxy.js";
 import {
 	CodexAppServer,
@@ -445,10 +446,7 @@ export class CodexAppServerManager implements SessionManager {
 	private sessions = new Map<string, AppServerContext>();
 	private pendingApprovals = new Map<string, PendingApproval>();
 	private pendingUserInputs = new Map<string, PendingUserInput>();
-	// Sessions the user hit Stop on while the codex thread was still starting
-	// up (before `ensureContext` registers a context). `sendMessage` consumes
-	// the intent after startup and tears the turn down instead of running it.
-	private abortRequested = new Set<string>();
+	private readonly turns = new ActiveTurnRegistry();
 
 	/** Called by index.ts when frontend responds to a permission prompt. */
 	resolvePermission(permissionId: string, behavior: "allow" | "deny"): void {
@@ -543,10 +541,12 @@ export class CodexAppServerManager implements SessionManager {
 			additionalDirectories,
 			images,
 		} = params;
-		// Drop any stale abort intent from a prior stop that landed with no
-		// live context. A genuine mid-startup stop for THIS turn is recorded
-		// again during the awaits below and caught right after ensureContext.
-		this.abortRequested.delete(sessionId);
+		// Register the turn before any startup await (goal pre-flight +
+		// ensureContext) so a Stop pressed mid-startup emits `aborted`
+		// instantly and tears the turn down via `tearDownTurn`.
+		this.turns.begin(sessionId, requestId, emitter, () =>
+			this.tearDownTurn(sessionId),
+		);
 		const workDir = cwd ?? process.cwd();
 		const effectiveFastMode =
 			fastMode === true && modelSupportsFastMode("codex", model);
@@ -588,13 +588,12 @@ export class CodexAppServerManager implements SessionManager {
 			effectiveFastMode,
 			agentProxy,
 		);
-		// User hit Stop while the thread was still starting up. stopSession
-		// couldn't find a context to kill and only recorded the intent — honor
-		// it now: tear down and report the abort instead of running the turn.
-		if (this.abortRequested.delete(sessionId)) {
+		// Stop pressed during startup — `requestStop` already emitted `aborted`.
+		// Kill the freshly-started server and bail instead of running the turn.
+		if (this.turns.isAbortRequested(sessionId)) {
 			ctx.server.kill();
 			this.sessions.delete(sessionId);
-			emitter.aborted(requestId, "user_requested");
+			this.turns.end(sessionId);
 			return;
 		}
 		// Codex usage notifications do not include a model id.
@@ -641,8 +640,6 @@ export class CodexAppServerManager implements SessionManager {
 		);
 		turnStartParams.sandboxPolicy = sandboxPolicy;
 
-		let aborted = false;
-
 		// Stash the active stream's routing info so `steer()` can fire a
 		// synthetic user passthrough on the correct request id / emitter.
 		ctx.activeRequestId = requestId;
@@ -650,10 +647,7 @@ export class CodexAppServerManager implements SessionManager {
 
 		return new Promise<void>((resolve, reject) => {
 			ctx.turnResolve = resolve;
-			ctx.turnReject = (err) => {
-				aborted = true;
-				reject(err);
-			};
+			ctx.turnReject = reject;
 
 			const emit = (event: object) => {
 				emitter.passthrough(requestId, event);
@@ -1055,11 +1049,12 @@ export class CodexAppServerManager implements SessionManager {
 					reject(err);
 				});
 		}).finally(() => {
-			if (aborted) {
-				emitter.aborted(requestId, "user_requested");
-			} else {
+			// `aborted` is terminal — `requestStop` already emitted it. Only
+			// emit `end` on natural completion / error-resolve, then clear.
+			if (!this.turns.isAbortRequested(sessionId)) {
 				emitter.end(requestId);
 			}
+			this.turns.end(sessionId);
 			if (ctx.activeRequestId === requestId) {
 				ctx.activeRequestId = null;
 				ctx.activeEmitter = null;
@@ -1388,17 +1383,13 @@ export class CodexAppServerManager implements SessionManager {
 
 	// ── stopSession / shutdown ───────────────────────────────────────────
 
-	async stopSession(sessionId: string): Promise<void> {
+	/** Tear down the active turn: drop pending prompts, interrupt the upstream
+	 *  turn (best-effort, no await), kill the app-server, reject the turn
+	 *  promise. No-op if no context is registered yet (mid-startup) — the
+	 *  post-`ensureContext` abort check kills the freshly-started server. */
+	private tearDownTurn(sessionId: string): void {
 		const ctx = this.sessions.get(sessionId);
-		if (!ctx) {
-			// Mid-startup: `ensureContext` (process spawn + initialize +
-			// thread/start) hasn't registered a context yet, so there's
-			// nothing to kill. Record the intent — `sendMessage` honors it
-			// the moment startup lands instead of dropping the abort and
-			// running the turn to completion.
-			this.abortRequested.add(sessionId);
-			return;
-		}
+		if (!ctx) return;
 		logger.info(`stopSession ${sessionId}`, {
 			threadId: ctx.providerThreadId ?? "(none)",
 		});
@@ -1436,9 +1427,14 @@ export class CodexAppServerManager implements SessionManager {
 		ctx.server.kill();
 		this.sessions.delete(sessionId);
 
-		// Use AbortError so the index catch can distinguish user-stop from real errors
-		const abortErr = new DOMException("Session stopped by user", "AbortError");
-		pendingReject?.(abortErr);
+		// AbortError lets the index catch distinguish user-stop from real errors.
+		pendingReject?.(new DOMException("Session stopped by user", "AbortError"));
+	}
+
+	async stopSession(sessionId: string): Promise<void> {
+		// Emits `aborted` instantly + runs `tearDownTurn` — works at any point,
+		// including during the first turn's startup (spawn + thread/start).
+		this.turns.requestStop(sessionId);
 	}
 
 	/**
@@ -1550,12 +1546,12 @@ export class CodexAppServerManager implements SessionManager {
 	}
 
 	async shutdown(): Promise<void> {
-		for (const [_id, ctx] of this.sessions) {
+		for (const sessionId of [...this.sessions.keys()]) {
 			try {
-				ctx.turnReject?.(new Error("Sidecar shutdown"));
-				ctx.turnResolve = null;
-				ctx.turnReject = null;
-				ctx.server.kill();
+				// Abort any active turn (emits `aborted` + rejects), then make
+				// sure the server is dead even on idle sessions.
+				this.turns.requestStop(sessionId);
+				this.sessions.get(sessionId)?.server.kill();
 			} catch (err) {
 				logger.error("shutdown: kill failed", errorDetails(err));
 			}

--- a/sidecar/src/cursor-session-manager.ts
+++ b/sidecar/src/cursor-session-manager.ts
@@ -14,6 +14,7 @@ import {
 	type SDKMessage,
 	type SDKUserMessage,
 } from "@cursor/sdk";
+import { ActiveTurnRegistry } from "./active-turn-registry.js";
 import { scanCursorSkills } from "./cursor-skill-scanner.js";
 import type { SidecarEmitter } from "./emitter.js";
 import { readImageWithResize } from "./image-resize.js";
@@ -45,11 +46,11 @@ interface LiveSession {
 	modelId: string;
 	currentRun: Run | null;
 	currentRequestId: string | null;
-	aborted: boolean;
 }
 
 export class CursorSessionManager implements SessionManager {
 	private readonly sessions = new Map<string, LiveSession>();
+	private readonly turns = new ActiveTurnRegistry();
 	/// Per-wire-id parameters[] cache. Populated by listModels(), read
 	/// by sendMessage() to build ModelParameterValue[].
 	private readonly modelParameters = new Map<
@@ -71,11 +72,8 @@ export class CursorSessionManager implements SessionManager {
 		this.apiKeyHostManaged = true;
 		// Drop existing sessions — they were minted with the old key.
 		// In-flight cursor turns abort; claude/codex unaffected.
-		for (const [, session] of this.sessions) {
-			session.aborted = true;
-			void session.currentRun?.cancel().catch(() => {
-				/* ignored — session may have already finished */
-			});
+		for (const [sessionId, session] of this.sessions) {
+			this.turns.requestStop(sessionId);
 			try {
 				session.agent.close();
 			} catch {
@@ -119,6 +117,16 @@ export class CursorSessionManager implements SessionManager {
 			return;
 		}
 
+		// Register the turn before any startup await so a Stop pressed during
+		// Agent.create / agent.send aborts instantly. Teardown reads the run
+		// lazily — it's null until agent.send resolves.
+		this.turns.begin(params.sessionId, requestId, emitter, () => {
+			void this.sessions
+				.get(params.sessionId)
+				?.currentRun?.cancel()
+				.catch(() => {});
+		});
+
 		const modelId = params.model ?? "composer-2";
 		const cwd = params.cwd ?? process.cwd();
 
@@ -138,7 +146,6 @@ export class CursorSessionManager implements SessionManager {
 					modelId,
 					currentRun: null,
 					currentRequestId: null,
-					aborted: false,
 				};
 				this.sessions.set(params.sessionId, session);
 				// Synthetic event — Rust persists agentId as provider_session_id.
@@ -156,6 +163,13 @@ export class CursorSessionManager implements SessionManager {
 				emitter.end(requestId);
 				return;
 			}
+		}
+
+		// Stop pressed during Agent.create — `requestStop` already emitted
+		// `aborted`. Keep the freshly-minted agent for reuse; just bail.
+		if (this.turns.isAbortRequested(params.sessionId)) {
+			this.turns.end(params.sessionId);
+			return;
 		}
 
 		// Use this turn's modelId, not the agent's create-time pick —
@@ -196,7 +210,13 @@ export class CursorSessionManager implements SessionManager {
 		}
 		session.currentRun = run;
 		session.currentRequestId = requestId;
-		session.aborted = false;
+
+		// Stop pressed during agent.send — the run now exists, so cancel it.
+		if (this.turns.isAbortRequested(params.sessionId)) {
+			void run.cancel().catch(() => {});
+			this.turns.end(params.sessionId);
+			return;
+		}
 
 		// Plan mode ends by calling the `createPlan` tool, whose `args.plan`
 		// is the finished plan markdown. We suppress the raw tool_call (so it
@@ -234,7 +254,7 @@ export class CursorSessionManager implements SessionManager {
 			}
 		} catch (error) {
 			const msg = error instanceof Error ? error.message : String(error);
-			if (session.aborted) {
+			if (this.turns.isAbortRequested(params.sessionId)) {
 				// run.cancel() throws inside stream() — clean abort, not failure.
 				logger.debug(`[${requestId}] Cursor stream aborted by user`);
 			} else {
@@ -248,10 +268,12 @@ export class CursorSessionManager implements SessionManager {
 			session.currentRequestId = null;
 		}
 
-		if (session.aborted) {
-			emitter.aborted(requestId, "user_requested");
+		// `aborted` is terminal — `requestStop` already emitted it. Only emit
+		// `end` on natural completion, then clear the turn.
+		if (!this.turns.isAbortRequested(params.sessionId)) {
+			emitter.end(requestId);
 		}
-		emitter.end(requestId);
+		this.turns.end(params.sessionId);
 	}
 
 	async generateTitle(
@@ -387,18 +409,9 @@ export class CursorSessionManager implements SessionManager {
 	}
 
 	async stopSession(sessionId: string): Promise<void> {
-		const session = this.sessions.get(sessionId);
-		if (!session) return;
-		session.aborted = true;
-		if (session.currentRun) {
-			try {
-				await session.currentRun.cancel();
-			} catch (error) {
-				logger.debug(
-					`[cursor] cancel rejected: ${error instanceof Error ? error.message : String(error)}`,
-				);
-			}
-		}
+		// Emits `aborted` instantly + cancels the run via teardown — works at
+		// any point, including during the first turn's Agent.create startup.
+		this.turns.requestStop(sessionId);
 	}
 
 	async steer(
@@ -412,18 +425,9 @@ export class CursorSessionManager implements SessionManager {
 	}
 
 	async shutdown(): Promise<void> {
-		const tasks: Promise<void>[] = [];
-		for (const [, session] of this.sessions) {
-			session.aborted = true;
-			if (session.currentRun) {
-				tasks.push(
-					session.currentRun.cancel().catch(() => {
-						/* swallow during shutdown */
-					}),
-				);
-			}
+		for (const [sessionId] of this.sessions) {
+			this.turns.requestStop(sessionId);
 		}
-		await Promise.all(tasks);
 		for (const [, session] of this.sessions) {
 			try {
 				session.agent.close();

--- a/sidecar/src/opencode-session-manager.ts
+++ b/sidecar/src/opencode-session-manager.ts
@@ -11,6 +11,7 @@ import type {
 	PermissionRuleset,
 	TextPartInput,
 } from "@opencode-ai/sdk/v2";
+import { ActiveTurnRegistry } from "./active-turn-registry.js";
 import type { SidecarEmitter } from "./emitter.js";
 import { prependLinkedDirectoriesContext } from "./linked-directories-context.js";
 import { errorDetails, logger } from "./logger.js";
@@ -42,7 +43,6 @@ interface SessionCtx {
 	activeRequestId: string | null;
 	activeEmitter: SidecarEmitter | null;
 	settle: TurnSettle | null;
-	aborted: boolean;
 	/** Mutable: replaced with a fresh controller when a stopped session is
 	 *  reused, so the next turn's pump subscribes with a live signal. */
 	abort: AbortController;
@@ -329,8 +329,7 @@ export class OpencodeSessionManager implements SessionManager {
 	private readonly server = new OpencodeServer(() => this.handleServerExit());
 	private readonly sessions = new Map<string, SessionCtx>();
 	private readonly byOpencodeId = new Map<string, SessionCtx>();
-	/** Stop pressed while sendMessage was still in startup (no ctx yet). */
-	private readonly pendingAborts = new Set<string>();
+	private readonly turns = new ActiveTurnRegistry();
 	/** `provider/model` slug → context-window size, for the usage ring. */
 	private readonly modelContextLimits = new Map<string, number>();
 	private readonly pendingPermissions = new Map<
@@ -427,21 +426,29 @@ export class OpencodeSessionManager implements SessionManager {
 		params: SendMessageParams,
 		emitter: SidecarEmitter,
 	): Promise<void> {
+		// Register before startup (server.start + session.create) so a Stop
+		// pressed mid-startup emits `aborted` instantly via `tearDownTurn`.
+		this.turns.begin(params.sessionId, requestId, emitter, () =>
+			this.tearDownTurn(params.sessionId),
+		);
 		let handle: Awaited<ReturnType<OpencodeServer["start"]>>;
 		try {
 			handle = await this.server.start(process.env);
 		} catch (error) {
-			emitter.error(requestId, `opencode: ${errorMessage(error)}`);
-			emitter.end(requestId);
+			if (!this.turns.isAbortRequested(params.sessionId)) {
+				emitter.error(requestId, `opencode: ${errorMessage(error)}`);
+				emitter.end(requestId);
+			}
+			this.turns.end(params.sessionId);
 			return;
 		}
 		const { client } = handle;
 		const directory = params.cwd ?? process.cwd();
 
-		// Stop pressed during server startup → bail before creating a session.
-		if (this.pendingAborts.delete(params.sessionId)) {
-			emitter.aborted(requestId, "user_requested");
-			emitter.end(requestId);
+		// Stop pressed during server startup — `requestStop` already emitted
+		// `aborted`; clear the turn and bail before creating a session.
+		if (this.turns.isAbortRequested(params.sessionId)) {
+			this.turns.end(params.sessionId);
 			return;
 		}
 
@@ -470,14 +477,20 @@ export class OpencodeSessionManager implements SessionManager {
 					});
 					openCodeSessionId = created.data?.id ?? null;
 				} catch (error) {
-					emitter.error(requestId, `opencode: ${errorMessage(error)}`);
-					emitter.end(requestId);
+					if (!this.turns.isAbortRequested(params.sessionId)) {
+						emitter.error(requestId, `opencode: ${errorMessage(error)}`);
+						emitter.end(requestId);
+					}
+					this.turns.end(params.sessionId);
 					return;
 				}
 			}
 			if (!openCodeSessionId) {
-				emitter.error(requestId, "opencode: session.create returned no id");
-				emitter.end(requestId);
+				if (!this.turns.isAbortRequested(params.sessionId)) {
+					emitter.error(requestId, "opencode: session.create returned no id");
+					emitter.end(requestId);
+				}
+				this.turns.end(params.sessionId);
 				return;
 			}
 			ctx = {
@@ -487,7 +500,6 @@ export class OpencodeSessionManager implements SessionManager {
 				activeRequestId: null,
 				activeEmitter: null,
 				settle: null,
-				aborted: false,
 				abort: new AbortController(),
 				pumpStarted: false,
 				subtaskParents: new Map(),
@@ -512,18 +524,16 @@ export class OpencodeSessionManager implements SessionManager {
 			});
 		}
 
-		// Stop pressed during session create/resume (after the startup check) →
-		// honor it now instead of running the turn.
-		if (this.pendingAborts.delete(params.sessionId)) {
-			emitter.aborted(requestId, "user_requested");
-			emitter.end(requestId);
+		// Stop pressed during session create/resume — `requestStop` already
+		// emitted `aborted`; clear the turn and bail.
+		if (this.turns.isAbortRequested(params.sessionId)) {
+			this.turns.end(params.sessionId);
 			return;
 		}
 
 		ctx.directory = directory;
 		ctx.activeRequestId = requestId;
 		ctx.activeEmitter = emitter;
-		ctx.aborted = false;
 		ctx.planMode = params.permissionMode === "plan";
 		resetPlanCapture(ctx.planCapture);
 		this.ensureSessionPump(client, ctx);
@@ -598,8 +608,11 @@ export class OpencodeSessionManager implements SessionManager {
 			ctx.settle = null;
 			ctx.activeRequestId = null;
 			ctx.activeEmitter = null;
-			emitter.error(requestId, `opencode: ${errorMessage(error)}`);
-			emitter.end(requestId);
+			if (!this.turns.isAbortRequested(params.sessionId)) {
+				emitter.error(requestId, `opencode: ${errorMessage(error)}`);
+				emitter.end(requestId);
+			}
+			this.turns.end(params.sessionId);
 			return;
 		}
 
@@ -614,9 +627,13 @@ export class OpencodeSessionManager implements SessionManager {
 			ctx.activeEmitter = null;
 		}
 
-		if (ctx.aborted) {
-			emitter.aborted(requestId, "user_requested");
-		} else if (turnError) {
+		// Stop pressed — `requestStop` already emitted the terminal `aborted`.
+		if (this.turns.isAbortRequested(params.sessionId)) {
+			this.turns.end(params.sessionId);
+			return;
+		}
+
+		if (turnError) {
 			emitter.error(requestId, `opencode: ${turnError.message}`);
 		} else if (ctx.planMode) {
 			// Re-surface the captured plan as a plan-review card (lands after the
@@ -632,7 +649,12 @@ export class OpencodeSessionManager implements SessionManager {
 		}
 		// Emit BEFORE `end`: Rust's stream loop breaks on the terminal event.
 		await this.emitContextUsage(ctx, requestId, emitter);
-		emitter.end(requestId);
+		// Re-check: a Stop landing during the await above already emitted the
+		// terminal `aborted`, so skip `end` to avoid a double terminal.
+		if (!this.turns.isAbortRequested(params.sessionId)) {
+			emitter.end(requestId);
+		}
+		this.turns.end(params.sessionId);
 	}
 
 	private ensureSessionPump(client: OpencodeClient, ctx: SessionCtx): void {
@@ -1113,25 +1135,21 @@ export class OpencodeSessionManager implements SessionManager {
 		}
 	}
 
-	async stopSession(sessionId: string): Promise<void> {
+	/** Tear down the active turn: unblock `await turnDone`, abort the pump, and
+	 *  fire a best-effort remote abort. No-op if no ctx is registered yet
+	 *  (mid-startup) — the post-startup abort checks bail instead. */
+	private tearDownTurn(sessionId: string): void {
 		const ctx = this.sessions.get(sessionId);
-		if (!ctx) {
-			// Mid-startup: sendMessage hasn't registered a ctx yet. Record the
-			// intent so it's honored once startup lands, not dropped.
-			this.pendingAborts.add(sessionId);
-			return;
-		}
-		this.pendingAborts.delete(sessionId);
-		ctx.aborted = true;
+		if (!ctx) return;
 		this.clearPending(ctx);
 		// Unblock the local turn FIRST — never gate it behind the remote abort
 		// RPC, which can hang against a wedged server and strand `await
-		// turnDone` forever (the bug this fixes). Stop the pump too so we don't
-		// leak the SSE subscription; reuse swaps in a fresh controller.
+		// turnDone` forever. Stop the pump too so we don't leak the SSE
+		// subscription; reuse swaps in a fresh controller.
 		ctx.settle?.resolve();
 		ctx.abort.abort();
 		ctx.pumpStarted = false;
-		// Best-effort remote abort, fire-and-forget: it tells opencode to stop
+		// Best-effort remote abort, fire-and-forget: tells opencode to stop
 		// server-side work but must not block (or fail) the local teardown.
 		void this.server
 			.start(process.env)
@@ -1144,6 +1162,12 @@ export class OpencodeSessionManager implements SessionManager {
 			.catch((error) =>
 				logger.debug("opencode abort failed", errorDetails(error)),
 			);
+	}
+
+	async stopSession(sessionId: string): Promise<void> {
+		// Emits `aborted` instantly + runs `tearDownTurn` — works at any point,
+		// including during the first turn's startup (server.start + create).
+		this.turns.requestStop(sessionId);
 	}
 
 	// Mid-turn steer via a second promptAsync on the busy session. RPC-first:
@@ -1194,15 +1218,12 @@ export class OpencodeSessionManager implements SessionManager {
 
 	async shutdown(): Promise<void> {
 		for (const ctx of this.byOpencodeId.values()) {
-			ctx.aborted = true;
-			ctx.settle?.resolve();
-			ctx.abort.abort();
+			this.turns.requestStop(ctx.helmorSessionId);
 		}
 		this.sessions.clear();
 		this.byOpencodeId.clear();
 		this.pendingPermissions.clear();
 		this.pendingQuestions.clear();
-		this.pendingAborts.clear();
 		this.server.kill();
 	}
 }


### PR DESCRIPTION
## Summary

Extract stop-turn handling into a shared `ActiveTurnRegistry` class used by all four session managers (Claude, Codex, Cursor, OpenCode). This fixes the Stop button lagging on the first message of new Codex, Cursor, and OpenCode sessions.

**Before:** Each manager had its own stop logic (`abortEmitted`, `abortRequested`, `aborted` fields), making it easy to miss the mid-startup case. Stop pressed during `ensureContext` / `Agent.create` / `server.start` couldn't abort instantly.

**After:** `sendMessage` calls `turns.begin()` *before* any await, registering the turn upfront. `stopSession` calls `turns.requestStop()`, which emits `aborted` instantly and runs teardown at any point—including mid-startup. The streaming loop checks `turns.isAbortRequested()` to avoid duplicate terminal events.

## Changes

- **New:** `sidecar/src/active-turn-registry.ts` — Shared registry handling instant abort + idempotent stop logic.
- **Refactored:** All four session managers to use `ActiveTurnRegistry` instead of per-manager abort state.
- **Simplified:** `stopSession` in each manager now delegates to `turns.requestStop()`.

## Testing

The streaming dedup logic mirrors Claude's proven pattern. All four managers now follow identical stop semantics:
1. Stop pressed → `requestStop()` emits `aborted` immediately
2. Teardown fires best-effort (abort controller / kill server / cancel run)
3. Streaming loop skips duplicate terminal if `isAbortRequested()` is true
4. Turn cleared once `end()` is called

Manual testing recommended: press Stop during the first turn's startup on Codex/Cursor/OpenCode and confirm the UI responds instantly (no 1–2s lag).