### PR TITLE
Fix marketing Next build prerender crash

### DIFF
--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -12,8 +12,8 @@
 	},
 	"dependencies": {
 		"next": "^15.5.0",
-		"react": "19.2.0",
-		"react-dom": "19.2.0"
+		"react": "19.2.7",
+		"react-dom": "19.2.7"
 	},
 	"devDependencies": {
 		"@tailwindcss/postcss": "4.2.2",

--- a/bun.lock
+++ b/bun.lock
@@ -114,8 +114,8 @@
       "version": "0.0.0",
       "dependencies": {
         "next": "^15.5.0",
-        "react": "19.2.0",
-        "react-dom": "19.2.0",
+        "react": "19.2.7",
+        "react-dom": "19.2.7",
       },
       "devDependencies": {
         "@tailwindcss/postcss": "4.2.2",
@@ -5078,10 +5078,6 @@
     "@eslint/eslintrc/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "@helmor/marketing/@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
-
-    "@helmor/marketing/react": ["react@19.2.0", "", {}, "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ=="],
-
-    "@helmor/marketing/react-dom": ["react-dom@19.2.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ=="],
 
     "@helmor/marketing/tailwindcss": ["tailwindcss@4.2.2", "", {}, "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q=="],
 


### PR DESCRIPTION
## Summary
- align the marketing app's React and React DOM versions with the workspace root
- remove the stale marketing-scoped React 19.2.0 lockfile entries so Next, React, and React DOM resolve consistently during SSR

## Verification
- bun install --frozen-lockfile --ignore-scripts
- cd apps/marketing && bun run build
- npx -y react-doctor@latest apps/marketing --verbose --diff