### PR TITLE
feat(settings): global custom prompt prepended to every message

### DIFF
--- a/.changeset/global-custom-prompt.md
+++ b/.changeset/global-custom-prompt.md
@@ -1,0 +1,5 @@
+---
+"helmor": minor
+---
+
+Add a global custom prompt setting (Settings → General). When enabled, its text is silently prepended to every message you send to the agent — the agent receives it, but your chat bubble and saved history show only what you typed.

--- a/src/features/conversation/hooks/use-streaming.test.tsx
+++ b/src/features/conversation/hooks/use-streaming.test.tsx
@@ -1727,6 +1727,144 @@ describe("useConversationStreaming", () => {
 		expect(result.current.isSending).toBe(true);
 	});
 
+	it("prepends the global custom prompt via promptPrefix on a normal send", async () => {
+		apiMocks.startAgentMessageStream.mockImplementation(async () => {});
+
+		const { Wrapper } = createWrapper();
+		const { result } = renderHook(
+			() =>
+				useConversationStreaming({
+					composerContextKey: "session:session-1",
+					displayedSelectedModelId: MODEL.id,
+					displayedSessionId: "session-1",
+					displayedWorkspaceId: "workspace-1",
+					selectionPending: false,
+					followUpBehavior: "steer",
+					submitQueue: noopSubmitQueue,
+					activeStreams: NO_ACTIVE_STREAMS,
+					globalCustomPromptPrefix: "Always answer in concise bullet points.",
+				}),
+			{ wrapper: Wrapper },
+		);
+
+		await act(async () => {
+			await result.current.handleComposerSubmit({
+				prompt: "What changed in this diff?",
+				imagePaths: [],
+				filePaths: [],
+				customTags: [],
+				model: MODEL,
+				workingDirectory: "/tmp/helmor",
+				effortLevel: "medium",
+				permissionMode: "default",
+				fastMode: false,
+			});
+		});
+
+		expect(apiMocks.startAgentMessageStream).toHaveBeenCalledWith(
+			expect.objectContaining({
+				prompt: "What changed in this diff?",
+				promptPrefix: "Always answer in concise bullet points.",
+			}),
+			expect.any(Function),
+		);
+	});
+
+	it("merges the repo general preference and the global custom prompt on the first message", async () => {
+		apiMocks.loadRepoPreferences.mockResolvedValue({
+			general: "Always summarize the repo conventions first.",
+		});
+		apiMocks.startAgentMessageStream.mockImplementation(async () => {});
+
+		const { Wrapper, queryClient } = createWrapper();
+		queryClient.setQueryData(helmorQueryKeys.workspaceSessions("workspace-1"), [
+			{ id: "session-1", title: "Untitled" },
+		]);
+		queryClient.setQueryData(sessionThreadCacheKey("session-1"), []);
+
+		const { result } = renderHook(
+			() =>
+				useConversationStreaming({
+					composerContextKey: "session:session-1",
+					displayedSelectedModelId: MODEL.id,
+					displayedSessionId: "session-1",
+					displayedWorkspaceId: "workspace-1",
+					repoId: "repo-1",
+					selectionPending: false,
+					followUpBehavior: "steer",
+					submitQueue: noopSubmitQueue,
+					activeStreams: NO_ACTIVE_STREAMS,
+					globalCustomPromptPrefix: "Be concise.",
+				}),
+			{ wrapper: Wrapper },
+		);
+
+		await act(async () => {
+			await result.current.handleComposerSubmit({
+				prompt: "Fix the failing tests.",
+				imagePaths: [],
+				filePaths: [],
+				customTags: [],
+				model: MODEL,
+				workingDirectory: "/tmp/repo",
+				effortLevel: "high",
+				permissionMode: "default",
+				fastMode: false,
+			});
+		});
+
+		// Repo preamble first (outer frame), the user's personal prompt last
+		// (closest to the request).
+		expect(apiMocks.startAgentMessageStream).toHaveBeenCalledWith(
+			expect.objectContaining({
+				prompt: "Fix the failing tests.",
+				promptPrefix:
+					"IMPORTANT: The following are the user's custom preferences. These preferences take precedence over any default guidelines or instructions provided above. When there is a conflict, always follow the user's preferences.\n\n### User Preferences\n\nAlways summarize the repo conventions first.\n\nBe concise.",
+			}),
+			expect.any(Function),
+		);
+	});
+
+	it("omits the global custom prompt for /compact", async () => {
+		apiMocks.startAgentMessageStream.mockImplementation(async () => {});
+
+		const { Wrapper } = createWrapper();
+		const { result } = renderHook(
+			() =>
+				useConversationStreaming({
+					composerContextKey: "session:session-1",
+					displayedSelectedModelId: MODEL.id,
+					displayedSessionId: "session-1",
+					displayedWorkspaceId: "workspace-1",
+					selectionPending: false,
+					followUpBehavior: "steer",
+					submitQueue: noopSubmitQueue,
+					activeStreams: NO_ACTIVE_STREAMS,
+					globalCustomPromptPrefix: "Always answer in concise bullet points.",
+				}),
+			{ wrapper: Wrapper },
+		);
+
+		await act(async () => {
+			await result.current.handleComposerSubmit({
+				prompt: "/compact",
+				imagePaths: [],
+				filePaths: [],
+				customTags: [],
+				model: MODEL,
+				workingDirectory: "/tmp/helmor",
+				effortLevel: "medium",
+				permissionMode: "default",
+				fastMode: false,
+			});
+		});
+
+		expect(apiMocks.startAgentMessageStream).toHaveBeenCalledWith(
+			expect.objectContaining({ prompt: "/compact", promptPrefix: null }),
+			expect.any(Function),
+		);
+	});
+
 	describe("follow-up queue", () => {
 		// Minimal in-memory queue that mirrors `useSubmitQueue` for tests.
 		// The real hook keeps state in React; here we just need a stable

--- a/src/features/conversation/hooks/use-streaming.ts
+++ b/src/features/conversation/hooks/use-streaming.ts
@@ -131,6 +131,11 @@ type UseConversationStreamingArgs = {
 	 *  as a new turn once the agent finishes; `'steer'` injects into
 	 *  the active turn (provider-native mid-turn steer). */
 	followUpBehavior: FollowUpBehavior;
+	/** Resolved global custom prompt, prepended to every send as a hidden
+	 *  `promptPrefix` (wire-only). `null` when the user hasn't enabled one.
+	 *  Unlike the repo "general preference" (first message only), this
+	 *  applies on every turn. Skipped for `/compact`. */
+	globalCustomPromptPrefix?: string | null;
 	/** App-level queue handle (read + mutate). Shared across session /
 	 *  workspace switches so the queue survives navigation. */
 	submitQueue: SubmitQueueApi;
@@ -157,6 +162,7 @@ export function useConversationStreaming({
 	displayedSelectedModelId,
 	selectionPending,
 	followUpBehavior,
+	globalCustomPromptPrefix,
 	submitQueue,
 	activeStreams,
 	getSessionContextReferences,
@@ -835,12 +841,16 @@ export function useConversationStreaming({
 			const repoPreferences = targetRepoId
 				? await loadRepoPreferences(targetRepoId)
 				: null;
-			// The general-preference preamble is prepended ONLY on the wire
-			// to the agent (Rust side stitches it onto `prompt_prefix`).
-			// `trimmedPrompt` is what the user typed — that's what we
-			// optimistically render in the chat bubble and what the Rust
-			// side persists to `session_messages` as the user_prompt body.
-			const promptPrefix =
+			// The preamble is prepended ONLY on the wire to the agent (Rust
+			// side stitches it onto `prompt_prefix`). `trimmedPrompt` is what
+			// the user typed — that's what we optimistically render in the
+			// chat bubble and what the Rust side persists to
+			// `session_messages` as the user_prompt body. Two sources combine:
+			// the repo "general preference" (first message only) and the
+			// global custom prompt (every message). Both are skipped for
+			// `/compact`. Repo preamble goes first (outer frame), the user's
+			// personal prompt last (closest to the request).
+			const repoGeneralPrefix =
 				isFirstUserMessage && !isCompactCommand
 					? [
 							buildSessionContextPrompt(
@@ -856,6 +866,9 @@ export function useConversationStreaming({
 			// Computed against `trimmedPrompt`, which is byte-identical to what
 			// the Rust side persists as the user_prompt body.
 			const pastedTexts = locatePastedTextRanges(trimmedPrompt, customTags);
+			const globalPrefix = isCompactCommand ? null : globalCustomPromptPrefix;
+			const promptPrefix =
+				[repoGeneralPrefix, globalPrefix].filter(Boolean).join("\n\n") || null;
 			const now = new Date().toISOString();
 			const userMessageId = crypto.randomUUID();
 			const optimisticUserMessage = createLiveThreadMessage({
@@ -1092,6 +1105,7 @@ export function useConversationStreaming({
 			activeStreams,
 			planReviewByContext,
 			followUpBehavior,
+			globalCustomPromptPrefix,
 			storeActions,
 			streamingStore,
 			submitQueue,

--- a/src/features/conversation/index.tsx
+++ b/src/features/conversation/index.tsx
@@ -409,6 +409,10 @@ export const WorkspaceConversationContainer = memo(
 			repoId,
 			selectionPending,
 			followUpBehavior: settings.followUpBehavior,
+			globalCustomPromptPrefix:
+				settings.customPromptEnabled && settings.customPrompt.trim()
+					? settings.customPrompt.trim()
+					: null,
 			submitQueue: submitQueueApi,
 			activeStreams,
 			getSessionContextReferences,
@@ -768,7 +772,9 @@ export const WorkspaceConversationContainer = memo(
 
 				<div
 					className={cn(
-						composerOnly ? "w-full" : "mt-auto px-4 pb-4 pt-0",
+						composerOnly
+							? "w-full"
+							: "mt-auto max-h-[70vh] shrink-0 overflow-y-auto px-4 pb-4 pt-0",
 						composerWrapperClassName,
 						isTerminalSession && "hidden",
 					)}

--- a/src/features/settings/index.tsx
+++ b/src/features/settings/index.tsx
@@ -69,6 +69,7 @@ import { AppearancePanel } from "./panels/appearance";
 import { ArchiveCleanupPanel } from "./panels/archive-cleanup";
 import { ComponentsPanel } from "./panels/components";
 import { ConductorImportPanel } from "./panels/conductor-import";
+import { CustomPromptSetting } from "./panels/custom-prompt";
 import { DevToolsPanel } from "./panels/dev-tools";
 import { InboxSettingsPanel } from "./panels/inbox";
 import { LocalLlmPanel } from "./panels/local-llm";
@@ -514,6 +515,7 @@ export const SettingsDialog = memo(function SettingsDialog({
 											</ToggleGroupItem>
 										</ToggleGroup>
 									</SettingsRow>
+									<CustomPromptSetting />
 									<ArchiveCleanupPanel />
 									<AppUpdatesPanel />
 									<ComponentsPanel />

--- a/src/features/settings/panels/custom-prompt.test.tsx
+++ b/src/features/settings/panels/custom-prompt.test.tsx
@@ -1,0 +1,55 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	type AppSettings,
+	DEFAULT_SETTINGS,
+	SettingsContext,
+} from "@/lib/settings";
+import { CustomPromptSetting } from "./custom-prompt";
+
+afterEach(cleanup);
+
+function renderWith(overrides: Partial<AppSettings>, updateSettings = vi.fn()) {
+	const settings: AppSettings = { ...DEFAULT_SETTINGS, ...overrides };
+	render(
+		<SettingsContext.Provider
+			value={{ settings, isLoaded: true, updateSettings }}
+		>
+			<CustomPromptSetting />
+		</SettingsContext.Provider>,
+	);
+	return { updateSettings };
+}
+
+describe("CustomPromptSetting", () => {
+	it("hides the textarea when the toggle is off", () => {
+		renderWith({ customPromptEnabled: false });
+		expect(screen.queryByRole("textbox")).toBeNull();
+	});
+
+	it("shows the textarea with the saved prompt when enabled", () => {
+		renderWith({ customPromptEnabled: true, customPrompt: "Be terse." });
+		expect(screen.getByRole("textbox")).toHaveValue("Be terse.");
+	});
+
+	it("enables the setting when the switch is turned on", () => {
+		const { updateSettings } = renderWith({ customPromptEnabled: false });
+		fireEvent.click(screen.getByRole("switch"));
+		expect(updateSettings).toHaveBeenCalledWith({ customPromptEnabled: true });
+	});
+
+	it("persists the edited prompt on blur", () => {
+		const { updateSettings } = renderWith({
+			customPromptEnabled: true,
+			customPrompt: "",
+		});
+		const textarea = screen.getByRole("textbox");
+		fireEvent.change(textarea, { target: { value: "Always use TypeScript." } });
+		// No write while typing.
+		expect(updateSettings).not.toHaveBeenCalled();
+		fireEvent.blur(textarea);
+		expect(updateSettings).toHaveBeenCalledWith({
+			customPrompt: "Always use TypeScript.",
+		});
+	});
+});

--- a/src/features/settings/panels/custom-prompt.tsx
+++ b/src/features/settings/panels/custom-prompt.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from "react";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import { useSettings } from "@/lib/settings";
+import { SettingsRow } from "../components/settings-row";
+
+// Global custom prompt: a fixed instruction prepended to every message the
+// user sends (wire-only — see `globalCustomPromptPrefix` in use-streaming).
+// The textarea keeps a local draft and persists on blur so we don't write
+// to SQLite on every keystroke.
+export function CustomPromptSetting() {
+	const { settings, updateSettings } = useSettings();
+	const [draft, setDraft] = useState(settings.customPrompt);
+
+	// Re-sync the draft if the persisted value changes from elsewhere
+	// (e.g. settings reload). Edits-in-progress are only clobbered when the
+	// stored value actually differs, which is the intended "external change
+	// wins" behaviour.
+	useEffect(() => {
+		setDraft(settings.customPrompt);
+	}, [settings.customPrompt]);
+
+	const commitDraft = () => {
+		if (draft !== settings.customPrompt) {
+			void updateSettings({ customPrompt: draft });
+		}
+	};
+
+	return (
+		<>
+			<SettingsRow
+				title="Custom prompt"
+				description="Prepend a fixed instruction to every message you send to the agent. It's sent to the agent but not shown in your chat."
+			>
+				<Switch
+					checked={settings.customPromptEnabled}
+					onCheckedChange={(checked) =>
+						updateSettings({ customPromptEnabled: checked })
+					}
+					aria-label="Enable custom prompt"
+				/>
+			</SettingsRow>
+			{settings.customPromptEnabled ? (
+				<Textarea
+					className="min-h-[120px] resize-y bg-app-base/30 font-mono text-small placeholder:text-small"
+					placeholder="e.g. Always respond in concise bullet points. Prefer TypeScript examples."
+					value={draft}
+					onChange={(event) => setDraft(event.target.value)}
+					onBlur={commitDraft}
+					aria-label="Custom prompt text"
+				/>
+			) : null}
+		</>
+	);
+}

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -375,6 +375,38 @@ describe("settings", () => {
 		);
 	});
 
+	it("hydrates and saves the global custom prompt and its toggle", async () => {
+		invokeMock.mockResolvedValue({
+			"app.custom_prompt": "Always answer in bullet points.",
+			"app.custom_prompt_enabled": "true",
+		});
+
+		const settings = await loadSettings();
+		expect(settings.customPrompt).toBe("Always answer in bullet points.");
+		expect(settings.customPromptEnabled).toBe(true);
+
+		invokeMock.mockResolvedValue({});
+		const defaulted = await loadSettings();
+		expect(defaulted.customPrompt).toBe("");
+		expect(defaulted.customPromptEnabled).toBe(false);
+
+		invokeMock.mockResolvedValue(undefined);
+		await saveSettings({
+			customPrompt: "Be concise.",
+			customPromptEnabled: true,
+		});
+
+		expect(invokeMock).toHaveBeenLastCalledWith(
+			"update_app_settings",
+			expect.objectContaining({
+				settingsMap: expect.objectContaining({
+					"app.custom_prompt": "Be concise.",
+					"app.custom_prompt_enabled": "true",
+				}),
+			}),
+		);
+	});
+
 	it("keeps default as a valid model id", async () => {
 		invokeMock.mockResolvedValue({
 			"app.default_model_id": "gpt-5.5",

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -308,6 +308,11 @@ export type AppSettings = {
 	/** How Claude Code returns thinking content. Plumbed through to the
 	 *  sidecar's `thinking.display` field. */
 	claudeThinkingDisplay: ClaudeThinkingDisplay;
+	/** Free-text prompt silently prepended to every message the user sends
+	 *  (wire-only, via `prompt_prefix`). Gated by `customPromptEnabled`. */
+	customPrompt: string;
+	/** Master toggle for `customPrompt`. */
+	customPromptEnabled: boolean;
 	/** Force the context-usage ring to always be visible. When false (the
 	 *  default), the ring auto-hides until usage crosses
 	 *  `CONTEXT_USAGE_AUTO_REVEAL_THRESHOLD`. */
@@ -409,6 +414,8 @@ export const DEFAULT_SETTINGS: AppSettings = {
 	zoomLevel: 1.0,
 	followUpBehavior: "steer",
 	claudeThinkingDisplay: "summarized",
+	customPrompt: "",
+	customPromptEnabled: false,
 	alwaysShowContextUsage: true,
 	showUsageStats: true,
 	autoArchiveOnMerge: false,
@@ -588,6 +595,8 @@ const SETTINGS_KEY_MAP: Record<
 	zoomLevel: "app.zoom_level",
 	followUpBehavior: "app.follow_up_behavior",
 	claudeThinkingDisplay: "app.claude_thinking_display",
+	customPrompt: "app.custom_prompt",
+	customPromptEnabled: "app.custom_prompt_enabled",
 	alwaysShowContextUsage: "app.always_show_context_usage",
 	showUsageStats: "app.show_usage_stats",
 	autoArchiveOnMerge: "app.auto_archive_on_merge",
@@ -1297,6 +1306,12 @@ export async function loadSettings(): Promise<AppSettings> {
 					? v
 					: DEFAULT_SETTINGS.claudeThinkingDisplay;
 			})(),
+			customPrompt:
+				raw[SETTINGS_KEY_MAP.customPrompt] ?? DEFAULT_SETTINGS.customPrompt,
+			customPromptEnabled:
+				raw[SETTINGS_KEY_MAP.customPromptEnabled] !== undefined
+					? raw[SETTINGS_KEY_MAP.customPromptEnabled] === "true"
+					: DEFAULT_SETTINGS.customPromptEnabled,
 			alwaysShowContextUsage:
 				raw[SETTINGS_KEY_MAP.alwaysShowContextUsage] !== undefined
 					? raw[SETTINGS_KEY_MAP.alwaysShowContextUsage] === "true"


### PR DESCRIPTION
## What

Adds a global **Custom prompt** setting under **Settings → General**: a toggle plus a text area. When enabled, the text is silently prepended to every message the user sends to any agent — the agent receives it, but the chat bubble and persisted history show only what the user typed.

## Why

Users frequently want a standing instruction applied to every turn (tone, output format, language, house style) without retyping it or polluting the visible conversation. The existing per-repo "general preferences" only applies to the *first* message of a chat; this is a global, every-message equivalent.

## How

It reuses the existing invisible `promptPrefix` wire mechanism (the same channel the per-repo general preferences use), so **no backend changes are required** — the Rust side already stitches the prefix onto the wire and persists only the user's text.

- `lib/settings.ts`: new `customPrompt` / `customPromptEnabled` fields, persisted as `app.custom_prompt` / `app.custom_prompt_enabled`.
- `features/settings/panels/custom-prompt.tsx`: toggle + text area (local draft, persists on blur to avoid a SQLite write per keystroke).
- `features/conversation/hooks/use-streaming.ts`: resolves the global prefix and merges it with the first-message repo general-preference prefix (repo preamble first, the user's personal prompt closest to the request). Skipped for `/compact`.

## Testing

- New unit tests for the settings round-trip, the send-path merge (applied on every send, merged with the repo preference, omitted for `/compact`), and the settings panel component.
- `tsc --noEmit` clean; full custom-prompt + streaming suites green (63 tests).