### PR TITLE
fix: start-screen branch picker syncs remote refs on open

### DIFF
--- a/.changeset/swift-branches-appear.md
+++ b/.changeset/swift-branches-appear.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix the start-screen branch picker not showing freshly pushed remote branches until a restart — it now syncs from the remote each time you open it.

--- a/src/shell/controllers/use-start-surface-controller.ts
+++ b/src/shell/controllers/use-start-surface-controller.ts
@@ -25,6 +25,7 @@ import {
 	getRepoCurrentBranch,
 	listBranchesForWorkspacePicker,
 	moveLocalWorkspaceToWorktree,
+	prefetchRemoteRefs,
 	prewarmSlashCommandsForRepo,
 	type RepositoryCreateOption,
 	renameSession,
@@ -434,8 +435,19 @@ export function useStartSurfaceController(
 	);
 
 	const refetchBranches = useCallback(() => {
+		// Show cached refs immediately, then sync the remote so freshly
+		// pushed branches appear without a restart. Mirrors the header
+		// target-branch picker; backend rate-limits the fetch to 10s.
 		void startBranchesQuery.refetch();
-	}, [startBranchesQuery]);
+		if (!startRepository) return;
+		void prefetchRemoteRefs({ repoId: startRepository.id })
+			.then((result) => {
+				if (result.fetched) {
+					void startBranchesQuery.refetch();
+				}
+			})
+			.catch(() => {});
+	}, [startBranchesQuery, startRepository]);
 
 	const moveLocalToWorktree = useCallback(
 		(workspaceId: string) => {


### PR DESCRIPTION
## What changed

The start-screen branch picker now calls `prefetchRemoteRefs` when opened, showing freshly pushed remote branches immediately instead of requiring an app restart.

## Why

When a user pushes a new branch from the command line, the start-screen branch picker previously only showed cached refs and wouldn't pick up new remote branches until Helmor was restarted. This mirrors the behavior already implemented in the header target-branch picker.

## Details

- Added a `prefetchRemoteRefs` call after the cached refetch in `useStartSurfaceController.refetchBranches`
- If the remote fetch returns new data, a second `refetch()` is triggered to update the picker UI
- The backend rate-limits remote fetches to 10s to prevent spamming