### PR TITLE
feat: group model picker by section, prefix custom labels, and fix provider config edge cases

### DIFF
--- a/src-tauri/src/agents/catalog.rs
+++ b/src-tauri/src/agents/catalog.rs
@@ -78,7 +78,7 @@ pub fn static_model_sections() -> Vec<AgentModelSection> {
 pub fn full_catalog_sections() -> Vec<AgentModelSection> {
     model_sections_for_inputs(
         crate::provider::claude::configured_models(),
-        codex_custom_catalog_options(),
+        codex_custom_catalog_options(crate::provider::codex::load_providers()),
         load_cursor_prefs(),
         load_opencode_prefs(),
         load_mimo_prefs(),
@@ -181,14 +181,24 @@ fn codex_custom_sections(
 }
 
 /// Flat unfiltered list of every custom Codex model, for the Settings picker.
-fn codex_custom_catalog_options() -> Vec<AgentModelOption> {
+/// Custom models merge into the Codex section here, so each label is prefixed
+/// with its provider name (`Name · model`) — otherwise a custom `gpt-5.5` is
+/// indistinguishable from the official one. Mirrors OpenCode's labelling.
+fn codex_custom_catalog_options(
+    providers: Vec<crate::provider::CustomProvider>,
+) -> Vec<AgentModelOption> {
     let mut out = Vec::new();
-    for provider in crate::provider::codex::load_providers() {
+    for provider in providers {
         let instance_id = provider.id.trim();
         if instance_id.is_empty() || provider.base_url.trim().is_empty() {
             continue;
         }
         let provider_id = crate::provider::codex::provider_id(instance_id);
+        let prefix = if provider.name.trim().is_empty() {
+            instance_id
+        } else {
+            provider.name.trim()
+        };
         let mut seen = std::collections::HashSet::new();
         for model in &provider.models {
             let wire = model.slug.trim();
@@ -204,7 +214,7 @@ fn codex_custom_catalog_options() -> Vec<AgentModelOption> {
                 instance_id,
                 &provider_id,
                 wire,
-                model_label,
+                &format!("{prefix} · {model_label}"),
             ));
         }
     }
@@ -1088,6 +1098,23 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["gpt-5.4"]
         );
+    }
+
+    #[test]
+    fn codex_custom_catalog_options_prefixes_label_with_provider_name() {
+        // Merged into the Codex section, so the name prefix disambiguates a
+        // custom `gpt-5.5` from the official one.
+        let opts =
+            codex_custom_catalog_options(vec![codex_custom("hundun", "Hundun", &["gpt-5.5"])]);
+        assert_eq!(opts.len(), 1);
+        assert_eq!(opts[0].label, "Hundun · gpt-5.5");
+        assert_eq!(opts[0].id, "codex:hundun|gpt-5.5");
+    }
+
+    #[test]
+    fn codex_custom_catalog_options_prefix_falls_back_to_id() {
+        let opts = codex_custom_catalog_options(vec![codex_custom("hundun", "", &["gpt-5.5"])]);
+        assert_eq!(opts[0].label, "hundun · gpt-5.5");
     }
 
     #[test]

--- a/src-tauri/src/provider/opencode.rs
+++ b/src-tauri/src/provider/opencode.rs
@@ -9,8 +9,10 @@ const NPM_CHAT: &str = "@ai-sdk/openai-compatible";
 const NPM_RESPONSES: &str = "@ai-sdk/openai";
 
 fn to_custom(p: OpencodeCustomProvider) -> CustomProvider {
-    // No baseURL → registry preset (apiKey-only); id is the models.dev key.
-    let is_preset = p.base_url.trim().is_empty();
+    // Registry presets (apiKey-only) never carry `npm`; manual providers always
+    // do. A freshly-added manual slot starts with an empty baseURL, so key off
+    // `npm` — else it'd be misread as a preset and lose its Base URL field.
+    let is_preset = p.npm.trim().is_empty();
     let api_style = if p.npm == NPM_RESPONSES {
         "responses"
     } else {
@@ -156,5 +158,21 @@ mod tests {
         };
         let custom = to_custom(oc);
         assert_eq!(custom.preset_key.as_deref(), Some("deepseek"));
+    }
+
+    #[test]
+    fn fresh_manual_block_without_base_url_stays_manual() {
+        // Regression: a just-added manual slot has no baseURL yet but does carry
+        // `npm`. It must stay manual so the card keeps showing the Base URL field.
+        let oc = OpencodeCustomProvider {
+            id: "a1b2c3d4".to_string(),
+            name: String::new(),
+            npm: NPM_CHAT.to_string(),
+            base_url: String::new(),
+            api_key: String::new(),
+            headers: Default::default(),
+            models: Vec::new(),
+        };
+        assert_eq!(to_custom(oc).preset_key, None);
     }
 }

--- a/src-tauri/src/provider/opencode_config.rs
+++ b/src-tauri/src/provider/opencode_config.rs
@@ -165,8 +165,34 @@ fn read_custom_providers_at(path: &Path) -> Result<Vec<OpencodeCustomProvider>> 
             models: read_models(block.get("models")),
         });
     }
-    out.sort_by(|a, b| a.id.cmp(&b.id));
+    // Preserve the file's declaration order so a newly-appended provider lands
+    // last (serde_json's map sorts keys; the CST keeps file order).
+    let order = provider_key_order(&text);
+    out.sort_by_key(|p| {
+        order
+            .iter()
+            .position(|id| *id == p.id)
+            .unwrap_or(usize::MAX)
+    });
     Ok(out)
+}
+
+// Provider ids in the order they appear in the config file.
+fn provider_key_order(text: &str) -> Vec<String> {
+    let Ok(root) = CstRootNode::parse(text, &ParseOptions::default()) else {
+        return Vec::new();
+    };
+    let Some(provider_obj) = root
+        .object_value()
+        .and_then(|root_obj| root_obj.object_value("provider"))
+    else {
+        return Vec::new();
+    };
+    provider_obj
+        .properties()
+        .into_iter()
+        .filter_map(|prop| prop.name().and_then(|name| name.decoded_value().ok()))
+        .collect()
 }
 
 fn read_headers(
@@ -436,7 +462,7 @@ mod tests {
         upsert_custom_provider_at(&path, &sample()).unwrap();
         let read = read_custom_providers_at(&path).unwrap();
         let ids: Vec<&str> = read.iter().map(|p| p.id.as_str()).collect();
-        assert_eq!(ids, vec!["hundun", "other"]);
+        assert_eq!(ids, vec!["other", "hundun"], "file order preserved");
         let hundun = read.iter().find(|p| p.id == "hundun").unwrap();
         assert_eq!(hundun.base_url, "http://rmb.hundun.cn/v1");
         assert_eq!(hundun.name, "DeepSeek (Hundun)");
@@ -475,7 +501,11 @@ mod tests {
 
         let read = read_custom_providers_at(&path).unwrap();
         let ids: Vec<&str> = read.iter().map(|p| p.id.as_str()).collect();
-        assert_eq!(ids, vec!["custom", "deepseek"], "bare block skipped");
+        assert_eq!(
+            ids,
+            vec!["deepseek", "custom"],
+            "bare block skipped, file order preserved"
+        );
         let deepseek = read.iter().find(|p| p.id == "deepseek").unwrap();
         assert_eq!(deepseek.api_key, "sk-x");
         assert_eq!(deepseek.base_url, "", "preset block has no baseURL");

--- a/src/features/settings/index.tsx
+++ b/src/features/settings/index.tsx
@@ -13,7 +13,10 @@ import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
+	DropdownMenuGroup,
 	DropdownMenuItem,
+	DropdownMenuLabel,
+	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
@@ -38,7 +41,6 @@ import { getShortcut } from "@/features/shortcuts/registry";
 import { ShortcutsSettingsPanel } from "@/features/shortcuts/settings-panel";
 import { InlineShortcutDisplay } from "@/features/shortcuts/shortcut-display";
 import {
-	type AgentModelOption,
 	type AgentModelSection,
 	isConductorAvailable,
 	type RepositoryCreateOption,
@@ -157,12 +159,14 @@ export const SettingsDialog = memo(function SettingsDialog({
 		enabled: open,
 	});
 	const repositories = reposQuery.data ?? [];
+	// Same source as the composer picker, so the Default/Review/PR rows show
+	// exactly the user's selected models, grouped by section (the section header
+	// distinguishes a custom `gpt-5.5` from the official one).
 	const modelSectionsQuery = useQuery({
 		...agentModelSectionsQueryOptions(),
 		enabled: open,
 	});
 	const modelSections = modelSectionsQuery.data ?? [];
-	const allModels = modelSections.flatMap((s) => s.options);
 
 	// Note: null review/pr model fields used to be promoted to default
 	// values here on every dialog open. That migration now runs once in
@@ -539,7 +543,6 @@ export const SettingsDialog = memo(function SettingsDialog({
 									<ModelSettingRow
 										title="Default model"
 										description="Model for new chats"
-										models={allModels}
 										modelSections={modelSections}
 										isLoadingModels={modelSectionsQuery.isPending}
 										// Each row reads its own state directly. The `?? default*`
@@ -568,7 +571,6 @@ export const SettingsDialog = memo(function SettingsDialog({
 									<ModelSettingRow
 										title="Review model"
 										description="Model for code review"
-										models={allModels}
 										modelSections={modelSections}
 										isLoadingModels={modelSectionsQuery.isPending}
 										modelId={
@@ -597,7 +599,6 @@ export const SettingsDialog = memo(function SettingsDialog({
 									<ModelSettingRow
 										title="Action model"
 										description="Model for PRs/MRs and commit-and-push"
-										models={allModels}
 										modelSections={modelSections}
 										isLoadingModels={modelSectionsQuery.isPending}
 										modelId={
@@ -710,7 +711,6 @@ type ModelRowChange = {
 function ModelSettingRow({
 	title,
 	description,
-	models,
 	modelSections,
 	isLoadingModels,
 	modelId,
@@ -721,7 +721,6 @@ function ModelSettingRow({
 }: {
 	title: string;
 	description: string;
-	models: AgentModelOption[];
 	modelSections: AgentModelSection[];
 	isLoadingModels: boolean;
 	modelId: string | null;
@@ -776,27 +775,37 @@ function ModelSettingRow({
 					<DropdownMenuContent
 						align="end"
 						sideOffset={4}
-						className="min-w-[10rem]"
+						className="max-h-[320px] min-w-[10rem] overflow-y-auto"
 					>
-						{models.map((m) => (
-							<DropdownMenuItem
-								key={m.id}
-								onClick={() =>
-									onChange({ modelId: m.id, provider: m.provider })
-								}
-								className="justify-between gap-2"
-							>
-								<span className="flex min-w-0 items-center gap-2">
-									<ModelIcon model={m} className="size-4" />
-									{m.label}
-								</span>
-								<CheckCircle2
-									className={cn(
-										"size-3.5 shrink-0 text-emerald-500",
-										m.id !== modelId && "invisible",
-									)}
-								/>
-							</DropdownMenuItem>
+						{/* Grouped by section like the composer, so a custom `gpt-5.5`
+						    sits under its provider header, not next to the official one. */}
+						{modelSections.map((section, index) => (
+							<DropdownMenuGroup key={section.id}>
+								{index > 0 ? <DropdownMenuSeparator /> : null}
+								<DropdownMenuLabel className="text-mini text-muted-foreground">
+									{section.label}
+								</DropdownMenuLabel>
+								{section.options.map((m) => (
+									<DropdownMenuItem
+										key={m.id}
+										onClick={() =>
+											onChange({ modelId: m.id, provider: m.provider })
+										}
+										className="justify-between gap-2"
+									>
+										<span className="flex min-w-0 items-center gap-2">
+											<ModelIcon model={m} className="size-4" />
+											{m.label}
+										</span>
+										<CheckCircle2
+											className={cn(
+												"size-3.5 shrink-0 text-emerald-500",
+												m.id !== modelId && "invisible",
+											)}
+										/>
+									</DropdownMenuItem>
+								))}
+							</DropdownMenuGroup>
 						))}
 					</DropdownMenuContent>
 				</DropdownMenu>

--- a/src/features/settings/panels/builtin-claude-providers.ts
+++ b/src/features/settings/panels/builtin-claude-providers.ts
@@ -3,17 +3,11 @@ import catalog from "@/shared/provider-catalog.json";
 
 export type BuiltinClaudeProviderKey = string;
 
-export type BuiltinClaudeProviderModel = {
-	id: string;
-	label: string;
-};
-
 export type BuiltinClaudeProvider = {
 	key: BuiltinClaudeProviderKey;
 	label: string;
 	baseUrl: string;
 	apiKeyUrl: string;
-	models: readonly BuiltinClaudeProviderModel[];
 	icon: ProviderBrandIconKey;
 };
 

--- a/src/features/settings/panels/providers/custom-providers-list.tsx
+++ b/src/features/settings/panels/providers/custom-providers-list.tsx
@@ -135,7 +135,12 @@ function AddProviderMenu({
 					<ChevronDown className="size-3 opacity-50" />
 				</Button>
 			</DropdownMenuTrigger>
-			<DropdownMenuContent align="start" className="max-h-[320px] w-[300px]">
+			{/* Don't refocus the trigger on close — that scroll-jumps the panel. */}
+			<DropdownMenuContent
+				align="start"
+				className="max-h-[320px] w-[300px]"
+				onCloseAutoFocus={(e) => e.preventDefault()}
+			>
 				{/* Custom always leads — most prominent, family-agnostic. */}
 				{customItem}
 				<DropdownMenuSeparator />

--- a/src/shared/provider-catalog.json
+++ b/src/shared/provider-catalog.json
@@ -5,12 +5,6 @@
 			"label": "MiniMax",
 			"baseUrl": "https://api.minimax.io/anthropic",
 			"apiKeyUrl": "https://platform.minimax.io/user-center/basic-information/interface-key",
-			"models": [
-				{
-					"id": "MiniMax-M2.7",
-					"label": "MiniMax M2.7"
-				}
-			],
 			"icon": "minimax"
 		},
 		{
@@ -18,12 +12,6 @@
 			"label": "MiniMax CN",
 			"baseUrl": "https://api.minimaxi.com/anthropic",
 			"apiKeyUrl": "https://platform.minimaxi.com/user-center/basic-information/interface-key",
-			"models": [
-				{
-					"id": "MiniMax-M2.7",
-					"label": "MiniMax M2.7"
-				}
-			],
 			"icon": "minimax"
 		},
 		{
@@ -31,12 +19,6 @@
 			"label": "Moonshot / Kimi",
 			"baseUrl": "https://api.moonshot.ai/anthropic",
 			"apiKeyUrl": "https://platform.kimi.ai/console/api-keys",
-			"models": [
-				{
-					"id": "kimi-k2.5",
-					"label": "Kimi K2.5"
-				}
-			],
 			"icon": "moonshot"
 		},
 		{
@@ -44,12 +26,6 @@
 			"label": "Moonshot / Kimi CN",
 			"baseUrl": "https://api.moonshot.cn/anthropic",
 			"apiKeyUrl": "https://platform.moonshot.cn/console/api-keys",
-			"models": [
-				{
-					"id": "kimi-k2.5",
-					"label": "Kimi K2.5"
-				}
-			],
 			"icon": "moonshot"
 		},
 		{
@@ -57,12 +33,6 @@
 			"label": "Z.AI / GLM",
 			"baseUrl": "https://api.z.ai/api/anthropic",
 			"apiKeyUrl": "https://z.ai/manage-apikey/apikey-list",
-			"models": [
-				{
-					"id": "glm-4.7",
-					"label": "GLM 4.7"
-				}
-			],
 			"icon": "zhipu"
 		},
 		{
@@ -70,12 +40,6 @@
 			"label": "Z.AI / GLM CN",
 			"baseUrl": "https://open.bigmodel.cn/api/anthropic",
 			"apiKeyUrl": "https://open.bigmodel.cn/usercenter/apikeys",
-			"models": [
-				{
-					"id": "glm-5.1",
-					"label": "GLM 5.1"
-				}
-			],
 			"icon": "zhipu"
 		},
 		{
@@ -83,12 +47,6 @@
 			"label": "Qwen / DashScope",
 			"baseUrl": "https://dashscope.aliyuncs.com/apps/anthropic",
 			"apiKeyUrl": "https://bailian.console.aliyun.com/?tab=model#/api-key",
-			"models": [
-				{
-					"id": "qwen3.6-plus",
-					"label": "Qwen 3.6 Plus"
-				}
-			],
 			"icon": "qwen"
 		},
 		{
@@ -96,12 +54,6 @@
 			"label": "Qwen / DashScope Intl",
 			"baseUrl": "https://dashscope-intl.aliyuncs.com/apps/anthropic",
 			"apiKeyUrl": "https://bailian.console.alibabacloud.com/?tab=model#/api-key",
-			"models": [
-				{
-					"id": "qwen3.5-plus",
-					"label": "Qwen 3.5 Plus"
-				}
-			],
 			"icon": "qwen"
 		},
 		{
@@ -109,12 +61,6 @@
 			"label": "Xiaomi MiMo",
 			"baseUrl": "https://api.xiaomimimo.com/anthropic",
 			"apiKeyUrl": "https://platform.xiaomimimo.com/#/console/api-keys",
-			"models": [
-				{
-					"id": "mimo-v2.5-pro",
-					"label": "MiMo V2.5 Pro"
-				}
-			],
 			"icon": "xiaomi"
 		},
 		{
@@ -122,16 +68,6 @@
 			"label": "DeepSeek",
 			"baseUrl": "https://api.deepseek.com/anthropic",
 			"apiKeyUrl": "https://platform.deepseek.com/api_keys",
-			"models": [
-				{
-					"id": "deepseek-v4-pro[1m]",
-					"label": "DeepSeek V4 Pro 1M"
-				},
-				{
-					"id": "deepseek-v4-flash",
-					"label": "DeepSeek V4 Flash"
-				}
-			],
 			"icon": "deepseek"
 		}
 	],


### PR DESCRIPTION
## What changed

- **Settings model picker** now groups models by section with headers and separators, matching the composer picker layout. This makes it clear which provider a model belongs to.
- **Custom Codex model labels** include a provider name prefix (e.g. `Hundun · gpt-5.5`) for disambiguation when mixed into the Codex section alongside official models.
- **Provider config order** is now preserved from the file's declaration order instead of being sorted alphabetically. A newly-appended provider lands last as expected.
- **OpenCode manual provider detection** now uses `npm` field presence instead of `baseURL` emptiness to distinguish presets from manual providers. This fixes a bug where a freshly-added manual slot (with no base URL yet) was incorrectly treated as a registry preset and lost its Base URL field.
- **Built-in Claude provider catalog** no longer ships hardcoded model lists — models are now discovered dynamically from the API.
- **Add Provider dropdown** no longer scroll-jumps the panel on close.

## Why

Custom provider management had several UX rough edges where manual providers could be misclassified, the model picker didn't show provenance, and provider order shifted unexpectedly after editing the config file.

## Test notes

- New unit tests added for Codex label prefixing and OpenCode manual provider regression
- Existing OpenCode config tests updated to expect file-order preservation
- Manual smoke test: add a custom provider, verify it shows correctly in the settings model picker dropdown
