### PR TITLE
fix: don't orphan Run-tab scripts and terminals on the fallback quit path

### DIFF
--- a/.changeset/quit-stops-orphans.md
+++ b/.changeset/quit-stops-orphans.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix a quit path where Helmor could exit without stopping your Run-tab scripts and embedded terminals, leaving them running as orphan processes.

--- a/src-tauri/src/commands/system_commands.rs
+++ b/src-tauri/src/commands/system_commands.rs
@@ -1836,7 +1836,13 @@ fn base64_decode(input: &str) -> anyhow::Result<Vec<u8>> {
 #[tauri::command]
 pub async fn request_quit(app: tauri::AppHandle, force: bool) {
     tracing::info!(force, "request_quit invoked from frontend");
+    cleanup_before_exit(&app, force);
 
+    // Done: terminate the process.
+    app.exit(0);
+}
+
+pub fn cleanup_before_exit(app: &tauri::AppHandle, force: bool) {
     // 1. Stop filesystem watchers so no new events arrive.
     app.state::<git_watcher::GitWatcherManager>().shutdown();
 
@@ -1858,29 +1864,47 @@ pub async fn request_quit(app: tauri::AppHandle, force: bool) {
     //    Helmor itself spawned. Each handle's owning `run_script` thread
     //    reaps its own `Child`, so we just need to deliver the signal.
     let scripts = app.state::<ScriptProcessManager>();
-    let signaled = scripts.kill_all();
+    let kill_attempts = scripts.kill_all();
+
+    // Belt-and-suspenders: stamp only rows for processes we just proved gone.
+    // The per-process `record_ended` calls in `run_script_with_shell` cover
+    // the common case; this catches handles that did not make it through their
+    // reaper before app exit. Prior maybe-alive stale rows must remain open so
+    // the next launch can keep reporting them.
+    let confirmed_gone: Vec<_> = kill_attempts
+        .iter()
+        .filter(|attempt| attempt.gone)
+        .map(
+            |attempt| crate::workspace::runtime_registry::RuntimeProcessIdentity {
+                repo_id: attempt.repo_id.clone(),
+                workspace_id: attempt.workspace_id.clone(),
+                script_type: attempt.script_type.clone(),
+                pid: attempt.pid,
+                pgid: attempt.pgid,
+            },
+        )
+        .collect();
+
+    let signaled = kill_attempts.len();
     if signaled > 0 {
+        let timed_out = signaled.saturating_sub(confirmed_gone.len());
         tracing::info!(
             signaled,
+            confirmed_gone = confirmed_gone.len(),
+            timed_out,
             "request_quit: signaled live script/terminal handles"
         );
     }
 
-    // Belt-and-suspenders: stamp every still-open runtime registry
-    // row as ended, so the next launch's classification sweep
-    // doesn't waste cycles probing PIDs we've already terminated.
-    // The per-process `record_ended` calls in `run_script_with_shell`
-    // cover the common case; this catches handles that didn't make
-    // it through their reaper before app exit.
-    match crate::workspace::runtime_registry::record_all_ended() {
+    match crate::workspace::runtime_registry::record_processes_ended(&confirmed_gone) {
         Ok(0) => {}
         Ok(stamped) => tracing::debug!(
             stamped,
-            "request_quit: stamped runtime registry rows as ended"
+            "request_quit: stamped confirmed runtime registry rows as ended"
         ),
         Err(error) => tracing::warn!(
             %error,
-            "request_quit: failed to stamp runtime registry rows ended; \
+            "request_quit: failed to stamp confirmed runtime registry rows ended; \
              next launch's sweep will reclassify"
         ),
     }
@@ -1899,9 +1923,6 @@ pub async fn request_quit(app: tauri::AppHandle, force: bool) {
         )
     };
     sidecar.shutdown(cooperative, escalation);
-
-    // 5. Done — terminate the process.
-    app.exit(0);
 }
 
 // ---------------------------------------------------------------------------

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -913,8 +913,12 @@ fn emit_quit_requested(app_handle: &tauri::AppHandle) {
     if let Err(e) = app_handle.emit("helmor://quit-requested", ()) {
         tracing::warn!(
             error = %e,
-            "Failed to emit quit-requested event; exiting directly",
+            "Failed to emit quit-requested event; cleaning up before exit",
         );
+        // force = false: the webview is already gone, so there are no live
+        // streams worth draining gracefully — run the fast teardown. The
+        // sidecar shutdown inside still kills any in-flight work on the way out.
+        commands::system_commands::cleanup_before_exit(app_handle, false);
         app_handle.exit(0);
     }
 }

--- a/src-tauri/src/workspace/runtime_registry.rs
+++ b/src-tauri/src/workspace/runtime_registry.rs
@@ -63,6 +63,15 @@ pub enum StaleProcessVerdict {
     MaybeAlive,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeProcessIdentity {
+    pub repo_id: String,
+    pub workspace_id: Option<String>,
+    pub script_type: String,
+    pub pid: i32,
+    pub pgid: i32,
+}
+
 /// Persist a row for a freshly-spawned script/terminal process. The
 /// returned id is used by `record_ended` (and any future surface
 /// that wants to address the registry row directly).
@@ -108,26 +117,47 @@ pub fn record_ended(id: &str) -> Result<()> {
     Ok(())
 }
 
-/// Force-stamp every still-open row to `ended_at = now()` — used by
-/// the graceful-quit path so the next launch's classification sweep
-/// doesn't waste cycles probing PIDs that we already terminated via
-/// `kill_all`. Returns the number of rows stamped.
-pub fn record_all_ended() -> Result<usize> {
-    let conn =
-        db::write_conn().context("Failed to borrow write connection for runtime registry sweep")?;
-    record_all_ended_in(&conn)
+/// Stamp only the runtime rows that match process identities Helmor just
+/// proved gone, leaving prior maybe-alive stale rows open so the next
+/// startup can keep reporting them.
+pub fn record_processes_ended(processes: &[RuntimeProcessIdentity]) -> Result<usize> {
+    let conn = db::write_conn()
+        .context("Failed to borrow write connection for runtime registry process update")?;
+    record_processes_ended_in(&conn, processes)
 }
 
 // Caller-supplied connection so tests can drive it against an in-memory DB.
-pub fn record_all_ended_in(conn: &Connection) -> Result<usize> {
-    let affected = conn
-        .execute(
-            "UPDATE runtime_processes
-             SET ended_at = datetime('now')
-             WHERE ended_at IS NULL",
-            [],
-        )
-        .context("Failed to mark live runtime registry rows as ended")?;
+pub fn record_processes_ended_in(
+    conn: &Connection,
+    processes: &[RuntimeProcessIdentity],
+) -> Result<usize> {
+    let mut affected = 0;
+    for process in processes {
+        affected += conn
+            .execute(
+                "UPDATE runtime_processes
+                 SET ended_at = datetime('now')
+                 WHERE ended_at IS NULL
+                   AND repo_id = ?1
+                   AND ((?2 IS NULL AND workspace_id IS NULL) OR workspace_id = ?2)
+                   AND script_type = ?3
+                   AND pid = ?4
+                   AND pgid = ?5",
+                rusqlite::params![
+                    process.repo_id.as_str(),
+                    process.workspace_id.as_deref(),
+                    process.script_type.as_str(),
+                    process.pid as i64,
+                    process.pgid as i64,
+                ],
+            )
+            .with_context(|| {
+                format!(
+                    "Failed to mark runtime process {} ({}/{}) as ended",
+                    process.pid, process.repo_id, process.script_type
+                )
+            })?;
+    }
     Ok(affected)
 }
 
@@ -274,10 +304,32 @@ mod tests {
     use crate::testkit::TestEnv;
 
     fn seed_row(conn: &Connection, id: &str, pid: i32, pgid: i32, ended_at: Option<&str>) {
+        seed_identity_row(conn, id, "r1", Some("w1"), "run", pid, pgid, ended_at);
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn seed_identity_row(
+        conn: &Connection,
+        id: &str,
+        repo_id: &str,
+        workspace_id: Option<&str>,
+        script_type: &str,
+        pid: i32,
+        pgid: i32,
+        ended_at: Option<&str>,
+    ) {
         conn.execute(
             "INSERT INTO runtime_processes (id, repo_id, workspace_id, script_type, pid, pgid, ended_at)
-             VALUES (?1, 'r1', 'w1', 'run', ?2, ?3, ?4)",
-            rusqlite::params![id, pid as i64, pgid as i64, ended_at],
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            rusqlite::params![
+                id,
+                repo_id,
+                workspace_id,
+                script_type,
+                pid as i64,
+                pgid as i64,
+                ended_at
+            ],
         )
         .unwrap();
     }
@@ -332,27 +384,68 @@ mod tests {
     }
 
     #[test]
-    fn record_all_ended_stamps_only_live_rows() {
+    fn record_processes_ended_only_stamps_matching_identities() {
         let conn = fresh_db();
-        seed_row(&conn, "live-1", 100, 100, None);
-        seed_row(&conn, "live-2", 200, 200, None);
-        seed_row(
+        seed_identity_row(&conn, "match", "r1", Some("w1"), "run", 100, 100, None);
+        seed_identity_row(
             &conn,
-            "already-ended",
-            300,
-            300,
-            Some("2026-01-01T00:00:00Z"),
+            "different-pid",
+            "r1",
+            Some("w1"),
+            "run",
+            101,
+            100,
+            None,
         );
+        seed_identity_row(
+            &conn,
+            "different-ws",
+            "r1",
+            Some("w2"),
+            "run",
+            100,
+            100,
+            None,
+        );
+        seed_identity_row(
+            &conn,
+            "different-repo",
+            "r2",
+            Some("w1"),
+            "run",
+            100,
+            100,
+            None,
+        );
+        seed_identity_row(&conn, "no-workspace", "r1", None, "run", 200, 200, None);
 
-        let affected = record_all_ended_in(&conn).unwrap();
+        let affected = record_processes_ended_in(
+            &conn,
+            &[
+                RuntimeProcessIdentity {
+                    repo_id: "r1".to_string(),
+                    workspace_id: Some("w1".to_string()),
+                    script_type: "run".to_string(),
+                    pid: 100,
+                    pgid: 100,
+                },
+                RuntimeProcessIdentity {
+                    repo_id: "r1".to_string(),
+                    workspace_id: None,
+                    script_type: "run".to_string(),
+                    pid: 200,
+                    pgid: 200,
+                },
+            ],
+        )
+        .unwrap();
+
         assert_eq!(affected, 2);
-        // Pre-stamped row's `ended_at` stays at the seed value.
-        assert_eq!(
-            read_ended_at(&conn, "already-ended").as_deref(),
-            Some("2026-01-01T00:00:00Z")
-        );
-        assert!(read_ended_at(&conn, "live-1").is_some());
-        assert!(read_ended_at(&conn, "live-2").is_some());
+        assert!(read_ended_at(&conn, "match").is_some());
+        assert!(read_ended_at(&conn, "no-workspace").is_some());
+        assert!(read_ended_at(&conn, "different-pid").is_none());
+        assert!(read_ended_at(&conn, "different-ws").is_none());
+        assert!(read_ended_at(&conn, "different-repo").is_none());
     }
 
     // ── classify_stale_processes ──────────────────────────────────────

--- a/src-tauri/src/workspace/scripts.rs
+++ b/src-tauri/src/workspace/scripts.rs
@@ -44,6 +44,16 @@ pub enum ScriptEvent {
 /// Key = (repo_id, script_type, workspace_id)
 type ProcessKey = (String, String, Option<String>);
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScriptKillAttempt {
+    pub repo_id: String,
+    pub script_type: String,
+    pub workspace_id: Option<String>,
+    pub pid: i32,
+    pub pgid: i32,
+    pub gone: bool,
+}
+
 const PROCESS_TERM_TIMEOUT: Duration = Duration::from_millis(200);
 const PROCESS_KILL_TIMEOUT: Duration = Duration::from_millis(500);
 const PTY_POLL_INTERVAL: Duration = Duration::from_millis(25);
@@ -197,7 +207,8 @@ impl ScriptProcessManager {
     /// Signal every live script and terminal handle the manager currently
     /// owns. Used by the graceful-quit path so Run-tab scripts and
     /// embedded-terminal PTY sessions don't outlive Helmor as orphan
-    /// process trees. Returns the number of handles that were signaled.
+    /// process trees. Returns one attempt per handle so callers can persist
+    /// only the processes we actually proved gone.
     ///
     /// Mirrors `kill_others_in_repo`'s lock discipline: snapshot the
     /// handles under the map lock, drop the lock, then call
@@ -207,18 +218,28 @@ impl ScriptProcessManager {
     ///
     /// Does **not** reap — each `run_script` thread still owns its own
     /// `child.wait()`.
-    pub fn kill_all(&self) -> usize {
-        let victims: Vec<ProcessHandle> = {
+    pub fn kill_all(&self) -> Vec<ScriptKillAttempt> {
+        let victims: Vec<(ProcessKey, ProcessHandle)> = {
             let map = self.processes.lock().expect("process map poisoned");
-            map.values().cloned().collect()
+            map.iter()
+                .map(|(key, handle)| (key.clone(), handle.clone()))
+                .collect()
         };
-        let count = victims.len();
-        for h in victims {
+        let mut attempts = Vec::with_capacity(victims.len());
+        for (key, h) in victims {
             h.killed.store(true, Ordering::Release);
             kill_in_flight_stop_command(&h.stop_pgid);
-            escalating_kill(h.pid, h.pgid);
+            let gone = escalating_kill(h.pid, h.pgid);
+            attempts.push(ScriptKillAttempt {
+                repo_id: key.0,
+                script_type: key.1,
+                workspace_id: key.2,
+                pid: pid_to_registry_i32(h.pid),
+                pgid: pid_to_registry_i32(h.pgid),
+                gone,
+            });
         }
-        count
+        attempts
     }
 
     /// Signal the process group (and leader as a fallback) with SIGTERM,
@@ -315,17 +336,26 @@ impl ScriptProcessManager {
 /// a separate thread. When the script owns a separate process group, also wait
 /// for that group to disappear so a fast leader exit cannot leave descendants
 /// running after Stop returns.
-fn escalating_kill(pid: Pid, pgid: Pid) {
+fn escalating_kill(pid: Pid, pgid: Pid) -> bool {
     let tree = crate::platform::process::ProcessTree::new(pid, pgid);
     crate::platform::process::terminate_tree(tree);
 
     if crate::platform::process::wait_for_tree_gone(tree, PROCESS_TERM_TIMEOUT, PTY_POLL_INTERVAL) {
-        return;
+        return true;
     }
 
     crate::platform::process::kill_tree(tree);
-    let _ =
-        crate::platform::process::wait_for_tree_gone(tree, PROCESS_KILL_TIMEOUT, PTY_POLL_INTERVAL);
+    crate::platform::process::wait_for_tree_gone(tree, PROCESS_KILL_TIMEOUT, PTY_POLL_INTERVAL)
+}
+
+#[cfg(unix)]
+fn pid_to_registry_i32(pid: Pid) -> i32 {
+    pid
+}
+
+#[cfg(windows)]
+fn pid_to_registry_i32(pid: Pid) -> i32 {
+    pid as i32
 }
 
 /// SIGKILL any `stop.command` cleanup tree currently published in
@@ -864,10 +894,7 @@ pub(crate) fn run_script_with_shell(
     // i32; on Windows it is u32, so reinterpret the bits. Crash recovery only
     // compares this against live PIDs read back through the same path. The
     // cfg-gated rebinds keep the cast a no-op on Unix (no `unnecessary_cast`).
-    #[cfg(unix)]
-    let (pid_i32, pgid_i32): (i32, i32) = (pid, pgid);
-    #[cfg(windows)]
-    let (pid_i32, pgid_i32): (i32, i32) = (pid as i32, pgid as i32);
+    let (pid_i32, pgid_i32): (i32, i32) = (pid_to_registry_i32(pid), pid_to_registry_i32(pgid));
     let registry_id = match super::runtime_registry::record_started(
         repo_id,
         workspace_id,
@@ -1271,8 +1298,11 @@ mod tests {
         let (mut c3, _, _, k3) = spawn_and_register(&mgr, b_terminal.clone());
         let (mut c4, _, _, k4) = spawn_and_register(&mgr, auth.clone());
 
-        let signaled = mgr.kill_all();
-        assert_eq!(signaled, 4);
+        let attempts = mgr.kill_all();
+        assert_eq!(attempts.len(), 4);
+        assert!(attempts.iter().any(|attempt| attempt.repo_id == "A"));
+        assert!(attempts.iter().any(|attempt| attempt.repo_id == "B"));
+        assert!(attempts.iter().any(|attempt| attempt.repo_id == "__auth__"));
 
         // Reap each child to release pid resources, then prove the
         // killed flag was flipped on every handle.
@@ -1289,7 +1319,7 @@ mod tests {
     #[test]
     fn kill_all_with_empty_manager_is_zero() {
         let mgr = ScriptProcessManager::new();
-        assert_eq!(mgr.kill_all(), 0);
+        assert!(mgr.kill_all().is_empty());
     }
 
     /// Regression: `kill_all` must drop the process-map lock BEFORE
@@ -1351,7 +1381,9 @@ mod tests {
         }
 
         let start = Instant::now();
-        assert_eq!(mgr.kill_all(), 1);
+        let attempts = mgr.kill_all();
+        assert_eq!(attempts.len(), 1);
+        assert!(attempts[0].gone);
         // run_script's reaper must have unregistered + returned. If
         // kill_all held the map lock past the signal, the unregister
         // would have blocked and this join would hang.
@@ -2055,6 +2087,7 @@ mod tests {
     #[test]
     #[ignore = "fork-heavy; run via `cargo test graceful_kill -- --ignored`"]
     fn graceful_kill_runs_stop_command_then_escalates() {
+        let _env = crate::testkit::TestEnv::new("graceful-kill-stop-command");
         let mgr = Arc::new(ScriptProcessManager::new());
         let ctx = empty_ctx();
         let key: ProcessKey = ("repo".into(), "run".into(), Some("ws".into()));
@@ -2136,6 +2169,7 @@ mod tests {
     #[test]
     #[ignore = "fork-heavy; run via `cargo test graceful_kill -- --ignored`"]
     fn graceful_kill_force_stop_on_second_click_short_circuits() {
+        let _env = crate::testkit::TestEnv::new("graceful-kill-force-stop");
         let mgr = Arc::new(ScriptProcessManager::new());
         let ctx = empty_ctx();
         let key: ProcessKey = ("repo".into(), "run".into(), Some("ws".into()));


### PR DESCRIPTION
## What & why

User-initiated quits (Cmd+Q, the Quit menu, macOS `ExitRequested`, non-macOS window close) normally route through the frontend quit-confirm flow → `request_quit`, which kills Run-tab scripts, embedded terminals, and the sidecar before exiting. Two gaps let processes leak or the runtime registry record a false state:

1. **The fallback quit bypassed cleanup.** When `emit_quit_requested` can't deliver the event (the webview is already gone), it called `app.exit(0)` directly — skipping `request_quit` entirely and leaving Run-tab scripts, terminals, and the sidecar running as orphan process trees.
2. **Graceful quit over-stamped the runtime registry.** `kill_all()` only returned a signaled *count*, then quit unconditionally called `record_all_ended()`, which marked **every** still-open row ended — including processes we never confirmed dead, and prior-launch "maybe alive" rows this instance never even owned a handle for. That hid genuinely-live leftovers from the next launch's startup classifier.

## Changes

- Extract the quit teardown into a shared `cleanup_before_exit()`, now called by **both** `request_quit` and the `emit_quit_requested` fallback — so the fallback no longer leaks processes.
- `escalating_kill()` returns whether it **confirmed** the process tree gone; `kill_all()` returns one `ScriptKillAttempt` per handle instead of a bare count.
- Graceful quit now stamps **only** the rows it proved gone via `record_processes_ended()`, keyed on the full `(repo_id, workspace_id, script_type, pid, pgid)` identity. Unconfirmed kills and prior maybe-alive rows stay open so the startup classifier can keep reporting them.

> Scope note: the runtime registry is still a startup **diagnostic** (it logs maybe-alive leftovers; no auto-kill, no UI yet), so the registry half is diagnostic-accuracy + groundwork. The fallback-cleanup fix (#1) is the part with direct user-facing impact today.

## Testing

- `cargo test --lib runtime_registry` and `--lib workspace::scripts` — green, incl. the new `record_processes_ended_only_stamps_matching_identities` and the `graceful_kill … --ignored` fork-heavy tests.
- `cargo clippy --all-targets -- -D warnings` — clean.

A changeset is included (`patch`).
