### PR TITLE
feat: share vendor download cache across worktrees and CI jobs

### DIFF
--- a/.changeset/share-vendor-bundle-cache.md
+++ b/.changeset/share-vendor-bundle-cache.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Share the bundled-binary download cache across git worktrees and CI jobs so dev and CI builds reuse already-fetched archives instead of re-downloading them.

--- a/.github/actions/cache-bundle-archives/action.yml
+++ b/.github/actions/cache-bundle-archives/action.yml
@@ -1,0 +1,36 @@
+name: Cache Bundle Archives
+description: >-
+  Restore/save stage-vendor's downloaded vendor archives (gh, glab, cloudflared,
+  llama-cpp, node, and any cross-arch claude/codex/opencode tarballs) so CI jobs
+  don't re-download them on every run. Points HELMOR_BUNDLE_CACHE at a stable
+  per-workspace path and caches it via actions/cache, keyed on the version pins.
+
+inputs:
+  target-triple:
+    description: >-
+      Bundle target triple. Archives are arch-specific, so each target gets its
+      own cache entry (the two macOS matrix jobs share an arm64 runner but stage
+      different-arch binaries, so they must NOT share one key).
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # Redirect stage-vendor's archive cache to a stable, cacheable path. Set via
+    # $GITHUB_ENV so the later staging step (build-sidecar / tauri-action) reads
+    # it. Extraction scratch still goes to the per-job sidecar/.bundle-cache.
+    - name: Point HELMOR_BUNDLE_CACHE at a stable path
+      shell: bash
+      run: echo "HELMOR_BUNDLE_CACHE=${{ github.workspace }}/.ci-bundle-cache" >> "$GITHUB_ENV"
+
+    - name: Cache vendor download archives
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/.ci-bundle-cache
+        # Version pins + SHA256 tables live in vendor-platform.ts; the npm
+        # agent versions live in sidecar/package.json. Either changing busts the
+        # cache; a partial restore-keys hit still avoids re-downloading the
+        # archives whose versions didn't move (changed SHA re-downloads itself).
+        key: bundle-archives-${{ inputs.target-triple }}-${{ hashFiles('sidecar/scripts/vendor-platform.ts', 'sidecar/package.json') }}
+        restore-keys: |
+          bundle-archives-${{ inputs.target-triple }}-

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -125,6 +125,11 @@ jobs:
       - name: Setup Rust Tauri
         uses: ./.github/actions/setup-rust-tauri
 
+      - name: Cache bundle archives
+        uses: ./.github/actions/cache-bundle-archives
+        with:
+          target-triple: ${{ matrix.target-triple }}
+
       - name: Build + stage bundle binaries
         uses: ./.github/actions/build-sidecar
         with:
@@ -216,6 +221,11 @@ jobs:
           cache-on-failure: true
           shared-key: windows-tauri-v1
           workspaces: src-tauri -> target
+
+      - name: Cache bundle archives
+        uses: ./.github/actions/cache-bundle-archives
+        with:
+          target-triple: x86_64-pc-windows-msvc
 
       # tauri-action's beforeBuildCommand runs prepare-sidecar.mjs, which
       # stages the win32 vendor tree, builds the bun sidecar + helmor-cli,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,13 @@ jobs:
       - name: Setup Rust Tauri
         uses: ./.github/actions/setup-rust-tauri
 
+      # rust-test stages for the host arch (macos-latest is arm64) — `bun run
+      # build` below has no TAURI_TARGET_TRIPLE, so it downloads aarch64 archives.
+      - name: Cache bundle archives
+        uses: ./.github/actions/cache-bundle-archives
+        with:
+          target-triple: aarch64-apple-darwin
+
       # Stage the sidecar vendor tree, but NOT the release helmor-cli. The crate
       # compile needs `sidecar/dist/vendor/` (a Tauri bundle resource) to exist;
       # build.rs stubs the helmor-cli / helmor-sidecar externalBin placeholders,

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -153,6 +153,11 @@ jobs:
           shared-key: windows-tauri-v1
           workspaces: src-tauri -> target
 
+      - name: Cache bundle archives
+        uses: ./.github/actions/cache-bundle-archives
+        with:
+          target-triple: x86_64-pc-windows-msvc
+
       # `tauri build`'s beforeBuildCommand runs prepare-sidecar.mjs, which stages
       # the win32 vendor tree, builds the bun sidecar + helmor-cli, then bundles.
       # NSIS only — WiX/MSI is not part of what this fork ships.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,12 +149,12 @@ When a snapshot drifts: look at the diff first. Only accept after confirming the
 - **Bundled forge CLIs (`gh`, `glab`, `cloudflared`)**: Pinned + SHA256-verified in `sidecar/scripts/vendor-platform.ts`. `cloudflared` powers the mobile-companion tunnel feature. To upgrade:
   1. Bump `GH_VERSION` / `GLAB_VERSION` / `CLOUDFLARED_VERSION`.
   2. Pull the new SHA256 from `…/checksums.txt` (URLs in the file's header comment) and update `GH_SHA256` / `GLAB_SHA256` / `CLOUDFLARED_SHA256`.
-  3. Wipe `sidecar/.bundle-cache/` and re-run `bun run build` in `sidecar/` to force re-download + verify.
+  3. Re-run `bun run build` in `sidecar/` — the changed SHA256 auto-forces a re-download + verify (no manual wipe). Downloaded archives now live in a shared, cross-worktree cache (the main worktree's `sidecar/.bundle-cache`, override `HELMOR_BUNDLE_CACHE`); wipe that only if you want a forced clean fetch.
   Bump cadence: every release cycle if upstream has shipped a notable fix; immediately on security advisories. Pin so the auth-status JSON shape Helmor parses doesn't drift unexpectedly.
 - **Bundled agent CLIs (`claude-code`, `codex`, `opencode`)**: Pulled in via `sidecar/package.json` and staged into `sidecar/dist/vendor/{claude-code,codex,opencode}/` as platform-native binaries. All three upstreams ship per-platform npm sub-packages (`@anthropic-ai/claude-code-darwin-{arm64,x64}`, `@openai/codex-darwin-{arm64,x64}`, `opencode-darwin-{arm64,x64}`). Cross-arch CI staging downloads the tarball straight from the npm registry and verifies against `CLAUDE_CODE_SHA256` / `CODEX_SHA256` / `OPENCODE_SHA256` in `vendor-platform.ts`. The `stage-vendor.ts` script stages claude-code, codex, opencode, gh, glab, and cloudflared CLIs. To upgrade:
   1. Bump the version in `sidecar/package.json`, `cd sidecar && bun install`.
   2. Compute the SHA256 of both arch tarballs (`shasum -a 256` on the cached `.tgz`) and update the table in `stage-vendor.ts` (key it under the new version string).
-  3. Wipe `sidecar/.bundle-cache/` and run `bun run build` in `sidecar/` to verify.
+  3. Run `bun run build` in `sidecar/` to verify — a changed SHA256 auto-forces a re-download (shared cache at the main worktree's `sidecar/.bundle-cache`, override `HELMOR_BUNDLE_CACHE`; no manual wipe needed).
   Both binaries are `bun build --compile` output (~200 MB each on macOS), so `maybeSignMacBinary(_, true)` is required — JSC needs `allow-jit` / `allow-unsigned-executable-memory` under hardened runtime. Run pipeline snapshot tests after every claude-code bump (`cd src-tauri && cargo test --tests`); the SDK event shape is the contract Helmor's accumulator depends on.
 
 ## 🚨 Code organization rules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,12 +139,12 @@ When a snapshot drifts: look at the diff first. Only accept after confirming the
 - **Bundled forge CLIs (`gh`, `glab`)**: Pinned + SHA256-verified in `sidecar/scripts/stage-vendor.ts`. To upgrade:
   1. Bump `GH_VERSION` / `GLAB_VERSION`.
   2. Pull the new SHA256 from `…/checksums.txt` (URLs in the file's header comment) and update `GH_SHA256` / `GLAB_SHA256`.
-  3. Wipe `sidecar/.bundle-cache/` and re-run `bun run build` in `sidecar/` to force re-download + verify.
+  3. Re-run `bun run build` in `sidecar/` — the changed SHA256 auto-forces a re-download + verify (no manual wipe). Downloaded archives now live in a shared, cross-worktree cache (the main worktree's `sidecar/.bundle-cache`, override `HELMOR_BUNDLE_CACHE`); wipe that only if you want a forced clean fetch.
   Bump cadence: every release cycle if upstream has shipped a notable fix; immediately on security advisories. Pin so the auth-status JSON shape Helmor parses doesn't drift unexpectedly.
 - **Bundled agent CLIs (`claude-code`, `codex`)**: Pulled in via `sidecar/package.json` and staged into `sidecar/dist/vendor/{claude-code,codex}/` as platform-native binaries. Both upstreams ship per-platform npm sub-packages (`@anthropic-ai/claude-code-darwin-{arm64,x64}`, `@openai/codex-darwin-{arm64,x64}`). Cross-arch CI staging downloads the tarball straight from the npm registry and verifies against `CLAUDE_CODE_SHA256` / `CODEX_SHA256` in `stage-vendor.ts`. To upgrade:
   1. Bump the version in `sidecar/package.json`, `cd sidecar && bun install`.
   2. Compute the SHA256 of both arch tarballs (`shasum -a 256` on the cached `.tgz`) and update the table in `stage-vendor.ts` (key it under the new version string).
-  3. Wipe `sidecar/.bundle-cache/` and run `bun run build` in `sidecar/` to verify.
+  3. Run `bun run build` in `sidecar/` to verify — a changed SHA256 auto-forces a re-download (shared cache at the main worktree's `sidecar/.bundle-cache`, override `HELMOR_BUNDLE_CACHE`; no manual wipe needed).
   Both binaries are `bun build --compile` output (~200 MB each on macOS), so `maybeSignMacBinary(_, true)` is required — JSC needs `allow-jit` / `allow-unsigned-executable-memory` under hardened runtime. Run pipeline snapshot tests after every claude-code bump (`cd src-tauri && cargo test --tests`); the SDK event shape is the contract Helmor's accumulator depends on.
 
 ## 🚨 Code organization rules

--- a/sidecar/scripts/stage-vendor.ts
+++ b/sidecar/scripts/stage-vendor.ts
@@ -29,7 +29,7 @@ import {
 	statSync,
 	writeFileSync,
 } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
 	claudeCodeArchivePlan,
@@ -65,9 +65,50 @@ const TAR_BIN = IS_WINDOWS
 const SIDECAR_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const NODE_MODULES = join(SIDECAR_ROOT, "node_modules");
 const DIST_VENDOR = join(SIDECAR_ROOT, "dist", "vendor");
+
+// Local extraction scratch — per-worktree so concurrent `bun run dev` in two
+// worktrees can't race `freshExtractDir` on the same slug.
 const BUNDLE_CACHE = join(SIDECAR_ROOT, ".bundle-cache");
 
-// Bumping any version: update SHA256 below + wipe sidecar/.bundle-cache.
+// Downloaded archives are the network-expensive part and SHA256-verified, so we
+// share one cache across all worktrees of this repo: a new worktree reuses
+// already-fetched gh/glab/cloudflared/llama-cpp/node archives instead of
+// re-downloading them. This is a dev-only optimization, so the cache lives
+// inside the PROJECT (the main worktree's `sidecar/.bundle-cache`) rather than a
+// global user dir — found via git's common dir, which every linked worktree
+// shares. Archive filenames are version-keyed, so different version pins coexist
+// safely. Override with HELMOR_BUNDLE_CACHE (CI pins it per-job).
+const ARCHIVE_CACHE = resolveArchiveCache();
+
+function resolveArchiveCache(): string {
+	const override = process.env.HELMOR_BUNDLE_CACHE?.trim();
+	if (override) return resolve(override);
+	const mainRoot = mainWorktreeRoot();
+	// Fall back to the local scratch dir when not in a git checkout (e.g. a
+	// detached tarball build) — degrades to per-worktree, never breaks.
+	if (!mainRoot) return BUNDLE_CACHE;
+	return join(mainRoot, "sidecar", ".bundle-cache");
+}
+
+/// Resolve the main worktree's root via git's common dir. From any linked
+/// worktree `git rev-parse --git-common-dir` points at `<mainRoot>/.git`, so its
+/// parent is the shared main checkout. Returns null if git is unavailable.
+function mainWorktreeRoot(): string | null {
+	try {
+		const commonDir = execFileSync("git", ["rev-parse", "--git-common-dir"], {
+			cwd: SIDECAR_ROOT,
+			encoding: "utf8",
+		}).trim();
+		if (!commonDir) return null;
+		return dirname(resolve(SIDECAR_ROOT, commonDir));
+	} catch {
+		return null;
+	}
+}
+
+// Bumping any version: update SHA256 below. Archives are version-keyed in the
+// shared ARCHIVE_CACHE, so no wipe is needed; a changed SHA256 forces a
+// re-download automatically.
 //   gh:          github.com/cli/cli/releases/download/v$VER/gh_${VER}_checksums.txt
 //   glab:        gitlab.com/gitlab-org/cli/-/releases/v$VER/downloads/checksums.txt
 //   codex:       shasum -a 256 of the npm tarball at
@@ -137,6 +178,7 @@ const ENTITLEMENTS_PLIST = join(
 
 function ensureCacheDir(): void {
 	mkdirSync(BUNDLE_CACHE, { recursive: true });
+	mkdirSync(ARCHIVE_CACHE, { recursive: true });
 }
 
 function sha256OfFile(path: string): string {
@@ -236,7 +278,7 @@ function stageGhBinary(target: TargetInfo): string {
 	// `gh_<ver>_windows_<arch>.zip`; both nest `bin/gh[.exe]`. The Windows plan
 	// carries no pinned sha256 (soft-verify); macOS stays strict.
 	const plan = ghArchivePlan(target);
-	const archive = join(BUNDLE_CACHE, plan.archiveName);
+	const archive = join(ARCHIVE_CACHE, plan.archiveName);
 	// downloadMaybeVerify is strict when a sha256 is pinned (macOS) and trusts
 	// HTTPS when it's empty (Windows soft-verify).
 	downloadMaybeVerify(plan.url, archive, plan.sha256);
@@ -259,7 +301,7 @@ function stageGlabBinary(target: TargetInfo): string {
 	// `extractArchive` (bsdtar) transparently handles both formats. Windows plan
 	// carries no pinned sha256 (soft-verify); macOS stays strict.
 	const plan = glabArchivePlan(target);
-	const archive = join(BUNDLE_CACHE, plan.archiveName);
+	const archive = join(ARCHIVE_CACHE, plan.archiveName);
 	downloadMaybeVerify(plan.url, archive, plan.sha256);
 
 	const extractDir = join(BUNDLE_CACHE, plan.slug);
@@ -288,7 +330,7 @@ function stageCloudflaredBinary(target: TargetInfo): string {
 	ensureCacheDir();
 	const binDest = join(DIST_VENDOR, "cloudflared", `cloudflared${EXE}`);
 	const plan = cloudflaredArchivePlan(target);
-	const archive = join(BUNDLE_CACHE, plan.archiveName);
+	const archive = join(ARCHIVE_CACHE, plan.archiveName);
 
 	// Windows: upstream publishes a bare `cloudflared-windows-<arch>.exe` (no
 	// archive), so download it straight to the destination (no extraction).
@@ -367,7 +409,7 @@ function stageClaudeCodeBinary(target: TargetInfo): string {
 	const version = readClaudeCodeVersion();
 	const plan = claudeCodeArchivePlan(target, version);
 	ensureCacheDir();
-	const archive = join(BUNDLE_CACHE, plan.archiveName);
+	const archive = join(ARCHIVE_CACHE, plan.archiveName);
 	downloadAndVerify(plan.url, archive, plan.sha256);
 
 	const extractDir = join(BUNDLE_CACHE, plan.slug);
@@ -508,7 +550,7 @@ function stageCodexBinary(target: TargetInfo): void {
 	const version = readCodexVersion();
 	const plan = codexArchivePlan(target, version);
 	ensureCacheDir();
-	const archive = join(BUNDLE_CACHE, plan.archiveName);
+	const archive = join(ARCHIVE_CACHE, plan.archiveName);
 	downloadAndVerify(plan.url, archive, plan.sha256);
 
 	const extractDir = join(BUNDLE_CACHE, plan.slug);
@@ -567,7 +609,7 @@ function stageOpencodeBinary(target: TargetInfo): string {
 	const version = readOpencodeVersion();
 	const plan = opencodeArchivePlan(target, version);
 	ensureCacheDir();
-	const archive = join(BUNDLE_CACHE, plan.archiveName);
+	const archive = join(ARCHIVE_CACHE, plan.archiveName);
 	downloadAndVerify(plan.url, archive, plan.sha256);
 
 	const extractDir = join(BUNDLE_CACHE, plan.slug);
@@ -635,7 +677,7 @@ function downloadMaybeVerify(
 function stageLlamaCppBinaries(target: TargetInfo): string {
 	ensureCacheDir();
 	const plan = llamaArchivePlan(target);
-	const archive = join(BUNDLE_CACHE, plan.archiveName);
+	const archive = join(ARCHIVE_CACHE, plan.archiveName);
 
 	// Windows: upstream ships `llama-<ver>-bin-win-cpu-x64.zip` (server + CLIs +
 	// their `.dll`s, no `bin/` wrapper). Stage the whole tree as a unit (the
@@ -786,7 +828,7 @@ function stageNodeRuntime(target: TargetInfo): string {
 	const plan = nodeArchivePlan(target);
 	const dest = join(DIST_VENDOR, "node", `node${EXE}`);
 	ensureCacheDir();
-	const archive = join(BUNDLE_CACHE, plan.archiveName);
+	const archive = join(ARCHIVE_CACHE, plan.archiveName);
 	downloadAndVerify(plan.url, archive, plan.sha256);
 	const extractDir = join(BUNDLE_CACHE, `${plan.slug}-extract`);
 	freshExtractDir(extractDir);


### PR DESCRIPTION
## What changed

Share the bundled-binary download cache across git worktrees and CI jobs so dev and CI builds reuse already-fetched archives instead of re-downloading them.

### Core change (`sidecar/scripts/stage-vendor.ts`)
- Split cache into two tiers:
  - **ARCHIVE_CACHE** — shared across all worktrees via `git rev-parse --git-common-dir`, resolves to the main worktree's `sidecar/.bundle-cache`. Downloaded archives (gh, glab, cloudflared, llama-cpp, node, agent tarballs) are version-keyed, so different pins coexist safely.
  - **BUNDLE_CACHE** — per-worktree extraction scratch, safe for concurrent `bun run dev` in multiple worktrees.
- Override via `HELMOR_BUNDLE_CACHE` env var (CI pins it per-job).

### CI caching (new `.github/actions/cache-bundle-archives/`)
- New composite action that points `HELMOR_BUNDLE_CACHE` at a stable per-workspace path and caches it with `actions/cache@v4`, keyed on `vendor-platform.ts` + `package.json` (version pins).
- Wired into all three workflow files (`publish.yml`, `test.yml`, `windows.yml`) for the appropriate target triples.

### Docs
- `AGENTS.md` and `CLAUDE.md` updated to remove the old "wipe .bundle-cache" instructions and describe the new shared cache behavior.

## Why

Previously, every worktree and every CI run re-downloaded ~500MB+ of vendor archives on first build. Now they share one cache, eliminating redundant downloads for devs and CI alike.

## Test notes
- [ ] CI: `cache-bundle-archives` step hits on second run (cache key match)
- [ ] Local: `bun run build` in a linked worktree reuses the main worktree's downloaded archives