### PR TITLE
feat: allow GUI-to-TUI session conversion with history, resume in terminal

### DIFF
--- a/.announcements/terminal-resume-conversation.json
+++ b/.announcements/terminal-resume-conversation.json
@@ -1,0 +1,7 @@
+{
+	"items": [
+		{
+			"text": "Switching a conversation to the terminal now picks up where you left off — it resumes the same Claude or Codex session in the TUI instead of starting fresh."
+		}
+	]
+}

--- a/.changeset/gui-to-tui-resume.md
+++ b/.changeset/gui-to-tui-resume.md
@@ -1,0 +1,5 @@
+---
+"helmor": minor
+---
+
+Switching a conversation with history to the terminal now resumes that same Claude or Codex session in the TUI, instead of starting a fresh terminal session.

--- a/src-tauri/src/models/sessions.rs
+++ b/src-tauri/src/models/sessions.rs
@@ -311,12 +311,11 @@ pub fn workspace_id_for_session(session_id: &str) -> Result<Option<String>> {
     Ok(workspace_id)
 }
 
-/// Convert a freshly-prepared GUI session into a Terminal session in place.
-/// Used by the start-surface terminal flow: the workspace-create pipeline
-/// mints a GUI session, and converting it (before it's ever used) avoids a
-/// throwaway placeholder. The message-less invariant is enforced by the
-/// UPDATE itself — a session with history (or an unknown id) errors instead
-/// of silently rewriting kind/agent/title.
+/// Convert a GUI session into a Terminal session in place. Works whether or
+/// not the session has history: an empty session boots fresh, a populated
+/// claude/codex session resumes by its `provider_session_id` in the TUI so the
+/// same conversation continues. One-way — there is no terminal→GUI path. Only
+/// an unknown id errors (no row updated).
 pub fn convert_session_to_terminal(session_id: &str, agent_type: &str) -> Result<()> {
     let connection = db::write_conn()?;
     // Leave `title` untouched ("Untitled" from prepare) so the prompt-captured
@@ -324,16 +323,12 @@ pub fn convert_session_to_terminal(session_id: &str, agent_type: &str) -> Result
     // overwrites "Untitled", so hardcoding "Terminal" here would freeze it.
     let rows = connection
         .execute(
-            "UPDATE sessions SET session_kind = 'terminal', agent_type = ?2 \
-             WHERE id = ?1 \
-               AND NOT EXISTS (SELECT 1 FROM session_messages WHERE session_id = ?1)",
+            "UPDATE sessions SET session_kind = 'terminal', agent_type = ?2 WHERE id = ?1",
             rusqlite::params![session_id, agent_type],
         )
         .with_context(|| format!("Failed to convert session {session_id} to terminal"))?;
     if rows != 1 {
-        anyhow::bail!(
-            "Refusing to convert session {session_id} to terminal: not found or it already has messages"
-        );
+        anyhow::bail!("Refusing to convert session {session_id} to terminal: not found");
     }
     Ok(())
 }
@@ -1397,7 +1392,7 @@ mod tests {
     }
 
     #[test]
-    fn convert_session_to_terminal_enforces_message_less_invariant() {
+    fn convert_session_to_terminal_converts_in_place() {
         // convert_session_to_terminal opens the app DB itself, so the test
         // must redirect the data dir before touching it.
         let _env = crate::testkit::TestEnv::new("convert-terminal");
@@ -1425,7 +1420,8 @@ mod tests {
             assert_eq!(title, "Test Session");
         }
 
-        // A session with history must be refused, untouched.
+        // A session WITH history also converts in place (it resumes by its
+        // provider_session_id in the TUI), and the agent_type is rewritten.
         {
             let conn = db::write_conn().unwrap();
             conn.execute(
@@ -1435,7 +1431,7 @@ mod tests {
             )
             .unwrap();
         }
-        assert!(convert_session_to_terminal("s1", "codex").is_err());
+        convert_session_to_terminal("s1", "codex").unwrap();
         {
             let conn = db::read_conn().unwrap();
             let agent_after: String = conn
@@ -1443,7 +1439,7 @@ mod tests {
                     r.get(0)
                 })
                 .unwrap();
-            assert_eq!(agent_after, "claude", "refused convert must not rewrite");
+            assert_eq!(agent_after, "codex", "populated session converts in place");
         }
 
         // Unknown ids error instead of silently no-opping.

--- a/src/features/terminal/terminal-presets.test.ts
+++ b/src/features/terminal/terminal-presets.test.ts
@@ -116,6 +116,23 @@ describe("terminal agent specs", () => {
 		expect(resumeBootCommand("gemini", "id")).toBeNull();
 	});
 
+	it("resume carries the composer prompt as the resumed turn's input", () => {
+		expect(
+			resumeBootCommand("claude", "abc-123", { prompt: "keep going" }),
+		).toBe(
+			"claude --resume 'abc-123' --dangerously-skip-permissions 'keep going'\n",
+		);
+		expect(
+			resumeBootCommand("codex", "abc-123", { prompt: "keep going" }),
+		).toBe(
+			`codex resume 'abc-123' -c model_reasoning_effort="high" --ask-for-approval never --sandbox danger-full-access 'keep going'\n`,
+		);
+		// Blank prompt → no trailing positional (bare resume).
+		expect(resumeBootCommand("claude", "abc-123", { prompt: "  " })).toBe(
+			"claude --resume 'abc-123' --dangerously-skip-permissions\n",
+		);
+	});
+
 	it("preset fallback launches the bare CLI", () => {
 		expect(presetBootCommand("claude")).toBe(
 			"claude --dangerously-skip-permissions\n",

--- a/src/features/terminal/terminal-presets.ts
+++ b/src/features/terminal/terminal-presets.ts
@@ -32,10 +32,11 @@ export type TerminalAgentSpec = {
 	 *  begins the turn immediately). */
 	boot(opts: TerminalBootOptions): string;
 	/** Resume a prior conversation by the agent's own session id;
-	 *  null = the CLI has no resume. */
+	 *  null = the CLI has no resume. `prompt`, when set, rides along as the
+	 *  resumed turn's initial input (composer convert-in-place → TUI). */
 	resume(
 		providerSessionId: string,
-		opts?: { addDirs?: readonly string[] | null },
+		opts?: { addDirs?: readonly string[] | null; prompt?: string | null },
 	): string | null;
 };
 
@@ -105,6 +106,9 @@ const CLAUDE_SPEC: TerminalAgentSpec = {
 			"--dangerously-skip-permissions",
 			...claudeAddDirFlags(opts?.addDirs),
 		];
+		// `claude [options] [prompt]` — a trailing positional prompt runs as the
+		// first turn of the resumed conversation.
+		if (opts?.prompt?.trim()) parts.push(shellQuotePrompt(opts.prompt));
 		return parts.join(" ");
 	},
 };
@@ -138,8 +142,13 @@ const CODEX_SPEC: TerminalAgentSpec = {
 		parts.push(shellQuotePrompt(opts.prompt));
 		return parts.join(" ");
 	},
-	resume(id) {
-		return `codex resume ${shellQuote(id)} -c model_reasoning_effort="high" --ask-for-approval never --sandbox danger-full-access`;
+	resume(id, opts) {
+		// `codex resume [OPTIONS] [SESSION_ID] [PROMPT]` — the trailing prompt
+		// starts the resumed session with the composer's input.
+		const base = `codex resume ${shellQuote(id)} -c model_reasoning_effort="high" --ask-for-approval never --sandbox danger-full-access`;
+		return opts?.prompt?.trim()
+			? `${base} ${shellQuotePrompt(opts.prompt)}`
+			: base;
 	},
 };
 
@@ -180,7 +189,7 @@ export function buildTerminalBootCommand(
 export function resumeBootCommand(
 	key: string | null | undefined,
 	sessionId: string,
-	opts?: { addDirs?: readonly string[] | null },
+	opts?: { addDirs?: readonly string[] | null; prompt?: string | null },
 ): string | null {
 	const invocation = findTerminalAgent(key)?.resume(sessionId, opts);
 	return invocation ? `${invocation}\n` : null;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -4398,8 +4398,9 @@ export async function deleteSession(sessionId: string): Promise<void> {
 	await invoke("delete_session", { sessionId });
 }
 
-/** Convert a freshly-prepared (message-less) GUI session into a Terminal
- * session in place — the start-surface terminal flow's no-placeholder path. */
+/** Convert a GUI session into a Terminal session in place (one-way). Works on
+ * empty and populated sessions alike — a session that already ran a turn resumes
+ * by its provider session id in the TUI so the same conversation continues. */
 export async function convertSessionToTerminal(
 	sessionId: string,
 	agentType: string,

--- a/src/shell/event-bus.ts
+++ b/src/shell/event-bus.ts
@@ -50,8 +50,9 @@ export type ShellEvent =
 			fastMode: boolean;
 			/** Explicit target; null = the currently selected workspace. */
 			workspaceId: string | null;
-			/** The composer's current session — converted in place when it has no
-			 *  messages yet, instead of creating a new terminal session. */
+			/** The composer's current session — always converted in place (one-way);
+			 *  a session that already ran a turn resumes its conversation in the TUI.
+			 *  null only when there is no current session to convert. */
 			sessionId: string | null;
 	  };
 

--- a/src/shell/hooks/use-session-actions.ts
+++ b/src/shell/hooks/use-session-actions.ts
@@ -6,7 +6,10 @@ import {
 } from "@/features/conversation/hooks/seed-session-title";
 import { seedNewSessionInCache } from "@/features/panel/session-cache";
 import type { SessionCloseRequest } from "@/features/panel/use-confirm-session-close";
-import { buildTerminalBootCommand } from "@/features/terminal/terminal-presets";
+import {
+	buildTerminalBootCommand,
+	resumeBootCommand,
+} from "@/features/terminal/terminal-presets";
 import { setPendingBoot } from "@/features/terminal/terminal-session-store";
 import {
 	closeMainWindow,
@@ -196,10 +199,13 @@ export function useSessionActions({
 		[handleSelectSession, pushWorkspaceToast, queryClient, selectionActions],
 	);
 
-	// Composer Terminal-Mode submit → terminal session booting the provider's
-	// TUI with the prompt + composer state as the initial invocation.
+	// Composer Terminal-Mode submit → convert the composer's CURRENT session into
+	// a Terminal session IN PLACE (one-way) and boot the provider's TUI. A
+	// session that already ran a turn resumes by its provider session id so the
+	// same conversation continues (the typed prompt rides along as the resumed
+	// turn); an empty one boots fresh with the prompt.
 	useShellEvent("create-terminal-session", (event) => {
-		const boot = buildTerminalBootCommand(event.provider, event);
+		const freshBoot = buildTerminalBootCommand(event.provider, event);
 
 		// Layer 1 of the two-layer title (same as GUI): provisional title from
 		// the prompt now; the agent hook drives the AI rename later.
@@ -212,14 +218,16 @@ export function useSessionActions({
 			});
 		};
 
+		// Fallback only: no current session to convert (cache miss / no id) →
+		// mint a fresh terminal session and boot it with the prompt.
 		const createNew = () => {
 			void handleCreateSession(
 				"terminal",
 				event.provider,
 				(sessionId) => {
-					if (boot) {
+					if (freshBoot) {
 						setPendingBoot(sessionId, {
-							bootCommand: boot,
+							bootCommand: freshBoot,
 							fastMode: event.fastMode,
 						});
 					}
@@ -229,9 +237,6 @@ export function useSessionActions({
 			);
 		};
 
-		// A brand-new (message-less) current session converts in place — no point
-		// stranding an empty Untitled session next to the terminal. Anything with
-		// history gets a fresh terminal session alongside it.
 		const sessions =
 			event.sessionId && event.workspaceId
 				? (queryClient.getQueryData<WorkspaceSessionSummary[]>(
@@ -241,22 +246,28 @@ export function useSessionActions({
 		const currentSession =
 			sessions.find((session) => session.id === event.sessionId) ?? null;
 
-		if (
-			!event.sessionId ||
-			!event.workspaceId ||
-			!isNewSession(currentSession)
-		) {
+		if (!event.sessionId || !event.workspaceId || !currentSession) {
 			createNew();
 			return;
 		}
 
 		const sessionId = event.sessionId;
 		const workspaceId = event.workspaceId;
+		// Resume continues the prior conversation; the typed prompt becomes the
+		// resumed turn's input. No provider id (turn never completed) → fresh boot.
+		const providerSessionId = currentSession.providerSessionId ?? null;
+		const boot = providerSessionId
+			? resumeBootCommand(event.provider, providerSessionId, {
+					addDirs: event.addDirs,
+					prompt: event.prompt,
+				})
+			: freshBoot;
+
 		void (async () => {
 			try {
 				await convertSessionToTerminal(sessionId, event.provider);
 			} catch (error) {
-				// Lost the message-less race / convert refused — fall back to new.
+				// Convert refused (unknown id race) — fall back to a new session.
 				console.warn(
 					"[terminal] in-place convert failed; creating new:",
 					error,


### PR DESCRIPTION
## What changed

Removed the message-less invariant from `convert_session_to_terminal`. Previously, only brand-new (no messages) GUI sessions could be converted to Terminal sessions — sessions with history required creating a fresh terminal session alongside. Now **any** GUI session converts in-place to a Terminal session.

## Why

When a user switches a conversation they're mid-flow in from the GUI composer to the Terminal, they expect to pick up where they left off — not start over. This change makes the TUI **resume** the same Claude or Codex session via its `provider_session_id`, with the composer's prompt riding along as the resumed turn's initial input.

## Details

- **Rust**: Remove `NOT EXISTS (SELECT 1 FROM session_messages)` guard from the UPDATE query in `convert_session_to_terminal`. The function now works on both empty and populated sessions.
- **Frontend**: `resumeBootCommand` now accepts an optional `prompt` that appends the composer's input as the resumed turn. `use-session-actions` detects whether the current session has a `providerSessionId` — if yes, it builds a resume command; if no, it falls back to a fresh boot.
- **Tests**: Updated Rust unit test to verify that populated sessions convert in-place with the agent type rewritten. Added frontend tests for resume-with-prompt boot commands.

## Test notes

- `cargo test --tests` passes (including updated `convert_session_to_terminal_converts_in_place` test)
- `bun run test:frontend` passes (including new resume prompt tests)
- Biome + clippy + fmt all pass (pre-commit hook)