### PR TITLE
Simplify agent login UI and remove MiMo Code provider

### DIFF
--- a/src/features/onboarding/steps/agent-login-step.tsx
+++ b/src/features/onboarding/steps/agent-login-step.tsx
@@ -91,8 +91,8 @@ export function AgentLoginStep({
 						Log in to your agents
 					</h2>
 					<p className="mt-2 max-w-xl text-body leading-6 text-muted-foreground">
-						Helmor uses your local Claude Code and Codex login sessions. You can
-						log in now, or continue and log in later.
+						Helmor uses your local login sessions. You can log in now, or
+						continue and log in later.
 					</p>
 
 					{/* Compact rows (h-12) so all four tiles + Back/Next stay inside

--- a/src/lib/agent-login.ts
+++ b/src/lib/agent-login.ts
@@ -6,7 +6,6 @@ import {
 	ClaudeIcon,
 	CursorIcon,
 	KimiIcon,
-	MiMoCodeIcon,
 	OpenAIIcon,
 	OpenCodeIcon,
 } from "@/components/icons";
@@ -24,17 +23,6 @@ export function buildAgentLoginItems(
 	const CHECKING_COPY = "Checking sign-in…";
 	return [
 		{
-			icon: ClaudeIcon,
-			provider: "claude",
-			label: "Claude Code",
-			description: checking
-				? CHECKING_COPY
-				: status?.claude
-					? "Signed in and ready to run in local workspaces."
-					: "Sign in to Claude Code to use Anthropic models in Helmor.",
-			status: resolve(status?.claude),
-		},
-		{
 			icon: OpenCodeIcon,
 			provider: "opencode",
 			label: "OpenCode",
@@ -46,15 +34,15 @@ export function buildAgentLoginItems(
 			status: resolve(status?.opencode),
 		},
 		{
-			icon: MiMoCodeIcon,
-			provider: "mimo",
-			label: "MiMo Code",
+			icon: ClaudeIcon,
+			provider: "claude",
+			label: "Claude Code",
 			description: checking
 				? CHECKING_COPY
-				: status?.mimo
-					? "Connected and ready to run MiMo Code models in Helmor."
-					: "Sign in with `mimo auth login` to use MiMo Code models in Helmor.",
-			status: resolve(status?.mimo),
+				: status?.claude
+					? "Signed in and ready to run in local workspaces."
+					: "Sign in to Claude Code to use Anthropic models in Helmor.",
+			status: resolve(status?.claude),
 		},
 		{
 			icon: OpenAIIcon,
@@ -66,7 +54,7 @@ export function buildAgentLoginItems(
 		{
 			icon: KimiIcon,
 			provider: "kimi",
-			label: "Kimi Code",
+			label: "Kimi",
 			description: checking
 				? CHECKING_COPY
 				: status?.kimi


### PR DESCRIPTION
## Summary

Refactors the agent login UI to simplify provider naming and remove the MiMo Code provider.

## Changes

- **Update onboarding description**: Changed from "Helmor uses your local Claude Code and Codex login sessions" to "Helmor uses your local login sessions" to be provider-agnostic
- **Remove MiMo Code provider**: Deleted MiMoCode entry from agent login items and removed unused `MiMoCodeIcon` import
- **Reorder agent providers**: Adjusted order to (OpenCode, Claude Code, OpenAI, Kimi)
- **Simplify Kimi label**: Changed from "Kimi Code" to "Kimi"

## Testing

- Verified onboarding step displays simplified description
- Confirmed agent login items are properly ordered and render correctly
- Removed unused icon import has no build side effects

## Files Changed

- `src/features/onboarding/steps/agent-login-step.tsx`
- `src/lib/agent-login.ts`