### PR TITLE
fix(opencode): surface session.error as non-terminal system notice instead of rejecting the turn

### DIFF
--- a/sidecar/src/opencode-session-manager.ts
+++ b/sidecar/src/opencode-session-manager.ts
@@ -807,7 +807,9 @@ export class OpencodeSessionManager implements SessionManager {
 			});
 		}
 
-		// Turn lifecycle: idle = done, error = fail. `settle` guards stray events.
+		// Turn lifecycle: only idle = done. `session.error` is a visible provider
+		// notice, not a terminal signal; opencode TUI also keeps the turn busy until
+		// a later idle/status event arrives.
 		switch (event.type) {
 			case "session.idle":
 				ctx.settle?.resolve();
@@ -817,11 +819,6 @@ export class OpencodeSessionManager implements SessionManager {
 					ctx.settle?.resolve();
 				}
 				break;
-			case "session.error": {
-				const detail = sessionErrorMessage(event.properties?.error);
-				ctx.settle?.reject(new Error(detail));
-				break;
-			}
 			default:
 				break;
 		}
@@ -1313,16 +1310,4 @@ function errorMessage(error: unknown): string {
 		}
 	}
 	return String(error);
-}
-
-function sessionErrorMessage(error: unknown): string {
-	if (!error || typeof error !== "object") return "opencode session failed";
-	const data =
-		"data" in error && error.data && typeof error.data === "object"
-			? (error.data as Record<string, unknown>)
-			: null;
-	const message = data && "message" in data ? data.message : null;
-	return typeof message === "string" && message.trim().length > 0
-		? message
-		: "opencode session failed";
 }

--- a/src-tauri/src/pipeline/accumulator/mod.rs
+++ b/src-tauri/src/pipeline/accumulator/mod.rs
@@ -528,8 +528,8 @@ impl StreamAccumulator {
             Some("opencode/session.idle") => opencode::handle_session_idle(self),
             Some("opencode/session.status") => opencode::handle_session_status(self, value),
             // Redundant/informational forms — handled as NoOps for the coverage guard.
-            Some("opencode/session.error")
-            | Some("opencode/session.created")
+            Some("opencode/session.error") => opencode::handle_session_error(self, value),
+            Some("opencode/session.created")
             | Some("opencode/session.updated")
             | Some("opencode/session.diff")
             | Some("opencode/todo.updated")

--- a/src-tauri/src/pipeline/accumulator/opencode.rs
+++ b/src-tauri/src/pipeline/accumulator/opencode.rs
@@ -10,6 +10,8 @@ use serde_json::{json, Value};
 use super::super::types::{CollectedTurn, MessageRole};
 use super::{now_ms, PushOutcome, StreamAccumulator};
 
+const SESSION_ERROR_PART_ID: &str = "__opencode_session_error";
+
 #[derive(Debug, Default)]
 pub(super) struct OpencodeRunState {
     pub turn_id: Option<String>,
@@ -489,6 +491,22 @@ pub(super) fn handle_session_status(acc: &mut StreamAccumulator, value: &Value) 
     }
 }
 
+pub(super) fn handle_session_error(acc: &mut StreamAccumulator, value: &Value) -> PushOutcome {
+    let body = session_error_body(value);
+    upsert_part(
+        acc,
+        SESSION_ERROR_PART_ID,
+        json!({
+            "type": "system-notice",
+            "severity": "error",
+            "label": "OpenCode error",
+            "body": body,
+        }),
+    );
+    rebuild_collected(acc);
+    PushOutcome::StreamingDelta
+}
+
 // Drain in-flight state on abort (no `session.idle` will arrive).
 pub(super) fn flush_in_progress(acc: &mut StreamAccumulator) {
     finalize(acc);
@@ -527,6 +545,39 @@ fn parse_text_delta(value: &Value) -> Option<(&str, &str)> {
         return None;
     }
     Some((part_id, delta))
+}
+
+fn session_error_body(value: &Value) -> String {
+    let error = value.get("error").unwrap_or(value);
+    if let Some(message) = find_error_message(error) {
+        return message.trim().to_string();
+    }
+    if let Value::String(message) = error {
+        let trimmed = message.trim();
+        if !trimmed.is_empty() {
+            return trimmed.to_string();
+        }
+    }
+    if let Ok(serialized) = serde_json::to_string(error) {
+        if serialized != "null" && serialized != "{}" {
+            return serialized;
+        }
+    }
+    "OpenCode session failed".to_string()
+}
+
+fn find_error_message(value: &Value) -> Option<&str> {
+    value
+        .get("message")
+        .and_then(Value::as_str)
+        .filter(|s| !s.trim().is_empty())
+        .or_else(|| {
+            value
+                .get("data")
+                .and_then(find_error_message)
+                .or_else(|| value.get("error").and_then(find_error_message))
+                .or_else(|| value.get("body").and_then(find_error_message))
+        })
 }
 
 // Append a streamed delta to the named part's `text`, creating a `text` part if
@@ -1056,6 +1107,31 @@ mod tests {
         assert_eq!(tool["output"], "hi");
     }
 
+    #[test]
+    fn session_error_surfaces_without_finalizing_turn() {
+        let mut acc = StreamAccumulator::new("opencode", "");
+        assistant(&mut acc, "m1");
+
+        let out = acc.push_event(
+            &json!({
+                "type": "opencode/session.error",
+                "session_id": "ses_1",
+                "error": { "data": { "message": "Quota exceeded. Try again in 5 hours." } },
+            }),
+            "",
+        );
+
+        assert_eq!(out, PushOutcome::StreamingDelta);
+        assert_eq!(acc.turns_len(), 0);
+        let parsed = acc.collected()[0].parsed.as_ref().unwrap();
+        assert_eq!(parsed["parts"][0]["type"], "system-notice");
+        assert_eq!(parsed["parts"][0]["severity"], "error");
+        assert_eq!(
+            parsed["parts"][0]["body"],
+            "Quota exceeded. Try again in 5 hours."
+        );
+    }
+
     fn assistant(acc: &mut StreamAccumulator, msg_id: &str) {
         acc.push_event(
             &json!({ "type": "opencode/message.updated", "session_id": "ses_1",
@@ -1321,7 +1397,6 @@ mod tests {
         let mut acc = StreamAccumulator::new("opencode", "");
         for ty in [
             "opencode/message.part.delta",
-            "opencode/session.error",
             "opencode/session.created",
             "opencode/session.updated",
             "opencode/session.diff",

--- a/src-tauri/src/pipeline/adapter/opencode_parts.rs
+++ b/src-tauri/src/pipeline/adapter/opencode_parts.rs
@@ -93,7 +93,33 @@ fn render_part(part: &Value, id: String, streaming_now: bool) -> Option<MessageP
                 body: None,
             })
         }
+        "system-notice" => Some(render_system_notice(part, id)),
         _ => None,
+    }
+}
+
+fn render_system_notice(part: &Value, id: String) -> MessagePart {
+    let severity = match part.get("severity").and_then(Value::as_str) {
+        Some("error") => NoticeSeverity::Error,
+        Some("warning") => NoticeSeverity::Warning,
+        _ => NoticeSeverity::Info,
+    };
+    let label = part
+        .get("label")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("Notice")
+        .to_string();
+    let body = part
+        .get("body")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    MessagePart::SystemNotice {
+        id,
+        severity,
+        label,
+        body,
     }
 }
 
@@ -622,6 +648,37 @@ mod tests {
             } => {
                 assert_eq!(severity, &NoticeSeverity::Info);
                 assert_eq!(label, "Context auto-compacted");
+            }
+            other => panic!("expected system-notice, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn session_error_notice_renders_as_error_system_notice() {
+        let msg = json!({
+            "type": "opencode_message",
+            "parts": [{
+                "type": "system-notice",
+                "severity": "error",
+                "label": "OpenCode error",
+                "body": "Quota exceeded. Try again in 5 hours.",
+            }],
+        });
+        let parts = render_parts(&msg, "m1", true);
+        assert_eq!(parts.len(), 1);
+        match &parts[0] {
+            MessagePart::SystemNotice {
+                severity,
+                label,
+                body,
+                ..
+            } => {
+                assert_eq!(severity, &NoticeSeverity::Error);
+                assert_eq!(label, "OpenCode error");
+                assert_eq!(
+                    body.as_deref(),
+                    Some("Quota exceeded. Try again in 5 hours.")
+                );
             }
             other => panic!("expected system-notice, got {other:?}"),
         }

--- a/src-tauri/tests/fixtures/streams/opencode/session-error-nonterminal.jsonl
+++ b/src-tauri/tests/fixtures/streams/opencode/session-error-nonterminal.jsonl
@@ -1,0 +1,2 @@
+{"type":"opencode/message.updated","session_id":"ses_1","info":{"id":"m1","role":"assistant"}}
+{"type":"opencode/session.error","session_id":"ses_1","error":{"data":{"message":"Quota exceeded. Try again in 5 hours."}}}

--- a/src-tauri/tests/pipeline_scenarios.rs
+++ b/src-tauri/tests/pipeline_scenarios.rs
@@ -428,6 +428,27 @@ fn opencode_reasoning_carries_thought_duration() {
     assert_yaml_snapshot!(run_normalized(msgs));
 }
 
+#[test]
+fn opencode_session_error_notice_round_trips() {
+    let assistant = json!({
+        "type": "opencode_message",
+        "session_id": "ses_1",
+        "role": "assistant",
+        "parts": [{
+            "type": "system-notice",
+            "severity": "error",
+            "label": "OpenCode error",
+            "body": "Quota exceeded. Try again in 5 hours.",
+        }],
+    });
+    let msgs = vec![make_record(
+        "om1",
+        "assistant",
+        &serde_json::to_string(&assistant).unwrap(),
+    )];
+    assert_yaml_snapshot!(run_normalized(msgs));
+}
+
 // opencode write/edit/apply_patch carry opencode's per-file unified diff
 // (`fileDiffs`), which the adapter reshapes into the shared apply_patch
 // `changes:[{path,diff}]` view so a colored diff renders on reload too.

--- a/src-tauri/tests/snapshots/pipeline_scenarios__opencode_session_error_notice_round_trips.snap
+++ b/src-tauri/tests/snapshots/pipeline_scenarios__opencode_session_error_notice_round_trips.snap
@@ -1,0 +1,14 @@
+---
+source: tests/pipeline_scenarios.rs
+expression: run_normalized(msgs)
+---
+- role: assistant
+  id: msg-1
+  content_length: 1
+  content:
+    - type: system-notice
+      severity: error
+      label: OpenCode error
+      body: Quota exceeded. Try again in 5 hours.
+  status: ~
+  streaming: ~

--- a/src-tauri/tests/snapshots/pipeline_streams__stream_replay@opencode__session-error-nonterminal.jsonl.snap
+++ b/src-tauri/tests/snapshots/pipeline_streams__stream_replay@opencode__session-error-nonterminal.jsonl.snap
@@ -1,0 +1,20 @@
+---
+source: tests/pipeline_streams.rs
+expression: snapshot
+input_file: tests/fixtures/streams/opencode/session-error-nonterminal.jsonl
+---
+line_count: 2
+checkpoint_count: 0
+checkpoints: []
+final_state:
+  message_count: 1
+  roles:
+    - assistant
+  total_parts: 1
+persisted_turns:
+  turn_count: 0
+  total_blocks: 0
+  turns: []
+historical_render:
+  message_count: 0
+  messages: []


### PR DESCRIPTION
## What changed

OpenCode `session.error` events were previously treated as terminal — the sidecar would reject the turn settle promise and the accumulator treated the event as a NoOp. In practice, `session.error` is a visible provider notice (e.g. quota exceeded, API key errors) that does **not** end the turn; the OpenCode TUI keeps the turn busy until a later `session.idle` or `session.status` event arrives.

This PR:

- **Sidecar**: Removes `session.error` from the turn lifecycle handler so it no longer rejects the settle promise. The removed `sessionErrorMessage` helper is also cleaned up.
- **Accumulator**: Routes `opencode/session.error` to a new `handle_session_error` that creates an inline `system-notice` part (severity: error, label: "OpenCode error") with the extracted error body, keeping the turn in-flight.
- **Adapter**: Adds `render_system_notice` to map accumulated `system-notice` parts to `MessagePart::SystemNotice` so they render in the chat panel.
- **Tests**: New unit tests in accumulator and adapter, plus a snapshot end-to-end test (`opencode_session_error_notice_round_trips`) and stream-replay fixture (`session-error-nonterminal.jsonl`).

## Why

Previously, transient provider errors (e.g. "Quota exceeded, try again in 5 hours") would kill the streaming turn entirely, making it impossible for the agent to self-correct or for the user to see what happened. By rendering these as inline system notices, errors stay visible in the conversation while the turn continues naturally.

## Follow-up

No breaking changes. All existing snapshot tests updated where needed (NoOp list in accumulator tests).