### PR TITLE
fix(sidecar): cross-compile sidecar to release target triple (Intel ships arm64 sidecar)

### DIFF
--- a/.changeset/x86_64-sidecar-arch.md
+++ b/.changeset/x86_64-sidecar-arch.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix Intel (x86_64) builds shipping an arm64 `helmor-sidecar`, which made the app fail to launch its sidecar with "Failed to start sidecar binary" / "bad CPU type in executable" on Intel Macs. The sidecar is now cross-compiled to the release target triple, and the bundle arch check covers it so the mismatch can't ship again.

--- a/scripts/verify-bundled-cli.sh
+++ b/scripts/verify-bundled-cli.sh
@@ -35,11 +35,16 @@ fi
 
 echo "Bundled CLI smoke check passed."
 
-# ----- Vendor binary architecture check -----------------------------------
+# ----- Bundled binary architecture check -----------------------------------
 # helmor-cli is built per-arch via cargo --target, so its lipo arch is the
-# source of truth for what this bundle is targeting. Every vendored binary
-# must match — otherwise an x64 .dmg ends up shipping arm64 `gh` and Intel
-# users see "bad CPU type in executable" (#293).
+# source of truth for what this bundle is targeting. Every other bundled
+# executable must match — otherwise an x64 .dmg ends up shipping an arm64
+# binary and Intel users see "bad CPU type in executable" (#293).
+#
+# This includes helmor-sidecar: it's a Bun `--compile` artifact built in
+# sidecar/scripts/build.ts, which historically ignored the target triple and
+# emitted a host-arch binary. The CLI/vendor checks below did NOT cover it, so
+# an arm64 sidecar shipped in the x86_64 release. Keep it first in the list.
 EXPECTED_ARCH="$(lipo -archs "${CLI_PATH}")"
 case "${EXPECTED_ARCH}" in
   arm64|x86_64) ;;
@@ -54,6 +59,7 @@ esac
 # under their sub-paths anymore.
 VENDOR_ROOT="${APP_BUNDLE}/Contents/Resources/vendor"
 VENDOR_BINARIES=(
+  "${APP_BUNDLE}/Contents/MacOS/helmor-sidecar"
   "${VENDOR_ROOT}/gh/gh"
   "${VENDOR_ROOT}/glab/glab"
   "${VENDOR_ROOT}/codex/codex"

--- a/sidecar/scripts/build.ts
+++ b/sidecar/scripts/build.ts
@@ -9,12 +9,59 @@ import { buildCursorWorker } from "./build-worker.ts";
 
 const SIDECAR_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
+// Cross-compile the sidecar to the release target. Tauri sets the target triple
+// on release builds (see scripts/prepare-sidecar.mjs / .github/workflows/publish.yml);
+// cargo cross-compiles the Rust side via `--target`, and this Bun binary MUST match.
+// Without it, Bun compiles for the runner's host arch — so an x86_64 .app built on
+// an arm64 CI runner ships an arm64 sidecar and Intel users hit
+// "bad CPU type in executable: …/helmor-sidecar" (#293).
+type BunCompileTarget =
+	| "bun-darwin-x64"
+	| "bun-darwin-arm64"
+	| "bun-windows-x64"
+	| "bun-windows-arm64"
+	| "bun-linux-x64"
+	| "bun-linux-arm64";
+
+const TRIPLE_TO_BUN_TARGET: Record<string, BunCompileTarget> = {
+	"x86_64-apple-darwin": "bun-darwin-x64",
+	"aarch64-apple-darwin": "bun-darwin-arm64",
+	"x86_64-pc-windows-msvc": "bun-windows-x64",
+	"aarch64-pc-windows-msvc": "bun-windows-arm64",
+	"x86_64-unknown-linux-gnu": "bun-linux-x64",
+	"aarch64-unknown-linux-gnu": "bun-linux-arm64",
+};
+
+const targetTriple = (
+	process.env.TAURI_TARGET_TRIPLE ??
+	process.env.TAURI_ENV_TARGET_TRIPLE ??
+	process.env.CARGO_BUILD_TARGET ??
+	""
+).trim();
+
+const bunTarget = targetTriple ? TRIPLE_TO_BUN_TARGET[targetTriple] : undefined;
+if (targetTriple && !bunTarget) {
+	// Fail loud rather than silently ship a host-arch sidecar for an unknown target.
+	throw new Error(
+		`build.ts: no Bun compile target mapped for triple "${targetTriple}"`,
+	);
+}
+if (bunTarget) {
+	console.log(
+		`[build] cross-compiling sidecar → ${bunTarget} (${targetTriple})`,
+	);
+}
+
 // Main sidecar — compiled Bun binary. No build plugins: Cursor's `@cursor/sdk`
 // (and its native sqlite3) now live in the separate Node worker, so the old
 // sqlite3 shim + cursor-chunk-inlining hacks are gone.
 const result = await Bun.build({
 	entrypoints: [join(SIDECAR_ROOT, "src/index.ts")],
-	compile: { outfile: join(SIDECAR_ROOT, "dist/helmor-sidecar") },
+	compile: {
+		// Omit `target` in dev (env unset) so Bun builds for the host, unchanged.
+		...(bunTarget ? { target: bunTarget } : {}),
+		outfile: join(SIDECAR_ROOT, "dist/helmor-sidecar"),
+	},
 });
 
 if (!result.success) {


### PR DESCRIPTION
## Problem

On Intel (x86_64) Macs, Helmor v0.38.0 fails at launch:

```
Sidecar send failed: Failed to start sidecar binary: /Applications/Helmor.app/Contents/MacOS/helmor-sidecar
```

The shipped x86_64 `.app` bundles an **arm64** `helmor-sidecar`. Every other binary in the bundle is x86_64:

| binary | arch |
|---|---|
| `helmor` (GUI) | x86_64 |
| `helmor-cli` | x86_64 |
| vendor (`gh`/`glab`/`codex`/`claude`, llama-cpp, node…) | x86_64 |
| **`helmor-sidecar`** | **arm64** ← |

The GUI (x86_64) execs the arm64 sidecar → kernel returns `bad CPU type in executable`. Intel cannot run arm64 (Rosetta only translates x86_64→arm64, never the reverse), so the install is unusable.

## Root cause

Both macOS matrix targets build on `runs-on: macos-26` (Apple Silicon / arm64). The x86_64 job does `rustup target add x86_64-apple-darwin` + `--target x86_64-apple-darwin`, so **cargo cross-compiles** the Rust host and `helmor-cli` correctly.

But the sidecar is a Bun `--compile` artifact built in `sidecar/scripts/build.ts`, which called `Bun.build({ compile: { outfile } })` with **no `target`** → Bun compiled for the runner's host arch (arm64). `scripts/prepare-sidecar.mjs` then copied that host-arch binary to the `helmor-sidecar-x86_64-apple-darwin` suffixed name and Tauri bundled it into the x86_64 `.app`.

This is the same failure class as #293 (wrong-arch vendor binaries) — but on the one binary the arch guard in `scripts/verify-bundled-cli.sh` didn't cover, so it shipped.

## Fix

- **`sidecar/scripts/build.ts`** — map the release target triple (`TAURI_TARGET_TRIPLE` / `TAURI_ENV_TARGET_TRIPLE` / `CARGO_BUILD_TARGET`, the same env Tauri/`prepare-sidecar.mjs` already set) to a Bun compile target and pass it to `Bun.build`. Dev builds (env unset) omit `target` and remain host-native. An unmapped-but-set triple throws instead of silently shipping host arch.
- **`scripts/verify-bundled-cli.sh`** — add `Contents/MacOS/helmor-sidecar` to the bundle arch check, so a wrong-arch sidecar fails CI from now on.

## Verification

Ran the patched `verify-bundled-cli.sh` against the broken installed v0.38.0 bundle — it now catches what the old guard missed:

```
Bundled CLI smoke check passed.
Verifying vendor binary archs (expect x86_64)...
  MISMATCH /Applications/Helmor.app/Contents/MacOS/helmor-sidecar: got 'arm64', want 'x86_64'
  ...
Vendor binary arch check failed (1 issue(s))   # exit 1
```

`biome check` passes on the edited `build.ts`. (Couldn't run a full cross-build locally — no Bun toolchain on the test machine — but CI exercises both target matrices and the new guard will gate them.)

Fixes the Intel "Failed to start sidecar binary" launch failure. Closes the gap left by #293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)