### PR TITLE
fix: hide session injector scrollbar

### DIFF
--- a/.changeset/calm-tabs-hide.md
+++ b/.changeset/calm-tabs-hide.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Hide the Inject sessions scrollbar while keeping session chips horizontally scrollable.

--- a/src/features/composer/session-context-injector.tsx
+++ b/src/features/composer/session-context-injector.tsx
@@ -29,7 +29,7 @@ export function SessionContextInjector({
 			<span className="shrink-0 text-small leading-none text-muted-foreground">
 				Inject sessions:
 			</span>
-			<div className="flex min-w-0 flex-1 flex-nowrap items-center justify-start gap-1 overflow-x-auto overscroll-x-contain">
+			<div className="scrollbar-none flex min-w-0 flex-1 flex-nowrap items-center justify-start gap-1 overflow-x-auto overscroll-x-contain">
 				{candidates.map((session) => {
 					const isSelected = selected.has(session.id);
 					const title = session.title?.trim() || "Untitled";


### PR DESCRIPTION
## What changed
- Hid the horizontal scrollbar in the Inject sessions chip row while preserving horizontal scrolling.
- Added a patch changeset for the visible UI polish.

## Why
The scrollbar was visually noisy in the composer session injector, but the chips still need to remain scrollable when they overflow.

## Test notes
- Pre-commit Biome check passed during commit.
- No full test suite run; change is a single Tailwind utility class plus changeset.