### PR TITLE
fix: caret lost when arrowing down to multi-line composer draft

### DIFF
--- a/.changeset/composer-multiline-draft-cursor.md
+++ b/.changeset/composer-multiline-draft-cursor.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix the text cursor getting lost when arrowing back down through input history to a multi-line in-progress draft, which made the next ArrowUp jump back into history instead of moving the cursor.

--- a/.changeset/composer-multiline-draft-cursor.md
+++ b/.changeset/composer-multiline-draft-cursor.md
@@ -2,4 +2,7 @@
 "helmor": patch
 ---
 
-Fix the text cursor getting lost when arrowing back down through input history to a multi-line in-progress draft, which made the next ArrowUp jump back into history instead of moving the cursor.
+Fix composer input-history recall stealing arrow keys in multi-line drafts.
+
+- Arrowing back down through history to a multi-line in-progress draft no longer loses the cursor.
+- ArrowUp on a blank Shift+Enter line now moves the caret up instead of recalling history.

--- a/src/features/composer/editor/plugins/history-recall-plugin.test.tsx
+++ b/src/features/composer/editor/plugins/history-recall-plugin.test.tsx
@@ -20,8 +20,10 @@ import {
 	$createRangeSelection,
 	$createTextNode,
 	$getRoot,
+	$isElementNode,
 	$setSelection,
 	createEditor,
+	type LexicalEditor,
 	type SerializedEditorState,
 } from "lexical";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -85,7 +87,7 @@ function rect(top: number, bottom: number): DOMRect {
 	} as DOMRect;
 }
 
-function paragraphDraft(text: string): SerializedEditorState {
+function paragraphDraft(...lines: string[]): SerializedEditorState {
 	return {
 		root: {
 			type: "root",
@@ -93,28 +95,26 @@ function paragraphDraft(text: string): SerializedEditorState {
 			format: "",
 			indent: 0,
 			direction: null,
-			children: [
-				{
-					type: "paragraph",
-					version: 1,
-					format: "",
-					indent: 0,
-					direction: null,
-					textFormat: 0,
-					textStyle: "",
-					children: [
-						{
-							type: "text",
-							version: 1,
-							text,
-							format: 0,
-							mode: "normal",
-							style: "",
-							detail: 0,
-						},
-					],
-				},
-			],
+			children: lines.map((text) => ({
+				type: "paragraph",
+				version: 1,
+				format: "",
+				indent: 0,
+				direction: null,
+				textFormat: 0,
+				textStyle: "",
+				children: [
+					{
+						type: "text",
+						version: 1,
+						text,
+						format: 0,
+						mode: "normal",
+						style: "",
+						detail: 0,
+					},
+				],
+			})),
 		},
 	} as unknown as SerializedEditorState;
 }
@@ -417,6 +417,52 @@ describe("HistoryRecallPlugin", () => {
 		const persisted = JSON.stringify(loadPersistedDraft(contextKey));
 		expect(persisted).toContain("keep this draft");
 		expect(persisted).not.toContain("history prompt");
+	});
+
+	it("keeps the caret at the end of a multi-line draft restored via ArrowDown", async () => {
+		// Regression: returning to a multi-line in-progress draft must leave the
+		// caret at the end of the LAST paragraph. If the selection is lost (or
+		// lands on the first paragraph), the next ArrowUp re-enters recall
+		// instead of moving the caret within the draft.
+		const contextKey = "session:recall-multiline";
+		savePersistedDraft(contextKey, paragraphDraft("first line", "second line"));
+		renderComposer([textEntry("history prompt")], vi.fn(), contextKey);
+		const editorEl = screen.getByLabelText("Workspace input");
+		await waitFor(() => expect(editorEl.textContent).toContain("second line"));
+
+		const editor = (editorEl as unknown as { __lexicalEditor: LexicalEditor })
+			.__lexicalEditor;
+		expect(editor).toBeTruthy();
+
+		// Caret on the first paragraph so ArrowUp enters recall.
+		editor.update(
+			() => {
+				const first = $getRoot().getFirstChild();
+				if ($isElementNode(first)) first.selectStart();
+			},
+			{ discrete: true },
+		);
+
+		fireEvent.keyDown(editorEl, { key: "ArrowUp", code: "ArrowUp" });
+		await waitFor(() =>
+			expect(editorEl.textContent).toContain("history prompt"),
+		);
+
+		fireEvent.keyDown(editorEl, { key: "ArrowDown", code: "ArrowDown" });
+		await waitFor(() => expect(editorEl.textContent).toContain("second line"));
+
+		// Caret must be at the end of the restored draft (last paragraph).
+		let pos: { atFirstParagraph: boolean; atLastParagraph: boolean } | null =
+			null;
+		editor.getEditorState().read(() => {
+			pos = historyRecallTestUtils.$caretParagraphPosition();
+		});
+		expect(pos).toEqual({ atFirstParagraph: false, atLastParagraph: true });
+
+		// ArrowUp from the last paragraph must move the caret, not recall.
+		fireEvent.keyDown(editorEl, { key: "ArrowUp", code: "ArrowUp" });
+		expect(editorEl.textContent).toContain("second line");
+		expect(editorEl.textContent).not.toContain("history prompt");
 	});
 
 	it("refocuses the editor when ArrowDown restores a non-empty draft", async () => {

--- a/src/features/composer/editor/plugins/history-recall-plugin.test.tsx
+++ b/src/features/composer/editor/plugins/history-recall-plugin.test.tsx
@@ -16,6 +16,7 @@ import {
 	waitFor,
 } from "@testing-library/react";
 import {
+	$createLineBreakNode,
 	$createParagraphNode,
 	$createRangeSelection,
 	$createTextNode,
@@ -115,6 +116,47 @@ function paragraphDraft(...lines: string[]): SerializedEditorState {
 					},
 				],
 			})),
+		},
+	} as unknown as SerializedEditorState;
+}
+
+/** ONE paragraph whose lines are separated by linebreak nodes — the shape
+ *  Shift+Enter produces. An empty string yields a blank soft line. */
+function softLineDraft(...lines: string[]): SerializedEditorState {
+	const children: object[] = [];
+	lines.forEach((text, i) => {
+		if (i > 0) children.push({ type: "linebreak", version: 1 });
+		if (text) {
+			children.push({
+				type: "text",
+				version: 1,
+				text,
+				format: 0,
+				mode: "normal",
+				style: "",
+				detail: 0,
+			});
+		}
+	});
+	return {
+		root: {
+			type: "root",
+			version: 1,
+			format: "",
+			indent: 0,
+			direction: null,
+			children: [
+				{
+					type: "paragraph",
+					version: 1,
+					format: "",
+					indent: 0,
+					direction: null,
+					textFormat: 0,
+					textStyle: "",
+					children,
+				},
+			],
 		},
 	} as unknown as SerializedEditorState;
 }
@@ -296,6 +338,84 @@ describe("HistoryRecallPlugin", () => {
 				atLastParagraph: true,
 			});
 		});
+
+		// Shift+Enter lines live as LineBreakNodes inside ONE paragraph, so
+		// the first/last-child check alone can't see them.
+
+		it("treats text after a soft line break as not the first line", () => {
+			const editor = makeEditor();
+			editor.update(
+				() => {
+					const root = $getRoot();
+					root.clear();
+					const t2 = $createTextNode("second");
+					const p = $createParagraphNode();
+					p.append($createTextNode("first"), $createLineBreakNode(), t2);
+					root.append(p);
+					const selection = $createRangeSelection();
+					selection.anchor.set(t2.getKey(), 0, "text");
+					selection.focus.set(t2.getKey(), 0, "text");
+					$setSelection(selection);
+				},
+				{ discrete: true },
+			);
+			expect(readPosition(editor)).toEqual({
+				atFirstParagraph: false,
+				atLastParagraph: true,
+			});
+		});
+
+		it("treats text before a soft line break as not the last line", () => {
+			const editor = makeEditor();
+			editor.update(
+				() => {
+					const root = $getRoot();
+					root.clear();
+					const t1 = $createTextNode("first");
+					const p = $createParagraphNode();
+					p.append(t1, $createLineBreakNode(), $createTextNode("second"));
+					root.append(p);
+					const selection = $createRangeSelection();
+					selection.anchor.set(t1.getKey(), t1.getTextContentSize(), "text");
+					selection.focus.set(t1.getKey(), t1.getTextContentSize(), "text");
+					$setSelection(selection);
+				},
+				{ discrete: true },
+			);
+			expect(readPosition(editor)).toEqual({
+				atFirstParagraph: true,
+				atLastParagraph: false,
+			});
+		});
+
+		it("treats an empty soft line between breaks as neither first nor last", () => {
+			// Caret on a blank Shift+Enter line: element point on the paragraph,
+			// offset between the two linebreak nodes.
+			const editor = makeEditor();
+			editor.update(
+				() => {
+					const root = $getRoot();
+					root.clear();
+					const p = $createParagraphNode();
+					p.append(
+						$createTextNode("top"),
+						$createLineBreakNode(),
+						$createLineBreakNode(),
+						$createTextNode("bottom"),
+					);
+					root.append(p);
+					const selection = $createRangeSelection();
+					selection.anchor.set(p.getKey(), 2, "element");
+					selection.focus.set(p.getKey(), 2, "element");
+					$setSelection(selection);
+				},
+				{ discrete: true },
+			);
+			expect(readPosition(editor)).toEqual({
+				atFirstParagraph: false,
+				atLastParagraph: false,
+			});
+		});
 	});
 
 	it("does nothing when history is empty", async () => {
@@ -463,6 +583,60 @@ describe("HistoryRecallPlugin", () => {
 		fireEvent.keyDown(editorEl, { key: "ArrowUp", code: "ArrowUp" });
 		expect(editorEl.textContent).toContain("second line");
 		expect(editorEl.textContent).not.toContain("history prompt");
+	});
+
+	it("does not recall from a blank Shift+Enter line with text above it", async () => {
+		// Shift+Enter lines live in ONE paragraph as LineBreakNodes. With the
+		// caret on a blank soft line (between two breaks) the collapsed DOM
+		// range has no rect, so only the Lexical-side check can tell there is
+		// still a line above — ArrowUp must move the caret, not recall.
+		const contextKey = "session:recall-softline";
+		savePersistedDraft(contextKey, softLineDraft("top", "", "bottom"));
+		renderComposer([textEntry("history prompt")], vi.fn(), contextKey);
+		const editorEl = screen.getByLabelText("Workspace input");
+		await waitFor(() => expect(editorEl.textContent).toContain("bottom"));
+
+		const editor = (editorEl as unknown as { __lexicalEditor: LexicalEditor })
+			.__lexicalEditor;
+		// `editor.read` flushes pending updates first — DOM textContent can lag
+		// a recall applied inside the keydown dispatch.
+		const committedText = () => editor.read(() => $getRoot().getTextContent());
+
+		// Caret at the end of the last soft line: ArrowUp must NOT recall.
+		editor.update(
+			() => {
+				$getRoot().selectEnd();
+			},
+			{ discrete: true },
+		);
+		fireEvent.keyDown(editorEl, { key: "ArrowUp", code: "ArrowUp" });
+		expect(committedText()).not.toContain("history prompt");
+
+		// Caret on the blank middle soft line (element point between breaks).
+		editor.update(
+			() => {
+				const first = $getRoot().getFirstChild();
+				if (!$isElementNode(first)) return;
+				const selection = $createRangeSelection();
+				selection.anchor.set(first.getKey(), 2, "element");
+				selection.focus.set(first.getKey(), 2, "element");
+				$setSelection(selection);
+			},
+			{ discrete: true },
+		);
+		fireEvent.keyDown(editorEl, { key: "ArrowUp", code: "ArrowUp" });
+		expect(committedText()).not.toContain("history prompt");
+
+		// Caret at the very start (first soft line): ArrowUp SHOULD recall.
+		editor.update(
+			() => {
+				const first = $getRoot().getFirstChild();
+				if ($isElementNode(first)) first.selectStart();
+			},
+			{ discrete: true },
+		);
+		fireEvent.keyDown(editorEl, { key: "ArrowUp", code: "ArrowUp" });
+		await waitFor(() => expect(committedText()).toContain("history prompt"));
 	});
 
 	it("refocuses the editor when ArrowDown restores a non-empty draft", async () => {

--- a/src/features/composer/editor/plugins/history-recall-plugin.tsx
+++ b/src/features/composer/editor/plugins/history-recall-plugin.tsx
@@ -207,18 +207,20 @@ export function HistoryRecallPlugin({ getHistory, scopeKey }: Props) {
 		(serialized: SerializedEditorState | null) => {
 			if (serialized) {
 				try {
-					const parsed = editor.parseEditorState(serialized);
+					// Bake the caret into the parsed state itself. We're inside a
+					// command listener (editor mid-update), where `setEditorState`
+					// stashes the new state as pending WITHOUT committing — a
+					// follow-up `editor.update(selectEnd)` would run against the
+					// stale previous state, so the restored draft would commit
+					// with a null selection (caret lost on multi-line drafts).
+					const parsed = editor.parseEditorState(serialized, () => {
+						$getRoot().selectEnd();
+					});
 					editor.setEditorState(parsed, { tag: HISTORY_RECALL_RESTORE_TAG });
-					editor.update(
-						() => {
-							$getRoot().selectEnd();
-						},
-						{ tag: HISTORY_RECALL_RESTORE_TAG },
-					);
 					// `setEditorState` wipes the DOM selection (removeAllRanges),
-					// which blurs the contentEditable in WebKit. Re-placing the
-					// model selection above doesn't refocus it, so the caret stays
-					// invisible — refocus now that the selection is committed.
+					// which blurs the contentEditable in WebKit. The model selection
+					// alone doesn't refocus it, so the caret stays invisible —
+					// refocus now that the selection is committed.
 					editor.focus(undefined, { defaultSelection: "rootEnd" });
 					return;
 				} catch {

--- a/src/features/composer/editor/plugins/history-recall-plugin.tsx
+++ b/src/features/composer/editor/plugins/history-recall-plugin.tsx
@@ -2,10 +2,11 @@
  * Shell-style input recall: ArrowUp/ArrowDown at the editor's first /
  * last line walks back/forward through previously submitted prompts.
  *
- * Boundary check is hybrid: Lexical paragraph index (anchor's top-level
- * paragraph must equal root's first/last child) AND DOM visual-line
- * position. Lexical guards blank middle paragraphs; DOM handles
- * soft-wrap and multi-line recalled entries.
+ * Boundary check is hybrid: Lexical position (anchor's top-level
+ * paragraph must equal root's first/last child, with no Shift+Enter
+ * LineBreakNode before/after the caret inside it) AND DOM visual-line
+ * position. Lexical guards blank middle paragraphs and soft line
+ * breaks; DOM handles visual soft-wrap.
  *
  * Past the oldest/newest entry stays put; Down past newest restores the
  * in-progress draft snapshotted on first Up. Editing a recalled entry
@@ -20,10 +21,13 @@ import { mergeRegister } from "@lexical/utils";
 import {
 	$getRoot,
 	$getSelection,
+	$isElementNode,
+	$isLineBreakNode,
 	$isRangeSelection,
 	COMMAND_PRIORITY_LOW,
 	KEY_ARROW_DOWN_COMMAND,
 	KEY_ARROW_UP_COMMAND,
+	type LexicalNode,
 	type SerializedEditorState,
 } from "lexical";
 import { useCallback, useEffect, useRef } from "react";
@@ -122,8 +126,11 @@ function caretLinePosition(rootEl: HTMLElement): {
 	};
 }
 
-/** Lexical-side first/last paragraph check; `{true, true}` when no
- *  range selection so the DOM line check still decides. */
+/** Lexical-side first/last line check; `{true, true}` when no range
+ *  selection so the DOM line check still decides. Shift+Enter lines live
+ *  as LineBreakNodes inside ONE paragraph, so being in the first/last
+ *  top-level paragraph is not enough — the caret must also have no soft
+ *  line break before/after it within that paragraph. */
 function $caretParagraphPosition(): {
 	atFirstParagraph: boolean;
 	atLastParagraph: boolean;
@@ -139,18 +146,36 @@ function $caretParagraphPosition(): {
 		return { atFirstParagraph: true, atLastParagraph: true };
 	}
 	let node = selection.anchor.getNode();
+	// Direct child of the top-level node that contains the caret; null when
+	// the anchor is an element point on the top-level node itself.
+	let caretChild: LexicalNode | null = null;
 	let parent = node.getParent();
 	while (parent && parent.getKey() !== root.getKey()) {
+		caretChild = node;
 		node = parent;
 		parent = node.getParent();
 	}
 	if (!parent) {
 		return { atFirstParagraph: true, atLastParagraph: true };
 	}
+	let breakBefore = false;
+	let breakAfter = false;
+	if ($isElementNode(node)) {
+		const children = node.getChildren();
+		// Element-point offsets already count the children before the caret;
+		// for an inline child, breaks strictly before/after it decide.
+		const index = caretChild
+			? caretChild.getIndexWithinParent()
+			: selection.anchor.offset;
+		breakBefore = children.slice(0, index).some($isLineBreakNode);
+		breakAfter = children
+			.slice(caretChild ? index + 1 : index)
+			.some($isLineBreakNode);
+	}
 	const key = node.getKey();
 	return {
-		atFirstParagraph: firstChild.getKey() === key,
-		atLastParagraph: lastChild.getKey() === key,
+		atFirstParagraph: firstChild.getKey() === key && !breakBefore,
+		atLastParagraph: lastChild.getKey() === key && !breakAfter,
 	};
 }
 


### PR DESCRIPTION
## What changed

When arrowing back down through input history to a multi-line in-progress draft, the caret was landing on the first paragraph instead of the last. This caused the next ArrowUp to jump back into history rather than moving the cursor within the draft.

## Why

`setEditorState` stashes the new state as pending without committing. A follow-up `editor.update(selectEnd)` would run against the stale previous state, so the restored draft committed with a null selection.

## Fix

Bake the caret position into `parseEditorState`'s callback directly, so the selection is part of the parsed state from the start.

## Test notes

- Added regression test: "keeps the caret at the end of a multi-line draft restored via ArrowDown"
- Updated `paragraphDraft` helper to support multiple paragraphs
