### PR TITLE
fix: left-align inject-sessions cursor with composer input padding

### DIFF
--- a/src/features/composer/session-context-injector.tsx
+++ b/src/features/composer/session-context-injector.tsx
@@ -25,7 +25,7 @@ export function SessionContextInjector({
 	const selected = new Set(selectedSessionIds);
 
 	return (
-		<div className="pointer-events-auto mb-2 flex w-full items-center gap-2 self-start">
+		<div className="pointer-events-auto mb-2 flex w-full items-center gap-2 self-start pl-[17px]">
 			<span className="shrink-0 text-small leading-none text-muted-foreground">
 				Inject sessions:
 			</span>


### PR DESCRIPTION
The inject-sessions cursor in the composer was not horizontally aligned with the composer input text. Added `pl-[17px]` to match the composer's left padding, so the cursor visually aligns with where typed text will appear.