### PR TITLE
fix/lets-ship-i18n

### DIFF
--- a/src/features/onboarding/steps/repo-import-step.tsx
+++ b/src/features/onboarding/steps/repo-import-step.tsx
@@ -192,7 +192,7 @@ export function RepoImportStep({
 						onClick={onComplete}
 						className="h-11 gap-2 px-4 text-title"
 					>
-						<I18nText source="letAposSShip" />
+						<I18nText source="letsShip" />
 						<ArrowRight data-icon="inline-end" className="size-4" />
 					</Button>
 				</div>

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -763,7 +763,7 @@
 	"lastUpdated": "Last updated",
 	"latestUpdateHasBeenDownloadedReady": "The latest update has been downloaded and is ready to install.",
 	"left": "% left",
-	"letAposSShip": "Let&apos;s ship",
+	"letsShip": "Let's ship",
 	"light": "Light",
 	"lightCleanupHandoffBeforeArchiving": "Light cleanup or handoff before archiving.",
 	"linear": "Linear",

--- a/src/lib/i18n/locales/zh-CN.json
+++ b/src/lib/i18n/locales/zh-CN.json
@@ -763,7 +763,7 @@
 	"lastUpdated": "最后更新",
 	"latestUpdateHasBeenDownloadedReady": "最新更新已下载，准备安装。",
 	"left": "% 剩余",
-	"letAposSShip": "准备交付",
+	"letsShip": "准备交付",
 	"light": "浅色",
 	"lightCleanupHandoffBeforeArchiving": "归档前进行轻量清理或交接。",
 	"linear": "Linear",


### PR DESCRIPTION
Fixes the onboarding “Let’s ship” button label by replacing translation text `Let&apos;s ship` with a real apostrophe, so React renders it correctly as `Let's ship`.  (React renders translation strings as text, not as HTML.)

Also renames the i18n key from `letAposSShip` to `letsShip` in both locale files and updates the only call site.

Proof of faulty render:
<img width="861" height="451" alt="image" src="https://github.com/user-attachments/assets/fbf265fc-7415-499f-877c-ecb6c389f711" />
