### PR TITLE
refactor: pin Claude default model to Opus 4.8 1M, drop the floating `default` sentinel

### DIFF
--- a/.changeset/claude-model-handling.md
+++ b/.changeset/claude-model-handling.md
@@ -1,0 +1,7 @@
+---
+"helmor": patch
+---
+
+Improve Claude model handling:
+- The default Claude model is pinned to Opus 4.8 (1M context) so it can't silently switch to a different model when the bundled Claude CLI updates; existing sessions and settings keep the same model.
+- Terminal mode is now limited to official Claude models — custom (BYOK) Claude models run in GUI mode instead, since the terminal can't carry their custom provider settings.

--- a/sidecar/src/model-catalog.ts
+++ b/sidecar/src/model-catalog.ts
@@ -11,7 +11,7 @@ const MODEL_CATALOG: Record<Provider, readonly ProviderModelInfo[]> = {
 	claude: [
 		// Fable 5 leads the list as the most capable pick, but it burns limits
 		// ~2x faster than Opus — `useEnsureDefaultModel` pins the app default
-		// to the `default` (Opus) entry below, NOT to the first entry. No fast
+		// to the Opus 4.8 entry below, NOT to the first entry. No fast
 		// mode (Opus 4.6+ only).
 		{
 			id: "claude-fable-5[1m]",
@@ -19,16 +19,17 @@ const MODEL_CATALOG: Record<Provider, readonly ProviderModelInfo[]> = {
 			cliModel: "claude-fable-5[1m]",
 			effortLevels: ["low", "medium", "high", "xhigh", "max"],
 		},
-		// `default` resolves to the newest Opus the bundled claude-code knows
-		// about — in 2.1.170 that is Opus 4.8 (1M context, adaptive thinking,
-		// default high effort, fast mode at 2x rate / 2.5x speed). Kept as
-		// `default` (rather than pinned `claude-opus-4-8`) so it stays the
-		// auto-latest pick AND remains the app default selection (see
-		// `useEnsureDefaultModel`, which prefers id == "default").
+		// App default selection (see `useEnsureDefaultModel`, which pins this
+		// id). Pinned to the explicit `claude-opus-4-8[1m]` wire id — the `[1m]`
+		// suffix selects the 1M-context variant, matching the label. We do NOT
+		// use the CLI's `default` sentinel: it resolves to whatever the bundled
+		// claude-code decides is "default" (non-deterministic across CLI bumps),
+		// whereas a pinned id is stable. Bump when a newer Opus ships. MUST stay
+		// in sync with the Rust catalog (`official_claude_section`).
 		{
-			id: "default",
+			id: "claude-opus-4-8[1m]",
 			label: "Opus 4.8 1M",
-			cliModel: "default",
+			cliModel: "claude-opus-4-8[1m]",
 			effortLevels: ["low", "medium", "high", "xhigh", "max"],
 			supportsFastMode: true,
 		},

--- a/sidecar/test/claude-session-manager.test.ts
+++ b/sidecar/test/claude-session-manager.test.ts
@@ -493,8 +493,9 @@ describe("ClaudeSessionManager.sendMessage", () => {
 			models.map((m) => [m.id, m.supportsFastMode]),
 		);
 
-		// `default` now resolves to Opus 4.8, which supports fast mode.
-		expect(bySupports.default).toBe(true);
+		// Opus 4.8 1M supports fast mode.
+		expect(bySupports["claude-opus-4-8[1m]"]).toBe(true);
+		expect(bySupports.default).toBeUndefined();
 		expect(bySupports.sonnet).toBeUndefined();
 		expect(bySupports["claude-opus-4-7[1m]"]).toBeUndefined();
 		expect(bySupports["claude-opus-4-6[1m]"]).toBe(true);
@@ -539,7 +540,7 @@ describe("ClaudeSessionManager.sendMessage", () => {
 			{
 				sessionId: `helmor-sess-effort-${level}`,
 				prompt: "test",
-				model: "default",
+				model: "claude-opus-4-8[1m]",
 				cwd: undefined,
 				resume: undefined,
 				permissionMode: undefined,
@@ -562,7 +563,7 @@ describe("ClaudeSessionManager.sendMessage", () => {
 			{
 				sessionId: "helmor-sess-effort-bogus",
 				prompt: "test",
-				model: "default",
+				model: "claude-opus-4-8[1m]",
 				cwd: undefined,
 				resume: undefined,
 				permissionMode: undefined,
@@ -585,7 +586,7 @@ describe("ClaudeSessionManager.sendMessage", () => {
 			{
 				sessionId: "helmor-sess-mcp-blocking",
 				prompt: "test",
-				model: "default",
+				model: "claude-opus-4-8[1m]",
 				cwd: undefined,
 				resume: undefined,
 				permissionMode: undefined,
@@ -633,7 +634,7 @@ describe("ClaudeSessionManager.sendMessage", () => {
 			{
 				sessionId: "helmor-sess-fm",
 				prompt: "hi",
-				model: "default",
+				model: "claude-opus-4-8[1m]",
 				cwd: undefined,
 				resume: undefined,
 				permissionMode: undefined,
@@ -675,7 +676,7 @@ describe("ClaudeSessionManager.sendMessage", () => {
 			{
 				sessionId: "helmor-sess-fm-init",
 				prompt: "hi",
-				model: "default",
+				model: "claude-opus-4-8[1m]",
 				cwd: undefined,
 				resume: undefined,
 				permissionMode: undefined,
@@ -714,7 +715,7 @@ describe("ClaudeSessionManager.sendMessage", () => {
 			{
 				sessionId: "helmor-sess-fm-on",
 				prompt: "hi",
-				model: "default",
+				model: "claude-opus-4-8[1m]",
 				cwd: undefined,
 				resume: undefined,
 				permissionMode: undefined,
@@ -1771,9 +1772,9 @@ describe("ClaudeSessionManager.listModels", () => {
 				effortLevels: ["low", "medium", "high", "xhigh", "max"],
 			},
 			{
-				id: "default",
+				id: "claude-opus-4-8[1m]",
 				label: "Opus 4.8 1M",
-				cliModel: "default",
+				cliModel: "claude-opus-4-8[1m]",
 				effortLevels: ["low", "medium", "high", "xhigh", "max"],
 				supportsFastMode: true,
 			},

--- a/src-tauri/src/agents.rs
+++ b/src-tauri/src/agents.rs
@@ -810,9 +810,12 @@ mod tests {
     #[test]
     fn resolve_model_infers_provider() {
         let _env = crate::testkit::TestEnv::new("resolve-model-infers-provider");
-        let claude = resolve_model("default", None);
+        // Hint-less ids that match no other provider infer to claude and pass
+        // through verbatim (legacy "default" rows are normalized by the DB
+        // migration, so resolve_model needs no special case for it).
+        let claude = resolve_model("claude-opus-4-8[1m]", None);
         assert_eq!(claude.provider, "claude");
-        assert_eq!(claude.cli_model, "default");
+        assert_eq!(claude.cli_model, "claude-opus-4-8[1m]");
 
         let codex = resolve_model("gpt-5.4", None);
         assert_eq!(codex.provider, "codex");

--- a/src-tauri/src/agents/catalog.rs
+++ b/src-tauri/src/agents/catalog.rs
@@ -277,7 +277,7 @@ fn official_claude_section() -> AgentModelSection {
         options: vec![
             // Fable 5 leads the list as the most capable pick, but it burns
             // limits ~2x faster than Opus — `useEnsureDefaultModel` therefore
-            // pins the app default to the `default` (Opus) entry below, NOT
+            // pins the app default to the Opus 4.8 entry below, NOT
             // to options[0]. No fast mode (Opus 4.6+ only).
             claude_model(
                 "claude-fable-5[1m]",
@@ -285,22 +285,21 @@ fn official_claude_section() -> AgentModelSection {
                 &["low", "medium", "high", "xhigh", "max"],
                 false,
             ),
-            // `default` resolves to the newest Opus the bundled claude-code
-            // knows about — 2.1.170 maps it to Opus 4.8 (1M context, adaptive
-            // thinking, default high effort, fast mode at 2x rate / 2.5x
-            // speed). Kept as `default` so it stays the auto-latest pick and
-            // remains the app's default selection (see
-            // `useEnsureDefaultModel`, which prefers id == "default"). MUST
-            // stay in sync with `sidecar/src/model-catalog.ts`.
+            // App default selection (see `useEnsureDefaultModel`, which pins
+            // this id). Pinned to the explicit `claude-opus-4-8[1m]` wire id —
+            // the `[1m]` suffix selects the 1M-context variant, matching the
+            // label. We do NOT use the CLI's `default` sentinel: it resolves to
+            // whatever the bundled claude-code decides (non-deterministic
+            // across CLI bumps), whereas a pinned id is stable. Bump when a
+            // newer Opus ships. MUST stay in sync with
+            // `sidecar/src/model-catalog.ts`.
             claude_model(
-                "default",
+                "claude-opus-4-8[1m]",
                 "Opus 4.8 1M",
                 &["low", "medium", "high", "xhigh", "max"],
                 true,
             ),
-            // Explicit 4.7 pin — this slot used to BE `default`; now that
-            // `default` advanced to 4.8 we surface 4.7 as its own selectable
-            // entry, above 4.6.
+            // Explicit 4.7 pin, above 4.6.
             claude_model(
                 "claude-opus-4-7[1m]",
                 "Opus 4.7 1M",
@@ -900,7 +899,7 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![
                 "claude-fable-5[1m]",
-                "default",
+                "claude-opus-4-8[1m]",
                 "claude-opus-4-7[1m]",
                 "claude-opus-4-6[1m]",
                 "sonnet",
@@ -970,7 +969,7 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![
                 "claude-fable-5[1m]",
-                "default",
+                "claude-opus-4-8[1m]",
                 "claude-opus-4-7[1m]",
                 "claude-opus-4-6[1m]",
                 "sonnet",
@@ -993,10 +992,11 @@ mod tests {
     #[test]
     fn resolve_claude_model() {
         let _env = crate::testkit::TestEnv::new("resolve-claude-model");
-        let m = resolve_model("default", None);
+        // The pinned Opus 4.8 1M id resolves to itself.
+        let m = resolve_model("claude-opus-4-8[1m]", None);
         assert_eq!(m.provider, "claude");
-        assert_eq!(m.cli_model, "default");
-        assert_eq!(m.id, "default");
+        assert_eq!(m.cli_model, "claude-opus-4-8[1m]");
+        assert_eq!(m.id, "claude-opus-4-8[1m]");
         assert!(m.supports_effort);
     }
 
@@ -1441,7 +1441,7 @@ mod tests {
             &ids[..4],
             &[
                 "claude-fable-5[1m]",
-                "default",
+                "claude-opus-4-8[1m]",
                 "claude-opus-4-7[1m]",
                 "claude-opus-4-6[1m]"
             ],
@@ -1449,7 +1449,7 @@ mod tests {
         );
 
         // Fable 5: most capable, leads the list, but is NOT the app default
-        // (too expensive) — `useEnsureDefaultModel` pins to id == "default".
+        // (too expensive) — `useEnsureDefaultModel` pins to the Opus 4.8 id.
         // No fast mode (Opus 4.6+ only); full effort tiers incl. xhigh.
         let fable = &claude.options[0];
         assert_eq!(fable.label, "Fable 5 1M");
@@ -1460,11 +1460,11 @@ mod tests {
             vec!["low", "medium", "high", "xhigh", "max"]
         );
 
-        // `default` → Opus 4.8: stays the app default selection, supports
-        // fast mode, and keeps the xhigh effort tier.
+        // Opus 4.8: the app default selection, supports fast mode, and keeps
+        // the xhigh effort tier. Pinned to its explicit `[1m]` wire id.
         let default = &claude.options[1];
         assert_eq!(default.label, "Opus 4.8 1M");
-        assert_eq!(default.cli_model, "default");
+        assert_eq!(default.cli_model, "claude-opus-4-8[1m]");
         assert!(default.supports_fast_mode, "Opus 4.8 supports fast mode");
         assert_eq!(
             default.effort_levels,
@@ -1490,10 +1490,12 @@ mod tests {
     #[test]
     fn claude_default_no_longer_collides_with_cursor_auto() {
         let _env = crate::testkit::TestEnv::new("claude-default-no-longer-collides-with-c");
-        // `default` belongs to Claude (Opus 4.8 1M). Cursor's Auto is
-        // `cursor-default`. They MUST resolve to different providers
-        // even when the picker / persistence flow doesn't pass a hint —
-        // this is the regression the namespace prefix exists to prevent.
+        // A hint-less bare `default` still infers to claude; cursor's Auto is
+        // the namespaced `cursor-default`. They MUST resolve to different
+        // providers even without a hint — the regression the namespace prefix
+        // exists to prevent. (Claude no longer ships a `default` model id; any
+        // legacy occurrence is normalized by the DB migration before it gets
+        // here, so resolve_model just passes it through.)
         let claude = resolve_model("default", None);
         assert_eq!(claude.provider, "claude");
         assert_eq!(claude.cli_model, "default");

--- a/src-tauri/src/import.rs
+++ b/src-tauri/src/import.rs
@@ -414,9 +414,11 @@ fn import_workspace_db_records(conn: &Connection, workspace_id: &str) -> Result<
     )
     .context("Failed to import sessions")?;
 
-    // 3b. Remap legacy "opus-1m" model ID (CLI no longer accepts it)
+    // 3b. Remap legacy "opus-1m" model ID to the pinned Opus 4.8 1M wire id
+    // (CLI no longer accepts "opus-1m"; claude no longer uses the "default"
+    // sentinel).
     conn.execute(
-        "UPDATE main.sessions SET model = 'default' WHERE model = 'opus-1m' AND workspace_id = ?1",
+        "UPDATE main.sessions SET model = 'claude-opus-4-8[1m]' WHERE model = 'opus-1m' AND workspace_id = ?1",
         [workspace_id],
     )
     .ok();

--- a/src-tauri/src/schema.rs
+++ b/src-tauri/src/schema.rs
@@ -711,6 +711,39 @@ fn run_migrations(connection: &Connection) -> Result<()> {
         .execute_batch("UPDATE sessions SET model = 'default' WHERE model = 'opus-1m'")
         .ok();
 
+    // Migration: claude retired the floating `default` sentinel — every model
+    // is now pinned to its explicit wire id, and the app default is
+    // `claude-opus-4-8[1m]` (same Opus 4.8 1M the CLI's `default` resolved to,
+    // so historical users see no change). This block is the ONE place that
+    // knows about the legacy id; runtime code never special-cases it. Three
+    // storage surfaces, all idempotent:
+    //
+    //   1. sessions.model — the pinned model of past runs.
+    //   2. The "Models" settings (`default`/`review`/`pr` model) — stored as
+    //      either a `{provider,modelId}` JSON object or a bare legacy id.
+    //   3. The provider "enabled models" list (`claude_enabled_model_ids`,
+    //      a JSON array) — else the picker drops Opus / shows a stale chip.
+    //
+    // Scoped to claude: cursor's `default` is its real "Auto" id (and appears
+    // only as the quote-safe `cursor-default`), so it is never touched. The
+    // `"default"` substring is precise — no other claude id contains it.
+    connection
+        .execute_batch(
+            "UPDATE sessions SET model = 'claude-opus-4-8[1m]' \
+             WHERE model = 'default' \
+             AND (agent_type IS NULL OR agent_type = '' OR agent_type = 'claude');\n\
+             UPDATE settings \
+             SET value = REPLACE(value, '\"default\"', '\"claude-opus-4-8[1m]\"') \
+             WHERE key IN ('app.claude_enabled_model_ids', 'app.default_model_id', \
+                           'app.review_model_id', 'app.pr_model_id') \
+             AND value LIKE '%\"default\"%';\n\
+             UPDATE settings SET value = 'claude-opus-4-8[1m]' \
+             WHERE key IN ('app.default_model_id', 'app.review_model_id', \
+                           'app.pr_model_id') \
+             AND value = 'default';",
+        )
+        .ok();
+
     // Migration: drop the old OAuth identity rows. The device-flow login
     // is gone — auth is now per-repo via the bundled `gh` CLI's own
     // credential store. Idempotent: DELETE on absent rows is a no-op.
@@ -1552,6 +1585,94 @@ mod tests {
         assert_eq!(
             read("m2"),
             r#"{"type":"user_prompt","text":"{\"foo\":\"bar\"}"}"#
+        );
+    }
+
+    #[test]
+    fn migration_remaps_claude_default_sentinel_to_pinned_opus_id() {
+        let (connection, _dir) = open_test_db();
+        ensure_schema(&connection).unwrap();
+
+        connection
+            .execute_batch(
+                r#"
+                -- Claude session pinned to the legacy "default" sentinel.
+                INSERT INTO sessions (id, model, agent_type) VALUES
+                  ('claude-sess', 'default', 'claude');
+                -- Legacy claude session with no agent_type (infers to claude).
+                INSERT INTO sessions (id, model, agent_type) VALUES
+                  ('legacy-sess', 'default', NULL);
+                -- Cursor's "default" is its real Auto id — must stay put.
+                INSERT INTO sessions (id, model, agent_type) VALUES
+                  ('cursor-sess', 'default', 'cursor');
+                -- Provider "enabled models" list still holding the sentinel.
+                INSERT INTO settings (key, value) VALUES
+                  ('app.claude_enabled_model_ids',
+                   '["claude-fable-5[1m]","default","sonnet"]');
+                -- "Models" settings: new JSON form, legacy bare form, and a
+                -- cursor value that must survive ("cursor-default" has no
+                -- quote-adjacent "default" substring).
+                INSERT INTO settings (key, value) VALUES
+                  ('app.default_model_id',
+                   '{"provider":"claude","modelId":"default"}'),
+                  ('app.review_model_id', 'default'),
+                  ('app.pr_model_id',
+                   '{"provider":"cursor","modelId":"cursor-default"}');
+                "#,
+            )
+            .unwrap();
+
+        run_migrations(&connection).unwrap();
+
+        let model = |id: &str| -> String {
+            connection
+                .query_row("SELECT model FROM sessions WHERE id = ?1", [id], |r| {
+                    r.get(0)
+                })
+                .unwrap()
+        };
+        let setting = |key: &str| -> String {
+            connection
+                .query_row("SELECT value FROM settings WHERE key = ?1", [key], |r| {
+                    r.get(0)
+                })
+                .unwrap()
+        };
+
+        assert_eq!(model("claude-sess"), "claude-opus-4-8[1m]");
+        assert_eq!(model("legacy-sess"), "claude-opus-4-8[1m]");
+        assert_eq!(model("cursor-sess"), "default", "cursor Auto untouched");
+
+        assert_eq!(
+            setting("app.claude_enabled_model_ids"),
+            r#"["claude-fable-5[1m]","claude-opus-4-8[1m]","sonnet"]"#
+        );
+        assert_eq!(
+            setting("app.default_model_id"),
+            r#"{"provider":"claude","modelId":"claude-opus-4-8[1m]"}"#,
+            "JSON modelId rewritten"
+        );
+        assert_eq!(
+            setting("app.review_model_id"),
+            "claude-opus-4-8[1m]",
+            "bare legacy id rewritten"
+        );
+        assert_eq!(
+            setting("app.pr_model_id"),
+            r#"{"provider":"cursor","modelId":"cursor-default"}"#,
+            "cursor model preference untouched"
+        );
+
+        // Idempotent: re-running is a no-op on already-migrated rows.
+        run_migrations(&connection).unwrap();
+        assert_eq!(model("claude-sess"), "claude-opus-4-8[1m]");
+        assert_eq!(
+            setting("app.claude_enabled_model_ids"),
+            r#"["claude-fable-5[1m]","claude-opus-4-8[1m]","sonnet"]"#
+        );
+        assert_eq!(
+            setting("app.default_model_id"),
+            r#"{"provider":"claude","modelId":"claude-opus-4-8[1m]"}"#
         );
     }
 

--- a/src-tauri/src/service.rs
+++ b/src-tauri/src/service.rs
@@ -164,8 +164,9 @@ pub fn send_message(
         },
     };
 
-    // 3. Resolve model — param > session row > "default". Provider hint
-    //    is required so cursor's `default` doesn't infer to claude.
+    // 3. Resolve model — param > session row > app default (Opus 4.8 1M).
+    //    Provider hint is required so cursor's `default` doesn't infer to
+    //    claude.
     let (session_model, session_provider) =
         crate::models::sessions::get_session_model_and_provider(&session_id)
             .unwrap_or((None, None));
@@ -174,7 +175,7 @@ pub fn send_message(
         .as_deref()
         .map(str::to_string)
         .or(session_model)
-        .unwrap_or_else(|| "default".to_string());
+        .unwrap_or_else(|| "claude-opus-4-8[1m]".to_string());
     let provider_hint = session_provider.as_deref();
     let model = crate::agents::resolve_model(&model_id, provider_hint);
 

--- a/src/features/composer/container.test.tsx
+++ b/src/features/composer/container.test.tsx
@@ -735,6 +735,90 @@ describe("WorkspaceComposerContainer", () => {
 		expect(composerMockState.lastOnChangeTerminalMode).toBeNull();
 	});
 
+	it("hides the terminal toggle for custom (BYOK) Claude models", () => {
+		const queryClient = createHelmorQueryClient();
+		// Same official Claude option plus a custom (BYOK) one carrying a
+		// providerKey — the terminal CLI can't carry its base URL / auth.
+		const sections = [
+			{
+				id: "claude",
+				label: "Claude",
+				options: [
+					...MODEL_SECTIONS[0].options,
+					{
+						id: "claude-custom|minimax|MiniMax-M2.7",
+						provider: "claude",
+						providerKey: "minimax",
+						label: "MiniMax M2.7",
+						cliModel: "MiniMax-M2.7",
+						effortLevels: ["low", "medium", "high"],
+					},
+				],
+			},
+			...MODEL_SECTIONS.slice(1),
+		];
+		queryClient.setQueryData(helmorQueryKeys.agentModelSections, sections);
+
+		const settings = {
+			...DEFAULT_SETTINGS,
+			enableTerminalMode: true,
+			startSurfacePreferences: {
+				...DEFAULT_SETTINGS.startSurfacePreferences,
+				// Persisted "on" — must be masked when a custom model is selected.
+				terminalModeActive: true,
+			},
+		};
+
+		const sharedProps = {
+			displayedWorkspaceId: null,
+			displayedSessionId: null,
+			disabled: false,
+			forceAvailable: true as const,
+			focusScope: "start-composer" as const,
+			contextKeyOverride: "start:repo:repo-1",
+			sending: false,
+			sendError: null,
+			restoreDraft: null,
+			restoreImages: [],
+			restoreFiles: [],
+			restoreNonce: 0,
+			effortLevels: {},
+			permissionModes: {},
+			fastModes: {},
+			onSelectModel: vi.fn(),
+			onSelectEffort: vi.fn(),
+			onChangePermissionMode: vi.fn(),
+			onChangeFastMode: vi.fn(),
+			onSubmit: vi.fn(),
+		};
+
+		const renderWith = (modelId: string) =>
+			render(
+				<SettingsContext.Provider
+					value={{ settings, isLoaded: true, updateSettings: vi.fn() }}
+				>
+					<QueryClientProvider client={queryClient}>
+						<WorkspaceComposerContainer
+							{...sharedProps}
+							modelSelections={{
+								"start:repo:repo-1": { provider: "claude", modelId },
+							}}
+						/>
+					</QueryClientProvider>
+				</SettingsContext.Provider>,
+			);
+
+		// Control: an official Claude model keeps the terminal toggle.
+		renderWith("opus-1m");
+		expect(composerMockState.lastOnChangeTerminalMode).not.toBeNull();
+		expect(composerMockState.lastTerminalMode).toBe(true);
+
+		// Custom model: toggle hidden and the persisted "on" is masked to GUI.
+		renderWith("claude-custom|minimax|MiniMax-M2.7");
+		expect(composerMockState.lastOnChangeTerminalMode).toBeNull();
+		expect(composerMockState.lastTerminalMode).toBe(false);
+	});
+
 	it("auto-submits queued CLI prompts using the model + permission_mode pinned on the session row", async () => {
 		const queryClient = createHelmorQueryClient();
 		queryClient.setQueryData(

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -891,11 +891,19 @@ export const WorkspaceComposerContainer = memo(
 		// Terminal sessions need a repo to spawn the PTY in — hide the toggle on
 		// chat surfaces (chat-mode start page via the prop, chat workspaces via
 		// the detail row) so a submit can't strand a session that never spawns.
+		// Custom (BYOK) Claude models hide it too: the terminal CLI only takes
+		// `--model`, with no way to carry their base URL / auth, so they behave
+		// like any provider without a terminal agent.
 		const showTerminalToggle =
 			settings.enableTerminalMode &&
 			terminalModeAvailable &&
 			workspaceDetailQuery.data?.mode !== "chat" &&
-			findTerminalAgent(effectiveModel?.provider) !== null;
+			findTerminalAgent(effectiveModel?.provider) !== null &&
+			!effectiveModel?.providerKey;
+		// Masked terminal mode: a stale `true` (toggled on under an official
+		// model, then switched to a custom one) must not leak terminal styling
+		// or a terminal submit — fall back to GUI until the toggle returns.
+		const effectiveTerminalMode = terminalMode && showTerminalToggle;
 
 		// App-scoped ⌘⇧T (global shortcut → shell event).
 		useShellEvent("toggle-terminal-mode", () => {
@@ -919,11 +927,7 @@ export const WorkspaceComposerContainer = memo(
 				if (!effectiveModel) {
 					return;
 				}
-				if (
-					terminalMode &&
-					showTerminalToggle &&
-					focusScope === "workspace-composer"
-				) {
+				if (effectiveTerminalMode && focusScope === "workspace-composer") {
 					// Terminal-Mode send: open the prompt in the provider's TUI
 					// instead of streaming a GUI turn. The shell listener creates
 					// the terminal session and boots it with the composer state.
@@ -973,7 +977,7 @@ export const WorkspaceComposerContainer = memo(
 					// Start composer only: the workspace doesn't exist yet, so the
 					// terminal intent rides the payload through create/finalize and
 					// is honored by the pending-submit consumer.
-					terminalMode: terminalMode && showTerminalToggle,
+					terminalMode: effectiveTerminalMode,
 				});
 			},
 			[
@@ -985,8 +989,7 @@ export const WorkspaceComposerContainer = memo(
 				fastMode,
 				supportsFastMode,
 				settings.followUpBehavior,
-				terminalMode,
-				showTerminalToggle,
+				effectiveTerminalMode,
 				linkedDirectories,
 				displayedWorkspaceId,
 				displayedSessionId,
@@ -1347,7 +1350,7 @@ export const WorkspaceComposerContainer = memo(
 						onChangeFastMode={
 							supportsFastMode ? handleChangeFastModeInner : undefined
 						}
-						terminalMode={terminalMode}
+						terminalMode={effectiveTerminalMode}
 						onChangeTerminalMode={
 							showTerminalToggle ? setTerminalMode : undefined
 						}

--- a/src/features/terminal/terminal-presets.test.ts
+++ b/src/features/terminal/terminal-presets.test.ts
@@ -73,13 +73,14 @@ describe("terminal agent specs", () => {
 		expect(slow).not.toContain("service_tier");
 	});
 
-	it("never passes the 'default' placeholder as a real model", () => {
+	it("omits --model when no model id is given", () => {
 		for (const provider of ["claude", "codex"]) {
 			const cmd = buildTerminalBootCommand(provider, {
 				prompt: "hi",
-				modelId: "default",
+				modelId: "  ",
 			});
-			expect(cmd, provider).not.toContain("default");
+			expect(cmd, provider).not.toContain("--model");
+			expect(cmd, provider).not.toContain("-m ");
 		}
 	});
 

--- a/src/features/terminal/terminal-presets.ts
+++ b/src/features/terminal/terminal-presets.ts
@@ -65,11 +65,10 @@ function shellQuotePrompt(value: string): string {
 	return `$'${escaped}'`;
 }
 
-/** Helmor's catalog uses the literal id "default" for "follow the CLI's own
- * default model" — that placeholder must never reach a real --model flag. */
+/** Empty/whitespace model id → no `--model` flag (the CLI falls back to its
+ * own default). Every catalog model is a real wire id, so nothing to strip. */
 function cliModelOrNull(modelId?: string | null): string | null {
-	const model = modelId?.trim();
-	return model && model !== "default" ? model : null;
+	return modelId?.trim() || null;
 }
 
 function claudeAddDirFlags(addDirs?: readonly string[] | null): string[] {

--- a/src/shell/hooks/use-ensure-default-model.test.tsx
+++ b/src/shell/hooks/use-ensure-default-model.test.tsx
@@ -171,9 +171,9 @@ describe("useEnsureDefaultModel", () => {
 		});
 	});
 
-	it("pins the repaired default to the claude `default` entry, not the first option", () => {
+	it("pins the repaired default to the Opus 4.8 1M entry, not the first option", () => {
 		// Fable 5 leads the picker but is too expensive to be the app
-		// default — the repair must skip it and land on `default` (Opus).
+		// default — the repair must skip it and land on Opus 4.8 1M.
 		const { updateSettings } = renderUseEnsureDefaultModel({
 			defaultModelId: null,
 			sections: [
@@ -189,10 +189,10 @@ describe("useEnsureDefaultModel", () => {
 							cliModel: "claude-fable-5[1m]",
 						},
 						{
-							id: "default",
+							id: "claude-opus-4-8[1m]",
 							provider: "claude",
 							label: "Opus 4.8 1M",
-							cliModel: "default",
+							cliModel: "claude-opus-4-8[1m]",
 						},
 					],
 				},
@@ -202,7 +202,7 @@ describe("useEnsureDefaultModel", () => {
 
 		expect(updateSettings).toHaveBeenCalledWith(
 			expect.objectContaining({
-				defaultModel: { provider: "claude", modelId: "default" },
+				defaultModel: { provider: "claude", modelId: "claude-opus-4-8[1m]" },
 			}),
 		);
 	});

--- a/src/shell/hooks/use-ensure-default-model.ts
+++ b/src/shell/hooks/use-ensure-default-model.ts
@@ -59,13 +59,14 @@ export function useEnsureDefaultModel() {
 		// Repair the default when it's never been set, or was set but is now
 		// definitively gone (wait for every provider to settle first).
 		if (!defaultOption && (settled || !settings.defaultModel)) {
-			// Prefer the Claude `default` entry (auto-latest Opus) over the
-			// first listed option — pricier models (Fable 5) sit above it in
-			// the picker but must not become the app default.
+			// Prefer the pinned Opus 4.8 1M entry over the first listed option —
+			// pricier models (Fable 5) sit above it in the picker but must not
+			// become the app default. A legacy stored "default" id no longer
+			// matches any option, so this re-pins it to the explicit wire id.
 			const claudeOptions =
 				sections.find((s) => s.id === "claude")?.options ?? [];
 			const pickOption =
-				claudeOptions.find((o) => o.id === "default") ??
+				claudeOptions.find((o) => o.id === "claude-opus-4-8[1m]") ??
 				claudeOptions[0] ??
 				allOptions[0] ??
 				null;


### PR DESCRIPTION
## What changed

Replaces Claude's floating `default` model sentinel with explicit pinned wire ids, and limits terminal mode to official Claude models.

**1. Pin the default Claude model to `claude-opus-4-8[1m]`**
- The model catalog (both `sidecar/src/model-catalog.ts` and the Rust `official_claude_section`) no longer ships an `id: "default"` entry. The app default is now the explicit `claude-opus-4-8[1m]` wire id.
- `useEnsureDefaultModel` pins the repaired default to this id instead of `"default"`.
- Runtime fallbacks (`service.rs`) and import remapping (`import.rs`) use the pinned id.
- A new idempotent DB migration (`schema.rs`) normalizes legacy `"default"` across three storage surfaces — `sessions.model`, the Models settings (`default`/`review`/`pr`, both JSON and bare forms), and the provider enabled-models list — scoped to Claude so Cursor's real `cursor-default` Auto id is untouched.
- The terminal preset helper no longer special-cases `"default"`; an empty/whitespace model id simply omits `--model`.

**2. Terminal mode only for official Claude models**
- Custom (BYOK) Claude models hide the terminal toggle and fall back to GUI mode, since the terminal CLI takes only `--model` and can't carry a custom base URL / auth. A stale "on" toggle is masked to avoid a terminal submit under a custom model.

## Why

The CLI's `default` sentinel resolves to whatever the bundled claude-code decides is "default", which can silently change across CLI bumps. Pinning to an explicit wire id makes the default deterministic. Existing sessions and settings keep the same effective model (Opus 4.8 1M) via the migration, so users see no behavioral change.

## Test notes

- New Rust migration test (`migration_remaps_claude_default_sentinel_to_pinned_opus_id`) covers all three storage surfaces, cursor isolation, and idempotency.
- Updated catalog/resolve tests in `agents.rs` and `agents/catalog.rs`.
- New composer test asserting the terminal toggle is hidden + masked for custom Claude models.
- Updated sidecar + terminal-preset + `useEnsureDefaultModel` tests.
- Run `cd src-tauri && cargo test --tests` for pipeline/migration coverage, plus `bun run test`.
