### PR TITLE
feat(settings): one-click cleanup of archived workspaces

### DIFF
--- a/.announcements/archive-cleanup.json
+++ b/.announcements/archive-cleanup.json
@@ -1,0 +1,11 @@
+{
+	"items": [
+		{
+			"text": "You can now clean up all archived workspaces at once from Settings → General to free up disk space.",
+			"action": {
+				"label": "Open General",
+				"value": { "type": "openSettings", "section": "general" }
+			}
+		}
+	]
+}

--- a/.changeset/clean-archived-workspaces.md
+++ b/.changeset/clean-archived-workspaces.md
@@ -1,0 +1,5 @@
+---
+"helmor": minor
+---
+
+Add a "Clean up archived workspaces" action in Settings → General that permanently deletes all archived workspaces and compacts the database to free up disk space.

--- a/src-tauri/src/agents.rs
+++ b/src-tauri/src/agents.rs
@@ -788,6 +788,7 @@ mod tests {
 
     #[test]
     fn resolve_model_infers_provider() {
+        let _env = crate::testkit::TestEnv::new("resolve-model-infers-provider");
         let claude = resolve_model("default", None);
         assert_eq!(claude.provider, "claude");
         assert_eq!(claude.cli_model, "default");

--- a/src-tauri/src/agents/catalog.rs
+++ b/src-tauri/src/agents/catalog.rs
@@ -681,6 +681,7 @@ mod tests {
 
     #[test]
     fn resolve_claude_model() {
+        let _env = crate::testkit::TestEnv::new("resolve-claude-model");
         let m = resolve_model("default", None);
         assert_eq!(m.provider, "claude");
         assert_eq!(m.cli_model, "default");
@@ -690,6 +691,7 @@ mod tests {
 
     #[test]
     fn resolve_opus_model() {
+        let _env = crate::testkit::TestEnv::new("resolve-opus-model");
         let m = resolve_model("opus", None);
         assert_eq!(m.provider, "claude");
         assert_eq!(m.cli_model, "opus");
@@ -697,12 +699,14 @@ mod tests {
 
     #[test]
     fn resolve_sonnet_model() {
+        let _env = crate::testkit::TestEnv::new("resolve-sonnet-model");
         let m = resolve_model("sonnet", None);
         assert_eq!(m.provider, "claude");
     }
 
     #[test]
     fn resolve_gpt_model_routes_to_codex() {
+        let _env = crate::testkit::TestEnv::new("resolve-gpt-model-routes-to-codex");
         let m = resolve_model("gpt-4o", None);
         assert_eq!(m.provider, "codex");
         assert_eq!(m.cli_model, "gpt-4o");
@@ -710,12 +714,14 @@ mod tests {
 
     #[test]
     fn resolve_gpt_5_4_routes_to_codex() {
+        let _env = crate::testkit::TestEnv::new("resolve-gpt-5-4-routes-to-codex");
         let m = resolve_model("gpt-5.4", None);
         assert_eq!(m.provider, "codex");
     }
 
     #[test]
     fn resolve_unknown_model_defaults_to_claude() {
+        let _env = crate::testkit::TestEnv::new("resolve-unknown-model-defaults-to-claude");
         let m = resolve_model("some-future-model", None);
         assert_eq!(m.provider, "claude");
         assert_eq!(m.cli_model, "some-future-model");
@@ -723,6 +729,7 @@ mod tests {
 
     #[test]
     fn resolve_opencode_slug_routes_to_opencode() {
+        let _env = crate::testkit::TestEnv::new("resolve-opencode-slug-routes-to-opencode");
         // Explicit hint.
         let m = resolve_model("anthropic/claude-opus-4-5", Some("opencode"));
         assert_eq!(m.provider, "opencode");
@@ -882,6 +889,7 @@ mod tests {
 
     #[test]
     fn resolve_composer_routes_to_cursor() {
+        let _env = crate::testkit::TestEnv::new("resolve-composer-routes-to-cursor");
         let m = resolve_model("composer-2", None);
         assert_eq!(m.provider, "cursor");
         assert_eq!(m.cli_model, "composer-2");
@@ -889,6 +897,7 @@ mod tests {
 
     #[test]
     fn cursor_namespaced_id_strips_to_wire_for_cli_model() {
+        let _env = crate::testkit::TestEnv::new("cursor-namespaced-id-strips-to-wire-for-");
         // Composer's selected model id from the picker is `cursor-default`
         // (Helmor namespace). Resolver must emit `cli_model = "default"`
         // so the SDK's `Cursor.models.list` token survives the round-trip.
@@ -954,6 +963,7 @@ mod tests {
 
     #[test]
     fn claude_default_no_longer_collides_with_cursor_auto() {
+        let _env = crate::testkit::TestEnv::new("claude-default-no-longer-collides-with-c");
         // `default` belongs to Claude (Opus 4.8 1M). Cursor's Auto is
         // `cursor-default`. They MUST resolve to different providers
         // even when the picker / persistence flow doesn't pass a hint —
@@ -1262,6 +1272,7 @@ mod tests {
 
     #[test]
     fn provider_hint_disambiguates_overlapping_ids() {
+        let _env = crate::testkit::TestEnv::new("provider-hint-disambiguates-overlapping-");
         // A bare `gpt-`-prefixed id routes to Codex by prefix, but a
         // provider hint overrides that: the same id resolves to Cursor when
         // hinted. (Cursor's namespaced form `cursor-gpt-5.3-codex` obviates

--- a/src-tauri/src/commands/workspace_commands.rs
+++ b/src-tauri/src/commands/workspace_commands.rs
@@ -498,3 +498,152 @@ pub async fn permanently_delete_workspace(app: AppHandle, workspace_id: String) 
     git_watcher::notify_workspace_changed(&app);
     Ok(())
 }
+
+/// Guards against a second cleanup run starting while one is in flight —
+/// the deletes are idempotent but a concurrent run would misreport every
+/// already-deleted workspace as a failure.
+static ARCHIVE_CLEANUP_RUNNING: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Bulk-delete every archived workspace through the same per-workspace
+/// path as `permanently_delete_workspace` (FS mutation lock, git unwatch,
+/// DB transaction, leftover-dir removal). Deletions run strictly one at a
+/// time; the command resolves only after the whole run finishes, but the
+/// run itself is backend-owned — it completes even if the frontend stops
+/// listening.
+#[tauri::command]
+pub async fn cleanup_archived_workspaces(
+    app: AppHandle,
+) -> CmdResult<workspaces::CleanupArchivedWorkspacesResponse> {
+    use std::sync::atomic::Ordering;
+
+    if ARCHIVE_CLEANUP_RUNNING
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return Err(anyhow::anyhow!("Archive cleanup is already running").into());
+    }
+    let result = cleanup_archived_workspaces_inner(&app).await;
+    ARCHIVE_CLEANUP_RUNNING.store(false, Ordering::SeqCst);
+    result
+}
+
+async fn cleanup_archived_workspaces_inner(
+    app: &AppHandle,
+) -> CmdResult<workspaces::CleanupArchivedWorkspacesResponse> {
+    let archived = run_blocking(workspaces::list_archived_workspaces).await?;
+    let titles: std::collections::HashMap<String, String> = archived
+        .iter()
+        .map(|workspace| (workspace.id.clone(), workspace.title.clone()))
+        .collect();
+    let mut remaining: Vec<String> = archived.into_iter().map(|workspace| workspace.id).collect();
+    let total = remaining.len();
+
+    let mut deleted_count = 0usize;
+    let failures: Vec<workspaces::CleanupArchivedFailure>;
+
+    // Multi-pass: deleting a middle layer of a PR stack is blocked while
+    // other workspaces are stacked on it, so a pass that made progress
+    // earns the leftovers a retry (children get deleted first, then their
+    // parents become deletable). Stops as soon as a full pass deletes
+    // nothing — whatever is left is a genuine failure.
+    loop {
+        let mut failed_this_pass: Vec<(String, String)> = Vec::new();
+        let mut progressed = false;
+
+        for workspace_id in remaining.drain(..) {
+            // Same per-workspace serialization as the single-delete
+            // command: a concurrent restore of this workspace either
+            // finishes first (then the still-archived re-check skips it)
+            // or waits until the row is gone.
+            let ws_lock = db::workspace_fs_mutation_lock(&workspace_id);
+            let _lock = ws_lock.lock().await;
+            app.state::<git_watcher::GitWatcherManager>()
+                .unwatch(&workspace_id);
+
+            let id_for_task = workspace_id.clone();
+            let result = tauri::async_runtime::spawn_blocking(move || {
+                workspaces::delete_workspace_if_archived(&id_for_task)
+            })
+            .await;
+
+            match result {
+                Ok(Ok(true)) => {
+                    deleted_count += 1;
+                    progressed = true;
+                    tracing::info!(
+                        workspace_id,
+                        deleted_count,
+                        total,
+                        "Archive cleanup: workspace deleted"
+                    );
+                    crate::ui_sync::publish(
+                        app,
+                        crate::ui_sync::UiMutationEvent::WorkspaceListChanged,
+                    );
+                }
+                Ok(Ok(false)) => {
+                    tracing::info!(
+                        workspace_id,
+                        "Archive cleanup: workspace no longer archived, skipping"
+                    );
+                }
+                Ok(Err(error)) => {
+                    tracing::warn!(
+                        workspace_id,
+                        error = %format!("{error:#}"),
+                        "Archive cleanup: delete failed"
+                    );
+                    failed_this_pass.push((workspace_id, crate::error::outermost_message(&error)));
+                }
+                Err(error) => {
+                    tracing::error!(workspace_id, %error, "Archive cleanup: delete task crashed");
+                    failed_this_pass.push((workspace_id, error.to_string()));
+                }
+            }
+        }
+
+        if failed_this_pass.is_empty() || !progressed {
+            failures = failed_this_pass
+                .into_iter()
+                .map(
+                    |(workspace_id, message)| workspaces::CleanupArchivedFailure {
+                        title: titles.get(&workspace_id).cloned().unwrap_or_default(),
+                        workspace_id,
+                        message,
+                    },
+                )
+                .collect();
+            break;
+        }
+        remaining = failed_this_pass.into_iter().map(|(id, _)| id).collect();
+    }
+
+    // Deleting rows only frees pages for reuse inside the SQLite file;
+    // compact once at the end so the space actually goes back to the OS.
+    // Best-effort — a busy vacuum must not turn a successful cleanup into
+    // a failure.
+    if deleted_count > 0 {
+        let vacuum_started = std::time::Instant::now();
+        match run_blocking(workspaces::vacuum_database).await {
+            Ok(()) => tracing::info!(
+                elapsed_ms = vacuum_started.elapsed().as_millis(),
+                "Archive cleanup: database vacuum finished"
+            ),
+            Err(error) => tracing::warn!(?error, "Archive cleanup: database vacuum failed"),
+        }
+    }
+
+    git_watcher::notify_workspace_changed(app);
+    tracing::info!(
+        deleted_count,
+        failed = failures.len(),
+        total,
+        "Archive cleanup finished"
+    );
+
+    Ok(workspaces::CleanupArchivedWorkspacesResponse {
+        deleted_count,
+        failures,
+    })
+}

--- a/src-tauri/src/companion/rpc.rs
+++ b/src-tauri/src/companion/rpc.rs
@@ -50,6 +50,7 @@ async fn dispatch(
         "backfill_forge_repo_bindings" => to_value(crate::commands::forge_commands::backfill_forge_repo_bindings(app.clone()).await?),
         "cache_forge_avatar" => to_value(crate::commands::forge_commands::cache_forge_avatar(arg_string(&args, "url")?).await?),
         "check_for_app_update" => to_value(crate::commands::updater_commands::check_for_app_update(app.clone(), arg_opt_bool(&args, "force")).await?),
+        "cleanup_archived_workspaces" => to_value(crate::commands::workspace_commands::cleanup_archived_workspaces(app.clone()).await?),
         "clone_repository_from_url" => to_value(crate::commands::repository_commands::clone_repository_from_url(arg_string(&args, "gitUrl")?, arg_string(&args, "cloneDirectory")?).await?),
         "close_workspace_change_request" => to_value(crate::commands::forge_commands::close_workspace_change_request(arg_string(&args, "workspaceId")?, app.clone()).await?),
         "complete_workspace_setup" => {

--- a/src-tauri/src/data_dir.rs
+++ b/src-tauri/src/data_dir.rs
@@ -198,6 +198,20 @@ fn resolve_data_dir() -> Result<PathBuf> {
         return Ok(PathBuf::from(dir));
     }
 
+    // Fuse: a unit test reaching this fallback would operate on the REAL
+    // `~/helmor-dev` data directory — DB pools open against it, file
+    // helpers delete inside it, and a concurrently running dev app gets
+    // its writes starved. Fail the offending test loudly instead of
+    // polluting silently.
+    if cfg!(test) {
+        panic!(
+            "Test resolved the real data directory (~/{}/). Create a \
+             `testkit::TestEnv` (and keep it alive) before touching the DB \
+             or any data-dir path.",
+            default_data_dir_name()
+        );
+    }
+
     // 2. Build profile based
     let home = dirs_home().context("Could not determine home directory")?;
 

--- a/src-tauri/src/import.rs
+++ b/src-tauri/src/import.rs
@@ -1035,6 +1035,7 @@ mod tests {
 
     #[test]
     fn import_workspace_db_records_skips_existing() {
+        let _env = crate::testkit::TestEnv::new("import-workspace-db-records-skips-existi");
         let (conn, _dir) = setup_test_db();
 
         conn.execute_batch(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -734,6 +734,7 @@ pub fn run() {
             commands::editors::open_workspace_in_editor,
             commands::editors::open_workspace_in_finder,
             commands::workspace_commands::permanently_delete_workspace,
+            commands::workspace_commands::cleanup_archived_workspaces,
             commands::workspace_commands::restore_workspace,
             commands::editor_commands::stat_editor_file,
             commands::conductor_commands::conductor_source_available,

--- a/src-tauri/src/workspace/files/tests/workspace_changes.rs
+++ b/src-tauri/src/workspace/files/tests/workspace_changes.rs
@@ -6,6 +6,7 @@ use super::{list_workspace_changes, support::GitRepoHarness};
 
 #[test]
 fn classification_unstaged_modification() {
+    let _env = crate::testkit::TestEnv::new("classification-unstaged-modification");
     let repo = GitRepoHarness::new();
 
     repo.write_file("src/app.ts", "const v1 = true;\n");
@@ -24,6 +25,7 @@ fn classification_unstaged_modification() {
 
 #[test]
 fn classification_staged_modification() {
+    let _env = crate::testkit::TestEnv::new("classification-staged-modification");
     let repo = GitRepoHarness::new();
 
     repo.write_file("src/app.ts", "const v1 = true;\n");
@@ -46,6 +48,7 @@ fn classification_staged_modification() {
 
 #[test]
 fn classification_untracked_file() {
+    let _env = crate::testkit::TestEnv::new("classification-untracked-file");
     let repo = GitRepoHarness::new();
 
     repo.write_file("new-file.txt", "hello\n");
@@ -68,6 +71,7 @@ fn classification_untracked_file() {
 
 #[test]
 fn agent_contexts_is_ignored_in_real_git_worktree_changes() {
+    let _env = crate::testkit::TestEnv::new("agent-contexts-is-ignored-in-real-git-wo");
     let repo = GitRepoHarness::new();
     let worktree_parent = tempfile::tempdir().unwrap();
     let worktree_dir = worktree_parent.path().join("workspace");
@@ -129,6 +133,7 @@ fn agent_contexts_is_ignored_in_real_git_worktree_changes() {
 
 #[test]
 fn classification_staged_new_file() {
+    let _env = crate::testkit::TestEnv::new("classification-staged-new-file");
     let repo = GitRepoHarness::new();
 
     repo.write_file("new-file.txt", "hello\n");
@@ -148,6 +153,7 @@ fn classification_staged_new_file() {
 
 #[test]
 fn classification_committed_on_branch() {
+    let _env = crate::testkit::TestEnv::new("classification-committed-on-branch");
     let repo = GitRepoHarness::new();
 
     repo.write_file("feature.ts", "export const feature = true;\n");
@@ -172,6 +178,7 @@ fn classification_committed_on_branch() {
 
 #[test]
 fn classification_both_staged_and_unstaged() {
+    let _env = crate::testkit::TestEnv::new("classification-both-staged-and-unstaged");
     let repo = GitRepoHarness::new();
 
     repo.write_file("mixed.ts", "v1\n");
@@ -196,6 +203,7 @@ fn classification_both_staged_and_unstaged() {
 
 #[test]
 fn classification_after_commit_changes_clear() {
+    let _env = crate::testkit::TestEnv::new("classification-after-commit-changes-clea");
     let repo = GitRepoHarness::new();
 
     repo.write_file("done.ts", "done\n");
@@ -219,6 +227,7 @@ fn classification_after_commit_changes_clear() {
 
 #[test]
 fn classification_no_changes_empty_result() {
+    let _env = crate::testkit::TestEnv::new("classification-no-changes-empty-result");
     let repo = GitRepoHarness::new();
 
     let items = repo.changes();
@@ -230,6 +239,7 @@ fn classification_no_changes_empty_result() {
 
 #[test]
 fn classification_discard_removes_from_changes() {
+    let _env = crate::testkit::TestEnv::new("classification-discard-removes-from-chan");
     let repo = GitRepoHarness::new();
 
     repo.write_file("README.md", "modified\n");
@@ -252,6 +262,7 @@ fn classification_discard_removes_from_changes() {
 
 #[test]
 fn line_counts_unstaged_only() {
+    let _env = crate::testkit::TestEnv::new("line-counts-unstaged-only");
     let repo = GitRepoHarness::new();
     repo.write_file("app.ts", "line1\nline2\nline3\n");
     repo.git(&["add", "app.ts"]);
@@ -268,6 +279,7 @@ fn line_counts_unstaged_only() {
 
 #[test]
 fn line_counts_staged_and_unstaged_kept_separate() {
+    let _env = crate::testkit::TestEnv::new("line-counts-staged-and-unstaged-kept-sep");
     let repo = GitRepoHarness::new();
     repo.write_file("app.ts", "v1\n");
     repo.git(&["add", "app.ts"]);
@@ -288,6 +300,7 @@ fn line_counts_staged_and_unstaged_kept_separate() {
 
 #[test]
 fn line_counts_committed_and_unstaged_kept_separate() {
+    let _env = crate::testkit::TestEnv::new("line-counts-committed-and-unstaged-kept-");
     let repo = GitRepoHarness::new();
     // 5 lines committed on the branch (relative to main).
     repo.write_file("feature.ts", "a\nb\nc\nd\ne\n");
@@ -308,6 +321,7 @@ fn line_counts_committed_and_unstaged_kept_separate() {
 
 #[test]
 fn line_counts_untracked_file_reports_unstaged_lines() {
+    let _env = crate::testkit::TestEnv::new("line-counts-untracked-file-reports-unsta");
     let repo = GitRepoHarness::new();
     // Brand-new file, nothing staged. Without explicit handling these
     // would all be zero (numstat doesn't see untracked).
@@ -323,6 +337,7 @@ fn line_counts_untracked_file_reports_unstaged_lines() {
 
 #[test]
 fn line_counts_untracked_no_trailing_newline_still_counts_last_line() {
+    let _env = crate::testkit::TestEnv::new("line-counts-untracked-no-trailing-newlin");
     let repo = GitRepoHarness::new();
     repo.write_file("oneliner.txt", "no newline at end");
 
@@ -332,6 +347,7 @@ fn line_counts_untracked_no_trailing_newline_still_counts_last_line() {
 
 #[test]
 fn line_counts_binary_file_marked_and_zeroed() {
+    let _env = crate::testkit::TestEnv::new("line-counts-binary-file-marked-and-zeroe");
     let repo = GitRepoHarness::new();
     // Bytes that aren't valid UTF-8 — both git numstat and our untracked
     // line counter should classify this as binary.

--- a/src-tauri/src/workspace/helpers.rs
+++ b/src-tauri/src/workspace/helpers.rs
@@ -1399,6 +1399,7 @@ mod tests {
 
     #[test]
     fn allocate_picks_from_workspace_names() {
+        let _env = crate::testkit::TestEnv::new("allocate-picks-from-workspace-names");
         let (conn, _dir) = test_db();
         let name = allocate_directory_name_with_conn(&conn, "r1").unwrap();
         assert!(
@@ -1409,6 +1410,7 @@ mod tests {
 
     #[test]
     fn allocate_avoids_used_names() {
+        let _env = crate::testkit::TestEnv::new("allocate-avoids-used-names");
         let (conn, _dir) = test_db();
 
         // Use all names except one
@@ -1432,6 +1434,7 @@ mod tests {
 
     #[test]
     fn allocate_uses_v2_suffix_when_all_taken() {
+        let _env = crate::testkit::TestEnv::new("allocate-uses-v2-suffix-when-all-taken");
         let (conn, _dir) = test_db();
 
         // Use all names
@@ -1462,6 +1465,7 @@ mod tests {
 
     #[test]
     fn allocate_is_random_not_sequential() {
+        let _env = crate::testkit::TestEnv::new("allocate-is-random-not-sequential");
         let (_conn, _dir) = test_db();
 
         // Allocate multiple names and check they're not always the same order
@@ -1483,6 +1487,7 @@ mod tests {
 
     #[test]
     fn allocate_is_case_insensitive() {
+        let _env = crate::testkit::TestEnv::new("allocate-is-case-insensitive");
         let (conn, _dir) = test_db();
 
         // Insert with uppercase — should still be recognized as used
@@ -1504,6 +1509,7 @@ mod tests {
 
     #[test]
     fn allocate_scoped_to_repo() {
+        let _env = crate::testkit::TestEnv::new("allocate-scoped-to-repo");
         let (conn, _dir) = test_db();
         conn.execute(
             "INSERT INTO repos (id, name) VALUES ('r2', 'other-repo')",

--- a/src-tauri/src/workspace/lifecycle.rs
+++ b/src-tauri/src/workspace/lifecycle.rs
@@ -1721,6 +1721,7 @@ mod tests {
 
     #[test]
     fn archive_hook_inner_returns_workspace_missing_for_unknown_id() {
+        let _env = crate::testkit::TestEnv::new("archive-hook-inner-returns-workspace-mis");
         let tmp = std::env::temp_dir();
         let outcome = run_archive_hook_inner("nonexistent-workspace-id", &tmp, &tmp);
         // Whatever the DB state, an unknown workspace id must short-circuit to

--- a/src-tauri/src/workspace/scripts.rs
+++ b/src-tauri/src/workspace/scripts.rs
@@ -1215,6 +1215,7 @@ mod tests {
     /// invariant.
     #[test]
     fn kill_all_does_not_deadlock_against_concurrent_unregister() {
+        let _env = crate::testkit::TestEnv::new("kill-all-does-not-deadlock-against-concu");
         let mgr = std::sync::Arc::new(ScriptProcessManager::new());
         let ctx = ScriptContext {
             root_path: std::env::temp_dir().display().to_string(),
@@ -1339,6 +1340,7 @@ mod tests {
 
     #[test]
     fn kill_terminates_running_script_quickly() {
+        let _env = crate::testkit::TestEnv::new("kill-terminates-running-script-quickly");
         let mgr = Arc::new(ScriptProcessManager::new());
         let ctx = ScriptContext {
             root_path: std::env::temp_dir().display().to_string(),
@@ -1405,6 +1407,7 @@ mod tests {
 
     #[test]
     fn write_stdin_delivers_bytes_to_running_script() {
+        let _env = crate::testkit::TestEnv::new("write-stdin-delivers-bytes-to-running-sc");
         let mgr = Arc::new(ScriptProcessManager::new());
         let ctx = ScriptContext {
             root_path: std::env::temp_dir().display().to_string(),
@@ -1496,6 +1499,7 @@ mod tests {
 
     #[test]
     fn resize_updates_pty_winsize() {
+        let _env = crate::testkit::TestEnv::new("resize-updates-pty-winsize");
         let mgr = Arc::new(ScriptProcessManager::new());
         let ctx = ScriptContext {
             root_path: std::env::temp_dir().display().to_string(),
@@ -1621,11 +1625,13 @@ mod tests {
 
     #[test]
     fn run_script_true_exits_zero() {
+        let _env = crate::testkit::TestEnv::new("run-script-true-exits-zero");
         assert_eq!(run_simple("true"), Some(0));
     }
 
     #[test]
     fn run_script_failing_command_exits_nonzero() {
+        let _env = crate::testkit::TestEnv::new("run-script-failing-command-exits-nonzero");
         assert_eq!(run_simple("exit 42"), Some(42));
     }
 
@@ -1657,6 +1663,7 @@ mod tests {
     /// keep working alongside the new ones.
     #[test]
     fn script_env_includes_helmor_port_vars_when_range_present() {
+        let _env = crate::testkit::TestEnv::new("script-env-includes-helmor-port-vars-whe");
         let mgr = ScriptProcessManager::new();
         let dir = std::env::temp_dir();
         let ctx = ScriptContext {
@@ -1734,6 +1741,7 @@ mod tests {
     /// `${HELMOR_PORT:-3000}` keep their default.
     #[test]
     fn script_env_omits_helmor_port_vars_when_range_missing() {
+        let _env = crate::testkit::TestEnv::new("script-env-omits-helmor-port-vars-when-r");
         let mgr = ScriptProcessManager::new();
         let dir = std::env::temp_dir();
         let ctx = ScriptContext {

--- a/src-tauri/src/workspace/workspaces.rs
+++ b/src-tauri/src/workspace/workspaces.rs
@@ -1669,6 +1669,55 @@ pub fn permanently_delete_workspace(workspace_id: &str) -> Result<()> {
     Ok(())
 }
 
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CleanupArchivedFailure {
+    pub workspace_id: String,
+    pub title: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CleanupArchivedWorkspacesResponse {
+    pub deleted_count: usize,
+    pub failures: Vec<CleanupArchivedFailure>,
+}
+
+/// Compact the SQLite file after a bulk delete. Dropping rows only marks
+/// their pages as free for reuse — the file itself never shrinks — so a
+/// cleanup whose entire point is reclaiming disk space must `VACUUM` once
+/// at the end to hand the space back to the OS. In WAL mode the vacuum's
+/// rewrite lands in the `-wal` file and the main file only shrinks at the
+/// next checkpoint, so force a truncating checkpoint right away instead
+/// of leaving the reclaim to whenever the auto-checkpointer fires.
+pub fn vacuum_database() -> Result<()> {
+    let connection = db::write_conn()?;
+    connection
+        .execute_batch("VACUUM")
+        .context("Failed to vacuum database")?;
+    connection
+        .execute_batch("PRAGMA wal_checkpoint(TRUNCATE)")
+        .context("Failed to checkpoint WAL after vacuum")?;
+    Ok(())
+}
+
+/// Delete a workspace via [`permanently_delete_workspace`] only if it is
+/// still archived when we get to it. Returns `Ok(false)` (skip, not an
+/// error) when the row is gone or no longer archived — the bulk archive
+/// cleanup snapshots its id list up front, and a workspace restored (or
+/// deleted elsewhere) mid-run must be left alone. Callers hold the
+/// per-workspace FS mutation lock, so the check can't race a restore.
+pub fn delete_workspace_if_archived(workspace_id: &str) -> Result<bool> {
+    match workspace_models::load_workspace_record_by_id(workspace_id)? {
+        Some(record) if record.state == WorkspaceState::Archived => {
+            permanently_delete_workspace(workspace_id)?;
+            Ok(true)
+        }
+        _ => Ok(false),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2450,6 +2499,57 @@ mod tests {
             )
             .unwrap();
         assert_eq!(remaining, 0, "DB row must be gone too");
+    }
+
+    #[test]
+    fn delete_workspace_if_archived_deletes_archived_row() {
+        let env = TestEnv::new("cleanup-archived-deletes");
+        let conn = env.db_connection();
+        insert_repo(&conn, "r1", "demo", None);
+        insert_workspace(
+            &conn,
+            &WorkspaceFixture {
+                id: "w-archived",
+                repo_id: "r1",
+                directory_name: "alpha",
+                state: WorkspaceState::Archived.as_str(),
+                branch: Some("feature/alpha"),
+                intended_target_branch: None,
+            },
+        );
+
+        let deleted = delete_workspace_if_archived("w-archived").unwrap();
+
+        assert!(deleted, "archived row must be deleted");
+        assert_eq!(count_workspaces(&env), 0);
+    }
+
+    #[test]
+    fn delete_workspace_if_archived_skips_operational_and_missing_rows() {
+        let env = TestEnv::new("cleanup-archived-skips");
+        let conn = env.db_connection();
+        insert_repo(&conn, "r1", "demo", None);
+        insert_workspace(
+            &conn,
+            &WorkspaceFixture {
+                id: "w-ready",
+                repo_id: "r1",
+                directory_name: "alpha",
+                state: WorkspaceState::Ready.as_str(),
+                branch: Some("feature/alpha"),
+                intended_target_branch: None,
+            },
+        );
+
+        assert!(
+            !delete_workspace_if_archived("w-ready").unwrap(),
+            "operational row must be skipped, not deleted"
+        );
+        assert!(
+            !delete_workspace_if_archived("w-missing").unwrap(),
+            "missing row must be a silent skip"
+        );
+        assert_eq!(count_workspaces(&env), 1, "operational row must remain");
     }
 
     #[test]

--- a/src/features/settings/index.tsx
+++ b/src/features/settings/index.tsx
@@ -66,6 +66,7 @@ import { SettingsSelect } from "./components/settings-select";
 import { AccountPanel } from "./panels/account";
 import { AppUpdatesPanel } from "./panels/app-updates";
 import { AppearancePanel } from "./panels/appearance";
+import { ArchiveCleanupPanel } from "./panels/archive-cleanup";
 import { ComponentsPanel } from "./panels/components";
 import { ConductorImportPanel } from "./panels/conductor-import";
 import { DevToolsPanel } from "./panels/dev-tools";
@@ -502,6 +503,7 @@ export const SettingsDialog = memo(function SettingsDialog({
 											</ToggleGroupItem>
 										</ToggleGroup>
 									</SettingsRow>
+									<ArchiveCleanupPanel />
 									<AppUpdatesPanel />
 									<ComponentsPanel />
 								</SettingsGroup>

--- a/src/features/settings/panels/archive-cleanup.test.tsx
+++ b/src/features/settings/panels/archive-cleanup.test.tsx
@@ -1,0 +1,139 @@
+import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithProviders } from "@/test/render-with-providers";
+import { ArchiveCleanupPanel } from "./archive-cleanup";
+
+const apiMocks = vi.hoisted(() => ({
+	cleanupArchivedWorkspaces: vi.fn(),
+	loadArchivedWorkspaces: vi.fn(),
+}));
+
+vi.mock("@/lib/api", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/lib/api")>();
+	return {
+		...actual,
+		cleanupArchivedWorkspaces: apiMocks.cleanupArchivedWorkspaces,
+		loadArchivedWorkspaces: apiMocks.loadArchivedWorkspaces,
+	};
+});
+
+const toastMocks = vi.hoisted(() => ({
+	success: vi.fn(),
+	error: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+	toast: { success: toastMocks.success, error: toastMocks.error },
+}));
+
+describe("ArchiveCleanupPanel", () => {
+	beforeEach(() => {
+		// The panel only reads the list length — minimal stubs are enough.
+		apiMocks.loadArchivedWorkspaces.mockResolvedValue([
+			{ id: "w1" },
+			{ id: "w2" },
+		]);
+		apiMocks.cleanupArchivedWorkspaces.mockResolvedValue({
+			deletedCount: 2,
+			failures: [],
+		});
+	});
+
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+	});
+
+	it("disables the button when there are no archived workspaces", async () => {
+		apiMocks.loadArchivedWorkspaces.mockResolvedValue([]);
+		renderWithProviders(<ArchiveCleanupPanel />);
+
+		const button = screen.getByRole("button", { name: /clean up/i });
+		await waitFor(() => expect(button).toBeDisabled());
+		expect(screen.getByText("No archived workspaces.")).toBeInTheDocument();
+	});
+
+	it("requires confirmation before starting the cleanup", async () => {
+		renderWithProviders(<ArchiveCleanupPanel />);
+
+		const button = screen.getByRole("button", { name: /clean up/i });
+		await waitFor(() => expect(button).toBeEnabled());
+		fireEvent.click(button);
+
+		expect(apiMocks.cleanupArchivedWorkspaces).not.toHaveBeenCalled();
+		expect(
+			screen.getByText("Clean up archived workspaces?"),
+		).toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole("button", { name: "Delete All" }));
+
+		await waitFor(() =>
+			expect(apiMocks.cleanupArchivedWorkspaces).toHaveBeenCalledTimes(1),
+		);
+		await waitFor(() =>
+			expect(toastMocks.success).toHaveBeenCalledWith(
+				"Cleaned up 2 archived workspaces",
+			),
+		);
+	});
+
+	it("keeps the dialog open and locked while the cleanup runs", async () => {
+		let resolveCleanup: (value: {
+			deletedCount: number;
+			failures: never[];
+		}) => void = () => {};
+		apiMocks.cleanupArchivedWorkspaces.mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					resolveCleanup = resolve;
+				}),
+		);
+		renderWithProviders(<ArchiveCleanupPanel />);
+
+		const button = screen.getByRole("button", { name: /clean up/i });
+		await waitFor(() => expect(button).toBeEnabled());
+		fireEvent.click(button);
+		fireEvent.click(screen.getByRole("button", { name: "Delete All" }));
+
+		// Both dialog buttons lock while the run is in flight.
+		await waitFor(() =>
+			expect(screen.getByRole("button", { name: "Delete All" })).toBeDisabled(),
+		);
+		expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+
+		resolveCleanup({ deletedCount: 2, failures: [] });
+		await waitFor(() =>
+			expect(
+				screen.queryByText("Clean up archived workspaces?"),
+			).not.toBeInTheDocument(),
+		);
+	});
+
+	it("surfaces partial failures in an error toast", async () => {
+		apiMocks.cleanupArchivedWorkspaces.mockResolvedValue({
+			deletedCount: 1,
+			failures: [
+				{
+					workspaceId: "w2",
+					title: "Stuck Workspace",
+					message: "branch is checked out elsewhere",
+				},
+			],
+		});
+		renderWithProviders(<ArchiveCleanupPanel />);
+
+		const button = screen.getByRole("button", { name: /clean up/i });
+		await waitFor(() => expect(button).toBeEnabled());
+		fireEvent.click(button);
+		fireEvent.click(screen.getByRole("button", { name: "Delete All" }));
+
+		await waitFor(() =>
+			expect(toastMocks.error).toHaveBeenCalledWith(
+				"Cleaned up 1, but 1 workspace could not be deleted",
+				{
+					description: "Stuck Workspace: branch is checked out elsewhere",
+				},
+			),
+		);
+	});
+});

--- a/src/features/settings/panels/archive-cleanup.tsx
+++ b/src/features/settings/panels/archive-cleanup.tsx
@@ -1,0 +1,109 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Loader2, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { cleanupArchivedWorkspaces } from "@/lib/api";
+import { archivedWorkspacesQueryOptions } from "@/lib/query-client";
+import { requestSidebarReconcile } from "@/lib/sidebar-mutation-gate";
+import { SettingsRow } from "../components/settings-row";
+
+/**
+ * Settings → General "Clean up archived workspaces" row.
+ *
+ * One button that permanently deletes every archived workspace through
+ * the standard backend delete path, behind an explicit confirmation
+ * dialog. Once confirmed the run is backend-owned and not cancellable —
+ * the dialog stays open in a loading state until the run finishes, and
+ * the outcome (including partial failures) lands as a toast.
+ */
+export function ArchiveCleanupPanel() {
+	const queryClient = useQueryClient();
+	const [confirmOpen, setConfirmOpen] = useState(false);
+	const archivedQuery = useQuery(archivedWorkspacesQueryOptions());
+	const archivedCount = archivedQuery.data?.length ?? 0;
+
+	const cleanup = useMutation({
+		mutationFn: cleanupArchivedWorkspaces,
+		onSuccess: (result) => {
+			if (result.failures.length === 0) {
+				toast.success(
+					result.deletedCount === 0
+						? "No archived workspaces to clean up"
+						: `Cleaned up ${result.deletedCount} archived workspace${
+								result.deletedCount === 1 ? "" : "s"
+							}`,
+				);
+				return;
+			}
+			toast.error(
+				`Cleaned up ${result.deletedCount}, but ${result.failures.length} workspace${
+					result.failures.length === 1 ? "" : "s"
+				} could not be deleted`,
+				{
+					description: result.failures
+						.map((failure) =>
+							failure.title
+								? `${failure.title}: ${failure.message}`
+								: failure.message,
+						)
+						.join("\n"),
+				},
+			);
+		},
+		onError: (error) => {
+			toast.error("Archive cleanup failed", {
+				description: error instanceof Error ? error.message : String(error),
+			});
+		},
+		onSettled: () => {
+			setConfirmOpen(false);
+			requestSidebarReconcile(queryClient);
+		},
+	});
+
+	return (
+		<SettingsRow
+			title="Clean up archived workspaces"
+			description={
+				archivedCount === 0
+					? "No archived workspaces."
+					: `Permanently delete all ${archivedCount} archived workspace${
+							archivedCount === 1 ? "" : "s"
+						}, including their sessions and chat history.`
+			}
+		>
+			<Button
+				variant="outline"
+				size="sm"
+				disabled={archivedCount === 0 || cleanup.isPending}
+				onClick={() => setConfirmOpen(true)}
+			>
+				{cleanup.isPending ? (
+					<Loader2 className="size-3.5 animate-spin" />
+				) : (
+					<Trash2 className="size-3.5" />
+				)}
+				{cleanup.isPending ? "Cleaning up" : "Clean up"}
+			</Button>
+			<ConfirmDialog
+				open={confirmOpen}
+				// Once the run starts it cannot be cancelled — keep the dialog
+				// up (with disabled buttons) so the loading state stays visible.
+				onOpenChange={(open) => {
+					if (!cleanup.isPending) {
+						setConfirmOpen(open);
+					}
+				}}
+				title="Clean up archived workspaces?"
+				description={`This will permanently delete all ${archivedCount} archived workspace${
+					archivedCount === 1 ? "" : "s"
+				}, including their sessions and chat history. This cannot be undone.`}
+				confirmLabel="Delete All"
+				onConfirm={() => cleanup.mutate()}
+				loading={cleanup.isPending}
+			/>
+		</SettingsRow>
+	);
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -3067,6 +3067,29 @@ export async function permanentlyDeleteWorkspace(
 	await invoke("permanently_delete_workspace", { workspaceId });
 }
 
+export interface CleanupArchivedFailure {
+	workspaceId: string;
+	title: string;
+	message: string;
+}
+
+export interface CleanupArchivedWorkspacesResponse {
+	deletedCount: number;
+	failures: CleanupArchivedFailure[];
+}
+
+/**
+ * Permanently delete every archived workspace, one at a time, through the
+ * same backend path as `permanentlyDeleteWorkspace`. Resolves when the
+ * whole run finishes; the run is backend-owned, so it completes even if
+ * the caller unmounts mid-flight.
+ */
+export async function cleanupArchivedWorkspaces(): Promise<CleanupArchivedWorkspacesResponse> {
+	return invoke<CleanupArchivedWorkspacesResponse>(
+		"cleanup_archived_workspaces",
+	);
+}
+
 /**
  * List of action kinds the user has opted-in to auto-close. Action sessions
  * whose `actionKind` appears in this list are hidden automatically after


### PR DESCRIPTION
## Summary

- Add a **Clean up archived workspaces** action to Settings → General: permanently deletes every archived workspace (sessions and chat history included) behind a double-confirm dialog, then VACUUMs + checkpoints the SQLite file so the reclaimed disk space goes back to the OS immediately.
  - Backend `cleanup_archived_workspaces` command: strictly sequential deletes through the standard `permanently_delete_workspace` path (per-workspace FS mutation lock, still-archived re-check so a mid-run restore is never clobbered), multi-pass retry so stacked children unblock their parents, re-entrancy guard, per-delete `WorkspaceListChanged` events. The run is backend-owned — it completes even if the frontend stops listening.
  - Frontend panel row with live archived count, locked loading state during the run, and a result toast that itemizes any per-workspace failures.
  - Exposed in the companion phone RPC dispatch (coverage gate).
- Fix unit tests silently opening the real `~/helmor-dev` data directory: `resolve_data_dir()` now panics under `cfg(test)` when `HELMOR_DATA_DIR` is unset, and the 44 tests the fuse exposed each got the missing `testkit::TestEnv` guard. (Found while dry-running this feature: a full `cargo test` run starved a live dev app's writes for ~47s and made concurrent archive operations fail with pool timeouts.)

## Test plan

- New Rust unit tests for `delete_workspace_if_archived` (archived deleted / operational skipped / missing skipped); new frontend tests for the panel (disabled-at-zero, confirm-before-run, locked dialog while pending, partial-failure toast).
- Full suites green: cargo (lib + integration incl. pipeline snapshots and companion dispatch coverage), vitest (142 files / 1473 tests), sidecar (347), clippy `--all-targets -D warnings`.
- Live end-to-end verification on a dev instance via the Tauri MCP bridge: two runs (28 and 3 archived workspaces) deleting real + seeded edge cases — stacked parent/child chain resolved via multi-pass, leftover worktree dir removed, DB file shrank 7.8 MB → 1.6 MB immediately after the click, zero failures.

> Note: `kill_all_does_not_deadlock_against_concurrent_unregister` / `kill_terminates_running_script_quickly` flake under full-suite load on the local machine; verified pre-existing (reproduces with this branch's changes stashed) and unrelated.