### PR TITLE
fix: forward fast=false explicitly so Cursor respects fast-mode-off toggle

### DIFF
--- a/.changeset/cursor-fast-mode-off-respected.md
+++ b/.changeset/cursor-fast-mode-off-respected.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix the Cursor Fast toggle being ignored so turning it off now runs Composer models (including Composer 2.5) in normal mode instead of fast mode.

--- a/sidecar/src/cursor-worker/cursor-helpers.ts
+++ b/sidecar/src/cursor-worker/cursor-helpers.ts
@@ -134,10 +134,14 @@ export function computeModelParameterValues(
 		out.push({ id: "thinking", value: "true" });
 	}
 
-	if (fastMode === true) {
-		const param = parameters.find((p) => p.id === "fast");
-		if (param?.values.some((v) => v.value === "true")) {
-			out.push({ id: "fast", value: "true" });
+	// Always forward an explicit fast value when the model exposes it.
+	// Omitting it lets Cursor fall back to a model-specific server default
+	// (Composer 2.5 defaults to fast), so OFF must be sent as fast=false.
+	const fastParam = parameters.find((p) => p.id === "fast");
+	if (fastParam) {
+		const desired = fastMode === true ? "true" : "false";
+		if (fastParam.values.some((v) => v.value === desired)) {
+			out.push({ id: "fast", value: desired });
 		}
 	}
 

--- a/sidecar/test/cursor-session-manager.test.ts
+++ b/sidecar/test/cursor-session-manager.test.ts
@@ -182,12 +182,15 @@ function sdkParams(id: string): SdkParam[] | undefined {
 }
 
 describe("computeModelParameterValues — fixture-driven", () => {
-	test("composer-2: only fast, effort silently dropped, no thinking", () => {
+	test("composer-2: fast forwarded explicitly on AND off, effort dropped", () => {
 		const params = fixtureParams("composer-2");
 		expect(computeModelParameterValues(params, "high", true)).toEqual([
 			{ id: "fast", value: "true" },
 		]);
-		expect(computeModelParameterValues(params, "high", false)).toEqual([]);
+		// OFF must be sent explicitly — omitting it lets Cursor default to fast.
+		expect(computeModelParameterValues(params, "high", false)).toEqual([
+			{ id: "fast", value: "false" },
+		]);
 	});
 
 	test("gpt-5.3-codex: reasoning + fast forwarded, no thinking auto-add", () => {
@@ -200,7 +203,10 @@ describe("computeModelParameterValues — fixture-driven", () => {
 
 	test("gpt-5.3-codex: invalid effort value silently dropped", () => {
 		const params = fixtureParams("gpt-5.3-codex");
-		expect(computeModelParameterValues(params, "max", false)).toEqual([]);
+		// Invalid effort dropped; fast=false still forwarded explicitly.
+		expect(computeModelParameterValues(params, "max", false)).toEqual([
+			{ id: "fast", value: "false" },
+		]);
 	});
 
 	test("claude-opus-4-7: thinking auto-on, effort surfaced, no fast", () => {


### PR DESCRIPTION
## What changed

`computeModelParameterValues` in the Cursor worker now always forwards an explicit `fast` value when the model supports it — including `fast=false` when fast mode is off.

## Why

Previously, when fast mode was off, the code omitted the `fast` parameter entirely. Cursor's server-side default for Composer 2.5 is `fast=true`, so omitting it meant the user's toggle had no effect — Cursor always ran in fast mode regardless.

## Test notes

Updated fixture-driven tests in `cursor-session-manager.test.ts` to verify both `fast=true` and `fast=false` are forwarded explicitly.