### PR TITLE
fix(terminal): normalize mouse-wheel scrolling in TUI sessions

### DIFF
--- a/.changeset/calm-wheels-spin.md
+++ b/.changeset/calm-wheels-spin.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix mouse-wheel scrolling in terminal sessions being far too slow inside TUIs like Claude and Codex — scrolling now tracks wheel travel like a native terminal.

--- a/src/components/terminal-output.tsx
+++ b/src/components/terminal-output.tsx
@@ -12,6 +12,7 @@ import {
 	flushTerminalWrites,
 	scheduleTerminalWrite,
 } from "./terminal-output-scheduler";
+import { createTuiWheelHandler } from "./terminal-wheel";
 
 type TerminalOutputProps = {
 	terminalRef?: React.RefObject<TerminalHandle | null>;
@@ -372,6 +373,9 @@ function TerminalOutputImpl({
 			}
 			return true;
 		});
+
+		// Restore proportional wheel scrolling inside TUIs (claude/codex).
+		terminal.attachCustomWheelEventHandler(createTuiWheelHandler(terminal));
 
 		const linkProviderDisposable = detectLinks
 			? terminal.registerLinkProvider(createHttpLinkProvider(terminal))

--- a/src/components/terminal-wheel.test.ts
+++ b/src/components/terminal-wheel.test.ts
@@ -1,0 +1,95 @@
+import type { Terminal } from "@xterm/xterm";
+import { describe, expect, it } from "vitest";
+import { createTuiWheelHandler } from "./terminal-wheel";
+
+type FakeOpts = {
+	tracking?: "none" | "vt200";
+	bufferType?: "normal" | "alternate";
+};
+
+function fakeTerminal({
+	tracking = "none",
+	bufferType = "normal",
+}: FakeOpts = {}): Terminal {
+	return {
+		rows: 40,
+		element: null, // cell height falls back to 16px
+		options: { fastScrollSensitivity: 5 },
+		modes: { mouseTrackingMode: tracking },
+		buffer: { active: { type: bufferType } },
+	} as unknown as Terminal;
+}
+
+function setup(opts?: FakeOpts) {
+	const handler = createTuiWheelHandler(fakeTerminal(opts));
+	const el = document.createElement("div");
+	// Mirrors xterm: handler true → xterm processes the event itself.
+	const processed: WheelEvent[] = [];
+	const swallowed: WheelEvent[] = [];
+	el.addEventListener("wheel", (ev) => {
+		(handler(ev) ? processed : swallowed).push(ev);
+	});
+	const wheel = (deltaY: number, init?: WheelEventInit) =>
+		el.dispatchEvent(
+			new WheelEvent("wheel", {
+				deltaY,
+				bubbles: true,
+				cancelable: true,
+				...init,
+			}),
+		);
+	return { wheel, processed, swallowed };
+}
+
+describe("createTuiWheelHandler", () => {
+	it("passes events through when no TUI handles scrolling", () => {
+		const t = setup();
+		t.wheel(160);
+		expect(t.processed).toHaveLength(1);
+		expect(t.swallowed).toHaveLength(0);
+	});
+
+	it("re-emits one single-line event per scrolled line in the alt screen", () => {
+		const t = setup({ bufferType: "alternate" });
+		t.wheel(160); // 10 lines at 16px cells
+		expect(t.swallowed).toHaveLength(1);
+		expect(t.processed).toHaveLength(10);
+		for (const ev of t.processed) expect(ev.deltaY).toBe(120);
+	});
+
+	it("intercepts when mouse tracking is active in the normal buffer", () => {
+		const t = setup({ tracking: "vt200" });
+		t.wheel(-32);
+		expect(t.processed).toHaveLength(2);
+		for (const ev of t.processed) expect(ev.deltaY).toBe(-120);
+	});
+
+	it("accumulates fractional deltas across events", () => {
+		const t = setup({ bufferType: "alternate" });
+		t.wheel(8);
+		expect(t.processed).toHaveLength(0);
+		t.wheel(8);
+		expect(t.processed).toHaveLength(1);
+	});
+
+	it("drops the remainder on direction flip", () => {
+		const t = setup({ bufferType: "alternate" });
+		t.wheel(15); // remainder 0.9375
+		t.wheel(-16); // without reset this would only reach -0.0625
+		expect(t.processed).toHaveLength(1);
+		expect(t.processed[0].deltaY).toBe(-120);
+	});
+
+	it("applies fast-scroll multiplier with alt held", () => {
+		const t = setup({ bufferType: "alternate" });
+		t.wheel(16, { altKey: true });
+		expect(t.processed).toHaveLength(5);
+	});
+
+	it("leaves shift+wheel to xterm", () => {
+		const t = setup({ bufferType: "alternate" });
+		t.wheel(160, { shiftKey: true });
+		expect(t.processed).toHaveLength(1);
+		expect(t.swallowed).toHaveLength(0);
+	});
+});

--- a/src/components/terminal-wheel.ts
+++ b/src/components/terminal-wheel.ts
@@ -1,0 +1,67 @@
+import type { Terminal } from "@xterm/xterm";
+
+// ≥50px so consumeWheelEvent's trackpad damping (×0.3 under 50px) can't eat it.
+const SYNTHETIC_DELTA_PX = 120;
+const FALLBACK_CELL_HEIGHT = 16;
+// Safety cap for pathological deltas (momentum flicks, page-mode events).
+const MAX_LINES_PER_EVENT = 60;
+
+/**
+ * xterm 6 sends at most ONE wheel report (mouse tracking) or arrow key (alt
+ * screen) per wheel event and damps small deltas, so TUIs scroll far slower
+ * than in iTerm. When the running app consumes scrolling itself, swallow the
+ * event and re-dispatch one marked single-line event per line of travel.
+ */
+export function createTuiWheelHandler(
+	terminal: Terminal,
+): (ev: WheelEvent) => boolean {
+	const synthetic = new WeakSet<WheelEvent>();
+	let remainder = 0;
+
+	const cellHeight = () => {
+		const screen = terminal.element?.querySelector(".xterm-screen");
+		return screen && terminal.rows > 0
+			? screen.clientHeight / terminal.rows
+			: FALLBACK_CELL_HEIGHT;
+	};
+
+	return (ev: WheelEvent): boolean => {
+		if (synthetic.has(ev)) return true;
+		if (ev.deltaY === 0 || ev.shiftKey) return true;
+		const tuiHandlesScroll =
+			terminal.modes.mouseTrackingMode !== "none" ||
+			terminal.buffer.active.type === "alternate";
+		if (!tuiHandlesScroll) return true;
+
+		const fast =
+			ev.altKey || ev.ctrlKey
+				? (terminal.options.fastScrollSensitivity ?? 5)
+				: 1;
+		const deltaLines =
+			(ev.deltaMode === WheelEvent.DOM_DELTA_LINE
+				? ev.deltaY
+				: ev.deltaMode === WheelEvent.DOM_DELTA_PAGE
+					? ev.deltaY * terminal.rows
+					: ev.deltaY / cellHeight()) * fast;
+		if (Math.sign(deltaLines) !== Math.sign(remainder)) remainder = 0;
+		remainder += deltaLines;
+		const lines = Math.trunc(remainder);
+		remainder -= lines;
+
+		const count = Math.min(Math.abs(lines), MAX_LINES_PER_EVENT);
+		for (let i = 0; i < count; i++) {
+			const clone = new WheelEvent("wheel", {
+				deltaY: Math.sign(lines) * SYNTHETIC_DELTA_PX,
+				deltaMode: WheelEvent.DOM_DELTA_PIXEL,
+				clientX: ev.clientX,
+				clientY: ev.clientY,
+				bubbles: true,
+				cancelable: true,
+			});
+			synthetic.add(clone);
+			ev.target?.dispatchEvent(clone);
+		}
+		ev.preventDefault();
+		return false;
+	};
+}


### PR DESCRIPTION
## What changed

Added a custom wheel event handler for xterm that normalizes scrolling speed inside TUIs (Claude, Codex). xterm's default behavior dispatches at most one wheel report per native wheel event and damps small deltas — making scrolling painfully slow compared to iTerm or native terminals.

## How it works

The handler intercepts wheel events when a TUI is active (mouse tracking mode or alt screen), accumulates fractional deltas across events, and re-dispatches one marked single-line synthetic event per accumulated line of travel. This matches native terminal scroll feel.

Key behaviors:
- **Accumulates** fractional deltas so partial lines carry over across events
- **Resets remainder** on direction flip so overscroll doesn't snap back
- **Respects fast-scroll** multiplier with Alt/Ctrl held
- **Leaves shift+wheel** to xterm's default (lateral scroll)
- **Caps at 60 lines/event** to prevent runaway from pathological deltas

## Files

- `src/components/terminal-wheel.ts` — new wheel handler module
- `src/components/terminal-wheel.test.ts` — unit tests covering pass-through, accumulation, direction flip, fast-scroll, and shift bypass
- `src/components/terminal-output.tsx` — wires the handler into terminal sessions
- `.changeset/calm-wheels-spin.md` — changeset (patch)