### PR TITLE
fix: recover orphaned run-action processes after a Helmor restart

### DIFF
--- a/.changeset/runtime-registry-recovers.md
+++ b/.changeset/runtime-registry-recovers.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Recover run-action Stop, Cleanup, and Run flows when a prior Helmor launch left the action process alive outside the in-memory script manager.

--- a/src-tauri/src/commands/script_commands.rs
+++ b/src-tauri/src/commands/script_commands.rs
@@ -15,6 +15,11 @@ fn run_script_type(action_id: &str) -> String {
     format!("run:{action_id}")
 }
 
+struct ResolvedScriptTarget {
+    context: ScriptContext,
+    working_dir: String,
+}
+
 /// Resolve which `RunAction` the caller is targeting.
 ///
 ///   - If `action_id` is supplied, look it up by id; error if it's gone.
@@ -41,6 +46,114 @@ fn resolve_run_target(
             .ok_or_else(|| anyhow::anyhow!("No run actions configured for repo {repo_id}"))?,
     };
     Ok(action)
+}
+
+fn resolve_script_target(
+    repo_id: &str,
+    workspace_id: Option<&str>,
+) -> anyhow::Result<ResolvedScriptTarget> {
+    let repo = repos::load_repository_by_id(repo_id)?
+        .ok_or_else(|| anyhow::anyhow!("Repository not found: {repo_id}"))?;
+    let workspace = match workspace_id {
+        Some(id) => crate::models::workspaces::load_workspace_record_by_id(id)?,
+        None => None,
+    };
+
+    // Run in the workspace directory when available, otherwise repo root.
+    let workspace_root = workspace
+        .as_ref()
+        .and_then(|ws| crate::workspace::helpers::workspace_path(ws).ok());
+    let working_dir = workspace_root
+        .as_ref()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| repo.root_path.clone());
+
+    // Allocate a stable per-workspace port range so HELMOR_PORT /
+    // HELMOR_PORT_COUNT can be injected below. Lazy: only allocates if
+    // the workspace has no range yet. Best-effort — a DB error here
+    // must not block the script run, scripts that don't read
+    // HELMOR_PORT continue to work exactly as before.
+    let port_range = workspace.as_ref().and_then(|ws| {
+        match crate::workspace::port_allocation::ensure_workspace_port_range(&ws.id) {
+            Ok(range) => range,
+            Err(error) => {
+                tracing::warn!(
+                    workspace_id = %ws.id,
+                    %error,
+                    "Failed to allocate workspace port range; skipping HELMOR_PORT env vars"
+                );
+                None
+            }
+        }
+    });
+
+    Ok(ResolvedScriptTarget {
+        context: ScriptContext {
+            root_path: repo.root_path.clone(),
+            workspace_path: Some(working_dir.clone()),
+            workspace_name: workspace.as_ref().map(|ws| ws.directory_name.clone()),
+            default_branch: repo.default_branch.clone(),
+            port_base: port_range.map(|r| r.base),
+            port_count: port_range.map(|r| r.count),
+        },
+        working_dir,
+    })
+}
+
+fn stop_orphaned_runtime_process(
+    repo_id: &str,
+    workspace_id: Option<&str>,
+    script_type: &str,
+    stop_command: Option<&str>,
+    channel: Option<&Channel<ScriptEvent>>,
+) -> anyhow::Result<Option<bool>> {
+    let Some(process) = crate::workspace::runtime_registry::live_process_for_identity(
+        repo_id,
+        workspace_id,
+        script_type,
+    )?
+    else {
+        return Ok(None);
+    };
+
+    tracing::warn!(
+        repo_id,
+        workspace_id = ?workspace_id,
+        script_type,
+        pid = process.pid,
+        pgid = process.pgid,
+        "Runtime registry: stopping live process not owned by the in-memory script manager"
+    );
+
+    if let Some(command) = stop_command
+        .map(str::trim)
+        .filter(|command| !command.is_empty())
+    {
+        let target = resolve_script_target(repo_id, workspace_id)?;
+        let sink = Channel::<ScriptEvent>::new(|_| Ok(()));
+        let tx = channel.unwrap_or(&sink);
+        crate::workspace::scripts::run_configured_stop_command(
+            command,
+            &target.working_dir,
+            &target.context,
+            tx,
+        );
+    }
+
+    let gone = crate::workspace::scripts::kill_registered_runtime_process(&process);
+    if gone {
+        crate::workspace::runtime_registry::record_processes_ended(std::slice::from_ref(&process))?;
+    }
+    tracing::info!(
+        repo_id,
+        workspace_id = ?workspace_id,
+        script_type,
+        pid = process.pid,
+        pgid = process.pgid,
+        gone,
+        "Runtime registry: orphaned process stop attempt finished"
+    );
+    Ok(Some(gone))
 }
 
 #[tauri::command]
@@ -80,6 +193,57 @@ pub async fn execute_repo_script(
         // independent because the filter compares the full string.
         if action.mode == "non-concurrent" {
             manager.kill_others_in_repo(&repo_id, &process_type, workspace_id.as_deref());
+        }
+
+        // Only fall back to the runtime registry when this exact action is NOT
+        // already owned by the in-memory manager. If it is live in-memory, the
+        // normal spawn path's register() collision handles the restart — running
+        // the registry orphan path here would re-run stop.command and kill the
+        // manager's own live process by PID.
+        let run_key = (repo_id.clone(), process_type.clone(), workspace_id.clone());
+        let orphan_stop: anyhow::Result<Option<bool>> = if manager.has_live_handle(&run_key) {
+            Ok(None)
+        } else {
+            tauri::async_runtime::spawn_blocking({
+                let repo_id = repo_id.clone();
+                let workspace_id = workspace_id.clone();
+                let process_type = process_type.clone();
+                let stop_command = action.stop_command.clone();
+                let channel = channel.clone();
+                move || {
+                    stop_orphaned_runtime_process(
+                        &repo_id,
+                        workspace_id.as_deref(),
+                        &process_type,
+                        stop_command.as_deref(),
+                        Some(&channel),
+                    )
+                }
+            })
+            .await
+            .map_err(|e| anyhow::anyhow!("spawn_blocking join failed: {e}"))?
+        };
+
+        match orphan_stop {
+            Ok(Some(true)) | Ok(None) => {}
+            Ok(Some(false)) => {
+                let _ = channel.send(ScriptEvent::Error {
+                    message: format!(
+                        "Cannot start {}; Helmor found a live process from a prior launch and could not stop it. Try Stop again.",
+                        action.name
+                    ),
+                });
+                return Ok(());
+            }
+            Err(error) => {
+                let _ = channel.send(ScriptEvent::Error {
+                    message: format!(
+                        "Failed to clean up prior {} process: {error:#}",
+                        action.name
+                    ),
+                });
+                return Ok(());
+            }
         }
 
         return spawn_script(
@@ -140,58 +304,15 @@ async fn spawn_script(
     channel: Channel<ScriptEvent>,
     stop_command: Option<String>,
 ) -> CmdResult<()> {
-    let (repo, workspace) = tauri::async_runtime::spawn_blocking({
+    let target = tauri::async_runtime::spawn_blocking({
         let repo_id = repo_id.clone();
-        let ws_id = workspace_id.clone();
-        move || -> anyhow::Result<(repos::RepositoryRecord, Option<crate::models::workspaces::WorkspaceRecord>)> {
-            let repo = repos::load_repository_by_id(&repo_id)?
-                .ok_or_else(|| anyhow::anyhow!("Repository not found: {repo_id}"))?;
-            let ws = match ws_id {
-                Some(id) => crate::models::workspaces::load_workspace_record_by_id(&id)?,
-                None => None,
-            };
-            Ok((repo, ws))
-        }
+        let workspace_id = workspace_id.clone();
+        move || resolve_script_target(&repo_id, workspace_id.as_deref())
     })
     .await
     .map_err(|e| anyhow::anyhow!("spawn_blocking join failed: {e}"))??;
-
-    // Run in the workspace directory when available, otherwise repo root.
-    let workspace_root = workspace
-        .as_ref()
-        .and_then(|ws| crate::workspace::helpers::workspace_path(ws).ok());
-    let working_dir = workspace_root
-        .as_ref()
-        .map(|p| p.display().to_string())
-        .unwrap_or_else(|| repo.root_path.clone());
-
-    // Allocate a stable per-workspace port range so HELMOR_PORT /
-    // HELMOR_PORT_COUNT can be injected below. Lazy: only allocates if
-    // the workspace has no range yet. Best-effort — a DB error here
-    // must not block the script run, scripts that don't read
-    // HELMOR_PORT continue to work exactly as before.
-    let port_range = workspace.as_ref().and_then(|ws| {
-        match crate::workspace::port_allocation::ensure_workspace_port_range(&ws.id) {
-            Ok(range) => range,
-            Err(error) => {
-                tracing::warn!(
-                    workspace_id = %ws.id,
-                    %error,
-                    "Failed to allocate workspace port range; skipping HELMOR_PORT env vars"
-                );
-                None
-            }
-        }
-    });
-
-    let context = ScriptContext {
-        root_path: repo.root_path.clone(),
-        workspace_path: Some(working_dir.clone()),
-        workspace_name: workspace.as_ref().map(|ws| ws.directory_name.clone()),
-        default_branch: repo.default_branch.clone(),
-        port_base: port_range.map(|r| r.base),
-        port_count: port_range.map(|r| r.count),
-    };
+    let working_dir = target.working_dir;
+    let context = target.context;
     let mgr = manager.inner().clone();
 
     // Build the graceful-stop bundle now (while we still own `context` /
@@ -248,8 +369,40 @@ pub async fn stop_repo_script(
     action_id: Option<String>,
 ) -> CmdResult<bool> {
     let process_type = process_type_for(&script_type, action_id.as_deref());
-    let key = (repo_id, process_type, workspace_id);
-    Ok(manager.kill(&key))
+    let key = (repo_id.clone(), process_type.clone(), workspace_id.clone());
+    if manager.kill(&key) {
+        return Ok(true);
+    }
+
+    let stop_command = if script_type == "run" {
+        let ws = workspace_id.clone();
+        let rid = repo_id.clone();
+        let aid = action_id.clone();
+        tauri::async_runtime::spawn_blocking(move || {
+            resolve_run_target(&rid, ws.as_deref(), aid.as_deref())
+                .map(|action| action.stop_command)
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("spawn_blocking join failed: {e}"))??
+    } else {
+        None
+    };
+
+    let stopped = tauri::async_runtime::spawn_blocking(move || {
+        stop_orphaned_runtime_process(
+            &repo_id,
+            workspace_id.as_deref(),
+            &process_type,
+            stop_command.as_deref(),
+            None,
+        )
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("spawn_blocking join failed: {e}"))??;
+
+    // `Some(false)` means we found an orphan but could not confirm it died —
+    // report that as "not stopped" instead of a false success.
+    Ok(matches!(stopped, Some(true)))
 }
 
 /// Run a run action's configured `stop_command` as a standalone script
@@ -307,6 +460,66 @@ pub async fn execute_repo_stop_command(
     };
 
     let process_type = run_script_type(&action.id);
+    let key = (
+        repo_id.clone(),
+        process_type.clone(),
+        Some(workspace_id.clone()),
+    );
+
+    if manager.has_live_handle(&key) {
+        let _ = channel.send(ScriptEvent::Error {
+            message: format!(
+                "{} is still running; click Stop instead of Cleanup.",
+                action.name
+            ),
+        });
+        return Ok(());
+    }
+
+    let orphan_stop = tauri::async_runtime::spawn_blocking({
+        let repo_id = repo_id.clone();
+        let workspace_id = workspace_id.clone();
+        let process_type = process_type.clone();
+        let stop_command = stop_command.clone();
+        let channel = channel.clone();
+        move || {
+            stop_orphaned_runtime_process(
+                &repo_id,
+                Some(&workspace_id),
+                &process_type,
+                Some(&stop_command),
+                Some(&channel),
+            )
+        }
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("spawn_blocking join failed: {e}"))?;
+
+    match orphan_stop {
+        Ok(Some(true)) => {
+            let _ = channel.send(ScriptEvent::Exited { code: None });
+            return Ok(());
+        }
+        Ok(Some(false)) => {
+            let _ = channel.send(ScriptEvent::Error {
+                message: format!(
+                    "Cannot clean up {}; Helmor found a live process from a prior launch and could not stop it. Try Stop again.",
+                    action.name
+                ),
+            });
+            return Ok(());
+        }
+        Ok(None) => {}
+        Err(error) => {
+            let _ = channel.send(ScriptEvent::Error {
+                message: format!(
+                    "Failed to clean up prior {} process: {error:#}",
+                    action.name
+                ),
+            });
+            return Ok(());
+        }
+    }
 
     spawn_script(
         app,

--- a/src-tauri/src/platform/process.rs
+++ b/src-tauri/src/platform/process.rs
@@ -192,6 +192,46 @@ fn can_signal_group(pgid: Pid) -> bool {
     }
 }
 
+/// System boot time as a Unix epoch (seconds), or `None` when it can't be
+/// determined. PIDs are unique only within a boot session, so a process
+/// recorded before the current boot can never still be the same process — the
+/// runtime registry uses this to refuse to signal a PID that may have been
+/// reused across a reboot.
+#[cfg(target_os = "macos")]
+pub fn boot_time_epoch() -> Option<i64> {
+    use std::ffi::CString;
+    let name = CString::new("kern.boottime").ok()?;
+    let mut tv = libc::timeval {
+        tv_sec: 0,
+        tv_usec: 0,
+    };
+    let mut size = std::mem::size_of::<libc::timeval>();
+    let ret = unsafe {
+        libc::sysctlbyname(
+            name.as_ptr(),
+            std::ptr::from_mut::<libc::timeval>(&mut tv).cast::<std::ffi::c_void>(),
+            &mut size,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    (ret == 0).then_some(tv.tv_sec)
+}
+
+/// `/proc/stat` carries a `btime <epoch-seconds>` line written at boot.
+#[cfg(target_os = "linux")]
+pub fn boot_time_epoch() -> Option<i64> {
+    let stat = std::fs::read_to_string("/proc/stat").ok()?;
+    stat.lines()
+        .find_map(|line| line.strip_prefix("btime "))
+        .and_then(|value| value.trim().parse::<i64>().ok())
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+pub fn boot_time_epoch() -> Option<i64> {
+    None
+}
+
 #[cfg(windows)]
 fn taskkill(pid: Pid, force: bool) -> std::io::Result<std::process::ExitStatus> {
     let pid = pid.to_string();

--- a/src-tauri/src/workspace/runtime_registry.rs
+++ b/src-tauri/src/workspace/runtime_registry.rs
@@ -126,6 +126,132 @@ pub fn record_processes_ended(processes: &[RuntimeProcessIdentity]) -> Result<us
     record_processes_ended_in(&conn, processes)
 }
 
+/// Parse a SQLite `datetime('now')` timestamp ("YYYY-MM-DD HH:MM:SS", UTC) into
+/// a Unix epoch. Returns `None` for any unexpected shape so callers treat an
+/// unparseable row as "boot session unknown" rather than guessing.
+fn started_at_epoch(started_at: &str) -> Option<i64> {
+    chrono::NaiveDateTime::parse_from_str(started_at, "%Y-%m-%d %H:%M:%S")
+        .ok()
+        .map(|naive| naive.and_utc().timestamp())
+}
+
+fn stamp_row_ended(conn: &Connection, id: &str) -> Result<()> {
+    conn.execute(
+        "UPDATE runtime_processes
+         SET ended_at = datetime('now')
+         WHERE id = ?1 AND ended_at IS NULL",
+        [id],
+    )
+    .with_context(|| format!("Failed to stamp ended_at on dead runtime row {id}"))?;
+    Ok(())
+}
+
+/// Return the newest still-open registry row for this exact process identity
+/// when its PID is alive **and** the row was recorded during the current boot
+/// session — the only case where the recorded PID is provably still ours.
+/// Rows whose PID is dead, or whose PID is alive but predates this boot (and so
+/// may have been reused for an unrelated process), are stamped ended instead of
+/// returned. When the boot time can't be read at all, an alive PID is left
+/// untouched rather than risk signalling a reused one.
+pub fn live_process_for_identity(
+    repo_id: &str,
+    workspace_id: Option<&str>,
+    script_type: &str,
+) -> Result<Option<RuntimeProcessIdentity>> {
+    let conn = db::write_conn()
+        .context("Failed to borrow write connection for runtime registry lookup")?;
+    let boot_epoch = crate::platform::process::boot_time_epoch();
+    live_process_for_identity_in(&conn, repo_id, workspace_id, script_type, boot_epoch)
+}
+
+pub fn live_process_for_identity_in(
+    conn: &Connection,
+    repo_id: &str,
+    workspace_id: Option<&str>,
+    script_type: &str,
+    boot_epoch: Option<i64>,
+) -> Result<Option<RuntimeProcessIdentity>> {
+    let rows: Vec<RawRuntimeRow> = {
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, repo_id, workspace_id, script_type, pid, pgid, started_at
+                 FROM runtime_processes
+                 WHERE ended_at IS NULL
+                   AND repo_id = ?1
+                   AND ((?2 IS NULL AND workspace_id IS NULL) OR workspace_id = ?2)
+                   AND script_type = ?3
+                 ORDER BY started_at DESC, id DESC",
+            )
+            .with_context(|| {
+                format!("Failed to prepare runtime registry lookup for {repo_id}/{script_type}")
+            })?;
+        let iter = stmt
+            .query_map(
+                rusqlite::params![repo_id, workspace_id, script_type],
+                |row| {
+                    Ok(RawRuntimeRow {
+                        id: row.get(0)?,
+                        repo_id: row.get(1)?,
+                        workspace_id: row.get(2)?,
+                        script_type: row.get(3)?,
+                        pid: row.get::<_, i64>(4)? as i32,
+                        pgid: row.get::<_, i64>(5)? as i32,
+                        started_at: row.get(6)?,
+                    })
+                },
+            )
+            .context("Failed to read matching runtime registry rows")?;
+        iter.collect::<rusqlite::Result<Vec<_>>>()
+            .context("Failed to materialise matching runtime registry rows")?
+    };
+
+    let mut live = None;
+    for row in rows {
+        if !probe_pid_alive(row.pid) {
+            // No such PID — the process is definitely gone. Close the row.
+            stamp_row_ended(conn, &row.id)?;
+            continue;
+        }
+
+        // The PID is alive, but that alone does not prove it is still *our*
+        // process: PIDs are reused across reboots. Only trust it when the row
+        // was recorded during the current boot session.
+        match (boot_epoch, started_at_epoch(&row.started_at)) {
+            (Some(boot), Some(started)) if started >= boot => {
+                // Same boot → the live PID is genuinely the process we recorded.
+                if live.is_none() {
+                    live = Some(RuntimeProcessIdentity {
+                        repo_id: row.repo_id,
+                        workspace_id: row.workspace_id,
+                        script_type: row.script_type,
+                        pid: row.pid,
+                        pgid: row.pgid,
+                    });
+                }
+            }
+            (Some(_), Some(_)) => {
+                // Alive PID, but the row predates this boot: the original
+                // process is gone and this PID now belongs to something
+                // unrelated. Close the stale row; never signal the stranger.
+                stamp_row_ended(conn, &row.id)?;
+            }
+            _ => {
+                // Boot session unknown (couldn't read boot time, or the
+                // timestamp didn't parse). Refuse to treat a maybe-reused PID
+                // as a kill target, and leave the row open — we have no proof
+                // it is dead — for a later attempt once we can verify it.
+                tracing::warn!(
+                    id = %row.id,
+                    pid = row.pid,
+                    "Runtime registry: cannot verify boot session for a live PID; not targeting it"
+                );
+            }
+        }
+    }
+
+    Ok(live)
+}
+
 // Caller-supplied connection so tests can drive it against an in-memory DB.
 pub fn record_processes_ended_in(
     conn: &Connection,
@@ -334,6 +460,35 @@ mod tests {
         .unwrap();
     }
 
+    #[allow(clippy::too_many_arguments)]
+    fn seed_identity_row_at(
+        conn: &Connection,
+        id: &str,
+        repo_id: &str,
+        workspace_id: Option<&str>,
+        script_type: &str,
+        pid: i32,
+        pgid: i32,
+        started_at: &str,
+        ended_at: Option<&str>,
+    ) {
+        conn.execute(
+            "INSERT INTO runtime_processes (id, repo_id, workspace_id, script_type, pid, pgid, started_at, ended_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            rusqlite::params![
+                id,
+                repo_id,
+                workspace_id,
+                script_type,
+                pid as i64,
+                pgid as i64,
+                started_at,
+                ended_at
+            ],
+        )
+        .unwrap();
+    }
+
     // Private in-memory DB so the classify/sweep tests are isolated from the
     // process-global file DB (concurrent writes there made count asserts flaky).
     fn fresh_db() -> Connection {
@@ -446,6 +601,201 @@ mod tests {
         assert!(read_ended_at(&conn, "different-pid").is_none());
         assert!(read_ended_at(&conn, "different-ws").is_none());
         assert!(read_ended_at(&conn, "different-repo").is_none());
+    }
+
+    #[test]
+    fn live_process_for_identity_returns_alive_match_and_stamps_dead_matches() {
+        let conn = fresh_db();
+        seed_identity_row(
+            &conn,
+            "dead-match",
+            "r1",
+            Some("w1"),
+            "run:action",
+            DEAD_SENTINEL_PID,
+            DEAD_SENTINEL_PID,
+            None,
+        );
+        seed_identity_row(
+            &conn,
+            "alive-match",
+            "r1",
+            Some("w1"),
+            "run:action",
+            alive_sentinel_pid(),
+            alive_sentinel_pid(),
+            None,
+        );
+        seed_identity_row(
+            &conn,
+            "different-action",
+            "r1",
+            Some("w1"),
+            "run:other",
+            DEAD_SENTINEL_PID,
+            DEAD_SENTINEL_PID,
+            None,
+        );
+
+        let live =
+            live_process_for_identity_in(&conn, "r1", Some("w1"), "run:action", Some(0)).unwrap();
+
+        assert_eq!(
+            live,
+            Some(RuntimeProcessIdentity {
+                repo_id: "r1".to_string(),
+                workspace_id: Some("w1".to_string()),
+                script_type: "run:action".to_string(),
+                pid: alive_sentinel_pid(),
+                pgid: alive_sentinel_pid(),
+            })
+        );
+        assert!(
+            read_ended_at(&conn, "dead-match").is_some(),
+            "dead matching rows should be closed while searching"
+        );
+        assert!(
+            read_ended_at(&conn, "alive-match").is_none(),
+            "live matching rows stay open for the caller to stop"
+        );
+        assert!(
+            read_ended_at(&conn, "different-action").is_none(),
+            "non-matching rows must not be touched"
+        );
+    }
+
+    #[test]
+    fn live_process_for_identity_handles_no_workspace_keys() {
+        let conn = fresh_db();
+        seed_identity_row(
+            &conn,
+            "no-workspace",
+            "r1",
+            None,
+            "terminal",
+            alive_sentinel_pid(),
+            alive_sentinel_pid(),
+            None,
+        );
+        seed_identity_row(
+            &conn,
+            "workspace-row",
+            "r1",
+            Some("w1"),
+            "terminal",
+            alive_sentinel_pid(),
+            alive_sentinel_pid(),
+            None,
+        );
+
+        let live = live_process_for_identity_in(&conn, "r1", None, "terminal", Some(0)).unwrap();
+
+        assert_eq!(live.as_ref().and_then(|p| p.workspace_id.as_deref()), None);
+        assert_eq!(live.map(|p| p.pid), Some(alive_sentinel_pid()));
+    }
+
+    #[test]
+    fn live_process_for_identity_refuses_a_pid_recorded_before_this_boot() {
+        let conn = fresh_db();
+        let boot = started_at_epoch("2026-06-01 00:00:00").expect("parse boot reference");
+        // PID is alive (sentinel = our own pid), but the row predates this boot,
+        // so the PID may have been reused. It must NOT be offered as a kill
+        // target, and the stale row should be closed instead.
+        seed_identity_row_at(
+            &conn,
+            "prior-boot",
+            "r1",
+            Some("w1"),
+            "run:action",
+            alive_sentinel_pid(),
+            alive_sentinel_pid(),
+            "2026-05-01 00:00:00",
+            None,
+        );
+
+        let live = live_process_for_identity_in(&conn, "r1", Some("w1"), "run:action", Some(boot))
+            .unwrap();
+
+        assert!(
+            live.is_none(),
+            "an alive PID recorded before this boot may be reused; never target it"
+        );
+        assert!(
+            read_ended_at(&conn, "prior-boot").is_some(),
+            "the prior-boot row is closed (its original process is gone)"
+        );
+    }
+
+    #[test]
+    fn live_process_for_identity_targets_this_boot_pid_over_a_prior_boot_row() {
+        let conn = fresh_db();
+        let boot = started_at_epoch("2026-06-01 00:00:00").expect("parse boot reference");
+        seed_identity_row_at(
+            &conn,
+            "prior-boot",
+            "r1",
+            Some("w1"),
+            "run:action",
+            alive_sentinel_pid(),
+            alive_sentinel_pid(),
+            "2026-05-01 00:00:00",
+            None,
+        );
+        seed_identity_row_at(
+            &conn,
+            "this-boot",
+            "r1",
+            Some("w1"),
+            "run:action",
+            alive_sentinel_pid(),
+            alive_sentinel_pid(),
+            "2026-06-02 00:00:00",
+            None,
+        );
+
+        let live = live_process_for_identity_in(&conn, "r1", Some("w1"), "run:action", Some(boot))
+            .unwrap();
+
+        assert_eq!(
+            live.map(|p| p.pid),
+            Some(alive_sentinel_pid()),
+            "the in-boot row is a valid kill target"
+        );
+        assert!(
+            read_ended_at(&conn, "prior-boot").is_some(),
+            "the prior-boot row is closed"
+        );
+        assert!(
+            read_ended_at(&conn, "this-boot").is_none(),
+            "the in-boot target stays open for the caller to stop"
+        );
+    }
+
+    #[test]
+    fn live_process_for_identity_will_not_target_a_pid_when_boot_time_is_unknown() {
+        let conn = fresh_db();
+        seed_identity_row(
+            &conn,
+            "alive",
+            "r1",
+            Some("w1"),
+            "run:action",
+            alive_sentinel_pid(),
+            alive_sentinel_pid(),
+            None,
+        );
+
+        let live =
+            live_process_for_identity_in(&conn, "r1", Some("w1"), "run:action", None).unwrap();
+
+        assert!(
+            live.is_none(),
+            "without a boot reference the PID can't be trusted; do not target it"
+        );
+        assert!(
+            read_ended_at(&conn, "alive").is_none(),
+            "an unverifiable live row stays open rather than being closed or killed"
+        );
     }
 
     // ── classify_stale_processes ──────────────────────────────────────

--- a/src-tauri/src/workspace/scripts.rs
+++ b/src-tauri/src/workspace/scripts.rs
@@ -282,6 +282,11 @@ impl ScriptProcessManager {
         }
     }
 
+    pub fn has_live_handle(&self, key: &ProcessKey) -> bool {
+        let map = self.processes.lock().expect("process map poisoned");
+        map.contains_key(key)
+    }
+
     /// Write bytes into the PTY master (user typing, paste, Ctrl+C).
     /// Returns `Ok(false)` if no live script matches the key — callers
     /// treat that as a silent no-op (the user typed into a dead terminal).
@@ -348,6 +353,18 @@ fn escalating_kill(pid: Pid, pgid: Pid) -> bool {
     crate::platform::process::wait_for_tree_gone(tree, PROCESS_KILL_TIMEOUT, PTY_POLL_INTERVAL)
 }
 
+pub fn kill_registered_runtime_process(
+    process: &super::runtime_registry::RuntimeProcessIdentity,
+) -> bool {
+    let Some(pid) = registry_i32_to_pid(process.pid) else {
+        return false;
+    };
+    let Some(pgid) = registry_i32_to_pid(process.pgid) else {
+        return false;
+    };
+    escalating_kill(pid, pgid)
+}
+
 #[cfg(unix)]
 fn pid_to_registry_i32(pid: Pid) -> i32 {
     pid
@@ -356,6 +373,16 @@ fn pid_to_registry_i32(pid: Pid) -> i32 {
 #[cfg(windows)]
 fn pid_to_registry_i32(pid: Pid) -> i32 {
     pid as i32
+}
+
+#[cfg(unix)]
+fn registry_i32_to_pid(pid: i32) -> Option<Pid> {
+    (pid > 0).then_some(pid)
+}
+
+#[cfg(windows)]
+fn registry_i32_to_pid(pid: i32) -> Option<Pid> {
+    u32::try_from(pid).ok().filter(|pid| *pid > 0)
 }
 
 /// SIGKILL any `stop.command` cleanup tree currently published in
@@ -379,6 +406,40 @@ enum StopOutcome {
     CleanExit,
     NonZeroExit(Option<i32>),
     SpawnFailed(String),
+}
+
+pub fn run_configured_stop_command(
+    command: &str,
+    working_dir: &str,
+    ctx: &ScriptContext,
+    event_tx: &Channel<ScriptEvent>,
+) -> bool {
+    let _ = event_tx.send(ScriptEvent::Stopping);
+    let _ = event_tx.send(ScriptEvent::Stdout {
+        data: format!(
+            "\r\n\x1b[2m[Helmor] Running stop.command: {}\x1b[0m\r\n",
+            command
+        ),
+    });
+    let pgid_slot = Mutex::new(None);
+    let started = Instant::now();
+    let outcome = run_stop_command(command, working_dir, ctx, event_tx, &pgid_slot);
+    let elapsed_ms = started.elapsed().as_millis();
+    let success = matches!(outcome, StopOutcome::CleanExit);
+    let footer = match outcome {
+        StopOutcome::CleanExit => {
+            format!("\r\n\x1b[2m[Helmor] stop.command exited cleanly in {elapsed_ms}ms\x1b[0m\r\n")
+        }
+        StopOutcome::NonZeroExit(code) => format!(
+            "\r\n\x1b[33m[Helmor] stop.command exited with code {} after {elapsed_ms}ms\x1b[0m\r\n",
+            code.map(|c| c.to_string()).unwrap_or_else(|| "?".to_string())
+        ),
+        StopOutcome::SpawnFailed(err) => format!(
+            "\r\n\x1b[33m[Helmor] stop.command failed to spawn ({err}) — proceeding with force-kill\x1b[0m\r\n"
+        ),
+    };
+    let _ = event_tx.send(ScriptEvent::Stdout { data: footer });
+    success
 }
 
 /// Spawn `command` via `/bin/sh -c`, stream its stdout/stderr into the


### PR DESCRIPTION
## What & why

Run actions (e.g. a "start DB" action whose `run-db.sh` wrapper holds a Docker container) record their process tree in the runtime registry, but the live handles live only in the in-memory `ScriptProcessManager`. After a Helmor restart/redeploy that in-memory state is gone while the wrapper process keeps running. The registry was a startup *diagnostic only* — it logged maybe-alive leftovers but never reclaimed them.

The result: Stop/Cleanup/Run couldn't see the old wrapper, but Cleanup's `stop.command` would still run — tearing down the service's container while the orphaned wrapper (`run-db.sh` + `sleep`) kept running. (The `143` exit code is just the normal SIGTERM code, not the root cause.)

## Changes

- **Registry-backed recovery.** `Stop`, `Cleanup`, and `Run` now fall back to the runtime registry when the in-memory manager has no handle: they look up the still-open row for this exact `(repo, workspace, action)`, run `stop.command`, and terminate the recorded process tree.
- **PID-reuse safety gate (single choke point).** `live_process_for_identity` only returns a kill target when the PID is alive **and** the row was recorded during the current boot session. PIDs are reused across reboots, so prior-boot rows are closed (`ended_at` stamped) but **never** signalled; if boot time can't be read, an alive PID is left untouched rather than risk hitting an unrelated process. All three entry points inherit this — `scripts.rs` does the actual kill but only ever sees a verified target.
- **Run gated on the in-memory handle.** The registry fallback runs only when `!manager.has_live_handle(&key)`, so a normal restart of an already-running action still goes through the manager's own `register()` collision path (no double `stop.command`, no PID-kill of a managed process). Matches the existing Cleanup guard.
- **Honest Stop result.** `stop_repo_script` returns `false` when an orphan is found but can't be confirmed gone, instead of reporting a false success.

## Testing

- `cargo test --lib runtime_registry` — green, incl. 3 new tests: a prior-boot PID is closed-not-killed, an in-boot PID is a valid target, and "boot time unknown → don't target."
- `cargo test --lib workspace::scripts` / `platform::process` — green.
- `cargo clippy --all-targets -- -D warnings` — clean.

## Known follow-ups (not in this PR)

- Same-boot PID reuse (a process died and its PID was reused within one boot, before its row was closed) is not covered by the boot gate; a per-process start-time check would close that smaller window.
- The lookup terminates the newest live row per call; multiple leaked rows for one action take repeated Stops to fully clear.

A `patch` changeset is included.
