### PR TITLE
fix: prevent terminal hint overlapping file mentions

### DIFF
--- a/.changeset/terminal-file-placeholder.md
+++ b/.changeset/terminal-file-placeholder.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix Terminal mode composer hints overlapping file mentions after inserting files with @.

--- a/src/features/composer/editor/plugins/terminal-directive-plugin.test.tsx
+++ b/src/features/composer/editor/plugins/terminal-directive-plugin.test.tsx
@@ -1,0 +1,109 @@
+import { LexicalComposer } from "@lexical/react/LexicalComposer";
+import { LexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { act, cleanup, render } from "@testing-library/react";
+import {
+	$createParagraphNode,
+	$createTextNode,
+	$getRoot,
+	type LexicalEditor,
+} from "lexical";
+import { useContext } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CustomTagBadgeNode } from "../custom-tag-badge-node";
+import { $createFileBadgeNode, FileBadgeNode } from "../file-badge-node";
+import { ImageBadgeNode } from "../image-badge-node";
+import {
+	$createTerminalDirectiveNode,
+	TerminalDirectiveNode,
+} from "../terminal-directive-node";
+import { TerminalDirectivePlugin } from "./terminal-directive-plugin";
+
+afterEach(() => {
+	cleanup();
+});
+
+function CaptureEditor({
+	onReady,
+}: {
+	onReady: (editor: LexicalEditor) => void;
+}) {
+	const ctx = useContext(LexicalComposerContext);
+	if (ctx) onReady(ctx[0]);
+	return null;
+}
+
+function renderPlugin(
+	onDirectiveChange: (state: { active: boolean; emptyAfter: boolean }) => void,
+) {
+	let editor!: LexicalEditor;
+	render(
+		<LexicalComposer
+			initialConfig={{
+				namespace: "terminal-directive-test",
+				onError: (error) => {
+					throw error;
+				},
+				nodes: [
+					TerminalDirectiveNode,
+					FileBadgeNode,
+					ImageBadgeNode,
+					CustomTagBadgeNode,
+				],
+			}}
+		>
+			<TerminalDirectivePlugin enabled onDirectiveChange={onDirectiveChange} />
+			<CaptureEditor
+				onReady={(nextEditor) => {
+					editor = nextEditor;
+				}}
+			/>
+		</LexicalComposer>,
+	);
+	return editor;
+}
+
+describe("TerminalDirectivePlugin", () => {
+	it("treats a file badge after the directive as content", () => {
+		const onDirectiveChange = vi.fn();
+		const editor = renderPlugin(onDirectiveChange);
+
+		act(() => {
+			editor.update(
+				() => {
+					const paragraph = $createParagraphNode();
+					paragraph.append(
+						$createTerminalDirectiveNode(),
+						$createTextNode(" "),
+					);
+					$getRoot().append(paragraph);
+				},
+				{ discrete: true },
+			);
+		});
+		expect(onDirectiveChange).toHaveBeenLastCalledWith({
+			active: true,
+			emptyAfter: true,
+		});
+
+		act(() => {
+			editor.update(
+				() => {
+					$getRoot().clear();
+					const paragraph = $createParagraphNode();
+					paragraph.append(
+						$createTerminalDirectiveNode(),
+						$createTextNode(" "),
+						$createFileBadgeNode("/tmp/src/foo.ts"),
+					);
+					$getRoot().append(paragraph);
+				},
+				{ discrete: true },
+			);
+		});
+
+		expect(onDirectiveChange).toHaveBeenLastCalledWith({
+			active: true,
+			emptyAfter: false,
+		});
+	});
+});

--- a/src/features/composer/editor/plugins/terminal-directive-plugin.tsx
+++ b/src/features/composer/editor/plugins/terminal-directive-plugin.tsx
@@ -14,11 +14,22 @@ import {
 	type TextNode,
 } from "lexical";
 import { useEffect } from "react";
+import { $isCustomTagBadgeNode } from "../custom-tag-badge-node";
+import { $isFileBadgeNode } from "../file-badge-node";
+import { $isImageBadgeNode } from "../image-badge-node";
 import {
 	$createTerminalDirectiveNode,
 	$isTerminalDirectiveNode,
 	TerminalDirectiveNode,
 } from "../terminal-directive-node";
+
+function $isBadgeNode(node: import("lexical").LexicalNode): boolean {
+	return (
+		$isImageBadgeNode(node) ||
+		$isFileBadgeNode(node) ||
+		$isCustomTagBadgeNode(node)
+	);
+}
 
 function $findBangTrigger(): TextNode | null {
 	const root = $getRoot();
@@ -47,6 +58,7 @@ function $readTerminalDirectiveState(): TerminalDirectiveState {
 			continue;
 		}
 		if (!$isElementNode(child)) {
+			if ($isBadgeNode(child)) hasMeaningfulContent = true;
 			if (child.getTextContent().trim()) hasMeaningfulContent = true;
 			continue;
 		}
@@ -56,6 +68,10 @@ function $readTerminalDirectiveState(): TerminalDirectiveState {
 				continue;
 			}
 			if ($isLineBreakNode(desc)) continue;
+			if ($isBadgeNode(desc)) {
+				hasMeaningfulContent = true;
+				continue;
+			}
 			if (desc.getTextContent().trim()) {
 				hasMeaningfulContent = true;
 			}

--- a/src/features/composer/index.tsx
+++ b/src/features/composer/index.tsx
@@ -529,7 +529,8 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 	const showFocusHint =
 		!isInputFocused && !hasContent && !inputDisabled && Boolean(focusShortcut);
 	const showTerminalDirectiveHint =
-		terminalDirectiveState.emptyAfter && !inputDisabled;
+		terminalDirectiveState.emptyAfter && !hasContent && !inputDisabled;
+	const showEditorPlaceholder = !hasContent && !showTerminalDirectiveHint;
 
 	// Lexical initial config — must be a new object per mount for key resets
 	const initialConfig = useRef({
@@ -896,12 +897,14 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 										/>
 									}
 									placeholder={
-										<div className="pointer-events-none absolute left-0 top-0 text-body leading-5 tracking-[-0.01em] text-muted-foreground/70">
-											{hasPlanReview && permissionMode === "plan"
-												? "Describe what to change, then click Request Changes"
-												: (placeholder ??
-													"Ask to make changes, @mention files, run /commands")}
-										</div>
+										showEditorPlaceholder ? (
+											<div className="pointer-events-none absolute left-0 top-0 text-body leading-5 tracking-[-0.01em] text-muted-foreground/70">
+												{hasPlanReview && permissionMode === "plan"
+													? "Describe what to change, then click Request Changes"
+													: (placeholder ??
+														"Ask to make changes, @mention files, run /commands")}
+											</div>
+										) : null
 									}
 									ErrorBoundary={LexicalErrorBoundary}
 								/>


### PR DESCRIPTION
## What changed

- Treat file, image, and custom tag badges after a Terminal mode directive as meaningful composer content.
- Hide the normal editor placeholder while the Terminal directive hint is showing.
- Add focused coverage for file badges after the directive.
- Add a patch changeset for the user-visible composer hint fix.

## Why

After inserting files with `@` in Terminal mode, the composer could still think the directive had no content after it, causing the Terminal hint and normal placeholder behavior to overlap with file mentions.

## Follow-up / test notes

- Ran `bun x vitest run src/features/composer/editor/plugins/terminal-directive-plugin.test.tsx`.
- Pre-commit ran Biome on staged frontend files.
