### PR TITLE
fix: concurrent PR creation and missing remote-tracking ref sync

### DIFF
--- a/.changeset/clever-otters-publish.md
+++ b/.changeset/clever-otters-publish.md
@@ -1,0 +1,7 @@
+---
+"helmor": patch
+---
+
+Fix the top-right Create PR / MR button getting stuck on "Create" after the pull request is already open:
+- Creating PRs across several workspaces around the same time now reliably syncs each one's PR and CI status and auto-closes its action session, instead of only the last workspace you triggered.
+- A workspace whose branch is already pushed to the remote now detects its open PR even when the local clone is missing the remote-tracking ref.

--- a/src-tauri/src/forge/branch.rs
+++ b/src-tauri/src/forge/branch.rs
@@ -6,21 +6,74 @@
 
 use crate::{git_ops, models::workspaces::WorkspaceRecord};
 
-/// Resolve the branch name to use as the forge's PR/MR head reference.
-/// Returns the upstream branch name when the workspace has a
-/// remote-tracking ref, otherwise falls back to the local branch name.
-/// Second tuple element is `true` when a remote-tracking ref was found.
+/// The branch a forge should use as its PR/MR head ref, plus whether that
+/// branch is published on the remote. `published` is the canonical,
+/// provider-agnostic name for this flag — both `forge::github::context` and
+/// `forge::gitlab::context` store it under the same name.
+pub(in crate::forge) struct ForgeHeadRef {
+    /// Branch name to pass as GitHub's `headRefName` / GitLab's
+    /// `source_branch`. The upstream branch name when it differs from local.
+    pub branch: String,
+    /// `true` when the branch has a ref the forge API can match against —
+    /// resolved from the local remote-tracking ref, or (when that's missing)
+    /// a remote `ls-remote` lookup.
+    pub published: bool,
+}
+
+/// Resolve the forge head ref for `record`. Prefers the upstream branch name
+/// when the workspace has a remote-tracking ref, otherwise falls back to the
+/// local branch name.
 pub(in crate::forge) fn forge_head_branch_for(
     record: &WorkspaceRecord,
     local_branch: &str,
-) -> (String, bool) {
-    let Some(remote_tracking_ref) = workspace_remote_tracking_ref(record) else {
-        return (local_branch.to_string(), false);
+) -> ForgeHeadRef {
+    if let Some(remote_tracking_ref) = workspace_remote_tracking_ref(record) {
+        let branch = remote_tracking_branch_name(&remote_tracking_ref)
+            .unwrap_or(local_branch)
+            .to_string();
+        return ForgeHeadRef {
+            branch,
+            published: true,
+        };
+    }
+    // No local remote-tracking ref — but the branch can still be published on
+    // the remote (a push that never updated the local ref, a pruned ref, or a
+    // PR opened by an agent before its session settled). Without this fallback
+    // those workspaces false-negative forever: `published == false`
+    // short-circuits PR lookup, so the open PR never surfaces. A same-named
+    // push is the realistic case, so the local branch name is the head ref.
+    if branch_published_on_remote(record, local_branch) {
+        return ForgeHeadRef {
+            branch: local_branch.to_string(),
+            published: true,
+        };
+    }
+    ForgeHeadRef {
+        branch: local_branch.to_string(),
+        published: false,
+    }
+}
+
+/// Network fallback: does `<remote>` actually carry `<branch>`? Only reached
+/// when the local worktree has no remote-tracking ref, so it costs an extra
+/// `ls-remote` for genuinely-unpublished branches but recovers the published
+/// ones the local refs can't see.
+fn branch_published_on_remote(record: &WorkspaceRecord, branch: &str) -> bool {
+    let Ok(workspace_dir) = crate::workspace::helpers::workspace_path(record) else {
+        return false;
     };
-    let head_branch = remote_tracking_branch_name(&remote_tracking_ref)
-        .unwrap_or(local_branch)
-        .to_string();
-    (head_branch, true)
+    if !workspace_dir.exists() {
+        return false;
+    }
+    let Some(remote) = record
+        .remote
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return false;
+    };
+    git_ops::remote_branch_exists(&workspace_dir, remote, branch)
 }
 
 fn remote_tracking_branch_name(remote_tracking_ref: &str) -> Option<&str> {

--- a/src-tauri/src/forge/github/context.rs
+++ b/src-tauri/src/forge/github/context.rs
@@ -10,7 +10,7 @@ use anyhow::{bail, Result};
 use crate::{models::workspaces as workspace_models, workspace_state::WorkspaceState};
 
 use super::api::parse_github_remote;
-use crate::forge::branch::forge_head_branch_for;
+use crate::forge::branch::{forge_head_branch_for, ForgeHeadRef};
 
 /// Snapshot of every value the GitHub backend needs once we've decided
 /// the workspace looks viable enough to query. The pre-flight in
@@ -26,10 +26,11 @@ pub(super) struct GithubContext {
     /// gh account login bound to this repo. Always non-empty (NULL
     /// rows short-circuit before a context is ever produced).
     pub login: String,
-    /// `true` when the workspace's branch has a remote-tracking ref
-    /// resolvable via `git rev-parse`. Drives the
-    /// "branch never published" short-circuit.
-    pub has_remote_tracking: bool,
+    /// `true` when the workspace's branch is published on the remote — a
+    /// queryable ref exists, via the local remote-tracking ref or an
+    /// `ls-remote` fallback. Drives the "branch never published"
+    /// short-circuit. (See `forge::branch::ForgeHeadRef::published`.)
+    pub published: bool,
 }
 
 /// Outcome of pre-flight resolution. Each non-`Ready` arm tells the
@@ -94,14 +95,14 @@ pub(super) fn load_github_context(workspace_id: &str) -> Result<GithubResolution
         return Ok(GithubResolution::Unauthenticated);
     };
 
-    let (branch, has_remote_tracking) = forge_head_branch_for(&record, &branch);
+    let ForgeHeadRef { branch, published } = forge_head_branch_for(&record, &branch);
 
     Ok(GithubResolution::Ready(GithubContext {
         owner,
         name,
         branch,
         login: login.to_string(),
-        has_remote_tracking,
+        published,
     }))
 }
 
@@ -289,11 +290,11 @@ mod tests {
         assert_eq!(ctx.name, "hello-world");
         assert_eq!(ctx.branch, "feature/auth");
         assert_eq!(ctx.login, "octocat");
-        // No worktree on disk → no remote-tracking ref. Real workspaces
+        // No worktree on disk → branch not published. Real workspaces
         // populate this via git, but the resolver still hands a Ready
         // context back so the caller can decide whether to short-circuit
-        // on `has_remote_tracking`.
-        assert!(!ctx.has_remote_tracking);
+        // on `published`.
+        assert!(!ctx.published);
     }
 
     #[test]
@@ -355,7 +356,77 @@ mod tests {
             panic!("expected Ready");
         };
         assert_eq!(ctx.branch, "feature/remote-name");
-        assert!(ctx.has_remote_tracking);
+        assert!(ctx.published);
+    }
+
+    /// Branch is published on the remote, but the local worktree has neither
+    /// upstream config nor a `refs/remotes/origin/<branch>` ref (e.g. a push
+    /// that never updated the local ref). The remote fallback must keep
+    /// `published` true so the open PR still surfaces.
+    #[test]
+    fn ready_with_remote_tracking_when_branch_published_but_local_ref_missing() {
+        let env = crate::testkit::TestEnv::new("github-ctx-published-no-local-ref");
+        let origin = crate::testkit::GitTestRepo::init();
+        let workspace_dir = crate::data_dir::workspace_dir("Repo", "workspace-dir").unwrap();
+        std::fs::create_dir_all(workspace_dir.parent().unwrap()).unwrap();
+        git_ops::run_git(
+            [
+                "clone",
+                &origin.path().display().to_string(),
+                &workspace_dir.display().to_string(),
+            ],
+            None,
+        )
+        .unwrap();
+        git_ops::run_git(
+            ["config", "user.email", "helmor@example.com"],
+            Some(&workspace_dir),
+        )
+        .unwrap();
+        git_ops::run_git(["config", "user.name", "Helmor Test"], Some(&workspace_dir)).unwrap();
+        git_ops::run_git(
+            ["checkout", "-b", "feature/published"],
+            Some(&workspace_dir),
+        )
+        .unwrap();
+        git_ops::run_git(
+            ["push", "origin", "HEAD:refs/heads/feature/published"],
+            Some(&workspace_dir),
+        )
+        .unwrap();
+        // Erase every local trace of the push so only the remote knows.
+        git_ops::run_git(
+            ["update-ref", "-d", "refs/remotes/origin/feature/published"],
+            Some(&workspace_dir),
+        )
+        .unwrap();
+
+        let conn = env.db_connection();
+        insert_repo(
+            &conn,
+            "r-published",
+            "Repo",
+            Some("git@github.com:octocat/hello-world.git"),
+            Some("octocat"),
+        );
+        insert_workspace(
+            &conn,
+            "w-published",
+            "r-published",
+            "ready",
+            Some("feature/published"),
+        );
+        drop(conn);
+
+        let resolution = load_github_context("w-published").unwrap();
+        let GithubResolution::Ready(ctx) = resolution else {
+            panic!("expected Ready");
+        };
+        assert_eq!(ctx.branch, "feature/published");
+        assert!(
+            ctx.published,
+            "remote fallback should recognise the published branch",
+        );
     }
 
     #[test]

--- a/src-tauri/src/forge/github/mod.rs
+++ b/src-tauri/src/forge/github/mod.rs
@@ -48,12 +48,12 @@ use self::pull_request::{
 ///     caller can surface a distinct "something went wrong" state).
 pub fn lookup_workspace_pr(workspace_id: &str) -> Result<Option<ChangeRequestInfo>> {
     let context = match load_github_context(workspace_id)? {
-        GithubResolution::Ready(ctx) if ctx.has_remote_tracking => ctx,
+        GithubResolution::Ready(ctx) if ctx.published => ctx,
         // Anything else short-circuits to "no PR linked":
-        //   - Initializing / unavailable / unauthenticated / no
-        //     remote-tracking → caller sees `None` and renders the
-        //     empty-PR state. Auth is not surfaced here because the
-        //     primary auth surface is the action-status path.
+        //   - Initializing / unavailable / unauthenticated / unpublished
+        //     branch → caller sees `None` and renders the empty-PR state.
+        //     Auth is not surfaced here because the primary auth surface
+        //     is the action-status path.
         _ => return Ok(None),
     };
 
@@ -93,7 +93,7 @@ pub fn lookup_workspace_pr_action_status(workspace_id: &str) -> Result<ForgeActi
         ));
     }
 
-    if !context.has_remote_tracking {
+    if !context.published {
         return Ok(ForgeActionStatus::no_change_request());
     }
 
@@ -134,7 +134,7 @@ pub fn lookup_workspace_pr_action_status(workspace_id: &str) -> Result<ForgeActi
 pub fn lookup_workspace_pr_check_insert_text(workspace_id: &str, item_id: &str) -> Result<String> {
     let resolution = load_github_context(workspace_id)?;
     let context = match resolution {
-        GithubResolution::Ready(ctx) if ctx.has_remote_tracking => ctx,
+        GithubResolution::Ready(ctx) if ctx.published => ctx,
         GithubResolution::Ready(_) | GithubResolution::Initializing => {
             bail!("Workspace branch is not published");
         }
@@ -219,7 +219,7 @@ pub fn close_workspace_pr(workspace_id: &str) -> Result<Option<ChangeRequestInfo
 /// just worked.
 fn mutation_context(workspace_id: &str) -> Result<Option<GithubContext>> {
     match load_github_context(workspace_id)? {
-        GithubResolution::Ready(ctx) if ctx.has_remote_tracking => Ok(Some(ctx)),
+        GithubResolution::Ready(ctx) if ctx.published => Ok(Some(ctx)),
         _ => Ok(None),
     }
 }

--- a/src-tauri/src/forge/gitlab/context.rs
+++ b/src-tauri/src/forge/gitlab/context.rs
@@ -5,7 +5,7 @@
 
 use anyhow::{bail, Result};
 
-use crate::forge::branch::forge_head_branch_for;
+use crate::forge::branch::{forge_head_branch_for, ForgeHeadRef};
 use crate::forge::remote::{parse_remote, ParsedRemote};
 use crate::models::workspaces as workspace_models;
 use crate::workspace_state::WorkspaceState;
@@ -68,7 +68,7 @@ pub(super) fn load_gitlab_context(workspace_id: &str) -> Result<GitlabResolution
         return Ok(GitlabResolution::Unauthenticated);
     };
 
-    let (branch, published) = forge_head_branch_for(&record, &branch);
+    let ForgeHeadRef { branch, published } = forge_head_branch_for(&record, &branch);
     let full_path = format!("{}/{}", remote.namespace, remote.repo);
 
     Ok(GitlabResolution::Ready(GitlabContext {
@@ -343,5 +343,74 @@ mod tests {
         };
         assert_eq!(ctx.branch, "feature/remote-name");
         assert!(ctx.published);
+    }
+
+    /// Mirror of the GitHub `ready_with_remote_tracking_when_branch_published_…`
+    /// test: both providers share `forge_head_branch_for`, so the remote
+    /// fallback that rescues a published-but-local-ref-missing branch must
+    /// keep `published` true here too.
+    #[test]
+    fn ready_published_when_branch_on_remote_but_local_ref_missing() {
+        let env = crate::testkit::TestEnv::new("gitlab-ctx-published-no-local-ref");
+        let origin = crate::testkit::GitTestRepo::init();
+        let workspace_dir = crate::data_dir::workspace_dir("Repo", "workspace-dir").unwrap();
+        std::fs::create_dir_all(workspace_dir.parent().unwrap()).unwrap();
+        git_ops::run_git(
+            [
+                "clone",
+                &origin.path().display().to_string(),
+                &workspace_dir.display().to_string(),
+            ],
+            None,
+        )
+        .unwrap();
+        git_ops::run_git(
+            ["config", "user.email", "helmor@example.com"],
+            Some(&workspace_dir),
+        )
+        .unwrap();
+        git_ops::run_git(["config", "user.name", "Helmor Test"], Some(&workspace_dir)).unwrap();
+        git_ops::run_git(
+            ["checkout", "-b", "feature/published"],
+            Some(&workspace_dir),
+        )
+        .unwrap();
+        git_ops::run_git(
+            ["push", "origin", "HEAD:refs/heads/feature/published"],
+            Some(&workspace_dir),
+        )
+        .unwrap();
+        // Wipe the local remote-tracking ref so only the remote knows.
+        git_ops::run_git(
+            ["update-ref", "-d", "refs/remotes/origin/feature/published"],
+            Some(&workspace_dir),
+        )
+        .unwrap();
+
+        let conn = env.db_connection();
+        insert_repo(
+            &conn,
+            "r-published",
+            "Repo",
+            Some("git@gitlab.com:acme/repo.git"),
+            Some("alice"),
+        );
+        insert_workspace(
+            &conn,
+            "w-published",
+            "r-published",
+            "ready",
+            Some("feature/published"),
+        );
+        drop(conn);
+
+        let GitlabResolution::Ready(ctx) = load_gitlab_context("w-published").unwrap() else {
+            panic!("expected Ready");
+        };
+        assert_eq!(ctx.branch, "feature/published");
+        assert!(
+            ctx.published,
+            "remote fallback should recognise the published branch",
+        );
     }
 }

--- a/src-tauri/src/git/ops.rs
+++ b/src-tauri/src/git/ops.rs
@@ -1336,6 +1336,29 @@ pub fn verify_remote_ref_exists(workspace_dir: &Path, remote: &str, branch: &str
     }
 }
 
+/// Returns `true` when `<remote>` actually has a branch named `<branch>`.
+/// Network call (bounded by `GIT_NETWORK_TIMEOUT`). Used as a fallback when
+/// the local worktree has no remote-tracking ref but the branch may still be
+/// published — e.g. a push that never updated the local ref, or a pruned ref.
+pub fn remote_branch_exists(workspace_dir: &Path, remote: &str, branch: &str) -> bool {
+    let workspace_dir = workspace_dir.display().to_string();
+    run_git_with_timeout(
+        [
+            "-C",
+            workspace_dir.as_str(),
+            "ls-remote",
+            "--exit-code",
+            "--heads",
+            remote,
+            branch,
+        ],
+        None,
+        GIT_NETWORK_TIMEOUT,
+    )
+    .map(|output| !output.trim().is_empty())
+    .unwrap_or(false)
+}
+
 /// Resolve `refs/remotes/<remote>/<branch>` to its current commit SHA.
 pub fn remote_ref_sha(workspace_dir: &Path, remote: &str, branch: &str) -> Result<String> {
     let workspace_dir = workspace_dir.display().to_string();
@@ -1806,6 +1829,46 @@ mod tests {
         assert_eq!(
             resolve_remote_tracking_ref(wt_dir.path(), Some("origin")).as_deref(),
             Some("origin/feature/published"),
+        );
+    }
+
+    #[test]
+    fn remote_branch_exists_detects_published_branch_without_local_ref() {
+        // Branch is pushed to the remote, then the local remote-tracking ref
+        // + upstream are wiped (mirrors a push that never updated the local
+        // ref). `resolve_remote_tracking_ref` goes blind, but the remote
+        // lookup still finds the branch.
+        let (_origin, clone) = init_repo_with_remote();
+        let wt_dir = tempfile::tempdir().unwrap();
+        create_worktree_from_start_point(
+            clone.path(),
+            wt_dir.path(),
+            "feature/ghost-ref",
+            "origin/main",
+        )
+        .unwrap();
+        run(
+            wt_dir.path(),
+            &["push", "origin", "HEAD:refs/heads/feature/ghost-ref"],
+        );
+        // Wipe the local remote-tracking ref so only the remote knows.
+        run(
+            wt_dir.path(),
+            &["update-ref", "-d", "refs/remotes/origin/feature/ghost-ref"],
+        );
+
+        assert_eq!(
+            resolve_remote_tracking_ref(wt_dir.path(), Some("origin")),
+            None,
+            "local lookup should be blind once the tracking ref is gone",
+        );
+        assert!(
+            remote_branch_exists(wt_dir.path(), "origin", "feature/ghost-ref"),
+            "remote lookup should still find the published branch",
+        );
+        assert!(
+            !remote_branch_exists(wt_dir.path(), "origin", "feature/never-pushed"),
+            "remote lookup should not invent a branch that was never pushed",
         );
     }
 

--- a/src/features/commit/hooks/use-commit-lifecycle.test.tsx
+++ b/src/features/commit/hooks/use-commit-lifecycle.test.tsx
@@ -426,6 +426,112 @@ describe("useWorkspaceCommitLifecycle", () => {
 		expect(onSelectSession).not.toHaveBeenCalled();
 	});
 
+	it("settles two workspaces' Create-PR actions dispatched back-to-back", async () => {
+		// Regression: a single-slot lifecycle let the second Create-PR clobber
+		// the first, so the first workspace never got its refresh + auto-close
+		// (stuck showing "Create PR" with an un-hidden session). Both must settle.
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false } },
+		});
+		for (const id of ["workspace-1", "workspace-2"]) {
+			queryClient.setQueryData<WorkspaceDetail | null>(
+				helmorQueryKeys.workspaceDetail(id),
+				{
+					id,
+					activeSessionId: `${id}-after-close`,
+					status: "in-progress",
+				} as unknown as WorkspaceDetail,
+			);
+		}
+
+		let liveWorkspaceId: string | null = "workspace-1";
+		const onSelectSession = vi.fn();
+
+		const { result, rerender } = renderHook(
+			({
+				selectedWorkspaceId,
+				completedSessionIds,
+				busySessionIds,
+			}: {
+				selectedWorkspaceId: string;
+				completedSessionIds: Set<string>;
+				busySessionIds: Set<string>;
+			}) =>
+				useWorkspaceCommitLifecycle({
+					queryClient,
+					selectedWorkspaceId,
+					getSelectedWorkspaceId: () => liveWorkspaceId,
+					selectedRepoId: "repo-1",
+					selectedWorkspaceTargetBranch: "main",
+					changeRequest: null,
+					forgeActionStatus: EMPTY_FORGE_ACTION_STATUS,
+					workspaceGitActionStatus: EMPTY_GIT_ACTION_STATUS,
+					completedSessionIds,
+					interactionRequiredSessionIds: new Set<string>(),
+					busySessionIds,
+					onSelectSession,
+				}),
+			{
+				initialProps: {
+					selectedWorkspaceId: "workspace-1",
+					completedSessionIds: new Set<string>(),
+					busySessionIds: new Set<string>(),
+				},
+				wrapper: createWrapper(queryClient),
+			},
+		);
+
+		// Dispatch on workspace-1.
+		apiMocks.createSession.mockResolvedValueOnce({ sessionId: "session-w1" });
+		await act(async () => {
+			await result.current.handleInspectorCommitAction("create-pr");
+		});
+		act(() => {
+			result.current.handlePendingPromptConsumed();
+		});
+		rerender({
+			selectedWorkspaceId: "workspace-1",
+			completedSessionIds: new Set<string>(),
+			busySessionIds: new Set(["session-w1"]),
+		});
+
+		// User switches to workspace-2 and dispatches there before w1 finishes.
+		liveWorkspaceId = "workspace-2";
+		apiMocks.createSession.mockResolvedValueOnce({ sessionId: "session-w2" });
+		await act(async () => {
+			await result.current.handleInspectorCommitAction("create-pr");
+		});
+		act(() => {
+			result.current.handlePendingPromptConsumed();
+		});
+		rerender({
+			selectedWorkspaceId: "workspace-2",
+			completedSessionIds: new Set<string>(),
+			busySessionIds: new Set(["session-w1", "session-w2"]),
+		});
+
+		// Both sessions complete.
+		rerender({
+			selectedWorkspaceId: "workspace-2",
+			completedSessionIds: new Set(["session-w1", "session-w2"]),
+			busySessionIds: new Set<string>(),
+		});
+
+		// Neither lifecycle was orphaned: both refresh and both auto-close.
+		await waitFor(() => {
+			expect(apiMocks.refreshWorkspaceChangeRequest).toHaveBeenCalledWith(
+				"workspace-1",
+			);
+			expect(apiMocks.refreshWorkspaceChangeRequest).toHaveBeenCalledWith(
+				"workspace-2",
+			);
+		});
+		await waitFor(() => {
+			expect(apiMocks.hideSession).toHaveBeenCalledWith("session-w1");
+			expect(apiMocks.hideSession).toHaveBeenCalledWith("session-w2");
+		});
+	});
+
 	it("clears the lifecycle when the tracked action session is aborted", async () => {
 		const queryClient = new QueryClient({
 			defaultOptions: { queries: { retry: false } },

--- a/src/features/commit/hooks/use-commit-lifecycle.ts
+++ b/src/features/commit/hooks/use-commit-lifecycle.ts
@@ -128,11 +128,24 @@ function getErrorMessage(error: unknown, fallback: string): string {
 }
 
 type CommitLifecycle = {
+	/** Per-instance id so dismiss timers / done-phase side effects target the
+	 *  exact lifecycle that scheduled them, even after the same workspace
+	 *  starts a new action. */
+	id: number;
 	workspaceId: string;
 	trackedSessionId: string | null;
 	mode: WorkspaceCommitButtonMode;
 	phase: "creating" | "streaming" | "verifying" | "done" | "error";
 	changeRequest: ChangeRequestInfo | null;
+};
+
+const EMPTY_LIFECYCLES: ReadonlyMap<string, CommitLifecycle> = new Map();
+
+/** Per-workspace settle tracking for in-flight action sessions. Kept in a ref
+ *  (not state) so updating it never re-renders or re-fires the settle effect. */
+type ActionTracking = {
+	observedSending: boolean;
+	handledSessionId: string | null;
 };
 
 export type PendingPromptForSession = {
@@ -188,8 +201,52 @@ export function useWorkspaceCommitLifecycle({
 }) {
 	const [pendingPromptForSession, setPendingPromptForSession] =
 		useState<PendingPromptForSession | null>(null);
-	const [commitLifecycle, setCommitLifecycle] =
-		useState<CommitLifecycle | null>(null);
+	// One in-flight action per workspace, keyed by workspaceId. A single slot
+	// would let a second Create-PR (on another workspace) clobber the first
+	// before its completion side effects — refresh + auto-close — ever ran.
+	const [commitLifecycles, setCommitLifecycles] =
+		useState<ReadonlyMap<string, CommitLifecycle>>(EMPTY_LIFECYCLES);
+	const lifecycleSeqRef = useRef(0);
+
+	const beginLifecycle = useCallback(
+		(value: Omit<CommitLifecycle, "id">): number => {
+			const id = ++lifecycleSeqRef.current;
+			setCommitLifecycles((prev) => {
+				const next = new Map(prev);
+				next.set(value.workspaceId, { ...value, id });
+				return next;
+			});
+			return id;
+		},
+		[],
+	);
+	const patchLifecycle = useCallback(
+		(
+			workspaceId: string,
+			updater: (prev: CommitLifecycle) => CommitLifecycle | null,
+		) => {
+			setCommitLifecycles((prev) => {
+				const existing = prev.get(workspaceId);
+				if (!existing) return prev;
+				const updated = updater(existing);
+				if (updated === existing) return prev;
+				const next = new Map(prev);
+				if (updated) next.set(workspaceId, updated);
+				else next.delete(workspaceId);
+				return next;
+			});
+		},
+		[],
+	);
+	const clearLifecycle = useCallback((workspaceId: string) => {
+		setCommitLifecycles((prev) => {
+			if (!prev.has(workspaceId)) return prev;
+			const next = new Map(prev);
+			next.delete(workspaceId);
+			return next;
+		});
+	}, []);
+
 	const { requestMergeConfirmation, mergeConfirmDialogNode } =
 		useMergeConfirmation();
 	const currentChangeRequest = changeRequest ?? null;
@@ -243,7 +300,10 @@ export function useWorkspaceCommitLifecycle({
 				return;
 			}
 
-			completedSessionHandledRef.current = null;
+			actionTrackingRef.current.set(workspaceId, {
+				observedSending: false,
+				handledSessionId: null,
+			});
 			console.log("[commitButton] begin", { mode, workspaceId });
 
 			const isMergeAction =
@@ -334,7 +394,7 @@ export function useWorkspaceCommitLifecycle({
 								isMerged: isMergeAction,
 							}
 						: null;
-				setCommitLifecycle({
+				beginLifecycle({
 					workspaceId,
 					trackedSessionId: null,
 					mode: isMergeAction ? "merge" : mode,
@@ -387,15 +447,11 @@ export function useWorkspaceCommitLifecycle({
 						void queryClient.invalidateQueries({
 							queryKey: helmorQueryKeys.workspaceForgeActionStatus(workspaceId),
 						});
-						setCommitLifecycle((prev) =>
-							prev
-								? {
-										...prev,
-										phase: "error",
-										changeRequest: cachedChangeRequest ?? null,
-									}
-								: prev,
-						);
+						patchLifecycle(workspaceId, (prev) => ({
+							...prev,
+							phase: "error",
+							changeRequest: cachedChangeRequest ?? null,
+						}));
 					} finally {
 						release();
 					}
@@ -403,7 +459,7 @@ export function useWorkspaceCommitLifecycle({
 				return;
 			}
 
-			setCommitLifecycle({
+			beginLifecycle({
 				workspaceId,
 				trackedSessionId: null,
 				mode,
@@ -414,16 +470,18 @@ export function useWorkspaceCommitLifecycle({
 			if (mode === "push") {
 				try {
 					await pushWorkspaceToRemote(workspaceId);
-					setCommitLifecycle((current) =>
-						current ? { ...current, phase: "done" } : current,
-					);
+					patchLifecycle(workspaceId, (current) => ({
+						...current,
+						phase: "done",
+					}));
 				} catch (error) {
 					console.error("[commitButton] Failed to push branch:", error);
 					const message = getErrorMessage(error, "Unable to push branch.");
 					pushToast?.(message, "Push failed", "destructive");
-					setCommitLifecycle((current) =>
-						current ? { ...current, phase: "error" } : current,
-					);
+					patchLifecycle(workspaceId, (current) => ({
+						...current,
+						phase: "error",
+					}));
 				}
 				return;
 			}
@@ -432,7 +490,7 @@ export function useWorkspaceCommitLifecycle({
 				console.warn(
 					`[commitButton] action ignored: no prompt for mode ${mode}`,
 				);
-				setCommitLifecycle(null);
+				clearLifecycle(workspaceId);
 				return;
 			}
 			try {
@@ -477,8 +535,8 @@ export function useWorkspaceCommitLifecycle({
 					queryKey: helmorQueryKeys.workspaceSessions(workspaceId),
 				});
 
-				setCommitLifecycle((current) =>
-					current && current.phase === "creating"
+				patchLifecycle(workspaceId, (current) =>
+					current.phase === "creating"
 						? { ...current, trackedSessionId: sessionId }
 						: current,
 				);
@@ -506,7 +564,7 @@ export function useWorkspaceCommitLifecycle({
 							predicate: (q) => q.queryKey[0] === "workspaceForgeActionStatus",
 							refetchType: "all",
 						});
-						setCommitLifecycle(null);
+						clearLifecycle(workspaceId);
 					});
 				}
 			} catch (error) {
@@ -516,9 +574,10 @@ export function useWorkspaceCommitLifecycle({
 					getActionFailureTitle(mode, changeRequestName),
 					"destructive",
 				);
-				setCommitLifecycle((current) =>
-					current ? { ...current, phase: "error" } : current,
-				);
+				patchLifecycle(workspaceId, (current) => ({
+					...current,
+					phase: "error",
+				}));
 			}
 		},
 		[
@@ -532,6 +591,9 @@ export function useWorkspaceCommitLifecycle({
 			selectedWorkspaceRemote,
 			getSelectedWorkspaceId,
 			requestMergeConfirmation,
+			beginLifecycle,
+			patchLifecycle,
+			clearLifecycle,
 		],
 	);
 
@@ -608,148 +670,132 @@ export function useWorkspaceCommitLifecycle({
 		],
 	);
 
+	const pendingPromptRef = useRef(pendingPromptForSession);
+	pendingPromptRef.current = pendingPromptForSession;
+
 	const handlePendingPromptConsumed = useCallback(() => {
 		console.log("[commitButton] pending prompt consumed by composer");
+		const consumedSessionId = pendingPromptRef.current?.sessionId ?? null;
 		setPendingPromptForSession(null);
-		setCommitLifecycle((current) =>
-			current && current.phase === "creating"
-				? { ...current, phase: "streaming" }
-				: current,
-		);
+		if (!consumedSessionId) return;
+		// Only flip the lifecycle whose session the composer just picked up —
+		// a sibling workspace mid-dispatch must not be dragged to "streaming".
+		setCommitLifecycles((prev) => {
+			let changed = false;
+			const next = new Map(prev);
+			for (const [workspaceId, lc] of prev) {
+				if (
+					lc.trackedSessionId === consumedSessionId &&
+					lc.phase === "creating"
+				) {
+					next.set(workspaceId, { ...lc, phase: "streaming" });
+					changed = true;
+				}
+			}
+			return changed ? next : prev;
+		});
 	}, []);
 
-	const commitLifecycleRef = useRef(commitLifecycle);
-	commitLifecycleRef.current = commitLifecycle;
-	const hasObservedSendingRef = useRef(false);
-	const completedSessionHandledRef = useRef<string | null>(null);
+	const commitLifecyclesRef = useRef(commitLifecycles);
+	commitLifecyclesRef.current = commitLifecycles;
+	// Per-workspace settle tracking (observed-streaming + handled session),
+	// keyed by workspaceId. Refs, so mutating them never re-renders.
+	const actionTrackingRef = useRef<Map<string, ActionTracking>>(new Map());
 
 	useEffect(() => {
-		const current = commitLifecycleRef.current;
-		console.log("[commitButton] action-session settlement check", {
-			sendingIds: Array.from(busySessionIds),
-			completedIds: Array.from(completedSessionIds),
-			abortedIds: abortedSessionIds ? Array.from(abortedSessionIds) : [],
-			interactionRequiredIds: Array.from(interactionRequiredSessionIds),
-			lifecyclePhase: current?.phase ?? null,
-			trackedSessionId: current?.trackedSessionId ?? null,
-			observedBefore: hasObservedSendingRef.current,
-			handledCompletedSessionId: completedSessionHandledRef.current,
-		});
+		// Settle EVERY in-flight action, not just the selected workspace's —
+		// concurrent Create-PRs each need their own completion side effects.
+		for (const [workspaceId, lc] of commitLifecyclesRef.current) {
+			if (!lc.trackedSessionId) continue;
+			if (lc.phase !== "creating" && lc.phase !== "streaming") continue;
 
-		if (!current?.trackedSessionId) return;
-		if (current.phase !== "creating" && current.phase !== "streaming") return;
+			const trackedSessionId = lc.trackedSessionId;
+			const tracking = actionTrackingRef.current.get(workspaceId) ?? {
+				observedSending: false,
+				handledSessionId: null,
+			};
 
-		const trackedSessionId = current.trackedSessionId;
-
-		// Aborted sessions clear the lifecycle — no PR was created, so the
-		// button returns to idle rather than proceeding to verify.
-		if (abortedSessionIds?.has(trackedSessionId)) {
-			console.log(
-				"[commitButton] tracked session aborted — clearing lifecycle",
-			);
-			hasObservedSendingRef.current = false;
-			completedSessionHandledRef.current = null;
-			setCommitLifecycle(null);
-			return;
-		}
-
-		const isSending = busySessionIds.has(trackedSessionId);
-		if (isSending) {
-			console.log("[commitButton] tracked session is streaming");
-			hasObservedSendingRef.current = true;
-			return;
-		}
-
-		if (!hasObservedSendingRef.current) {
-			console.log(
-				"[commitButton] tracked session not yet observed streaming — waiting",
-			);
-			return;
-		}
-
-		if (!completedSessionIds.has(trackedSessionId)) {
-			console.log("[commitButton] tracked session not yet completed — waiting");
-			return;
-		}
-
-		if (interactionRequiredSessionIds.has(trackedSessionId)) {
-			console.log(
-				"[commitButton] tracked session still requires interaction — waiting",
-			);
-			return;
-		}
-
-		if (completedSessionHandledRef.current === trackedSessionId) {
-			console.log(
-				"[commitButton] tracked session completion already handled — skipping",
-			);
-			return;
-		}
-
-		console.log(
-			"[commitButton] tracked session completed and settled — transitioning to verifying phase",
-		);
-		hasObservedSendingRef.current = false;
-		completedSessionHandledRef.current = trackedSessionId;
-		setCommitLifecycle((prev) =>
-			prev ? { ...prev, phase: "verifying" } : prev,
-		);
-
-		const workspaceId = current.workspaceId;
-		void (async () => {
-			try {
+			// Aborted sessions clear the lifecycle — no PR was created, so the
+			// button returns to idle rather than proceeding to verify.
+			if (abortedSessionIds?.has(trackedSessionId)) {
 				console.log(
-					"[commitButton] calling refreshWorkspaceChangeRequest",
+					"[commitButton] tracked session aborted — clearing lifecycle",
 					workspaceId,
 				);
-				const currentChangeRequest =
-					await refreshWorkspaceChangeRequest(workspaceId);
-				console.log(
-					"[commitButton] refreshWorkspaceChangeRequest result",
-					currentChangeRequest,
-				);
-				// Seed caches directly from the result we just awaited so the
-				// downstream invalidation in `refreshWorkspaceRemoteStatus`
-				// doesn't trigger a duplicate `gh pr view`, and so the sidebar
-				// lane / inspector header reflect the PR state on the same
-				// frame as the lifecycle transition.
-				queryClient.setQueryData(
-					helmorQueryKeys.workspaceChangeRequest(workspaceId),
-					currentChangeRequest ?? null,
-				);
-				const optimisticStatus = deriveStatusFromChangeRequest(
-					currentChangeRequest ?? null,
-				);
-				if (optimisticStatus) {
-					applyOptimisticWorkspaceStatus(
-						queryClient,
+				actionTrackingRef.current.delete(workspaceId);
+				clearLifecycle(workspaceId);
+				continue;
+			}
+
+			if (busySessionIds.has(trackedSessionId)) {
+				tracking.observedSending = true;
+				actionTrackingRef.current.set(workspaceId, tracking);
+				continue;
+			}
+
+			if (!tracking.observedSending) continue;
+			if (!completedSessionIds.has(trackedSessionId)) continue;
+			if (interactionRequiredSessionIds.has(trackedSessionId)) continue;
+			if (tracking.handledSessionId === trackedSessionId) continue;
+
+			console.log(
+				"[commitButton] tracked session completed and settled — verifying",
+				workspaceId,
+			);
+			tracking.observedSending = false;
+			tracking.handledSessionId = trackedSessionId;
+			actionTrackingRef.current.set(workspaceId, tracking);
+			patchLifecycle(workspaceId, (prev) => ({ ...prev, phase: "verifying" }));
+
+			const mode = lc.mode;
+			void (async () => {
+				try {
+					const currentChangeRequest =
+						await refreshWorkspaceChangeRequest(workspaceId);
+					console.log(
+						"[commitButton] refreshWorkspaceChangeRequest result",
 						workspaceId,
-						optimisticStatus,
+						currentChangeRequest,
 					);
-				}
-				setCommitLifecycle((prev) => {
-					if (!prev || prev.workspaceId !== workspaceId) return prev;
-					return {
+					// Seed caches directly from the result we just awaited so the
+					// downstream invalidation in `refreshWorkspaceRemoteStatus`
+					// doesn't trigger a duplicate `gh pr view`, and so the sidebar
+					// lane / inspector header reflect the PR state on the same
+					// frame as the lifecycle transition.
+					queryClient.setQueryData(
+						helmorQueryKeys.workspaceChangeRequest(workspaceId),
+						currentChangeRequest ?? null,
+					);
+					const optimisticStatus = deriveStatusFromChangeRequest(
+						currentChangeRequest ?? null,
+					);
+					if (optimisticStatus) {
+						applyOptimisticWorkspaceStatus(
+							queryClient,
+							workspaceId,
+							optimisticStatus,
+						);
+					}
+					patchLifecycle(workspaceId, (prev) => ({
 						...prev,
 						phase: "done",
 						changeRequest: currentChangeRequest ?? null,
-					};
-				});
-				refreshWorkspaceRemoteStatus(workspaceId);
-			} catch (error) {
-				console.error("[commitButton] PR lookup failed:", error);
-				pushToast?.(
-					getErrorMessage(error, "Unable to verify action result."),
-					getActionFailureTitle(current.mode, changeRequestName),
-					"destructive",
-				);
-				setCommitLifecycle((prev) =>
-					prev && prev.workspaceId === workspaceId
-						? { ...prev, phase: "error" }
-						: prev,
-				);
-			}
-		})();
+					}));
+					refreshWorkspaceRemoteStatus(workspaceId);
+				} catch (error) {
+					console.error("[commitButton] PR lookup failed:", error);
+					pushToast?.(
+						getErrorMessage(error, "Unable to verify action result."),
+						getActionFailureTitle(mode, changeRequestName),
+						"destructive",
+					);
+					patchLifecycle(workspaceId, (prev) => ({
+						...prev,
+						phase: "error",
+					}));
+				}
+			})();
+		}
 	}, [
 		changeRequestName,
 		completedSessionIds,
@@ -759,76 +805,102 @@ export function useWorkspaceCommitLifecycle({
 		queryClient,
 		refreshWorkspaceRemoteStatus,
 		busySessionIds,
+		clearLifecycle,
+		patchLifecycle,
 	]);
 
+	// Done-phase side effects (auto-close) run once per lifecycle instance; the
+	// dismiss timer reschedules if the phase flips (done → error) so the error
+	// state still gets its longer display window. Keyed by lifecycle id so a
+	// later action on the same workspace can't be dismissed by a stale timer.
+	const donePhaseHandledRef = useRef<Set<number>>(new Set());
+	const dismissStateRef = useRef<Map<number, { phase: string; timer: number }>>(
+		new Map(),
+	);
+
 	useEffect(() => {
-		if (!commitLifecycle) return;
-		if (commitLifecycle.phase !== "done" && commitLifecycle.phase !== "error") {
-			return;
-		}
+		for (const [workspaceId, lc] of commitLifecycles) {
+			if (lc.phase !== "done" && lc.phase !== "error") continue;
+			const prevDismiss = dismissStateRef.current.get(lc.id);
+			if (prevDismiss && prevDismiss.phase === lc.phase) continue;
 
-		const { phase, mode, trackedSessionId, workspaceId } = commitLifecycle;
+			const { phase, mode, trackedSessionId, id } = lc;
 
-		if (phase === "done") {
-			if (mode !== "merge" && mode !== "closed") {
-				refreshWorkspaceRemoteStatus(workspaceId);
-			}
-			queryClient.invalidateQueries({
-				queryKey: ["workspaceChanges"],
-			});
-
-			void (async () => {
-				try {
-					if (!trackedSessionId) return;
-					if (mode === "checks-running" || mode === "merge-blocked") return;
-					const optedIn = await loadAutoCloseActionKinds();
-					if (!optedIn.includes(mode)) return;
-					await hideSession(trackedSessionId);
-					await Promise.all([
-						queryClient.invalidateQueries({
-							queryKey: helmorQueryKeys.workspaceSessions(workspaceId),
-						}),
-						queryClient.invalidateQueries({
-							queryKey: helmorQueryKeys.workspaceDetail(workspaceId),
-						}),
-					]);
-					// Never hijack selection when the user has navigated to another
-					// workspace — the cached detail there is stale anyway (inactive
-					// queries don't refetch, so activeSessionId may still point at
-					// the session we just hid).
-					if (getSelectedWorkspaceIdRef.current() !== workspaceId) return;
-					const detail = queryClient.getQueryData<WorkspaceDetail | null>(
-						helmorQueryKeys.workspaceDetail(workspaceId),
-					);
-					onSelectSession(detail?.activeSessionId ?? null);
-				} catch (error) {
-					console.error(
-						"[commitButton] done-phase side effects failed:",
-						error,
-					);
+			if (phase === "done" && !donePhaseHandledRef.current.has(id)) {
+				donePhaseHandledRef.current.add(id);
+				if (mode !== "merge" && mode !== "closed") {
+					refreshWorkspaceRemoteStatus(workspaceId);
 				}
-			})();
-		}
+				queryClient.invalidateQueries({ queryKey: ["workspaceChanges"] });
 
-		const timeoutId = window.setTimeout(
-			() => {
-				setCommitLifecycle(null);
-			},
-			phase === "done" ? 1200 : 1600,
-		);
-		return () => window.clearTimeout(timeoutId);
+				void (async () => {
+					try {
+						if (!trackedSessionId) return;
+						if (mode === "checks-running" || mode === "merge-blocked") return;
+						const optedIn = await loadAutoCloseActionKinds();
+						if (!optedIn.includes(mode)) return;
+						await hideSession(trackedSessionId);
+						await Promise.all([
+							queryClient.invalidateQueries({
+								queryKey: helmorQueryKeys.workspaceSessions(workspaceId),
+							}),
+							queryClient.invalidateQueries({
+								queryKey: helmorQueryKeys.workspaceDetail(workspaceId),
+							}),
+						]);
+						// Never hijack selection when the user has navigated to another
+						// workspace — the cached detail there is stale anyway (inactive
+						// queries don't refetch, so activeSessionId may still point at
+						// the session we just hid).
+						if (getSelectedWorkspaceIdRef.current() !== workspaceId) return;
+						const detail = queryClient.getQueryData<WorkspaceDetail | null>(
+							helmorQueryKeys.workspaceDetail(workspaceId),
+						);
+						onSelectSession(detail?.activeSessionId ?? null);
+					} catch (error) {
+						console.error(
+							"[commitButton] done-phase side effects failed:",
+							error,
+						);
+					}
+				})();
+			}
+
+			if (prevDismiss) window.clearTimeout(prevDismiss.timer);
+			const timer = window.setTimeout(
+				() => {
+					dismissStateRef.current.delete(id);
+					donePhaseHandledRef.current.delete(id);
+					actionTrackingRef.current.delete(workspaceId);
+					patchLifecycle(workspaceId, (prev) => (prev.id === id ? null : prev));
+				},
+				phase === "done" ? 1200 : 1600,
+			);
+			dismissStateRef.current.set(id, { phase, timer });
+		}
 	}, [
-		commitLifecycle,
+		commitLifecycles,
 		onSelectSession,
 		queryClient,
 		refreshWorkspaceRemoteStatus,
+		patchLifecycle,
 	]);
 
-	// Only honour the lifecycle if it belongs to the currently-selected workspace.
+	// Clear any in-flight dismiss timers on unmount.
+	useEffect(() => {
+		const timers = dismissStateRef.current;
+		return () => {
+			for (const { timer } of timers.values()) window.clearTimeout(timer);
+			timers.clear();
+		};
+	}, []);
+
+	// The button only ever reflects the selected workspace's in-flight action;
+	// sibling lifecycles still settle (refresh + auto-close) in the effects above.
 	const activeLifecycle =
-		commitLifecycle && commitLifecycle.workspaceId === selectedWorkspaceId
-			? commitLifecycle
-			: null;
+		(selectedWorkspaceId
+			? commitLifecycles.get(selectedWorkspaceId)
+			: undefined) ?? null;
 
 	const commitButtonMode = useMemo<WorkspaceCommitButtonMode>(
 		() =>


### PR DESCRIPTION
## What changed

- **Per-workspace commit lifecycles**: The Create PR / MR button now tracks in-flight actions per workspace instead of using a single slot. When you dispatch Create PR on two workspaces back-to-back, both get their refresh + PR sync + auto-close side effects instead of only the last one.
- **Remote branch fallback in forge context**: `forge_head_branch_for()` now falls back to `git ls-remote` when the local clone has no remote-tracking ref for the branch. This fixes workspaces whose branch is already pushed to the remote but whose local refs are missing — the forge correctly marks the branch as published and surfaces its open PR.
- **Renamed `has_remote_tracking` → `published`** across GitHub and GitLab contexts for provider-agnostic clarity, backed by the new `ForgeHeadRef` struct.

## Why

- Users creating PRs across multiple workspaces around the same time saw the second dispatch clobber the first lifecycle, leaving the first workspace stuck showing "Create PR" with the action session still visible.
- Workspaces whose branches were pushed but whose local remote-tracking refs were pruned or never created got stuck in an "unpublished" state, permanently hiding their open PRs.

## Testing

- New test in `use-commit-lifecycle.test.tsx`: "settles two workspaces' Create-PR actions dispatched back-to-back"
- New tests in `github/context.rs` and `gitlab/context.rs`: `ready_with_remote_tracking_when_branch_published_but_local_ref_missing`
- New test in `git/ops.rs`: `remote_branch_exists_detects_published_branch_without_local_ref`