### PR TITLE
feat: add Claude Fable 5 model, upgrade bundled claude-code to 2.1.170

### DIFF
--- a/.announcements/claude-fable-5.json
+++ b/.announcements/claude-fable-5.json
@@ -1,0 +1,7 @@
+{
+	"items": [
+		{
+			"text": "Claude Fable 5 (1M context) is now available at the top of the Claude Code model list — Anthropic's most capable model for the hardest, longest-running tasks. Opus 4.8 remains the default."
+		}
+	]
+}

--- a/.changeset/claude-fable-5-model.md
+++ b/.changeset/claude-fable-5-model.md
@@ -1,0 +1,7 @@
+---
+"helmor": minor
+---
+
+Add Claude Fable 5 support:
+- Fable 5 (1M context) now sits at the top of the Claude Code model list. Opus 4.8 stays the app default — Fable 5 uses limits about 2× faster.
+- Upgrade the bundled Claude Code CLI to 2.1.170.

--- a/sidecar/bun.lock
+++ b/sidecar/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "@helmor/sidecar",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.154",
-        "@anthropic-ai/claude-code": "2.1.154",
+        "@anthropic-ai/claude-agent-sdk": "0.3.170",
+        "@anthropic-ai/claude-code": "2.1.170",
         "@cursor/sdk": "1.0.18",
         "@earendil-works/pi-agent-core": "^0.75.4",
         "@earendil-works/pi-ai": "^0.75.4",
@@ -25,41 +25,41 @@
     "sqlite3",
   ],
   "packages": {
-    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.154", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.154", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.154", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.154", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.154", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.154", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.154", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.154", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.154" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-iEn25urI2QrMPFIhId3h7v/7EG5gsmF7ooe+6EvsAosePeLmpVVerp5nXtHnlmBkMinLecurcPA+OddKw76jYw=="],
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.170", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.170", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.170", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.170", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.170", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.170", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.170", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.170", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.170" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-pAvhfk+iTodXZ6RF18Kz7BEUWFjL7EcR3tKuhUNdPpE1NAYCR3mSHGbafi72JsrNwKEDIs7FU31z3fqhwy8QzA=="],
 
-    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.154", "", { "os": "darwin", "cpu": "arm64" }, "sha512-oFW3LD5lYrKAU+AKu27Z8hrzqkrh362qQrwi/i3DxGcud9BXUycsXYjShpDj3D3JZu169UzZuSPhx1Wajmbiwg=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.170", "", { "os": "darwin", "cpu": "arm64" }, "sha512-rwfgArIa5WI0QPNqFsRBgvtSI0mrtpynUm0oK6+l6/KX4hcgnYGEzciZR1bOeD9/7sSZlTdIgt+T9alKeZmXcg=="],
 
-    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.154", "", { "os": "darwin", "cpu": "x64" }, "sha512-5BgWEueP+cqoctWjZYhCbyltuaV/N2DmKDXD3/69cKaVmJp8XL9OCzlq/HEirA/+Ssjskx6hDUBaOcpuZ3iwQA=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.170", "", { "os": "darwin", "cpu": "x64" }, "sha512-0e58h8UQMtsQxLGIv9r4foxfBFWKZ7NeDtoplLhuD7EwQonehomw1sBXCch77t/IfUS+q5vQ5zv+fOGmap5nLQ=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.154", "", { "os": "linux", "cpu": "arm64" }, "sha512-rRkW4SBL3W7zQvKscCIfIGlmoeuTbMV6dXFbPdmpRGvmYZIs79RpzO6xrGBnnhmm+B7znQ9oHAnffi/2FBgJbA=="],
+    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.170", "", { "os": "linux", "cpu": "arm64" }, "sha512-gLbaFqcGppFJQd4DLNV4IXoeahejT/p2/M8bSSvRDbla9GOsBr1AxV5XLRyBn1e7xFGozZIAIQr3+1chp7NJgQ=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.154", "", { "os": "linux", "cpu": "arm64" }, "sha512-o2bCQN4Xn3UqCLErC5m4T7u0yYArJYmgFCUFnA6K96DdW2RERvx+gTKXxWuHEBkDO+eMoHLHLxk0u2jGES00Ng=="],
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.170", "", { "os": "linux", "cpu": "arm64" }, "sha512-SRYfQcsXlOq+CD/FqkQBTSHbaD++w73GnnO+NUV9adLYrca3kfetRwWT1iguY1cNS0l34dCR3rlzCPq78vg1Jg=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.3.154", "", { "os": "linux", "cpu": "x64" }, "sha512-GpiFF8Ez6PbM3m0gqtCo/FKM346qyRdP7VhbmJzdnbNKTiiUZ66vDQyEUPZPCG24ZkrG4m96KpRIUwY08rHiNg=="],
+    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.3.170", "", { "os": "linux", "cpu": "x64" }, "sha512-Xl/m7TaSC3T5IDBdHrZQ9fCQYyDmPELN34CL+MoyPIf7uSmuZnjE9fUOqDh2Rv26JxWssi1M6X+BBvVuKd6Cpg=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.154", "", { "os": "linux", "cpu": "x64" }, "sha512-zA7S8Lm6O4QBsUpbhiOht8BgiXHOBBFUIo8ZLK6r5wAatK3Q44syWVxICeyCnR6wqfnkf3cugCw27ycS6vVgaA=="],
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.170", "", { "os": "linux", "cpu": "x64" }, "sha512-m4+I0qBEk7cxRKS+pL+eoWXbXTFOAo83fQ0tQvap4z/mDMm06IWJtEPoYTaMBwsp32GJWLkHWKbZSBCHZnp2DQ=="],
 
-    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.154", "", { "os": "win32", "cpu": "arm64" }, "sha512-cDW1YFbU/PJFlrGXhlAGcbkXt80sEO6WtnH8nN8YHXLn5NWduy2q7o/qC6i8XozgvRGf6t/eMoH7IasGIEDhDw=="],
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.170", "", { "os": "win32", "cpu": "arm64" }, "sha512-IG+8isJNNJKbnnhO7m+PGhfVCg+XoQ/MDxGde5eigFI0WsEfitjuWSWwx82bT9ghxI1aa6qNvI+UPgPcZuo5Fg=="],
 
-    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.3.154", "", { "os": "win32", "cpu": "x64" }, "sha512-tSKaIIpL72OPg3WfzZTCIl8OJgcbq4qieu8/fDWjsdeQuari9gQMIuEflFphk9HqNsxpSmDqKi8Sm5mW2V566Q=="],
+    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.3.170", "", { "os": "win32", "cpu": "x64" }, "sha512-7cuqSKbHVItPGVwRbd3A0BEJwcNtc7Fhoh6qHN4C6yrmjSrvdYYx3MLvq/VI768/RoG7mAMDxb+j7WfEfoP9BA=="],
 
-    "@anthropic-ai/claude-code": ["@anthropic-ai/claude-code@2.1.154", "", { "optionalDependencies": { "@anthropic-ai/claude-code-darwin-arm64": "2.1.154", "@anthropic-ai/claude-code-darwin-x64": "2.1.154", "@anthropic-ai/claude-code-linux-arm64": "2.1.154", "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.154", "@anthropic-ai/claude-code-linux-x64": "2.1.154", "@anthropic-ai/claude-code-linux-x64-musl": "2.1.154", "@anthropic-ai/claude-code-win32-arm64": "2.1.154", "@anthropic-ai/claude-code-win32-x64": "2.1.154" }, "bin": { "claude": "bin/claude.exe" } }, "sha512-1LSc7Jtm7Jy/GgqzoC4jDtTeV4GphGdB2+r49QDJnDa4fDsJfxVHR4TQNETeyNtGw/uD1+voo7f2Vhjldyqe8w=="],
+    "@anthropic-ai/claude-code": ["@anthropic-ai/claude-code@2.1.170", "", { "optionalDependencies": { "@anthropic-ai/claude-code-darwin-arm64": "2.1.170", "@anthropic-ai/claude-code-darwin-x64": "2.1.170", "@anthropic-ai/claude-code-linux-arm64": "2.1.170", "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.170", "@anthropic-ai/claude-code-linux-x64": "2.1.170", "@anthropic-ai/claude-code-linux-x64-musl": "2.1.170", "@anthropic-ai/claude-code-win32-arm64": "2.1.170", "@anthropic-ai/claude-code-win32-x64": "2.1.170" }, "bin": { "claude": "bin/claude.exe" } }, "sha512-/kMpp+fz72boi8KvAW4EZ1G8FWtPAR3vH1uKGlYpoZ2O9SU5XdaYCTvw5tPyYGDoB+eFiOnolfTiKPUK8vnP7g=="],
 
-    "@anthropic-ai/claude-code-darwin-arm64": ["@anthropic-ai/claude-code-darwin-arm64@2.1.154", "", { "os": "darwin", "cpu": "arm64" }, "sha512-/oZeZPtEeAzgQHWMaIyYsh8te+wnUitfJkasBjANq1vYGZe6tpRNp6s51/iWPwLebid6Pe4ioqWvowtRwg6G2Q=="],
+    "@anthropic-ai/claude-code-darwin-arm64": ["@anthropic-ai/claude-code-darwin-arm64@2.1.170", "", { "os": "darwin", "cpu": "arm64" }, "sha512-lnBfVVTO+Wk31IAh5KDOY+Cuu1vIHC3N3UjHY9SEroDat8XKqjFtckY50jPi50m5x0oWkeQiyDl4nPstgdkNwQ=="],
 
-    "@anthropic-ai/claude-code-darwin-x64": ["@anthropic-ai/claude-code-darwin-x64@2.1.154", "", { "os": "darwin", "cpu": "x64" }, "sha512-Iai2FUf/xd5AwSruM/TBlEBdqApfNhBY4bdMGgfTZdPW8uwNPPMyrDV1xPpg9Ne1hd+7pU3Rp35b3genzk+CaA=="],
+    "@anthropic-ai/claude-code-darwin-x64": ["@anthropic-ai/claude-code-darwin-x64@2.1.170", "", { "os": "darwin", "cpu": "x64" }, "sha512-w2lZwSsKDVqrY8O6N65SSP309JJleWrUx9tltW2SIGaPRLybtrZf7q6KxDz3I/gEMBhpwnC2MHXYMU0sw6JXzg=="],
 
-    "@anthropic-ai/claude-code-linux-arm64": ["@anthropic-ai/claude-code-linux-arm64@2.1.154", "", { "os": "linux", "cpu": "arm64" }, "sha512-kUx+agGdSbKdSUPPWxq8O/4XsbGrMDQ89APe/vb4jvsCnt5hQAPWYd+gMaspL/QlvHd77wd8BJf5+fuqt5ck4g=="],
+    "@anthropic-ai/claude-code-linux-arm64": ["@anthropic-ai/claude-code-linux-arm64@2.1.170", "", { "os": "linux", "cpu": "arm64" }, "sha512-J2682NcqJbDouDcmR8VeVDAB4UxWryDMUZfPYdvbwiG3sM6SyupBHPuXgwIEcaT1M1jlpBiWRdJ4ActHF5Drng=="],
 
-    "@anthropic-ai/claude-code-linux-arm64-musl": ["@anthropic-ai/claude-code-linux-arm64-musl@2.1.154", "", { "os": "linux", "cpu": "arm64" }, "sha512-PwxQfvGVa56CuT0AAJZSH+yPNDvQgFOM8/a5DIpsjlN6VAtcZWvV4hkD8UhpAVpWJLkEICI9B2U/1YGfcRRz4w=="],
+    "@anthropic-ai/claude-code-linux-arm64-musl": ["@anthropic-ai/claude-code-linux-arm64-musl@2.1.170", "", { "os": "linux", "cpu": "arm64" }, "sha512-ClnCeAnKuOqyuEqU4jiEZSsdQfA8gzuEoiTCQtGEEYHWSwu341aZa35EmNl90JIXqIl5i8sNbA+ZMD+GEKGfUQ=="],
 
-    "@anthropic-ai/claude-code-linux-x64": ["@anthropic-ai/claude-code-linux-x64@2.1.154", "", { "os": "linux", "cpu": "x64" }, "sha512-AQxDm3rhPLnS5DLKYYUUSC4G40Fgc/zD7yOSTFyGvLLtI7S9Enuj8ltxVNWAQqF5U6mdWvnjuu8hZS1Ftk1IaQ=="],
+    "@anthropic-ai/claude-code-linux-x64": ["@anthropic-ai/claude-code-linux-x64@2.1.170", "", { "os": "linux", "cpu": "x64" }, "sha512-SSQ6TsGbZJSC1s6R5pxlTZPq1bilSpoTR8JANOq8ALUkbRVhgVSl0PiSSNSnc3zNdDCA1iA3ywLmAuISuhlvKA=="],
 
-    "@anthropic-ai/claude-code-linux-x64-musl": ["@anthropic-ai/claude-code-linux-x64-musl@2.1.154", "", { "os": "linux", "cpu": "x64" }, "sha512-XO6/peeBZWaPujCyRMYBS1zKXD1koJWz4LB7oJ/hUnvZ4l4NALesVWzZ8N8Hn9Sc0+wm3DK8zZMS6yG4tk6aXQ=="],
+    "@anthropic-ai/claude-code-linux-x64-musl": ["@anthropic-ai/claude-code-linux-x64-musl@2.1.170", "", { "os": "linux", "cpu": "x64" }, "sha512-mPwe4thBIj8nAbhzkKGmCLnqWuFxUI1wvrFai7TttlPMMeM2gelXaJnfgo9LEgEkp5KqqBFZRNeYQREiJsEqUQ=="],
 
-    "@anthropic-ai/claude-code-win32-arm64": ["@anthropic-ai/claude-code-win32-arm64@2.1.154", "", { "os": "win32", "cpu": "arm64" }, "sha512-CSNmhIgDWqjts60Yf6DUSnlCGMGhMZilbokgFFqj8XYqWrBtcVp6w8vGC6rQtI3jTM9ZYdAIFm8Jw8ZISwF0tA=="],
+    "@anthropic-ai/claude-code-win32-arm64": ["@anthropic-ai/claude-code-win32-arm64@2.1.170", "", { "os": "win32", "cpu": "arm64" }, "sha512-c3coVcbv6Ea8UBM4EYPbW341AC691Z9bCMEIWn/7YogLzRbBrhBQiMfPXN0qnapUMF8Osii093239PmdgXAHrA=="],
 
-    "@anthropic-ai/claude-code-win32-x64": ["@anthropic-ai/claude-code-win32-x64@2.1.154", "", { "os": "win32", "cpu": "x64" }, "sha512-VblD2yuEPT0Bx0gdjkClIiWKueMJdIW41xF+WXnRsIyjrsWbBphK+i19jiW+SRYIA73l20T0hbW2RHV60xeuug=="],
+    "@anthropic-ai/claude-code-win32-x64": ["@anthropic-ai/claude-code-win32-x64@2.1.170", "", { "os": "win32", "cpu": "x64" }, "sha512-wUcLJQuxirInc9mOqIY/z9i7eXxJFy7ShXtN+PZJpZRJJR8Evbx2ZbBwT/zcUNN1nyhHao34gwLp6LXHd3G9lg=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.91.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw=="],
 

--- a/sidecar/package.json
+++ b/sidecar/package.json
@@ -14,8 +14,8 @@
 		"typecheck": "bunx tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.3.154",
-		"@anthropic-ai/claude-code": "2.1.154",
+		"@anthropic-ai/claude-agent-sdk": "0.3.170",
+		"@anthropic-ai/claude-code": "2.1.170",
 		"@cursor/sdk": "1.0.18",
 		"@earendil-works/pi-agent-core": "^0.75.4",
 		"@earendil-works/pi-ai": "^0.75.4",

--- a/sidecar/scripts/vendor-platform.ts
+++ b/sidecar/scripts/vendor-platform.ts
@@ -78,6 +78,10 @@ export const CLAUDE_CODE_SHA256: Readonly<
 		arm64: "2394afa765253caaac8cb030c7954650c4052b537aacc664c634d6397bed064a",
 		x64: "95643be424f07808e7b67195695191b05d0edc6ad7c3c274424dfb062c875fb5",
 	},
+	"2.1.170": {
+		arm64: "95d699dd2f03827e95286fe854999d42e3d0bfeec37af88c5bf49908ee56aa53",
+		x64: "f3e63255173dc3a9fcaa4cbe945b87454c8530e5d245affcd5b207b20c3e8bb0",
+	},
 };
 
 export const OPENCODE_SHA256: Readonly<

--- a/sidecar/src/model-catalog.ts
+++ b/sidecar/src/model-catalog.ts
@@ -9,12 +9,22 @@ const CURSOR_REASONING_LEVELS = ["low", "medium", "high"] as const;
 // `list_agent_model_sections` command; this one feeds `listModels`.
 const MODEL_CATALOG: Record<Provider, readonly ProviderModelInfo[]> = {
 	claude: [
+		// Fable 5 leads the list as the most capable pick, but it burns limits
+		// ~2x faster than Opus — `useEnsureDefaultModel` pins the app default
+		// to the `default` (Opus) entry below, NOT to the first entry. No fast
+		// mode (Opus 4.6+ only).
+		{
+			id: "claude-fable-5[1m]",
+			label: "Fable 5 1M",
+			cliModel: "claude-fable-5[1m]",
+			effortLevels: ["low", "medium", "high", "xhigh", "max"],
+		},
 		// `default` resolves to the newest Opus the bundled claude-code knows
-		// about — in 2.1.154 that is Opus 4.8 (1M context, adaptive thinking,
+		// about — in 2.1.170 that is Opus 4.8 (1M context, adaptive thinking,
 		// default high effort, fast mode at 2x rate / 2.5x speed). Kept as
 		// `default` (rather than pinned `claude-opus-4-8`) so it stays the
-		// auto-latest pick AND remains the catalog's first entry, which
-		// `useEnsureDefaultModel` selects as the app default.
+		// auto-latest pick AND remains the app default selection (see
+		// `useEnsureDefaultModel`, which prefers id == "default").
 		{
 			id: "default",
 			label: "Opus 4.8 1M",

--- a/sidecar/test/claude-session-manager.test.ts
+++ b/sidecar/test/claude-session-manager.test.ts
@@ -1765,6 +1765,12 @@ describe("ClaudeSessionManager.listModels", () => {
 
 		expect(models).toEqual([
 			{
+				id: "claude-fable-5[1m]",
+				label: "Fable 5 1M",
+				cliModel: "claude-fable-5[1m]",
+				effortLevels: ["low", "medium", "high", "xhigh", "max"],
+			},
+			{
 				id: "default",
 				label: "Opus 4.8 1M",
 				cliModel: "default",

--- a/src-tauri/src/agents/catalog.rs
+++ b/src-tauri/src/agents/catalog.rs
@@ -72,12 +72,23 @@ fn official_claude_section() -> AgentModelSection {
         label: "Claude Code".to_string(),
         status: AgentModelSectionStatus::Ready,
         options: vec![
+            // Fable 5 leads the list as the most capable pick, but it burns
+            // limits ~2x faster than Opus — `useEnsureDefaultModel` therefore
+            // pins the app default to the `default` (Opus) entry below, NOT
+            // to options[0]. No fast mode (Opus 4.6+ only).
+            claude_model(
+                "claude-fable-5[1m]",
+                "Fable 5 1M",
+                &["low", "medium", "high", "xhigh", "max"],
+                false,
+            ),
             // `default` resolves to the newest Opus the bundled claude-code
-            // knows about — 2.1.154 maps it to Opus 4.8 (1M context, adaptive
+            // knows about — 2.1.170 maps it to Opus 4.8 (1M context, adaptive
             // thinking, default high effort, fast mode at 2x rate / 2.5x
             // speed). Kept as `default` so it stays the auto-latest pick and
-            // remains the first entry (the app's default selection). MUST stay
-            // in sync with `sidecar/src/model-catalog.ts`.
+            // remains the app's default selection (see
+            // `useEnsureDefaultModel`, which prefers id == "default"). MUST
+            // stay in sync with `sidecar/src/model-catalog.ts`.
             claude_model(
                 "default",
                 "Opus 4.8 1M",
@@ -598,6 +609,7 @@ mod tests {
                 .map(|model| model.id.as_str())
                 .collect::<Vec<_>>(),
             vec![
+                "claude-fable-5[1m]",
                 "default",
                 "claude-opus-4-7[1m]",
                 "claude-opus-4-6[1m]",
@@ -659,6 +671,7 @@ mod tests {
                 .map(|model| model.id.as_str())
                 .collect::<Vec<_>>(),
             vec![
+                "claude-fable-5[1m]",
                 "default",
                 "claude-opus-4-7[1m]",
                 "claude-opus-4-6[1m]",
@@ -668,14 +681,14 @@ mod tests {
             ]
         );
         assert_eq!(
-            sections[0].options[5].provider_key.as_deref(),
+            sections[0].options[6].provider_key.as_deref(),
             Some("minimax")
         );
         assert_eq!(
-            sections[0].options[5].effort_levels,
+            sections[0].options[6].effort_levels,
             vec!["low", "medium", "high", "xhigh", "max"]
         );
-        assert!(!sections[0].options[5].supports_context_usage);
+        assert!(!sections[0].options[6].supports_context_usage);
         assert_eq!(sections[1].id, "codex");
     }
 
@@ -914,20 +927,37 @@ mod tests {
     }
 
     #[test]
-    fn official_claude_section_surfaces_opus_4_8_default_above_4_7_and_4_6() {
+    fn official_claude_section_surfaces_fable_5_above_opus_lineage() {
         let sections = model_sections_for_inputs(Vec::new(), None, None);
         let claude = sections.iter().find(|s| s.id == "claude").unwrap();
         let ids: Vec<&str> = claude.options.iter().map(|o| o.id.as_str()).collect();
-        // User-facing ordering: 4.8 (default) on top, then 4.7, then 4.6.
+        // User-facing ordering: Fable 5 on top, then 4.8 (default), 4.7, 4.6.
         assert_eq!(
-            &ids[..3],
-            &["default", "claude-opus-4-7[1m]", "claude-opus-4-6[1m]"],
-            "Opus 4.8 must lead, with explicit 4.7 / 4.6 beneath it"
+            &ids[..4],
+            &[
+                "claude-fable-5[1m]",
+                "default",
+                "claude-opus-4-7[1m]",
+                "claude-opus-4-6[1m]"
+            ],
+            "Fable 5 must lead, with Opus 4.8 (default) / 4.7 / 4.6 beneath it"
         );
 
-        // `default` → Opus 4.8: leads the list (so `useEnsureDefaultModel`
-        // picks it), supports fast mode, and keeps the xhigh effort tier.
-        let default = &claude.options[0];
+        // Fable 5: most capable, leads the list, but is NOT the app default
+        // (too expensive) — `useEnsureDefaultModel` pins to id == "default".
+        // No fast mode (Opus 4.6+ only); full effort tiers incl. xhigh.
+        let fable = &claude.options[0];
+        assert_eq!(fable.label, "Fable 5 1M");
+        assert_eq!(fable.cli_model, "claude-fable-5[1m]");
+        assert!(!fable.supports_fast_mode);
+        assert_eq!(
+            fable.effort_levels,
+            vec!["low", "medium", "high", "xhigh", "max"]
+        );
+
+        // `default` → Opus 4.8: stays the app default selection, supports
+        // fast mode, and keeps the xhigh effort tier.
+        let default = &claude.options[1];
         assert_eq!(default.label, "Opus 4.8 1M");
         assert_eq!(default.cli_model, "default");
         assert!(default.supports_fast_mode, "Opus 4.8 supports fast mode");
@@ -937,7 +967,7 @@ mod tests {
         );
 
         // Explicit 4.7 pin: same effort tiers as before, still no fast mode.
-        let opus47 = &claude.options[1];
+        let opus47 = &claude.options[2];
         assert_eq!(opus47.label, "Opus 4.7 1M");
         assert_eq!(opus47.cli_model, "claude-opus-4-7[1m]");
         assert!(!opus47.supports_fast_mode);
@@ -947,7 +977,7 @@ mod tests {
         );
 
         // 4.6 unchanged.
-        let opus46 = &claude.options[2];
+        let opus46 = &claude.options[3];
         assert_eq!(opus46.label, "Opus 4.6 1M");
         assert!(opus46.supports_fast_mode);
     }

--- a/src/shell/hooks/use-ensure-default-model.test.tsx
+++ b/src/shell/hooks/use-ensure-default-model.test.tsx
@@ -168,6 +168,40 @@ describe("useEnsureDefaultModel", () => {
 		});
 	});
 
+	it("pins the repaired default to the claude `default` entry, not the first option", () => {
+		// Fable 5 leads the picker but is too expensive to be the app
+		// default — the repair must skip it and land on `default` (Opus).
+		const { updateSettings } = renderUseEnsureDefaultModel({
+			defaultModelId: null,
+			sections: [
+				{
+					id: "claude",
+					label: "Claude Code",
+					status: "ready",
+					options: [
+						{
+							id: "claude-fable-5[1m]",
+							provider: "claude",
+							label: "Fable 5 1M",
+							cliModel: "claude-fable-5[1m]",
+						},
+						{
+							id: "default",
+							provider: "claude",
+							label: "Opus 4.8 1M",
+							cliModel: "default",
+						},
+					],
+				},
+				{ id: "codex", label: "Codex", status: "unavailable", options: [] },
+			],
+		});
+
+		expect(updateSettings).toHaveBeenCalledWith(
+			expect.objectContaining({ defaultModelId: "default" }),
+		);
+	});
+
 	it("preserves an invalid saved model while any provider is still in error", () => {
 		const { updateSettings } = renderUseEnsureDefaultModel({
 			defaultModelId: "gpt-legacy",

--- a/src/shell/hooks/use-ensure-default-model.ts
+++ b/src/shell/hooks/use-ensure-default-model.ts
@@ -63,8 +63,14 @@ export function useEnsureDefaultModel() {
 		// Repair the default when it's never been set, or was set but is now
 		// definitively gone (wait for every provider to settle first).
 		if (!defaultValid && (settled || !settings.defaultModelId)) {
+			// Prefer the Claude `default` entry (auto-latest Opus) over the
+			// first listed option — pricier models (Fable 5) sit above it in
+			// the picker but must not become the app default.
+			const claudeOptions =
+				sections.find((s) => s.id === "claude")?.options ?? [];
 			const pick =
-				sections.find((s) => s.id === "claude")?.options[0]?.id ??
+				claudeOptions.find((o) => o.id === "default")?.id ??
+				claudeOptions[0]?.id ??
 				allOptions[0]?.id ??
 				null;
 			if (pick) {


### PR DESCRIPTION
## Summary

- Add **Claude Fable 5** (`claude-fable-5[1m]`, 1M context) to the Claude Code model catalogs (Rust `agents/catalog.rs` + sidecar `model-catalog.ts`), placed above Opus 4.8 as the most capable pick.
- Fable 5 costs 2× Opus ($10/$50 vs $5/$25 per MTok), so it must **not** become the app default: `useEnsureDefaultModel` now pins the repaired default to the `default` (Opus 4.8) entry instead of blindly taking the first listed claude option.
- Upgrade bundled `@anthropic-ai/claude-code` 2.1.154 → **2.1.170** and `@anthropic-ai/claude-agent-sdk` 0.3.154 → **0.3.170** — the bundled 2.1.154 CLI predates Fable 5. New SHA256 pins for both darwin arch tarballs in `vendor-platform.ts`; bundle cache wiped and sidecar rebuilt to verify (staged CLI reports 2.1.170).
- Changeset (minor) + pending in-app release announcement included.

## Capability details (verified against docs + 2.1.170 CLI metadata)

- Effort levels: `low`–`max` including `xhigh` (CLI: "Fable 5, Opus 4.8/4.7 only" for xhigh).
- No fast mode (Opus 4.8/4.7/4.6 only per CLI).
- Fable 5 rejects explicit `thinking: {type: "disabled"}` — the sidecar's main path uses `adaptive` (safe), and the disabled-thinking title path never receives the picker model (defaults to haiku).

## Test plan

- [x] Rust: catalog unit tests (31) + full pipeline snapshot suite (1476 passed; one unrelated flaky timing test passes in isolation)
- [x] Frontend: vitest 141 files / 1469 tests, incl. new "Fable leads but Opus stays default" case
- [x] Sidecar: 347 tests (updated `listModels` expectation)
- [x] `cargo clippy --all-targets -- -D warnings` clean, biome clean, typecheck clean