### PR TITLE
feat(kimi): enable thinking for Kimi effort support

### DIFF
--- a/sidecar/src/kimi/session-manager.ts
+++ b/sidecar/src/kimi/session-manager.ts
@@ -197,6 +197,7 @@ export class KimiSessionManager implements SessionManager {
 		ctx.activeEmitter = emitter;
 		this.connection.setActiveRequestId(requestId);
 		await this.applyModel(ctx, params.model);
+		await this.applyThinking(ctx.acpSessionId, "on");
 
 		const prompt = await buildPromptBlocks(
 			prependLinkedDirectoriesContext(
@@ -377,6 +378,26 @@ export class KimiSessionManager implements SessionManager {
 				model: next,
 				...errorDetails(error),
 			});
+		}
+	}
+
+	/** Kimi exposes thinking as a 2-value `thought_level` config option
+	 *  (`thinking` = `on`/`off`), not an effort gradient. Helmor has no UI for a
+	 *  toggle, so the chat path forces `on` and title generation forces `off`.
+	 *  A model without thinking support silently no-ops this (kimi accepts the
+	 *  call without validating); the try/catch only guards a dead connection. */
+	private async applyThinking(
+		acpSessionId: string,
+		value: "on" | "off",
+	): Promise<void> {
+		try {
+			await this.connection.sendRequest("session/set_config_option", {
+				sessionId: acpSessionId,
+				configId: "thinking",
+				value,
+			});
+		} catch (error) {
+			logger.debug(`kimi set thinking=${value} skipped`, errorDetails(error));
 		}
 	}
 
@@ -671,6 +692,8 @@ export class KimiSessionManager implements SessionManager {
 					})
 					.catch(() => {});
 			}
+			// Titles are one-shot — never burn thinking tokens on them.
+			await this.applyThinking(acpSessionId, "off");
 			await this.connection.sendRequest<AcpPromptResult>(
 				"session/prompt",
 				{ sessionId: acpSessionId, prompt: [{ type: "text", text: prompt }] },


### PR DESCRIPTION
## Summary

Add thinking mode support for Kimi sessions by introducing an `applyThinking()` method that controls the `thinking` config option per session.

- Enable thinking in chat streams to leverage Kimi's extended reasoning
- Disable thinking for one-shot operations (title generation) to conserve tokens
- Gracefully no-op on models that don't support thinking; dead connections are caught and logged

## Changes

- Added `applyThinking(acpSessionId, "on" | "off")` private method to `KimiSessionManager`
- Enable thinking when starting a streaming chat session
- Disable thinking when generating thread titles
- Added defensive error handling with debug logging for unsupported or disconnected sessions

## Test plan

- [x] Code review for Kimi API integration correctness
- [x] Verify no-op behavior on Kimi models without thinking support (silent accept, no validation error)
- [] Integration test with Kimi sessions to confirm thinking is enabled/disabled as expected