### PR TITLE
Cmd+click to open terminal URLs, primary Update button, confirm-dialog spinner

### DIFF
--- a/.announcements/terminal-url-click.json
+++ b/.announcements/terminal-url-click.json
@@ -1,0 +1,7 @@
+{
+	"items": [
+		{
+			"text": "URLs in terminal output are now clickable — ⌘+click a link in the Terminal, Run, or Setup panels to open it in your browser."
+		}
+	]
+}

--- a/.changeset/calm-links-open.md
+++ b/.changeset/calm-links-open.md
@@ -1,0 +1,5 @@
+---
+"helmor": minor
+---
+
+URLs in terminal output are now clickable — hold ⌘ (or Ctrl) and click a link in the Terminal, Run, or Setup panels to open it in your browser.

--- a/.changeset/calm-links-open.md
+++ b/.changeset/calm-links-open.md
@@ -2,4 +2,7 @@
 "helmor": minor
 ---
 
-URLs in terminal output are now clickable — hold ⌘ (or Ctrl) and click a link in the Terminal, Run, or Setup panels to open it in your browser.
+Make terminal links clickable and polish a couple of UI states:
+- URLs in terminal output are now clickable — hold ⌘ (or Ctrl) and click a link in the Terminal, Run, or Setup panels to open it in your browser.
+- The sidebar Update button now uses the primary style so a ready-to-install update stands out.
+- Confirmation dialogs now show a spinner on the confirm button while the action is running (e.g. cleaning up archived workspaces).

--- a/src/components/terminal-output.tsx
+++ b/src/components/terminal-output.tsx
@@ -16,7 +16,15 @@ import {
 type TerminalOutputProps = {
 	terminalRef?: React.RefObject<TerminalHandle | null>;
 	className?: string;
-	detectLinks?: boolean;
+	/**
+	 * URL detection in terminal output.
+	 * - `true`: plain click opens the URL (read-only previews like login
+	 *   dialogs, where clicking the link is the primary action).
+	 * - `"modifier-click"`: Cmd/Ctrl+click opens the URL — standard terminal
+	 *   behavior (Terminal.app, iTerm2, VS Code), so plain clicks still
+	 *   select text without accidentally opening the browser.
+	 */
+	detectLinks?: boolean | "modifier-click";
 	fontSize?: number;
 	fontFamily?: string;
 	lineHeight?: number;
@@ -101,6 +109,10 @@ function openHttpUrl(value: string) {
 	void openUrl(url);
 }
 
+function shouldActivateLink(event: MouseEvent, requireModifier: boolean) {
+	return !requireModifier || event.metaKey || event.ctrlKey;
+}
+
 function findLineForOffset(
 	lineOffsets: readonly number[],
 	lineTexts: readonly string[],
@@ -115,7 +127,10 @@ function findLineForOffset(
 	return null;
 }
 
-function createHttpLinkProvider(terminal: Terminal): ILinkProvider {
+function createHttpLinkProvider(
+	terminal: Terminal,
+	requireModifier: boolean,
+): ILinkProvider {
 	return {
 		provideLinks(bufferLineNumber, callback) {
 			const buffer = terminal.buffer.active;
@@ -184,8 +199,10 @@ function createHttpLinkProvider(terminal: Terminal): ILinkProvider {
 							pointerCursor: true,
 							underline: true,
 						},
-						activate: (_event: MouseEvent, linkText: string) => {
-							openHttpUrl(linkText);
+						activate: (event: MouseEvent, linkText: string) => {
+							if (shouldActivateLink(event, requireModifier)) {
+								openHttpUrl(linkText);
+							}
 						},
 					};
 				})
@@ -330,8 +347,10 @@ function TerminalOutputImpl({
 			macOptionIsMeta: true,
 			linkHandler: detectLinks
 				? {
-						activate: (_event, text) => {
-							openHttpUrl(text);
+						activate: (event, text) => {
+							if (shouldActivateLink(event, detectLinks === "modifier-click")) {
+								openHttpUrl(text);
+							}
 						},
 					}
 				: null,
@@ -374,7 +393,9 @@ function TerminalOutputImpl({
 		});
 
 		const linkProviderDisposable = detectLinks
-			? terminal.registerLinkProvider(createHttpLinkProvider(terminal))
+			? terminal.registerLinkProvider(
+					createHttpLinkProvider(terminal, detectLinks === "modifier-click"),
+				)
 			: null;
 
 		// Leading + trailing throttled fit. fit.fit() reflows the 5000-line

--- a/src/components/ui/confirm-dialog.tsx
+++ b/src/components/ui/confirm-dialog.tsx
@@ -1,3 +1,4 @@
+import { Loader2 } from "lucide-react";
 import type { ReactNode } from "react";
 import { Button } from "@/components/ui/button";
 import {
@@ -51,6 +52,7 @@ export function ConfirmDialog({
 						onClick={onConfirm}
 						disabled={loading}
 					>
+						{loading ? <Loader2 className="size-3.5 animate-spin" /> : null}
 						{confirmLabel}
 					</Button>
 				</div>

--- a/src/features/inspector/sections/run.tsx
+++ b/src/features/inspector/sections/run.tsx
@@ -327,6 +327,7 @@ export function RunTab({
 						<TerminalOutput
 							terminalRef={termRef}
 							className="h-full"
+							detectLinks="modifier-click"
 							onData={handleData}
 							onResize={handleResize}
 						/>

--- a/src/features/inspector/sections/setup.tsx
+++ b/src/features/inspector/sections/setup.tsx
@@ -164,6 +164,7 @@ export function SetupTab({
 						<TerminalOutput
 							terminalRef={termRef}
 							className="h-full"
+							detectLinks="modifier-click"
 							onData={handleData}
 							onResize={handleResize}
 						/>

--- a/src/features/inspector/sections/terminal.tsx
+++ b/src/features/inspector/sections/terminal.tsx
@@ -158,6 +158,7 @@ export function TerminalInstancePanel({
 				<TerminalOutput
 					terminalRef={termRef}
 					className="h-full"
+					detectLinks="modifier-click"
 					onData={handleData}
 					onResize={handleResize}
 					isVisible={isActive}

--- a/src/features/terminal/terminal-session-panel.tsx
+++ b/src/features/terminal/terminal-session-panel.tsx
@@ -186,6 +186,7 @@ export function TerminalSessionPanel({
 			<TerminalOutput
 				terminalRef={termRef}
 				className="h-full"
+				detectLinks="modifier-click"
 				onData={handleData}
 				onResize={handleResize}
 				isVisible={isActive}

--- a/src/features/updater/app-update-button.tsx
+++ b/src/features/updater/app-update-button.tsx
@@ -31,12 +31,11 @@ export function AppUpdateButton({ status, className }: AppUpdateButtonProps) {
 			<TooltipTrigger asChild>
 				<Button
 					type="button"
-					variant="ghost"
+					variant="default"
 					size="xs"
 					aria-label={`Update Helmor to ${update.version}`}
 					className={cn(
-						"h-6 gap-1 rounded-sm px-1.5 text-mini font-medium tracking-[0.01em] text-muted-foreground transition-[background-color,color,border-color,box-shadow] duration-200 hover:bg-accent/60 hover:text-foreground dark:hover:bg-muted/45",
-						"relative overflow-hidden shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--border)_36%,transparent)] hover:shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--foreground)_12%,transparent)]",
+						"h-6 gap-1 rounded-sm px-1.5 text-mini font-medium tracking-[0.01em] transition-[background-color,color,border-color,box-shadow] duration-200 hover:bg-primary/90",
 						className,
 					)}
 					onClick={() => {
@@ -61,9 +60,9 @@ export function AppUpdateButton({ status, className }: AppUpdateButtonProps) {
 					disabled={installing}
 				>
 					{installing ? (
-						<Loader2 className="size-3 animate-spin text-foreground/70" />
+						<Loader2 className="size-3 animate-spin" />
 					) : (
-						<Download className="size-3 text-foreground/72" />
+						<Download className="size-3" />
 					)}
 					<span>Update</span>
 				</Button>


### PR DESCRIPTION
## What changed

- **⌘+click terminal links** — URLs in terminal output are now clickable in the Terminal, Run, and Setup panels. Hold ⌘ (or Ctrl) and click to open in the browser; plain clicks still select text. Implemented as a new `"modifier-click"` mode on `TerminalOutput`'s `detectLinks` prop. Read-only login dialogs keep their existing plain-click behavior.
- **Primary Update button** — the sidebar app-update button now uses the primary variant instead of the faint ghost style, so a ready-to-install update stands out.
- **Confirm-dialog spinner** — `ConfirmDialog` now shows a spinner on the confirm button while `loading`, so long-running confirms (e.g. cleaning up archived workspaces) no longer look stuck.

Includes a changeset (minor) and a pending in-app announcement for the terminal-links feature.

## Testing

- `bun x tsc --noEmit` clean
- Biome clean
- Frontend tests for terminal/inspector/components pass (158 + 120 runs across iterations)