### PR TITLE
fix: prevent auto-close from hijacking workspace selection

### DIFF
--- a/.changeset/calm-windows-wave.md
+++ b/.changeset/calm-windows-wave.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix auto-closed action sessions hijacking your selection — completing an action in a background workspace no longer switches you away from the workspace you're viewing or leaves it with no session selected.

--- a/src/features/commit/hooks/use-commit-lifecycle.test.tsx
+++ b/src/features/commit/hooks/use-commit-lifecycle.test.tsx
@@ -348,6 +348,84 @@ describe("useWorkspaceCommitLifecycle", () => {
 		});
 	});
 
+	it("auto-closes without stealing selection when the user is on another workspace", async () => {
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false } },
+		});
+		queryClient.setQueryData<WorkspaceDetail | null>(
+			helmorQueryKeys.workspaceDetail("workspace-1"),
+			{
+				id: "workspace-1",
+				activeSessionId: "session-after-close",
+				status: "in-progress",
+			} as unknown as WorkspaceDetail,
+		);
+
+		// Dispatch happens on workspace-1; the user then navigates away.
+		let liveWorkspaceId: string | null = "workspace-1";
+		const onSelectSession = vi.fn();
+
+		const { result, rerender } = renderHook(
+			({
+				completedSessionIds,
+				busySessionIds,
+			}: {
+				completedSessionIds: Set<string>;
+				busySessionIds: Set<string>;
+			}) =>
+				useWorkspaceCommitLifecycle({
+					queryClient,
+					selectedWorkspaceId: "workspace-1",
+					getSelectedWorkspaceId: () => liveWorkspaceId,
+					selectedRepoId: "repo-1",
+					selectedWorkspaceTargetBranch: "main",
+					changeRequest: null,
+					forgeActionStatus: EMPTY_FORGE_ACTION_STATUS,
+					workspaceGitActionStatus: EMPTY_GIT_ACTION_STATUS,
+					completedSessionIds,
+					interactionRequiredSessionIds: new Set<string>(),
+					busySessionIds,
+					onSelectSession,
+				}),
+			{
+				initialProps: {
+					completedSessionIds: new Set<string>(),
+					busySessionIds: new Set<string>(),
+				},
+				wrapper: createWrapper(queryClient),
+			},
+		);
+
+		await act(async () => {
+			await result.current.handleInspectorCommitAction("create-pr");
+		});
+		act(() => {
+			result.current.handlePendingPromptConsumed();
+		});
+		onSelectSession.mockClear();
+
+		// User switches to a different workspace while the action runs.
+		liveWorkspaceId = "workspace-2";
+
+		rerender({
+			completedSessionIds: new Set<string>(),
+			busySessionIds: new Set(["session-action"]),
+		});
+		rerender({
+			completedSessionIds: new Set(["session-action"]),
+			busySessionIds: new Set<string>(),
+		});
+
+		// Session still auto-closes, but selection stays untouched.
+		await waitFor(() => {
+			expect(apiMocks.hideSession).toHaveBeenCalledWith("session-action");
+		});
+		await waitFor(() => {
+			expect(result.current.commitButtonState).toBe("idle");
+		});
+		expect(onSelectSession).not.toHaveBeenCalled();
+	});
+
 	it("clears the lifecycle when the tracked action session is aborted", async () => {
 		const queryClient = new QueryClient({
 			defaultOptions: { queries: { retry: false } },

--- a/src/features/commit/hooks/use-commit-lifecycle.ts
+++ b/src/features/commit/hooks/use-commit-lifecycle.ts
@@ -202,6 +202,11 @@ export function useWorkspaceCommitLifecycle({
 	const forgeActionStatusRef = useRef(currentForgeActionStatus);
 	forgeActionStatusRef.current = currentForgeActionStatus;
 
+	// Ref mirror so the done-phase effect can read the live selection without
+	// re-firing on every render (the getter is an inline arrow upstream).
+	const getSelectedWorkspaceIdRef = useRef(getSelectedWorkspaceId);
+	getSelectedWorkspaceIdRef.current = getSelectedWorkspaceId;
+
 	// `workspaceChangeRequest` is intentionally NOT invalidated here. Callers
 	// that need fresh PR data already write it directly via setQueryData
 	// (either from `await refreshWorkspaceChangeRequest(...)` or from an
@@ -787,6 +792,11 @@ export function useWorkspaceCommitLifecycle({
 							queryKey: helmorQueryKeys.workspaceDetail(workspaceId),
 						}),
 					]);
+					// Never hijack selection when the user has navigated to another
+					// workspace — the cached detail there is stale anyway (inactive
+					// queries don't refetch, so activeSessionId may still point at
+					// the session we just hid).
+					if (getSelectedWorkspaceIdRef.current() !== workspaceId) return;
 					const detail = queryClient.getQueryData<WorkspaceDetail | null>(
 						helmorQueryKeys.workspaceDetail(workspaceId),
 					);


### PR DESCRIPTION
## What changed

When a forge action (create-pr, send-for-review, etc.) completes and auto-hides its session, the completion hook () no longer switches the user away from their current workspace or leaves the workspace with no session selected.

## Why

Previously, the done-phase effect unconditionally read the cached workspace detail and called . If the user had navigated to a different workspace while the action was running, this would hijack their selection — the sidebar would jump back to the action's workspace. If the cached detail on the other workspace was stale (inactive queries don't refetch), it could also leave the workspace with no visible session.

## What changed technically

- Added a  that mirrors the live selection without re-firing the effect on every render.
- The done-phase guard now checks  before reading the cached detail and calling . If the user moved on, the effect skips selection entirely.
- Added a test that simulates navigating away mid-action and checks that  is not called.

## Test notes

- 
 RUN  v4.1.2 /Users/liangeqiang/helmor/workspaces/helmor/lepus


 Test Files  141 passed (141)
      Tests  1471 passed (1471)
   Start at  12:48:14
   Duration  38.09s (transform 68.68s, setup 50.16s, import 120.51s, tests 67.89s, environment 83.42s) — the new test covers the exact scenario.