### PR TITLE
feat: persist start-composer terminal-mode toggle across visits

### DIFF
--- a/.changeset/sticky-start-terminal-toggle.md
+++ b/.changeset/sticky-start-terminal-toggle.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+The start page composer now remembers your Terminal Mode toggle across visits, like its other pickers.

--- a/src/features/composer/container.test.tsx
+++ b/src/features/composer/container.test.tsx
@@ -60,6 +60,8 @@ const composerMockState = vi.hoisted(() => ({
 	lastOnSelectEffort: null as ((level: string) => void) | null,
 	lastOnChangePermissionMode: null as ((mode: string) => void) | null,
 	lastOnChangeFastMode: null as ((enabled: boolean) => void) | null,
+	lastTerminalMode: null as boolean | null,
+	lastOnChangeTerminalMode: null as ((enabled: boolean) => void) | null,
 }));
 
 vi.mock("./index", async () => {
@@ -91,6 +93,8 @@ vi.mock("./index", async () => {
 			permissionMode?: string;
 			onChangePermissionMode?: (mode: string) => void;
 			onChangeFastMode?: (enabled: boolean) => void;
+			terminalMode?: boolean;
+			onChangeTerminalMode?: (enabled: boolean) => void;
 		}) => {
 			composerMockState.renders.push(props.contextKey);
 			composerMockState.lastSlashCommands = [...(props.slashCommands ?? [])];
@@ -110,6 +114,9 @@ vi.mock("./index", async () => {
 			composerMockState.lastOnChangePermissionMode =
 				props.onChangePermissionMode ?? null;
 			composerMockState.lastOnChangeFastMode = props.onChangeFastMode ?? null;
+			composerMockState.lastTerminalMode = props.terminalMode ?? null;
+			composerMockState.lastOnChangeTerminalMode =
+				props.onChangeTerminalMode ?? null;
 			React.useEffect(() => {
 				composerMockState.mounts += 1;
 				return () => {
@@ -271,6 +278,8 @@ describe("WorkspaceComposerContainer", () => {
 		composerMockState.lastOnSelectEffort = null;
 		composerMockState.lastOnChangePermissionMode = null;
 		composerMockState.lastOnChangeFastMode = null;
+		composerMockState.lastTerminalMode = null;
+		composerMockState.lastOnChangeTerminalMode = null;
 		apiMockState.listSlashCommands.mockReset();
 		apiMockState.listWorkspaceLinkedDirectories.mockReset();
 		apiMockState.listWorkspaceLinkedDirectories.mockResolvedValue([]);
@@ -576,6 +585,68 @@ describe("WorkspaceComposerContainer", () => {
 			startSurfacePreferences: {
 				...DEFAULT_SETTINGS.startSurfacePreferences,
 				createState: "in-progress",
+			},
+		});
+	});
+
+	it("persists the start composer's terminal toggle in settings", () => {
+		const queryClient = createHelmorQueryClient();
+		const updateSettings = vi.fn();
+		queryClient.setQueryData(
+			helmorQueryKeys.agentModelSections,
+			MODEL_SECTIONS,
+		);
+
+		const settings = {
+			...DEFAULT_SETTINGS,
+			enableTerminalMode: true,
+			startSurfacePreferences: {
+				...DEFAULT_SETTINGS.startSurfacePreferences,
+				terminalModeActive: true,
+			},
+		};
+
+		render(
+			<SettingsContext.Provider
+				value={{ settings, isLoaded: true, updateSettings }}
+			>
+				<QueryClientProvider client={queryClient}>
+					<WorkspaceComposerContainer
+						displayedWorkspaceId={null}
+						displayedSessionId={null}
+						disabled={false}
+						forceAvailable
+						focusScope="start-composer"
+						contextKeyOverride="start:repo:repo-1"
+						sending={false}
+						sendError={null}
+						restoreDraft={null}
+						restoreImages={[]}
+						restoreFiles={[]}
+						restoreNonce={0}
+						modelSelections={{}}
+						effortLevels={{}}
+						permissionModes={{}}
+						fastModes={{}}
+						onSelectModel={vi.fn()}
+						onSelectEffort={vi.fn()}
+						onChangePermissionMode={vi.fn()}
+						onChangeFastMode={vi.fn()}
+						onSubmit={vi.fn()}
+					/>
+				</QueryClientProvider>
+			</SettingsContext.Provider>,
+		);
+
+		// Persisted preference drives the toggle on mount (not local state).
+		expect(composerMockState.lastTerminalMode).toBe(true);
+
+		composerMockState.lastOnChangeTerminalMode?.(false);
+
+		expect(updateSettings).toHaveBeenCalledWith({
+			startSurfacePreferences: {
+				...settings.startSurfacePreferences,
+				terminalModeActive: false,
 			},
 		});
 	});

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -823,17 +823,38 @@ export const WorkspaceComposerContainer = memo(
 		const [goalReplaceConfirm, setGoalReplaceConfirm] =
 			useState<PendingGoalReplace | null>(null);
 
-		// Terminal-Mode toggle: composer-local, off on every mount. Only offered
+		// Terminal-Mode toggle. Workspace composer: local, off on every mount.
+		// Start composer: persisted in `startSurfacePreferences` (same path as
+		// the submit-mode picker) so the choice survives re-entry. Only offered
 		// when the General setting is on and the provider has a terminal agent
 		// spec (cursor has no TUI CLI, so it stays hidden there).
-		const [terminalMode, setTerminalMode] = useState(false);
+		const isStartComposer = focusScope === "start-composer";
+		const [localTerminalMode, setLocalTerminalMode] = useState(false);
+		const terminalMode = isStartComposer
+			? settings.startSurfacePreferences.terminalModeActive
+			: localTerminalMode;
+		const setTerminalMode = useCallback(
+			(enabled: boolean) => {
+				if (isStartComposer) {
+					void updateSettings({
+						startSurfacePreferences: {
+							...settings.startSurfacePreferences,
+							terminalModeActive: enabled,
+						},
+					});
+					return;
+				}
+				setLocalTerminalMode(enabled);
+			},
+			[isStartComposer, settings.startSurfacePreferences, updateSettings],
+		);
 		const showTerminalToggle =
 			settings.enableTerminalMode &&
 			findTerminalAgent(effectiveModel?.provider) !== null;
 
 		// App-scoped ⌘⇧T (global shortcut → shell event).
 		useShellEvent("toggle-terminal-mode", () => {
-			if (showTerminalToggle) setTerminalMode((value) => !value);
+			if (showTerminalToggle) setTerminalMode(!terminalMode);
 		});
 
 		const handleComposerSubmitInner = useCallback(

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -62,6 +62,7 @@ describe("settings", () => {
 			modeByRepoId: { "repo-1": "local" },
 			branchIntentByRepoId: { "repo-1": "use_branch" },
 			chatModeActive: false,
+			terminalModeActive: false,
 		});
 	});
 
@@ -161,6 +162,7 @@ describe("settings", () => {
 			modeByRepoId: { "repo-1": "local" },
 			branchIntentByRepoId: { "repo-1": "use_branch" },
 			chatModeActive: false,
+			terminalModeActive: false,
 		});
 
 		const writeCall = invokeMock.mock.calls.find(

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -245,6 +245,8 @@ export type StartSurfacePreferences = {
 	branchIntentByRepoId: Record<string, WorkspaceBranchIntent>;
 	/** Top-level "Just chat" toggle. Independent of the selected repo. */
 	chatModeActive: boolean;
+	/** Start-composer Terminal-Mode toggle. */
+	terminalModeActive: boolean;
 };
 
 export type AppSettings = {
@@ -343,6 +345,7 @@ export const DEFAULT_START_SURFACE_PREFERENCES: StartSurfacePreferences = {
 	modeByRepoId: {},
 	branchIntentByRepoId: {},
 	chatModeActive: false,
+	terminalModeActive: false,
 };
 
 /** Fallbacks for repos without a per-repo entry. */
@@ -938,6 +941,10 @@ function parseStartSurfacePreferences(
 			modeByRepoId,
 			branchIntentByRepoId,
 			chatModeActive,
+			terminalModeActive:
+				typeof o.terminalModeActive === "boolean"
+					? o.terminalModeActive
+					: false,
 		};
 	} catch {
 		return DEFAULT_START_SURFACE_PREFERENCES;


### PR DESCRIPTION
## What changed

The start page composer's Terminal Mode toggle now persists across visits via `startSurfacePreferences.terminalModeActive`, matching the behavior of its other pickers (submit mode, branch intent, etc.).

## Why

Previously the toggle was local component state — it reset to `false` on every mount. Users who prefer terminal mode had to re-enable it every time they opened the start page. Workspace composers still use local state (off on every mount) since the terminal session is intrinsically tied to a single composer lifecycle.

## What was touched

- `src/lib/settings.ts` — added `terminalModeActive: boolean` to `StartSurfacePreferences`, defaulting to `false`
- `src/features/composer/container.tsx` — split toggle state: start composer reads/writes settings, workspace composer stays local
- Tests updated in `container.test.tsx` and `settings.test.ts`
- Changeset: patch (user-facing behavior change)