### PR TITLE
fix(terminal): guard against WKWebView IME quirks in xterm sessions

### DIFF
--- a/.changeset/quiet-ime-keys.md
+++ b/.changeset/quiet-ime-keys.md
@@ -1,0 +1,7 @@
+---
+"helmor": patch
+---
+
+Fix Chinese IME input in terminal sessions:
+- Full-width punctuation (e.g. ？) typed with a Chinese input method no longer gets swallowed.
+- Switching to another input method mid-composition no longer commits pinyin letters with stray spaces.

--- a/src/components/terminal-ime.test.ts
+++ b/src/components/terminal-ime.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	createTerminalImeGuard,
+	isAbandonedImeAsciiBuffer,
+	type TerminalImeGuard,
+} from "./terminal-ime";
+
+function keyEvent(type: string, keyCode: number): KeyboardEvent {
+	return { type, keyCode } as unknown as KeyboardEvent;
+}
+
+function dispatchInput(
+	textarea: HTMLTextAreaElement,
+	init: { data: string; inputType?: string; isComposing?: boolean },
+) {
+	textarea.dispatchEvent(
+		new InputEvent("input", {
+			data: init.data,
+			inputType: init.inputType ?? "insertText",
+			isComposing: init.isComposing ?? false,
+			bubbles: true,
+			cancelable: true,
+		}),
+	);
+}
+
+function dispatchCompositionEnd(textarea: HTMLTextAreaElement, data: string) {
+	textarea.dispatchEvent(
+		new CompositionEvent("compositionend", { data, bubbles: true }),
+	);
+}
+
+describe("isAbandonedImeAsciiBuffer", () => {
+	it("matches a pinyin buffer with segmentation spaces", () => {
+		expect(isAbandonedImeAsciiBuffer("ni hao")).toBe(true);
+		expect(isAbandonedImeAsciiBuffer("sl dkjf")).toBe(true);
+	});
+
+	it("rejects CJK, space-free, and whitespace-only commits", () => {
+		expect(isAbandonedImeAsciiBuffer("你好")).toBe(false);
+		expect(isAbandonedImeAsciiBuffer("你好 hello")).toBe(false);
+		expect(isAbandonedImeAsciiBuffer("nihao")).toBe(false);
+		expect(isAbandonedImeAsciiBuffer(" ")).toBe(false);
+		expect(isAbandonedImeAsciiBuffer("")).toBe(false);
+	});
+});
+
+describe("createTerminalImeGuard", () => {
+	let textarea: HTMLTextAreaElement;
+	let send: ReturnType<typeof vi.fn<(data: string) => void>>;
+	let guard: TerminalImeGuard;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		textarea = document.createElement("textarea");
+		document.body.appendChild(textarea);
+		send = vi.fn<(data: string) => void>();
+		guard = createTerminalImeGuard(send);
+	});
+
+	afterEach(() => {
+		guard.detach();
+		textarea.remove();
+		vi.useRealTimers();
+	});
+
+	describe("dropped insertText (quirk 1)", () => {
+		it("forwards an IME instant commit xterm drops while keydown is held", () => {
+			guard.attach(textarea);
+			guard.observeKeyEvent(keyEvent("keydown", 191));
+			dispatchInput(textarea, { data: "？" });
+			expect(send).toHaveBeenCalledExactlyOnceWith("？");
+		});
+
+		it("stays inert when keydown was IME-consumed (keyCode 229)", () => {
+			guard.attach(textarea);
+			guard.observeKeyEvent(keyEvent("keydown", 229));
+			dispatchInput(textarea, { data: "？" });
+			expect(send).not.toHaveBeenCalled();
+		});
+
+		it("stays inert when a keypress already handled the char", () => {
+			guard.attach(textarea);
+			guard.observeKeyEvent(keyEvent("keydown", 65));
+			guard.observeKeyEvent(keyEvent("keypress", 97));
+			dispatchInput(textarea, { data: "a" });
+			expect(send).not.toHaveBeenCalled();
+		});
+
+		it("stays inert when xterm preventDefaulted the input event", () => {
+			textarea.addEventListener("input", (ev) => ev.preventDefault());
+			guard.attach(textarea);
+			guard.observeKeyEvent(keyEvent("keydown", 191));
+			dispatchInput(textarea, { data: "？" });
+			expect(send).not.toHaveBeenCalled();
+		});
+
+		it("ignores mid-composition input events", () => {
+			guard.attach(textarea);
+			guard.observeKeyEvent(keyEvent("keydown", 191));
+			dispatchInput(textarea, { data: "n", isComposing: true });
+			expect(send).not.toHaveBeenCalled();
+		});
+
+		it("ignores non-insertText input types", () => {
+			guard.attach(textarea);
+			guard.observeKeyEvent(keyEvent("keydown", 191));
+			dispatchInput(textarea, { data: "x", inputType: "insertFromPaste" });
+			expect(send).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("composition commit fallback (quirk 2)", () => {
+		it("resends the commit when xterm never delivers it", () => {
+			guard.attach(textarea);
+			dispatchCompositionEnd(textarea, "？");
+			vi.advanceTimersByTime(100);
+			expect(send).toHaveBeenCalledExactlyOnceWith("？");
+		});
+
+		it("does nothing when xterm delivers the commit", () => {
+			guard.attach(textarea);
+			dispatchCompositionEnd(textarea, "你好");
+			expect(guard.filterData("你好")).toBe("你好");
+			vi.advanceTimersByTime(100);
+			expect(send).not.toHaveBeenCalled();
+		});
+
+		it("strips segmentation spaces from a resent abandoned buffer", () => {
+			guard.attach(textarea);
+			dispatchCompositionEnd(textarea, "ni hao");
+			vi.advanceTimersByTime(100);
+			expect(send).toHaveBeenCalledExactlyOnceWith("nihao");
+		});
+
+		it("skips the fallback when xterm flushed the composition synchronously", () => {
+			guard.attach(textarea);
+			guard.filterData("nihao");
+			dispatchCompositionEnd(textarea, "nihao");
+			vi.advanceTimersByTime(100);
+			expect(send).not.toHaveBeenCalled();
+		});
+
+		it("skips the fallback for empty compositionend", () => {
+			guard.attach(textarea);
+			dispatchCompositionEnd(textarea, "");
+			vi.advanceTimersByTime(100);
+			expect(send).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("abandoned buffer strip (quirk 3)", () => {
+		it("strips spaces from the commit xterm delivers after compositionend", () => {
+			guard.attach(textarea);
+			dispatchCompositionEnd(textarea, "sl dkjf");
+			expect(guard.filterData("sl dkjf")).toBe("sldkjf");
+		});
+
+		it("strips only the committed prefix when chars were appended", () => {
+			guard.attach(textarea);
+			dispatchCompositionEnd(textarea, "ni hao");
+			expect(guard.filterData("ni hao2")).toBe("nihao2");
+		});
+
+		it("consumes the pending commit after one data event", () => {
+			guard.attach(textarea);
+			dispatchCompositionEnd(textarea, "ni hao");
+			expect(guard.filterData("ni hao")).toBe("nihao");
+			expect(guard.filterData("ni hao")).toBe("ni hao");
+		});
+
+		it("leaves non-matching data untouched", () => {
+			guard.attach(textarea);
+			dispatchCompositionEnd(textarea, "ni hao");
+			expect(guard.filterData("xyz")).toBe("xyz");
+		});
+
+		it("leaves CJK commits untouched", () => {
+			guard.attach(textarea);
+			dispatchCompositionEnd(textarea, "你好");
+			expect(guard.filterData("你好")).toBe("你好");
+		});
+
+		it("does not let ESC-prefixed reports consume the pending commit", () => {
+			guard.attach(textarea);
+			dispatchCompositionEnd(textarea, "ni hao");
+			expect(guard.filterData("\x1b[I")).toBe("\x1b[I");
+			expect(guard.filterData("ni hao")).toBe("nihao");
+		});
+	});
+
+	it("detach removes listeners and cancels the fallback", () => {
+		guard.attach(textarea);
+		dispatchCompositionEnd(textarea, "？");
+		guard.detach();
+		vi.advanceTimersByTime(100);
+		guard.observeKeyEvent(keyEvent("keydown", 191));
+		dispatchInput(textarea, { data: "？" });
+		expect(send).not.toHaveBeenCalled();
+	});
+});

--- a/src/components/terminal-ime.ts
+++ b/src/components/terminal-ime.ts
@@ -1,0 +1,117 @@
+// IME guards for xterm in WKWebView. Three quirks xterm 6 mishandles:
+// 1. An IME's instant commit (e.g. full-width "？") can arrive as keydown +
+//    `input` with no keypress; xterm drops insertText while a key is down.
+// 2. WebKit can populate the textarea before compositionstart fires, so
+//    xterm's composition substring reads empty and the commit never sends.
+// 3. Switching input source mid-composition commits the raw pinyin buffer
+//    with segmentation spaces ("ni hao") — native terminals get "nihao".
+//    Same heuristic as the composer's composition-guard-plugin.
+
+const PURE_PRINTABLE_ASCII = /^[\x20-\x7E]+$/;
+/** No data event after a non-empty compositionend within this window →
+ * xterm read an empty substring (quirk 2); resend the commit ourselves. */
+const COMMIT_FALLBACK_MS = 80;
+/** Data this close BEFORE compositionend means xterm already flushed the
+ * composition synchronously (e.g. Enter mid-composition) — no fallback. */
+const SYNC_FLUSH_MS = 30;
+
+/** Raw pinyin buffer committed by an input-source switch: pure printable
+ * ASCII with IME segmentation spaces. Real CJK commits contain non-ASCII. */
+export function isAbandonedImeAsciiBuffer(data: string): boolean {
+	return (
+		PURE_PRINTABLE_ASCII.test(data) && data.includes(" ") && data.trim() !== ""
+	);
+}
+
+export type TerminalImeGuard = {
+	/** Feed every event seen by attachCustomKeyEventHandler. */
+	observeKeyEvent: (event: KeyboardEvent) => void;
+	/** Add input/compositionend listeners. Call after terminal.open(). */
+	attach: (textarea: HTMLTextAreaElement) => void;
+	detach: () => void;
+	/** Route terminal.onData output through this before forwarding. */
+	filterData: (data: string) => string;
+};
+
+export function createTerminalImeGuard(
+	send: (data: string) => void,
+): TerminalImeGuard {
+	let textarea: HTMLTextAreaElement | null = null;
+	// keyCode 229 → the IME consumed the key; xterm's textarea-diff path owns it.
+	let keydownConsumedByIme = false;
+	let keypressFired = false;
+	let lastDataAt = Number.NEGATIVE_INFINITY;
+	let pendingStrip: string | null = null;
+	let fallbackTimer: ReturnType<typeof setTimeout> | null = null;
+
+	const cancelFallback = () => {
+		if (fallbackTimer !== null) {
+			clearTimeout(fallbackTimer);
+			fallbackTimer = null;
+		}
+	};
+
+	// Quirk 1. Inert whenever xterm handled the key: keydown-handled keys
+	// preventDefault (no input event at all), keypress-handled chars set
+	// keypressFired, IME-consumed keys come as 229, and xterm's own
+	// `_inputEvent` preventDefaults what it forwards.
+	const handleInput = (event: Event) => {
+		const ev = event as InputEvent;
+		if (ev.inputType !== "insertText" || !ev.data || ev.isComposing) return;
+		if (ev.defaultPrevented || keypressFired || keydownConsumedByIme) return;
+		cancelFallback();
+		send(ev.data);
+	};
+
+	const handleCompositionEnd = (event: Event) => {
+		const data = (event as CompositionEvent).data;
+		cancelFallback();
+		pendingStrip = data && isAbandonedImeAsciiBuffer(data) ? data : null;
+		if (!data) return;
+		if (performance.now() - lastDataAt < SYNC_FLUSH_MS) return;
+		// Quirk 2 fallback — cancelled when xterm delivers the commit itself.
+		const payload = pendingStrip ? data.replace(/\s+/g, "") : data;
+		fallbackTimer = setTimeout(() => {
+			fallbackTimer = null;
+			pendingStrip = null;
+			send(payload);
+		}, COMMIT_FALLBACK_MS);
+	};
+
+	return {
+		observeKeyEvent(event) {
+			if (event.type === "keydown") {
+				keydownConsumedByIme = event.keyCode === 229;
+				keypressFired = false;
+			} else if (event.type === "keypress") {
+				keypressFired = true;
+			}
+		},
+		attach(target) {
+			textarea = target;
+			target.addEventListener("input", handleInput);
+			target.addEventListener("compositionend", handleCompositionEnd);
+		},
+		detach() {
+			cancelFallback();
+			textarea?.removeEventListener("input", handleInput);
+			textarea?.removeEventListener("compositionend", handleCompositionEnd);
+			textarea = null;
+		},
+		filterData(data) {
+			// ESC-prefixed traffic (mouse reports, arrows, focus events) is not
+			// typed text — it must not consume the pending commit or fallback.
+			if (data.startsWith("\x1b")) return data;
+			lastDataAt = performance.now();
+			cancelFallback();
+			const pending = pendingStrip;
+			pendingStrip = null;
+			// Quirk 3. startsWith: xterm appends chars typed right after the
+			// commit to the same data event.
+			if (pending !== null && data.startsWith(pending)) {
+				return pending.replace(/\s+/g, "") + data.slice(pending.length);
+			}
+			return data;
+		},
+	};
+}

--- a/src/components/terminal-output.tsx
+++ b/src/components/terminal-output.tsx
@@ -6,6 +6,7 @@ import { resolveCssColor } from "@/lib/css-color";
 import { openUrl } from "@/lib/platform-bridge";
 import { useSettings } from "@/lib/settings";
 import "@xterm/xterm/css/xterm.css";
+import { createTerminalImeGuard } from "./terminal-ime";
 import {
 	clearTerminalWrites,
 	disposeTerminalWrites,
@@ -349,8 +350,14 @@ function TerminalOutputImpl({
 		// visible terminals hold a GPU context — Chromium/WKWebView cap the
 		// number of live contexts, and N background terminals would exhaust it.
 
+		// WKWebView IME quirks: dropped full-width commits, lost composition
+		// commits, pinyin segmentation spaces. See terminal-ime.ts.
+		const ime = createTerminalImeGuard((data) => onDataRef.current?.(data));
+		if (terminal.textarea) ime.attach(terminal.textarea);
+
 		// Translate macOS Cmd combos to readline control codes.
 		terminal.attachCustomKeyEventHandler((event) => {
+			ime.observeKeyEvent(event);
 			if (event.type !== "keydown") return true;
 			if (!event.metaKey || event.ctrlKey || event.altKey) return true;
 
@@ -424,7 +431,7 @@ function TerminalOutputImpl({
 		// the key → byte translation (e.g. Ctrl+C → `\x03`), we just
 		// forward whatever it produced.
 		const dataSub = terminal.onData((data) => {
-			onDataRef.current?.(data);
+			onDataRef.current?.(ime.filterData(data));
 		});
 
 		// xterm fires onResize after FitAddon changes the grid, font size
@@ -532,6 +539,7 @@ function TerminalOutputImpl({
 			}
 			dataSub.dispose();
 			resizeSub.dispose();
+			ime.detach();
 			linkProviderDisposable?.dispose();
 			themeObserver.disconnect();
 			resizeObserver.disconnect();


### PR DESCRIPTION
## What changed

Added a `TerminalImeGuard` that works around three WKWebView IME quirks in xterm terminal sessions, specifically affecting Chinese and CJK input methods.

### Quirk 1: Dropped full-width punctuation commits
xterm drops `insertText` while a key is still held down, so full-width characters like ？ are silently swallowed. The guard detects these instant commits from the `input` event and forwards them when xterm hasn't handled the keystroke.

### Quirk 2: Lost composition commits
WebKit can populate the textarea before `compositionstart` fires, causing xterm to read an empty substring — the commit never sends. A fallback timer resends the commit string when no data event arrives within 80ms of `compositionend`.

### Quirk 3: Abandoned pinyin buffer with segmentation spaces
Switching input source mid-composition commits raw pinyin with spaces (e.g. "ni hao" instead of "nihao"). The guard detects and strips spaces from these abandoned ASCII buffers, matching the same heuristic used in the composer's `composition-guard-plugin`.

## Files changed
- **New**: `src/components/terminal-ime.ts` — the IME guard implementation
- **New**: `src/components/terminal-ime.test.ts` — 17 test cases covering all three quirks plus lifecycle
- **Modified**: `src/components/terminal-output.tsx` — integrates the guard into terminal mount/unmount
- **New**: `.changeset/quiet-ime-keys.md` — patch-level changeset

## Test plan
- `bun run test:frontend` — the 17 new tests in `terminal-ime.test.ts` cover all quirk scenarios
- Manual testing with Chinese Pinyin, Japanese Romaji, and full-width punctuation in terminal sessions