### PR TITLE
fix: session tab rename/close icons stay visible after focus click

### DIFF
--- a/.changeset/quick-tabs-settle.md
+++ b/.changeset/quick-tabs-settle.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix the session tab's rename and close icons staying visible after you click to select a tab and move the mouse away.

--- a/src/features/panel/header.tsx
+++ b/src/features/panel/header.tsx
@@ -668,7 +668,7 @@ export const WorkspacePanelHeader = memo(function WorkspacePanelHeader({
 															) : null}
 														</span>
 														{!isEditing ? (
-															<span className="pointer-events-none invisible absolute inset-y-0 right-0 flex items-center gap-0.5 pr-1 group-hover/tab:pointer-events-auto group-hover/tab:visible group-focus-within/tab:pointer-events-auto group-focus-within/tab:visible">
+															<span className="pointer-events-none invisible absolute inset-y-0 right-0 flex items-center gap-0.5 pr-1 group-hover/tab:pointer-events-auto group-hover/tab:visible">
 																<span
 																	role="button"
 																	aria-label="Rename session"


### PR DESCRIPTION
## What changed

Removed `group-focus-within/tab` visibility rules from the tab action buttons container in `src/features/panel/header.tsx`.

## Why

Previously, clicking a session tab to select it would programmatically focus the container element, which matched the `group-focus-within/tab:visible` Tailwind selector. This kept the rename and close action icons visible even after the mouse cursor left the tab — they'd persist until you clicked elsewhere to defocus.

Now the actions only appear on hover (`group-hover/tab:visible`), matching the expected UX.

## Test notes

- Click a session tab to select it, then move the mouse away — the rename/close icons should disappear.
- Hover a tab — icons should still appear normally.