### PR TITLE
fix: prevent system-notice label from wrapping when body wraps

### DIFF
--- a/src/features/panel/message-components.test.tsx
+++ b/src/features/panel/message-components.test.tsx
@@ -160,6 +160,36 @@ describe("MemoConversationMessage plan review", () => {
 		);
 	});
 
+	it("renders system notices inside assistant messages", () => {
+		const message: ThreadMessageLike = {
+			id: "opencode-error",
+			role: "assistant",
+			createdAt: "2026-04-12T12:00:00.000Z",
+			content: [
+				{
+					type: "system-notice",
+					id: "opencode-error:notice",
+					severity: "error",
+					label: "OpenCode error",
+					body: 'Bad Request: {"detail":"Unsupported parameter: max_output_tokens"}',
+				},
+			],
+		};
+
+		render(
+			<MemoConversationMessage
+				message={message}
+				sessionId="session-1"
+				itemIndex={1}
+			/>,
+		);
+
+		expect(screen.getByText("OpenCode error")).toBeInTheDocument();
+		expect(
+			screen.getByText(/Unsupported parameter: max_output_tokens/),
+		).toBeInTheDocument();
+	});
+
 	it("copies the previous assistant message from the system meta row", () => {
 		const assistantMessage: ThreadMessageLike = {
 			id: "assistant-copy-source",

--- a/src/features/panel/message-components/assistant-message.tsx
+++ b/src/features/panel/message-components/assistant-message.tsx
@@ -30,6 +30,7 @@ import {
 	isImagePart,
 	isPlanReviewPart,
 	isReasoningPart,
+	isSystemNoticePart,
 	isTextPart,
 	isTodoListPart,
 	isToolCallPart,
@@ -42,6 +43,7 @@ import {
 	SubAgentSpawnGroup,
 	SubAgentToolCall,
 } from "./subagent-tool";
+import { SystemNotice } from "./system-message";
 import { AssistantToolCall, CollapsedToolGroup } from "./tool-call";
 
 // --- AssistantText ---
@@ -287,6 +289,16 @@ export function ChatAssistantMessage({
 				}
 				if (isImagePart(part)) {
 					return <ImageBlock key={key} part={part} />;
+				}
+				if (isSystemNoticePart(part)) {
+					return (
+						<div
+							key={key}
+							className="min-w-0 py-1 text-mini leading-snug text-muted-foreground"
+						>
+							<SystemNotice part={part} wrap />
+						</div>
+					);
 				}
 				if (isPlanReviewPart(part)) {
 					return <PlanReviewCard key={key} part={part} />;

--- a/src/features/panel/message-components/system-message.tsx
+++ b/src/features/panel/message-components/system-message.tsx
@@ -60,12 +60,16 @@ export function SystemNotice({
 				className={cn("size-3 shrink-0", iconClass, wrap ? "mt-0.5" : null)}
 				strokeWidth={1.8}
 			/>
-			<span>{part.label}</span>
+			<span className={wrap ? "shrink-0 whitespace-nowrap" : undefined}>
+				{part.label}
+			</span>
 			{part.body ? (
 				<span
 					className={cn(
 						"ml-1 text-muted-foreground/70",
-						wrap ? "min-w-0 whitespace-pre-wrap break-words" : "truncate",
+						wrap
+							? "min-w-0 flex-1 whitespace-pre-wrap break-words"
+							: "truncate",
 					)}
 				>
 					- {part.body}

--- a/src/features/panel/message-components/system-message.tsx
+++ b/src/features/panel/message-components/system-message.tsx
@@ -28,7 +28,13 @@ import {
 
 // --- sub-components ---
 
-function SystemNotice({ part }: { part: SystemNoticePart }) {
+export function SystemNotice({
+	part,
+	wrap = false,
+}: {
+	part: SystemNoticePart;
+	wrap?: boolean;
+}) {
 	const Icon =
 		part.severity === "error"
 			? AlertCircle
@@ -42,11 +48,26 @@ function SystemNotice({ part }: { part: SystemNoticePart }) {
 				? "text-chart-5"
 				: "text-chart-3";
 	return (
-		<span className="inline-flex min-h-4 items-center gap-1 whitespace-nowrap leading-none">
-			<Icon className={cn("size-3 shrink-0", iconClass)} strokeWidth={1.8} />
+		<span
+			className={cn(
+				"inline-flex min-h-4 gap-1",
+				wrap
+					? "min-w-0 items-start whitespace-normal break-words leading-snug"
+					: "items-center whitespace-nowrap leading-none",
+			)}
+		>
+			<Icon
+				className={cn("size-3 shrink-0", iconClass, wrap ? "mt-0.5" : null)}
+				strokeWidth={1.8}
+			/>
 			<span>{part.label}</span>
 			{part.body ? (
-				<span className="ml-1 truncate text-muted-foreground/70">
+				<span
+					className={cn(
+						"ml-1 text-muted-foreground/70",
+						wrap ? "min-w-0 whitespace-pre-wrap break-words" : "truncate",
+					)}
+				>
 					- {part.body}
 				</span>
 			) : null}


### PR DESCRIPTION
## What

Fix the system-notice layout so the label stays on one line when the body needs to wrap.

## Why

When a system notice body is long enough to wrap, the label (icon + text) would previously also wrap, breaking the visual alignment. The label and body should each handle flex sizing independently: the label stays static (), and the body takes remaining space ().

## Changes

- `system-message.tsx`: Add `shrink-0 whitespace-nowrap` to the label span and `flex-1` to the body span when `wrap` is enabled.