### PR TITLE
fix: add minimumContrastRatio to xterm to improve TUI readability on light themes

### DIFF
--- a/src/components/terminal-output.tsx
+++ b/src/components/terminal-output.tsx
@@ -322,6 +322,10 @@ function TerminalOutputImpl({
 			fontFamily: resolveTerminalFontFamily(terminalFontFamily),
 			lineHeight,
 			theme: resolveTerminalTheme(),
+			// TUIs emit truecolor picked for dark backgrounds; on light themes it
+			// reads near-invisible. Nudge low-contrast fg at render time (VS
+			// Code's default ratio).
+			minimumContrastRatio: 4.5,
 			cursorBlink: false,
 			cursorStyle: "bar",
 			cursorInactiveStyle: "none",


### PR DESCRIPTION
## What changed

Added `minimumContrastRatio: 4.5` to the xterm.js terminal options in `src/components/terminal-output.tsx`.

## Why

TUIs emit truecolor values picked for dark backgrounds. On light Helmor themes, these colors render near-invisible. Setting a WCAG AA minimum contrast ratio (4.5:1) nudges low-contrast foreground text at render time, matching VS Code's default behavior.

## Test notes

- Verify TUI output (e.g., `htop`, `lazygit`) is readable in both light and dark Helmor themes.
- No regression expected for dark themes — xterm's minimumContrastRatio only adjusts colors below the threshold.