### PR TITLE
fix(terminal): launch TUI for multi-line prompts, convert empty session in place

### DIFF
--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -877,6 +877,7 @@ export const WorkspaceComposerContainer = memo(
 						addDirs: linkedDirectories.length > 0 ? linkedDirectories : null,
 						fastMode: supportsFastMode ? fastMode : false,
 						workspaceId: displayedWorkspaceId,
+						sessionId: displayedSessionId,
 					});
 					return;
 				}
@@ -922,6 +923,7 @@ export const WorkspaceComposerContainer = memo(
 				showTerminalToggle,
 				linkedDirectories,
 				displayedWorkspaceId,
+				displayedSessionId,
 				focusScope,
 			],
 		);

--- a/src/features/terminal/terminal-presets.test.ts
+++ b/src/features/terminal/terminal-presets.test.ts
@@ -90,6 +90,24 @@ describe("terminal agent specs", () => {
 		expect(cmd).toBe("claude 'it'\\''s; $(rm -rf /)'\n");
 	});
 
+	it("ANSI-C quotes multi-line prompts so the boot stays one physical line", () => {
+		const cmd = buildTerminalBootCommand("claude", {
+			prompt: "line one\nline two\twith tab\nit's fine",
+		});
+		// $'...' keeps the command on a single physical line — the only newline
+		// is the trailing submit; \n/\t/' are escaped, so none reach the
+		// interactive shell's line editor early.
+		expect(cmd).toBe(
+			"claude $'line one\\nline two\\twith tab\\nit\\'s fine'\n",
+		);
+	});
+
+	it("keeps plain single-line prompts on the portable single-quote path", () => {
+		const cmd = buildTerminalBootCommand("codex", { prompt: "fix the bug" });
+		expect(cmd).toContain("'fix the bug'");
+		expect(cmd).not.toContain("$'");
+	});
+
 	it("resume quotes the session id and is null for unknown agents", () => {
 		expect(resumeBootCommand("claude", "abc-123")).toBe(
 			"claude --resume 'abc-123' --dangerously-skip-permissions\n",

--- a/src/features/terminal/terminal-presets.ts
+++ b/src/features/terminal/terminal-presets.ts
@@ -45,6 +45,25 @@ function shellQuote(value: string): string {
 	return `'${value.replaceAll("'", "'\\''")}'`;
 }
 
+/** Quote the user prompt for the boot command. A multi-line prompt single-
+ * quoted with literal newlines makes the boot command span multiple physical
+ * lines; the interactive shell's line editor then submits at the first newline
+ * (dangling quote → `quote>`, the CLI never launches) and a literal tab fires
+ * completion. When the prompt has those control chars, use `$'...'` ANSI-C
+ * quoting so the command stays one physical line and the shell rebuilds the
+ * real newlines/tabs in the CLI's argv. zsh/bash both support it (the boot
+ * prefix already requires one via `export VAR=...;`). */
+function shellQuotePrompt(value: string): string {
+	if (!/[\n\r\t]/.test(value)) return shellQuote(value);
+	const escaped = value
+		.replaceAll("\\", "\\\\")
+		.replaceAll("'", "\\'")
+		.replaceAll("\n", "\\n")
+		.replaceAll("\r", "\\r")
+		.replaceAll("\t", "\\t");
+	return `$'${escaped}'`;
+}
+
 /** Helmor's catalog uses the literal id "default" for "follow the CLI's own
  * default model" — that placeholder must never reach a real --model flag. */
 function cliModelOrNull(modelId?: string | null): string | null {
@@ -73,7 +92,7 @@ const CLAUDE_SPEC: TerminalAgentSpec = {
 		if (effort) parts.push("--effort", shellQuote(effort));
 		if (permission) parts.push("--permission-mode", shellQuote(permission));
 		parts.push(...claudeAddDirFlags(opts.addDirs));
-		parts.push(shellQuote(opts.prompt));
+		parts.push(shellQuotePrompt(opts.prompt));
 		return parts.join(" ");
 	},
 	resume(id, opts) {
@@ -116,7 +135,7 @@ const CODEX_SPEC: TerminalAgentSpec = {
 				"danger-full-access",
 			);
 		}
-		parts.push(shellQuote(opts.prompt));
+		parts.push(shellQuotePrompt(opts.prompt));
 		return parts.join(" ");
 	},
 	resume(id) {

--- a/src/shell/event-bus.ts
+++ b/src/shell/event-bus.ts
@@ -50,6 +50,9 @@ export type ShellEvent =
 			fastMode: boolean;
 			/** Explicit target; null = the currently selected workspace. */
 			workspaceId: string | null;
+			/** The composer's current session — converted in place when it has no
+			 *  messages yet, instead of creating a new terminal session. */
+			sessionId: string | null;
 	  };
 
 export type ShellEventType = ShellEvent["type"];

--- a/src/shell/hooks/use-session-actions.ts
+++ b/src/shell/hooks/use-session-actions.ts
@@ -10,6 +10,7 @@ import { buildTerminalBootCommand } from "@/features/terminal/terminal-presets";
 import { setPendingBoot } from "@/features/terminal/terminal-session-store";
 import {
 	closeMainWindow,
+	convertSessionToTerminal,
 	createSession,
 	renameSession,
 	type WorkspaceDetail,
@@ -199,33 +200,100 @@ export function useSessionActions({
 	// TUI with the prompt + composer state as the initial invocation.
 	useShellEvent("create-terminal-session", (event) => {
 		const boot = buildTerminalBootCommand(event.provider, event);
-		void handleCreateSession(
-			"terminal",
-			event.provider,
-			(sessionId) => {
-				if (boot) {
-					setPendingBoot(sessionId, {
-						bootCommand: boot,
-						fastMode: event.fastMode,
-					});
-				}
-				// Layer 1 of the two-layer title (same as GUI): provisional title
-				// from the prompt now; the agent hook drives the AI rename later.
-				if (event.prompt) {
-					const titleSeed = buildTitleSeed(event.prompt);
-					seedSessionTitle(
-						queryClient,
-						sessionId,
-						event.workspaceId,
-						titleSeed,
-					);
-					void renameSession(sessionId, titleSeed).catch((error) => {
-						console.warn("[terminal] failed to seed title:", error);
-					});
-				}
-			},
-			event.workspaceId,
-		);
+
+		// Layer 1 of the two-layer title (same as GUI): provisional title from
+		// the prompt now; the agent hook drives the AI rename later.
+		const seedTitle = (sessionId: string) => {
+			if (!event.prompt) return;
+			const titleSeed = buildTitleSeed(event.prompt);
+			seedSessionTitle(queryClient, sessionId, event.workspaceId, titleSeed);
+			void renameSession(sessionId, titleSeed).catch((error) => {
+				console.warn("[terminal] failed to seed title:", error);
+			});
+		};
+
+		const createNew = () => {
+			void handleCreateSession(
+				"terminal",
+				event.provider,
+				(sessionId) => {
+					if (boot) {
+						setPendingBoot(sessionId, {
+							bootCommand: boot,
+							fastMode: event.fastMode,
+						});
+					}
+					seedTitle(sessionId);
+				},
+				event.workspaceId,
+			);
+		};
+
+		// A brand-new (message-less) current session converts in place — no point
+		// stranding an empty Untitled session next to the terminal. Anything with
+		// history gets a fresh terminal session alongside it.
+		const sessions =
+			event.sessionId && event.workspaceId
+				? (queryClient.getQueryData<WorkspaceSessionSummary[]>(
+						helmorQueryKeys.workspaceSessions(event.workspaceId),
+					) ?? [])
+				: [];
+		const currentSession =
+			sessions.find((session) => session.id === event.sessionId) ?? null;
+
+		if (
+			!event.sessionId ||
+			!event.workspaceId ||
+			!isNewSession(currentSession)
+		) {
+			createNew();
+			return;
+		}
+
+		const sessionId = event.sessionId;
+		const workspaceId = event.workspaceId;
+		void (async () => {
+			try {
+				await convertSessionToTerminal(sessionId, event.provider);
+			} catch (error) {
+				// Lost the message-less race / convert refused — fall back to new.
+				console.warn(
+					"[terminal] in-place convert failed; creating new:",
+					error,
+				);
+				createNew();
+				return;
+			}
+			if (boot) {
+				setPendingBoot(sessionId, {
+					bootCommand: boot,
+					fastMode: event.fastMode,
+				});
+			}
+			seedTitle(sessionId);
+			// Flip the cached row to terminal so the panel renders the TUI now,
+			// before the backend round-trip reconciles.
+			queryClient.setQueryData<WorkspaceSessionSummary[]>(
+				helmorQueryKeys.workspaceSessions(workspaceId),
+				(current) =>
+					(current ?? []).map((session) =>
+						session.id === sessionId
+							? {
+									...session,
+									sessionKind: "terminal",
+									agentType: event.provider,
+								}
+							: session,
+					),
+			);
+			requestSidebarReconcile(queryClient);
+			void queryClient.invalidateQueries({
+				queryKey: helmorQueryKeys.workspaceSessions(workspaceId),
+			});
+			void queryClient.invalidateQueries({
+				queryKey: helmorQueryKeys.workspaceDetail(workspaceId),
+			});
+		})();
 	});
 
 	useEffect(() => {


### PR DESCRIPTION
Two Terminal Mode follow-ups (built on #801).

## What's fixed

**Multi-line prompts now launch the TUI.** The boot command passes the prompt as a single-quoted positional arg fed into the interactive shell. A prompt with literal newlines made the command span multiple physical lines, so the shell's line editor submitted it at the first newline (dangling quote → `quote>` continuation) and the agent CLI never launched. The prompt is now ANSI-C quoted (`$'...'`) when it contains `\n`/`\r`/`\t`, keeping the boot command on one physical line while the shell rebuilds the real newlines in the CLI's argv. Plain single-line prompts stay on the portable single-quote path.

**Empty current session converts in place.** Sending in terminal mode from a brand-new, message-less session now converts that session into a terminal session (reusing the start-page `convert_session_to_terminal` path) instead of spawning a new one and stranding an empty `Untitled` session next to it. A session with history still gets a fresh terminal session alongside it. The frontend `isNewSession` check is backed by the backend's message-less guard + a `try/catch` fallback to creating a new session, so it can never drop the prompt or convert a session with messages.

The composer threads its current `sessionId` through the `create-terminal-session` shell event so the handler knows which session to consider.

## Tests
- `bun run test:frontend` — new `terminal-presets` cases: multi-line prompt → `$'...'` single line; plain prompt → single-quote path. All green.
- `bun run typecheck` + `biome check` clean.
