### PR TITLE
fix: keep background subagents/tasks alive so they report back

### DIFF
--- a/.changeset/late-tasks-report-back.md
+++ b/.changeset/late-tasks-report-back.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix background subagents and background shell commands being killed when an agent finishes its turn — they now run to completion and report their results back instead of silently dying.

--- a/sidecar/src/claude/background-resume.test.ts
+++ b/sidecar/src/claude/background-resume.test.ts
@@ -105,16 +105,28 @@ function result(terminalReason: string): SDKMessage {
 	} as unknown as SDKMessage;
 }
 
-function taskNotification(): SDKMessage {
+function taskNotification(taskId = "t1"): SDKMessage {
 	return {
 		type: "system",
 		subtype: "task_notification",
-		task_id: "t1",
+		task_id: taskId,
 		status: "completed",
 		output_file: "",
 		summary: "done",
 		session_id: "s1",
-		uuid: "tn-1",
+		uuid: `tn-${taskId}`,
+	} as unknown as SDKMessage;
+}
+
+function taskStarted(taskId = "t1"): SDKMessage {
+	return {
+		type: "system",
+		subtype: "task_started",
+		task_id: taskId,
+		tool_use_id: `tu-${taskId}`,
+		parent_tool_use_id: null,
+		session_id: "s1",
+		uuid: `ts-${taskId}`,
 	} as unknown as SDKMessage;
 }
 
@@ -194,5 +206,118 @@ describe("ClaudeSessionManager backgrounded-task resume (#891)", () => {
 			.map((m) => (m as { terminal_reason?: string }).terminal_reason)
 			.filter(Boolean);
 		expect(passedReasons).not.toContain("background_requested");
+	});
+});
+
+describe("ClaudeSessionManager run_in_background drain (completed with pending bg tasks)", () => {
+	const completedResultCount = (spy: EmitterSpy) =>
+		spy.passthroughs.filter(
+			(m) =>
+				(m as { type?: string }).type === "result" &&
+				(m as { terminal_reason?: string }).terminal_reason === "completed",
+		).length;
+
+	test("defers `completed` while a bg task is pending, resumes on task_notification, ends once", async () => {
+		scenario = [
+			assistant("dispatching"),
+			taskStarted("bg1"),
+			result("completed"), // intermediate — bg1 still pending, must be deferred
+			taskNotification("bg1"), // bg1 settles
+			assistant("synthesizing"),
+			result("completed"), // genuinely terminal
+		];
+		const spy = makeSpyEmitter();
+		await new ClaudeSessionManager().sendMessage(
+			"req-bg-1",
+			baseParams(),
+			spy.emitter,
+		);
+
+		// One terminal end — the intermediate `completed` must not fire it.
+		expect(spy.ends).toBe(1);
+		// Only the FINAL `completed` reaches the pipeline (one result per turn).
+		expect(completedResultCount(spy)).toBe(1);
+		// Continuation flows through: notification + the post-resume assistant.
+		const subtypes = spy.passthroughs.map(
+			(m) => (m as { subtype?: string }).subtype,
+		);
+		expect(subtypes).toContain("task_notification");
+		const assistantTexts = spy.passthroughs
+			.filter((m) => (m as { type?: string }).type === "assistant")
+			.map(
+				(m) =>
+					(m as { message?: { content?: { text?: string }[] } }).message
+						?.content?.[0]?.text,
+			);
+		expect(assistantTexts).toContain("synthesizing");
+		// Usage recorded at the deferred pause AND the terminal result.
+		expect(spy.contextUsageUpdates).toBeGreaterThanOrEqual(2);
+	});
+
+	test("waits for ALL of several bg tasks before ending", async () => {
+		scenario = [
+			assistant("dispatch 3"),
+			taskStarted("a"),
+			taskStarted("b"),
+			taskStarted("c"),
+			result("completed"), // pending {a,b,c} — deferred
+			taskNotification("a"),
+			result("completed"), // pending {b,c} — deferred
+			taskNotification("b"),
+			taskNotification("c"), // pending now empty
+			assistant("all settled"),
+			result("completed"), // terminal
+		];
+		const spy = makeSpyEmitter();
+		await new ClaudeSessionManager().sendMessage(
+			"req-bg-2",
+			baseParams(),
+			spy.emitter,
+		);
+
+		expect(spy.ends).toBe(1);
+		expect(completedResultCount(spy)).toBe(1); // only the final completed
+		const notifs = spy.passthroughs.filter(
+			(m) => (m as { subtype?: string }).subtype === "task_notification",
+		);
+		expect(notifs).toHaveLength(3);
+	});
+
+	test("safe fallback: SDK ends the iterator before the notification arrives", async () => {
+		scenario = [
+			assistant("dispatching"),
+			taskStarted("bg1"),
+			result("completed"), // deferred; iterator then ends without a notification
+		];
+		const spy = makeSpyEmitter();
+		await new ClaudeSessionManager().sendMessage(
+			"req-bg-3",
+			baseParams(),
+			spy.emitter,
+		);
+
+		// Loop exits naturally → post-loop end fires once; no hang, no double end.
+		expect(spy.ends).toBe(1);
+		expect(completedResultCount(spy)).toBe(0); // deferred, never reached pipeline
+	});
+
+	test("error terminal is NOT deferred even with a bg task pending", async () => {
+		scenario = [
+			assistant("dispatching"),
+			taskStarted("bg1"),
+			result("max_turns"), // non-`completed` terminal — must end immediately
+		];
+		const spy = makeSpyEmitter();
+		await new ClaudeSessionManager().sendMessage(
+			"req-bg-4",
+			baseParams(),
+			spy.emitter,
+		);
+
+		expect(spy.ends).toBe(1);
+		const reasons = spy.passthroughs
+			.map((m) => (m as { terminal_reason?: string }).terminal_reason)
+			.filter(Boolean);
+		expect(reasons).toContain("max_turns"); // passed through, not deferred
 	});
 });

--- a/sidecar/src/claude/session-manager.ts
+++ b/sidecar/src/claude/session-manager.ts
@@ -690,6 +690,13 @@ export class ClaudeSessionManager implements SessionManager {
 		try {
 			let lastRateLimitInfo: RateLimitOverageInfo | undefined;
 			let fastModeNoticeEmitted = false;
+			// In-flight `run_in_background` tasks (subagents / background Bash),
+			// keyed by task_id. They settle asynchronously via `task_notification`
+			// AFTER the agent ends its turn; closing the query on the turn's
+			// `completed` while any are still pending would `q.close()` the
+			// claude-code subprocess and kill them before they notify, so we keep
+			// draining the SAME query until they all settle (see deferral below).
+			const pendingBgTasks = new Set<string>();
 			for await (const message of q) {
 				// stopSession already emitted the terminal `aborted` and tore the
 				// session down. The new SDK keeps the child alive ~2s after abort,
@@ -734,6 +741,36 @@ export class ClaudeSessionManager implements SessionManager {
 				// per turn) and do NOT end the turn — must intercept before the
 				// unconditional passthrough below.
 				if (isBackgroundPauseResult(message)) {
+					const meta = buildClaudeStoredMeta(message, model ?? "");
+					if (meta) {
+						emitter.contextUsageUpdated(
+							requestId,
+							sessionId,
+							JSON.stringify(meta),
+						);
+					}
+					continue;
+				}
+				// Track in-flight background tasks (run_in_background subagents /
+				// Bash) by task_id: `task_started` opens one, `task_notification`
+				// settles it. These system events still pass through below.
+				if (message.type === "system") {
+					const subtype = (message as { subtype?: string }).subtype;
+					const taskId = (message as { task_id?: string }).task_id;
+					if (taskId) {
+						if (subtype === "task_started") pendingBgTasks.add(taskId);
+						else if (subtype === "task_notification")
+							pendingBgTasks.delete(taskId);
+					}
+				}
+				// A `completed` result while background tasks are still pending is
+				// NOT terminal: ending here closes the query and kills the
+				// in-flight subagents before they emit `task_notification`. Keep it
+				// OUT of the pipeline (one-result-per-turn) and keep draining the
+				// SAME query — mirror of the `background_requested` pause above.
+				// The final `completed` (pending drained) and any error terminal
+				// fall through to the terminal branch below.
+				if (isCompletedResult(message) && pendingBgTasks.size > 0) {
 					const meta = buildClaudeStoredMeta(message, model ?? "");
 					if (meta) {
 						emitter.contextUsageUpdated(
@@ -1312,6 +1349,18 @@ function isBackgroundPauseResult(message: SDKMessage): boolean {
 		message.type === "result" &&
 		(message as { terminal_reason?: string }).terminal_reason ===
 			"background_requested"
+	);
+}
+
+/** A turn's natural `completed` result. While `run_in_background` tasks are
+ *  still pending it is filtered (like `background_requested`) so the query —
+ *  and the claude-code subprocess hosting the in-flight subagents — stays
+ *  alive until their `task_notification`s arrive. Only `completed` is
+ *  deferred; error / aborted terminals end the turn immediately. */
+function isCompletedResult(message: SDKMessage): boolean {
+	return (
+		message.type === "result" &&
+		(message as { terminal_reason?: string }).terminal_reason === "completed"
 	);
 }
 


### PR DESCRIPTION
## Problem

When an agent spawns `run_in_background` subagents (or a background `Bash`) and then finishes its turn, the SDK emits a `result` with `terminal_reason: "completed"`. The claude session manager treated that as terminal — `emitter.end()` + `q.close()` — and per the SDK contract `Query.close()` **terminates the claude-code CLI subprocess**, killing the still-running in-process background tasks before they can deliver their `task_notification`.

Result: any background task slower than its (usually few-second) dispatching turn was silently lost. "I'll research this in the background and report back" never actually reported back — the classic symptom of a subagent that "starts an investigation" and then goes quiet forever.

This was reproduced with PID-level timing on a dev build: the host claude-code subprocess exited ~2s after the turn's `completed`, and the dispatched `sleep 300` subagents vanished with zero `task_notification`s.

## Fix (sidecar-only)

Track in-flight background tasks by `task_id` (`task_started` opens one, `task_notification` settles it). When a `completed` result arrives while any are still pending, **defer it**: filter it out (preserving the pipeline's one-result-per-turn invariant) and keep draining the *same* query until every task settles — exactly mirroring the existing `background_requested` pause handling. The turn ends on the final `completed` (no pending tasks) or on any error/aborted terminal.

- No Rust / pipeline / persistence / schema change. `task_started`/`task_notification` are already suppressed in the pipeline, so tracking them in the sidecar is invisible downstream, and the intermediate `completed` is filtered before it reaches the accumulator.
- Heartbeats keep flowing during the drain (`activeStreamIds` membership is tied to the in-flight `sendMessage`, not the SDK `completed`), so the Rust 45s heartbeat watchdog stays satisfied for the whole wait.

## Tests

Extended `sidecar/src/claude/background-resume.test.ts` (the `#891`/`#897` regression harness) with four cases: deferred-then-resumed, multiple-tasks-all-settle, safe-fallback (SDK ends the iterator before the notification), and error-terminal-not-deferred. Full sidecar suite green; `tsc --noEmit` and biome clean.

## Verified end-to-end (dev build)

- A `run_in_background` `sleep 60` turn: the claude-code subprocess now **survives ~69s** until the task settles and reports back, with exactly one persisted `result` row despite two `completed` events in the SDK stream (the intermediate one was deferred). Before the fix the same scenario died ~2s after `completed` with zero notifications.
- A nested 3-subagent repro drained **9/9** background tasks (subagents + their own backgrounded commands) and ended cleanly with zero pending leftover.

## Follow-up (not in this PR)

Optionally present the turn as "done" immediately and stream background results back as new turns/blocks, instead of the turn staying "running" until background work settles. That's a UX change spanning the Rust pipeline/persistence/frontend and is deferred.
