### PR TITLE
fix: refocus editor after restoring history draft in WebKit

### DIFF
--- a/.changeset/composer-history-cursor.md
+++ b/.changeset/composer-history-cursor.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix the composer's text cursor disappearing when you arrow back down through input history to your in-progress draft.

--- a/src/features/composer/editor/plugins/history-recall-plugin.test.tsx
+++ b/src/features/composer/editor/plugins/history-recall-plugin.test.tsx
@@ -418,4 +418,34 @@ describe("HistoryRecallPlugin", () => {
 		expect(persisted).toContain("keep this draft");
 		expect(persisted).not.toContain("history prompt");
 	});
+
+	it("refocuses the editor when ArrowDown restores a non-empty draft", async () => {
+		// Regression: `setEditorState` clears the DOM selection, blurring the
+		// contentEditable in WebKit. Restoring the draft must refocus the editor
+		// so the caret stays visible. jsdom can't reproduce the blur, so assert
+		// the explicit refocus call instead.
+		const focusSpy = vi.spyOn(
+			Object.getPrototypeOf(createEditor()) as { focus: () => void },
+			"focus",
+		);
+		try {
+			const contextKey = "session:recall-refocus";
+			savePersistedDraft(contextKey, paragraphDraft("my draft"));
+			renderComposer([textEntry("history prompt")], vi.fn(), contextKey);
+			const editor = screen.getByLabelText("Workspace input");
+
+			await waitFor(() => expect(editor.textContent).toContain("my draft"));
+			fireEvent.keyDown(editor, { key: "ArrowUp", code: "ArrowUp" });
+			await waitFor(() =>
+				expect(editor.textContent).toContain("history prompt"),
+			);
+
+			focusSpy.mockClear();
+			fireEvent.keyDown(editor, { key: "ArrowDown", code: "ArrowDown" });
+			await waitFor(() => expect(editor.textContent).toContain("my draft"));
+			expect(focusSpy).toHaveBeenCalled();
+		} finally {
+			focusSpy.mockRestore();
+		}
+	});
 });

--- a/src/features/composer/editor/plugins/history-recall-plugin.tsx
+++ b/src/features/composer/editor/plugins/history-recall-plugin.tsx
@@ -215,6 +215,11 @@ export function HistoryRecallPlugin({ getHistory, scopeKey }: Props) {
 						},
 						{ tag: HISTORY_RECALL_RESTORE_TAG },
 					);
+					// `setEditorState` wipes the DOM selection (removeAllRanges),
+					// which blurs the contentEditable in WebKit. Re-placing the
+					// model selection above doesn't refocus it, so the caret stays
+					// invisible — refocus now that the selection is committed.
+					editor.focus(undefined, { defaultSelection: "rootEnd" });
 					return;
 				} catch {
 					// Fall through to empty restore.


### PR DESCRIPTION
## What changed

Added an explicit `editor.focus()` call after restoring a draft from history recall in the Lexical composer. `setEditorState` calls `removeAllRanges()`, which blurs the `contentEditable` in WebKit — restoring the model selection alone doesn't refocus, leaving the caret invisible.

## Why it changed

On WebKit (Safari/Tauri webview), pressing ArrowDown to restore a history draft would place the selection correctly but the caret remained hidden because the editor lost focus during the state swap.

## Test notes

- Added a regression test in `history-recall-plugin.test.tsx` that asserts `editor.focus()` is called after ArrowDown restores a non-empty draft.