### PR TITLE
fix(cursor): sign worker native deps so the release bundle notarizes

### DIFF
--- a/sidecar/scripts/stage-vendor.ts
+++ b/sidecar/scripts/stage-vendor.ts
@@ -16,12 +16,15 @@ import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
 	chmodSync,
+	closeSync,
 	cpSync,
 	existsSync,
 	lstatSync,
 	mkdirSync,
+	openSync,
 	readdirSync,
 	readFileSync,
+	readSync,
 	rmSync,
 	statSync,
 	writeFileSync,
@@ -865,7 +868,60 @@ function stageCursorWorkerDeps(target: TargetInfo): string {
 	);
 
 	verifyCursorWorkerArch(dest, npmOs, npmArch);
+	signCursorWorkerMachOs(dest);
 	return dest;
+}
+
+/// The staged node_modules ships native Mach-O (node_sqlite3.node, rg,
+/// cursorsandbox) that arrive ad-hoc/linker-signed. Tauri's signing doesn't
+/// reach nested Resources, so re-sign each with our Developer ID + hardened
+/// runtime (no entitlements — none of them JIT) or notarization rejects the
+/// bundle. No-op when not signing (dev) and skips non-Mach-O (e.g. Windows PE).
+function signCursorWorkerMachOs(dest: string): void {
+	if (!process.env.APPLE_SIGNING_IDENTITY?.trim()) return;
+	const root = join(dest, "node_modules");
+	if (!existsSync(root)) return;
+	let signed = 0;
+	const stack = [root];
+	while (stack.length > 0) {
+		const cur = stack.pop();
+		if (!cur) break;
+		for (const entry of readdirSync(cur)) {
+			const p = join(cur, entry);
+			const st = lstatSync(p);
+			if (st.isSymbolicLink()) continue; // .bin/* point inside the tree
+			if (st.isDirectory()) {
+				stack.push(p);
+			} else if (st.isFile() && isMachO(p)) {
+				maybeSignMacBinary(p, false);
+				signed += 1;
+			}
+		}
+	}
+	console.log(`[stage-vendor] cursor worker: signed ${signed} Mach-O file(s)`);
+}
+
+function isMachO(path: string): boolean {
+	let fd: number | undefined;
+	try {
+		fd = openSync(path, "r");
+		const buf = Buffer.alloc(4);
+		if (readSync(fd, buf, 0, 4, 0) < 4) return false;
+		const magic = buf.toString("hex");
+		// thin Mach-O (LE 64/32, BE 64/32) + fat/universal.
+		return (
+			magic === "cffaedfe" ||
+			magic === "cefaedfe" ||
+			magic === "feedfacf" ||
+			magic === "feedface" ||
+			magic === "cafebabe" ||
+			magic === "bebafeca"
+		);
+	} catch {
+		return false;
+	} finally {
+		if (fd !== undefined) closeSync(fd);
+	}
 }
 
 /// Fail the build if the staged cursor-worker deps aren't the bundle target's

--- a/sidecar/src/cursor-worker/cursor-core.ts
+++ b/sidecar/src/cursor-worker/cursor-core.ts
@@ -22,7 +22,6 @@ import type {
 	ProviderModelInfo,
 	SendMessageParams,
 	SlashCommandInfo,
-	UserInputResolution,
 } from "../session-manager.js";
 import {
 	buildTitlePrompt,
@@ -86,14 +85,6 @@ export class CursorCore {
 
 	private resolveApiKey(): string | null {
 		return this.apiKey;
-	}
-
-	resolveUserInput(
-		_userInputId: string,
-		_resolution: UserInputResolution,
-	): boolean {
-		// SDK auto-handles permission prompts; no waiters to resolve.
-		return false;
 	}
 
 	async sendMessage(
@@ -406,16 +397,6 @@ export class CursorCore {
 		// Emits `aborted` instantly + cancels the run via teardown — works at
 		// any point, including during the first turn's Agent.create startup.
 		this.turns.requestStop(sessionId);
-	}
-
-	async steer(
-		_sessionId: string,
-		_prompt: string,
-		_files: readonly string[],
-		_images: readonly string[],
-	): Promise<boolean> {
-		// SDK has no mid-turn injection; caller queues as a new turn.
-		return false;
 	}
 
 	async shutdown(): Promise<void> {


### PR DESCRIPTION
Follow-up to #765 (Cursor → Node worker).

#765 bundles the Cursor SDK's native deps into `Resources/vendor/cursor-worker/node_modules` (`node_sqlite3.node`, `@cursor/sdk-darwin-*/bin/{rg,cursorsandbox}`). Those Mach-O files ship only ad-hoc / linker-signed, and Helmor's release flow signs vendor binaries **per-file** (no deep-sign) — `stageCursorWorkerDeps` left them untouched, so macOS notarization (and native-addon load under hardened runtime) would fail.

## Changes
- **`stage-vendor.ts`** — after staging + arch-verifying the worker deps, recursively walk the tree, detect Mach-O by magic bytes (skip symlinks and non-Mach-O like Windows PE), and `maybeSignMacBinary(path, false)` each: Developer ID + hardened runtime, no entitlements (none JIT). Gated on `APPLE_SIGNING_IDENTITY`, so it's a no-op in dev / non-mac targets.
- **`cursor-core.ts`** — drop dead `resolveUserInput` / `steer` methods; the worker never calls them (the proxy in `cursor-session-manager.ts` owns those).

No new changeset — the user-facing fix is already covered by #765's; this is packaging correctness for that (still unreleased) change.
