### PR TITLE
[codex] Fix release announcement title localization

### DIFF
--- a/.changeset/fresh-cameras-wave.md
+++ b/.changeset/fresh-cameras-wave.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix the Chinese release announcement title so the version appears in the natural sentence order.

--- a/src/features/announcements/index.test.tsx
+++ b/src/features/announcements/index.test.tsx
@@ -1,0 +1,39 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { setAppLanguage } from "@/lib/i18n";
+import packageJson from "../../../package.json";
+import { ReleaseAnnouncementToastHost } from "./index";
+import { LAST_SEEN_INSTALL_VERSION_STORAGE_KEY } from "./storage";
+
+describe("ReleaseAnnouncementToastHost", () => {
+	beforeEach(() => {
+		window.localStorage.clear();
+		setAppLanguage("en");
+	});
+
+	afterEach(() => {
+		cleanup();
+		setAppLanguage("en");
+	});
+
+	it("renders the Chinese release title with the version in sentence order", async () => {
+		setAppLanguage("zh-CN");
+		window.localStorage.setItem(
+			LAST_SEEN_INSTALL_VERSION_STORAGE_KEY,
+			"0.40.0",
+		);
+
+		render(
+			<ReleaseAnnouncementToastHost
+				onOpenChangelog={() => {}}
+				onOpenSettings={() => {}}
+				onSetRightSidebarMode={() => {}}
+				onOpenStartPage={() => {}}
+			/>,
+		);
+
+		expect(
+			await screen.findByText(`v${packageJson.version}版本新增`),
+		).toBeInTheDocument();
+	});
+});

--- a/src/features/announcements/index.tsx
+++ b/src/features/announcements/index.tsx
@@ -135,6 +135,7 @@ function ReleaseAnnouncementToast({
 	onOpenChangelog: () => void;
 	onRunAction: (action: ReleaseAnnouncementAction) => void;
 }) {
+	const { f } = useI18n();
 	const [collapsed, setCollapsed] = useState(false);
 
 	return (
@@ -147,8 +148,9 @@ function ReleaseAnnouncementToast({
 						className="shrink-0 opacity-90"
 					/>
 					<div className="truncate text-ui font-semibold leading-none text-foreground">
-						<I18nText source="newV" />
-						{announcement.version}
+						{f("newVersionAnnouncementTitle", {
+							version: announcement.version,
+						})}
 					</div>
 				</div>
 				<div className="-mr-1 flex items-center gap-1">

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -1004,7 +1004,7 @@
 	"newSession2": "New session in",
 	"newTerminal": "New terminal",
 	"newTerminalModeRunPromptAgent": "New: Terminal Mode — run your prompt in the agent's own terminal UI (⌘⇧T).",
-	"newV": "New in v",
+	"newVersionAnnouncementTitle": "New in v{version}",
 	"newWorkspace": "New Workspace",
 	"newWorkspace2": "New workspace",
 	"newWorkspace3": "New workspace in",

--- a/src/lib/i18n/locales/zh-CN.json
+++ b/src/lib/i18n/locales/zh-CN.json
@@ -1004,7 +1004,7 @@
 	"newSession2": "新会话位于",
 	"newTerminal": "新终端",
 	"newTerminalModeRunPromptAgent": "新增：终端模式，可在 agent 自己的终端 UI 中运行提示（⌘⇧T）。",
-	"newV": "v 版本新增",
+	"newVersionAnnouncementTitle": "v{version}版本新增",
 	"newWorkspace": "新工作区",
 	"newWorkspace2": "新工作区",
 	"newWorkspace3": "新工作区位于",


### PR DESCRIPTION
## Summary
- Format the release announcement title through a full localized string with a `{version}` placeholder.
- Fix the Simplified Chinese title order so it renders as `v0.41.0版本新增` instead of `v 版本新增0.41.0`.
- Add a regression test for the Chinese announcement title and a patch changeset.

## Root Cause
The title was assembled as a shared localized prefix plus the raw version. That works for English word order but forced Chinese into the wrong sequence.

## Validation
- `bun x biome check src/features/announcements/index.tsx src/features/announcements/index.test.tsx src/lib/i18n/locales/en.json src/lib/i18n/locales/zh-CN.json .changeset/fresh-cameras-wave.md`
- `bun x vitest run src/features/announcements src/lib/i18n/resources.test.ts src/lib/i18n/keys-in-catalog.test.ts`
- `bun run typecheck`