### PR TITLE
fix: render opencode tool output while running, add rAF fallback timer

### DIFF
--- a/src-tauri/src/pipeline/accumulator/opencode.rs
+++ b/src-tauri/src/pipeline/accumulator/opencode.rs
@@ -436,7 +436,7 @@ fn render_tool_part(part: &Value) -> Value {
     }
     match status {
         "completed" => {
-            let output = state.and_then(|s| s.get("output")).and_then(Value::as_str);
+            let output = tool_output(state);
             if let Some(o) = output {
                 out["output"] = json!(o);
             }
@@ -446,13 +446,30 @@ fn render_tool_part(part: &Value) -> Value {
             out["output"] = json!(err.unwrap_or("Tool failed"));
             out["isError"] = json!(true);
         }
-        _ => {}
+        _ => {
+            if let Some(o) = tool_output(state) {
+                out["output"] = json!(o);
+            }
+        }
     }
     let file_diffs = opencode_file_diffs(state, title);
     if !file_diffs.is_empty() {
         out["fileDiffs"] = json!(file_diffs);
     }
     out
+}
+
+fn tool_output(state: Option<&Value>) -> Option<&str> {
+    state
+        .and_then(|s| s.get("output"))
+        .and_then(Value::as_str)
+        .or_else(|| {
+            state?
+                .get("metadata")
+                .and_then(|m| m.get("output"))
+                .and_then(Value::as_str)
+        })
+        .filter(|output| !output.is_empty())
 }
 
 pub(super) fn handle_session_idle(acc: &mut StreamAccumulator) -> PushOutcome {
@@ -1011,6 +1028,32 @@ mod tests {
         assert_eq!(parts[1]["type"], "tool");
         assert_eq!(parts[1]["tool"], "bash");
         assert_eq!(parts[1]["output"], "a.txt");
+    }
+
+    #[test]
+    fn running_tool_carries_metadata_output() {
+        let mut acc = StreamAccumulator::new("opencode", "");
+        assistant(&mut acc, "m1");
+        acc.push_event(
+            &json!({
+                "type": "opencode/message.part.updated", "session_id": "ses_1",
+                "part": {
+                    "type": "tool", "id": "p1", "messageID": "m1",
+                    "callID": "call_1", "tool": "bash",
+                    "state": {
+                        "status": "running",
+                        "input": { "command": "printf hi" },
+                        "metadata": { "output": "hi" },
+                    },
+                },
+            }),
+            "",
+        );
+
+        let parsed = acc.collected()[0].parsed.as_ref().unwrap();
+        let tool = &parsed["parts"][0];
+        assert_eq!(tool["status"], "running");
+        assert_eq!(tool["output"], "hi");
     }
 
     fn assistant(acc: &mut StreamAccumulator, msg_id: &str) {

--- a/src-tauri/tests/pipeline_scenarios.rs
+++ b/src-tauri/tests/pipeline_scenarios.rs
@@ -454,6 +454,29 @@ fn opencode_write_tool_renders_unified_diff() {
     assert_yaml_snapshot!(run_normalized(msgs));
 }
 
+// opencode bash output can arrive while the tool is still running under
+// `state.metadata.output`; the live accumulator maps that to `output` so
+// streaming renders don't wait for `status=completed`.
+#[test]
+fn opencode_running_tool_renders_output() {
+    let assistant = json!({
+        "type": "opencode_message",
+        "session_id": "ses_1",
+        "role": "assistant",
+        "parts": [{
+            "type": "tool", "callID": "c1", "tool": "bash", "status": "running",
+            "input": { "command": "printf hi" },
+            "output": "hi",
+        }],
+    });
+    let msgs = vec![make_record(
+        "om1",
+        "assistant",
+        &serde_json::to_string(&assistant).unwrap(),
+    )];
+    assert_yaml_snapshot!(run_normalized(msgs));
+}
+
 // ============================================================================
 // 4. Edge cases
 // ============================================================================

--- a/src-tauri/tests/snapshots/pipeline_scenarios__opencode_running_tool_renders_output.snap
+++ b/src-tauri/tests/snapshots/pipeline_scenarios__opencode_running_tool_renders_output.snap
@@ -1,0 +1,20 @@
+---
+source: tests/pipeline_scenarios.rs
+expression: run_normalized(msgs)
+---
+- role: assistant
+  id: msg-1
+  content_length: 1
+  content:
+    - type: tool-call
+      tool_name: Bash
+      tool_call_id: c1
+      args_keys:
+        - command
+      args_text_length: 23
+      has_result: true
+      result_kind: string
+      result_preview: hi
+      streaming_status: running
+  status: ~
+  streaming: ~

--- a/src/features/conversation/hooks/dispatch-stream-event.test.ts
+++ b/src/features/conversation/hooks/dispatch-stream-event.test.ts
@@ -1,0 +1,85 @@
+import { QueryClient } from "@tanstack/react-query";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ThreadMessageLike } from "@/lib/api";
+import { sessionThreadCacheKey } from "@/lib/session-thread-cache";
+import {
+	createStreamFlushers,
+	type StreamAccumulator,
+} from "./dispatch-stream-event";
+
+function userMessage(id: string): ThreadMessageLike {
+	return {
+		id,
+		role: "user",
+		content: [{ type: "text", id: `${id}:text`, text: "prompt" }],
+	};
+}
+
+function assistantMessage(id: string, text: string): ThreadMessageLike {
+	return {
+		id,
+		role: "assistant",
+		streaming: true,
+		content: [{ type: "text", id: `${id}:text`, text }],
+	};
+}
+
+describe("createStreamFlushers", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	it("flushes through the fallback timer when requestAnimationFrame stalls", () => {
+		vi.useFakeTimers();
+		const queryClient = new QueryClient();
+		const optimisticUserMessage = userMessage("u1");
+		queryClient.setQueryData(sessionThreadCacheKey("session-1"), [
+			optimisticUserMessage,
+		]);
+		const accumulator: StreamAccumulator = {
+			baseMessages: [assistantMessage("a1", "hello")],
+			pendingPartial: null,
+			needsFlush: false,
+			frameId: null,
+			fallbackTimerId: null,
+		};
+		const rafSpy = vi
+			.spyOn(window, "requestAnimationFrame")
+			.mockImplementation(() => 42);
+		const cancelSpy = vi
+			.spyOn(window, "cancelAnimationFrame")
+			.mockImplementation(() => {});
+		const interval = window.setInterval(() => {}, 1_000);
+		const { cleanup, scheduleFlush } = createStreamFlushers({
+			accumulator,
+			queryClient,
+			cacheSessionId: "session-1",
+			userMessageId: "u1",
+			optimisticUserMessage,
+			changesRefreshInterval: interval,
+		});
+
+		scheduleFlush();
+
+		expect(rafSpy).toHaveBeenCalledTimes(1);
+		expect(
+			queryClient.getQueryData<ThreadMessageLike[]>(
+				sessionThreadCacheKey("session-1"),
+			),
+		).toHaveLength(1);
+
+		vi.advanceTimersByTime(120);
+
+		const cached = queryClient.getQueryData<ThreadMessageLike[]>(
+			sessionThreadCacheKey("session-1"),
+		);
+		expect(cached).toHaveLength(2);
+		expect(cached?.[1]?.content[0]).toEqual(
+			expect.objectContaining({ text: "hello" }),
+		);
+		expect(cancelSpy).toHaveBeenCalledWith(42);
+
+		cleanup();
+	});
+});

--- a/src/features/conversation/hooks/dispatch-stream-event.ts
+++ b/src/features/conversation/hooks/dispatch-stream-event.ts
@@ -54,7 +54,16 @@ export type StreamAccumulator = {
 	pendingPartial: ThreadMessageLike | null;
 	needsFlush: boolean;
 	frameId: number | null;
+	fallbackTimerId?: number | null;
 };
+
+const STREAM_FLUSH_FALLBACK_MS = 120;
+
+function clearFallbackTimer(accumulator: StreamAccumulator): void {
+	if (accumulator.fallbackTimerId == null) return;
+	window.clearTimeout(accumulator.fallbackTimerId);
+	accumulator.fallbackTimerId = null;
+}
 
 export type StreamDispatchDeps = {
 	// Send-time invariants. Captured once at the top of handleComposerSubmit.
@@ -316,6 +325,7 @@ export function createStreamFlushers(opts: {
 } {
 	const flushStreamMessages = () => {
 		opts.accumulator.frameId = null;
+		clearFallbackTimer(opts.accumulator);
 		if (!opts.accumulator.needsFlush) return;
 		opts.accumulator.needsFlush = false;
 
@@ -342,10 +352,20 @@ export function createStreamFlushers(opts: {
 
 	const scheduleFlush = () => {
 		opts.accumulator.needsFlush = true;
-		if (opts.accumulator.frameId !== null) return;
-		opts.accumulator.frameId = window.requestAnimationFrame(() =>
-			flushStreamMessages(),
-		);
+		if (opts.accumulator.frameId === null) {
+			opts.accumulator.frameId = window.requestAnimationFrame(() =>
+				flushStreamMessages(),
+			);
+		}
+		if (opts.accumulator.fallbackTimerId == null) {
+			opts.accumulator.fallbackTimerId = window.setTimeout(() => {
+				if (opts.accumulator.frameId !== null) {
+					window.cancelAnimationFrame(opts.accumulator.frameId);
+					opts.accumulator.frameId = null;
+				}
+				flushStreamMessages();
+			}, STREAM_FLUSH_FALLBACK_MS);
+		}
 	};
 
 	const cleanup = () => {
@@ -357,6 +377,7 @@ export function createStreamFlushers(opts: {
 			window.cancelAnimationFrame(opts.accumulator.frameId);
 			opts.accumulator.frameId = null;
 		}
+		clearFallbackTimer(opts.accumulator);
 	};
 
 	return { flushStreamMessages, scheduleFlush, cleanup };

--- a/src/features/conversation/hooks/use-streaming.ts
+++ b/src/features/conversation/hooks/use-streaming.ts
@@ -929,6 +929,7 @@ export function useConversationStreaming({
 					pendingPartial: null,
 					needsFlush: false,
 					frameId: null,
+					fallbackTimerId: null,
 				};
 
 				// Refresh the Changes diff WHILE streaming. 7s (was 3s) cuts the

--- a/src/features/conversation/hooks/use-watch-session-stream.ts
+++ b/src/features/conversation/hooks/use-watch-session-stream.ts
@@ -41,7 +41,10 @@ type WatchAccumulator = {
 	pendingPartial: ThreadMessageLike | null;
 	needsFlush: boolean;
 	frameId: number | null;
+	fallbackTimerId: number | null;
 };
+
+const STREAM_FLUSH_FALLBACK_MS = 120;
 
 export function useWatchSessionStream({ sessionId, activeStreams }: Args) {
 	const queryClient = useQueryClient();
@@ -73,6 +76,7 @@ export function useWatchSessionStream({ sessionId, activeStreams }: Args) {
 			pendingPartial: null,
 			needsFlush: false,
 			frameId: null,
+			fallbackTimerId: null,
 		};
 		// Gate rendering until the user prompt is guaranteed persisted. The
 		// backend writes the prompt row BEFORE the first sidecar event, so by
@@ -92,6 +96,10 @@ export function useWatchSessionStream({ sessionId, activeStreams }: Args) {
 
 		const flush = () => {
 			accumulator.frameId = null;
+			if (accumulator.fallbackTimerId !== null) {
+				window.clearTimeout(accumulator.fallbackTimerId);
+				accumulator.fallbackTimerId = null;
+			}
 			if (!accumulator.needsFlush) return;
 			accumulator.needsFlush = false;
 
@@ -120,8 +128,18 @@ export function useWatchSessionStream({ sessionId, activeStreams }: Args) {
 
 		const scheduleFlush = () => {
 			accumulator.needsFlush = true;
-			if (accumulator.frameId !== null) return;
-			accumulator.frameId = window.requestAnimationFrame(flush);
+			if (accumulator.frameId === null) {
+				accumulator.frameId = window.requestAnimationFrame(flush);
+			}
+			if (accumulator.fallbackTimerId === null) {
+				accumulator.fallbackTimerId = window.setTimeout(() => {
+					if (accumulator.frameId !== null) {
+						window.cancelAnimationFrame(accumulator.frameId);
+						accumulator.frameId = null;
+					}
+					flush();
+				}, STREAM_FLUSH_FALLBACK_MS);
+			}
 		};
 
 		const handle = (event: AgentStreamEvent) => {
@@ -144,6 +162,10 @@ export function useWatchSessionStream({ sessionId, activeStreams }: Args) {
 				if (accumulator.frameId !== null) {
 					window.cancelAnimationFrame(accumulator.frameId);
 					accumulator.frameId = null;
+				}
+				if (accumulator.fallbackTimerId !== null) {
+					window.clearTimeout(accumulator.fallbackTimerId);
+					accumulator.fallbackTimerId = null;
 				}
 				flush();
 				// Reconcile to canonical DB rows now the turn is finalized.
@@ -195,6 +217,9 @@ export function useWatchSessionStream({ sessionId, activeStreams }: Args) {
 			disposed = true;
 			if (accumulator.frameId !== null) {
 				window.cancelAnimationFrame(accumulator.frameId);
+			}
+			if (accumulator.fallbackTimerId !== null) {
+				window.clearTimeout(accumulator.fallbackTimerId);
 			}
 			unlisten?.();
 			// On teardown (turn ended or navigated away), pull canonical DB


### PR DESCRIPTION
## What changed

- **Backend (accumulator)**: OpenCode tool output can arrive in `state.metadata.output` while the tool is still `running`. Previously the accumulator only read `state.output` on `completed`, so streaming renders showed a blank tool block until the tool finished. Now `tool_output()` checks both paths, and all status arms (`running`, `completed`, and unhandled) emit output when present.
- **Frontend (stream flush)**: `requestAnimationFrame` is throttled/disabled when the browser tab is in the background. Added a 120ms `setTimeout` fallback in both `dispatch-stream-event.ts` and `use-watch-session-stream.ts` so streamed messages still flush and render when Helmor is backgrounded.

## Why

Live streaming felt broken — tool output appeared only after the tool completed, and messages could stall indefinitely when the tab lost focus.

## Tests

- Added `opencode_running_tool_renders_output` pipeline scenario with snapshot.
- Added unit test in `dispatch-stream-event.test.ts` for the rAF + fallback timer behavior.
- Added Rust unit test in `opencode.rs` covering metadata output extraction.