### PR TITLE
fix(terminal): stop terminal spinners sticking after user interrupt or mid-turn quit

### DIFF
--- a/.changeset/calm-spinners-rest.md
+++ b/.changeset/calm-spinners-rest.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix the sidebar and session-tab spinners staying stuck after interrupting a terminal agent with Esc/Ctrl+C or quitting it mid-turn.

--- a/src-tauri/src/agents/streaming/active_streams.rs
+++ b/src-tauri/src/agents/streaming/active_streams.rs
@@ -106,6 +106,18 @@ impl ActiveStreams {
         }
     }
 
+    /// True iff a stream is registered for `session_id`. Busy guard for the
+    /// terminal interrupt inference (`crate::terminal::observe_stdin`).
+    pub(crate) fn is_session_active(&self, session_id: &str) -> bool {
+        self.inner
+            .lock()
+            .map(|map| {
+                map.values()
+                    .any(|h| h.helmor_session_id.as_deref() == Some(session_id))
+            })
+            .unwrap_or(false)
+    }
+
     fn snapshot(&self) -> Vec<ActiveStreamHandle> {
         self.inner
             .lock()
@@ -261,6 +273,18 @@ mod tests {
         // Anonymous streams never collide.
         assert!(streams.try_register_for_session(handle("r3", None)));
         assert!(streams.try_register_for_session(handle("r4", None)));
+    }
+
+    #[test]
+    fn is_session_active_tracks_registration() {
+        let streams = ActiveStreams::new();
+        assert!(!streams.is_session_active("s1"));
+
+        assert!(streams.set_session_active("s1", Some("ws-s1".into()), "terminal", true));
+        assert!(streams.is_session_active("s1"));
+
+        assert!(streams.set_session_active("s1", Some("ws-s1".into()), "terminal", false));
+        assert!(!streams.is_session_active("s1"));
     }
 
     #[test]

--- a/src-tauri/src/cli/terminal_hook.rs
+++ b/src-tauri/src/cli/terminal_hook.rs
@@ -77,13 +77,15 @@ pub fn run(agent: &str, _cli: &Cli) -> Result<()> {
 }
 
 /// Map a hook event to a busy/idle transition (None = not state-changing).
-/// Busy on prompt submit / tool use, idle on Stop. SessionStart is NOT busy —
-/// the agent fires it just by opening, which would spin the sidebar before any
-/// input (mirrors ORCA's hook state machine).
+/// Busy on prompt submit / tool use, idle on Stop or SessionEnd — Stop never
+/// fires on a user interrupt, so SessionEnd is the only hook left when the
+/// user quits claude mid-turn. SessionStart is NOT busy — the agent fires it
+/// just by opening, which would spin the sidebar before any input (mirrors
+/// ORCA's hook state machine).
 fn event_to_busy(payload: &serde_json::Value) -> Option<bool> {
     match payload.get("hook_event_name").and_then(|v| v.as_str()) {
         Some("UserPromptSubmit" | "PreToolUse" | "PostToolUse") => Some(true),
-        Some("Stop") => Some(false),
+        Some("Stop" | "SessionEnd") => Some(false),
         _ => None,
     }
 }
@@ -166,9 +168,11 @@ mod tests {
     }
 
     #[test]
-    fn stop_clears_busy() {
-        let p = json!({ "hook_event_name": "Stop" });
-        assert_eq!(event_to_busy(&p), Some(false));
+    fn stop_and_session_end_clear_busy() {
+        for name in ["Stop", "SessionEnd"] {
+            let p = json!({ "hook_event_name": name });
+            assert_eq!(event_to_busy(&p), Some(false), "{name}");
+        }
     }
 
     #[test]

--- a/src-tauri/src/commands/terminal_commands.rs
+++ b/src-tauri/src/commands/terminal_commands.rs
@@ -166,7 +166,11 @@ fn ensure_agent_hooks_file(
             "SessionStart": [{ "hooks": [{ "type": "command", "command": command }] }],
             "UserPromptSubmit": [{ "hooks": [{ "type": "command", "command": command }] }],
             "PreToolUse": [{ "hooks": [{ "type": "command", "command": command }] }],
-            "Stop": [{ "hooks": [{ "type": "command", "command": command }] }]
+            "Stop": [{ "hooks": [{ "type": "command", "command": command }] }],
+            // Stop does NOT fire on a user interrupt; SessionEnd is the only
+            // signal when the user quits claude mid-turn (the shell stays
+            // alive, so the PTY-exit fallback never sees it either).
+            "SessionEnd": [{ "hooks": [{ "type": "command", "command": command }] }]
         }
     });
     if fast_mode {
@@ -343,14 +347,26 @@ pub async fn stop_terminal(
 
 #[tauri::command]
 pub async fn write_terminal_stdin(
+    app: tauri::AppHandle,
     manager: State<'_, ScriptProcessManager>,
     repo_id: String,
     workspace_id: String,
     instance_id: String,
     data: String,
 ) -> CmdResult<bool> {
-    let key = (repo_id, make_script_type(&instance_id), Some(workspace_id));
-    Ok(manager.write_stdin(&key, data.as_bytes())?)
+    let key = (
+        repo_id,
+        make_script_type(&instance_id),
+        Some(workspace_id.clone()),
+    );
+    let written = manager.write_stdin(&key, data.as_bytes())?;
+    if written {
+        // instance_id == the helmor session id (it rides into the agent as
+        // HELMOR_TERMINAL_SESSION_ID); see terminal::observe_stdin for why
+        // interrupt inference hangs off this write path.
+        crate::terminal::observe_stdin(&app, &instance_id, &workspace_id, &data);
+    }
+    Ok(written)
 }
 
 #[tauri::command]
@@ -384,35 +400,12 @@ pub async fn convert_session_to_terminal(session_id: String, agent_type: String)
 #[tauri::command]
 pub async fn set_terminal_session_busy(
     app: tauri::AppHandle,
-    active_streams: State<'_, crate::agents::ActiveStreams>,
     session_id: String,
     workspace_id: String,
     provider: Option<String>,
     busy: bool,
 ) -> CmdResult<()> {
-    active_streams.set_session_active(
-        &session_id,
-        Some(workspace_id.clone()),
-        provider.as_deref().unwrap_or("terminal"),
-        busy,
-    );
-
-    let status = if busy { "streaming" } else { "idle" };
-    let sid = session_id.clone();
-    tauri::async_runtime::spawn_blocking(move || {
-        crate::models::sessions::set_session_status(&sid, status)
-    })
-    .await
-    .map_err(|e| anyhow::anyhow!("spawn_blocking join failed: {e}"))??;
-
-    crate::ui_sync::publish(&app, crate::ui_sync::UiMutationEvent::ActiveStreamsChanged);
-    // The session tab's spinner also reads sessions.status — refetch it now
-    // (interrupt/exit paths come through here, not through the hook's
-    // TerminalSessionIdle, so without this the tab lags the sidebar).
-    crate::ui_sync::publish(
-        &app,
-        crate::ui_sync::UiMutationEvent::SessionListChanged { workspace_id },
-    );
+    crate::terminal::set_busy(&app, &session_id, &workspace_id, provider.as_deref(), busy).await?;
     Ok(())
 }
 

--- a/src-tauri/src/companion/rpc.rs
+++ b/src-tauri/src/companion/rpc.rs
@@ -259,7 +259,6 @@ async fn dispatch(
         "set_terminal_session_busy" => {
             crate::commands::terminal_commands::set_terminal_session_busy(
                 app.clone(),
-                app.state::<crate::agents::ActiveStreams>(),
                 arg_string(&args, "sessionId")?,
                 arg_string(&args, "workspaceId")?,
                 arg_opt_string(&args, "provider"),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -29,6 +29,7 @@ pub mod sidecar;
 pub mod sidecar_host;
 pub mod slack;
 mod system_limits;
+pub mod terminal;
 pub mod triage;
 pub mod ui_sync;
 pub mod updater;

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -1,0 +1,150 @@
+//! Terminal-session busy state.
+//!
+//! `set_busy` mirrors a Terminal session's working/idle state into the shared
+//! active-stream registry (sidebar spinner) and `sessions.status` (tab
+//! spinner). The working state itself is hook-driven (`cli/terminal_hook.rs`),
+//! but hooks cannot signal the one transition this module infers instead: a
+//! user interrupt. Claude fires NO hook on Esc-abort (Stop is documented as
+//! "does not run on user interrupt"), so without `observe_stdin` an aborted
+//! turn would spin forever.
+
+use std::time::Duration;
+
+use tauri::{AppHandle, Manager, Runtime};
+
+const INTERRUPT_SETTLE: Duration = Duration::from_millis(500);
+
+/// Apply a busy/idle transition for a Terminal session: active-stream
+/// registry + `sessions.status` + the UI events both spinners listen to.
+pub async fn set_busy<R: Runtime>(
+    app: &AppHandle<R>,
+    session_id: &str,
+    workspace_id: &str,
+    provider: Option<&str>,
+    busy: bool,
+) -> anyhow::Result<()> {
+    app.state::<crate::agents::ActiveStreams>()
+        .set_session_active(
+            session_id,
+            Some(workspace_id.to_string()),
+            provider.unwrap_or("terminal"),
+            busy,
+        );
+
+    let status = if busy { "streaming" } else { "idle" };
+    let sid = session_id.to_string();
+    tauri::async_runtime::spawn_blocking(move || {
+        crate::models::sessions::set_session_status(&sid, status)
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("spawn_blocking join failed: {e}"))??;
+
+    crate::ui_sync::publish(app, crate::ui_sync::UiMutationEvent::ActiveStreamsChanged);
+    // The session tab's spinner also reads sessions.status — refetch it now
+    // (interrupt/exit paths come through here, not through the hook's
+    // TerminalSessionIdle, so without this the tab lags the sidebar).
+    crate::ui_sync::publish(
+        app,
+        crate::ui_sync::UiMutationEvent::SessionListChanged {
+            workspace_id: workspace_id.to_string(),
+        },
+    );
+    Ok(())
+}
+
+/// Infer a user interrupt from the bytes the renderer writes to the PTY:
+/// Esc/Ctrl+C on a busy session clears busy after a settle window unless a
+/// hook flipped it idle first.
+///
+/// Deliberately liberal — claude's Esc is overloaded (close menu / clear
+/// input / press-twice-to-interrupt) — because the failure modes are
+/// asymmetric: a false idle self-heals on the next PreToolUse/Stop hook,
+/// while a missed interrupt sticks the spinner until app restart. Lives
+/// backend-side so a misfire costs the renderer nothing; the old
+/// renderer-side heuristic was removed because each misfire's IPC +
+/// invalidation re-render could break an in-flight IME composition.
+pub fn observe_stdin<R: Runtime>(
+    app: &AppHandle<R>,
+    session_id: &str,
+    workspace_id: &str,
+    data: &str,
+) {
+    if !is_interrupt_keypress(data) {
+        return;
+    }
+    if !app
+        .state::<crate::agents::ActiveStreams>()
+        .is_session_active(session_id)
+    {
+        return;
+    }
+    let app = app.clone();
+    let session_id = session_id.to_string();
+    let workspace_id = workspace_id.to_string();
+    tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(INTERRUPT_SETTLE).await;
+        // Still busy after the settle → no Stop/SessionEnd hook claimed the
+        // turn; trust the keypress.
+        if !app
+            .state::<crate::agents::ActiveStreams>()
+            .is_session_active(&session_id)
+        {
+            return;
+        }
+        if let Err(error) = set_busy(&app, &session_id, &workspace_id, None, false).await {
+            tracing::warn!(%session_id, "interrupt inference failed to clear busy: {error}");
+        }
+    });
+}
+
+/// True iff `data` is a lone interrupt keypress. xterm.js delivers each
+/// keystroke as one onData chunk: plain Esc is exactly ESC (arrow keys arrive
+/// as full CSI sequences, bracketed paste wraps any pasted ESC) and Ctrl+C is
+/// ETX. The CSI-u forms are their kitty-keyboard-protocol encodings, in case
+/// a future xterm.js supports it.
+fn is_interrupt_keypress(data: &str) -> bool {
+    matches!(
+        data,
+        "\x1b" | "\x03" | "\x1b[27u" | "\x1b[27;1u" | "\x1b[99;5u"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn esc_and_ctrl_c_are_interrupt_keypresses() {
+        assert!(is_interrupt_keypress("\x1b"));
+        assert!(is_interrupt_keypress("\x03"));
+    }
+
+    #[test]
+    fn kitty_encodings_are_interrupt_keypresses() {
+        assert!(is_interrupt_keypress("\x1b[27u"));
+        assert!(is_interrupt_keypress("\x1b[27;1u"));
+        assert!(is_interrupt_keypress("\x1b[99;5u"));
+    }
+
+    #[test]
+    fn other_input_is_not_an_interrupt() {
+        // Printable text, arrow key, Alt+f, function key, bracketed paste
+        // containing a lone ESC — none are a plain Esc/Ctrl+C press.
+        for data in [
+            "a",
+            "hello",
+            "\x1b[A",
+            "\x1bf",
+            "\x1bOP",
+            "\r",
+            "\x1b[200~\x1b\x1b[201~",
+        ] {
+            assert!(!is_interrupt_keypress(data), "{data:?}");
+        }
+    }
+
+    #[test]
+    fn empty_input_is_not_an_interrupt() {
+        assert!(!is_interrupt_keypress(""));
+    }
+}

--- a/src/features/terminal/terminal-session-store.ts
+++ b/src/features/terminal/terminal-session-store.ts
@@ -243,13 +243,13 @@ export function detach(sessionId: string) {
 export function writeStdin(sessionId: string, data: string) {
 	const entry = instances.get(sessionId);
 	if (!entry) return;
-	// NOTE: no ESC-keypress interrupt heuristic here. claude's ESC is
-	// overloaded (close menu / clear input / press-twice-to-interrupt), so
-	// keystroke sniffing misfires — and each misfire kicked an IPC +
-	// session-list invalidation whose re-render could break an in-flight IME
-	// composition (typing went dead until a session switch). Interrupts are
-	// hook-driven like ORCA: a real interrupt fires Stop (is_interrupt=true),
-	// which terminal-hook already maps to idle.
+	// NOTE: no ESC-keypress interrupt heuristic here, and don't re-add one.
+	// claude fires NO hook on a user interrupt (Stop is documented as not
+	// running then), so interrupt inference IS needed — but it lives in the
+	// backend off this same write (terminal::observe_stdin in src-tauri). A
+	// renderer-side heuristic was removed because each misfire kicked an IPC
+	// + session-list invalidation whose re-render could break an in-flight
+	// IME composition (typing went dead until a session switch).
 	void writeTerminalStdin(entry.repoId, entry.workspaceId, sessionId, data);
 }
 


### PR DESCRIPTION
## What changed

Terminal agent spinners (sidebar + session tab) could stick indefinitely when the user interrupted a running agent (Esc/Ctrl+C) or quit it mid-turn. Two root causes:

1. **Claude never fires the Stop hook on user interrupt** — documented behavior. Without it, idle was never signaled.
2. **No SessionEnd listener** — when the user quit claude mid-turn, Stop also doesn't fire, leaving no hook after the final output.

## What this does

- **Adds SessionEnd hook registration** so idle is reliably cleared when the agent process exits.
- **Extracts busy/idle state management into terminal.rs** — a new dedicated module that centralizes active-stream registration, sessions.status update, and the two UI-sync events both spinners consume.
- **Implements backend-side interrupt inference** via observe_stdin — detects Esc/Ctrl+C on the PTY stdin write path, waits 500ms for a hook to claim the turn, and clears busy if still active. Lives backend-side so a misfire costs the renderer nothing (unlike the old renderer-side heuristic that could break IME composition).
- **Adds is_session_active() to ActiveStreams** as the busy guard for the inference.
- **Refactors set_terminal_session_busy and companion RPC** to delegate through terminal::set_busy.

## Test notes

- Manual: interrupt a busy terminal agent with Esc × 2, verify both spinners clear within ~500ms.
- Manual: quit claude mid-turn, verify spinners clear.
- Unit: is_session_active_tracks_registration, stop_and_session_end_clear_busy, is_interrupt_keypress coverage.
