### PR TITLE
fix: deduplicate assistant text during streaming

### DIFF
--- a/.changeset/fix-streaming-text-duplication.md
+++ b/.changeset/fix-streaming-text-duplication.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix Cursor responses briefly rendering their text twice while a turn is still streaming; the duplicate text now collapses to a single copy as it streams.

--- a/src/features/conversation/streaming-tail-collapse.test.ts
+++ b/src/features/conversation/streaming-tail-collapse.test.ts
@@ -312,4 +312,62 @@ describe("stabilizeStreamingMessages", () => {
 		expect(part.result).toBe("ok");
 		expect(part.args).toHaveProperty("file_path");
 	});
+
+	it("dedupes the assistant text the base snapshot and pending partial both carry", () => {
+		// Live-streaming reproduction (cursor): the backend Full snapshot already
+		// includes the in-flight assistant text, and the pending partial re-sends
+		// the same text. Without text dedupe the bubble renders the paragraph twice.
+		const dup = "仓库里没有单独的 `provider/` 根目录；";
+		const messages = stabilizeStreamingMessages([
+			assistant(
+				"base",
+				[toolCall("cmd1", "ls", "done"), { type: "text", id: "t0", text: dup }],
+				true,
+			),
+			assistant("partial", [{ type: "text", id: "t1", text: dup }], true),
+		]);
+
+		expect(messages).toHaveLength(1);
+		const textParts = (messages[0]?.content ?? []).filter(
+			(p) => p.type === "text",
+		);
+		expect(textParts).toHaveLength(1);
+		if (textParts[0]?.type !== "text") throw new Error("expected text");
+		expect(textParts[0].text).toBe(dup);
+	});
+
+	it("keeps the longer copy when the partial text extends the base snapshot", () => {
+		const messages = stabilizeStreamingMessages([
+			assistant("base", [{ type: "text", id: "t0", text: "Hello" }], true),
+			assistant(
+				"partial",
+				[{ type: "text", id: "t1", text: "Hello world" }],
+				true,
+			),
+		]);
+
+		expect(messages).toHaveLength(1);
+		expect(messages[0]?.content).toHaveLength(1);
+		const [part] = messages[0]?.content ?? [];
+		if (part?.type !== "text") throw new Error("expected text");
+		expect(part.text).toBe("Hello world");
+	});
+
+	it("does not merge two genuinely distinct adjacent text blocks", () => {
+		const messages = stabilizeStreamingMessages([
+			assistant(
+				"base",
+				[{ type: "text", id: "t0", text: "First paragraph." }],
+				true,
+			),
+			assistant(
+				"partial",
+				[{ type: "text", id: "t1", text: "Different paragraph." }],
+				true,
+			),
+		]);
+
+		expect(messages).toHaveLength(1);
+		expect(messages[0]?.content).toHaveLength(2);
+	});
 });

--- a/src/features/conversation/streaming-tail-collapse.ts
+++ b/src/features/conversation/streaming-tail-collapse.ts
@@ -287,6 +287,28 @@ function collapseAssistantParts(
 			result.push(part);
 			continue;
 		}
+		if (part.type === "text") {
+			// A streaming turn exposes the same assistant text twice when this
+			// run is merged: the stable base snapshot carries it (the backend
+			// Full includes the in-flight partial) AND the pending partial
+			// re-sends it. Text parts have no shared id to dedupe on (unlike
+			// reasoning / tool-call), so collapse an adjacent text part when one
+			// side is a prefix of the other — keep the longer (newer) copy.
+			flushGroup();
+			const prev = result[result.length - 1];
+			if (prev?.type === "text") {
+				const prevText = prev.text ?? "";
+				const curText = part.text ?? "";
+				if (curText.startsWith(prevText) || prevText.startsWith(curText)) {
+					if (curText.length >= prevText.length) {
+						result[result.length - 1] = part;
+					}
+					continue;
+				}
+			}
+			result.push(part);
+			continue;
+		}
 		// Flush so the group stays BEFORE this part — letting reads straddle
 		// a reasoning/text block reorders the thread.
 		flushGroup();


### PR DESCRIPTION
## What changed
Added text deduplication logic to the streaming tail-collapse pipeline. When a Cursor turn streams, the backend sends both:
1. A stable base snapshot (Full) that includes the in-flight assistant text
2. A pending partial update that re-sends the same text

Without this fix, the bubble renders the same paragraph twice while the turn is still streaming.

## Why
This improves UX for Cursor (and any agent) responses during streaming. The duplicate text now cleanly collapses to a single copy as it streams in.

## Implementation
- Added prefix-aware dedupe logic in `collapseAssistantParts()`: when adjacent text parts overlap (one is a prefix of the other), keep the longer (newer) copy
- Three new test cases cover: exact duplication, prefix extension, and genuinely distinct adjacent text blocks

## Testing
- New tests in `streaming-tail-collapse.test.ts` validate the three cases
- Existing pipeline snapshot tests still pass
- Manual verification in dev build (cursor streaming scenarios)