### PR TITLE
feat: add quick panel — global-hotkey floating window to create tasks and chat

### DIFF
--- a/.announcements/quick-panel.json
+++ b/.announcements/quick-panel.json
@@ -1,0 +1,11 @@
+{
+	"items": [
+		{
+			"text": "Quick panel: press ⇧⌥Space anywhere to spin up a task in a small floating window — pick a repo, send the prompt, and keep chatting without opening Helmor. Hotkey configurable in Settings → Shortcuts.",
+			"action": {
+				"label": "Try it",
+				"value": { "type": "toggleQuickPanel" }
+			}
+		}
+	]
+}

--- a/.changeset/quick-panel-window.md
+++ b/.changeset/quick-panel-window.md
@@ -1,0 +1,5 @@
+---
+"helmor": minor
+---
+
+Add the quick panel: press ⇧⌥Space (configurable) anywhere to summon a small always-on-top floating window that creates a workspace and chats with an agent without opening the app.

--- a/index.html
+++ b/index.html
@@ -28,6 +28,10 @@
     <style>
       body { background-color: #0E0E0E; }
       html:not(.dark) body { background-color: #FFFFFF; }
+      /* Quick panel window (class injected via initialization script in
+         src-tauri/src/quick_panel.rs): the window is transparent and the
+         rounded card paints its own background. */
+      html.helmor-quick-window body { background-color: transparent; }
     </style>
   </head>
 

--- a/scripts/consume-release-announcements.ts
+++ b/scripts/consume-release-announcements.ts
@@ -16,6 +16,12 @@ type ReleaseAnnouncementAction =
 	| {
 			type: "openSettings";
 			section?: string;
+	  }
+	| {
+			type: "openStartPage";
+	  }
+	| {
+			type: "toggleQuickPanel";
 	  };
 
 type ReleaseAnnouncementItem = {

--- a/scripts/verify-release-announcements.ts
+++ b/scripts/verify-release-announcements.ts
@@ -5,7 +5,8 @@ import { fileURLToPath } from "node:url";
 type AnnouncementAction =
 	| { type: "openSettings"; section?: string }
 	| { type: "setRightSidebarMode"; mode: string }
-	| { type: "openStartPage" };
+	| { type: "openStartPage" }
+	| { type: "toggleQuickPanel" };
 
 type AnnouncementItem = {
 	text: string;
@@ -74,6 +75,7 @@ function assertItem(
 		return;
 	}
 	if (action.type === "openStartPage") return;
+	if (action.type === "toggleQuickPanel") return;
 	fail(`${path} has an unsupported action value`);
 }
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -68,7 +68,7 @@ serde_json = "1"
 jsonc-parser = { version = "0.32", features = ["cst", "serde"] }
 sha2 = "0.10"
 hex = "0.4"
-tauri = { version = "2", features = ["protocol-asset", "test", "devtools"] }
+tauri = { version = "2", features = ["macos-private-api", "protocol-asset", "test", "devtools"] }
 tempfile = "3"
 tauri-plugin-deep-link = "2"
 tauri-plugin-dialog = "2"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,8 +1,8 @@
 {
 	"$schema": "../gen/schemas/desktop-schema.json",
 	"identifier": "default",
-	"description": "Capability for the main window",
-	"windows": ["main"],
+	"description": "Capability for the main and quick panel windows",
+	"windows": ["main", "quick"],
 	"permissions": [
 		"core:default",
 		"core:window:allow-start-dragging",

--- a/src-tauri/src/companion/rpc.rs
+++ b/src-tauri/src/companion/rpc.rs
@@ -470,6 +470,10 @@ async fn dispatch(
         |         "resize_repo_script"
         |         "reveal_path_in_finder"
         |         "show_image_in_finder"
+        // Quick-panel window management exists only on the desktop host.
+        |         "toggle_quick_panel"
+        |         "hide_quick_panel"
+        |         "reveal_workspace_in_main_window"
         |         "stop_agent_login_terminal"
         |         "stop_forge_cli_auth_terminal"
         |         "stop_repo_script"

--- a/src-tauri/src/global_hotkey.rs
+++ b/src-tauri/src/global_hotkey.rs
@@ -1,4 +1,4 @@
-use std::{str::FromStr, sync::Mutex};
+use std::{collections::HashMap, str::FromStr, sync::Mutex};
 
 use anyhow::{anyhow, Context, Result};
 use serde_json::Value;
@@ -9,28 +9,59 @@ use crate::error::CommandError;
 
 const SHORTCUTS_SETTING_KEY: &str = "app.shortcuts";
 const GLOBAL_HOTKEY_ID: &str = "global.hotkey";
+const QUICK_PANEL_HOTKEY_ID: &str = "quickPanel.hotkey";
+const OS_HOTKEY_IDS: [&str; 2] = [GLOBAL_HOTKEY_ID, QUICK_PANEL_HOTKEY_ID];
 const MAIN_WINDOW_LABEL: &str = "main";
 
 // Rust owns plugin registration, so no frontend plugin capability is needed.
-// Startup reads only stored overrides; keep the TS default null unless this
-// module learns the registry default too.
+// The registry defaults below MUST stay in sync with `defaultHotkey` in
+// src/features/shortcuts/registry.ts: the startup sync registers them when the
+// stored overrides have no entry for the id, while an explicit `null` override
+// means the user unbound the hotkey.
+fn default_hotkey(id: &str) -> Option<&'static str> {
+    match id {
+        QUICK_PANEL_HOTKEY_ID => Some("Shift+Alt+Space"),
+        _ => None,
+    }
+}
+
+/// Registered accelerators by hotkey id.
 #[derive(Default)]
 pub struct GlobalHotkeyState {
-    current: Mutex<Option<String>>,
+    current: Mutex<HashMap<String, String>>,
 }
 
 pub fn sync_from_settings(app: &AppHandle) -> Result<()> {
     let raw = crate::settings::load_setting_value(SHORTCUTS_SETTING_KEY)?;
-    let hotkey = raw.as_deref().and_then(global_hotkey_from_shortcuts_json);
-    sync_global_hotkey_inner(app, hotkey)
+    let mut first_error = None;
+    for id in OS_HOTKEY_IDS {
+        let hotkey = hotkey_from_shortcuts_json(raw.as_deref(), id);
+        // One hotkey failing to register must not block the other.
+        if let Err(error) = sync_hotkey_inner(app, id, hotkey) {
+            tracing::warn!(
+                error = %format!("{error:#}"),
+                hotkey_id = id,
+                "Failed to register startup global hotkey",
+            );
+            first_error.get_or_insert(error);
+        }
+    }
+    first_error.map_or(Ok(()), Err)
 }
 
 #[tauri::command]
-pub fn sync_global_hotkey(app: AppHandle, hotkey: Option<String>) -> Result<(), CommandError> {
-    Ok(sync_global_hotkey_inner(&app, hotkey)?)
+pub fn sync_global_hotkey(
+    app: AppHandle,
+    id: String,
+    hotkey: Option<String>,
+) -> Result<(), CommandError> {
+    if !OS_HOTKEY_IDS.contains(&id.as_str()) {
+        return Err(anyhow!("Unknown global hotkey id {id}").into());
+    }
+    Ok(sync_hotkey_inner(&app, &id, hotkey)?)
 }
 
-fn sync_global_hotkey_inner(app: &AppHandle, hotkey: Option<String>) -> Result<()> {
+fn sync_hotkey_inner(app: &AppHandle, id: &str, hotkey: Option<String>) -> Result<()> {
     let normalized = hotkey
         .as_deref()
         .map(str::trim)
@@ -40,11 +71,12 @@ fn sync_global_hotkey_inner(app: &AppHandle, hotkey: Option<String>) -> Result<(
 
     let state = app.state::<GlobalHotkeyState>();
     let mut current = state.current.lock().expect("global hotkey state poisoned");
-    if *current == normalized {
+    if current.get(id).cloned() == normalized {
         return Ok(());
     }
 
-    let previous = current.clone();
+    let handler = handler_for(id);
+    let previous = current.get(id).cloned();
     if let Some(previous) = previous.as_deref() {
         app.global_shortcut()
             .unregister(previous)
@@ -52,32 +84,36 @@ fn sync_global_hotkey_inner(app: &AppHandle, hotkey: Option<String>) -> Result<(
     }
 
     if let Some(next) = normalized.as_deref() {
-        if let Err(error) = app
-            .global_shortcut()
-            .on_shortcut(next, handle_global_hotkey)
-        {
+        if let Err(error) = app.global_shortcut().on_shortcut(next, handler) {
             if let Some(previous) = previous.as_deref() {
-                if let Err(restore_error) = app
-                    .global_shortcut()
-                    .on_shortcut(previous, handle_global_hotkey)
-                {
+                if let Err(restore_error) = app.global_shortcut().on_shortcut(previous, handler) {
                     tracing::warn!(
                         error = %restore_error,
                         hotkey = %previous,
                         "Failed to restore previous global hotkey",
                     );
-                    *current = None;
+                    current.remove(id);
                 }
             }
             return Err(error).with_context(|| format!("Failed to register global hotkey {next}"));
         }
     }
 
-    *current = normalized;
+    match normalized {
+        Some(accelerator) => current.insert(id.to_owned(), accelerator),
+        None => current.remove(id),
+    };
     Ok(())
 }
 
-fn handle_global_hotkey(
+fn handler_for(id: &str) -> fn(&AppHandle, &Shortcut, ShortcutEvent) {
+    match id {
+        QUICK_PANEL_HOTKEY_ID => handle_quick_panel_hotkey,
+        _ => handle_main_hotkey,
+    }
+}
+
+fn handle_main_hotkey(
     app: &AppHandle,
     _shortcut: &tauri_plugin_global_shortcut::Shortcut,
     event: ShortcutEvent,
@@ -87,6 +123,19 @@ fn handle_global_hotkey(
     }
     if let Err(error) = toggle_main_window(app) {
         tracing::warn!(error = %format!("{error:#}"), "Failed to toggle main window from global hotkey");
+    }
+}
+
+fn handle_quick_panel_hotkey(
+    app: &AppHandle,
+    _shortcut: &tauri_plugin_global_shortcut::Shortcut,
+    event: ShortcutEvent,
+) {
+    if event.state != ShortcutState::Pressed {
+        return;
+    }
+    if let Err(error) = crate::quick_panel::toggle(app) {
+        tracing::warn!(error = %format!("{error:#}"), "Failed to toggle quick panel from global hotkey");
     }
 }
 
@@ -106,12 +155,21 @@ fn toggle_main_window(app: &AppHandle) -> Result<()> {
     Ok(())
 }
 
-fn global_hotkey_from_shortcuts_json(raw: &str) -> Option<String> {
-    let value = serde_json::from_str::<Value>(raw).ok()?;
-    value
-        .get(GLOBAL_HOTKEY_ID)
-        .and_then(Value::as_str)
-        .map(str::to_owned)
+fn hotkey_from_shortcuts_json(raw: Option<&str>, id: &str) -> Option<String> {
+    let fallback = || default_hotkey(id).map(str::to_owned);
+    let Some(raw) = raw else {
+        return fallback();
+    };
+    let Ok(value) = serde_json::from_str::<Value>(raw) else {
+        return fallback();
+    };
+    match value.get(id) {
+        // No override stored: the registry default applies.
+        None => fallback(),
+        // Explicit null: the user unbound this hotkey.
+        Some(Value::Null) => None,
+        Some(other) => other.as_str().map(str::to_owned),
+    }
 }
 
 fn to_tauri_accelerator(hotkey: &str) -> Result<String> {
@@ -151,12 +209,50 @@ mod tests {
     #[test]
     fn extracts_global_hotkey_from_shortcuts_json() {
         assert_eq!(
-            global_hotkey_from_shortcuts_json(r#"{"global.hotkey":"Mod+Shift+Space"}"#),
+            hotkey_from_shortcuts_json(
+                Some(r#"{"global.hotkey":"Mod+Shift+Space"}"#),
+                GLOBAL_HOTKEY_ID
+            ),
             Some("Mod+Shift+Space".to_owned()),
         );
         assert_eq!(
-            global_hotkey_from_shortcuts_json(r#"{"global.hotkey":null}"#),
+            hotkey_from_shortcuts_json(Some(r#"{"global.hotkey":null}"#), GLOBAL_HOTKEY_ID),
             None,
+        );
+        // No override stored: global.hotkey has no registry default.
+        assert_eq!(hotkey_from_shortcuts_json(None, GLOBAL_HOTKEY_ID), None);
+        assert_eq!(
+            hotkey_from_shortcuts_json(Some("{}"), GLOBAL_HOTKEY_ID),
+            None,
+        );
+    }
+
+    #[test]
+    fn quick_panel_hotkey_falls_back_to_registry_default() {
+        // No settings / no override: the registry default applies.
+        assert_eq!(
+            hotkey_from_shortcuts_json(None, QUICK_PANEL_HOTKEY_ID),
+            Some("Shift+Alt+Space".to_owned()),
+        );
+        assert_eq!(
+            hotkey_from_shortcuts_json(Some("{}"), QUICK_PANEL_HOTKEY_ID),
+            Some("Shift+Alt+Space".to_owned()),
+        );
+        // Explicit null: the user unbound it.
+        assert_eq!(
+            hotkey_from_shortcuts_json(
+                Some(r#"{"quickPanel.hotkey":null}"#),
+                QUICK_PANEL_HOTKEY_ID
+            ),
+            None,
+        );
+        // Override wins over the default.
+        assert_eq!(
+            hotkey_from_shortcuts_json(
+                Some(r#"{"quickPanel.hotkey":"Mod+Shift+K"}"#),
+                QUICK_PANEL_HOTKEY_ID
+            ),
+            Some("Mod+Shift+K".to_owned()),
         );
     }
 
@@ -169,6 +265,10 @@ mod tests {
         assert_eq!(
             to_tauri_accelerator("Control+Alt+ArrowUp").unwrap(),
             "Ctrl+Alt+Up",
+        );
+        assert_eq!(
+            to_tauri_accelerator("Shift+Alt+Space").unwrap(),
+            "Shift+Alt+Space",
         );
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,6 +20,7 @@ pub mod mcp;
 pub mod models;
 pub mod pipeline;
 pub(crate) mod platform;
+pub mod quick_panel;
 pub mod rate_limits;
 pub mod schema;
 pub mod service;
@@ -99,7 +100,13 @@ pub fn run() {
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
-        .plugin(tauri_plugin_window_state::Builder::default().build())
+        // The quick panel positions itself (bottom-center, stage-anchored
+        // resizes) — restoring stale geometry would fight that.
+        .plugin(
+            tauri_plugin_window_state::Builder::default()
+                .with_denylist(&[quick_panel::QUICK_PANEL_LABEL])
+                .build(),
+        )
         // Inline Slack file previews. The webview hits
         // `slack-file://files-tmb/T…-F…/image.png`, we proxy the request
         // through the workspace cookie, and stream the bytes back as a
@@ -765,6 +772,9 @@ pub fn run() {
             commands::settings_commands::load_auto_close_opt_in_asked,
             commands::settings_commands::save_auto_close_opt_in_asked,
             global_hotkey::sync_global_hotkey,
+            quick_panel::toggle_quick_panel,
+            quick_panel::hide_quick_panel,
+            quick_panel::reveal_workspace_in_main_window,
             ui_sync::subscribe_ui_mutations,
             ui_sync::unsubscribe_ui_mutations,
             commands::updater_commands::get_app_update_status,
@@ -845,6 +855,18 @@ pub fn run() {
             // window quits the app.
             #[cfg(not(target_os = "macos"))]
             emit_quit_requested(app_handle);
+        }
+        // Quick panel: closing always just hides it (its conversation state
+        // lives in the webview and must survive across summons).
+        tauri::RunEvent::WindowEvent {
+            label,
+            event: tauri::WindowEvent::CloseRequested { api, .. },
+            ..
+        } if label == quick_panel::QUICK_PANEL_LABEL => {
+            api.prevent_close();
+            if let Some(window) = app_handle.get_webview_window(quick_panel::QUICK_PANEL_LABEL) {
+                let _ = window.hide();
+            }
         }
         // macOS Dock-icon click while the window is hidden: show it again.
         #[cfg(target_os = "macos")]

--- a/src-tauri/src/quick_panel.rs
+++ b/src-tauri/src/quick_panel.rs
@@ -1,0 +1,121 @@
+//! The quick panel: a small always-on-top companion window (label `quick`)
+//! summoned by a global hotkey. It loads the same frontend bundle as the main
+//! window; `App.tsx` routes the `quick` label to the QuickShell UI. The window
+//! is created lazily on first summon and then only ever hidden (never
+//! destroyed) so its conversation state survives across summons.
+
+use anyhow::{anyhow, Context, Result};
+use tauri::{AppHandle, Manager, WebviewUrl, WebviewWindowBuilder};
+
+use crate::error::CommandError;
+
+pub const QUICK_PANEL_LABEL: &str = "quick";
+
+/// Fixed logical size — the panel never resizes between views.
+const PANEL_WIDTH: f64 = 507.0;
+const PANEL_HEIGHT: f64 = 640.0;
+
+/// Fraction of the monitor height where the panel's BOTTOM edge sits.
+const BOTTOM_EDGE_RATIO: f64 = 0.96;
+
+/// Global-hotkey entry point: summon (creating on first use) or dismiss.
+pub fn toggle(app: &AppHandle) -> Result<()> {
+    if let Some(window) = app.get_webview_window(QUICK_PANEL_LABEL) {
+        if window.is_visible()? && window.is_focused()? {
+            window.hide()?;
+        } else {
+            window.show()?;
+            window.set_focus()?;
+        }
+        return Ok(());
+    }
+    create(app)
+}
+
+fn create(app: &AppHandle) -> Result<()> {
+    let (x, y) = initial_position(app, PANEL_HEIGHT);
+    WebviewWindowBuilder::new(app, QUICK_PANEL_LABEL, WebviewUrl::App("index.html".into()))
+        .title("Helmor")
+        .inner_size(PANEL_WIDTH, PANEL_HEIGHT)
+        .position(x, y)
+        .decorations(false)
+        .transparent(true)
+        .shadow(true)
+        .always_on_top(true)
+        .visible_on_all_workspaces(true)
+        .skip_taskbar(true)
+        .resizable(false)
+        .accept_first_mouse(true)
+        .focused(true)
+        // Runs before any page script: lets index.html's CSS make the body
+        // transparent for this window only, so the dark main-window background
+        // never flashes behind the rounded card.
+        .initialization_script("document.documentElement.classList.add('helmor-quick-window');")
+        .build()
+        .context("Failed to create quick panel window")?;
+    Ok(())
+}
+
+/// Initial logical position: horizontally centered, bottom edge near the lower
+/// third of the monitor under the cursor (fallback: primary monitor).
+fn initial_position(app: &AppHandle, height: f64) -> (f64, f64) {
+    let monitor = app
+        .cursor_position()
+        .ok()
+        .and_then(|cursor| app.monitor_from_point(cursor.x, cursor.y).ok().flatten())
+        .or_else(|| app.primary_monitor().ok().flatten());
+
+    let Some(monitor) = monitor else {
+        // No monitor info (headless edge case): let the OS place it.
+        return (0.0, 0.0);
+    };
+
+    let scale = monitor.scale_factor();
+    let monitor_x = monitor.position().x as f64 / scale;
+    let monitor_y = monitor.position().y as f64 / scale;
+    let monitor_w = monitor.size().width as f64 / scale;
+    let monitor_h = monitor.size().height as f64 / scale;
+
+    let x = monitor_x + (monitor_w - PANEL_WIDTH) / 2.0;
+    let y = monitor_y + monitor_h * BOTTOM_EDGE_RATIO - height;
+    (x, y)
+}
+
+#[tauri::command]
+pub fn toggle_quick_panel(app: AppHandle) -> Result<(), CommandError> {
+    Ok(toggle(&app)?)
+}
+
+#[tauri::command]
+pub fn hide_quick_panel(app: AppHandle) -> Result<(), CommandError> {
+    if let Some(window) = app.get_webview_window(QUICK_PANEL_LABEL) {
+        window.hide().map_err(anyhow::Error::from)?;
+    }
+    Ok(())
+}
+
+/// "Open in Helmor" from the quick panel: bring the main window forward and
+/// broadcast a reveal request. The main window's ui-sync bridge navigates to
+/// the workspace; the quick panel ignores the event.
+#[tauri::command]
+pub fn reveal_workspace_in_main_window(
+    app: AppHandle,
+    workspace_id: String,
+    session_id: Option<String>,
+) -> Result<(), CommandError> {
+    let window = app
+        .get_webview_window("main")
+        .ok_or_else(|| anyhow!("Main window is not available"))?;
+    window.show().map_err(anyhow::Error::from)?;
+    window.unminimize().map_err(anyhow::Error::from)?;
+    window.set_focus().map_err(anyhow::Error::from)?;
+
+    crate::ui_sync::publish(
+        &app,
+        crate::ui_sync::UiMutationEvent::WorkspaceRevealRequested {
+            workspace_id,
+            session_id,
+        },
+    );
+    Ok(())
+}

--- a/src-tauri/src/ui_sync/events.rs
+++ b/src-tauri/src/ui_sync/events.rs
@@ -122,6 +122,12 @@ pub enum UiMutationEvent {
     /// The mobile-companion paired-device list changed (paired or revoked).
     /// Frontends invalidate the `pairedDevices` query.
     PairedDevicesChanged,
+    /// "Open in Helmor" from the quick panel. Only the MAIN window acts on
+    /// this (navigates to the workspace/session); the quick panel ignores it.
+    WorkspaceRevealRequested {
+        workspace_id: String,
+        session_id: Option<String>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -23,6 +23,7 @@
 		}
 	},
 	"app": {
+		"macOSPrivateApi": true,
 		"windows": [
 			{
 				"title": "Helmor",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,6 @@
 import "./App.css";
+import { QuickShell } from "./features/quick-panel";
+import { isQuickPanelWindow } from "./lib/window-role";
 import { resolveE2eScenarioElement } from "./shell/boot/e2e-routes";
 import { AppProviders } from "./shell/components/app-providers";
 import { AppShell } from "./shell/components/app-shell";
@@ -7,12 +9,19 @@ import { useAppBootstrap } from "./shell/hooks/use-app-bootstrap";
 function App() {
 	const e2eElement = resolveE2eScenarioElement();
 	if (e2eElement) return e2eElement;
-	return <MainApp />;
+	// Same bundle, two windows: the `quick` window mounts the QuickShell
+	// (floating quick-task panel), everything else is the main shell.
+	return isQuickPanelWindow ? <QuickApp /> : <MainApp />;
 }
 
 function MainApp() {
 	const bootstrap = useAppBootstrap();
 	return <AppProviders {...bootstrap} AppShell={AppShell} />;
+}
+
+function QuickApp() {
+	const bootstrap = useAppBootstrap();
+	return <AppProviders {...bootstrap} AppShell={QuickShell} />;
 }
 
 export default App;

--- a/src/components/chrome/traffic-light-spacer.tsx
+++ b/src/components/chrome/traffic-light-spacer.tsx
@@ -1,5 +1,6 @@
 import { isMac, isTauriRuntime } from "@/lib/platform";
 import { cn } from "@/lib/utils";
+import { isQuickPanelWindow } from "@/lib/window-role";
 
 /**
  * Reserves horizontal space for the OS window controls so header content
@@ -24,6 +25,10 @@ export function TrafficLightSpacer({
 	className?: string;
 }) {
 	if (!isTauriRuntime()) {
+		return null;
+	}
+	// The frameless quick panel has no OS window controls to clear.
+	if (isQuickPanelWindow) {
 		return null;
 	}
 	const mac = isMac();

--- a/src/features/announcements/announcements.ts
+++ b/src/features/announcements/announcements.ts
@@ -14,6 +14,9 @@ export type ReleaseAnnouncementAction =
 	  }
 	| {
 			type: "openStartPage";
+	  }
+	| {
+			type: "toggleQuickPanel";
 	  };
 
 export type ReleaseAnnouncementItem = {

--- a/src/features/announcements/index.tsx
+++ b/src/features/announcements/index.tsx
@@ -6,6 +6,7 @@ import {
 	SettingsIcon,
 	SquarePenIcon,
 	XIcon,
+	ZapIcon,
 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { GithubBrandIcon } from "@/components/brand-icon";
@@ -28,6 +29,7 @@ import {
 	writeLastSeenInstallVersion,
 } from "@/features/announcements/storage";
 import type { SettingsSection } from "@/features/settings";
+import { toggleQuickPanel } from "@/lib/api";
 import type { WorkspaceRightSidebarMode } from "@/lib/settings";
 import packageJson from "../../../package.json";
 
@@ -93,6 +95,9 @@ export function ReleaseAnnouncementToastHost({
 				break;
 			case "openStartPage":
 				onOpenStartPage();
+				break;
+			case "toggleQuickPanel":
+				void toggleQuickPanel();
 				break;
 		}
 	};
@@ -267,6 +272,8 @@ function ActionIcon({
 			return <SettingsIcon className={className} />;
 		case "openStartPage":
 			return <SquarePenIcon className={className} />;
+		case "toggleQuickPanel":
+			return <ZapIcon className={className} />;
 	}
 }
 

--- a/src/features/composer/index.tsx
+++ b/src/features/composer/index.tsx
@@ -55,6 +55,7 @@ import type {
 } from "@/lib/composer-insert";
 import { recordComposerRender } from "@/lib/dev-render-debug";
 import { cn } from "@/lib/utils";
+import { isQuickPanelWindow } from "@/lib/window-role";
 import { clampEffort } from "@/lib/workspace-helpers";
 import { ComposerButton } from "./button";
 import { ContextBar } from "./context-bar";
@@ -688,6 +689,9 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 		alternateStartSubmitMode === "saveForLater"
 			? "Save for later"
 			: "Start now";
+	// Narrow surfaces show only the first word ("New" / "Save" / "Start");
+	// the dropdown items keep the full labels.
+	const compactStartSubmitLabel = preferredStartSubmitLabel.split(" ")[0];
 
 	const handleComposerKeyDownCapture = useCallback(
 		(event: React.KeyboardEvent<HTMLDivElement>) => {
@@ -767,7 +771,10 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 			data-focus-scope={focusScope}
 			onKeyDownCapture={handleComposerKeyDownCapture}
 			className={cn(
-				"relative flex flex-col rounded-2xl border border-border/40 bg-sidebar shadow-[0_-1px_8px_rgba(0,0,0,0.05),0_0_0_1px_rgba(255,255,255,0.02)]",
+				// Named container: the footer toolbar sheds label text and
+				// re-aligns in narrow surfaces (quick panel, mini mode) via
+				// pure CSS container queries — no JS width checks.
+				"@container/composer relative flex flex-col rounded-2xl border border-border/40 bg-sidebar shadow-[0_-1px_8px_rgba(0,0,0,0.05),0_0_0_1px_rgba(255,255,255,0.02)]",
 				// Pending-interaction panels fill the shell edge-to-edge and own
 				// their own internal padding; the default composer gets the
 				// legacy px-4 pt-3 pb-3 breathing room.
@@ -961,7 +968,7 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 						</div>
 					) : null}
 
-					<div className="mt-2.5 flex items-end justify-between gap-3">
+					<div className="@max-lg/composer:items-center mt-2.5 flex items-end justify-between gap-3">
 						<div className="flex flex-wrap items-center gap-2">
 							{modelsLoading ? (
 								<ShimmerText className="px-1 py-0.5 text-ui text-muted-foreground">
@@ -1210,8 +1217,7 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 										</DropdownMenu>
 									)}
 									{supportsPlanMode ? (
-										<ComposerButton
-											aria-label="Plan mode"
+										<PlanModeButton
 											disabled={toolbarDisabled}
 											className={cn(
 												`gap-1 px-1.5 text-mini ${composerToolbarTriggerClassName}`,
@@ -1219,20 +1225,14 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 													? "text-plan hover:text-plan"
 													: "text-muted-foreground/70 hover:text-muted-foreground/70",
 											)}
-											onClick={() =>
+											onToggle={() =>
 												onChangePermissionMode(
 													permissionMode === "plan"
 														? "bypassPermissions"
 														: "plan",
 												)
 											}
-										>
-											<ClipboardList
-												className="size-[13px]"
-												strokeWidth={1.8}
-											/>
-											<span>Plan</span>
-										</ComposerButton>
+										/>
 									) : null}
 									{onToggleContextPanel ? (
 										<Tooltip>
@@ -1359,7 +1359,12 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 													) : (
 														<ArrowUp className="size-3.5" strokeWidth={2.2} />
 													)}
-													<span>{preferredStartSubmitLabel}</span>
+													<span className="@max-lg/composer:hidden">
+														{preferredStartSubmitLabel}
+													</span>
+													<span className="hidden @max-lg/composer:inline">
+														{compactStartSubmitLabel}
+													</span>
 												</Button>
 												<DropdownMenuTrigger asChild>
 													<Button
@@ -1427,6 +1432,47 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 		</div>
 	);
 });
+
+function PlanModeButton({
+	disabled,
+	className,
+	onToggle,
+}: {
+	disabled: boolean;
+	className: string;
+	onToggle: () => void;
+}) {
+	const button = (
+		<ComposerButton
+			aria-label="Plan mode"
+			disabled={disabled}
+			className={className}
+			onClick={onToggle}
+		>
+			<ClipboardList className="size-[13px]" strokeWidth={1.8} />
+			{/* Collapses to icon-only in narrow surfaces. */}
+			<span className="@max-lg/composer:hidden">Plan</span>
+		</ComposerButton>
+	);
+	// Main window: the bare button, exactly as before this feature (also keeps
+	// composer tests free of a TooltipProvider requirement). Quick panel: the
+	// label collapses to icon-only, so hover gets a tooltip.
+	if (!isQuickPanelWindow) {
+		return button;
+	}
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>{button}</TooltipTrigger>
+			<TooltipContent
+				side="top"
+				sideOffset={4}
+				className="flex h-[24px] items-center rounded-md px-2 text-small leading-none"
+			>
+				<span>Plan</span>
+			</TooltipContent>
+		</Tooltip>
+	);
+}
 
 function EffortBrainIcon({ level }: { level: string }) {
 	const cls = "shrink-0";

--- a/src/features/dock-badge/use-dock-unread-badge.ts
+++ b/src/features/dock-badge/use-dock-unread-badge.ts
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useEffect } from "react";
 import { workspaceGroupsQueryOptions } from "@/lib/query-client";
+import { isQuickPanelWindow } from "@/lib/window-role";
 import { selectUnreadSessionCount } from "./selector";
 
 /**
@@ -25,6 +26,8 @@ export function useDockUnreadBadge(): void {
 	const count = selectUnreadSessionCount(groups);
 
 	useEffect(() => {
+		// The Dock badge is app-wide; let the main window be its single writer.
+		if (isQuickPanelWindow) return;
 		// Wrap in try/catch because the Tauri window handle may lack
 		// `setBadgeCount` entirely — e.g. in the Playwright E2E harness where
 		// `@tauri-apps/api/window` is aliased to a stub, or in any future

--- a/src/features/quick-panel/index.tsx
+++ b/src/features/quick-panel/index.tsx
@@ -1,0 +1,1 @@
+export { QuickShell } from "./quick-shell";

--- a/src/features/quick-panel/quick-panel-actions.tsx
+++ b/src/features/quick-panel/quick-panel-actions.tsx
@@ -1,0 +1,86 @@
+import { ArrowUpRight, Plus, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { hideQuickPanel, revealWorkspaceInMainWindow } from "@/lib/api";
+
+function ActionButton({
+	label,
+	onClick,
+	children,
+}: {
+	label: string;
+	onClick: () => void;
+	children: React.ReactNode;
+}) {
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<Button
+					type="button"
+					variant="ghost"
+					size="sm"
+					onClick={onClick}
+					aria-label={label}
+					className="px-2 text-muted-foreground hover:text-foreground"
+				>
+					{children}
+				</Button>
+			</TooltipTrigger>
+			<TooltipContent
+				side="bottom"
+				sideOffset={4}
+				className="flex h-[24px] items-center rounded-md px-2 text-small leading-none"
+			>
+				<span>{label}</span>
+			</TooltipContent>
+		</Tooltip>
+	);
+}
+
+export function QuickPanelCloseButton() {
+	return (
+		<ActionButton label="Close" onClick={() => void hideQuickPanel()}>
+			<X className="size-3.5" strokeWidth={1.8} />
+		</ActionButton>
+	);
+}
+
+/**
+ * Icon-only panel actions riding in the conversation header's actions slot —
+ * one row holds branch, new, open, and close.
+ */
+export function QuickPanelActions({
+	selectedWorkspaceId,
+	selectedSessionId,
+	onNewTask,
+}: {
+	selectedWorkspaceId: string | null;
+	selectedSessionId: string | null;
+	onNewTask: () => void;
+}) {
+	return (
+		<>
+			<ActionButton label="New Workspace" onClick={onNewTask}>
+				<Plus className="size-3.5" strokeWidth={1.8} />
+			</ActionButton>
+			{selectedWorkspaceId ? (
+				<ActionButton
+					label="Open in Helmor"
+					onClick={() =>
+						void revealWorkspaceInMainWindow(
+							selectedWorkspaceId,
+							selectedSessionId,
+						)
+					}
+				>
+					<ArrowUpRight className="size-3.5" strokeWidth={1.8} />
+				</ActionButton>
+			) : null}
+			<QuickPanelCloseButton />
+		</>
+	);
+}

--- a/src/features/quick-panel/quick-shell.tsx
+++ b/src/features/quick-panel/quick-shell.tsx
@@ -1,0 +1,91 @@
+// The quick panel's whole surface — the AppShell counterpart for the `quick`
+// window. Runs the SAME `useAppShellState` orchestration (its own React root,
+// router and selection, fully independent from the main window) but renders
+// only the workspace pane inside a rounded floating card: no sidebar, no
+// inspector, no overlays. The panel actions (new / open / close) ride in the
+// conversation header's actions slot; on the start surface a lone close
+// button floats top-right. Window-level behaviors live in
+// `useQuickPanelWindow`; per-app singletons inside the shared hooks are gated
+// by `isQuickPanelWindow`.
+import { useMemo } from "react";
+import { Toaster } from "@/components/ui/sonner";
+import type { SettingsSection } from "@/features/settings";
+import { resolveTheme } from "@/lib/settings";
+import { AppShellProviderStack } from "@/shell/components/app-shell-provider-stack";
+import { buildWorkspacePaneProps } from "@/shell/components/workspace-pane-props";
+import { WorkspacePaneSurface } from "@/shell/components/workspace-pane-surface";
+import { useAppShellState } from "@/shell/hooks/use-app-shell-state";
+import {
+	QuickPanelActions,
+	QuickPanelCloseButton,
+} from "./quick-panel-actions";
+import { useQuickPanelWindow } from "./use-quick-panel-window";
+
+export function QuickShell({
+	onOpenSettings,
+}: {
+	onOpenSettings: (
+		workspaceId: string | null,
+		workspaceRepoId: string | null,
+		initialSection?: SettingsSection,
+	) => void;
+}) {
+	const s = useAppShellState({ onOpenSettings });
+	useQuickPanelWindow({
+		openWorkspaceStart: s.handleOpenWorkspaceStart,
+	});
+
+	const { selectedWorkspaceId, selectedSessionId, handleOpenWorkspaceStart } =
+		s;
+	const headerActionsNode = useMemo(
+		() => (
+			<QuickPanelActions
+				selectedWorkspaceId={selectedWorkspaceId}
+				selectedSessionId={selectedSessionId}
+				onNewTask={() => handleOpenWorkspaceStart({ persist: false })}
+			/>
+		),
+		[selectedWorkspaceId, selectedSessionId, handleOpenWorkspaceStart],
+	);
+
+	const paneProps = buildWorkspacePaneProps({
+		s,
+		headerLeadingNode: null,
+		headerActionsNode,
+	});
+
+	return (
+		<AppShellProviderStack
+			selectionStore={s.sel.selectionStore}
+			pushWorkspaceToast={s.pushWorkspaceToast}
+			sessionRunStates={s.data.effectiveSessionRunStates}
+			insertIntoComposer={s.data.pendingQueueActions.insertIntoComposer}
+			showQuitConfirm={false}
+		>
+			<Toaster
+				theme={resolveTheme(s.appSettings.theme)}
+				position="bottom-right"
+				visibleToasts={3}
+			/>
+			<main
+				aria-label="Quick panel"
+				className="h-dvh w-dvw overflow-hidden bg-transparent font-sans text-foreground antialiased"
+			>
+				<div className="relative flex h-full min-h-0 flex-col overflow-hidden rounded-xl border border-border/60 bg-background">
+					{s.workspaceViewMode === "start" ? (
+						<div className="absolute top-1.5 right-1.5 z-20">
+							<QuickPanelCloseButton />
+						</div>
+					) : null}
+					{/* The panel never shows the context sidebar; keep the
+					    composer's toggle visually inert. */}
+					<WorkspacePaneSurface
+						{...paneProps}
+						contextPanelOpen={false}
+						startComposerAtBottom
+					/>
+				</div>
+			</main>
+		</AppShellProviderStack>
+	);
+}

--- a/src/features/quick-panel/use-quick-panel-window.ts
+++ b/src/features/quick-panel/use-quick-panel-window.ts
@@ -1,0 +1,55 @@
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { useEffect, useRef } from "react";
+import { hideQuickPanel } from "@/lib/api";
+import { publishShellEvent, useShellEvent } from "@/shell/event-bus";
+
+/**
+ * Window-side behaviors of the quick panel: land on the start surface, react
+ * to ⌘N, Esc-to-dismiss, and composer focus on every summon.
+ */
+export function useQuickPanelWindow({
+	openWorkspaceStart,
+}: {
+	openWorkspaceStart: (opts?: { persist?: boolean }) => void;
+}) {
+	// The panel always boots onto the start surface — its whole purpose is a
+	// fresh task. The main window's `lastSurface` restore doesn't apply here
+	// (location persistence is disabled for this window, so `persist` is moot;
+	// passing false keeps the intent explicit).
+	const bootedRef = useRef(false);
+	useEffect(() => {
+		if (bootedRef.current) return;
+		bootedRef.current = true;
+		openWorkspaceStart({ persist: false });
+	}, [openWorkspaceStart]);
+
+	// ⌘N / ⌘⇧N publish this event. In the main window the sidebar navigates to
+	// the start surface; the panel has no sidebar, so navigate here. The mode
+	// override ("just chat") is consumed by the start-surface controller.
+	useShellEvent("open-new-workspace", () => {
+		openWorkspaceStart({ persist: false });
+	});
+
+	// Esc dismisses the panel — unless something closer to the focus already
+	// handled it (typeahead popups, source preview, …) and preventDefault'ed.
+	useEffect(() => {
+		const handleKeyDown = (event: KeyboardEvent) => {
+			if (event.key !== "Escape" || event.defaultPrevented) return;
+			event.preventDefault();
+			void hideQuickPanel();
+		};
+		window.addEventListener("keydown", handleKeyDown);
+		return () => window.removeEventListener("keydown", handleKeyDown);
+	}, []);
+
+	// The window is hidden, not destroyed, between summons — refocus the
+	// composer every time it comes back.
+	useEffect(() => {
+		const unlistenPromise = getCurrentWindow().listen("tauri://focus", () => {
+			publishShellEvent({ type: "focus-composer" });
+		});
+		return () => {
+			void unlistenPromise.then((unlisten) => unlisten());
+		};
+	}, []);
+}

--- a/src/features/shortcuts/registry.ts
+++ b/src/features/shortcuts/registry.ts
@@ -210,6 +210,17 @@ export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
 		editable: true,
 	},
 	{
+		// OS-level hotkey registered by the Rust backend. The default below
+		// MUST stay in sync with `default_hotkey` in src-tauri/src/global_hotkey.rs.
+		id: "quickPanel.hotkey",
+		title: "Quick panel hotkey",
+		description: "Open the quick task panel from anywhere.",
+		group: "System",
+		defaultHotkey: "Shift+Alt+Space",
+		scopes: ["app"],
+		editable: true,
+	},
+	{
 		id: "theme.toggle",
 		title: "Toggle theme (dark/light)",
 		group: "System",

--- a/src/features/shortcuts/settings-panel.tsx
+++ b/src/features/shortcuts/settings-panel.tsx
@@ -40,7 +40,10 @@ const GROUPS: ShortcutGroup[] = [
 	"Editor",
 	"Terminal",
 ];
-const PINNED_SHORTCUT_IDS: ShortcutId[] = ["global.hotkey"];
+const PINNED_SHORTCUT_IDS: ShortcutId[] = [
+	"global.hotkey",
+	"quickPanel.hotkey",
+];
 const PINNED_SHORTCUT_ID_SET = new Set<ShortcutId>(PINNED_SHORTCUT_IDS);
 
 const MODIFIER_KEYS = new Set(["Alt", "Control", "Meta", "Shift"]);

--- a/src/features/shortcuts/types.ts
+++ b/src/features/shortcuts/types.ts
@@ -26,6 +26,7 @@ export type ShortcutId =
 	| "zoom.out"
 	| "zoom.reset"
 	| "global.hotkey"
+	| "quickPanel.hotkey"
 	| "action.createPr"
 	| "action.commitAndPush"
 	| "action.pullLatest"

--- a/src/features/shortcuts/use-global-hotkey-sync.test.tsx
+++ b/src/features/shortcuts/use-global-hotkey-sync.test.tsx
@@ -49,6 +49,25 @@ describe("useGlobalHotkeySync", () => {
 		cleanup();
 	});
 
+	it("syncs every OS-level hotkey, including registry defaults", async () => {
+		apiMocks.syncGlobalHotkey.mockResolvedValue(undefined);
+
+		render(<Harness shortcuts={{}} updateShortcuts={vi.fn()} />);
+
+		await waitFor(() => {
+			// No overrides stored: global.hotkey has no default (null), the
+			// quick panel ships bound to Shift+Alt+Space.
+			expect(apiMocks.syncGlobalHotkey).toHaveBeenCalledWith(
+				"global.hotkey",
+				null,
+			);
+			expect(apiMocks.syncGlobalHotkey).toHaveBeenCalledWith(
+				"quickPanel.hotkey",
+				"Shift+Alt+Space",
+			);
+		});
+	});
+
 	it("clears a persisted global hotkey when registration fails", async () => {
 		apiMocks.syncGlobalHotkey.mockRejectedValue(
 			new Error("Hotkey unavailable"),
@@ -63,7 +82,13 @@ describe("useGlobalHotkeySync", () => {
 		);
 
 		await waitFor(() => {
+			// global.hotkey override removed (its default is null)…
 			expect(updateShortcuts).toHaveBeenCalledWith({});
+			// …and the default-bound quick panel hotkey unbound explicitly.
+			expect(updateShortcuts).toHaveBeenCalledWith({
+				"global.hotkey": "Mod+Shift+Space",
+				"quickPanel.hotkey": null,
+			});
 		});
 		expect(toastMocks.error).toHaveBeenCalledWith("Hotkey unavailable");
 	});

--- a/src/features/shortcuts/use-global-hotkey-sync.ts
+++ b/src/features/shortcuts/use-global-hotkey-sync.ts
@@ -1,8 +1,15 @@
 import { useEffect, useRef } from "react";
 import { toast } from "sonner";
-import { syncGlobalHotkey } from "@/lib/api";
+import { type OsGlobalHotkeyId, syncGlobalHotkey } from "@/lib/api";
 import type { ShortcutOverrides } from "@/lib/settings";
+import { isQuickPanelWindow } from "@/lib/window-role";
 import { getShortcut, updateShortcutOverride } from "./registry";
+
+/** Shortcut ids registered at the OS level by the Rust backend. */
+const OS_GLOBAL_HOTKEY_IDS: readonly OsGlobalHotkeyId[] = [
+	"global.hotkey",
+	"quickPanel.hotkey",
+];
 
 type GlobalHotkeySyncOptions = {
 	isLoaded: boolean;
@@ -15,35 +22,35 @@ export function useGlobalHotkeySync({
 	shortcuts,
 	updateShortcuts,
 }: GlobalHotkeySyncOptions) {
-	const globalHotkey = getShortcut(shortcuts, "global.hotkey");
-	const lastFailureRef = useRef<string | null>(null);
+	const lastFailureRef = useRef<Map<OsGlobalHotkeyId, string>>(new Map());
 
 	useEffect(() => {
-		if (!isLoaded) return;
+		// The main window owns OS-hotkey registration; the quick panel mounts
+		// the same shell stack but must not double-drive (or race) the sync.
+		if (!isLoaded || isQuickPanelWindow) return;
 
-		void syncGlobalHotkey(globalHotkey)
-			.then(() => {
-				lastFailureRef.current = null;
-			})
-			.catch((error) => {
-				const key = globalHotkey ?? "<disabled>";
-				if (lastFailureRef.current !== key) {
-					lastFailureRef.current = key;
-					toast.error(
-						error instanceof Error
-							? error.message
-							: "Failed to register global hotkey",
-					);
-				}
+		for (const id of OS_GLOBAL_HOTKEY_IDS) {
+			const hotkey = getShortcut(shortcuts, id);
+			void syncGlobalHotkey(id, hotkey)
+				.then(() => {
+					lastFailureRef.current.delete(id);
+				})
+				.catch((error) => {
+					const key = hotkey ?? "<disabled>";
+					if (lastFailureRef.current.get(id) !== key) {
+						lastFailureRef.current.set(id, key);
+						toast.error(
+							error instanceof Error
+								? error.message
+								: "Failed to register global hotkey",
+						);
+					}
 
-				if (globalHotkey) {
-					const nextShortcuts = updateShortcutOverride(
-						shortcuts,
-						"global.hotkey",
-						null,
-					);
-					updateShortcuts(nextShortcuts as ShortcutOverrides);
-				}
-			});
-	}, [globalHotkey, isLoaded, shortcuts, updateShortcuts]);
+					if (hotkey) {
+						const nextShortcuts = updateShortcutOverride(shortcuts, id, null);
+						updateShortcuts(nextShortcuts as ShortcutOverrides);
+					}
+				});
+		}
+	}, [isLoaded, shortcuts, updateShortcuts]);
 }

--- a/src/features/updater/use-app-updater.ts
+++ b/src/features/updater/use-app-updater.ts
@@ -7,6 +7,7 @@ import {
 	listenAppUpdateStatus,
 } from "@/lib/api";
 import { openUrl } from "@/lib/platform-bridge";
+import { isQuickPanelWindow } from "@/lib/window-role";
 
 function toastIdForUpdate(status: AppUpdateStatus): string | null {
 	return status.update ? `app-update-${status.update.version}` : null;
@@ -66,6 +67,9 @@ export function useAppUpdater(): AppUpdateStatus | null {
 	const [status, setStatus] = useState<AppUpdateStatus | null>(null);
 
 	useEffect(() => {
+		// Update checks, download toasts and install actions are app-wide
+		// singletons — the main window owns them.
+		if (isQuickPanelWindow) return;
 		let cleanup: (() => void) | undefined;
 		let mounted = true;
 

--- a/src/features/workspace-start/index.tsx
+++ b/src/features/workspace-start/index.tsx
@@ -89,6 +89,10 @@ type WorkspaceStartPageProps = {
 	headerLeading?: React.ReactNode;
 	showWindowSafeTop?: boolean;
 	onClosePreview?: () => void;
+	/** Quick panel layout: pin the composer to the bottom edge and center
+	 * the heading in the space above it (instead of centering the whole
+	 * block at mid-height). */
+	composerAtBottom?: boolean;
 	children: React.ReactNode;
 };
 
@@ -111,6 +115,7 @@ export function WorkspaceStartPage({
 	headerLeading,
 	showWindowSafeTop = false,
 	onClosePreview,
+	composerAtBottom = false,
 	children,
 }: WorkspaceStartPageProps) {
 	const [createBranchOpen, setCreateBranchOpen] = useState(false);
@@ -265,24 +270,29 @@ export function WorkspaceStartPage({
 				<div
 					className={cn(
 						"absolute left-1/2 flex w-full max-w-3xl -translate-x-1/2 flex-col items-center transition-[top,transform,opacity,gap] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)]",
-						previewCard
-							? "top-[calc(100%-11rem)] gap-0"
-							: "top-1/2 gap-7 -translate-y-1/2",
+						composerAtBottom
+							? "inset-y-0 gap-7 pb-3"
+							: previewCard
+								? "top-[calc(100%-11rem)] gap-0"
+								: "top-1/2 gap-7 -translate-y-1/2",
 					)}
 				>
 					<div
 						aria-hidden={previewCard ? true : undefined}
 						className={cn(
 							"relative w-full overflow-hidden transition-[height,opacity,transform] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)]",
-							previewCard
-								? "pointer-events-none h-0 translate-y-2 opacity-0"
-								: "h-10 translate-y-0 opacity-100",
+							composerAtBottom
+								? "min-h-0 flex-1"
+								: previewCard
+									? "pointer-events-none h-0 translate-y-2 opacity-0"
+									: "h-10 translate-y-0 opacity-100",
 						)}
 					>
 						<div
 							className={cn(
-								"absolute top-0 flex items-center gap-x-2 whitespace-nowrap text-center font-semibold leading-tight tracking-normal text-foreground transition-[left,transform,font-size] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)]",
+								"absolute flex items-center gap-x-2 whitespace-nowrap text-center font-semibold leading-tight tracking-normal text-foreground transition-[left,transform,font-size] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)]",
 								"left-1/2 -translate-x-1/2 text-[24px]",
+								composerAtBottom ? "top-1/2 -translate-y-1/2" : "top-0",
 							)}
 						>
 							{mode === "chat" ? (

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -837,12 +837,35 @@ export async function installDownloadedAppUpdate(): Promise<AppUpdateStatus> {
 	return invoke<AppUpdateStatus>("install_downloaded_app_update");
 }
 
-export async function syncGlobalHotkey(hotkey: string | null): Promise<void> {
+export type OsGlobalHotkeyId = "global.hotkey" | "quickPanel.hotkey";
+
+export async function syncGlobalHotkey(
+	id: OsGlobalHotkeyId,
+	hotkey: string | null,
+): Promise<void> {
 	try {
-		await invoke<void>("sync_global_hotkey", { hotkey });
+		await invoke<void>("sync_global_hotkey", { id, hotkey });
 	} catch (error) {
 		throw new Error(describeInvokeError(error, "Unable to set global hotkey."));
 	}
+}
+
+export async function toggleQuickPanel(): Promise<void> {
+	return invoke<void>("toggle_quick_panel");
+}
+
+export async function hideQuickPanel(): Promise<void> {
+	return invoke<void>("hide_quick_panel");
+}
+
+export async function revealWorkspaceInMainWindow(
+	workspaceId: string,
+	sessionId: string | null,
+): Promise<void> {
+	return invoke<void>("reveal_workspace_in_main_window", {
+		workspaceId,
+		sessionId,
+	});
 }
 
 export async function listenAppUpdateStatus(
@@ -2207,6 +2230,11 @@ export type UiMutationEvent =
 			sessionId: string;
 			workspaceId: string;
 			prompt: string;
+	  }
+	| {
+			type: "workspaceRevealRequested";
+			workspaceId: string;
+			sessionId: string | null;
 	  };
 
 export type TriageConfig = {

--- a/src/lib/window-role.ts
+++ b/src/lib/window-role.ts
@@ -1,0 +1,26 @@
+import { getCurrentWindow } from "@tauri-apps/api/window";
+
+export const QUICK_PANEL_WINDOW_LABEL = "quick";
+
+function resolveWindowLabel(): string {
+	try {
+		// jsdom test mocks return a window object without `label`; treat any
+		// non-quick (including missing) label as the main window.
+		return getCurrentWindow().label ?? "main";
+	} catch {
+		return "main";
+	}
+}
+
+/**
+ * Which Tauri window this webview is running in. Resolved once at module load —
+ * a webview can never migrate between windows.
+ *
+ * `isQuickPanelWindow` gates the per-app singleton concerns that must run in
+ * exactly one window (updater, dock badge, settings-persisted navigation,
+ * OS-hotkey sync) so the quick panel can mount the same shell stack without
+ * double-driving them.
+ */
+export const windowLabel: string = resolveWindowLabel();
+export const isQuickPanelWindow: boolean =
+	windowLabel === QUICK_PANEL_WINDOW_LABEL;

--- a/src/shell/components/app-providers.tsx
+++ b/src/shell/components/app-providers.tsx
@@ -9,6 +9,7 @@ import { SettingsDialog } from "@/features/settings";
 import { getPendingPairingToken } from "@/lib/ipc";
 import { helmorQueryPersister, QUERY_CACHE_BUSTER } from "@/lib/query-client";
 import { SettingsContext } from "@/lib/settings";
+import { isQuickPanelWindow } from "@/lib/window-role";
 import { router } from "@/router";
 import { EMPTY_SESSION_RUN_STATES } from "@/shell/constants";
 import type { AppBootstrap } from "@/shell/hooks/use-app-bootstrap";
@@ -84,14 +85,24 @@ export function AppProviders({
 				) : companionAuth === "unauthed" ? (
 					<CompanionPairingScreen />
 				) : appSettings === null ? null : !appSettings.onboardingCompleted ? (
-					<>
-						<AppOnboarding onComplete={completeOnboarding} />
-						<QuitConfirmDialog sessionRunStates={EMPTY_SESSION_RUN_STATES} />
-					</>
+					isQuickPanelWindow ? (
+						// The onboarding flow belongs to the main window; the panel
+						// summoned mid-onboarding just points the user there.
+						<div className="flex h-dvh items-center justify-center bg-background p-6 text-center text-ui text-muted-foreground">
+							Finish setting up Helmor in the main window first.
+						</div>
+					) : (
+						<>
+							<AppOnboarding onComplete={completeOnboarding} />
+							<QuitConfirmDialog sessionRunStates={EMPTY_SESSION_RUN_STATES} />
+						</>
+					)
 				) : (
 					<RouterProvider router={router} context={routerContext} />
 				)}
-				{splashMounted && <SplashScreen visible={splashVisible} />}
+				{splashMounted && !isQuickPanelWindow && (
+					<SplashScreen visible={splashVisible} />
+				)}
 				<SettingsDialog
 					open={settingsOpen}
 					workspaceId={settingsWorkspaceId}

--- a/src/shell/components/app-shell-provider-stack.tsx
+++ b/src/shell/components/app-shell-provider-stack.tsx
@@ -17,6 +17,8 @@ type Props = {
 	pushWorkspaceToast: ComponentProps<typeof WorkspaceToastProvider>["value"];
 	sessionRunStates: ComponentProps<typeof SessionRunStatesProvider>["value"];
 	insertIntoComposer: ComponentProps<typeof ComposerInsertProvider>["value"];
+	/** The quick panel opts out: only the main window confirms app quit. */
+	showQuitConfirm?: boolean;
 	children: ReactNode;
 };
 
@@ -25,6 +27,7 @@ export function AppShellProviderStack({
 	pushWorkspaceToast,
 	sessionRunStates,
 	insertIntoComposer,
+	showQuitConfirm = true,
 	children,
 }: Props) {
 	return (
@@ -37,7 +40,9 @@ export function AppShellProviderStack({
 						</ComposerInsertProvider>
 					</SessionRunStatesProvider>
 				</WorkspaceToastProvider>
-				<QuitConfirmDialog sessionRunStates={sessionRunStates} />
+				{showQuitConfirm && (
+					<QuitConfirmDialog sessionRunStates={sessionRunStates} />
+				)}
 			</SelectionStoreProvider>
 		</TooltipProvider>
 	);

--- a/src/shell/components/app-shell.tsx
+++ b/src/shell/components/app-shell.tsx
@@ -12,6 +12,7 @@ import { useAppShellState } from "@/shell/hooks/use-app-shell-state";
 import { AppShellLayout } from "./app-shell-layout";
 import { WorkspaceHeaderActions } from "./workspace-header-actions";
 import { WorkspaceHeaderLeading } from "./workspace-header-leading";
+import { buildWorkspacePaneProps } from "./workspace-pane-props";
 
 export function AppShell({
 	onOpenSettings,
@@ -136,54 +137,11 @@ export function AppShell({
 			sidebarCollapsed={panels.sidebarCollapsed}
 			isSidebarResizing={panels.isSidebarResizing}
 			sidebarWidth={panels.sidebarWidth}
-			workspacePane={{
-				workspaceViewMode: s.workspaceViewMode,
-				editorSession: data.editorSession,
-				workspaceRootPath: data.workspaceRootPath,
-				appShortcuts: s.appSettings.shortcuts,
-				sidebarCollapsed: panels.sidebarCollapsed,
-				contextPanelOpen: sel.contextPanel.contextPanelOpen,
-				handleEditorSessionChange: data.handleEditorSessionChange,
-				editorSessionActions: data.editorSessionActions,
-				repositories: s.repositories,
-				selectionActions: sel.selectionActions,
-				readStateActions: data.readStateActions,
-				pendingQueueActions: data.pendingQueueActions,
-				contextPanelActions: sel.contextPanelActions,
-				startSurfaceActions: sel.startSurfaceActions,
-				activeStreams: data.activeStreams,
-				effectiveBusySessionIds: data.effectiveBusySessionIds,
-				effectiveStoppableSessionIds: data.effectiveStoppableSessionIds,
-				interactionRequiredSessionIds: data.interactionRequiredSessionIds,
-				pendingComposerInserts: data.pendingComposerInserts,
-				onSelectSession: sel.handleSelectSession,
-				onRequestCloseSession: data.requestCloseSession,
-				handlePendingPromptConsumed: data.handlePendingPromptConsumed,
-				queuePendingPromptForSession: data.queuePendingPromptForSession,
-				startRepository: sel.startSurface.startRepository,
-				startSourceBranch: sel.startSurface.startSourceBranch,
-				startBranches: sel.startSurface.startBranches,
-				startBranchesLoading: sel.startSurface.startBranchesLoading,
-				startMode: sel.startSurface.startMode,
-				startBranchIntent: sel.startSurface.startBranchIntent,
-				startPreviewCard: sel.contextPanel.startPreviewCard,
-				startComposerInsertTarget: sel.startSurface.startComposerInsertTarget,
-				startComposerContextKey: sel.startSurface.startComposerContextKey,
-				startCreateContext: s.startCreateContext,
-				startLinkedDirectoriesController:
-					sel.startSurface.startLinkedDirectoriesController,
-				repoId: data.selectedWorkspaceDetailQuery.data?.repoId ?? null,
-				sessionSelectionHistory: s.sessionSelectionHistory,
-				workspaceChangeRequest: data.workspaceChangeRequest,
-				pendingPromptForSession: data.pendingPromptForSession,
-				pendingCreatedWorkspaceSubmit: sel.pendingCreatedWorkspaceSubmit,
-				handlePendingCreatedWorkspaceSubmitConsumed:
-					data.handlePendingCreatedWorkspaceSubmitConsumed,
-				contextPreviewCard: sel.contextPanel.workspacePreviewCard,
-				contextPreviewActive: sel.contextPanel.workspacePreviewActive,
+			workspacePane={buildWorkspacePaneProps({
+				s,
 				headerLeadingNode,
 				headerActionsNode,
-			}}
+			})}
 			rightSidebarAvailable={sel.contextPanel.rightSidebarAvailable}
 			selectedWorkspaceDetail={data.selectedWorkspaceDetail}
 			inspector={{

--- a/src/shell/components/start-surface-pane.tsx
+++ b/src/shell/components/start-surface-pane.tsx
@@ -52,6 +52,8 @@ type Props = {
 	onPendingPromptConsumed: () => void;
 	queuePendingPromptForSession: ConversationProps["onQueuePendingPromptForSession"];
 	headerLeading: React.ReactNode;
+	/** Quick panel: composer pinned to the bottom, heading centered above. */
+	composerAtBottom?: boolean;
 };
 
 export function StartSurfacePane({
@@ -85,6 +87,7 @@ export function StartSurfacePane({
 	onPendingPromptConsumed,
 	queuePendingPromptForSession,
 	headerLeading,
+	composerAtBottom,
 }: Props) {
 	return (
 		<WorkspaceStartPage
@@ -112,6 +115,7 @@ export function StartSurfacePane({
 			headerLeading={headerLeading}
 			showWindowSafeTop={sidebarCollapsed}
 			onClosePreview={contextPanelActions.closeStartContextPreview}
+			composerAtBottom={composerAtBottom}
 		>
 			<WorkspaceConversationContainer
 				selectedWorkspaceId={null}

--- a/src/shell/components/workspace-pane-props.ts
+++ b/src/shell/components/workspace-pane-props.ts
@@ -1,0 +1,69 @@
+// The `workspacePane` prop bag for `WorkspacePaneSurface`, assembled from the
+// `useAppShellState` orchestration result. Shared by the main AppShell and the
+// quick panel's QuickShell so the wiring can never drift between the two
+// surfaces — only the header nodes (and any explicit overrides) differ.
+import type { ComponentProps, ReactNode } from "react";
+import type { useAppShellState } from "@/shell/hooks/use-app-shell-state";
+import type { WorkspacePaneSurface } from "./workspace-pane-surface";
+
+type AppShellState = ReturnType<typeof useAppShellState>;
+
+export function buildWorkspacePaneProps({
+	s,
+	headerLeadingNode,
+	headerActionsNode,
+}: {
+	s: AppShellState;
+	headerLeadingNode: ReactNode;
+	headerActionsNode: ReactNode;
+}): ComponentProps<typeof WorkspacePaneSurface> {
+	const { sel, data, panels } = s;
+	return {
+		workspaceViewMode: s.workspaceViewMode,
+		editorSession: data.editorSession,
+		workspaceRootPath: data.workspaceRootPath,
+		appShortcuts: s.appSettings.shortcuts,
+		sidebarCollapsed: panels.sidebarCollapsed,
+		contextPanelOpen: sel.contextPanel.contextPanelOpen,
+		handleEditorSessionChange: data.handleEditorSessionChange,
+		editorSessionActions: data.editorSessionActions,
+		repositories: s.repositories,
+		selectionActions: sel.selectionActions,
+		readStateActions: data.readStateActions,
+		pendingQueueActions: data.pendingQueueActions,
+		contextPanelActions: sel.contextPanelActions,
+		startSurfaceActions: sel.startSurfaceActions,
+		activeStreams: data.activeStreams,
+		effectiveBusySessionIds: data.effectiveBusySessionIds,
+		effectiveStoppableSessionIds: data.effectiveStoppableSessionIds,
+		interactionRequiredSessionIds: data.interactionRequiredSessionIds,
+		pendingComposerInserts: data.pendingComposerInserts,
+		onSelectSession: sel.handleSelectSession,
+		onRequestCloseSession: data.requestCloseSession,
+		handlePendingPromptConsumed: data.handlePendingPromptConsumed,
+		queuePendingPromptForSession: data.queuePendingPromptForSession,
+		startRepository: sel.startSurface.startRepository,
+		startSourceBranch: sel.startSurface.startSourceBranch,
+		startBranches: sel.startSurface.startBranches,
+		startBranchesLoading: sel.startSurface.startBranchesLoading,
+		startMode: sel.startSurface.startMode,
+		startBranchIntent: sel.startSurface.startBranchIntent,
+		startPreviewCard: sel.contextPanel.startPreviewCard,
+		startComposerInsertTarget: sel.startSurface.startComposerInsertTarget,
+		startComposerContextKey: sel.startSurface.startComposerContextKey,
+		startCreateContext: s.startCreateContext,
+		startLinkedDirectoriesController:
+			sel.startSurface.startLinkedDirectoriesController,
+		repoId: data.selectedWorkspaceDetailQuery.data?.repoId ?? null,
+		sessionSelectionHistory: s.sessionSelectionHistory,
+		workspaceChangeRequest: data.workspaceChangeRequest,
+		pendingPromptForSession: data.pendingPromptForSession,
+		pendingCreatedWorkspaceSubmit: sel.pendingCreatedWorkspaceSubmit,
+		handlePendingCreatedWorkspaceSubmitConsumed:
+			data.handlePendingCreatedWorkspaceSubmitConsumed,
+		contextPreviewCard: sel.contextPanel.workspacePreviewCard,
+		contextPreviewActive: sel.contextPanel.workspacePreviewActive,
+		headerLeadingNode,
+		headerActionsNode,
+	};
+}

--- a/src/shell/components/workspace-pane-surface.tsx
+++ b/src/shell/components/workspace-pane-surface.tsx
@@ -68,6 +68,8 @@ type Props = {
 	startComposerContextKey: string;
 	startCreateContext: ComposerCreateContext | null;
 	startLinkedDirectoriesController: ConversationProps["composerLinkedDirectoriesController"];
+	/** Quick panel: composer pinned to the bottom of the start surface. */
+	startComposerAtBottom?: boolean;
 	// Conversation (chat) only
 	repoId: string | null;
 	sessionSelectionHistory: string[];
@@ -116,6 +118,7 @@ export function WorkspacePaneSurface({
 	startComposerContextKey,
 	startCreateContext,
 	startLinkedDirectoriesController,
+	startComposerAtBottom,
 	repoId,
 	sessionSelectionHistory,
 	workspaceChangeRequest,
@@ -201,6 +204,7 @@ export function WorkspacePaneSurface({
 							onPendingPromptConsumed={handlePendingPromptConsumed}
 							queuePendingPromptForSession={queuePendingPromptForSession}
 							headerLeading={headerLeadingNode}
+							composerAtBottom={startComposerAtBottom}
 						/>
 					) : (
 						<ShellWorkspaceConversation

--- a/src/shell/controllers/use-selection-controller.ts
+++ b/src/shell/controllers/use-selection-controller.ts
@@ -29,6 +29,7 @@ import {
 	workspaceSessionsQueryOptions,
 } from "@/lib/query-client";
 import type { AppSettings } from "@/lib/settings";
+import { isQuickPanelWindow } from "@/lib/window-role";
 import { router } from "@/router";
 import { locationToSelection } from "@/router/location-mapping";
 import {
@@ -189,6 +190,10 @@ export function useSelectionController(
 	// and the `openStart` persist write. Always reads the latest
 	// `updateSettings` through the ref so the subscription can mount once.
 	useEffect(() => {
+		// Only the main window persists its location. The quick panel navigates
+		// its own router (start → fresh workspace) and must not clobber the
+		// `lastSurface` / `lastWorkspaceId` the main window restores at boot.
+		if (isQuickPanelWindow) return;
 		return installLocationPersistence((patch) => {
 			void updateSettingsRef.current(patch);
 		});

--- a/src/shell/controllers/use-start-surface-controller.ts
+++ b/src/shell/controllers/use-start-surface-controller.ts
@@ -586,11 +586,22 @@ export function useStartSurfaceController(
 						},
 						finalized: false,
 					});
-					requestAnimationFrame(() => {
+					// WKWebView pauses rAF entirely while the webview is hidden or
+					// occluded (`document.visibilityState === "hidden"` — e.g. the
+					// quick panel dismissed right after submit, or a window on
+					// another Space). Race a timer fallback so the view switch can
+					// never be lost; when rAF is alive it wins and keeps the
+					// paint-first behavior.
+					let viewSwitchDone = false;
+					const switchToConversation = () => {
+						if (viewSwitchDone) return;
+						viewSwitchDone = true;
 						selectWorkspaceRef.current(outcome.workspaceId);
 						selectSessionRef.current(outcome.sessionId);
 						setViewModeRef.current("conversation");
-					});
+					};
+					requestAnimationFrame(switchToConversation);
+					setTimeout(switchToConversation, 120);
 
 					let finalizedWorkingDirectory: string | null =
 						preparedWorkingDirectory;

--- a/src/shell/hooks/use-app-bootstrap.ts
+++ b/src/shell/hooks/use-app-bootstrap.ts
@@ -11,6 +11,7 @@ import {
 	loadSettings,
 	saveSettings,
 } from "@/lib/settings";
+import { isQuickPanelWindow } from "@/lib/window-role";
 import {
 	SPLASH_FADE_MS,
 	SPLASH_MIN_DURATION_MS,
@@ -129,6 +130,11 @@ export function useAppBootstrap(): AppBootstrap {
 
 	useEffect(() => {
 		if (appSettings?.onboardingCompleted !== true) {
+			return;
+		}
+		// The command restores the INVOKING window's size constraints — from
+		// the quick panel it would blow the small card up to main-window size.
+		if (isQuickPanelWindow) {
 			return;
 		}
 

--- a/src/shell/hooks/use-app-shell-state.tsx
+++ b/src/shell/hooks/use-app-shell-state.tsx
@@ -12,12 +12,13 @@
 // verbatim out of the old inline AppShell body — call order, dependency arrays
 // and `getSnapshot()` readbacks are preserved exactly.
 import { useQueryClient } from "@tanstack/react-query";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import type { ComposerCreateContext } from "@/features/conversation";
 import { useDockUnreadBadge } from "@/features/dock-badge";
 import type { SettingsSection } from "@/features/settings";
 import { useAppUpdater } from "@/features/updater/use-app-updater";
 import { useSettings } from "@/lib/settings";
+import { isQuickPanelWindow } from "@/lib/window-role";
 import { useRouterSelection } from "@/router/use-router-selection";
 import { publishShellEvent } from "@/shell/event-bus";
 import { useEnsureDefaultModel } from "@/shell/hooks/use-ensure-default-model";
@@ -221,10 +222,21 @@ export function useAppShellState({
 		workspaceViewMode,
 	});
 
+	const handleWorkspaceReveal = useCallback(
+		(workspaceId: string, sessionId: string | null) => {
+			sel.handleSelectWorkspace(workspaceId);
+			if (sessionId) {
+				sel.handleSelectSession(sessionId);
+			}
+		},
+		[sel.handleSelectWorkspace, sel.handleSelectSession],
+	);
 	useUiSyncBridge({
 		queryClient,
 		processPendingCliSends: data.pendingQueueActions.processPendingCliSends,
 		reloadSettings: () => publishShellEvent({ type: "reload-settings" }),
+		// Quick-panel "Open in Helmor": only the main window navigates.
+		onWorkspaceReveal: isQuickPanelWindow ? undefined : handleWorkspaceReveal,
 	});
 
 	// Close-confirmation is handled by <QuitConfirmDialog /> which registers

--- a/src/shell/hooks/use-ensure-default-model.ts
+++ b/src/shell/hooks/use-ensure-default-model.ts
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 import type { AgentModelSection } from "@/lib/api";
 import { agentModelSectionsQueryOptions } from "@/lib/query-client";
 import { type AppSettings, useSettings } from "@/lib/settings";
+import { isQuickPanelWindow } from "@/lib/window-role";
 import { findModelOption } from "@/lib/workspace-helpers";
 
 const KNOWN_MODEL_PROVIDERS = ["claude", "codex"] as const;
@@ -32,6 +33,9 @@ export function useEnsureDefaultModel() {
 	const sections = modelSectionsQuery.data;
 
 	useEffect(() => {
+		// Settings self-repair runs from one window only to avoid racing
+		// concurrent `updateSettings` patches across webviews.
+		if (isQuickPanelWindow) return;
 		if (!isLoaded) return;
 		if (!sections || sections.length === 0) return;
 		const settled = isModelCatalogSettled(sections);

--- a/src/shell/hooks/use-global-shortcut-handlers.ts
+++ b/src/shell/hooks/use-global-shortcut-handlers.ts
@@ -5,8 +5,9 @@ import {
 	type ShortcutHandler,
 	useAppShortcuts,
 } from "@/features/shortcuts/use-app-shortcuts";
-import { closeMainWindow } from "@/lib/api";
+import { closeMainWindow, hideQuickPanel } from "@/lib/api";
 import type { AppSettings } from "@/lib/settings";
+import { isQuickPanelWindow } from "@/lib/window-role";
 import type { ContextPanelActions } from "@/shell/controllers/use-context-panel-controller";
 import { publishShellEvent } from "@/shell/event-bus";
 import { clampZoom, ZOOM_STEP } from "@/shell/use-zoom";
@@ -138,10 +139,14 @@ export function useGlobalShortcutHandlers({
 			{
 				id: "workspace.quickSwitchNext" as const,
 				callback: () => quickSwitch.open("next"),
+				// The quick-switch overlay lives in AppOverlays, which the quick
+				// panel doesn't mount — opening it there would set invisible state.
+				enabled: !isQuickPanelWindow,
 			},
 			{
 				id: "workspace.quickSwitchPrevious" as const,
 				callback: () => quickSwitch.open("previous"),
+				enabled: !isQuickPanelWindow,
 			},
 			{
 				id: "session.previous" as const,
@@ -181,7 +186,10 @@ export function useGlobalShortcutHandlers({
 			},
 			{
 				id: "window.close" as const,
-				callback: () => void closeMainWindow(),
+				// In the quick panel "close window" dismisses the panel itself —
+				// it must never close the (possibly hidden) main window.
+				callback: () =>
+					void (isQuickPanelWindow ? hideQuickPanel() : closeMainWindow()),
 			},
 			{
 				id: "script.run" as const,
@@ -194,6 +202,8 @@ export function useGlobalShortcutHandlers({
 			{
 				id: "window.miniMode.toggle" as const,
 				callback: handleToggleMiniMode,
+				// Mini mode resizes the INVOKING window; meaningless for the panel.
+				enabled: !isQuickPanelWindow,
 			},
 			{
 				id: "sidebar.left.toggle" as const,

--- a/src/shell/hooks/use-opencode-startup-sync.ts
+++ b/src/shell/hooks/use-opencode-startup-sync.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import { useOpencodeModelSync } from "@/features/settings/panels/providers/use-opencode-model-sync";
 import { useSettings } from "@/lib/settings";
+import { isQuickPanelWindow } from "@/lib/window-role";
 
 /** On app start, restart `opencode serve` once to re-read ~/.config/opencode,
  *  so config edits made while Helmor was closed land in the composer's model
@@ -13,6 +14,9 @@ export function useOpencodeStartupSync() {
 
 	const usedOpencode = settings.opencodeProvider.cachedModels !== null;
 	useEffect(() => {
+		// One restart per APP start — the main window owns it; the quick panel
+		// mounting later must not bounce the server again.
+		if (isQuickPanelWindow) return;
 		if (!isLoaded || ranRef.current || !usedOpencode) return;
 		ranRef.current = true;
 		void sync({ forceReload: true });

--- a/src/shell/hooks/use-ui-sync-bridge.ts
+++ b/src/shell/hooks/use-ui-sync-bridge.ts
@@ -12,6 +12,12 @@ type Options = {
 	queryClient: QueryClient;
 	processPendingCliSends: () => Promise<void> | void;
 	reloadSettings: () => Promise<void> | void;
+	/**
+	 * "Open in Helmor" from the quick panel. Wired in the MAIN window only —
+	 * the event broadcasts to every webview, and the quick panel must not
+	 * navigate itself.
+	 */
+	onWorkspaceReveal?: (workspaceId: string, sessionId: string | null) => void;
 };
 
 function invalidateAllWorkspaceChanges(queryClient: QueryClient) {
@@ -301,6 +307,9 @@ function handleUiMutation(
 			});
 			return;
 		}
+		case "workspaceRevealRequested":
+			options.onWorkspaceReveal?.(event.workspaceId, event.sessionId);
+			return;
 	}
 }
 
@@ -308,14 +317,17 @@ export function useUiSyncBridge({
 	queryClient,
 	processPendingCliSends,
 	reloadSettings,
+	onWorkspaceReveal,
 }: Options) {
 	const processPendingCliSendsRef = useRef(processPendingCliSends);
 	const reloadSettingsRef = useRef(reloadSettings);
+	const onWorkspaceRevealRef = useRef(onWorkspaceReveal);
 
 	useEffect(() => {
 		processPendingCliSendsRef.current = processPendingCliSends;
 		reloadSettingsRef.current = reloadSettings;
-	}, [processPendingCliSends, reloadSettings]);
+		onWorkspaceRevealRef.current = onWorkspaceReveal;
+	}, [processPendingCliSends, reloadSettings, onWorkspaceReveal]);
 
 	useEffect(() => {
 		let disposed = false;
@@ -329,6 +341,8 @@ export function useUiSyncBridge({
 			handleUiMutation(event, queryClient, {
 				processPendingCliSends: () => processPendingCliSendsRef.current(),
 				reloadSettings: () => reloadSettingsRef.current(),
+				onWorkspaceReveal: (workspaceId, sessionId) =>
+					onWorkspaceRevealRef.current?.(workspaceId, sessionId),
 			});
 		}).then((cleanup) => {
 			if (disposed) {


### PR DESCRIPTION
## What

Press **⇧⌥Space** anywhere (configurable in Settings → Shortcuts) to summon a small always-on-top floating window that creates a workspace, sends the first prompt, and supports full multi-turn chat — without opening the app.

- Frameless rounded card (507×640) near the bottom of the screen; draggable, stays visible until explicitly dismissed (×, Esc, or the hotkey again)
- Reuses the start surface ("What should we build in …?", Shift+Tab repo cycling) and the full Lexical composer + conversation stack in its own webview (`QuickShell`) — image paste, large-text collapse, model/effort pickers all work as in the main window
- Hidden, never destroyed, between summons: drafts and the running conversation survive
- Icon actions ride in the conversation header row: new task (⌘N works too), **Open in Helmor** (reveals the workspace in the main window), close
- Release announcement ships with a **Try it** action (new `toggleQuickPanel` announcement action type)

## Zero impact when unused

Every per-app singleton is gated by window role (`src/lib/window-role.ts`): updater, dock badge, location persistence, OS-hotkey sync, settings self-repair, opencode startup sync, onboarding window-mode restore. The main window's `workspacePane` wiring is extracted into `buildWorkspacePaneProps` shared by both shells (field-for-field identical to the previous inline bag). Composer compaction (icon-only Plan, "New"/"Save"/"Start" labels) is pure CSS container queries that only engage below a 512px container.

Inherent exceptions reviewers should know about:
- ⇧⌥Space is registered OS-wide by default; if taken, registration fails with a one-time toast and auto-unbinds
- A new "Quick panel hotkey" row appears in Settings → Shortcuts
- `macOSPrivateApi` is now enabled (transparent webview for the rounded card)

## Bug fix that benefits the main window

The start surface's post-create view switch sat in a bare `requestAnimationFrame`, which WKWebView pauses entirely while the webview is hidden/occluded — the navigation could be lost (e.g. workspace created via CLI handoff while the window is hidden). Now raced with a 120ms timer fallback (the #770 pattern).

## Verification

- `tsc`, `biome`, `cargo clippy --all-targets -- -D warnings`: clean
- vitest: 1493/1493 (after rebase onto main incl. Terminal Mode)
- cargo: all integration targets green; lib 1505/1507 — the 2 failures are the pre-existing flaky `workspace::scripts` tests (untouched by this branch; 16/16 in isolation)
- Manual E2E against the dev data dir via the Tauri MCP bridge: summon → create → exactly one user message → streamed reply → multi-turn → Open in Helmor → new task → hide/re-summon state retention