### PR TITLE
Hide inert slash commands

### DIFF
--- a/.changeset/hide-inert-slash-commands.md
+++ b/.changeset/hide-inert-slash-commands.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Hide the `/compact` (Claude) and `/clear` (all agents) slash commands, which showed up in the command menu but did nothing when run.

--- a/src/features/composer/container.test.tsx
+++ b/src/features/composer/container.test.tsx
@@ -1216,13 +1216,13 @@ describe("WorkspaceComposerContainer", () => {
 			apiMockState.listSlashCommands.mockResolvedValue({
 				commands: [
 					{
-						name: "compact",
-						description: "Compact the context",
+						name: "review",
+						description: "Review the diff",
 						source: "builtin",
 					},
 					{
-						name: "clear",
-						description: "Clear history",
+						name: "status",
+						description: "Show status",
 						source: "builtin",
 					},
 				],
@@ -1237,8 +1237,8 @@ describe("WorkspaceComposerContainer", () => {
 					"add-dir",
 					"goal",
 					"workflows",
-					"compact",
-					"clear",
+					"review",
+					"status",
 				]);
 			});
 			expect(composerMockState.lastSlashCommands[0]).toEqual({
@@ -1246,6 +1246,75 @@ describe("WorkspaceComposerContainer", () => {
 				description: "Link extra directories to this workspace",
 				source: "client-action",
 			});
+		});
+
+		it("suppresses the SDK-reported /compact command for Claude sessions", async () => {
+			// claude-code lists /compact among its slash commands, but the Agent
+			// SDK has no programmatic compaction path, so Helmor hides it for
+			// Claude (Codex/OpenCode keep their built-in /compact).
+			apiMockState.listSlashCommands.mockResolvedValue({
+				commands: [
+					{
+						name: "compact",
+						description: "Compact the context",
+						source: "builtin",
+					},
+					{
+						name: "review",
+						description: "Review the diff",
+						source: "builtin",
+					},
+				],
+				isComplete: true,
+			});
+
+			renderWithLinkedDirs([]);
+
+			await waitFor(() => {
+				expect(composerMockState.lastSlashCommands.map((c) => c.name)).toEqual([
+					"add-dir",
+					"goal",
+					"workflows",
+					"review",
+				]);
+			});
+			expect(
+				composerMockState.lastSlashCommands.some((c) => c.name === "compact"),
+			).toBe(false);
+		});
+
+		it("suppresses the SDK-reported /clear command (no-op for every provider)", async () => {
+			// claude-code lists /clear, but sent through the SDK it never clears
+			// context (the next turn resumes the same session), so Helmor hides it.
+			apiMockState.listSlashCommands.mockResolvedValue({
+				commands: [
+					{
+						name: "clear",
+						description: "Clear history",
+						source: "builtin",
+					},
+					{
+						name: "review",
+						description: "Review the diff",
+						source: "builtin",
+					},
+				],
+				isComplete: true,
+			});
+
+			renderWithLinkedDirs([]);
+
+			await waitFor(() => {
+				expect(composerMockState.lastSlashCommands.map((c) => c.name)).toEqual([
+					"add-dir",
+					"goal",
+					"workflows",
+					"review",
+				]);
+			});
+			expect(
+				composerMockState.lastSlashCommands.some((c) => c.name === "clear"),
+			).toBe(false);
 		});
 
 		it("adds built-in /compact and /goal commands for Codex sessions", async () => {
@@ -1310,8 +1379,8 @@ describe("WorkspaceComposerContainer", () => {
 						source: "builtin",
 					},
 					{
-						name: "clear",
-						description: "Clear history",
+						name: "review",
+						description: "Review the diff",
 						source: "builtin",
 					},
 				],
@@ -1325,7 +1394,7 @@ describe("WorkspaceComposerContainer", () => {
 					"add-dir",
 					"goal",
 					"workflows",
-					"clear",
+					"review",
 				]);
 			});
 			expect(composerMockState.lastSlashCommands[1]).toEqual({

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -144,6 +144,24 @@ const BUILTIN_CLIENT_COMMANDS: readonly SlashCommandEntry[] = [
 	CLAUDE_WORKFLOWS_COMMAND,
 ];
 
+// SDK-reported commands to hide per provider. claude-code lists /compact among
+// its slash commands, but the Agent SDK exposes no programmatic compaction path
+// (unlike Codex's thread/compact/start and OpenCode's session.summarize), so
+// sending it is a no-op — suppress it instead of showing a dead command.
+const SUPPRESSED_AGENT_COMMANDS: Partial<
+	Record<AgentProvider, ReadonlySet<string>>
+> = {
+	claude: new Set(["compact"]),
+};
+
+// SDK-reported commands to hide for every provider. /clear is a REPL-only
+// command: sent through the SDK it's a literal no-op (the next turn still
+// resumes the same provider session, so context is never cleared). No provider
+// wires it up, so hide it everywhere rather than show a dead command.
+const GLOBALLY_SUPPRESSED_AGENT_COMMANDS: ReadonlySet<string> = new Set([
+	"clear",
+]);
+
 type WorkspaceComposerContainerProps = {
 	displayedWorkspaceId: string | null;
 	displayedSessionId: string | null;
@@ -804,10 +822,14 @@ export const WorkspaceComposerContainer = memo(
 			const builtinNames = new Set(
 				builtinCommands.map((command) => command.name),
 			);
+			const suppressed = SUPPRESSED_AGENT_COMMANDS[slashProvider];
 			return [
 				...builtinCommands,
 				...agentSlashCommands.filter(
-					(command) => !builtinNames.has(command.name),
+					(command) =>
+						!builtinNames.has(command.name) &&
+						!suppressed?.has(command.name) &&
+						!GLOBALLY_SUPPRESSED_AGENT_COMMANDS.has(command.name),
 				),
 			];
 		}, [agentSlashCommands, slashProvider, t]);


### PR DESCRIPTION
closes #794 
closes #635
## Summary
Hide the `/compact` (Claude-only) and `/clear` (all agents) slash commands from the composer menu, which showed up in the command list but were no-ops when executed.

## What changed
- Added `SUPPRESSED_AGENT_COMMANDS` map to filter out `/compact` for Claude sessions (the Agent SDK exposes no programmatic compaction path, unlike Codex's `thread/compact/start`)
- Added `GLOBALLY_SUPPRESSED_AGENT_COMMANDS` set to filter out `/clear` for all agents (it's a REPL-only command; sent through the SDK, the next turn still resumes the same session, so context is never cleared)
- Updated `memoizedFilteredSlashCommands` to apply both filters when merging SDK-reported and builtin commands
- Added test coverage for both suppression rules

## Why
These commands appeared in the UI but provided no functionality, creating a poor user experience. Codex and OpenCode keep their working `/compact` implementations; Claude suppresses only the broken one to avoid confusion.

## Testing
- Two new test cases verify `/compact` suppression for Claude and `/clear` suppression globally
- Updated existing tests to reflect the new filtering behavior
- All existing composer tests pass