### PR TITLE
fix(terminal): consume staged boot at spawn time and hide toggle on chat surfaces

### DIFF
--- a/.changeset/terminal-boot-reliability.md
+++ b/.changeset/terminal-boot-reliability.md
@@ -1,0 +1,7 @@
+---
+"helmor": patch
+---
+
+Make Terminal Mode launches more reliable:
+- Consume the staged boot command at PTY spawn time so a terminal session can no longer open without the prompt it was launched with.
+- Hide the Terminal Mode toggle on chat surfaces, where there is no repository to spawn a terminal in — submitting there left the session stuck on "Starting…".

--- a/src/features/composer/container.test.tsx
+++ b/src/features/composer/container.test.tsx
@@ -651,6 +651,83 @@ describe("WorkspaceComposerContainer", () => {
 		});
 	});
 
+	it("hides the terminal toggle on chat surfaces (no repo to spawn the PTY in)", () => {
+		const queryClient = createHelmorQueryClient();
+		queryClient.setQueryData(
+			helmorQueryKeys.agentModelSections,
+			MODEL_SECTIONS,
+		);
+
+		const settings = {
+			...DEFAULT_SETTINGS,
+			enableTerminalMode: true,
+			startSurfacePreferences: {
+				...DEFAULT_SETTINGS.startSurfacePreferences,
+				terminalModeActive: true,
+			},
+		};
+
+		const sharedProps = {
+			disabled: false,
+			sending: false,
+			sendError: null,
+			restoreDraft: null,
+			restoreImages: [],
+			restoreFiles: [],
+			restoreNonce: 0,
+			modelSelections: {},
+			effortLevels: {},
+			permissionModes: {},
+			fastModes: {},
+			onSelectModel: vi.fn(),
+			onSelectEffort: vi.fn(),
+			onChangePermissionMode: vi.fn(),
+			onChangeFastMode: vi.fn(),
+			onSubmit: vi.fn(),
+		};
+
+		// Chat-mode start page: availability threaded in via the prop.
+		render(
+			<SettingsContext.Provider
+				value={{ settings, isLoaded: true, updateSettings: vi.fn() }}
+			>
+				<QueryClientProvider client={queryClient}>
+					<WorkspaceComposerContainer
+						{...sharedProps}
+						displayedWorkspaceId={null}
+						displayedSessionId={null}
+						forceAvailable
+						focusScope="start-composer"
+						contextKeyOverride="start:chat"
+						terminalModeAvailable={false}
+					/>
+				</QueryClientProvider>
+			</SettingsContext.Provider>,
+		);
+		expect(composerMockState.lastOnChangeTerminalMode).toBeNull();
+
+		// Chat workspace: derived from the workspace detail row's mode.
+		queryClient.setQueryData(helmorQueryKeys.workspaceDetail("workspace-1"), {
+			...WORKSPACE_DETAIL,
+			mode: "chat",
+			repoId: "",
+		});
+		render(
+			<SettingsContext.Provider
+				value={{ settings, isLoaded: true, updateSettings: vi.fn() }}
+			>
+				<QueryClientProvider client={queryClient}>
+					<WorkspaceComposerContainer
+						{...sharedProps}
+						displayedWorkspaceId="workspace-1"
+						displayedSessionId="session-1"
+					/>
+				</QueryClientProvider>
+			</SettingsContext.Provider>,
+		);
+		expect(composerMockState.lastOnChangeTerminalMode).toBeNull();
+	});
+
 	it("auto-submits queued CLI prompts using the model + permission_mode pinned on the session row", async () => {
 		const queryClient = createHelmorQueryClient();
 		queryClient.setQueryData(

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -252,6 +252,9 @@ type WorkspaceComposerContainerProps = {
 	 *  `data-focus-scope` and gates surface-only hotkeys (plan-mode toggle
 	 *  vs cycle-repository). */
 	focusScope?: "start-composer" | "workspace-composer";
+	/** False when the surrounding surface can't host a terminal session
+	 *  (chat-mode start page — no repo to spawn the PTY in). */
+	terminalModeAvailable?: boolean;
 };
 
 const noopUserInputResponse: UserInputResponseHandler = () => {};
@@ -307,6 +310,7 @@ export const WorkspaceComposerContainer = memo(
 		startSubmitMenu = false,
 		linkedDirectoriesController = null,
 		focusScope = "workspace-composer",
+		terminalModeAvailable = true,
 	}: WorkspaceComposerContainerProps) {
 		const queryClient = useQueryClient();
 		const { settings, updateSettings } = useSettings();
@@ -848,8 +852,13 @@ export const WorkspaceComposerContainer = memo(
 			},
 			[isStartComposer, settings.startSurfacePreferences, updateSettings],
 		);
+		// Terminal sessions need a repo to spawn the PTY in — hide the toggle on
+		// chat surfaces (chat-mode start page via the prop, chat workspaces via
+		// the detail row) so a submit can't strand a session that never spawns.
 		const showTerminalToggle =
 			settings.enableTerminalMode &&
+			terminalModeAvailable &&
+			workspaceDetailQuery.data?.mode !== "chat" &&
 			findTerminalAgent(effectiveModel?.provider) !== null;
 
 		// App-scoped ⌘⇧T (global shortcut → shell event).

--- a/src/features/conversation/index.tsx
+++ b/src/features/conversation/index.tsx
@@ -168,6 +168,9 @@ export type WorkspaceConversationContainerProps = {
 	 *  on the workspace-start page, `workspace-composer` everywhere else.
 	 *  See `WorkspaceComposerContainerProps.focusScope`. */
 	composerFocusScope?: "start-composer" | "workspace-composer";
+	/** False when the surrounding surface can't host a terminal session
+	 *  (chat-mode start page — no repo to spawn the PTY in). */
+	composerTerminalModeAvailable?: boolean;
 	/** Pre-workspace linked-directories controller. Forwarded to the
 	 *  composer; see `WorkspaceComposerContainerProps.linkedDirectoriesController`.
 	 *  Used by the start-page composer to collect /add-dir picks before any
@@ -223,6 +226,7 @@ export const WorkspaceConversationContainer = memo(
 		onToggleContextPanel,
 		composerStartSubmitMenu = false,
 		composerFocusScope = "workspace-composer",
+		composerTerminalModeAvailable = true,
 		composerLinkedDirectoriesController = null,
 	}: WorkspaceConversationContainerProps) {
 		const [composerModelSelections, setComposerModelSelections] = useState<
@@ -689,6 +693,7 @@ export const WorkspaceConversationContainer = memo(
 						onToggleContextPanel={onToggleContextPanel}
 						startSubmitMenu={composerStartSubmitMenu}
 						focusScope={composerFocusScope}
+						terminalModeAvailable={composerTerminalModeAvailable}
 						linkedDirectoriesController={composerLinkedDirectoriesController}
 					/>
 				</div>

--- a/src/features/terminal/terminal-session-panel.tsx
+++ b/src/features/terminal/terminal-session-panel.tsx
@@ -11,7 +11,6 @@ import {
 	attach,
 	detach,
 	ensureTerminal,
-	type PendingBoot,
 	resize,
 	TRUNCATION_NOTICE,
 	takePendingBoot,
@@ -76,13 +75,6 @@ export function TerminalSessionPanel({
 				: null) ?? presetBootCommand(agentKind);
 	}
 
-	// Consume the composer-initiated boot once (boot command + fast mode).
-	// Lazy-init ref so an effect re-run never re-reads it as null.
-	const pendingBootRef = useRef<PendingBoot | null | undefined>(undefined);
-	if (pendingBootRef.current === undefined) {
-		pendingBootRef.current = takePendingBoot(sessionId);
-	}
-
 	// Attach the live listener + one-shot replay. Independent of spawn: the
 	// listener is keyed by sessionId and receives output once the PTY starts.
 	const focusAssertedRef = useRef(false);
@@ -145,7 +137,10 @@ export function TerminalSessionPanel({
 				return;
 			}
 			spawnedRef.current = true;
-			const pending = pendingBootRef.current;
+			// Consume the composer-staged boot here (commit phase, exactly once,
+			// right before spawn). Taking it during render would leak the
+			// one-shot value if React ever discards that render attempt.
+			const pending = takePendingBoot(sessionId);
 			const boot = pending?.bootCommand ?? bootCommandRef.current ?? null;
 			ensureTerminal(
 				repoId,

--- a/src/shell/components/start-surface-pane.tsx
+++ b/src/shell/components/start-surface-pane.tsx
@@ -155,6 +155,7 @@ export function StartSurfacePane({
 				composerPlaceholder="Describe what you want to build"
 				composerCreateContext={startCreateContext}
 				composerFocusScope="start-composer"
+				composerTerminalModeAvailable={startMode !== "chat"}
 				contextPanelOpen={contextPanelOpen}
 				onToggleContextPanel={contextPanelActions.toggleContextPanel}
 				composerStartSubmitMenu


### PR DESCRIPTION
## What changed

Two fixes that make Terminal Mode launches more reliable:

1. **Boot command consumed at spawn time instead of render time.** Previously, `takePendingBoot()` was called in the render phase via a `useRef` trick, which leaked the one-shot value if React ever discarded that render attempt. Now it's called in the spawn effect callback, right before `ensureTerminal()`, so the boot command is always paired with the PTY spawn.

2. **Terminal Mode toggle is hidden on chat surfaces.** Chat-mode start pages and chat workspaces have no repository, so there's nothing to spawn a PTY in. Submitting with the toggle on left the session stuck on "Starting…". Now the toggle is hidden when the surface can't host a terminal session.

## Why

These were two real reliability gaps reported during Terminal Mode testing. The boot-command race could silently drop the user's prompt; the chat-surface toggle was a UX trap.

## Test notes

- Added a test in `container.test.tsx` verifying the toggle is correctly hidden on chat surfaces.
- The boot-command fix moves an existing side effect from render to commit phase; existing Terminal Mode tests cover the happy path.