### PR TITLE
fix: pin Claude default to Opus 4.8

### DIFF
--- a/.changeset/tame-llamas-pin.md
+++ b/.changeset/tame-llamas-pin.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix the "Opus 4.8" model option so selecting it runs Opus 4.8 instead of falling back to a different model your plan may not have access to.

--- a/sidecar/src/model-catalog.ts
+++ b/sidecar/src/model-catalog.ts
@@ -19,16 +19,19 @@ const MODEL_CATALOG: Record<Provider, readonly ProviderModelInfo[]> = {
 			cliModel: "claude-fable-5[1m]",
 			effortLevels: ["low", "medium", "high", "xhigh", "max"],
 		},
-		// `default` resolves to the newest Opus the bundled claude-code knows
-		// about — in 2.1.170 that is Opus 4.8 (1M context, adaptive thinking,
-		// default high effort, fast mode at 2x rate / 2.5x speed). Kept as
-		// `default` (rather than pinned `claude-opus-4-8`) so it stays the
-		// auto-latest pick AND remains the app default selection (see
-		// `useEnsureDefaultModel`, which prefers id == "default").
+		// `default` is the app default selection (see `useEnsureDefaultModel`,
+		// which pins id == "default") and the picker's "latest Opus 1M" slot.
+		// `cliModel` is pinned to the explicit `claude-opus-4-8` wire id rather
+		// than the literal "default": the bundled claude-code's own default
+		// model drifted from Opus to Fable 5 in 2.1.17x, so a bare "default"
+		// (terminal strips it, emitting no `--model`; streaming forwards it)
+		// silently launched Fable 5, which Max plans can't access. Bump this
+		// pin when a newer Opus ships. MUST stay in sync with the Rust catalog
+		// (`official_claude_section`) and `resolve_model`'s `default` arm.
 		{
 			id: "default",
 			label: "Opus 4.8 1M",
-			cliModel: "default",
+			cliModel: "claude-opus-4-8",
 			effortLevels: ["low", "medium", "high", "xhigh", "max"],
 			supportsFastMode: true,
 		},
@@ -176,8 +179,14 @@ export function modelSupportsFastMode(
 	modelId: string | undefined | null,
 ): boolean {
 	if (!modelId) return false;
+	// The streaming path looks this up by the resolved `cliModel` (e.g.
+	// "claude-opus-4-8"), while the picker uses `id` (e.g. "default"). Match
+	// either so the `default` entry, whose id and cliModel differ, keeps fast
+	// mode.
 	return MODEL_CATALOG[provider].some(
-		(model) => model.id === modelId && model.supportsFastMode === true,
+		(model) =>
+			(model.id === modelId || model.cliModel === modelId) &&
+			model.supportsFastMode === true,
 	);
 }
 

--- a/sidecar/test/claude-session-manager.test.ts
+++ b/sidecar/test/claude-session-manager.test.ts
@@ -1773,7 +1773,7 @@ describe("ClaudeSessionManager.listModels", () => {
 			{
 				id: "default",
 				label: "Opus 4.8 1M",
-				cliModel: "default",
+				cliModel: "claude-opus-4-8",
 				effortLevels: ["low", "medium", "high", "xhigh", "max"],
 				supportsFastMode: true,
 			},

--- a/src-tauri/src/agents.rs
+++ b/src-tauri/src/agents.rs
@@ -807,7 +807,7 @@ mod tests {
         let _env = crate::testkit::TestEnv::new("resolve-model-infers-provider");
         let claude = resolve_model("default", None);
         assert_eq!(claude.provider, "claude");
-        assert_eq!(claude.cli_model, "default");
+        assert_eq!(claude.cli_model, "claude-opus-4-8");
 
         let codex = resolve_model("gpt-5.4", None);
         assert_eq!(codex.provider, "codex");

--- a/src-tauri/src/agents/catalog.rs
+++ b/src-tauri/src/agents/catalog.rs
@@ -85,19 +85,26 @@ fn official_claude_section() -> AgentModelSection {
                 &["low", "medium", "high", "xhigh", "max"],
                 false,
             ),
-            // `default` resolves to the newest Opus the bundled claude-code
-            // knows about — 2.1.170 maps it to Opus 4.8 (1M context, adaptive
-            // thinking, default high effort, fast mode at 2x rate / 2.5x
-            // speed). Kept as `default` so it stays the auto-latest pick and
-            // remains the app's default selection (see
-            // `useEnsureDefaultModel`, which prefers id == "default"). MUST
-            // stay in sync with `sidecar/src/model-catalog.ts`.
-            claude_model(
-                "default",
-                "Opus 4.8 1M",
-                &["low", "medium", "high", "xhigh", "max"],
-                true,
-            ),
+            // `default` is the app's default selection (see
+            // `useEnsureDefaultModel`, which pins id == "default") and the
+            // picker's "latest Opus 1M" slot. Its `cli_model` is pinned to the
+            // explicit `claude-opus-4-8` wire id rather than the literal
+            // "default": the bundled claude-code's own default model drifted
+            // from Opus to Fable 5 in 2.1.17x, so leaving it as "default" made
+            // the terminal (which strips "default", emitting no `--model`) and
+            // the streaming path silently launch Fable 5 — which Max plans
+            // can't access. Bump this pin when a newer Opus ships. MUST stay in
+            // sync with `sidecar/src/model-catalog.ts` and `resolve_model`'s
+            // `default` arm.
+            AgentModelOption {
+                cli_model: "claude-opus-4-8".to_string(),
+                ..claude_model(
+                    "default",
+                    "Opus 4.8 1M",
+                    &["low", "medium", "high", "xhigh", "max"],
+                    true,
+                )
+            },
             // Explicit 4.7 pin — this slot used to BE `default`; now that
             // `default` advanced to 4.8 we surface 4.7 as its own selectable
             // entry, above 4.6.
@@ -617,6 +624,13 @@ pub fn resolve_model(model_id: &str, provider_hint: Option<&str>) -> ResolvedMod
             .strip_prefix("cursor-")
             .unwrap_or(model_id)
             .to_string()
+    } else if provider == "claude" && model_id == "default" {
+        // Pin claude's `default` sentinel to the explicit latest-Opus wire id
+        // for the streaming/GUI path. The bundled claude-code's own default
+        // model drifted from Opus to Fable 5 in 2.1.17x; forwarding the literal
+        // "default" lets the CLI pick Fable 5, which Max plans can't access.
+        // Keep in sync with the `cli_model` pin in `official_claude_section`.
+        "claude-opus-4-8".to_string()
     } else {
         model_id.to_string()
     };
@@ -745,7 +759,7 @@ mod tests {
         let _env = crate::testkit::TestEnv::new("resolve-claude-model");
         let m = resolve_model("default", None);
         assert_eq!(m.provider, "claude");
-        assert_eq!(m.cli_model, "default");
+        assert_eq!(m.cli_model, "claude-opus-4-8");
         assert_eq!(m.id, "default");
         assert!(m.supports_effort);
     }
@@ -1050,7 +1064,7 @@ mod tests {
         // fast mode, and keeps the xhigh effort tier.
         let default = &claude.options[1];
         assert_eq!(default.label, "Opus 4.8 1M");
-        assert_eq!(default.cli_model, "default");
+        assert_eq!(default.cli_model, "claude-opus-4-8");
         assert!(default.supports_fast_mode, "Opus 4.8 supports fast mode");
         assert_eq!(
             default.effort_levels,
@@ -1082,7 +1096,7 @@ mod tests {
         // this is the regression the namespace prefix exists to prevent.
         let claude = resolve_model("default", None);
         assert_eq!(claude.provider, "claude");
-        assert_eq!(claude.cli_model, "default");
+        assert_eq!(claude.cli_model, "claude-opus-4-8");
 
         let cursor = resolve_model("cursor-default", None);
         assert_eq!(cursor.provider, "cursor");


### PR DESCRIPTION
## What changed

- Pin Helmor's Claude `default` model slot to the explicit `claude-opus-4-8` CLI model while preserving the `default` picker id.
- Keep sidecar and Rust model catalogs in sync, including fast-mode lookup for the resolved CLI model.
- Add a patch changeset for the Opus 4.8 selection fix.

## Why

The bundled Claude CLI default drifted away from Opus, so selecting Helmor's "Opus 4.8 1M" default could launch a different model that some plans cannot access. Pinning the wire model keeps the app default stable while still allowing the displayed `default` slot to represent the latest Opus 1M choice.

## Tests

- `bun test sidecar/test/claude-session-manager.test.ts`
- `cd src-tauri && cargo test resolve_model`
- pre-commit: Biome, `cargo fmt`, `cargo clippy -- -D warnings`
