### PR TITLE
feat: resume a chat in a new terminal session, behind a heads-up

### DIFF
--- a/.changeset/gui-to-tui-resume.md
+++ b/.changeset/gui-to-tui-resume.md
@@ -2,4 +2,4 @@
 "helmor": minor
 ---
 
-Switching a conversation with history to the terminal now resumes that same Claude or Codex session in the TUI, instead of starting a fresh terminal session.
+Sending a conversation with history to the terminal now opens a new Terminal session that resumes the same Claude or Codex conversation, after a quick heads-up that messages typed in the terminal won't sync back to the chat.

--- a/src-tauri/src/models/sessions.rs
+++ b/src-tauri/src/models/sessions.rs
@@ -311,11 +311,14 @@ pub fn workspace_id_for_session(session_id: &str) -> Result<Option<String>> {
     Ok(workspace_id)
 }
 
-/// Convert a GUI session into a Terminal session in place. Works whether or
-/// not the session has history: an empty session boots fresh, a populated
-/// claude/codex session resumes by its `provider_session_id` in the TUI so the
-/// same conversation continues. One-way — there is no terminal→GUI path. Only
-/// an unknown id errors (no row updated).
+/// Convert a freshly-prepared (message-less) GUI session into a Terminal
+/// session in place. Used by the terminal start flows where the pipeline mints
+/// an empty GUI session and converting it (before it's ever used) avoids a
+/// throwaway placeholder. A session that already has history is NOT converted
+/// here — that path opens a SEPARATE Terminal session that resumes the
+/// conversation instead (see the composer terminal flow). The message-less
+/// invariant is enforced by the UPDATE itself — a session with history (or an
+/// unknown id) errors instead of silently rewriting kind/agent/title.
 pub fn convert_session_to_terminal(session_id: &str, agent_type: &str) -> Result<()> {
     let connection = db::write_conn()?;
     // Leave `title` untouched ("Untitled" from prepare) so the prompt-captured
@@ -323,12 +326,16 @@ pub fn convert_session_to_terminal(session_id: &str, agent_type: &str) -> Result
     // overwrites "Untitled", so hardcoding "Terminal" here would freeze it.
     let rows = connection
         .execute(
-            "UPDATE sessions SET session_kind = 'terminal', agent_type = ?2 WHERE id = ?1",
+            "UPDATE sessions SET session_kind = 'terminal', agent_type = ?2 \
+             WHERE id = ?1 \
+               AND NOT EXISTS (SELECT 1 FROM session_messages WHERE session_id = ?1)",
             rusqlite::params![session_id, agent_type],
         )
         .with_context(|| format!("Failed to convert session {session_id} to terminal"))?;
     if rows != 1 {
-        anyhow::bail!("Refusing to convert session {session_id} to terminal: not found");
+        anyhow::bail!(
+            "Refusing to convert session {session_id} to terminal: not found or it already has messages"
+        );
     }
     Ok(())
 }
@@ -1392,7 +1399,7 @@ mod tests {
     }
 
     #[test]
-    fn convert_session_to_terminal_converts_in_place() {
+    fn convert_session_to_terminal_enforces_message_less_invariant() {
         // convert_session_to_terminal opens the app DB itself, so the test
         // must redirect the data dir before touching it.
         let _env = crate::testkit::TestEnv::new("convert-terminal");
@@ -1420,8 +1427,8 @@ mod tests {
             assert_eq!(title, "Test Session");
         }
 
-        // A session WITH history also converts in place (it resumes by its
-        // provider_session_id in the TUI), and the agent_type is rewritten.
+        // A session with history must be refused, untouched — those go through
+        // the resume-into-a-new-terminal flow instead.
         {
             let conn = db::write_conn().unwrap();
             conn.execute(
@@ -1431,7 +1438,7 @@ mod tests {
             )
             .unwrap();
         }
-        convert_session_to_terminal("s1", "codex").unwrap();
+        assert!(convert_session_to_terminal("s1", "codex").is_err());
         {
             let conn = db::read_conn().unwrap();
             let agent_after: String = conn
@@ -1439,7 +1446,7 @@ mod tests {
                     r.get(0)
                 })
                 .unwrap();
-            assert_eq!(agent_after, "codex", "populated session converts in place");
+            assert_eq!(agent_after, "claude", "refused convert must not rewrite");
         }
 
         // Unknown ids error instead of silently no-opping.

--- a/src/features/terminal/terminal-resume-dialog.tsx
+++ b/src/features/terminal/terminal-resume-dialog.tsx
@@ -1,0 +1,76 @@
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogTitle,
+} from "@/components/ui/dialog";
+
+type TerminalResumeDialogProps = {
+	open: boolean;
+	/** Display name of the agent the terminal resumes ("Claude" / "Codex"). */
+	providerLabel: string;
+	dontRemind: boolean;
+	onDontRemindChange: (checked: boolean) => void;
+	/** Called with `false` on Cancel / dismiss. */
+	onOpenChange: (open: boolean) => void;
+	onConfirm: () => void;
+};
+
+/** Heads-up shown before sending a conversation with history to the terminal:
+ *  we open a NEW Terminal session that resumes the chat, and anything typed in
+ *  the TUI won't sync back to this GUI conversation. */
+export function TerminalResumeDialog({
+	open,
+	providerLabel,
+	dontRemind,
+	onDontRemindChange,
+	onOpenChange,
+	onConfirm,
+}: TerminalResumeDialogProps) {
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent
+				className="max-w-[360px] gap-0 p-4"
+				showCloseButton={false}
+			>
+				<DialogTitle className="text-ui font-semibold">
+					Open in terminal?
+				</DialogTitle>
+				<DialogDescription asChild>
+					<ul className="mt-2 list-disc space-y-1 pl-4 text-small leading-relaxed text-muted-foreground">
+						<li>Opens a new Terminal session.</li>
+						<li>Resumes this conversation in {providerLabel}.</li>
+						<li>New terminal messages won't sync back here.</li>
+					</ul>
+				</DialogDescription>
+				<div className="mt-3 flex w-fit items-center gap-2">
+					<Checkbox
+						id="terminal-resume-dont-remind"
+						checked={dontRemind}
+						onCheckedChange={(checked) => onDontRemindChange(checked === true)}
+					/>
+					<label
+						htmlFor="terminal-resume-dont-remind"
+						className="cursor-pointer text-small text-muted-foreground"
+					>
+						Don't remind me again
+					</label>
+				</div>
+				<div className="mt-3 flex justify-end gap-2">
+					<Button
+						variant="outline"
+						size="sm"
+						onClick={() => onOpenChange(false)}
+					>
+						Cancel
+					</Button>
+					<Button size="sm" onClick={onConfirm}>
+						Open terminal
+					</Button>
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/src/features/terminal/use-terminal-resume-confirm.tsx
+++ b/src/features/terminal/use-terminal-resume-confirm.tsx
@@ -1,0 +1,67 @@
+import { type ReactNode, useCallback, useState } from "react";
+import { useSettings } from "@/lib/settings";
+import { TerminalResumeDialog } from "./terminal-resume-dialog";
+
+const PROVIDER_LABELS: Record<string, string> = {
+	claude: "Claude",
+	codex: "Codex",
+};
+
+type PendingResume = { provider: string; run: () => void };
+
+type UseTerminalResumeConfirmReturn = {
+	/** Gate `run` behind the heads-up dialog. Runs immediately when the user has
+	 *  opted out via "don't remind again". */
+	confirmResume: (provider: string, run: () => void) => void;
+	dialogNode: ReactNode;
+};
+
+/** Heads-up confirmation for sending a conversation-with-history to the terminal:
+ *  it opens a NEW Terminal session that resumes the chat, and TUI messages don't
+ *  sync back. Mount `dialogNode` once near the top of the tree (mirrors
+ *  `useConfirmSessionClose`); call `confirmResume` from the terminal-send path. */
+export function useTerminalResumeConfirm(): UseTerminalResumeConfirmReturn {
+	const { settings, updateSettings } = useSettings();
+	const [pending, setPending] = useState<PendingResume | null>(null);
+	const [dontRemind, setDontRemind] = useState(false);
+
+	const confirmResume = useCallback(
+		(provider: string, run: () => void) => {
+			if (settings.suppressTerminalResumeWarning) {
+				run();
+				return;
+			}
+			setPending({ provider, run });
+		},
+		[settings.suppressTerminalResumeWarning],
+	);
+
+	const close = useCallback(() => {
+		setPending(null);
+		setDontRemind(false);
+	}, []);
+
+	const dialogNode = (
+		<TerminalResumeDialog
+			open={pending !== null}
+			providerLabel={
+				(pending && PROVIDER_LABELS[pending.provider]) || "the agent"
+			}
+			dontRemind={dontRemind}
+			onDontRemindChange={setDontRemind}
+			onOpenChange={(open) => {
+				if (!open) close();
+			}}
+			onConfirm={() => {
+				const run = pending?.run;
+				if (dontRemind) {
+					void updateSettings({ suppressTerminalResumeWarning: true });
+				}
+				close();
+				run?.();
+			}}
+		/>
+	);
+
+	return { confirmResume, dialogNode };
+}

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -282,6 +282,9 @@ export type AppSettings = {
 	/** Shows the Terminal-Mode toggle in the composer; sending with it on
 	 *  opens the prompt in an agent TUI instead of a GUI session. */
 	enableTerminalMode: boolean;
+	/** When true, skip the heads-up dialog shown before sending a conversation
+	 *  with history to the terminal (new Terminal session + resume). */
+	suppressTerminalResumeWarning: boolean;
 	lastWorkspaceId: string | null;
 	lastSessionId: string | null;
 	lastSurface: AppSurface;
@@ -400,6 +403,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
 	notificationSound: "off",
 	terminalHoverExpansion: true,
 	enableTerminalMode: false,
+	suppressTerminalResumeWarning: false,
 	lastWorkspaceId: null,
 	lastSessionId: null,
 	lastSurface: "workspace",
@@ -585,6 +589,7 @@ const SETTINGS_KEY_MAP: Record<
 	notificationSound: "app.notification_sound",
 	terminalHoverExpansion: "app.terminal_hover_expansion",
 	enableTerminalMode: "app.enable_terminal_mode",
+	suppressTerminalResumeWarning: "app.suppress_terminal_resume_warning",
 	lastWorkspaceId: "app.last_workspace_id",
 	lastSessionId: "app.last_session_id",
 	lastSurface: "app.last_surface",
@@ -1280,6 +1285,8 @@ export async function loadSettings(): Promise<AppSettings> {
 					? raw[SETTINGS_KEY_MAP.terminalHoverExpansion] === "true"
 					: DEFAULT_SETTINGS.terminalHoverExpansion,
 			enableTerminalMode: raw[SETTINGS_KEY_MAP.enableTerminalMode] === "true",
+			suppressTerminalResumeWarning:
+				raw[SETTINGS_KEY_MAP.suppressTerminalResumeWarning] === "true",
 			lastWorkspaceId: raw[SETTINGS_KEY_MAP.lastWorkspaceId] || null,
 			lastSessionId: raw[SETTINGS_KEY_MAP.lastSessionId] || null,
 			lastSurface:

--- a/src/shell/components/app-overlays.tsx
+++ b/src/shell/components/app-overlays.tsx
@@ -21,6 +21,7 @@ type Props = {
 	quickSwitch: QuickSwitchControls;
 	liveWorkspaceRowMap: Map<string, WorkspaceRow>;
 	closeConfirmDialog: ReactNode;
+	terminalResumeDialog: ReactNode;
 	editorDiscardConfirmDialog: ReactNode;
 	mergeConfirmDialogNode: ReactNode;
 };
@@ -34,6 +35,7 @@ export function AppOverlays({
 	quickSwitch,
 	liveWorkspaceRowMap,
 	closeConfirmDialog,
+	terminalResumeDialog,
 	editorDiscardConfirmDialog,
 	mergeConfirmDialogNode,
 }: Props) {
@@ -60,6 +62,7 @@ export function AppOverlays({
 				}}
 			/>
 			{closeConfirmDialog}
+			{terminalResumeDialog}
 			{editorDiscardConfirmDialog}
 			{mergeConfirmDialogNode}
 		</>

--- a/src/shell/components/app-shell.tsx
+++ b/src/shell/components/app-shell.tsx
@@ -199,6 +199,7 @@ export function AppShell({
 				quickSwitch: data.quickSwitch,
 				liveWorkspaceRowMap: data.liveWorkspaceRowMap,
 				closeConfirmDialog: data.closeConfirmDialog,
+				terminalResumeDialog: data.terminalResumeDialog,
 				editorDiscardConfirmDialog: data.editorDiscardConfirmDialog,
 				mergeConfirmDialogNode: data.mergeConfirmDialogNode,
 			}}

--- a/src/shell/hooks/use-session-actions.ts
+++ b/src/shell/hooks/use-session-actions.ts
@@ -44,6 +44,7 @@ export function useSessionActions({
 	queryClient,
 	selectionActions,
 	requestCloseSession,
+	confirmTerminalResume,
 	handleSelectSession,
 	pushWorkspaceToast,
 	workspaceViewMode,
@@ -51,6 +52,9 @@ export function useSessionActions({
 	queryClient: QueryClient;
 	selectionActions: SelectionActions;
 	requestCloseSession: (request: SessionCloseRequest) => Promise<void>;
+	/** Gate a conversation-with-history → terminal resume behind the heads-up
+	 *  dialog (skipped when the user opted out). */
+	confirmTerminalResume: (provider: string, run: () => void) => void;
 	handleSelectSession: (sessionId: string | null) => void;
 	pushWorkspaceToast: PushWorkspaceToast;
 	workspaceViewMode: string;
@@ -199,11 +203,12 @@ export function useSessionActions({
 		[handleSelectSession, pushWorkspaceToast, queryClient, selectionActions],
 	);
 
-	// Composer Terminal-Mode submit → convert the composer's CURRENT session into
-	// a Terminal session IN PLACE (one-way) and boot the provider's TUI. A
-	// session that already ran a turn resumes by its provider session id so the
-	// same conversation continues (the typed prompt rides along as the resumed
-	// turn); an empty one boots fresh with the prompt.
+	// Composer Terminal-Mode submit → open the prompt in the provider's TUI.
+	// An EMPTY current session converts in place (no throwaway placeholder). A
+	// session that already has history is NOT converted — it stays a GUI chat,
+	// and we open a SEPARATE Terminal session that resumes the conversation,
+	// after a heads-up dialog (TUI messages don't sync back). The dialog is
+	// skippable via "don't remind again".
 	useShellEvent("create-terminal-session", (event) => {
 		const freshBoot = buildTerminalBootCommand(event.provider, event);
 
@@ -218,16 +223,15 @@ export function useSessionActions({
 			});
 		};
 
-		// Fallback only: no current session to convert (cache miss / no id) →
-		// mint a fresh terminal session and boot it with the prompt.
-		const createNew = () => {
+		// Mint a fresh Terminal session and boot it with `boot`.
+		const spawnTerminal = (boot: string | null) => {
 			void handleCreateSession(
 				"terminal",
 				event.provider,
 				(sessionId) => {
-					if (freshBoot) {
+					if (boot) {
 						setPendingBoot(sessionId, {
-							bootCommand: freshBoot,
+							bootCommand: boot,
 							fastMode: event.fastMode,
 						});
 					}
@@ -246,65 +250,78 @@ export function useSessionActions({
 		const currentSession =
 			sessions.find((session) => session.id === event.sessionId) ?? null;
 
+		// No current session to convert → just open a fresh Terminal session.
 		if (!event.sessionId || !event.workspaceId || !currentSession) {
-			createNew();
+			spawnTerminal(freshBoot);
 			return;
 		}
 
 		const sessionId = event.sessionId;
 		const workspaceId = event.workspaceId;
-		// Resume continues the prior conversation; the typed prompt becomes the
-		// resumed turn's input. No provider id (turn never completed) → fresh boot.
-		const providerSessionId = currentSession.providerSessionId ?? null;
-		const boot = providerSessionId
-			? resumeBootCommand(event.provider, providerSessionId, {
-					addDirs: event.addDirs,
-					prompt: event.prompt,
-				})
-			: freshBoot;
 
-		void (async () => {
-			try {
-				await convertSessionToTerminal(sessionId, event.provider);
-			} catch (error) {
-				// Convert refused (unknown id race) — fall back to a new session.
-				console.warn(
-					"[terminal] in-place convert failed; creating new:",
-					error,
+		// Empty current session → convert it in place (no throwaway placeholder).
+		if (isNewSession(currentSession)) {
+			void (async () => {
+				try {
+					await convertSessionToTerminal(sessionId, event.provider);
+				} catch (error) {
+					// Lost the message-less race / convert refused — fall back to new.
+					console.warn(
+						"[terminal] in-place convert failed; creating new:",
+						error,
+					);
+					spawnTerminal(freshBoot);
+					return;
+				}
+				if (freshBoot) {
+					setPendingBoot(sessionId, {
+						bootCommand: freshBoot,
+						fastMode: event.fastMode,
+					});
+				}
+				seedTitle(sessionId);
+				// Flip the cached row to terminal so the panel renders the TUI now,
+				// before the backend round-trip reconciles.
+				queryClient.setQueryData<WorkspaceSessionSummary[]>(
+					helmorQueryKeys.workspaceSessions(workspaceId),
+					(current) =>
+						(current ?? []).map((session) =>
+							session.id === sessionId
+								? {
+										...session,
+										sessionKind: "terminal",
+										agentType: event.provider,
+									}
+								: session,
+						),
 				);
-				createNew();
-				return;
-			}
-			if (boot) {
-				setPendingBoot(sessionId, {
-					bootCommand: boot,
-					fastMode: event.fastMode,
+				requestSidebarReconcile(queryClient);
+				void queryClient.invalidateQueries({
+					queryKey: helmorQueryKeys.workspaceSessions(workspaceId),
 				});
-			}
-			seedTitle(sessionId);
-			// Flip the cached row to terminal so the panel renders the TUI now,
-			// before the backend round-trip reconciles.
-			queryClient.setQueryData<WorkspaceSessionSummary[]>(
-				helmorQueryKeys.workspaceSessions(workspaceId),
-				(current) =>
-					(current ?? []).map((session) =>
-						session.id === sessionId
-							? {
-									...session,
-									sessionKind: "terminal",
-									agentType: event.provider,
-								}
-							: session,
-					),
-			);
-			requestSidebarReconcile(queryClient);
-			void queryClient.invalidateQueries({
-				queryKey: helmorQueryKeys.workspaceSessions(workspaceId),
-			});
-			void queryClient.invalidateQueries({
-				queryKey: helmorQueryKeys.workspaceDetail(workspaceId),
-			});
-		})();
+				void queryClient.invalidateQueries({
+					queryKey: helmorQueryKeys.workspaceDetail(workspaceId),
+				});
+			})();
+			return;
+		}
+
+		// Session with history. Resuming needs the agent's provider session id;
+		// without one there's nothing to resume, so just open a fresh terminal.
+		const providerSessionId = currentSession.providerSessionId ?? null;
+		if (!providerSessionId) {
+			spawnTerminal(freshBoot);
+			return;
+		}
+
+		// Open a NEW Terminal session that resumes the prior conversation (the
+		// typed prompt rides along as the resumed turn) — after the heads-up
+		// dialog, unless the user opted out.
+		const resumeBoot = resumeBootCommand(event.provider, providerSessionId, {
+			addDirs: event.addDirs,
+			prompt: event.prompt,
+		});
+		confirmTerminalResume(event.provider, () => spawnTerminal(resumeBoot));
 	});
 
 	useEffect(() => {

--- a/src/shell/hooks/use-workspace-action-controllers.ts
+++ b/src/shell/hooks/use-workspace-action-controllers.ts
@@ -15,6 +15,7 @@ import { useWorkspaceCommitLifecycle } from "@/features/commit/hooks/use-commit-
 import type { PendingCreatedWorkspaceSubmit } from "@/features/conversation";
 import { useFeedbackSubmit } from "@/features/feedback/use-feedback-submit";
 import { useConfirmSessionClose } from "@/features/panel/use-confirm-session-close";
+import { useTerminalResumeConfirm } from "@/features/terminal/use-terminal-resume-confirm";
 import type { WorkspaceGroup, WorkspaceRow } from "@/lib/api";
 import { usesActionModelOverride } from "@/lib/commit-button-prompts";
 import type { AppSettings } from "@/lib/settings";
@@ -161,6 +162,11 @@ export function useWorkspaceActionControllers({
 			queryClient,
 		});
 
+	const {
+		confirmResume: confirmTerminalResume,
+		dialogNode: terminalResumeDialog,
+	} = useTerminalResumeConfirm();
+
 	const handleReopenClosedSession = readStateActions.reopenClosedSession;
 
 	const {
@@ -171,6 +177,7 @@ export function useWorkspaceActionControllers({
 		queryClient,
 		selectionActions,
 		requestCloseSession,
+		confirmTerminalResume,
 		handleSelectSession,
 		pushWorkspaceToast,
 		workspaceViewMode,
@@ -228,6 +235,7 @@ export function useWorkspaceActionControllers({
 		handleCommitAction,
 		requestCloseSession,
 		closeConfirmDialog,
+		terminalResumeDialog,
 		handleReopenClosedSession,
 		getCloseableCurrentSession,
 		handleCloseSelectedSession,


### PR DESCRIPTION
Refines the GUI→TUI terminal flow shipped in #826 (merged, not yet released), per design feedback.

### Before
Sending a conversation **with history** to the terminal converted the GUI session **in place** to a terminal that resumed the chat.

### After
- **Empty session** → still converts in place (unchanged).
- **Session with history** → a quick heads-up dialog first:
  - Opens a new Terminal session.
  - Resumes this conversation in Claude/Codex.
  - New terminal messages won't sync back here.

  On confirm, a **separate** Terminal session opens and resumes the conversation (`claude --resume <id>` / `codex resume <id>`); the GUI chat stays put. The dialog has a **"Don't remind me again"** option backed by a new `suppressTerminalResumeWarning` setting.

The in-place `convert_session_to_terminal` message-less invariant is restored (history sessions are no longer converted in place).

### Notes
- Updates the still-pending `gui-to-tui-resume` changeset to describe the final behavior.
- Verified: `bun run typecheck`, biome, `cargo test`/clippy (pre-commit), terminal-presets vitest.