### PR TITLE
docs: add Helmor user guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,119 @@
 <p align="center">
-  <img src="src/assets/helmor-logo-light.png" alt="Helmor logo" width="120" style="margin-bottom: 28px;" />
+  <img src="src/assets/helmor-logo-light.png" alt="Helmor logo" width="120" />
 </p>
 
 <h1 align="center">Helmor</h1>
 
 <p align="center">
-  Helmor is an open-source local workbench for multi-agent software development.
+  The local-first workbench for orchestrating coding agents.
 </p>
 
 <p align="center">
+  <a href="https://github.com/dohooo/helmor/releases"><img src="https://img.shields.io/github/v/release/dohooo/helmor?style=flat&label=Release&color=0A7CFF" alt="Latest release" /></a>
   <a href="https://discord.gg/ukyyuNfnDp"><img src="https://img.shields.io/discord/1499667625267957920?style=flat&logo=discord&label=Discord&color=5865F2" alt="Discord" /></a>
-  <a href="https://app.dosu.dev/9207e853-a462-496b-ac67-bc8e8fde3782"><img src="https://app.dosu.dev/api/images/badge?h=20&message=Docs" alt="Dosu Docs" /></a>
+  <a href="docs/user/README.md"><img src="https://img.shields.io/badge/Docs-User_Guide-8A2BE2" alt="User docs" /></a>
+  <a href="./LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-3DA639" alt="License: Apache 2.0" /></a>
 </p>
 
-> AI made coding faster.
->
-> Helmor is about finishing the rest of the loop.
->
-> Not just generating more code.
->
-> Orchestrating, reviewing, testing, merging, and actually shipping software.
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="src/assets/helmor-screenshot-dark.png" />
+  <img src="src/assets/helmor-screenshot-light.png" alt="Helmor screenshot" width="100%" />
+</picture>
+
+> AI made coding faster. Helmor is about finishing the rest of the loop —
+> orchestrating, reviewing, testing, merging, and actually shipping software.
+
+Helmor runs many coding agents in parallel, each inside its own isolated git
+workspace, and gives you one place to steer them all: conversation, diffs, a
+real editor, terminals, run scripts, and one-click PR actions. Everything is
+stored in a local SQLite database on your machine.
+
+## Highlights
+
+- **Isolated workspaces** — every task gets its own git worktree and branch.
+  Agents never trample each other's changes, and your `main` stays clean.
+- **Bring your own agents** — Claude Code, OpenAI Codex, Cursor, and OpenCode
+  side by side, using your existing logins and API keys. Pick the model,
+  effort level, plan mode, or fast mode per message.
+- **Steer mid-flight** — watch output stream live, inject follow-ups while the
+  agent is still working, queue prompts, paste images, mention files with `@`.
+- **Review without leaving** — changed files, side-by-side diffs, a Monaco
+  editor, and built-in terminals sit right next to the conversation.
+- **Ship from one button** — Create PR, Commit & Push, Pull Latest, Merge,
+  Fix CI, Resolve Conflicts. Stacked PRs included. GitHub and GitLab.
+- **Local-first** — your code, sessions, and credentials never leave your
+  machine, except for the agent API calls you choose to make.
+- **Scriptable** — a full `helmor` CLI and a built-in MCP server, so your
+  terminal — or another agent — can drive Helmor too.
 
 ## Install
 
-<p align="center">
-  <img src="src/assets/helmor-screenshot-light.png" alt="Helmor screenshot" width="100%" />
-</p>
-
 [**Download Helmor** →](https://github.com/dohooo/helmor/releases)
 
-- macOS: Apple Silicon and Intel DMG
-- Windows: x64 setup installer
+- **macOS** — Apple Silicon and Intel (DMG)
+- **Windows** — x64 setup installer
+
+On first launch, Helmor walks you through connecting GitHub or GitLab and
+signing in to your first agent. Agent CLIs are bundled — there is nothing else
+to install. See the [install guide](docs/user/get-started/install.md) for
+details.
+
+## How it works
+
+1. **Add a repository** — link a local clone, or clone from a URL.
+2. **Create a workspace** — Helmor makes a fresh git worktree and branch under
+   `~/helmor/workspaces/` and runs your project's setup script.
+3. **Prompt an agent** — choose a model, describe the task, and move on to the
+   next workspace while it runs.
+4. **Review and ship** — read the diff, run your tests, then create and merge
+   the PR from the inspector.
+
+Repeat in parallel. Each workspace is fully independent, so five agents can
+work on five tasks in the same repository at once.
 
 ## Documentation
 
-[**Read the Helmor docs** →](https://app.dosu.dev/9207e853-a462-496b-ac67-bc8e8fde3782)
+The full user guide lives in [`docs/user/`](docs/user/README.md):
 
-## Contributing
+- [Introduction](docs/user/get-started/introduction.md) · [Install](docs/user/get-started/install.md) · [Your first workspace](docs/user/get-started/your-first-workspace.md) · [Configure your project](docs/user/get-started/configure-your-project.md)
+- Concepts: [Workspaces](docs/user/concepts/workspaces.md) · [Agents & models](docs/user/concepts/agents-and-models.md) · [Sessions](docs/user/concepts/sessions.md) · [Parallel agents](docs/user/concepts/parallel-agents.md) · [Stacked PRs](docs/user/concepts/stacked-prs.md)
+- Reference: [Composer](docs/user/reference/composer.md) · [Review & ship](docs/user/reference/review-and-ship.md) · [Editor](docs/user/reference/editor.md) · [Settings](docs/user/reference/settings.md) · [Keyboard shortcuts](docs/user/reference/keyboard-shortcuts.md) · [CLI & MCP](docs/user/reference/cli-and-mcp.md)
+- [Privacy](docs/user/security/privacy.md) · [FAQ](docs/user/troubleshooting/faq.md) · [Troubleshooting](docs/user/troubleshooting/troubleshooting.md)
 
-Open Helmor, Import Helmor, Ask Helmor:
+## CLI
 
-> _"How do I contribute to Helmor?"_
+Helmor ships a companion CLI that works against the same local database as the
+app — even while the app is running:
 
-That's the guide.
+```bash
+helmor workspace new --repo myapp
+helmor send --workspace myapp/feature-x "Add a test for the parser edge case."
+helmor workspace status myapp/feature-x
+```
+
+`helmor mcp` exposes the same surface as an MCP server over stdio, so other
+agents and tools can operate Helmor. See [CLI & MCP](docs/user/reference/cli-and-mcp.md).
+
+## Building from source
+
+Prerequisites: [Bun](https://bun.sh) 1.3+, a stable [Rust](https://rustup.rs)
+toolchain, and platform build tools (Xcode Command Line Tools on macOS). A Nix
+flake is also available — see [NIX_SETUP.md](NIX_SETUP.md).
+
+```bash
+bun install        # installs frontend + sidecar dependencies
+bun run dev        # full desktop app in development mode
+bun run test       # frontend, sidecar, and Rust test suites
+```
+
+Architecture notes for contributors (and their agents) live in
+[AGENTS.md](AGENTS.md).
+
+## Community
+
+- [Discord](https://discord.gg/ukyyuNfnDp) — questions, feedback, release chat
+- [GitHub Issues](https://github.com/dohooo/helmor/issues) — bugs and feature requests
+- Or use the feedback button at the bottom of Helmor's sidebar
 
 ## License
 

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -1,0 +1,51 @@
+# Helmor User Guide
+
+Helmor is a local-first desktop app for running many coding agents in
+parallel, each in its own isolated git workspace — with everything you need to
+review, test, and ship their work in one window.
+
+New here? Start with the [Introduction](get-started/introduction.md), then
+follow [Your first workspace](get-started/your-first-workspace.md).
+
+## Get Started
+
+| Page | What it covers |
+| --- | --- |
+| [Introduction](get-started/introduction.md) | What Helmor is, the core ideas, and a tour of the window |
+| [Install](get-started/install.md) | Download, first-launch setup, updates, and the CLI |
+| [Your first workspace](get-started/your-first-workspace.md) | From adding a repository to merging your first agent-written PR |
+| [Configure your project](get-started/configure-your-project.md) | `helmor.json`: setup, run, and archive scripts; repository settings |
+
+## Concepts
+
+| Page | What it covers |
+| --- | --- |
+| [Workspaces](concepts/workspaces.md) | Git worktrees, workspace modes, lifecycle, archive and restore |
+| [Agents & models](concepts/agents-and-models.md) | Claude Code, Codex, Cursor, OpenCode — auth, models, effort, modes |
+| [Sessions](concepts/sessions.md) | Session tabs, streaming, steering, queueing, context usage |
+| [Parallel agents](concepts/parallel-agents.md) | Running many workspaces at once without losing the thread |
+| [Stacked PRs](concepts/stacked-prs.md) | Building dependent changes as a stack of workspaces |
+
+## Reference
+
+| Page | What it covers |
+| --- | --- |
+| [Composer](reference/composer.md) | Everything the prompt input can do |
+| [Review & ship](reference/review-and-ship.md) | The inspector: changes, diffs, git actions, terminals, run scripts |
+| [Editor](reference/editor.md) | The built-in Monaco file editor |
+| [Settings](reference/settings.md) | Every settings panel, explained |
+| [Keyboard shortcuts](reference/keyboard-shortcuts.md) | The full shortcut map |
+| [CLI & MCP](reference/cli-and-mcp.md) | Driving Helmor from the terminal or from other agents |
+
+## Security
+
+| Page | What it covers |
+| --- | --- |
+| [Privacy](security/privacy.md) | What stays local, what leaves your machine, and where data lives |
+
+## Troubleshooting
+
+| Page | What it covers |
+| --- | --- |
+| [FAQ](troubleshooting/faq.md) | Short answers to common questions |
+| [Troubleshooting](troubleshooting/troubleshooting.md) | Logs, auth issues, sync conflicts, and recovery steps |

--- a/docs/user/concepts/agents-and-models.md
+++ b/docs/user/concepts/agents-and-models.md
@@ -1,0 +1,84 @@
+# Agents & models
+
+Helmor is agent-agnostic: it orchestrates the agents you already use, with
+the accounts you already have. All agent CLIs are bundled inside the app —
+there is nothing to install, and Helmor never proxies your traffic through its
+own servers.
+
+## Supported agents
+
+| Agent | Sign in with | Notes |
+| --- | --- | --- |
+| **Claude Code** | Your existing Claude Code login (Claude subscription) or an Anthropic API key | The default provider. Supports skills, MCP servers, extended thinking |
+| **OpenAI Codex** | Your existing Codex login (ChatGPT) or an OpenAI API key | Supports goal tracking and skills |
+| **Cursor** | Cursor API key (Settings → Models) | Cursor's agent models; the section appears once a key is set |
+| **OpenCode** | Providers from your `~/.config/opencode/opencode.jsonc` | Bring any OpenCode-compatible provider/model |
+
+If you are already signed in to Claude Code or Codex on this machine, Helmor
+picks the login up automatically. Otherwise, onboarding (or Settings) walks
+you through signing in.
+
+You can also add **custom Claude-compatible providers** — any endpoint that
+speaks the Claude API, with its own base URL and key — in Settings → Models.
+They appear in the model picker alongside the official models.
+
+## Picking a model
+
+The model picker lives in the composer toolbar (**⌥P**). Models are grouped by
+provider, and your choice is per-session — different sessions, different
+models, even within one workspace. A default model for new sessions is set in
+**Settings → General**.
+
+## Effort levels
+
+Most models expose an **effort** dropdown next to the model picker: `low`,
+`medium`, `high`, `xhigh`, up to `max` depending on the model. Higher effort
+means deeper reasoning and longer runs; lower effort is snappier for mechanical
+tasks. Helmor remembers your choice per session.
+
+## Modes
+
+- **Plan mode** (⇧Tab) — the agent reads and proposes; it does not modify
+  files. Review the plan, then approve it to switch into implementation. Great
+  for anything you'd want to see an approach for first.
+- **Fast mode** — on supported models, trades some thoroughness for
+  significantly faster turns. Good for small, well-scoped edits.
+- **Terminal mode** (⌘⇧T) — sends your prompt to the agent's own terminal UI
+  inside a built-in terminal, instead of a GUI turn. Useful for agent-native
+  flows that only exist in the TUI.
+
+Permission behavior for new sessions (how much the agent may do without
+asking) is configurable in Settings → General, and per message from the CLI
+(`--permission-mode plan|auto|yolo|default`).
+
+## Skills and slash commands
+
+Type `/` in the composer to browse what the current agent can do:
+
+- **Claude Code** exposes its built-in commands and any skills installed in
+  your project or user scope.
+- **Codex and Cursor** discover skills from `.agents/skills`,
+  `.claude/skills`, `.cursor/skills`, and `.codex/skills` directories (project
+  and user scope).
+
+## MCP servers
+
+Claude Code sessions load the MCP servers you have configured for the project
+(and your user-scope servers), exactly as they would in the terminal. Tools
+that ask questions or request input pop a form right in the conversation.
+
+Helmor itself can also *be* an MCP server for other tools — see
+[CLI & MCP](../reference/cli-and-mcp.md).
+
+## Local models
+
+Helmor bundles a llama.cpp runtime used for small on-device features (like
+automatic session titles), with models managed under **Settings → Local LLM**.
+Your prompts to coding agents always go to the provider you selected — never
+to a third party.
+
+## Network and proxies
+
+Agent processes inherit your proxy configuration: Helmor can follow the macOS
+system proxy or use a custom HTTP/SOCKS5 proxy (**Settings**). This applies to
+Claude Code, Codex, and Cursor traffic alike.

--- a/docs/user/concepts/parallel-agents.md
+++ b/docs/user/concepts/parallel-agents.md
@@ -1,0 +1,66 @@
+# Parallel agents
+
+Helmor's whole premise: agents are fast, you are the bottleneck. The fix is
+not a faster agent — it's running several and getting good at switching.
+
+## The rhythm
+
+1. **Fan out.** Create a workspace per task (**⌘N**) and dispatch each one.
+   Isolation makes this safe — five agents in five worktrees can't conflict
+   ([Workspaces](workspaces.md)).
+2. **Rotate.** While agents work, you review. Move to whichever workspace
+   needs you, read the diff, steer or approve, move on.
+3. **Ship and archive.** Merged work leaves the sidebar; new tasks enter.
+
+## Knowing where you're needed
+
+The sidebar is your control tower:
+
+- **Running** — the agent is mid-turn; nothing needed from you.
+- **Needs input** — the agent asked a question or wants permission.
+- **Unread** — finished while you were elsewhere.
+- A **glowing border** means run scripts (dev server, tests) are active.
+
+Desktop notifications (with optional sounds) fire when an agent finishes or
+needs you — configurable in Settings → General.
+
+## Switching fast
+
+- **⌃Tab** — quick-switch overlay between recent workspaces (hold ⇧ to go
+  backwards)
+- **⌘⌥↑ / ⌘⌥↓** — previous / next workspace in the sidebar
+- **⌘⇧F** — filter and sort the sidebar
+- **⌘L** — jump focus straight to the composer
+
+## Organizing the fleet
+
+- **Group** the sidebar by repository or by status, or keep a flat list.
+- **Status lanes** — assign workspaces *In Progress*, *Review*, *Done*,
+  *Backlog*, or *Canceled* and group by status for a kanban-style view.
+- **Pin** the workspaces you keep coming back to; **mark unread** anything you
+  want to revisit; drag to reorder.
+
+## Drive-by tasks
+
+The **quick panel** (⇧⌥Space) is a small floating window for tasks that don't
+deserve a context switch — fire off a prompt from anywhere, glance at the
+response, and either dismiss it or open it fully in the main window.
+
+## Dispatching from the terminal
+
+Parallelism composes with your shell. The CLI can create workspaces and send
+prompts without touching the GUI:
+
+```bash
+helmor workspace new --repo myapp
+helmor send --workspace myapp/refactor-auth "Extract the session logic into its own module."
+```
+
+See [CLI & MCP](../reference/cli-and-mcp.md).
+
+## How many is too many?
+
+In practice the limit is your review bandwidth, not the machine. A good
+starting shape: two or three substantive tasks plus a couple of small ones.
+Plan mode helps you keep risky work cheap to supervise — let the agent propose
+before it implements.

--- a/docs/user/concepts/sessions.md
+++ b/docs/user/concepts/sessions.md
@@ -1,0 +1,60 @@
+# Sessions
+
+A session is one conversation with one agent. Workspaces hold sessions as
+tabs, so a single task can have several threads — an implementation session, a
+review session, a "explain this subsystem" session — each with its own model
+and settings.
+
+## Tabs
+
+- **⌘T** — new session in the current workspace
+- **⌘W** — close the current session
+- **⌘⇧R** — reopen the last closed session
+- **⌘⌥←/→** — switch between sessions
+
+Titles are generated automatically from the conversation (you can rename via
+double-click). Sessions persist in your local database — closing a tab hides
+it, it never deletes history.
+
+## Streaming and steering
+
+Agent output streams live: text, tool calls, file edits, and (where the model
+supports it) reasoning. While a turn is running you have three options:
+
+- **Watch** — or don't. The sidebar marks workspaces that need attention.
+- **Steer** — type a message and hit **Send** (the button reads *Steer* during
+  a turn). Your message is injected into the running turn, redirecting the
+  agent without restarting it.
+- **Queue** — **⌘Enter** queues the message to send after the current turn
+  finishes. Queued prompts appear above the composer, where you can edit,
+  remove, or promote them to steer immediately.
+
+**Stop** aborts the turn cleanly; the session records that it was stopped and
+remains usable.
+
+## Questions and permissions
+
+When an agent needs something from you — a clarifying question, a permission
+to proceed, a plan approval — the request renders as an interactive panel in
+the conversation. Workspaces waiting on you are flagged in the sidebar, and
+desktop notifications can alert you (Settings → General).
+
+## Context usage
+
+The donut ring in the composer shows how full the model's context window is.
+Hover for a breakdown. When a long-running session gets close to the limit,
+that's your cue to wrap up or start a fresh session.
+
+## Resume
+
+Sessions survive restarts. If the app quits mid-turn, the conversation is
+intact and you can continue where things left off — the underlying provider
+session is resumed rather than replayed.
+
+## Several sessions, one workspace
+
+Sessions in a workspace share the same working directory, so they see each
+other's file changes. Use this deliberately: a common pattern is one session
+implementing while a second session reviews the diff or writes tests. For
+truly independent tasks, prefer separate workspaces — that's what isolation is
+for ([Workspaces](workspaces.md)).

--- a/docs/user/concepts/stacked-prs.md
+++ b/docs/user/concepts/stacked-prs.md
@@ -1,0 +1,51 @@
+# Stacked PRs
+
+Some changes are too big for one PR but too interdependent for parallel
+workspaces. Stacking solves this: a chain of workspaces where each builds on
+the previous one, reviewed and merged as a sequence of small PRs.
+
+## How a stack works in Helmor
+
+When you create a **stacked workspace** from an existing workspace:
+
+- the child's branch is created **from the parent's branch** (not from the
+  repository's default branch);
+- the child's **target branch is the parent's branch**, so its PR shows only
+  its own changes;
+- the sidebar nests the child under its parent, so the stack reads
+  root → tip.
+
+Example: workspace A introduces a new API, stacked workspace B migrates
+callers to it, stacked C deletes the old path. Three reviewable PRs, one
+dependency chain.
+
+## Working with a stack
+
+- **Inspect it** — right-click → stack view in the app, or:
+
+  ```bash
+  helmor workspace stack myapp/new-api
+  ```
+
+  which prints the chain from root to tip.
+
+- **Keep children fresh** — when a parent gains commits, run *Pull Latest* in
+  the child to merge the parent's branch in (the child's target branch *is*
+  the parent).
+
+- **Merge bottom-up** — merge the root PR first. As lower layers merge,
+  retarget and sync the remaining children; Helmor keeps each child's PR
+  pointed at its parent's branch and updates targets when a stack is
+  restored or rearranged.
+
+## When to stack vs. when to parallelize
+
+| Situation | Use |
+| --- | --- |
+| Independent tasks | Separate workspaces ([Parallel agents](parallel-agents.md)) |
+| One big change, reviewable in slices | A stack |
+| Exploratory work that might be thrown away | A single workspace, split later |
+
+Stacks shine when review latency is the bottleneck: reviewers approve small
+PRs faster, and the agent can keep building on unmerged layers instead of
+waiting.

--- a/docs/user/concepts/workspaces.md
+++ b/docs/user/concepts/workspaces.md
@@ -1,0 +1,86 @@
+# Workspaces
+
+A workspace is Helmor's unit of work: one task, one directory, one branch, one
+(or more) agent conversations. Understanding workspaces is understanding
+Helmor.
+
+## Isolation through git worktrees
+
+By default a workspace is a **git worktree** — a first-class git feature that
+gives a repository multiple working directories, each checked out to its own
+branch. Helmor creates them under:
+
+```
+~/helmor/workspaces/<repo-name>/<workspace-name>/
+```
+
+Worktrees share the repository's object store, so they are cheap to create,
+but their files are fully independent. That is what makes parallel agents
+safe: an agent in one workspace physically cannot touch another workspace's
+files, your original clone, or your checked-out `main`.
+
+Each workspace also gets its own **branch**, named from your repository's
+branch prefix (e.g. `helmor/fix-login-flow`). You can instead attach a
+workspace to an existing branch when creating it — useful for picking up
+review feedback on a colleague's PR.
+
+## Workspace modes
+
+| Mode | What it is | When to use it |
+| --- | --- | --- |
+| **Worktree** (default) | Isolated worktree + branch under `~/helmor/workspaces/` | Almost always |
+| **Local** | Operates directly on your existing clone's directory | When you want the agent in your real working copy — e.g. alongside a running dev setup |
+| **Chat** | A scratch directory with no git binding | Questions, explorations, anything that isn't a code change (**⌘⇧N**) |
+
+A Local workspace can be converted into a Worktree workspace later
+(right-click → *Move to worktree*) — your changes move with it.
+
+## Target branch
+
+Every workspace has an **intended target branch** — the branch its PR will
+target and the branch *Pull Latest* merges from. It defaults to the
+repository's default branch and can be changed in the branch picker at the top
+of the panel. Stacked workspaces target their parent's branch instead
+([Stacked PRs](stacked-prs.md)).
+
+**Sync** (*Pull Latest*, ⌘⇧L) merges the target branch into your workspace.
+Uncommitted work is stashed first and restored after; if the merge or the
+stash restore conflicts, Helmor tells you and you can dispatch the
+*Resolve Conflicts* action. Helmor also auto-fetches remotes in the background
+every couple of minutes, so ahead/behind counts in the inspector stay honest.
+
+## Lifecycle
+
+```
+create ──► setup ──► ready ──► archived ──► (restored | deleted)
+```
+
+- **Create** — instant; the worktree and setup run are finalized in the
+  background.
+- **Ready** — work happens here. Pin it, mark it unread, give it a status
+  lane (*In Progress*, *Review*, *Done*, *Backlog*, *Canceled*) to organize
+  the sidebar.
+- **Archive** — when the work ships. The worktree directory is removed; the
+  branch is deleted *only if Helmor auto-generated it* (branches you picked
+  yourself are preserved). The conversation history, and the commit the
+  workspace was at, are kept.
+- **Restore** — recreates the worktree from the recorded commit, with checks
+  that the target branch still exists. Local and Chat workspaces restore
+  instantly since nothing was deleted.
+- **Delete** — permanent: removes database rows, worktree, and files.
+
+Archive can be automated per repository with **archive on merge**, and your
+project can run a cleanup script on archive
+([Configure your project](../get-started/configure-your-project.md)).
+
+## Renaming and branches
+
+You can rename a workspace's branch at any time (branch picker → rename);
+Helmor updates git and its own records atomically. The branch picker also lets
+you switch the target branch and create branches from any start point.
+
+## Disk usage
+
+Worktrees are real checkouts, so big repositories add up. Right-click a
+workspace → *Open in Finder* to inspect it, and archive workspaces you're done
+with — that reclaims the disk while keeping the history.

--- a/docs/user/get-started/configure-your-project.md
+++ b/docs/user/get-started/configure-your-project.md
@@ -1,0 +1,111 @@
+# Configure your project
+
+A new workspace is a fresh checkout. To make it instantly productive —
+dependencies installed, env files in place, dev server one keystroke away —
+add a `helmor.json` to your repository root.
+
+## `helmor.json`
+
+```json
+{
+	"scripts": {
+		"setup": "cp \"$HELMOR_ROOT_PATH/.env.local\" \"$HELMOR_WORKSPACE_PATH/.env.local\"\nbun install",
+		"run": [
+			{
+				"name": "Dev",
+				"command": "bun run dev",
+				"stopCommand": "",
+				"mode": "non-concurrent"
+			},
+			{
+				"name": "Tests",
+				"command": "bun run test",
+				"stopCommand": "",
+				"mode": "non-concurrent"
+			}
+		],
+		"archive": ""
+	}
+}
+```
+
+### `setup`
+
+A shell script that runs once when a workspace is created (and can be re-run
+from the workspace at any time). Typical jobs:
+
+- install dependencies (`bun install`, `npm ci`, `cargo fetch`, …)
+- copy untracked files from your main clone — `.env.local`, local
+  certificates, build caches
+
+Multi-line scripts are fine; the whole string runs in your `$SHELL`.
+
+### `run`
+
+An array of named actions that appear in the workspace's scripts panel
+(**⌘J**) — dev servers, test suites, builds. Each action has:
+
+| Field | Meaning |
+| --- | --- |
+| `name` | Label shown in the UI |
+| `command` | Shell command to run |
+| `stopCommand` | Optional graceful-stop command; otherwise Helmor terminates the process |
+| `mode` | `non-concurrent` actions stop the previous run before starting again |
+
+Run the selected action with **⌘R**. Output streams into the panel with full
+color support, and the sidebar shows a glow on workspaces with scripts
+running.
+
+### `archive`
+
+An optional script that runs just before a workspace is archived — for
+cleanup like stopping containers or releasing ports. Failures never block the
+archive.
+
+## Environment variables
+
+Every script runs with these variables set:
+
+| Variable | Value |
+| --- | --- |
+| `HELMOR_ROOT_PATH` | Path to your original clone of the repository |
+| `HELMOR_WORKSPACE_PATH` | Path to the workspace's worktree |
+| `HELMOR_WORKSPACE_NAME` | The workspace's directory name |
+| `HELMOR_DEFAULT_BRANCH` | The repository's default branch |
+
+The `setup` example above uses `HELMOR_ROOT_PATH` to copy untracked files from
+your main clone into the new worktree — the standard trick for `.env` files
+that aren't in git.
+
+## Where the file is read from
+
+Helmor looks for `helmor.json` in the **workspace directory first**, then
+falls back to the **repository root**. That means a branch can ship its own
+script changes, and they take effect in workspaces created from it.
+
+You can also edit scripts without touching the file at all:
+**Settings → Repository** has a script editor per repository.
+
+## Per-repository settings
+
+Alongside scripts, each repository has a few knobs (in Settings, or via the
+sidebar's right-click menu):
+
+- **Default branch** — what new workspaces target (auto-detected).
+- **Branch prefix** — auto-generated branches are named
+  `<prefix>/<workspace-name>`; use the default or set a custom prefix.
+- **Remote** — which remote to push to and fetch from (usually `origin`).
+- **Auto-run setup** — whether the setup script runs automatically on
+  workspace creation (on by default).
+- **Archive on merge** — automatically archive a workspace once its PR
+  merges.
+
+## Checking the effective configuration
+
+From the terminal:
+
+```bash
+helmor scripts show --workspace <repo>/<workspace>
+```
+
+shows exactly which setup/run/archive scripts a workspace resolved to.

--- a/docs/user/get-started/install.md
+++ b/docs/user/get-started/install.md
@@ -1,0 +1,67 @@
+# Install
+
+## Download
+
+Grab the latest release from
+[github.com/dohooo/helmor/releases](https://github.com/dohooo/helmor/releases):
+
+- **macOS** — DMG for Apple Silicon and Intel. Open the DMG and drag Helmor to
+  Applications.
+- **Windows** — x64 setup installer.
+
+Everything Helmor needs is bundled inside the app: the agent CLIs
+(Claude Code, Codex, and friends) and the GitHub/GitLab CLIs (`gh`, `glab`).
+You do not need to install any of them separately.
+
+## First launch
+
+On first launch, Helmor walks you through a short onboarding:
+
+1. **Connect GitHub or GitLab.** Helmor uses the bundled `gh`/`glab` CLIs and
+   their standard login flow. If you are already signed in to `gh` on this
+   machine, Helmor picks that up automatically; otherwise it opens an
+   interactive sign-in right inside the app. Multiple accounts are supported —
+   each repository remembers which account it belongs to.
+2. **Sign in to an agent.** Use your existing Claude Code or Codex login, or
+   enter an API key. You can add more providers later in
+   [Settings → Models](../reference/settings.md). See
+   [Agents & models](../concepts/agents-and-models.md) for what each provider
+   needs.
+3. **Add a repository.** Point Helmor at a local clone, or clone from a URL.
+4. **Optional extras.** Install recommended skills and the `helmor`
+   command-line tool.
+
+That's it — you are ready for
+[your first workspace](your-first-workspace.md).
+
+## Where your data lives
+
+Helmor stores everything under `~/helmor/`:
+
+- `helmor.db` — the SQLite database (workspaces, sessions, settings)
+- `workspaces/<repo>/<name>/` — one directory per workspace (a git worktree)
+- `chats/` — scratch directories for chat-only workspaces
+- `logs/` — application logs
+
+Nothing is synced anywhere. See [Privacy](../security/privacy.md) for the full
+picture.
+
+## Updates
+
+Helmor checks for updates automatically and installs them on restart. You can
+trigger a check manually in **Settings → App Updates**. After an update, a
+"What's new" toast summarizes the changes — full notes are in the
+[GitHub releases](https://github.com/dohooo/helmor/releases).
+
+## Installing the CLI
+
+The `helmor` terminal command is optional but recommended:
+
+**Settings → Experimental → Command Line Tool → Install**
+
+This installs a small launcher (to `/usr/local/bin/helmor` on macOS, or
+`%LOCALAPPDATA%\Helmor\bin\helmor.cmd` on Windows) that always points at your
+installed app, so the CLI and the app never drift apart. On Windows, open a
+new terminal afterwards so the updated `PATH` is picked up.
+
+See [CLI & MCP](../reference/cli-and-mcp.md) for what you can do with it.

--- a/docs/user/get-started/introduction.md
+++ b/docs/user/get-started/introduction.md
@@ -1,0 +1,69 @@
+# Introduction
+
+Helmor is a desktop app for people who work *with* coding agents rather than
+just chatting with one. It runs Claude Code, OpenAI Codex, Cursor, and
+OpenCode side by side, gives each task its own isolated git workspace, and
+keeps the whole loop — prompt, review, test, merge — in a single window.
+
+## The problem it solves
+
+A single agent in a single terminal is a queue: you wait, you review, you
+start the next thing. Agents are fast enough now that *you* become the
+bottleneck.
+
+Helmor turns that queue into a fleet:
+
+- **Each task gets its own workspace.** A workspace is a real git worktree
+  with its own branch and directory. Five agents can work on five tasks in the
+  same repository without ever touching each other's files — or your `main`.
+- **You stay in the review seat.** While one agent works, you review another's
+  diff, run its tests, and ship its PR. Status indicators in the sidebar tell
+  you which workspaces need you.
+- **Everything is local.** Workspaces, sessions, and settings live in a SQLite
+  database and plain directories under `~/helmor/` on your machine. The only
+  network traffic is the agent API calls and git operations you initiate, with
+  your own credentials.
+
+## A tour of the window
+
+```
+┌────────────┬──────────────────────────────┬────────────────┐
+│  Sidebar   │       Conversation           │   Inspector    │
+│            │                              │                │
+│ Workspaces │  Agent messages, tool calls, │  Changed files │
+│ grouped by │  diffs, reasoning, streaming │  Diff viewer   │
+│ repo or    │                              │  Git actions   │
+│ status     ├──────────────────────────────┤  Terminals     │
+│            │       Composer               │  Run scripts   │
+│            │  Prompt input + model picker │                │
+└────────────┴──────────────────────────────┴────────────────┘
+```
+
+- **Sidebar** — your fleet. Every workspace, grouped and sorted how you like,
+  with dots for *running*, *needs input*, and *unread*.
+- **Conversation** — the active session with an agent. Sessions are tabs; a
+  workspace can hold several.
+- **Composer** — where you type. File mentions, slash commands, images, model
+  and effort pickers, plan mode, and a queue for follow-up prompts.
+- **Inspector** — the shipping side: changed files, diffs, one-click git/PR
+  actions, terminals, and your project's run scripts.
+
+There is also a built-in [editor](../reference/editor.md) for when you want to
+touch the code yourself, and a floating quick panel for drive-by tasks.
+
+## Core ideas in 30 seconds
+
+1. **Workspace = task.** Create one per thing you want done. Archive it when
+   it merges. ([Workspaces](../concepts/workspaces.md))
+2. **Agents are pluggable.** Use whichever provider and model fits the task,
+   per message, with your existing accounts.
+   ([Agents & models](../concepts/agents-and-models.md))
+3. **Shipping is part of the loop.** Create PR, Fix CI, Resolve Conflicts, and
+   Merge are buttons, not chores. ([Review & ship](../reference/review-and-ship.md))
+
+## Where to go next
+
+- [Install Helmor](install.md)
+- [Your first workspace](your-first-workspace.md) — a 10-minute walkthrough
+- [Configure your project](configure-your-project.md) — make workspaces
+  self-sufficient with setup and run scripts

--- a/docs/user/get-started/your-first-workspace.md
+++ b/docs/user/get-started/your-first-workspace.md
@@ -1,0 +1,82 @@
+# Your first workspace
+
+This walkthrough takes you from an empty sidebar to a merged pull request.
+
+## 1. Add a repository
+
+Click **Add Repository** in the sidebar (or right-click → *Add repository*).
+You can either:
+
+- **Link a local clone** — pick any folder that is already a git repository.
+- **Clone from URL** — paste a git URL and choose where to clone it.
+
+Helmor detects the default branch and remotes, and binds the repository to the
+GitHub/GitLab account that has access to it. Requirements: the repository must
+have at least one remote (usually `origin`).
+
+## 2. Create a workspace
+
+Press **⌘N** (or click **New Workspace**). Pick the repository, give the task
+a name, and go.
+
+Behind the scenes, Helmor:
+
+1. creates a **git worktree** under `~/helmor/workspaces/<repo>/<name>/` —
+   a full working copy on its own branch, isolated from your clone;
+2. names the branch from your repo's branch prefix (configurable per repo);
+3. runs your project's **setup script** if one is configured — installing
+   dependencies, copying `.env` files, whatever the project needs
+   (see [Configure your project](configure-your-project.md)).
+
+Prefer a chat without any repository? **⌘⇧N** creates a *Just chat* workspace
+in a scratch directory.
+
+## 3. Prompt an agent
+
+Type what you want in the composer at the bottom:
+
+- Mention files with `@` — type `@` and fuzzy-search the workspace.
+- Paste screenshots or drag files straight into the input.
+- Pick the **model** (⌥P) and an **effort level** from the toolbar.
+- Not sure about the approach? Toggle **Plan mode** (⇧Tab) and the agent will
+  propose a plan before touching any files.
+
+Press **Enter**. The agent's work streams in live — messages, tool calls, file
+edits, reasoning. You don't have to watch: switch to another workspace and the
+sidebar will show a dot when this one needs you.
+
+Want to redirect a running agent? Just type again — the button becomes
+**Steer** and your message is injected mid-turn. **⌘Enter** queues the message
+for after the current turn instead.
+
+## 4. Review the changes
+
+Open the inspector (**⌘⌥B**). The **Changes** section lists every modified
+file with insertions/deletions; click one to read a side-by-side diff. Need to
+tweak something by hand? Switch the diff to edit mode (**⌘E**) — it's a full
+Monaco editor.
+
+Run your project's dev server or tests from the **run scripts** panel (**⌘J**,
+then **⌘R** to run), or open a built-in **terminal** in the workspace
+directory.
+
+## 5. Ship it
+
+The inspector's action button adapts to the workspace state:
+
+- **Commit & Push** (⌘⇧Y) — commit everything and push the branch.
+- **Create PR** (⌘⇧P) — open a pull request against the target branch.
+- **Pull Latest** (⌘⇧L) — merge the target branch in if you've fallen behind.
+- **Fix CI** / **Resolve Conflicts** — dispatch an agent at the problem.
+- **Merge** (⌘⇧M) — merge the PR when checks are green.
+
+When the PR merges, archive the workspace (right-click → *Archive*, or enable
+*archive on merge* per repository). The worktree is removed, the branch is
+cleaned up if Helmor created it, and the conversation stays in your history —
+restorable any time.
+
+## Next
+
+- Run several of these at once: [Parallel agents](../concepts/parallel-agents.md)
+- Make new workspaces instantly productive: [Configure your project](configure-your-project.md)
+- Build dependent changes: [Stacked PRs](../concepts/stacked-prs.md)

--- a/docs/user/reference/cli-and-mcp.md
+++ b/docs/user/reference/cli-and-mcp.md
@@ -1,0 +1,88 @@
+# CLI & MCP
+
+Helmor ships a companion CLI that works against the same local database as the
+desktop app — you can use both at the same time. It also runs as an MCP
+server, so other agents and tools can drive Helmor.
+
+## Installing
+
+**Settings → Experimental → Command Line Tool → Install.** This puts a
+`helmor` launcher on your PATH that always points at the installed app, so CLI
+and app versions never drift. (On Windows, open a new terminal afterwards.)
+
+## The essentials
+
+```bash
+helmor repo list                       # registered repositories
+helmor repo add /path/to/repo          # link a local clone
+
+helmor workspace list                  # active workspaces, grouped by status
+helmor workspace new --repo myapp      # create a workspace
+helmor workspace show myapp/feature-x  # details for one workspace
+helmor workspace status myapp/feature-x  # ahead/behind, conflicts, push state
+
+helmor send --workspace myapp/feature-x "Add a test for the parser edge case."
+```
+
+Workspaces are addressed by UUID **or** the `repo-name/directory-name`
+shorthand — the shorthand is what you'll actually use.
+
+### Sending prompts
+
+`helmor send` dispatches to the workspace's active session (or a specific one
+with `--session`):
+
+```bash
+helmor send --workspace myapp/feature-x --plan "Sketch the refactor first."
+helmor send --workspace myapp/feature-x --model <model-id> "…"
+cat task.md | helmor send --workspace myapp/feature-x -
+```
+
+- `--plan` is shorthand for `--permission-mode plan`; full options are
+  `plan`, `auto`, `yolo`, and `default`.
+- `helmor models` lists the model IDs you can pass to `--model`.
+- `-` reads the prompt from stdin — handy for long or generated prompts.
+
+### The ship flow
+
+```bash
+helmor workspace sync myapp/feature-x        # pull latest from target branch
+helmor workspace push myapp/feature-x        # push the branch
+helmor workspace run-action myapp/feature-x  # dispatch a ship action
+helmor workspace stack myapp/feature-x       # view the PR stack
+helmor workspace archive myapp/feature-x
+helmor github                                # auth, PR lookup, merge
+```
+
+### Scripting
+
+Every command accepts:
+
+- `--json` — machine-readable output
+- `--quiet` — IDs only (or nothing)
+- `--data-dir <path>` — point at a different data directory
+
+```bash
+helmor workspace list --json | jq '.[].name'
+```
+
+Shell completions: `helmor completions <shell>`.
+
+Other useful subcommands: `helmor session` (inspect conversations),
+`helmor files` (read/write workspace files), `helmor scripts show` (effective
+setup/run/archive scripts), `helmor settings`, `helmor data info`, and
+`helmor conductor` (migration). Each has `--help` with examples.
+
+## MCP server
+
+`helmor mcp` runs Helmor as an MCP (Model Context Protocol) server over stdio,
+exposing read-only tools for repositories, workspaces, sessions, and settings.
+Register it with any MCP client — for example, with Claude Code:
+
+```bash
+claude mcp add helmor -- helmor mcp
+```
+
+Now an agent anywhere on your machine can list your workspaces, read session
+history, and check workspace status — useful for building your own
+orchestration on top of Helmor, or letting one agent supervise the others.

--- a/docs/user/reference/composer.md
+++ b/docs/user/reference/composer.md
@@ -1,0 +1,47 @@
+# Composer
+
+The composer is the prompt input at the bottom of every session. It looks like
+a text box; it does considerably more.
+
+## Writing the prompt
+
+| Feature | How |
+| --- | --- |
+| **File mentions** | Type `@` and fuzzy-search files in the workspace; the agent receives the path |
+| **Slash commands & skills** | Type `/` to browse the agent's commands and installed skills |
+| **Images** | Paste a screenshot, or drag image files onto the input — they attach as chips |
+| **Large pastes** | Big blocks of pasted text collapse into a badge (hover to preview) instead of flooding the input |
+| **Linked directories** | `/add-dir` links another directory into the session's context; linked dirs show as chips above the input |
+| **Prompt history** | **↑** at the start of the input recalls previous prompts, shell-style; **↓** walks back to your draft |
+
+## The toolbar
+
+| Control | What it does |
+| --- | --- |
+| **Model picker** (⌥P) | Choose provider and model for this session ([Agents & models](../concepts/agents-and-models.md)) |
+| **Effort** | Reasoning depth: `low` → `max`, model-dependent |
+| **Plan mode** (⇧Tab) | Agent proposes a plan instead of editing files; approve to implement |
+| **Fast mode** | Faster, lighter turns on supported models |
+| **Terminal mode** (⌘⇧T) | Send the prompt to the agent's own TUI in a built-in terminal |
+| **Context panel** (⌘⌥C) | Browse issues, PRs, and notifications from connected sources and drop them into the prompt |
+| **Context usage ring** | How full the model's context window is; hover for details |
+
+## Sending
+
+- **Enter** — send. During a running turn the button becomes **Steer**, and
+  your message is injected into the turn in progress.
+- **⌘Enter** — the opposite of whatever the button currently does: queue the
+  message for after the turn instead of steering (or vice versa).
+- **Queued prompts** are listed above the composer — edit, remove, or promote
+  any of them to steer immediately.
+
+## When the agent asks back
+
+Permission requests, plan approvals, and clarifying questions render as
+interactive panels in place of the composer — answer them inline and the agent
+continues. A free-text "Other" answer is always available on multiple-choice
+questions.
+
+## Focus
+
+**⌘L** focuses the composer from anywhere in the app.

--- a/docs/user/reference/editor.md
+++ b/docs/user/reference/editor.md
@@ -1,0 +1,36 @@
+# Editor
+
+Helmor includes a real code editor — Monaco, the engine inside VS Code — so
+small fixes don't require leaving the app.
+
+## Opening files
+
+- Click a file in the inspector's **Changes** tree to open its diff, then
+  press **⌘E** to switch from diff to edit mode (and back).
+- **⌘T** (while the editor is focused) opens a file picker for anything in
+  the workspace.
+
+## Working in the editor
+
+- Tabs across the top, one per open file (**⌘W** closes the active one).
+- Full syntax highlighting, search, and the editing behavior you expect from
+  VS Code's editor component.
+- A breadcrumb shows the file's path — click to copy.
+- Edits save into the workspace's worktree like any other change, so they show
+  up in the Changes tree and in the next commit.
+
+## Diff mode vs. edit mode
+
+| Mode | What you see | Use it for |
+| --- | --- | --- |
+| **Diff** | Before/after, side-by-side or unified, read-only | Reviewing agent output |
+| **Edit** | The live file, editable | Quick fixes, tweaking a line the agent almost got right |
+
+**⌘E** toggles between them.
+
+## Prefer your own editor?
+
+**⌘O** opens the workspace in your external editor of choice (configurable),
+and right-click → *Reveal in Finder* gets you to the directory. The worktree
+is a plain checkout — any tool can work on it; Helmor picks up external
+changes automatically.

--- a/docs/user/reference/keyboard-shortcuts.md
+++ b/docs/user/reference/keyboard-shortcuts.md
@@ -1,0 +1,77 @@
+# Keyboard shortcuts
+
+Defaults on macOS. On Windows, ⌘ maps to Ctrl. Every binding can be changed in
+**Settings → Shortcuts** (per scope, with conflict detection).
+
+## Workspaces
+
+| Shortcut | Action |
+| --- | --- |
+| ⌘N | New workspace |
+| ⌘⇧N | New workspace (just chat) |
+| ⌘⌥↑ / ⌘⌥↓ | Previous / next workspace |
+| ⌃Tab / ⌃⇧Tab | Quick-switch between recent workspaces |
+| ⌘⇧F | Filter and sort the sidebar |
+| ⌘⇧C | Copy workspace path |
+| ⌘O | Open workspace in external editor |
+
+## Sessions
+
+| Shortcut | Action |
+| --- | --- |
+| ⌘T | New session |
+| ⌘W | Close session |
+| ⌘⇧R | Reopen closed session |
+| ⌘⌥← / ⌘⌥→ | Previous / next session |
+
+## Composer
+
+| Shortcut | Action |
+| --- | --- |
+| ⌘L | Focus the composer |
+| Enter | Send (or steer, during a running turn) |
+| ⌘Enter | Queue instead of steer (and vice versa) |
+| ⇧Tab | Toggle plan mode |
+| ⌘⇧T | Toggle terminal mode |
+| ⌥P | Open the model picker |
+| ⌘⌥C | Toggle the context panel |
+| ↑ / ↓ | Recall previous prompts / return to draft |
+
+## Ship actions
+
+| Shortcut | Action |
+| --- | --- |
+| ⌘⇧Y | Commit & push |
+| ⌘⇧P | Create PR |
+| ⌘⇧L | Pull latest from the target branch |
+| ⌘⇧M | Merge PR |
+| ⌘⇧X | Fix CI |
+| ⌘⇧G | Open PR in browser |
+
+## Editor & terminal
+
+| Shortcut | Action |
+| --- | --- |
+| ⌘E | Toggle diff / edit mode |
+| ⌘T / ⌘W | Open / close file (editor focused) |
+| ⌘J | Toggle the run-scripts panel |
+| ⌘R | Run / stop the selected script |
+| ⌘⇧J | Focus the terminal |
+| ⌘T / ⌘W | New / close terminal (terminal focused) |
+| ⌘⌥← / ⌘⌥→ | Previous / next terminal |
+
+## Window & app
+
+| Shortcut | Action |
+| --- | --- |
+| ⌘B | Toggle left sidebar |
+| ⌘⌥B | Toggle inspector |
+| ⌘. | Zen mode (hide all chrome) |
+| ⌘⌃M | Mini mode (compact window) |
+| ⌘⌥T | Toggle light / dark theme |
+| ⌘+ / ⌘− / ⌘0 | Zoom in / out / reset |
+| ⌘, | Settings |
+| ⇧⌥Space | Quick panel (floating window) |
+
+A global show/hide-Helmor hotkey is available but unbound by default — assign
+one in Settings → Shortcuts.

--- a/docs/user/reference/review-and-ship.md
+++ b/docs/user/reference/review-and-ship.md
@@ -1,0 +1,74 @@
+# Review & ship
+
+The inspector (right panel, **⌘⌥B**) is where agent output becomes shipped
+software. It has four sections: actions, changes, terminals, and run scripts.
+
+## Changes
+
+Every modified file in the workspace, as a tree:
+
+- status badges (modified / added / deleted) and per-file +/− line counts;
+- click a file to open its **diff** — side-by-side or unified, fully
+  syntax-highlighted;
+- **⌘E** flips the diff into edit mode when you want to fix something
+  yourself ([Editor](editor.md));
+- right-click for *Reveal in Finder*, *Copy path*, or *Open on
+  GitHub/GitLab*.
+
+## Actions
+
+The action area reads the workspace's git and PR state — uncommitted changes,
+conflicts, ahead/behind the target branch, PR status, CI checks — and offers
+the next sensible step as a button:
+
+| Action | Shortcut | What it does |
+| --- | --- | --- |
+| **Commit & Push** | ⌘⇧Y | Commit all changes and push the branch |
+| **Create PR / MR** | ⌘⇧P | Open a pull request against the target branch |
+| **Pull Latest** | ⌘⇧L | Merge the target branch into the workspace (stashes and restores uncommitted work) |
+| **Merge** | ⌘⇧M | Merge the PR (uses the repo's allowed merge method) |
+| **Fix CI** | ⌘⇧X | Dispatch an agent at the failing checks |
+| **Resolve Conflicts** | — | Dispatch an agent at the merge conflicts |
+| **Open PR** | ⌘⇧G | Open the PR in your browser |
+
+Notes:
+
+- *Commit & Push*, *Create PR*, *Fix CI*, and *Resolve Conflicts* are
+  agent-dispatched — they start a session you can watch and steer like any
+  other.
+- *Merge* respects branch protection: if checks are still running or the PR
+  is blocked, the button says so instead of failing.
+- PR state (open / merged / closed) and check results refresh automatically;
+  Helmor also background-fetches the remote so ahead/behind counts stay
+  current.
+
+Works with **GitHub** and **GitLab**, via the accounts you connected during
+onboarding.
+
+## Terminals
+
+Open real terminals in the workspace directory — multiple tabs, full color:
+
+- **⌘⇧J** — focus the terminal section
+- **⌘T / ⌘W** — new / close terminal (while the terminal is focused)
+
+Anything you'd normally do in a checkout — `git log`, one-off scripts, manual
+testing — works here without leaving the app.
+
+## Run scripts
+
+Your project's configured actions (dev server, tests, builds) appear in the
+scripts panel:
+
+- **⌘J** — toggle the panel
+- **⌘R** — run / stop the selected script
+
+Output streams in with color; the sidebar glows on workspaces with active
+scripts. Configure the actions in
+[`helmor.json`](../get-started/configure-your-project.md).
+
+## After the merge
+
+Archive the workspace — manually, or automatically with the per-repository
+**archive on merge** setting. See
+[Workspaces → Lifecycle](../concepts/workspaces.md#lifecycle).

--- a/docs/user/reference/settings.md
+++ b/docs/user/reference/settings.md
@@ -1,0 +1,80 @@
+# Settings
+
+Open settings with **⌘,**. Panels, from top to bottom:
+
+## General
+
+Defaults for new sessions and app-wide behavior:
+
+- **Default model**, **default effort**, and default toggles for fast mode and
+  permission behavior.
+- **Notifications** — desktop notifications and sounds for when agents finish
+  or need input.
+
+## Appearance
+
+- Theme (light / dark / system — quick-toggle with **⌘⌥T**), accent color,
+  font, zoom level (**⌘+ / ⌘− / ⌘0**).
+- Sidebar layout: grouping (flat, by repository, by status) and sort order.
+
+## Models
+
+Provider configuration:
+
+- **Cursor** — API key; once set, Cursor models appear in the picker.
+- **OpenCode** — connect providers and choose which models to expose
+  (read from your `~/.config/opencode/opencode.jsonc`).
+- **Custom Claude-compatible providers** — base URL + API key for any endpoint
+  speaking the Claude API.
+
+Claude Code and Codex sign-in is handled through their own login flows during
+onboarding (or re-run from here). See
+[Agents & models](../concepts/agents-and-models.md).
+
+## Accounts
+
+GitHub and GitLab accounts, via the bundled `gh`/`glab` CLIs. Multiple
+accounts are supported; each repository binds to the account that has access.
+Re-authenticate from here if a token expires — the login flow runs in an
+embedded terminal.
+
+## Repository
+
+Per-repository configuration (also reachable from the sidebar):
+
+- **Scripts** — setup / run / archive scripts, with an editor
+  ([Configure your project](../get-started/configure-your-project.md))
+- **Default branch**, **branch prefix**, **remote**
+- **Auto-run setup** on workspace creation
+- **Archive on merge**
+
+## Shortcuts
+
+Every keybinding in the app is rebindable, per scope (app, chat, composer,
+editor, terminal), with conflict detection and a reset-to-defaults. The full
+map: [Keyboard shortcuts](keyboard-shortcuts.md).
+
+## App Updates
+
+Current version, update channel status, manual *Check for updates*. Updates
+download in the background and apply on restart.
+
+## Local LLM
+
+Manage the on-device models that power local features such as automatic
+session titles. Downloads can be paused and resumed.
+
+## Mobile companion *(experimental)*
+
+Pair a phone to keep an eye on sessions away from your desk.
+
+## Conductor import
+
+Migrating from Conductor? One click imports your repositories, workspaces,
+and session history.
+
+## Experimental
+
+- **Command Line Tool** — install the `helmor` CLI to your PATH
+  ([CLI & MCP](cli-and-mcp.md)).
+- Other in-progress features, clearly labeled.

--- a/docs/user/security/privacy.md
+++ b/docs/user/security/privacy.md
@@ -1,0 +1,61 @@
+# Privacy
+
+Helmor is local-first by design. There is no Helmor cloud, no account to
+create, and no server your code passes through.
+
+## What stays on your machine
+
+Everything Helmor manages lives under `~/helmor/`:
+
+| Path | Contents |
+| --- | --- |
+| `helmor.db` | SQLite database: repositories, workspaces, sessions, full conversation history, settings |
+| `workspaces/` | Workspace worktrees — your code |
+| `chats/` | Scratch directories for chat-only workspaces |
+| `logs/` | Application logs (JSONL) |
+| `cache/` | Avatars, pasted images, UI caches |
+| `local-llm/` | Downloaded on-device model files |
+
+Conversation history is never uploaded. Settings are never synced. Deleting
+`~/helmor/` removes everything Helmor knows (your repositories' original
+clones are untouched — Helmor never moves or modifies them).
+
+## What leaves your machine, and when
+
+Only traffic you initiate, with your own credentials:
+
+- **Agent API calls** — your prompts, and the file contents the agent chooses
+  to read, go to the provider of the model you selected (Anthropic, OpenAI,
+  Cursor, or your OpenCode/custom provider endpoints). Helmor does not proxy
+  or inspect this traffic; the agent CLIs talk to their providers directly,
+  authenticated by your login or API key.
+- **Git operations** — fetch, push, clone, against your repository's remotes.
+- **GitHub / GitLab API calls** — PR status, checks, create/merge, using
+  tokens from your `gh`/`glab` logins. Tokens are managed by those CLIs, not
+  copied into Helmor's database.
+- **Update checks** — the app checks GitHub releases for new versions.
+- **Feedback** — only if you use the feedback button, and only what you type
+  there.
+
+There is no analytics pipeline collecting your code or conversations.
+
+## Credentials
+
+Helmor does not have its own credential store for agents and forges — it
+reuses the standard ones:
+
+- Claude Code and Codex logins live where those CLIs keep them.
+- `gh` / `glab` tokens live in those CLIs' own config/keychain.
+- Keys you enter in Helmor settings (e.g. a Cursor API key, custom provider
+  keys) are stored locally in your settings database.
+
+## Local models
+
+Features powered by the bundled local LLM (such as automatic session titles)
+run entirely on-device.
+
+## Taking your data with you
+
+It's a SQLite file and plain directories. Back up `~/helmor/`, move it to a
+new machine, or point Helmor elsewhere with the `HELMOR_DATA_DIR` environment
+variable. The CLI (`helmor data info`) shows exactly where everything is.

--- a/docs/user/troubleshooting/faq.md
+++ b/docs/user/troubleshooting/faq.md
@@ -1,0 +1,72 @@
+# FAQ
+
+### Is Helmor free?
+
+The app is open source (Apache 2.0) and free. You pay your model providers
+directly — Claude/Anthropic, OpenAI, Cursor — through the subscriptions or API
+keys you already have.
+
+### Do I need Claude Code / Codex / gh installed first?
+
+No. Helmor bundles the agent CLIs and the GitHub/GitLab CLIs inside the app.
+You only need your accounts; if you're already signed in to these tools on
+your machine, Helmor picks the logins up automatically.
+
+### Which platforms are supported?
+
+macOS (Apple Silicon and Intel) and Windows (x64).
+
+### Where is my data?
+
+`~/helmor/` — a SQLite database plus one directory per workspace. Nothing is
+synced anywhere. See [Privacy](../security/privacy.md).
+
+### Can several agents really work on the same repo at once?
+
+Yes — that's the point. Each workspace is an isolated git worktree with its
+own branch and directory, so parallel agents can't interfere with each other
+or with your own checkout. See [Workspaces](../concepts/workspaces.md).
+
+### Does Helmor work with GitLab?
+
+Yes. GitHub and GitLab are both supported, including PR/MR creation and merge,
+via the bundled `gh` and `glab` CLIs.
+
+### What happens to my branch when I archive a workspace?
+
+The worktree directory is removed and the conversation is kept. The branch is
+deleted only if Helmor auto-generated it; branches you picked yourself are
+preserved. Archived workspaces can be restored later.
+
+### Can I use my own editor instead of the built-in one?
+
+Yes. A workspace is a plain git checkout — **⌘O** opens it in your external
+editor, and Helmor picks up changes made by any tool.
+
+### Does Helmor work offline?
+
+The app and your history do — browsing, diffs, editing, terminals all work
+offline. Agents need network access to reach their providers; git/PR actions
+need your remotes.
+
+### Can I drive Helmor without the GUI?
+
+Yes — the `helmor` CLI covers repositories, workspaces, sessions, prompts, and
+ship actions, and `helmor mcp` exposes Helmor to other agents over MCP. See
+[CLI & MCP](../reference/cli-and-mcp.md).
+
+### I'm coming from Conductor — do I start over?
+
+No. **Settings → Conductor import** migrates your repositories, workspaces,
+and session history.
+
+### A keyboard shortcut clashes with another app
+
+Every binding is rebindable in **Settings → Shortcuts**, with conflict
+detection.
+
+### Where do I ask questions or report bugs?
+
+The [Discord](https://discord.gg/ukyyuNfnDp), the feedback button at the
+bottom of Helmor's sidebar, or
+[GitHub issues](https://github.com/dohooo/helmor/issues).

--- a/docs/user/troubleshooting/troubleshooting.md
+++ b/docs/user/troubleshooting/troubleshooting.md
@@ -1,0 +1,82 @@
+# Troubleshooting
+
+## First stop: the logs
+
+Helmor writes structured JSONL logs to `~/helmor/logs/`. When something
+misbehaves, the most recent file there usually says why. Attach the relevant
+lines when reporting a bug.
+
+## GitHub / GitLab auth stopped working
+
+Symptoms: PR status missing, *Create PR* / *Merge* failing with auth errors.
+
+1. Open **Settings → Accounts** and check the account state.
+2. Re-authenticate from there — the `gh auth login` / `glab auth login` flow
+   runs in an embedded terminal.
+3. Multiple accounts: each repository binds to one login. If a repo shows the
+   wrong account or none, retry the binding from the repository settings.
+
+## Workspace creation fails
+
+- **"Repository has no remote"** — Helmor needs at least one git remote
+  (usually `origin`) to create worktree workspaces. Add one:
+  `git remote add origin <url>`.
+- **Branch name collisions** — if a branch with the generated name already
+  exists, pick a different workspace name or attach to the existing branch
+  explicitly.
+
+## Setup script failed
+
+The workspace is created anyway, in a *setup pending* state. Fix the script
+(repository settings → Scripts, or `helmor.json`) and re-run setup from the
+workspace. Remember setup runs in a fresh worktree: untracked files from your
+main clone (like `.env.local`) aren't there unless your script copies them —
+see [Configure your project](../get-started/configure-your-project.md).
+
+## Pull Latest reports conflicts
+
+*Pull Latest* stashes your uncommitted work, merges the target branch, and
+restores the stash. Two things can conflict:
+
+- **The merge itself** — Helmor aborts cleanly and offers
+  **Resolve Conflicts**, which dispatches an agent at the conflict markers.
+  You can also resolve by hand in the editor or a terminal.
+- **The stash restore** — your uncommitted changes overlap the merged ones.
+  The work is safe in the stash; resolve in a terminal (`git stash pop` after
+  fixing) or let the agent sort it out.
+
+## An agent turn hangs or errors
+
+- **Stop** the turn — the session stays usable; send again to continue.
+- Check the provider sign-in (Claude Code / Codex login, API keys in
+  Settings → Models).
+- Behind a proxy? Configure it in Settings — agent processes inherit the
+  system or custom proxy you set there.
+
+## The `helmor` CLI isn't found
+
+- Install it via **Settings → Experimental → Command Line Tool**.
+- On Windows, open a *new* terminal after installing so the updated `PATH` is
+  visible.
+- `helmor cli-status` reports what's installed and which data directory it
+  points at.
+
+## Updates won't install
+
+Check **Settings → App Updates** for state, then the logs. As a fallback,
+download the latest release from
+[GitHub releases](https://github.com/dohooo/helmor/releases) and install over
+the existing app — your data in `~/helmor/` is untouched.
+
+## Disk usage creeping up
+
+Worktrees are full checkouts. Archive workspaces you're done with — that
+removes their directories while keeping history. The sidebar's right-click
+menu and `helmor workspace archive` both work.
+
+## Still stuck?
+
+- [Discord](https://discord.gg/ukyyuNfnDp) — fastest answers
+- The feedback button at the bottom of Helmor's sidebar (can attach
+  screenshots)
+- [GitHub issues](https://github.com/dohooo/helmor/issues)


### PR DESCRIPTION
## What changed
- Reworked the README to explain Helmor's positioning, install flow, documentation entry points, CLI, and source build steps.
- Added a structured user guide under `docs/user/` covering getting started, core concepts, reference pages, privacy, FAQ, and troubleshooting.

## Why
Helmor needed first-party user-facing documentation in the repository so new users can understand installation, workspace flow, agent usage, review actions, and recovery paths without relying on external docs.

## Follow-up / test notes
- No automated test suite was run; this is documentation-only.
- Pre-commit reported no lint-staged tasks matched the staged documentation files.