### PR TITLE
fix(cursor): retry transient network failures, survive connection resets

### DIFF
--- a/.changeset/cursor-network-retry.md
+++ b/.changeset/cursor-network-retry.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Cursor now retries transient network failures (Cursor's API occasionally resets the connection) instead of failing the turn, and a dropped connection no longer crashes the Cursor worker with "Cursor worker exited unexpectedly".

--- a/sidecar/src/active-turn-registry.ts
+++ b/sidecar/src/active-turn-registry.ts
@@ -76,4 +76,24 @@ export class ActiveTurnRegistry {
 	end(sessionId: string): void {
 		this.turns.delete(sessionId);
 	}
+
+	/** Terminal-fail every live turn (worker-fatal network blow-up): emit
+	 *  error+end on each non-aborted turn, then clear. Returns the affected
+	 *  requestIds so the caller can release any external (proxy) waiters. */
+	failAll(message: string, internal = true): string[] {
+		const ids: string[] = [];
+		for (const turn of this.turns.values()) {
+			ids.push(turn.requestId);
+			if (turn.abortEmitted) continue;
+			turn.abortEmitted = true;
+			try {
+				turn.emitter.error(turn.requestId, message, internal);
+				turn.emitter.end(turn.requestId);
+			} catch {
+				// best-effort — must never throw past recovery
+			}
+		}
+		this.turns.clear();
+		return ids;
+	}
 }

--- a/sidecar/src/cursor-worker/cursor-core.ts
+++ b/sidecar/src/cursor-worker/cursor-core.ts
@@ -32,6 +32,7 @@ import {
 	buildCursorMessage,
 	computeModelParameterValues,
 	extractCreatePlanText,
+	isRetryableCursorError,
 	modelInfoToProviderInfo,
 	namespaceEvent,
 	toCursorMode,
@@ -39,6 +40,33 @@ import {
 
 /// Cheapest model on the title-gen hot path.
 const TITLE_MODEL_ID = "composer-2";
+
+/// Retry transient network failures (Cursor's API intermittently resets the
+/// TLS handshake) on the SDK's connection-setup calls. 3 attempts, linear
+/// backoff. Non-retryable errors throw immediately.
+const RETRY_ATTEMPTS = 3;
+const RETRY_BACKOFF_MS = 400;
+
+async function withCursorRetry<T>(
+	label: string,
+	fn: () => Promise<T>,
+): Promise<T> {
+	let lastErr: unknown;
+	for (let attempt = 1; attempt <= RETRY_ATTEMPTS; attempt++) {
+		try {
+			return await fn();
+		} catch (err) {
+			lastErr = err;
+			if (attempt === RETRY_ATTEMPTS || !isRetryableCursorError(err)) throw err;
+			const wait = RETRY_BACKOFF_MS * attempt;
+			logger.info(
+				`[cursor] ${label} transient network failure (attempt ${attempt}/${RETRY_ATTEMPTS}), retrying in ${wait}ms: ${err instanceof Error ? err.message : String(err)}`,
+			);
+			await new Promise((resolve) => setTimeout(resolve, wait));
+		}
+	}
+	throw lastErr;
+}
 
 interface LiveSession {
 	readonly agent: SDKAgent;
@@ -118,14 +146,16 @@ export class CursorCore {
 		let session = this.sessions.get(params.sessionId);
 		if (!session) {
 			try {
-				const agent = params.resume
-					? await Agent.resume(params.resume, { apiKey })
-					: await Agent.create({
-							apiKey,
-							model: { id: modelId },
-							local: { cwd },
-							mode: toCursorMode(params.permissionMode),
-						});
+				const agent = await withCursorRetry("Agent.create", () =>
+					params.resume
+						? Agent.resume(params.resume, { apiKey })
+						: Agent.create({
+								apiKey,
+								model: { id: modelId },
+								local: { cwd },
+								mode: toCursorMode(params.permissionMode),
+							}),
+				);
 				session = {
 					agent,
 					modelId,
@@ -172,18 +202,21 @@ export class CursorCore {
 		// `{ data, mimeType }` SDKImage variant (`url` throws).
 		const { text, imagePaths } = parseImageRefs(params.prompt, params.images);
 		const message = await buildCursorMessage(text, imagePaths);
+		const activeSession = session;
 		let run: Run;
 		try {
-			run = await session.agent.send(message, {
-				// Pass mode every turn — Cursor sticks with the create-time
-				// mode otherwise, so toggling Plan on/off mid-conversation
-				// (incl. "Implement" → back to agent) wouldn't take effect.
-				mode: toCursorMode(params.permissionMode),
-				model: {
-					id: modelId,
-					...(modelParams.length > 0 ? { params: modelParams } : {}),
-				},
-			});
+			run = await withCursorRetry("agent.send", () =>
+				activeSession.agent.send(message, {
+					// Pass mode every turn — Cursor sticks with the create-time
+					// mode otherwise, so toggling Plan on/off mid-conversation
+					// (incl. "Implement" → back to agent) wouldn't take effect.
+					mode: toCursorMode(params.permissionMode),
+					model: {
+						id: modelId,
+						...(modelParams.length > 0 ? { params: modelParams } : {}),
+					},
+				}),
+			);
 		} catch (error) {
 			const msg = error instanceof Error ? error.message : String(error);
 			logger.error(`[${requestId}] Cursor agent.send failed: ${msg}`, {
@@ -284,13 +317,14 @@ export class CursorCore {
 		const timeout = timeoutMs ?? TITLE_GENERATION_TIMEOUT_MS;
 
 		// One-shot — never reuses an existing user session.
-		const titleRun = Agent.prompt(prompt, {
-			apiKey,
-			model: { id: modelId },
-			local: { cwd },
-		});
 		const result = await Promise.race([
-			titleRun,
+			withCursorRetry("Agent.prompt", () =>
+				Agent.prompt(prompt, {
+					apiKey,
+					model: { id: modelId },
+					local: { cwd },
+				}),
+			),
 			new Promise<never>((_, reject) =>
 				setTimeout(
 					() =>
@@ -345,7 +379,9 @@ export class CursorCore {
 		// On override mode we propagate errors so the caller can probe
 		// key validity. On stored-key mode we also propagate now (the
 		// older silent-fallback path masked "key invalid" failures).
-		const models = await Cursor.models.list({ apiKey });
+		const models = await withCursorRetry("Cursor.models.list", () =>
+			Cursor.models.list({ apiKey }),
+		);
 		const out = models.map(modelInfoToProviderInfo);
 		if (!overrideKey) this.cacheModelParameters(out);
 		return out;
@@ -360,7 +396,9 @@ export class CursorCore {
 		const cached = this.modelParameters.get(wireId);
 		if (cached) return cached;
 		try {
-			const models = await Cursor.models.list({ apiKey });
+			const models = await withCursorRetry("Cursor.models.list", () =>
+				Cursor.models.list({ apiKey }),
+			);
 			this.cacheModelParameters(models.map(modelInfoToProviderInfo));
 			return this.modelParameters.get(wireId) ?? null;
 		} catch (error) {
@@ -411,5 +449,23 @@ export class CursorCore {
 			}
 		}
 		this.sessions.clear();
+	}
+
+	/// Terminal-fail every in-flight turn with a clean error and drop all
+	/// sessions (their HTTP/2 connections are presumed dead). Called by the
+	/// worker's uncaughtException net so a transient network blow-up surfaces
+	/// as a real error instead of a silent worker death. Returns the affected
+	/// requestIds so the caller can release the proxy's awaiting send promises.
+	failActiveTurns(message: string): string[] {
+		const requestIds = this.turns.failAll(message);
+		for (const [, session] of this.sessions) {
+			try {
+				session.agent.close();
+			} catch {
+				/* swallow */
+			}
+		}
+		this.sessions.clear();
+		return requestIds;
 	}
 }

--- a/sidecar/src/cursor-worker/cursor-helpers.ts
+++ b/sidecar/src/cursor-worker/cursor-helpers.ts
@@ -180,6 +180,47 @@ export function modelInfoToProviderInfo(
 	};
 }
 
+/// Transient network failures worth retrying / recovering from rather than
+/// surfacing as a hard failure: TLS/connection resets, timeouts, DNS hiccups.
+/// `api2.cursor.sh` intermittently resets the TLS handshake from some networks,
+/// and the SDK's HTTP/2 client throws that as a ConnectError whose `cause` is a
+/// Node socket error. We match by error `code`, nested `cause.code`, and the
+/// message text so it works across ConnectError and raw socket errors.
+const RETRYABLE_NET_CODES = new Set([
+	"ECONNRESET",
+	"ETIMEDOUT",
+	"ECONNREFUSED",
+	"ECONNABORTED",
+	"EPIPE",
+	"ENOTFOUND",
+	"EAI_AGAIN",
+	"ENETUNREACH",
+	"EHOSTUNREACH",
+]);
+
+const RETRYABLE_NET_MESSAGES = [
+	"socket disconnected",
+	"before secure tls",
+	"socket hang up",
+	"econnreset",
+	"etimedout",
+	"timed out",
+	"network socket disconnected",
+];
+
+export function isRetryableCursorError(err: unknown, depth = 0): boolean {
+	if (!err || typeof err !== "object" || depth > 4) return false;
+	const o = err as { code?: unknown; message?: unknown; cause?: unknown };
+	if (typeof o.code === "string" && RETRYABLE_NET_CODES.has(o.code))
+		return true;
+	if (typeof o.message === "string") {
+		const m = o.message.toLowerCase();
+		if (RETRYABLE_NET_MESSAGES.some((needle) => m.includes(needle)))
+			return true;
+	}
+	return isRetryableCursorError(o.cause, depth + 1);
+}
+
 // Test-only export.
 export const __CURSOR_INTERNAL = {
 	namespaceEvent,
@@ -189,4 +230,5 @@ export const __CURSOR_INTERNAL = {
 	extToMimeType,
 	toCursorMode,
 	extractCreatePlanText,
+	isRetryableCursorError,
 };

--- a/sidecar/src/cursor-worker/worker.ts
+++ b/sidecar/src/cursor-worker/worker.ts
@@ -10,6 +10,7 @@ import { createInterface } from "node:readline";
 import { applyAgentProxyToProcessEnv } from "../agent-proxy.js";
 import type { SidecarEmitter } from "../emitter.js";
 import { CursorCore } from "./cursor-core.js";
+import { isRetryableCursorError } from "./cursor-helpers.js";
 import type { EmitMsg, FromWorker, ToWorker } from "./protocol.js";
 
 // Keep stdout pristine: any stray console.log from the SDK would corrupt the
@@ -55,6 +56,39 @@ const wireEmitter: SidecarEmitter = {
 };
 
 const core = new CursorCore();
+
+// A stray async network error from the SDK's HTTP/2 client (Cursor's API
+// intermittently resets the TLS handshake) surfaces as an uncaughtException,
+// which would otherwise kill the worker and show the user a bare "worker
+// exited unexpectedly". Catch it: fail in-flight turns with a real error and
+// release the proxy's awaiting send promises. For a transient network error
+// stay alive (sessions are dropped; the next turn reconnects); for anything
+// else exit so the supervisor respawns a clean worker.
+let fatalExiting = false;
+function handleFatal(kind: string, err: unknown): void {
+	const message = errMessage(err);
+	console.error(`[cursor-worker] ${kind}: ${message}`);
+	const transient = isRetryableCursorError(err);
+	try {
+		const reason = transient
+			? "Cursor lost its network connection. Please send the message again."
+			: `Cursor worker error: ${message}`;
+		for (const requestId of core.failActiveTurns(reason)) {
+			out({ t: "sendDone", requestId });
+		}
+	} catch (recoverErr) {
+		console.error(`[cursor-worker] recovery failed: ${errMessage(recoverErr)}`);
+	}
+	if (transient || fatalExiting) return;
+	fatalExiting = true;
+	// Let the terminal events flush to the parent, then exit.
+	setTimeout(() => process.exit(1), 30);
+}
+
+process.on("uncaughtException", (err) => handleFatal("uncaughtException", err));
+process.on("unhandledRejection", (reason) =>
+	handleFatal("unhandledRejection", reason),
+);
 
 async function handle(msg: ToWorker): Promise<void> {
 	switch (msg.t) {

--- a/sidecar/test/cursor-session-manager.test.ts
+++ b/sidecar/test/cursor-session-manager.test.ts
@@ -12,7 +12,65 @@ const {
 	extToMimeType,
 	toCursorMode,
 	extractCreatePlanText,
+	isRetryableCursorError,
 } = __CURSOR_INTERNAL;
+
+describe("isRetryableCursorError — transient network classification", () => {
+	test("real ConnectError shape (TLS reset) → retryable", () => {
+		// Mirrors the observed crash: ConnectError code 10 (aborted) wrapping a
+		// Node ECONNRESET cause from api2.cursor.sh.
+		const err = Object.assign(
+			new Error(
+				"[aborted] Client network socket disconnected before secure TLS connection was established",
+			),
+			{
+				code: 10,
+				cause: Object.assign(
+					new Error(
+						"Client network socket disconnected before secure TLS connection was established",
+					),
+					{ code: "ECONNRESET" },
+				),
+			},
+		);
+		expect(isRetryableCursorError(err)).toBe(true);
+	});
+
+	test("plain socket error codes → retryable", () => {
+		for (const code of ["ECONNRESET", "ETIMEDOUT", "ECONNREFUSED", "EPIPE"]) {
+			expect(
+				isRetryableCursorError(Object.assign(new Error("x"), { code })),
+			).toBe(true);
+		}
+	});
+
+	test("message-only match (no code) → retryable", () => {
+		expect(isRetryableCursorError(new Error("socket hang up"))).toBe(true);
+		expect(isRetryableCursorError(new Error("request timed out"))).toBe(true);
+	});
+
+	test("non-network errors → not retryable", () => {
+		expect(isRetryableCursorError(new Error("Invalid API key"))).toBe(false);
+		expect(
+			isRetryableCursorError(
+				Object.assign(new Error("unauthenticated"), { code: 16 }),
+			),
+		).toBe(false);
+	});
+
+	test("non-error inputs → not retryable", () => {
+		expect(isRetryableCursorError(null)).toBe(false);
+		expect(isRetryableCursorError(undefined)).toBe(false);
+		expect(isRetryableCursorError("ECONNRESET")).toBe(false);
+		expect(isRetryableCursorError(42)).toBe(false);
+	});
+
+	test("deeply nested cause is bounded (no infinite loop)", () => {
+		const cyclic: { message: string; cause?: unknown } = { message: "nope" };
+		cyclic.cause = cyclic;
+		expect(isRetryableCursorError(cyclic)).toBe(false);
+	});
+});
 
 describe("plan mode", () => {
 	test("toCursorMode: only 'plan' maps to plan; everything else → agent", () => {


### PR DESCRIPTION
Follow-up to #765 / #766 (Cursor → Node worker).

## The bug
Field report: Cursor failed ~1 in 3 turns with **"Cursor worker exited unexpectedly"**. The release build is fine — the bundled Node runs, native deps load, no `NGHTTP2`. The real cause is the network: `api2.cursor.sh` intermittently **resets the TLS handshake** (`ECONNRESET` / "socket disconnected before secure TLS connection was established"). The SDK's HTTP/2 client (`@connectrpc/connect-node`) raised that as an **async error that escaped the per-turn try/catch → uncaughtException → the whole worker process died.** No retry meant one network blip = one failed turn.

Confirmed empirically: the bundled Node connects to `api2.cursor.sh` fine (with and without proxy) — it's intermittent, not systemic.

## Fix
- **Retry** the SDK connection-setup calls — `Agent.create`/`resume`, `agent.send`, `Cursor.models.list`, `Agent.prompt` — on transient network errors (3 attempts, linear backoff). Most blips now recover invisibly.
- **uncaughtException / unhandledRejection net** in the worker: fail in-flight turns with a *real* error (and release the proxy's awaiting send promises) instead of dying silently. On a transient network error it stays alive (sessions dropped, next turn reconnects); on anything else it exits so the supervisor respawns a clean worker.
- `isRetryableCursorError` is a pure, `@cursor/sdk`-free helper (matches by error `code`, nested `cause.code`, and message) — unit-tested under Bun.

## Process-leak check (asked separately)
No opencode-style leak risk: the worker is **not** `detached` and never re-execs, so it shares the sidecar's process group (verified: worker PGID == sidecar PGID) and is reaped by Rust's existing group-SIGTERM + tree-SIGKILL. Backed up by the worker's stdin-EOF self-exit and the proxy's cooperative `shutdown()`. Verified live: exactly one worker under the running sidecar, no accumulation.

## Tests
`bun test` (sidecar) green — 347 pass, incl. 6 new `isRetryableCursorError` cases. `tsc` + biome clean.
