### PR TITLE
fix: streaming timer briefly shows previous session's elapsed time on workspace switch

### DIFF
--- a/.changeset/swift-timers-sync.md
+++ b/.changeset/swift-timers-sync.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix the streaming timer briefly showing the previous session's elapsed time when switching workspaces, so it now updates to the correct value immediately.

--- a/src/features/panel/thread-viewport.tsx
+++ b/src/features/panel/thread-viewport.tsx
@@ -1220,16 +1220,16 @@ function ConversationBottomSpacer() {
 }
 
 function StreamingFooter({ startTime }: { startTime: number }) {
-	const [elapsed, setElapsed] = useState(() =>
-		Math.floor((Date.now() - startTime) / 1000),
-	);
+	// Derive elapsed from a ticking clock so a startTime change (e.g. workspace
+	// switch) reflects immediately instead of waiting for the next tick.
+	const [now, setNow] = useState(() => Date.now());
 
 	useEffect(() => {
-		const intervalId = window.setInterval(() => {
-			setElapsed(Math.floor((Date.now() - startTime) / 1000));
-		}, 1000);
+		const intervalId = window.setInterval(() => setNow(Date.now()), 1000);
 		return () => window.clearInterval(intervalId);
-	}, [startTime]);
+	}, []);
+
+	const elapsed = Math.max(0, Math.floor((now - startTime) / 1000));
 
 	const display =
 		elapsed < 60


### PR DESCRIPTION
## What changed

Derived the streaming footer elapsed time from a ticking `now` clock instead of baking `Date.now() - startTime` directly into state. When a workspace switch updates `startTime`, a re-render immediately computes the correct elapsed value rather than waiting for the next interval tick.

## Why

Switching workspaces could briefly display the previous session's elapsed time in the streaming footer until the next 1-second tick fired. This fix makes the timer reflect the new session immediately.

## Test notes

- Verify the streaming timer starts from 0 when switching between workspaces with active streams.
- Confirm the timer still ticks correctly at 1-second intervals.