### PR TITLE
feat: show skipped CI checks with dedicated skip icon

### DIFF
--- a/.changeset/ci-skipped-check-status.md
+++ b/.changeset/ci-skipped-check-status.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Show skipped CI checks in the sidebar with a dedicated skip icon instead of a green checkmark, and drop their misleading 0s duration. Works for both GitHub and GitLab checks.

--- a/src-tauri/src/forge/github/actions.rs
+++ b/src-tauri/src/forge/github/actions.rs
@@ -324,6 +324,7 @@ fn normalize_check_context(node: &ActionCheckContextNode) -> Option<ForgeActionI
             } else {
                 provider
             };
+            let status = normalize_check_run_status(&check.status, check.conclusion.as_deref());
             Some(ForgeActionItem {
                 id: check
                     .database_id
@@ -331,11 +332,13 @@ fn normalize_check_context(node: &ActionCheckContextNode) -> Option<ForgeActionI
                     .unwrap_or_else(|| format!("check-run-{}", check.name)),
                 name: check.name.clone(),
                 provider,
-                status: normalize_check_run_status(&check.status, check.conclusion.as_deref()),
-                duration: format_duration(
-                    check.started_at.as_deref(),
-                    check.completed_at.as_deref(),
-                ),
+                status,
+                // Skipped checks never ran, so a "0s" duration is misleading.
+                duration: if status == ActionStatusKind::Skipped {
+                    None
+                } else {
+                    format_duration(check.started_at.as_deref(), check.completed_at.as_deref())
+                },
                 url,
             })
         }
@@ -413,13 +416,15 @@ fn action_status_priority(status: ActionStatusKind) -> u8 {
         ActionStatusKind::Running => 1,
         ActionStatusKind::Pending => 2,
         ActionStatusKind::Success => 3,
+        ActionStatusKind::Skipped => 4,
     }
 }
 
 fn normalize_check_run_status(status: &str, conclusion: Option<&str>) -> ActionStatusKind {
     match status {
         "COMPLETED" => match conclusion {
-            Some("SUCCESS" | "NEUTRAL" | "SKIPPED") => ActionStatusKind::Success,
+            Some("SKIPPED") => ActionStatusKind::Skipped,
+            Some("SUCCESS" | "NEUTRAL") => ActionStatusKind::Success,
             _ => ActionStatusKind::Failure,
         },
         "IN_PROGRESS" => ActionStatusKind::Running,
@@ -496,6 +501,7 @@ fn action_provider_label(provider: ActionProvider) -> &'static str {
 fn action_status_label(status: ActionStatusKind) -> &'static str {
     match status {
         ActionStatusKind::Success => "success",
+        ActionStatusKind::Skipped => "skipped",
         ActionStatusKind::Pending => "pending",
         ActionStatusKind::Running => "running",
         ActionStatusKind::Failure => "failure",
@@ -605,7 +611,7 @@ mod tests {
         );
         assert_eq!(
             normalize_check_run_status("COMPLETED", Some("SKIPPED")),
-            ActionStatusKind::Success
+            ActionStatusKind::Skipped
         );
         assert_eq!(
             normalize_check_run_status("COMPLETED", Some("FAILURE")),

--- a/src-tauri/src/forge/gitlab/pipeline.rs
+++ b/src-tauri/src/forge/gitlab/pipeline.rs
@@ -48,6 +48,7 @@ pub(super) fn load_job_trace(context: &GitlabContext, job_id: i64) -> Result<Opt
 /// Render a pipeline (parent of jobs) as a single check row — used as a
 /// fallback when job enumeration fails or the pipeline has no jobs yet.
 pub(super) fn pipeline_item(pipeline: &GitlabPipeline) -> ForgeActionItem {
+    let status = normalize_gitlab_status(pipeline.status.as_deref());
     ForgeActionItem {
         id: pipeline
             .id
@@ -58,8 +59,13 @@ pub(super) fn pipeline_item(pipeline: &GitlabPipeline) -> ForgeActionItem {
             .map(|id| format!("Pipeline #{id}"))
             .unwrap_or_else(|| "Pipeline".to_string()),
         provider: ActionProvider::Gitlab,
-        status: normalize_gitlab_status(pipeline.status.as_deref()),
-        duration: pipeline.duration.and_then(format_seconds_duration),
+        status,
+        // Skipped pipelines never ran, so a "0s" duration is misleading.
+        duration: if status == ActionStatusKind::Skipped {
+            None
+        } else {
+            pipeline.duration.and_then(format_seconds_duration)
+        },
         url: pipeline.web_url.clone(),
     }
 }
@@ -95,15 +101,20 @@ pub(super) fn build_gitlab_check_insert_text(
 }
 
 fn job_item(job: GitlabJob) -> ForgeActionItem {
+    let status = normalize_gitlab_status(Some(&job.status));
     ForgeActionItem {
         id: format!("gitlab-job-{}", job.id),
         name: job.name,
         provider: ActionProvider::Gitlab,
-        status: normalize_gitlab_status(Some(&job.status)),
-        duration: job
-            .duration
-            .and_then(format_seconds_duration)
-            .or_else(|| format_duration(job.started_at.as_deref(), job.finished_at.as_deref())),
+        status,
+        // Skipped jobs never ran, so a "0s" duration is misleading.
+        duration: if status == ActionStatusKind::Skipped {
+            None
+        } else {
+            job.duration
+                .and_then(format_seconds_duration)
+                .or_else(|| format_duration(job.started_at.as_deref(), job.finished_at.as_deref()))
+        },
         url: job.web_url,
     }
 }
@@ -131,7 +142,8 @@ fn normalize_gitlab_status(status: Option<&str>) -> ActionStatusKind {
     // GitLab only gives us per-job status, so we lean toward the
     // pipeline-level reading.
     match status.unwrap_or_default() {
-        "success" | "skipped" => ActionStatusKind::Success,
+        "skipped" => ActionStatusKind::Skipped,
+        "success" => ActionStatusKind::Success,
         "failed" | "canceled" => ActionStatusKind::Failure,
         "running" | "preparing" | "waiting_for_resource" | "pending" | "created" => {
             ActionStatusKind::Running
@@ -171,6 +183,7 @@ fn parse_gitlab_datetime(value: &str) -> Option<DateTime<Utc>> {
 fn action_status_label(status: ActionStatusKind) -> &'static str {
     match status {
         ActionStatusKind::Success => "success",
+        ActionStatusKind::Skipped => "skipped",
         ActionStatusKind::Pending => "pending",
         ActionStatusKind::Running => "running",
         ActionStatusKind::Failure => "failure",
@@ -223,7 +236,7 @@ mod tests {
         );
         assert_eq!(
             normalize_gitlab_status(Some("skipped")),
-            ActionStatusKind::Success
+            ActionStatusKind::Skipped
         );
         assert_eq!(
             normalize_gitlab_status(Some("canceled")),

--- a/src-tauri/src/forge/types.rs
+++ b/src-tauri/src/forge/types.rs
@@ -83,6 +83,7 @@ pub struct ChangeRequestInfo {
 #[serde(rename_all = "camelCase")]
 pub enum ActionStatusKind {
     Success,
+    Skipped,
     Pending,
     Running,
     Failure,

--- a/src/features/inspector/sections/actions.tsx
+++ b/src/features/inspector/sections/actions.tsx
@@ -3,6 +3,7 @@ import {
 	ArrowUpRightIcon,
 	CheckIcon,
 	ChevronDown,
+	CircleSlashIcon,
 	EyeIcon,
 	LoaderCircleIcon,
 	TriangleIcon,
@@ -545,6 +546,16 @@ function StatusIcon({ status }: { status: ActionStatusKind }) {
 		);
 	}
 
+	if (status === "skipped") {
+		return (
+			<CircleSlashIcon
+				aria-label="Skipped"
+				className="size-3 shrink-0 text-muted-foreground"
+				strokeWidth={2}
+			/>
+		);
+	}
+
 	const label =
 		status === "running"
 			? "Running"
@@ -745,10 +756,16 @@ function ActionStatusRow({
 				>
 					{item.name}
 				</span>
-				{item.duration && (
+				{item.status === "skipped" ? (
 					<span className="shrink-0 text-micro text-muted-foreground">
-						{item.duration}
+						skipped
 					</span>
+				) : (
+					item.duration && (
+						<span className="shrink-0 text-micro text-muted-foreground">
+							{item.duration}
+						</span>
+					)
 				)}
 			</div>
 			<div className="flex shrink-0 items-center justify-end gap-0">
@@ -837,5 +854,7 @@ function actionPriority(status: ActionStatusKind): number {
 			return 2;
 		case "success":
 			return 3;
+		case "skipped":
+			return 4;
 	}
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2886,7 +2886,12 @@ export type ChangeRequestInfo = {
 	isMerged: boolean;
 };
 
-export type ActionStatusKind = "success" | "pending" | "running" | "failure";
+export type ActionStatusKind =
+	| "success"
+	| "skipped"
+	| "pending"
+	| "running"
+	| "failure";
 export type ActionProvider = "github" | "gitlab" | "vercel" | "unknown";
 export type WorkspaceGitSyncStatus = "upToDate" | "behind" | "unknown";
 export type WorkspacePushStatus = "published" | "unpublished" | "unknown";


### PR DESCRIPTION
## What changed

Skipped CI checks (both GitHub Actions and GitLab pipelines) now get their own visual state instead of being collapsed into “success.” The inspector sidebar shows a CircleSlashIcon for skipped items, labels them “skipped,” and no longer displays a misleading “0s” duration.

## Why

Skipped checks are not the same as passing checks — they were intentionally skipped (path filters, conditional rules, etc.). Treating them as green success was confusing when a PR coasted through on skip-only CI while actual test suites never ran.

## Details

- Added ActionStatusKind::Skipped variant to the Rust enum, mirrored in the TypeScript type
- GitHub: COMPLETED + SKIPPED conclusion → Skipped (was Success)
- GitLab: "skipped" status → Skipped (was Success)
- Duration suppressed for skipped items on both backends
- Sorting order: skipped items placed after success items
- Updated backend unit tests for the new behavior