### PR TITLE
fix(terminal): PTY size, start-page state sync, titles, icon flash, cursor alignment

### DIFF
--- a/.changeset/terminal-rendering-and-start-fixes.md
+++ b/.changeset/terminal-rendering-and-start-fixes.md
@@ -1,0 +1,10 @@
+---
+"helmor": patch
+---
+
+Polish Terminal Mode rendering and the start-page flow:
+- The agent TUI now boots at the panel's real size, so its bottom rows no longer render garbled.
+- Opening a terminal from the start page no longer gets stuck on a loading screen until you switch tabs.
+- New terminal sessions get a generated title from your prompt instead of staying named "Terminal".
+- The composer's terminal-mode icon no longer flashes white for a frame while toggling.
+- The terminal cursor stays aligned with the TUI input instead of stranding at the top.

--- a/src-tauri/src/commands/forge_commands.rs
+++ b/src-tauri/src/commands/forge_commands.rs
@@ -263,6 +263,7 @@ pub async fn spawn_forge_cli_auth_terminal(
             &context,
             channel.clone(),
             Some(&boot_input),
+            None,
         ) {
             let _ = channel.send(ScriptEvent::Error {
                 message: error.to_string(),

--- a/src-tauri/src/commands/system_commands.rs
+++ b/src-tauri/src/commands/system_commands.rs
@@ -1507,6 +1507,7 @@ pub async fn spawn_agent_login_terminal(
             &context,
             channel.clone(),
             Some(&boot_input),
+            None,
         ) {
             tracing::warn!(
                 provider = %provider,

--- a/src-tauri/src/commands/terminal_commands.rs
+++ b/src-tauri/src/commands/terminal_commands.rs
@@ -34,6 +34,8 @@ pub async fn spawn_terminal(
     agent_kind: Option<String>,
     boot_command: Option<String>,
     fast_mode: Option<bool>,
+    initial_cols: Option<u16>,
+    initial_rows: Option<u16>,
     channel: Channel<ScriptEvent>,
 ) -> CmdResult<()> {
     let (repo, workspace) = tauri::async_runtime::spawn_blocking({
@@ -91,6 +93,12 @@ pub async fn spawn_terminal(
     };
     let mgr = manager.inner().clone();
     let script_type = make_script_type(&instance_id);
+    // Spawn the PTY at the renderer's real size. An inline TUI paints its first
+    // frame against this; a stale default leaves ghost rows after fit/SIGWINCH.
+    let initial_size = match (initial_cols, initial_rows) {
+        (Some(c), Some(r)) if c > 0 && r > 0 => Some((c, r)),
+        _ => None,
+    };
 
     tauri::async_runtime::spawn_blocking(move || {
         // Wrap the preset command: export the hook env (so the agent hook can
@@ -111,6 +119,7 @@ pub async fn spawn_terminal(
             &context,
             channel.clone(),
             boot_input.as_deref(),
+            initial_size,
         ) {
             let _ = channel.send(ScriptEvent::Error {
                 message: e.to_string(),

--- a/src-tauri/src/commands/triage_lark_cli_commands.rs
+++ b/src-tauri/src/commands/triage_lark_cli_commands.rs
@@ -78,6 +78,7 @@ pub async fn spawn_lark_cli_auth_terminal(
             &context,
             channel.clone(),
             Some(&boot_input),
+            None,
         ) {
             let _ = channel.send(ScriptEvent::Error {
                 message: error.to_string(),

--- a/src-tauri/src/commands/workspace_commands.rs
+++ b/src-tauri/src/commands/workspace_commands.rs
@@ -111,6 +111,16 @@ pub async fn finalize_workspace_from_repo(
         let workspace_id = workspace_id.clone();
         run_blocking(move || workspaces::finalize_workspace_from_repo_impl(&workspace_id)).await?
     };
+    // Finalize flips the DB row initializing → ready / setup_pending. Broadcast
+    // it so every consumer's `workspaceDetail` refreshes off the stale
+    // `initializing` (the Terminal panel gates its PTY spawn on this; chat reads
+    // the pending-submit payload instead and never noticed the gap).
+    crate::ui_sync::publish(
+        &app,
+        crate::ui_sync::UiMutationEvent::WorkspaceChanged {
+            workspace_id: workspace_id.clone(),
+        },
+    );
     notify_workspace_changed_in_background(app);
     Ok(result)
 }

--- a/src-tauri/src/models/sessions.rs
+++ b/src-tauri/src/models/sessions.rs
@@ -319,9 +319,12 @@ pub fn workspace_id_for_session(session_id: &str) -> Result<Option<String>> {
 /// of silently rewriting kind/agent/title.
 pub fn convert_session_to_terminal(session_id: &str, agent_type: &str) -> Result<()> {
     let connection = db::write_conn()?;
+    // Leave `title` untouched ("Untitled" from prepare) so the prompt-captured
+    // title generation can still replace it — `can_replace_session_title` only
+    // overwrites "Untitled", so hardcoding "Terminal" here would freeze it.
     let rows = connection
         .execute(
-            "UPDATE sessions SET session_kind = 'terminal', agent_type = ?2, title = 'Terminal' \
+            "UPDATE sessions SET session_kind = 'terminal', agent_type = ?2 \
              WHERE id = ?1 \
                AND NOT EXISTS (SELECT 1 FROM session_messages WHERE session_id = ?1)",
             rusqlite::params![session_id, agent_type],
@@ -589,15 +592,13 @@ pub fn create_session(
     let session_id =
         crate::workspace::lifecycle::resolve_seed_session_id(overrides.seed_session_id);
     let session_kind = overrides.session_kind.unwrap_or("gui");
-    let title = if session_kind == "terminal" {
-        "Terminal".to_string()
-    } else {
-        default_session_title_for_action_kind_with_workspace(
-            &transaction,
-            workspace_id,
-            action_kind,
-        )?
-    };
+    // Terminal sessions default to "Untitled" too (not "Terminal"), so the
+    // prompt-captured title generation can replace it like a normal session.
+    let title = default_session_title_for_action_kind_with_workspace(
+        &transaction,
+        workspace_id,
+        action_kind,
+    )?;
 
     transaction
         .execute(
@@ -1418,7 +1419,10 @@ mod tests {
                 .unwrap();
             assert_eq!(kind, "terminal");
             assert_eq!(agent, "claude");
-            assert_eq!(title, "Terminal");
+            // Convert must NOT clobber the title — leaving it ("Untitled" in
+            // prod, "Test Session" here) is what lets prompt-captured title
+            // generation replace it later.
+            assert_eq!(title, "Test Session");
         }
 
         // A session with history must be refused, untouched.

--- a/src-tauri/src/platform/pty.rs
+++ b/src-tauri/src/platform/pty.rs
@@ -91,23 +91,27 @@ pub fn is_session_disconnect(err: &io::Error) -> bool {
     }
 }
 
-/// Spawn `cmd` attached to a new PTY. The caller owns the rest of the
-/// orchestration (registering the handle, the reader thread, feeding the
-/// initial command, and reaping via `child.wait()`).
-pub fn spawn(cmd: Command) -> Result<PtySession> {
+/// Spawn `cmd` attached to a new PTY at an optional initial `(cols, rows)`. The
+/// caller owns the rest of the orchestration (registering the handle, the
+/// reader thread, feeding the initial command, and reaping via `child.wait()`).
+///
+/// An inline TUI paints its first frame against the size at spawn time —
+/// defaults leave ghost rows behind once the real fit arrives, so callers that
+/// know the renderer's size must pass it.
+pub fn spawn_with_size(cmd: Command, size: Option<(u16, u16)>) -> Result<PtySession> {
     #[cfg(unix)]
     {
-        spawn_unix(cmd)
+        spawn_unix(cmd, size)
     }
 
     #[cfg(windows)]
     {
-        spawn_windows(cmd)
+        spawn_windows(cmd, size)
     }
 
     #[cfg(not(any(unix, windows)))]
     {
-        let _ = cmd;
+        let _ = (cmd, size);
         anyhow::bail!("PTY sessions are not yet implemented on this platform")
     }
 }
@@ -118,15 +122,16 @@ pub fn spawn(cmd: Command) -> Result<PtySession> {
 // drain loop relies on a 0-byte read (the pipe closing when the child exits)
 // to stop, which is what the orchestration already treats as `hung_up`.
 #[cfg(windows)]
-fn spawn_windows(cmd: Command) -> Result<PtySession> {
+fn spawn_windows(cmd: Command, size: Option<(u16, u16)>) -> Result<PtySession> {
     use std::sync::{Arc, Mutex};
 
     use portable_pty::{native_pty_system, CommandBuilder, PtySize};
 
+    let (cols, rows) = size.unwrap_or((120, 30));
     let pair = native_pty_system()
         .openpty(PtySize {
-            rows: 30,
-            cols: 120,
+            rows,
+            cols,
             pixel_width: 0,
             pixel_height: 0,
         })
@@ -331,13 +336,13 @@ impl PtyReader for UnixPtyReader {
 }
 
 #[cfg(unix)]
-fn spawn_unix(mut cmd: Command) -> Result<PtySession> {
+fn spawn_unix(mut cmd: Command, size: Option<(u16, u16)>) -> Result<PtySession> {
     use std::fs::File;
     use std::os::fd::FromRawFd;
     use std::os::unix::process::CommandExt;
     use std::process::Stdio;
 
-    let (master_fd, slave_fd) = open_pty()?;
+    let (master_fd, slave_fd) = open_pty(size)?;
     set_nonblocking(master_fd)?;
 
     // Dup master for the write side. `O_NONBLOCK` is shared with the read side
@@ -398,12 +403,13 @@ fn spawn_unix(mut cmd: Command) -> Result<PtySession> {
 
 /// Allocate a PTY pair via `openpty`. Returns (master_fd, slave_fd).
 #[cfg(unix)]
-fn open_pty() -> Result<(libc::c_int, libc::c_int)> {
+fn open_pty(size: Option<(u16, u16)>) -> Result<(libc::c_int, libc::c_int)> {
+    let (cols, rows) = size.unwrap_or((DEFAULT_COLS, DEFAULT_ROWS));
     let mut master: libc::c_int = 0;
     let mut slave: libc::c_int = 0;
     let ws = libc::winsize {
-        ws_row: DEFAULT_ROWS,
-        ws_col: DEFAULT_COLS,
+        ws_row: rows,
+        ws_col: cols,
         ws_xpixel: 0,
         ws_ypixel: 0,
     };
@@ -442,7 +448,7 @@ mod tests {
     fn spawn_runs_a_command_and_streams_pty_output() {
         let mut cmd = Command::new("/bin/sh");
         cmd.arg("-c").arg("printf hello; exit 0");
-        let mut session = spawn(cmd).expect("spawn pty");
+        let mut session = spawn_with_size(cmd, None).expect("spawn pty");
 
         // Drain the merged PTY output until the child exits / slave closes,
         // exactly like the orchestration's reader thread.

--- a/src-tauri/src/workspace/scripts.rs
+++ b/src-tauri/src/workspace/scripts.rs
@@ -705,6 +705,7 @@ pub fn run_script(
         &shell,
         &args_ref,
         None,
+        None,
         stop,
     )
 }
@@ -730,6 +731,7 @@ pub fn run_terminal_session(
     context: &ScriptContext,
     channel: Channel<ScriptEvent>,
     boot_input: Option<&str>,
+    initial_size: Option<(u16, u16)>,
 ) -> Result<Option<i32>> {
     let (shell, args) = default_shell();
     let args_ref: Vec<&str> = args.iter().map(String::as_str).collect();
@@ -745,6 +747,7 @@ pub fn run_terminal_session(
         &shell,
         &args_ref,
         boot_input,
+        initial_size,
         None,
     )
 }
@@ -776,6 +779,7 @@ pub(crate) fn run_script_with_shell(
     shell_path: &str,
     shell_args: &[&str],
     boot_input: Option<&str>,
+    initial_size: Option<(u16, u16)>,
     stop: Option<ScriptStop>,
 ) -> Result<Option<i32>> {
     if let Some(s) = script {
@@ -821,7 +825,7 @@ pub(crate) fn run_script_with_shell(
     // Open a PTY, make the child a session + controlling-terminal leader, and
     // attach it. The OS-specific PTY mechanics live behind the
     // `platform::pty` seam; macOS/Unix is the reference, Windows fills ConPTY.
-    let session = crate::platform::pty::spawn(cmd)
+    let session = crate::platform::pty::spawn_with_size(cmd, initial_size)
         .with_context(|| format!("Failed to spawn {shell_path}"))?;
     // Writable PTY master, kept alive in `ProcessHandle` for the lifetime of
     // the child so `write_stdin` / `resize` can reach the PTY.
@@ -1325,6 +1329,7 @@ mod tests {
                 &[],
                 None,
                 None,
+                None,
             )
         }));
 
@@ -1451,6 +1456,7 @@ mod tests {
                 &[],
                 None,
                 None,
+                None,
             )
         });
 
@@ -1534,6 +1540,7 @@ mod tests {
                 ch,
                 "/bin/sh",
                 &[],
+                None,
                 None,
                 None,
             )
@@ -1628,6 +1635,7 @@ mod tests {
                 &[],
                 None,
                 None,
+                None,
             )
         });
 
@@ -1657,6 +1665,77 @@ mod tests {
         assert!(
             combined.contains("33 77"),
             "expected 33 77 from stty size; got: {combined:?}"
+        );
+    }
+
+    // ── initial PTY size threads to the spawned shell ─────────────────────
+    // The renderer's real cols/rows must reach the PTY at spawn time so an
+    // inline TUI paints its first frame correctly (no fit/SIGWINCH ghosting).
+    #[test]
+    fn initial_size_sets_pty_winsize() {
+        let _env = crate::testkit::TestEnv::new("initial-size-sets-pty-winsize");
+        let mgr = Arc::new(ScriptProcessManager::new());
+        let ctx = ScriptContext {
+            root_path: std::env::temp_dir().display().to_string(),
+            workspace_path: None,
+            workspace_name: None,
+            default_branch: None,
+            port_base: None,
+            port_count: None,
+        };
+        let key: ProcessKey = ("repo".into(), "run".into(), Some("ws".into()));
+
+        let (tx, rx) = mpsc::channel::<String>();
+        let ch = Channel::<ScriptEvent>::new(move |msg| {
+            if let tauri::ipc::InvokeResponseBody::Json(json) = msg {
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(&json) {
+                    if v.get("type").and_then(|t| t.as_str()) == Some("stdout") {
+                        if let Some(data) = v.get("data").and_then(|d| d.as_str()) {
+                            let _ = tx.send(data.to_string());
+                        }
+                    }
+                }
+            }
+            Ok(())
+        });
+
+        let mgr_c = mgr.clone();
+        let key_c = key.clone();
+        let tempdir = std::env::temp_dir().display().to_string();
+        let handle = std::thread::spawn(move || {
+            run_script_with_shell(
+                &mgr_c,
+                &key_c.0,
+                &key_c.1,
+                key_c.2.as_deref(),
+                // No resize — `stty size` must report the spawn-time winsize.
+                Some("/bin/stty size"),
+                &tempdir,
+                &ctx,
+                ch,
+                "/bin/sh",
+                &[],
+                None,
+                Some((90, 40)),
+                None,
+            )
+        });
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut combined = String::new();
+        while Instant::now() < deadline {
+            if let Ok(chunk) = rx.recv_timeout(Duration::from_millis(100)) {
+                combined.push_str(&chunk);
+                // `stty size` prints "<rows> <cols>" — 40 rows, 90 cols.
+                if combined.contains("40 90") {
+                    break;
+                }
+            }
+        }
+        let _ = handle.join();
+        assert!(
+            combined.contains("40 90"),
+            "expected 40 90 from stty size; got: {combined:?}"
         );
     }
 
@@ -1692,6 +1771,7 @@ mod tests {
             make_channel(),
             shell_path,
             shell_args,
+            None,
             None,
             None,
         )
@@ -1790,6 +1870,7 @@ mod tests {
             &[],
             None,
             None,
+            None,
         )
         .unwrap();
         assert_eq!(exit, Some(0));
@@ -1864,6 +1945,7 @@ mod tests {
             ch,
             "/bin/sh",
             &[],
+            None,
             None,
             None,
         )
@@ -2000,6 +2082,7 @@ mod tests {
                 "/bin/sh",
                 &[],
                 None,
+                None,
                 Some(stop),
             )
         });
@@ -2081,6 +2164,7 @@ mod tests {
                 ch,
                 "/bin/sh",
                 &[],
+                None,
                 None,
                 Some(stop),
             )

--- a/src/components/terminal-output.tsx
+++ b/src/components/terminal-output.tsx
@@ -62,6 +62,21 @@ export type TerminalHandle = {
 	 * new terminal is spawned via `+` / shortcut.
 	 */
 	focus: () => void;
+	/**
+	 * The cols/rows FitAddon would fit to at the container's current pixel
+	 * size, or null while the container is still 0×0 (laid out / hidden).
+	 * Lets a caller spawn a PTY at the renderer's real size without waiting
+	 * for an `onResize` (which only fires on a size *change*).
+	 */
+	proposeSize: () => { cols: number; rows: number } | null;
+	/**
+	 * Re-emit a focus-in (`CSI I`) to a focus-tracking TUI by bouncing the
+	 * textarea's DOM focus — but only when it is already the active element,
+	 * so this never steals focus. A TUI (e.g. claude) that enabled focus
+	 * reporting AFTER our initial `focus()` never saw the event and parks its
+	 * cursor at home until the next keystroke; this delivers the missed event.
+	 */
+	reassertFocus: () => void;
 };
 
 const URL_PATTERN = /https?:\/\/[^\s<>"'`]+/gi;
@@ -484,6 +499,17 @@ function TerminalOutputImpl({
 				dispose: () => terminal.dispose(),
 				refit: () => runFit(),
 				focus: () => terminal.focus(),
+				proposeSize: () => {
+					const d = fit.proposeDimensions();
+					return d ? { cols: d.cols, rows: d.rows } : null;
+				},
+				reassertFocus: () => {
+					const ta = terminal.textarea;
+					if (ta && document.activeElement === ta) {
+						ta.blur();
+						ta.focus();
+					}
+				},
 			};
 		}
 
@@ -541,6 +567,10 @@ function TerminalOutputImpl({
 		}
 		flushTerminalWrites(terminal);
 		runFitRef.current?.();
+		// A freshly (re)attached WebGL renderer can paint the cursor cell at the
+		// stale home position until the next cursor move — force a full redraw so
+		// it reflects the buffer's real cursor row after a tab switch back.
+		terminal.refresh(0, terminal.rows - 1);
 		return () => {
 			webglRef.current?.dispose();
 			webglRef.current = null;

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -58,7 +58,7 @@ import {
 	isNewSession,
 	resolveSessionSelectedModelId,
 } from "@/lib/workspace-helpers";
-import { publishShellEvent } from "@/shell/event-bus";
+import { publishShellEvent, useShellEvent } from "@/shell/event-bus";
 import { CodexGoalBanner } from "../panel/codex-goal-banner";
 import {
 	type ComposerQuickAction,
@@ -830,6 +830,11 @@ export const WorkspaceComposerContainer = memo(
 		const showTerminalToggle =
 			settings.enableTerminalMode &&
 			findTerminalAgent(effectiveModel?.provider) !== null;
+
+		// App-scoped ⌘⇧T (global shortcut → shell event).
+		useShellEvent("toggle-terminal-mode", () => {
+			if (showTerminalToggle) setTerminalMode((value) => !value);
+		});
 
 		const handleComposerSubmitInner = useCallback(
 			(

--- a/src/features/composer/index.tsx
+++ b/src/features/composer/index.tsx
@@ -735,18 +735,7 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 				return;
 			}
 
-			// Terminal-Mode toggle — only when the toggle is offered (setting
-			// on + provider supports it), and workspace-composer only like plan.
-			if (
-				toggleTerminalShortcut &&
-				hotkey === toggleTerminalShortcut &&
-				onChangeTerminalMode &&
-				focusScope === "workspace-composer"
-			) {
-				event.preventDefault();
-				event.stopPropagation();
-				onChangeTerminalMode(!terminalMode);
-			}
+			// Terminal-Mode toggle (⌘⇧T) is app-scoped — handled globally, not here.
 		},
 		[
 			inputDisabled,
@@ -755,9 +744,6 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 			permissionMode,
 			supportsPlanMode,
 			togglePlanShortcut,
-			toggleTerminalShortcut,
-			onChangeTerminalMode,
-			terminalMode,
 			toggleFollowUpShortcut,
 			handleSubmitOpposite,
 			submitEnabled,

--- a/src/features/composer/index.tsx
+++ b/src/features/composer/index.tsx
@@ -986,7 +986,10 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 														composerToolbarTriggerClassName,
 														terminalMode
 															? "text-emerald-500 hover:bg-emerald-500/10 hover:text-emerald-500"
-															: "text-muted-foreground",
+															: // Pin the hover text color (like the Plan toggle) so the
+																// toolbar base `hover:text-foreground` can't flash the icon
+																// white for a frame while `transition-colors` runs on toggle.
+																"text-muted-foreground hover:text-muted-foreground",
 														toolbarDisabled
 															? "cursor-not-allowed opacity-45 hover:bg-transparent hover:text-muted-foreground"
 															: null,

--- a/src/features/conversation/hooks/seed-session-title.ts
+++ b/src/features/conversation/hooks/seed-session-title.ts
@@ -5,6 +5,27 @@
 import type { QueryClient } from "@tanstack/react-query";
 import { helmorQueryKeys } from "@/lib/query-client";
 
+/** Provisional session title from a prompt: first line, whitespace-collapsed,
+ * clamped to 36 chars. Shared by the GUI send path and Terminal Mode so both
+ * show the same instant title before the AI rename lands. */
+export function buildTitleSeed(prompt: string): string {
+	const normalized = prompt
+		.trim()
+		.split(/\r?\n/g)[0]
+		?.trim()
+		.replace(/\s+/g, " ");
+
+	if (!normalized) {
+		return "Untitled";
+	}
+
+	if (normalized.length <= 36) {
+		return normalized;
+	}
+
+	return `${normalized.slice(0, 33).trimEnd()}...`;
+}
+
 export function seedSessionTitle(
 	queryClient: QueryClient,
 	sessionId: string,

--- a/src/features/conversation/hooks/use-streaming.ts
+++ b/src/features/conversation/hooks/use-streaming.ts
@@ -63,28 +63,10 @@ import {
 	createStreamFlushers,
 	type StreamAccumulator,
 } from "./dispatch-stream-event";
-import { seedSessionTitle } from "./seed-session-title";
+import { buildTitleSeed, seedSessionTitle } from "./seed-session-title";
 
 const EMPTY_IMAGES: string[] = [];
 const EMPTY_FILES: string[] = [];
-
-function buildTitleSeed(prompt: string): string {
-	const normalized = prompt
-		.trim()
-		.split(/\r?\n/g)[0]
-		?.trim()
-		.replace(/\s+/g, " ");
-
-	if (!normalized) {
-		return "Untitled";
-	}
-
-	if (normalized.length <= 36) {
-		return normalized;
-	}
-
-	return `${normalized.slice(0, 33).trimEnd()}...`;
-}
 
 /**
  * Re-export from the streaming store — kept here so existing import

--- a/src/features/shortcuts/registry.ts
+++ b/src/features/shortcuts/registry.ts
@@ -312,7 +312,8 @@ export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
 		title: "Toggle terminal mode",
 		group: "Composer",
 		defaultHotkey: "Mod+Shift+T",
-		scopes: ["workspace-composer"],
+		// App-scoped — handled in the global shortcut table, not composer-local.
+		scopes: ["app"],
 		editable: true,
 	},
 	{

--- a/src/features/terminal/terminal-session-panel.tsx
+++ b/src/features/terminal/terminal-session-panel.tsx
@@ -11,6 +11,7 @@ import {
 	attach,
 	detach,
 	ensureTerminal,
+	type PendingBoot,
 	resize,
 	TRUNCATION_NOTICE,
 	takePendingBoot,
@@ -54,7 +55,7 @@ export function TerminalSessionPanel({
 	const queryClient = useQueryClient();
 	const termRef = useRef<TerminalHandle | null>(null);
 	// Spawn-to-first-byte takes a moment (worktree finalize + CLI cold start
-	// + the boot-echo gate); show a spinner instead of a blank screen.
+	// + the boot-echo gate); show an overlay instead of a blank screen.
 	const [booting, setBooting] = useState(true);
 	// Resume the agent's prior session when we have its id at mount time;
 	// otherwise run the fresh preset command. (M4) Pinned in a ref: the boot
@@ -75,25 +76,29 @@ export function TerminalSessionPanel({
 				: null) ?? presetBootCommand(agentKind);
 	}
 
+	// Consume the composer-initiated boot once (boot command + fast mode).
+	// Lazy-init ref so an effect re-run never re-reads it as null.
+	const pendingBootRef = useRef<PendingBoot | null | undefined>(undefined);
+	if (pendingBootRef.current === undefined) {
+		pendingBootRef.current = takePendingBoot(sessionId);
+	}
+
+	// Attach the live listener + one-shot replay. Independent of spawn: the
+	// listener is keyed by sessionId and receives output once the PTY starts.
+	const focusAssertedRef = useRef(false);
 	useEffect(() => {
-		if (!repoId || !workspaceReady) return;
-		// A composer-initiated terminal carries its own boot (prompt + composer
-		// state, incl. fast mode); ensureTerminal is idempotent so the consumed
-		// value only matters on the spawning mount.
-		const pending = takePendingBoot(sessionId);
-		const boot = pending?.bootCommand ?? bootCommandRef.current ?? null;
-		ensureTerminal(
-			repoId,
-			workspaceId,
-			sessionId,
-			boot,
-			agentKind,
-			pending?.fastMode ?? false,
-		);
 		const existing = attach(sessionId, {
 			onChunk: (data) => {
 				setBooting(false);
 				termRef.current?.write(data);
+				// First real output ≈ the TUI is up and has enabled focus
+				// reporting. Re-assert focus (no-op unless already focused) so a
+				// CLI that booted after our mount-time focus() gets the focus-in
+				// it missed and positions its cursor instead of parking it at home.
+				if (!focusAssertedRef.current) {
+					focusAssertedRef.current = true;
+					requestAnimationFrame(() => termRef.current?.reassertFocus());
+				}
 			},
 			onStatusChange: () => {},
 		});
@@ -119,6 +124,43 @@ export function TerminalSessionPanel({
 		return () => {
 			if (rafId !== null) cancelAnimationFrame(rafId);
 			detach(sessionId);
+		};
+	}, [sessionId]);
+
+	// Spawn the PTY once the workspace is ready AND the renderer has a real
+	// size. Polls `proposeSize()` (container-derived, NOT an onResize change
+	// event) so a panel whose first fit yields no size delta still spawns —
+	// otherwise the PTY launches at a stale default and the inline TUI paints
+	// its first frame at the wrong width (ghost rows after the fit/SIGWINCH).
+	const spawnedRef = useRef(false);
+	useEffect(() => {
+		if (!repoId || !workspaceReady || spawnedRef.current) return;
+		let rafId: number | null = null;
+		const trySpawn = () => {
+			rafId = null;
+			if (spawnedRef.current) return;
+			const size = termRef.current?.proposeSize();
+			if (!size) {
+				rafId = requestAnimationFrame(trySpawn);
+				return;
+			}
+			spawnedRef.current = true;
+			const pending = pendingBootRef.current;
+			const boot = pending?.bootCommand ?? bootCommandRef.current ?? null;
+			ensureTerminal(
+				repoId,
+				workspaceId,
+				sessionId,
+				boot,
+				agentKind,
+				pending?.fastMode ?? false,
+				size.cols,
+				size.rows,
+			);
+		};
+		trySpawn();
+		return () => {
+			if (rafId !== null) cancelAnimationFrame(rafId);
 		};
 	}, [repoId, workspaceId, sessionId, agentKind, workspaceReady]);
 

--- a/src/features/terminal/terminal-session-store.ts
+++ b/src/features/terminal/terminal-session-store.ts
@@ -94,18 +94,36 @@ const TUI_START_RE = /\x1b\[\?(?:1049|1047|47|2026|1004)h/;
  * (a non-TUI command would otherwise render nothing at all). */
 const BOOT_GATE_TIMEOUT_MS = 3000;
 
+// Terminal protocol sequences (CSI / OSC / two-byte ESC) the shell emits
+// before the TUI marker — bracketed paste (?2004h), cursor hide (?25l), kitty
+// keyboard (>1u), etc. Their plain-text neighbours (prompt, boot echo) are
+// dropped, but swallowing the sequences too desyncs xterm's mode state, so we
+// replay them ahead of the visible region.
+const PRELUDE_SEQ_RE =
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI is ESC-framed.
+	/\x1b(?:\[[0-9;?>=]*[A-Za-z]|\][^\x07\x1b]*(?:\x07|\x1b\\)|[=>78])/g;
+
 /** Stop gating: emit from `fromIndex` (the TUI start sequence itself must
- * reach xterm) — or everything on a timeout/exit fallback (fromIndex 0). */
+ * reach xterm) — or everything on a timeout/exit fallback (fromIndex 0). The
+ * dropped prefix's control sequences are still replayed so xterm's mode state
+ * stays in sync with the TUI. */
 function releaseGate(entry: Instance, fromIndex: number) {
 	const gate = entry.gate;
 	if (!gate) return;
 	clearTimeout(gate.timer);
 	entry.gate = null;
-	const visible = gate.buf.slice(fromIndex);
-	if (visible) deliver(entry, visible);
+	const prelude =
+		fromIndex > 0
+			? (gate.buf.slice(0, fromIndex).match(PRELUDE_SEQ_RE)?.join("") ?? "")
+			: "";
+	const payload = prelude + gate.buf.slice(fromIndex);
+	if (payload) deliver(entry, payload);
 }
 
-/** Spawn the PTY for a session if not already running. Idempotent. */
+/** Spawn the PTY for a session if not already running. Idempotent.
+ *
+ * `cols`/`rows` are the renderer's real size — an inline TUI paints its first
+ * frame against them, so callers spawn only once their xterm has fit. */
 export function ensureTerminal(
 	repoId: string,
 	workspaceId: string,
@@ -113,6 +131,8 @@ export function ensureTerminal(
 	bootCommand: string | null,
 	agentKind: string | null,
 	fastMode = false,
+	cols?: number | null,
+	rows?: number | null,
 ) {
 	if (instances.has(sessionId)) return;
 	const entry: Instance = {
@@ -196,6 +216,8 @@ export function ensureTerminal(
 		bootCommand,
 		agentKind,
 		fastMode,
+		cols,
+		rows,
 	).catch((err) => {
 		const current = instances.get(sessionId);
 		if (!current) return;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -4687,6 +4687,8 @@ export async function spawnTerminal(
 	bootCommand?: string | null,
 	agentKind?: string | null,
 	fastMode?: boolean,
+	initialCols?: number | null,
+	initialRows?: number | null,
 ): Promise<void> {
 	const channel = new Channel<ScriptEvent>();
 	channel.onmessage = onEvent;
@@ -4697,6 +4699,8 @@ export async function spawnTerminal(
 		agentKind: agentKind ?? null,
 		bootCommand: bootCommand ?? null,
 		fastMode: fastMode ?? null,
+		initialCols: initialCols ?? null,
+		initialRows: initialRows ?? null,
 		channel,
 	});
 }

--- a/src/shell/controllers/use-start-surface-controller.ts
+++ b/src/shell/controllers/use-start-surface-controller.ts
@@ -684,6 +684,17 @@ export function useStartSurfaceController(
 							: current,
 					);
 					requestSidebarReconcile(queryClient);
+					// Backend finalize transitions the row initializing → ready /
+					// setup_pending but only syncs git watchers — it never publishes
+					// a UiMutationEvent, so `workspaceDetail` stays stale at
+					// `initializing`. The Terminal panel gates its PTY spawn on
+					// `workspace.state !== "initializing"`; without this refetch it
+					// stays on the loading overlay until a manual tab switch forces
+					// one. (Chat paths read the pending payload, so they never
+					// noticed the missing invalidation.)
+					void queryClient.invalidateQueries({
+						queryKey: helmorQueryKeys.workspaceDetail(outcome.workspaceId),
+					});
 					return { shouldStream: false };
 				}
 

--- a/src/shell/controllers/use-start-surface-controller.ts
+++ b/src/shell/controllers/use-start-surface-controller.ts
@@ -11,6 +11,10 @@ import type {
 	ComposerSubmitPayload,
 	PendingCreatedWorkspaceSubmit,
 } from "@/features/conversation";
+import {
+	buildTitleSeed,
+	seedSessionTitle,
+} from "@/features/conversation/hooks/seed-session-title";
 import { buildTerminalBootCommand } from "@/features/terminal/terminal-presets";
 import { setPendingBoot } from "@/features/terminal/terminal-session-store";
 import { createWorkspaceFromStartComposer } from "@/features/workspace-start/create-workspace";
@@ -23,6 +27,7 @@ import {
 	moveLocalWorkspaceToWorktree,
 	prewarmSlashCommandsForRepo,
 	type RepositoryCreateOption,
+	renameSession,
 	type ThreadMessageLike,
 	type WorkspaceBranchIntent,
 	type WorkspaceDetail,
@@ -574,6 +579,19 @@ export function useStartSurfaceController(
 					if (payload.terminalMode) {
 						try {
 							await convertSessionToTerminal(sessionId, payload.model.provider);
+							// Layer 1 of the two-layer title (same as GUI): show a
+							// provisional title from the prompt immediately; the agent's
+							// UserPromptSubmit hook later triggers the AI rename (layer 2).
+							const titleSeed = buildTitleSeed(payload.prompt);
+							seedSessionTitle(
+								queryClient,
+								sessionId,
+								outcome.workspaceId,
+								titleSeed,
+							);
+							void renameSession(sessionId, titleSeed).catch((error) => {
+								console.warn("[start] failed to seed terminal title:", error);
+							});
 							const boot = buildTerminalBootCommand(payload.model.provider, {
 								prompt: payload.prompt,
 								modelId: payload.model.cliModel || null,

--- a/src/shell/controllers/use-start-surface-controller.ts
+++ b/src/shell/controllers/use-start-surface-controller.ts
@@ -684,17 +684,9 @@ export function useStartSurfaceController(
 							: current,
 					);
 					requestSidebarReconcile(queryClient);
-					// Backend finalize transitions the row initializing → ready /
-					// setup_pending but only syncs git watchers — it never publishes
-					// a UiMutationEvent, so `workspaceDetail` stays stale at
-					// `initializing`. The Terminal panel gates its PTY spawn on
-					// `workspace.state !== "initializing"`; without this refetch it
-					// stays on the loading overlay until a manual tab switch forces
-					// one. (Chat paths read the pending payload, so they never
-					// noticed the missing invalidation.)
-					void queryClient.invalidateQueries({
-						queryKey: helmorQueryKeys.workspaceDetail(outcome.workspaceId),
-					});
+					// `workspaceDetail` (initializing → ready) is refreshed by the
+					// backend's `WorkspaceChanged` event from finalize, so the
+					// Terminal panel's spawn gate opens without a manual tab switch.
 					return { shouldStream: false };
 				}
 

--- a/src/shell/event-bus.ts
+++ b/src/shell/event-bus.ts
@@ -33,6 +33,8 @@ export type ShellEvent =
 	| { type: "focus-composer" }
 	| { type: "toggle-context-panel" }
 	| { type: "focus-active-terminal" }
+	// App-scoped ⌘⇧T — the mounted composer flips its terminalMode.
+	| { type: "toggle-terminal-mode" }
 	// Imperative archive from surfaces outside the sidebar controller (reuses its optimistic path).
 	| { type: "request-archive-workspace"; workspaceId: string }
 	// Composer Terminal-Mode submit: create a terminal session in the current

--- a/src/shell/hooks/use-global-shortcut-handlers.ts
+++ b/src/shell/hooks/use-global-shortcut-handlers.ts
@@ -250,6 +250,15 @@ export function useGlobalShortcutHandlers({
 					workspaceViewMode === "conversation" || workspaceViewMode === "start",
 			},
 			{
+				id: "composer.toggleTerminalMode" as const,
+				callback: () => publishShellEvent({ type: "toggle-terminal-mode" }),
+				// Composer is the final gate; this just limits to surfaces with one.
+				enabled:
+					appSettings.enableTerminalMode &&
+					(workspaceViewMode === "conversation" ||
+						workspaceViewMode === "start"),
+			},
+			{
 				id: "composer.openModelPicker" as const,
 				callback: handleOpenModelPicker,
 				enabled: workspaceViewMode === "conversation",
@@ -286,6 +295,7 @@ export function useGlobalShortcutHandlers({
 		],
 		[
 			appSettings.zoomLevel,
+			appSettings.enableTerminalMode,
 			getCloseableCurrentSession,
 			handleCloseSelectedSession,
 			handleCopyWorkspacePath,

--- a/src/shell/hooks/use-session-actions.ts
+++ b/src/shell/hooks/use-session-actions.ts
@@ -1,5 +1,9 @@
 import type { QueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect } from "react";
+import {
+	buildTitleSeed,
+	seedSessionTitle,
+} from "@/features/conversation/hooks/seed-session-title";
 import { seedNewSessionInCache } from "@/features/panel/session-cache";
 import type { SessionCloseRequest } from "@/features/panel/use-confirm-session-close";
 import { buildTerminalBootCommand } from "@/features/terminal/terminal-presets";
@@ -7,6 +11,7 @@ import { setPendingBoot } from "@/features/terminal/terminal-session-store";
 import {
 	closeMainWindow,
 	createSession,
+	renameSession,
 	type WorkspaceDetail,
 	type WorkspaceSessionSummary,
 } from "@/lib/api";
@@ -202,6 +207,20 @@ export function useSessionActions({
 					setPendingBoot(sessionId, {
 						bootCommand: boot,
 						fastMode: event.fastMode,
+					});
+				}
+				// Layer 1 of the two-layer title (same as GUI): provisional title
+				// from the prompt now; the agent hook drives the AI rename later.
+				if (event.prompt) {
+					const titleSeed = buildTitleSeed(event.prompt);
+					seedSessionTitle(
+						queryClient,
+						sessionId,
+						event.workspaceId,
+						titleSeed,
+					);
+					void renameSession(sessionId, titleSeed).catch((error) => {
+						console.warn("[terminal] failed to seed title:", error);
 					});
 				}
 			},

--- a/src/shell/hooks/use-ui-sync-bridge.ts
+++ b/src/shell/hooks/use-ui-sync-bridge.ts
@@ -1,5 +1,6 @@
 import type { QueryClient } from "@tanstack/react-query";
 import { useEffect, useRef } from "react";
+import { buildTitleSeed } from "@/features/conversation/hooks/seed-session-title";
 import { useStreamingStore } from "@/features/conversation/state/streaming-store";
 import {
 	generateSessionTitle,
@@ -320,17 +321,22 @@ function handleUiMutation(
 			// Run the same title + branch generator GUI sessions use; it's
 			// gated server-side so only the first turn actually renames.
 			const { sessionId, workspaceId, prompt } = event;
-			void generateSessionTitle(sessionId, prompt).then((result) => {
-				if (result?.title || result?.branchRenamed) {
-					requestSidebarReconcile(queryClient);
-					void queryClient.invalidateQueries({
-						queryKey: helmorQueryKeys.workspaceSessions(workspaceId),
-					});
-					void queryClient.invalidateQueries({
-						queryKey: helmorQueryKeys.workspaceDetail(workspaceId),
-					});
-				}
-			});
+			// Pass the same seed layer 1 wrote (buildTitleSeed is deterministic on
+			// the prompt) so `can_replace_session_title` lets the AI rename replace
+			// it — without the seed it would only overwrite a literal "Untitled".
+			void generateSessionTitle(sessionId, prompt, buildTitleSeed(prompt)).then(
+				(result) => {
+					if (result?.title || result?.branchRenamed) {
+						requestSidebarReconcile(queryClient);
+						void queryClient.invalidateQueries({
+							queryKey: helmorQueryKeys.workspaceSessions(workspaceId),
+						});
+						void queryClient.invalidateQueries({
+							queryKey: helmorQueryKeys.workspaceDetail(workspaceId),
+						});
+					}
+				},
+			);
 			return;
 		}
 		case "workspaceRevealRequested":


### PR DESCRIPTION
Follow-up fixes for Terminal Mode rendering and the start-page flow.

## What's fixed
- **Garbled TUI bottom rows** — the PTY now spawns at the renderer's real size (polled via `proposeSize()` instead of waiting on an `onResize` delta), so the inline TUI paints its first frame correctly. Initial size threads through `spawn_terminal → run_terminal_session → run_script_with_shell → platform::pty` (with a regression test on `stty size`).
- **Start-page terminal stuck on loading** — `finalize_workspace_from_repo` only synced git watchers and never invalidated `workspaceDetail`, so the panel's `workspaceReady` gate stayed `initializing` until a manual tab switch forced a refetch. The start-surface controller now invalidates `workspaceDetail` after finalize. (Chat paths read the pending payload, so they never noticed.)
- **Terminal sessions stuck named "Terminal"** — both `convert_session_to_terminal` and `create_session` no longer hardcode the title, leaving it `"Untitled"` so prompt-captured title generation can replace it (`can_replace_session_title` only overwrites `"Untitled"`).
- **Composer terminal icon white flash** — the inactive toggle now pins `hover:text-muted-foreground` (matching the Plan toggle) so the toolbar's base `hover:text-foreground` can't flash the icon white for a frame during the `transition-colors`.
- **Cursor stranding at the top** — re-assert focus on first output (delivers the focus-in a TUI that enabled focus reporting after mount missed) and `refresh()` on WebGL re-attach, so the cursor stays aligned with the TUI input.

Also drops the earlier fake-TUI boot overlay in favor of the simpler centered loading.

## Tests
- `cargo test` (Rust): new `initial_size_sets_pty_winsize`, updated `convert_session_to_terminal_enforces_message_less_invariant`, full lib suite green.
- `bun run typecheck` + `biome check` clean; `cargo clippy --all-targets -- -D warnings` clean.
