### PR TITLE
fix(terminal): advertise truecolor to prevent CLI color quantization

### DIFF
--- a/.changeset/coral-terminals-glow.md
+++ b/.changeset/coral-terminals-glow.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix shifted colors in terminal sessions by advertising truecolor support, so CLIs like Claude Code render their exact palette instead of a 256-color approximation.

--- a/src-tauri/src/workspace/scripts.rs
+++ b/src-tauri/src/workspace/scripts.rs
@@ -792,7 +792,10 @@ pub(crate) fn run_script_with_shell(
     cmd.args(shell_args)
         .current_dir(working_dir)
         .env("TERM", "xterm-256color")
-        .env("FORCE_COLOR", "1")
+        // Truecolor advertisement — without it chalk/supports-color caps at
+        // 256 colors and CLIs quantize their palette (orange → pink).
+        .env("COLORTERM", "truecolor")
+        .env("FORCE_COLOR", "3")
         .env("CLICOLOR_FORCE", "1")
         .env("HELMOR_ROOT_PATH", &context.root_path);
 


### PR DESCRIPTION
## What changed

Set `COLORTERM=truecolor` and bump `FORCE_COLOR` from `1` to `3` in the terminal PTY environment.

## Why

CLIs like Claude Code use chalk/supports-color to detect terminal color support. Without the truecolor advertisement, they fall back to a 256-color palette and quantize their output — noticeable as shifted colors (e.g. orange → pink). The `FORCE_COLOR=3` level tells Node.js CLIs to output 16M colors when truecolor is available.

## Test notes

- Verified in a terminal session: Claude Code and other chalk-based CLIs now render their exact palette.
- `cargo clippy` and `cargo fmt` pass.