### PR TITLE
fix(cursor): recover wedged Cursor agents and survive transient auth/network errors

### DIFF
--- a/.changeset/tame-cursors-recover.md
+++ b/.changeset/tame-cursors-recover.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix Cursor agents getting stuck after a transient authentication or network error, so a single blip no longer stops every running Cursor session and wedged chats recover on the next message.

--- a/sidecar/src/cursor-worker/cursor-core.ts
+++ b/sidecar/src/cursor-worker/cursor-core.ts
@@ -32,6 +32,7 @@ import {
 	buildCursorMessage,
 	computeModelParameterValues,
 	extractCreatePlanText,
+	isAgentBusyError,
 	isRetryableCursorError,
 	modelInfoToProviderInfo,
 	namespaceEvent,
@@ -203,28 +204,57 @@ export class CursorCore {
 		const { text, imagePaths } = parseImageRefs(params.prompt, params.images);
 		const message = await buildCursorMessage(text, imagePaths);
 		const activeSession = session;
+		// `local.force` expires a wedged active run (left non-terminal in the
+		// cwd-scoped store by a worker that died mid-turn) before starting this
+		// one. Only set on the recovery retry — never force-expire a run that's
+		// legitimately in flight.
+		const sendOptions = (force: boolean) => ({
+			// Pass mode every turn — Cursor sticks with the create-time mode
+			// otherwise, so toggling Plan on/off mid-conversation (incl.
+			// "Implement" → back to agent) wouldn't take effect.
+			mode: toCursorMode(params.permissionMode),
+			model: {
+				id: modelId,
+				...(modelParams.length > 0 ? { params: modelParams } : {}),
+			},
+			...(force ? { local: { force: true } } : {}),
+		});
 		let run: Run;
 		try {
 			run = await withCursorRetry("agent.send", () =>
-				activeSession.agent.send(message, {
-					// Pass mode every turn — Cursor sticks with the create-time
-					// mode otherwise, so toggling Plan on/off mid-conversation
-					// (incl. "Implement" → back to agent) wouldn't take effect.
-					mode: toCursorMode(params.permissionMode),
-					model: {
-						id: modelId,
-						...(modelParams.length > 0 ? { params: modelParams } : {}),
-					},
-				}),
+				activeSession.agent.send(message, sendOptions(false)),
 			);
 		} catch (error) {
-			const msg = error instanceof Error ? error.message : String(error);
-			logger.error(`[${requestId}] Cursor agent.send failed: ${msg}`, {
-				...errorDetails(error),
-			});
-			emitter.error(requestId, `Cursor: ${msg}`);
-			emitter.end(requestId);
-			return;
+			// A run wedged in the local store ("already has active run") blocks
+			// every follow-up send and survives app restarts. Retry once with
+			// `local.force` — the SDK's recovery path for agents left wedged by a
+			// crashed CLI/worker process — before surfacing a hard failure.
+			if (!isAgentBusyError(error)) {
+				const msg = error instanceof Error ? error.message : String(error);
+				logger.error(`[${requestId}] Cursor agent.send failed: ${msg}`, {
+					...errorDetails(error),
+				});
+				emitter.error(requestId, `Cursor: ${msg}`);
+				emitter.end(requestId);
+				return;
+			}
+			logger.info(
+				`[${requestId}] Cursor agent has a wedged active run; retrying agent.send with local.force`,
+			);
+			try {
+				run = await withCursorRetry("agent.send(force)", () =>
+					activeSession.agent.send(message, sendOptions(true)),
+				);
+			} catch (retryError) {
+				const msg =
+					retryError instanceof Error ? retryError.message : String(retryError);
+				logger.error(`[${requestId}] Cursor agent.send(force) failed: ${msg}`, {
+					...errorDetails(retryError),
+				});
+				emitter.error(requestId, `Cursor: ${msg}`);
+				emitter.end(requestId);
+				return;
+			}
 		}
 		session.currentRun = run;
 		session.currentRequestId = requestId;

--- a/sidecar/src/cursor-worker/cursor-helpers.test.ts
+++ b/sidecar/src/cursor-worker/cursor-helpers.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import { isAgentBusyError, isAuthError } from "./cursor-helpers.js";
+
+describe("isAgentBusyError", () => {
+	test("matches the local store's plain 'already has active run' Error", () => {
+		const err = new Error(
+			"Agent agent-3adca04b-04a5-4491-baf5-1bf9914e1629 already has active run",
+		);
+		expect(isAgentBusyError(err)).toBe(true);
+	});
+
+	test("matches the 'already has an active run' wording too", () => {
+		expect(
+			isAgentBusyError(new Error("Agent x already has an active run")),
+		).toBe(true);
+	});
+
+	test("matches by AgentBusyError class/errorName", () => {
+		expect(isAgentBusyError({ name: "AgentBusyError" })).toBe(true);
+		expect(isAgentBusyError({ errorName: "AgentBusyError" })).toBe(true);
+	});
+
+	test("walks the cause chain", () => {
+		const wrapped = new Error("send failed");
+		(wrapped as { cause?: unknown }).cause = new Error(
+			"Agent y already has active run",
+		);
+		expect(isAgentBusyError(wrapped)).toBe(true);
+	});
+
+	test("does not match unrelated errors", () => {
+		expect(isAgentBusyError(new Error("ECONNRESET"))).toBe(false);
+		expect(isAgentBusyError(new Error("[unauthenticated] Error"))).toBe(false);
+		expect(isAgentBusyError(null)).toBe(false);
+		expect(isAgentBusyError(undefined)).toBe(false);
+	});
+});
+
+describe("isAuthError", () => {
+	test("matches a raw ConnectError [unauthenticated] message", () => {
+		expect(isAuthError(new Error("[unauthenticated] Error"))).toBe(true);
+	});
+
+	test("matches by ConnectError code", () => {
+		expect(isAuthError({ code: "unauthenticated", message: "Error" })).toBe(
+			true,
+		);
+		expect(isAuthError({ code: "permission_denied" })).toBe(true);
+	});
+
+	test("matches the wrapped AuthenticationError class", () => {
+		expect(isAuthError({ name: "AuthenticationError" })).toBe(true);
+		expect(isAuthError({ errorName: "AuthenticationError" })).toBe(true);
+	});
+
+	test("matches 'invalid api key' text", () => {
+		expect(
+			isAuthError(new Error("Invalid API key. Please check your key.")),
+		).toBe(true);
+	});
+
+	test("walks the cause chain", () => {
+		const wrapped = new Error("send failed");
+		(wrapped as { cause?: unknown }).cause = {
+			code: "unauthenticated",
+		};
+		expect(isAuthError(wrapped)).toBe(true);
+	});
+
+	test("does not match network or busy errors", () => {
+		expect(isAuthError(new Error("ECONNRESET"))).toBe(false);
+		expect(isAuthError(new Error("Agent x already has active run"))).toBe(
+			false,
+		);
+		expect(isAuthError(null)).toBe(false);
+	});
+});

--- a/sidecar/src/cursor-worker/cursor-helpers.ts
+++ b/sidecar/src/cursor-worker/cursor-helpers.ts
@@ -225,6 +225,64 @@ export function isRetryableCursorError(err: unknown, depth = 0): boolean {
 	return isRetryableCursorError(o.cause, depth + 1);
 }
 
+/// "Agent already has an active run" conflict (SDK AgentBusyError / 409). A run
+/// left non-terminal in the cwd-scoped local store — e.g. the worker was killed
+/// mid-turn before it could cancel — blocks every follow-up `agent.send`. The
+/// local store throws it as a plain `Error("Agent <id> already has active run")`;
+/// the cloud path wraps it as AgentBusyError. Match both, walking `cause`.
+export function isAgentBusyError(err: unknown, depth = 0): boolean {
+	if (!err || typeof err !== "object" || depth > 4) return false;
+	const o = err as {
+		name?: unknown;
+		errorName?: unknown;
+		message?: unknown;
+		cause?: unknown;
+	};
+	if (o.name === "AgentBusyError" || o.errorName === "AgentBusyError")
+		return true;
+	if (
+		typeof o.message === "string" &&
+		/already has (an )?active run/i.test(o.message)
+	)
+		return true;
+	return isAgentBusyError(o.cause, depth + 1);
+}
+
+/// Authentication failures (SDK AuthenticationError / 401). Raw ConnectErrors
+/// from the SDK's background streaming tasks surface as `[unauthenticated] …`
+/// and never get wrapped, so match by ConnectError `code` and message text in
+/// addition to the wrapped class name. Walks `cause`.
+const AUTH_ERROR_CODES = new Set([
+	"unauthenticated",
+	"unauthorized",
+	"permission_denied",
+]);
+
+export function isAuthError(err: unknown, depth = 0): boolean {
+	if (!err || typeof err !== "object" || depth > 4) return false;
+	const o = err as {
+		name?: unknown;
+		errorName?: unknown;
+		code?: unknown;
+		message?: unknown;
+		cause?: unknown;
+	};
+	if (o.name === "AuthenticationError" || o.errorName === "AuthenticationError")
+		return true;
+	if (typeof o.code === "string" && AUTH_ERROR_CODES.has(o.code.toLowerCase()))
+		return true;
+	if (typeof o.message === "string") {
+		const m = o.message.toLowerCase();
+		if (
+			m.includes("[unauthenticated]") ||
+			m.includes("[unauthorized]") ||
+			m.includes("invalid api key")
+		)
+			return true;
+	}
+	return isAuthError(o.cause, depth + 1);
+}
+
 // Test-only export.
 export const __CURSOR_INTERNAL = {
 	namespaceEvent,
@@ -235,4 +293,6 @@ export const __CURSOR_INTERNAL = {
 	toCursorMode,
 	extractCreatePlanText,
 	isRetryableCursorError,
+	isAgentBusyError,
+	isAuthError,
 };

--- a/sidecar/src/cursor-worker/worker.ts
+++ b/sidecar/src/cursor-worker/worker.ts
@@ -10,7 +10,7 @@ import { createInterface } from "node:readline";
 import { applyAgentProxyToProcessEnv } from "../agent-proxy.js";
 import type { SidecarEmitter } from "../emitter.js";
 import { CursorCore } from "./cursor-core.js";
-import { isRetryableCursorError } from "./cursor-helpers.js";
+import { isAuthError, isRetryableCursorError } from "./cursor-helpers.js";
 import type { EmitMsg, FromWorker, ToWorker } from "./protocol.js";
 
 // Keep stdout pristine: any stray console.log from the SDK would corrupt the
@@ -58,30 +58,56 @@ const wireEmitter: SidecarEmitter = {
 
 const core = new CursorCore();
 
-// A stray async network error from the SDK's HTTP/2 client (Cursor's API
-// intermittently resets the TLS handshake) surfaces as an uncaughtException,
-// which would otherwise kill the worker and show the user a bare "worker
-// exited unexpectedly". Catch it: fail in-flight turns with a real error and
-// release the proxy's awaiting send promises. For a transient network error
-// stay alive (sessions are dropped; the next turn reconnects); for anything
-// else exit so the supervisor respawns a clean worker.
+// The worker is a permanent resident shared by every cursor session. Errors
+// reach this handler only when they escape every try/catch — in practice that's
+// the SDK's HTTP/2 client throwing an operational error from a detached
+// background task (a network reset, or a raw `[unauthenticated]` ConnectError
+// from an event stream). Operational errors don't corrupt the process, and
+// `failActiveTurns` already drops every session, so the worker is as clean as a
+// fresh one afterwards. Killing it would only cold-restart every *other*
+// session for nothing — so we stay alive: log, fail the in-flight turns with an
+// actionable message, drop sessions (the next send re-resumes cleanly).
+//
+// Error type selects ONLY the user-facing copy, never the process lifecycle.
+//
+// The sole reason to give up the process is a crash-loop: if fatals keep firing
+// in a tight window the process is genuinely wedged (e.g. a leaked SDK
+// background loop faulting on repeat that `agent.close()` didn't stop), so we
+// exit once and let the supervisor respawn a clean worker.
+const FATAL_LOOP_WINDOW_MS = 10_000;
+const FATAL_LOOP_THRESHOLD = 5;
 let fatalExiting = false;
+let recentFatals: number[] = [];
+
+function fatalReason(err: unknown, message: string): string {
+	if (isRetryableCursorError(err))
+		return "Cursor lost its network connection. Please send the message again.";
+	if (isAuthError(err))
+		return "Cursor authentication failed. Please send the message again; if it keeps failing, re-check your Cursor API key in Settings → Models → Cursor.";
+	return `Cursor worker error: ${message}`;
+}
+
 function handleFatal(kind: string, err: unknown): void {
 	const message = errMessage(err);
 	console.error(`[cursor-worker] ${kind}: ${message}`);
-	const transient = isRetryableCursorError(err);
 	try {
-		const reason = transient
-			? "Cursor lost its network connection. Please send the message again."
-			: `Cursor worker error: ${message}`;
-		for (const requestId of core.failActiveTurns(reason)) {
+		for (const requestId of core.failActiveTurns(fatalReason(err, message))) {
 			out({ t: "sendDone", requestId });
 		}
 	} catch (recoverErr) {
 		console.error(`[cursor-worker] recovery failed: ${errMessage(recoverErr)}`);
 	}
-	if (transient || fatalExiting) return;
+
+	// Crash-loop breaker — the only condition under which the permanent worker
+	// gives up and lets the supervisor respawn.
+	const now = Date.now();
+	recentFatals = recentFatals.filter((t) => now - t < FATAL_LOOP_WINDOW_MS);
+	recentFatals.push(now);
+	if (recentFatals.length < FATAL_LOOP_THRESHOLD || fatalExiting) return;
 	fatalExiting = true;
+	console.error(
+		`[cursor-worker] ${recentFatals.length} fatal errors within ${FATAL_LOOP_WINDOW_MS}ms — respawning a clean worker`,
+	);
 	// Let the terminal events flush to the parent, then exit.
 	setTimeout(() => process.exit(1), 30);
 }


### PR DESCRIPTION
## What changed

- **agent.send recovery**: When a Cursor agent's previous run was left wedged in the cwd-scoped local store (e.g. worker crashed mid-turn), the next message now retries once with `local.force` instead of failing permanently. This lets users recover a stuck chat by simply sending another message.
- **Auth error detection**: Added `isAuthError()` helper that recognizes Cursor `AuthenticationError`, raw ConnectError `[unauthenticated]` codes, and invalid API key messages — walking `cause` chains. Previously these were lumped in with generic network errors.
- **Worker crash-loop breaker**: The Cursor worker is now a permanent resident that survives transient fatal errors (network resets, auth blips). It only exits when 5+ fatals fire in a 10-second window — a genuine crash-loop — at which point the supervisor respawns a clean worker. Before this, every single fatal killed the worker and took down every other active Cursor session.
- **Recovery copy**: Error messages are now type-aware — auth failures get a distinct message pointing users to Settings → Models → Cursor, while network errors get the existing "lost connection" message.
- **Tests**: New `cursor-helpers.test.ts` covering `isAgentBusyError` and `isAuthError` against real SDK error shapes.

## Why

Cursor's SDK has a known sharp edge: if the worker process dies mid-turn before calling `run.cancel()`, the cwd-scoped local store holds the run as "active" forever. Every subsequent `agent.send()` throws — even across app restarts. The only recovery path the SDK offers is `local.force: true`. This PR adds that retry, plus better error classification so users get actionable messages instead of bare stack traces.

## Follow-up

- The crash-loop threshold (5 fatals / 10s) is conservative. We'll tune it if real-world usage shows a need.
- Run pipeline snapshot tests after merging to confirm no SDK event shape drift.
