### PR TITLE
fix: recursively sign nested Mach-O binaries in codex-resources to fix notarization

### DIFF
--- a/sidecar/scripts/stage-vendor.ts
+++ b/sidecar/scripts/stage-vendor.ts
@@ -508,20 +508,39 @@ function stageCodexFromVendorRoot(archRoot: string): void {
 		}
 	}
 
-	// Windows codex (layoutVersion 1) ships a `codex-resources/` dir
-	// (command-runner + sandbox helpers) that the flattened binary expects
-	// adjacent to itself. Copy it next to codex.exe.
+	// codex (layoutVersion 1) ships a `codex-resources/` dir that the flattened
+	// binary expects adjacent to itself. On macOS it nests a `zsh/bin/zsh`
+	// Mach-O; on Windows it carries command-runner + sandbox helpers. Copy it
+	// next to codex[.exe] and re-sign every nested Mach-O — notarization rejects
+	// any unsigned executable inside the bundle, even several dirs deep.
 	if (resourcesDir) {
 		const resSrc = join(archRoot, resourcesDir);
 		if (existsSync(resSrc)) {
 			const resDest = join(DIST_VENDOR, "codex", resourcesDir);
 			cpSync(resSrc, resDest, { recursive: true });
-			for (const entry of readdirSync(resDest)) {
-				const file = join(resDest, entry);
-				if (statSync(file).isFile()) {
-					chmodSync(file, 0o755);
-					maybeSignMacBinary(file, false);
-				}
+			signCodexResourcesTree(resDest);
+		}
+	}
+}
+
+// Walk `codex-resources/` recursively: make every file executable and re-sign
+// each Mach-O with our Developer ID + hardened runtime. The tree can nest
+// binaries (e.g. `zsh/bin/zsh`), so a flat top-level pass misses them and
+// notarization fails.
+function signCodexResourcesTree(root: string): void {
+	const stack = [root];
+	while (stack.length > 0) {
+		const cur = stack.pop();
+		if (!cur) continue;
+		for (const entry of readdirSync(cur)) {
+			const p = join(cur, entry);
+			const st = lstatSync(p);
+			if (st.isSymbolicLink()) continue;
+			if (st.isDirectory()) {
+				stack.push(p);
+			} else if (st.isFile()) {
+				chmodSync(p, 0o755);
+				if (isMachO(p)) maybeSignMacBinary(p, false);
 			}
 		}
 	}


### PR DESCRIPTION
## What changed

Refactored the codex-resources signing logic in `stage-vendor.ts` from a flat top-level pass to a recursive tree walker.

## Why

macOS codex (layoutVersion 1) now nests a `zsh/bin/zsh` Mach-O binary inside `codex-resources/`. The previous flat loop only signed files at the top level of that directory, missing nested binaries entirely. This caused notarization failures when publishing — Apple's notary service rejects any unsigned executable inside the app bundle, even several directories deep.

## What the fix does

- New `signCodexResourcesTree()` walks the entire `codex-resources/` directory tree
- Skips symlinks (via `lstatSync`)
- Signs every Mach-O file recursively with our Developer ID + hardened runtime
- All files in the tree get `chmod 755`

## Test notes

- Run a publish build and verify notarization succeeds
- Confirm `stage-vendor.ts` completes without errors on an Apple Silicon Mac