### PR TITLE
chore(deps): bump bundled agents to latest

### DIFF
--- a/sidecar/scripts/vendor-platform.ts
+++ b/sidecar/scripts/vendor-platform.ts
@@ -150,7 +150,7 @@ export const OPENCODE_SHA256: Readonly<
 // release URL rather than from node_modules. Bumping: pull each platform's
 // SHA256 from the release's `*.zip.sha256` sidecar (or the GitHub asset
 // `digest`) and wipe sidecar/.bundle-cache. Keyed `version → platformSlug`.
-export const KIMI_VERSION = "0.20.3";
+export const KIMI_VERSION = "0.21.0";
 export const KIMI_SHA256: Readonly<Record<string, Record<string, string>>> = {
 	"0.19.1": {
 		"darwin-arm64":
@@ -181,6 +181,16 @@ export const KIMI_SHA256: Readonly<Record<string, Record<string, string>>> = {
 			"270e44215fb89112135dfb8bbbbe54beb1269031ca20311b4cc4d9a5b267b35a",
 		"win32-x64":
 			"fbd2c89b61cfd48474f99aeaee536b3f34c1da3879588dbd1150f80b34064535",
+	},
+	"0.21.0": {
+		"darwin-arm64":
+			"9a20e6680de77cacdeacd768877e0ddf2e04553d305f82fb989719389c243beb",
+		"darwin-x64":
+			"6559c2392f268bc1ad437cbbc20ab02a898f44bb6e8db970b6ff833eca2b64b7",
+		"win32-arm64":
+			"65c410c38e193c4c99da6b64a536440ea5896796995e7963fa7911cdcb2580d2",
+		"win32-x64":
+			"b6e875f1fcd7967713f0b99c040c72b853962d1e7f88377e6125478b79e5999d",
 	},
 };
 


### PR DESCRIPTION
## Bundled agent version sweep

Daily automated check of Helmor's bundled coding agents against latest **stable** upstream.

| Vendor | Current | Target | Action |
|---|---|---|---|
| Kimi (`MoonshotAI/kimi-code`) | 0.20.3 | **0.21.0** | ⬆️ bumped |
| Claude Code (`@anthropic-ai/claude-code`) | 2.1.197 | 2.1.197 | ✅ current |
| claude-agent-sdk (`@anthropic-ai/claude-agent-sdk`) | 0.3.197 | 0.3.197 | ✅ current |
| Codex (`@openai/codex`) | 0.142.5 | 0.142.5 | ✅ current |
| Cursor SDK (`@cursor/sdk`) | 1.0.22 | 1.0.22 | ✅ current |
| OpenCode (`@opencode-ai/sdk` + `opencode-ai`) | 1.17.12 | 1.17.12 | ✅ current |

Only **Kimi** was behind. Bump applied in `sidecar/scripts/vendor-platform.ts`:
- `KIMI_VERSION` → `0.21.0`
- Added `KIMI_SHA256["0.21.0"]` (darwin + win32, arm64 + x64), prior keys retained.

Kimi is a class-C GitHub-release binary (not in `package.json`), so no npm/lockfile change.

### Breaking-change assessment — Kimi 0.21.0
Release notes are TUI/web-focused: plugin slash-commands, conversation-compaction rework, thinking-effort refactor, a server-side KV store, and keyboard-shortcut fixes. **No ACP protocol-version change** — Helmor's `kimi acp` integration (`ACP_PROTOCOL_VERSION` handshake) is unaffected. No stdout event-shape impact on the Rust pipeline. Assessed **no impact** on Helmor.

### Local verification gates
| Gate | Result |
|---|---|
| `bun install` | ✅ (no dep change — Kimi is not an npm pin) |
| `bun run typecheck` | ✅ pass |
| `bun test` | ✅ 410 pass / 1 skip / 0 fail |
| `cargo test --test pipeline_scenarios --test pipeline_fixtures --test pipeline_streams` | ✅ pass |
| Kimi darwin arm64+x64 SHA256 re-download check | ✅ match pinned |

Changeset: existing `.changeset/bump-bundled-agents.md` (`helmor: patch`) already lists Kimi among the bundled agents brought to latest — accurate for this bump, no new changeset added.

🤖 Automated daily bundled-vendor bump.

https://claude.ai/code/session_01DxuxbxKqvRAKtSeZiRg4Xe

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxuxbxKqvRAKtSeZiRg4Xe)_