### PR TITLE
fix: sidecar OpenCode leak, real Kimi titles, login-based readiness

### DIFF
--- a/.changeset/sidecar-leak-and-provider-followups.md
+++ b/.changeset/sidecar-leak-and-provider-followups.md
@@ -1,0 +1,9 @@
+---
+"helmor": patch
+---
+
+Fix a sidecar process leak and refine provider behavior.
+
+- The sidecar now tears down its provider servers and exits when the parent process goes away, fixing leaked OpenCode `serve` processes (and their memory) when an app instance dies.
+- Kimi now generates real, model-written session titles and branch names (preferring the configured custom model), consistent with the other agents.
+- OpenCode and MiMo show "Ready" only after an actual sign-in, so the Login action stays available when only environment variables or custom providers are configured.

--- a/sidecar/src/index.ts
+++ b/sidecar/src/index.ts
@@ -269,7 +269,8 @@ function parseTitleAttempts(raw: unknown): TitleAttempt[] {
 				obj.provider === "codex" ||
 				obj.provider === "cursor" ||
 				obj.provider === "opencode" ||
-				obj.provider === "mimo"
+				obj.provider === "mimo" ||
+				obj.provider === "kimi"
 					? obj.provider
 					: null;
 			if (!provider) continue;
@@ -737,4 +738,15 @@ for await (const line of rl) {
 	}
 }
 
+// Parent (Rust) is gone. opencode/mimo run as DETACHED children whose live
+// SSE/HTTP connections keep our event loop alive, so falling off the end here
+// would NOT exit — we'd linger as an orphan (ppid=1) holding a `serve`, which
+// `reapOrphans` can't reap (the serve's parent, us, is still alive). Tear the
+// servers down and exit explicitly; a backstop timer guards a stalled shutdown.
 logger.info("stdin closed — sidecar exiting");
+setTimeout(() => process.exit(0), 3000);
+try {
+	await Promise.allSettled(Object.values(managers).map((m) => m.shutdown()));
+} finally {
+	process.exit(0);
+}

--- a/sidecar/src/kimi-session-manager.ts
+++ b/sidecar/src/kimi-session-manager.ts
@@ -10,7 +10,7 @@
  */
 
 import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { dirname } from "node:path";
+import { dirname, isAbsolute, resolve } from "node:path";
 import { ActiveTurnRegistry } from "./active-turn-registry.js";
 import type { SidecarEmitter } from "./emitter.js";
 import {
@@ -45,7 +45,11 @@ import type {
 	SlashCommandInfo,
 	UserInputResolution,
 } from "./session-manager.js";
-import { parseTitleAndBranch } from "./title.js";
+import {
+	buildTitlePrompt,
+	parseTitleAndBranchWithDiagnostics,
+	TITLE_GENERATION_TIMEOUT_MS,
+} from "./title.js";
 
 const KIMI_PERMISSION_PREFIX = "kimi-";
 const AUTH_REQUIRED_CODE = -32000;
@@ -91,6 +95,9 @@ export class KimiSessionManager implements SessionManager {
 	private readonly pendingQuestions = new Map<string, PendingPrompt>();
 	/** Latest `available_commands_update`, surfaced by `listSlashCommands`. */
 	private cachedCommands: SlashCommandInfo[] = [];
+	/** Throwaway title-generation sessions: acpSessionId → collected message
+	 *  text. Lets `generateTitle` capture streamed output off the chat path. */
+	private readonly titleCollectors = new Map<string, string[]>();
 
 	constructor() {
 		this.connection = new KimiAcpConnection({
@@ -378,6 +385,24 @@ export class KimiSessionManager implements SessionManager {
 		const params = notification.params as AcpSessionNotification | undefined;
 		const acpSessionId = params?.sessionId;
 		if (!acpSessionId || !params?.update) return;
+
+		// Throwaway title-generation session: collect streamed message text and
+		// skip the chat-routing path entirely (it isn't a registered ctx).
+		const collector = this.titleCollectors.get(acpSessionId);
+		if (collector) {
+			const update = params.update as {
+				sessionUpdate?: string;
+				content?: { type?: string; text?: string };
+			};
+			if (
+				update.sessionUpdate === "agent_message_chunk" &&
+				update.content?.type === "text"
+			) {
+				collector.push(update.content.text ?? "");
+			}
+			return;
+		}
+
 		const ctx = this.byAcpId.get(acpSessionId);
 		if (!ctx) return;
 
@@ -498,11 +523,22 @@ export class KimiSessionManager implements SessionManager {
 		);
 	}
 
+	/** Resolve an ACP fs path. Paths are absolute per spec, but a relative one
+	 *  must resolve against the session's cwd (the workspace) — NOT the sidecar's
+	 *  own process cwd (its install dir), which is where `readFile`/`writeFile`
+	 *  would otherwise land it. */
+	private resolveFsPath(acpSessionId: string, path: string): string {
+		if (isAbsolute(path)) return path;
+		const cwd = this.byAcpId.get(acpSessionId)?.cwd ?? process.cwd();
+		return resolve(cwd, path);
+	}
+
 	private async handleReadTextFile(request: JsonRpcRequest): Promise<void> {
 		const params = request.params as AcpReadTextFileParams | undefined;
 		try {
 			if (!params?.path) throw new Error("missing path");
-			const raw = await readFile(params.path, "utf8");
+			const path = this.resolveFsPath(params.sessionId, params.path);
+			const raw = await readFile(path, "utf8");
 			let content = raw;
 			if (params.line || params.limit) {
 				const lines = raw.split(/\r?\n/);
@@ -524,8 +560,9 @@ export class KimiSessionManager implements SessionManager {
 		const params = request.params as AcpWriteTextFileParams | undefined;
 		try {
 			if (!params?.path) throw new Error("missing path");
-			await mkdir(dirname(params.path), { recursive: true });
-			await writeFile(params.path, params.content ?? "", "utf8");
+			const path = this.resolveFsPath(params.sessionId, params.path);
+			await mkdir(dirname(path), { recursive: true });
+			await writeFile(path, params.content ?? "", "utf8");
 			this.connection.sendResponse(request.id, {});
 		} catch (error) {
 			this.connection.sendError(request.id, -32603, errorMessage(error));
@@ -597,15 +634,79 @@ export class KimiSessionManager implements SessionManager {
 	async generateTitle(
 		requestId: string,
 		userMessage: string,
-		_branchRenamePrompt: string | null,
+		branchRenamePrompt: string | null,
 		emitter: SidecarEmitter,
-		_timeoutMs?: number,
-		_options?: GenerateTitleOptions,
+		timeoutMs?: number,
+		options?: GenerateTitleOptions,
 	): Promise<void> {
-		const firstLine =
-			userMessage.split("\n").find((l) => l.trim()) ?? userMessage;
-		const { title } = parseTitleAndBranch(`title: ${firstLine}`);
-		emitter.titleGenerated(requestId, title, undefined);
+		const generateBranch = options?.generateBranch ?? true;
+		const prompt = buildTitlePrompt(
+			userMessage,
+			branchRenamePrompt,
+			generateBranch,
+		);
+		const timeout = timeoutMs ?? TITLE_GENERATION_TIMEOUT_MS;
+
+		// Run a throwaway ACP turn so the title comes from the same model the
+		// user configured — consistent with claude/codex/opencode/mimo.
+		let text = "";
+		let acpSessionId: string | null = null;
+		try {
+			await this.connection.start();
+			const created = await this.connection.sendRequest<AcpNewSessionResult>(
+				"session/new",
+				{ cwd: process.cwd(), mcpServers: [] },
+				timeout,
+			);
+			acpSessionId = created?.sessionId ?? null;
+			if (!acpSessionId) throw new Error("session/new returned no sessionId");
+			const chunks: string[] = [];
+			this.titleCollectors.set(acpSessionId, chunks);
+			if (options?.model) {
+				// Best-effort — fall back to the session default if unsupported.
+				await this.connection
+					.sendRequest("session/set_model", {
+						sessionId: acpSessionId,
+						modelId: options.model,
+					})
+					.catch(() => {});
+			}
+			await this.connection.sendRequest<AcpPromptResult>(
+				"session/prompt",
+				{ sessionId: acpSessionId, prompt: [{ type: "text", text: prompt }] },
+				timeout,
+			);
+			text = chunks.join("");
+		} catch (error) {
+			logger.debug("kimi generateTitle failed", errorDetails(error));
+		} finally {
+			if (acpSessionId) {
+				this.titleCollectors.delete(acpSessionId);
+				try {
+					this.connection.writeNotification("session/cancel", {
+						sessionId: acpSessionId,
+					});
+				} catch {
+					// best-effort cleanup
+				}
+			}
+		}
+
+		const { title, branchName } = parseTitleAndBranchWithDiagnostics(
+			requestId,
+			text,
+			{
+				...(options?.model ? { model: options.model } : {}),
+				generateBranch,
+				logError: (message, meta) => logger.error(message, meta),
+			},
+		);
+		// Throw on empty so the cascade falls through to the next attempt
+		// instead of treating a failed/empty kimi run as success.
+		if (!title) {
+			throw new Error("kimi title generation produced no title");
+		}
+		emitter.titleGenerated(requestId, title, branchName);
 	}
 
 	async listSlashCommands(

--- a/src-tauri/src/agents/queries.rs
+++ b/src-tauri/src/agents/queries.rs
@@ -81,6 +81,7 @@ fn build_title_attempts() -> Vec<Value> {
         .next();
     let opencode_custom = first_opencode_custom_model();
     let mimo_custom = first_mimo_custom_model();
+    let kimi_custom = first_kimi_custom_model();
     let mut attempts: Vec<Value> = Vec::new();
     for provider in detect_title_providers() {
         // Custom Codex providers run through the Codex sidecar with the
@@ -132,6 +133,14 @@ fn build_title_attempts() -> Vec<Value> {
                     }));
                 }
             }
+            "kimi" => {
+                if let Some(model) = &kimi_custom {
+                    attempts.push(serde_json::json!({
+                        "provider": "kimi",
+                        "model": model,
+                    }));
+                }
+            }
             _ => {}
         }
         // Provider's own fast/default model. For claude this is the
@@ -159,6 +168,19 @@ fn first_slug_custom_model(
     let provider = providers.into_iter().next()?;
     let model = provider.models.into_iter().next()?;
     Some(format!("{}/{}", provider.id, model.id))
+}
+
+/// First custom kimi model the user configured in `config.toml`, as the
+/// `provider/model` key kimi expects (e.g. `a8d84452/gpt-5.5`). `None` when no
+/// custom kimi provider is set up. Mirrors `first_opencode_custom_model` —
+/// custom is tried before the provider's session default.
+fn first_kimi_custom_model() -> Option<String> {
+    crate::provider::kimi::read_provider_config()
+        .ok()?
+        .models
+        .into_iter()
+        .next()
+        .map(|model| model.id)
 }
 
 fn can_replace_session_title(current_title: &str, title_seed: Option<&str>) -> bool {
@@ -1750,6 +1772,49 @@ mod tests {
         // No custom configured → no attempt carries an explicit model.
         assert!(attempts.iter().all(|a| a.get("model").is_none()));
 
+        std::env::remove_var("HELMOR_DATA_DIR");
+    }
+
+    #[test]
+    fn build_title_attempts_includes_kimi_custom_model() {
+        let dir = tempfile::tempdir().unwrap();
+        let _guard = crate::data_dir::TEST_ENV_LOCK.lock().unwrap();
+        std::env::set_var("HELMOR_DATA_DIR", dir.path());
+        setup_test_db(dir.path());
+
+        // Custom kimi provider lives in `$KIMI_CODE_HOME/config.toml`, exactly
+        // like opencode/mimo read theirs from their config — NOT from settings.
+        let kimi_home = dir.path().join("kimi-home");
+        std::fs::create_dir_all(&kimi_home).unwrap();
+        std::fs::write(
+            kimi_home.join("config.toml"),
+            "[providers.acme]\ntype = \"openai\"\napi_key = \"sk-test\"\nbase_url = \"https://api.acme.test/v1\"\n\n[models.\"acme/gpt-5.5\"]\nprovider = \"acme\"\nmodel = \"gpt-5.5\"\nmax_context_size = 128000\n",
+        )
+        .unwrap();
+        std::env::set_var("KIMI_CODE_HOME", &kimi_home);
+
+        // Selecting a kimi model makes kimi a detected title provider.
+        crate::settings::upsert_setting_value(
+            "app.default_model_id",
+            r#"{"provider":"kimi","modelId":"kimi:acme/gpt-5.5"}"#,
+        )
+        .unwrap();
+
+        // Consistent with claude/opencode/mimo: the custom model (config key, no
+        // `kimi:` prefix) is tried first, then kimi's session default.
+        let attempts = build_title_attempts();
+        let chain: Vec<(&str, Option<&str>)> = attempts
+            .iter()
+            .map(|a| {
+                (
+                    a.get("provider").unwrap().as_str().unwrap(),
+                    a.get("model").and_then(serde_json::Value::as_str),
+                )
+            })
+            .collect();
+        assert_eq!(chain, vec![("kimi", Some("acme/gpt-5.5")), ("kimi", None)]);
+
+        std::env::remove_var("KIMI_CODE_HOME");
         std::env::remove_var("HELMOR_DATA_DIR");
     }
 

--- a/src-tauri/src/commands/system_commands.rs
+++ b/src-tauri/src/commands/system_commands.rs
@@ -1319,38 +1319,80 @@ fn resolve_agent_binary(provider: &str) -> PathBuf {
     bundled_path.unwrap_or_else(|| crate::platform::executable::resolve_for_spawn(provider))
 }
 
-// Read from the sidecar-computed settings row, NOT `auth.json` (which misses env/config/Zen providers).
+// "Ready" means the user explicitly SIGNED IN (`<cli> auth login`), i.e. the
+// "Credentials" section of `<cli> auth list` is non-empty. Ambient env-var
+// providers and Helmor-configured custom providers (jsonc) still populate the
+// model list, but they are NOT a login — the Login entry must stay available
+// until the user signs in, so it can't be hidden behind a "Ready" badge.
 fn opencode_login_ready() -> bool {
-    slug_login_ready("app.opencode_provider")
+    auth_list_has_credentials("opencode")
 }
 
 fn mimo_login_ready() -> bool {
-    slug_login_ready("app.mimo_provider")
+    auth_list_has_credentials("mimo")
 }
 
-fn slug_login_ready(setting_key: &str) -> bool {
-    let raw = match crate::models::settings::load_setting_value(setting_key) {
-        Ok(Some(value)) => value,
-        Ok(None) => return false,
-        Err(error) => {
-            tracing::debug!("Failed to read {setting_key}: {error}");
-            return false;
+fn auth_list_has_credentials(provider: &str) -> bool {
+    let mut command = std::process::Command::new(resolve_agent_binary(provider));
+    crate::platform::process::configure_background_cli(&mut command);
+    match command.args(["auth", "list"]).output() {
+        Ok(output) if output.status.success() => {
+            parse_auth_list_credentials(&String::from_utf8_lossy(&output.stdout))
         }
-    };
-    let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&raw) else {
-        return false;
-    };
-    let status_ready = parsed
-        .get("status")
-        .and_then(serde_json::Value::as_str)
-        .map(|status| status == "ready")
-        .unwrap_or(false);
-    let connected_nonempty = parsed
-        .get("connected")
-        .and_then(serde_json::Value::as_array)
-        .map(|arr| !arr.is_empty())
-        .unwrap_or(false);
-    status_ready || connected_nonempty
+        Ok(output) => {
+            tracing::trace!(
+                provider,
+                stderr = %String::from_utf8_lossy(&output.stderr).trim(),
+                "auth list returned non-zero"
+            );
+            false
+        }
+        Err(error) => {
+            tracing::debug!("{provider} auth list unavailable: {error}");
+            false
+        }
+    }
+}
+
+/// Parse the credential count from `<cli> auth list`. Its "Credentials" section
+/// prints "<N> credentials"; the "Environment" section prints "environment
+/// variable(s)" (no "credential" token), so the count preceding a `credential*`
+/// token is exactly the logged-in (auth.json) total — env providers are
+/// excluded by construction. ANSI styling is stripped first.
+fn parse_auth_list_credentials(output: &str) -> bool {
+    let stripped = strip_ansi(output);
+    let tokens: Vec<&str> = stripped.split_whitespace().collect();
+    for (i, token) in tokens.iter().enumerate() {
+        if token.starts_with("credential") {
+            if let Some(count) = i
+                .checked_sub(1)
+                .and_then(|j| tokens.get(j))
+                .and_then(|prev| prev.parse::<u64>().ok())
+            {
+                return count > 0;
+            }
+        }
+    }
+    false
+}
+
+/// Drop ANSI CSI escape sequences (`ESC [ … m`) so token parsing isn't fooled
+/// by color codes wrapping the count.
+fn strip_ansi(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut chars = input.chars();
+    while let Some(c) = chars.next() {
+        if c == '\u{1b}' {
+            for next in chars.by_ref() {
+                if next.is_ascii_alphabetic() {
+                    break;
+                }
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
 }
 
 fn claude_login_ready() -> bool {
@@ -2238,6 +2280,23 @@ mod tests {
     }
 
     #[cfg(target_os = "macos")]
+    #[test]
+    fn parse_auth_list_credentials_counts_only_credentials_section() {
+        // 0 credentials + an env var present → signed OUT (env ≠ login).
+        assert!(!parse_auth_list_credentials(
+            "Credentials ~/.local/share/opencode/auth.json\n0 credentials\nEnvironment\nOpenAI OPENAI_API_KEY\n1 environment variable"
+        ));
+        // A real login → ready, regardless of env providers.
+        assert!(parse_auth_list_credentials(
+            "Credentials ~/x/auth.json\n2 credentials\nEnvironment\n0 environment variables"
+        ));
+        // ANSI-wrapped count still parses.
+        assert!(parse_auth_list_credentials(
+            "Credentials\n\u{1b}[1m1\u{1b}[0m credential\n"
+        ));
+        assert!(!parse_auth_list_credentials("garbage with no count"));
+    }
+
     #[test]
     fn applescript_shell_arg_quotes_plain_path() {
         assert_eq!(


### PR DESCRIPTION
Follow-up fixes on top of the merged Kimi Code integration (#797).

## Changes
- **Fix OpenCode / sidecar process leak.** When the parent (Rust host) dies, the sidecar now tears down its provider servers and exits on stdin EOF. Previously it logged "stdin closed" but never exited — OpenCode's detached `serve` + its persistent SSE connection kept the event loop alive — leaving orphaned `opencode serve` processes that piled up and ate memory. (The reliable exit was lost in #407, which removed the EPIPE-based exit; it only became a leak once OpenCode added a long-lived connection.)
- **Real Kimi title / branch generation.** Kimi now runs a throwaway ACP turn to generate the session title (and branch name) with the model instead of using the prompt's first line, and prefers the user's configured custom model first — consistent with claude / codex / opencode / mimo.
- **Kimi ACP fs path safety.** `fs/read_text_file` / `fs/write_text_file` now resolve relative paths against the session cwd instead of the sidecar's own cwd.
- **Login-based readiness for OpenCode / MiMo.** "Ready" now reflects an actual sign-in (`auth login` credentials) rather than ambient env vars or auto-connected providers, so the Login action stays available until the user signs in. Model lists and custom providers are unaffected.

## Tests
- Rust: `agents::queries` (incl. new `build_title_attempts_includes_kimi_custom_model`) + `parse_auth_list_credentials` unit test; `cargo clippy -D warnings` clean.
- Sidecar: `tsc` + `biome` + `bun test` (402) green.

## Open question
Codex still reports "Ready" via an env-var API key without `codex login`. Should it be tightened to the same login-only rule, or is the configured API key an intended auth method? Left unchanged here.
