### PR TITLE
fix(cursor): pass cwd when resuming Cursor agent to fix 'Agent not found'

### DIFF
--- a/.changeset/cursor-resume-agent-not-found.md
+++ b/.changeset/cursor-resume-agent-not-found.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix Cursor sessions failing with "Agent not found" when resumed after an app restart.

--- a/sidecar/src/cursor-worker/cursor-core.ts
+++ b/sidecar/src/cursor-worker/cursor-core.ts
@@ -148,7 +148,7 @@ export class CursorCore {
 			try {
 				const agent = await withCursorRetry("Agent.create", () =>
 					params.resume
-						? Agent.resume(params.resume, { apiKey })
+						? Agent.resume(params.resume, { apiKey, local: { cwd } })
 						: Agent.create({
 								apiKey,
 								model: { id: modelId },


### PR DESCRIPTION
## What changed

Pass `local: { cwd }` when calling `Agent.resume()` in the Cursor sidecar worker, matching the same option already passed to `Agent.create()`.

## Why

Without `cwd`, resumed Cursor sessions fail with an "Agent not found" error after an app restart. The agent needs to know its working directory to reattach to the correct session.

## Follow-up / test notes

- Manual testing: create a Cursor session, restart Helmor, verify the resumed session loads correctly.