### PR TITLE
fix: re-target stacked workspaces when their base PR merges

### DIFF
--- a/.changeset/retarget-stack-on-merge.md
+++ b/.changeset/retarget-stack-on-merge.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Stacked workspaces now re-target automatically when their base PR merges — the layer above a merged PR moves onto that layer's own base (the repo default branch for a bottom-of-stack merge) instead of staying pinned to the now-merged branch, and stacks already left in this state are healed on launch.

--- a/src-tauri/src/commands/forge_commands.rs
+++ b/src-tauri/src/commands/forge_commands.rs
@@ -366,6 +366,16 @@ pub async fn refresh_workspace_change_request(
     if outcome.transitioned_to_merged {
         crate::workspace::archive::try_auto_archive_after_merge(&app, &workspace_id);
     }
+    // A merged layer's stacked children were re-homed onto its base; refresh
+    // each so the sidebar re-nests and the child's header retargets.
+    for child_id in &outcome.retargeted_children {
+        ui_sync::publish(
+            &app,
+            UiMutationEvent::WorkspaceChanged {
+                workspace_id: child_id.clone(),
+            },
+        );
+    }
     Ok(result)
 }
 
@@ -436,6 +446,16 @@ async fn run_change_request_action(
     }
     if outcome.transitioned_to_merged {
         crate::workspace::archive::try_auto_archive_after_merge(&app, &workspace_id);
+    }
+    // A merged layer's stacked children were re-homed onto its base; refresh
+    // each so the sidebar re-nests and the child's header retargets.
+    for child_id in &outcome.retargeted_children {
+        ui_sync::publish(
+            &app,
+            UiMutationEvent::WorkspaceChanged {
+                workspace_id: child_id.clone(),
+            },
+        );
     }
     Ok(result)
 }

--- a/src-tauri/src/commands/tests/workspace_creation.rs
+++ b/src-tauri/src/commands/tests/workspace_creation.rs
@@ -96,6 +96,85 @@ fn stack_deletion_constraint_tip_free_root_pops_middle_blocked() {
 }
 
 #[test]
+fn stack_bottom_merge_pops_children_to_default_and_keeps_merged_row() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let harness = CreateTestHarness::new();
+
+    // root -> mid -> tip
+    let root = workspaces::create_workspace_from_repo_impl(&harness.repo_id).unwrap();
+    let mid = workspaces::create_stacked_workspace_impl(&root.created_workspace_id).unwrap();
+    let tip = workspaces::create_stacked_workspace_impl(&mid.created_workspace_id).unwrap();
+
+    // The bottom layer's PR merges.
+    let merged = crate::forge::ChangeRequestInfo {
+        url: "https://example.test/pr/1".to_string(),
+        number: 1,
+        state: "MERGED".to_string(),
+        title: "root PR".to_string(),
+        is_merged: true,
+    };
+    let outcome =
+        workspaces::sync_workspace_pr_state(&root.created_workspace_id, Some(&merged)).unwrap();
+    assert!(outcome.transitioned_to_merged);
+    // Only the direct child (mid) is re-homed; the tip stays put.
+    assert_eq!(
+        outcome.retargeted_children,
+        vec![mid.created_workspace_id.clone()]
+    );
+
+    let connection = Connection::open(harness.db_path()).unwrap();
+
+    // The merged bottom layer SURVIVES (not deleted) and is marked done/merged.
+    let (root_pr_state, root_status): (String, String) = connection
+        .query_row(
+            "SELECT pr_sync_state, status FROM workspaces WHERE id = ?1",
+            [&root.created_workspace_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(root_pr_state, "merged");
+    assert_eq!(root_status, "done");
+
+    // mid detaches to a root, retargeting the repo default branch — exactly the
+    // "upper layer auto-points to main once the bottom merged" behaviour.
+    let (mid_parent, mid_target): (Option<String>, Option<String>) = connection
+        .query_row(
+            "SELECT parent_workspace_id, intended_target_branch FROM workspaces WHERE id = ?1",
+            [&mid.created_workspace_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(
+        mid_parent, None,
+        "mid should detach to a root after the bottom merged"
+    );
+    let default_branch: String = connection
+        .query_row(
+            "SELECT default_branch FROM repos WHERE id = ?1",
+            [&harness.repo_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(mid_target.as_deref(), Some(default_branch.as_str()));
+
+    // tip is untouched: still stacked on mid, still targeting mid's branch.
+    let (tip_parent, tip_target): (Option<String>, Option<String>) = connection
+        .query_row(
+            "SELECT parent_workspace_id, intended_target_branch FROM workspaces WHERE id = ?1",
+            [&tip.created_workspace_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(
+        tip_parent.as_deref(),
+        Some(mid.created_workspace_id.as_str())
+    );
+    assert_eq!(tip_target.as_deref(), Some(mid.branch.as_str()));
+}
+
+#[test]
 fn load_workspace_stack_returns_root_to_tip_chain() {
     let _guard = TEST_LOCK
         .lock()

--- a/src-tauri/src/models/workspaces.rs
+++ b/src-tauri/src/models/workspaces.rs
@@ -794,6 +794,93 @@ pub(crate) fn update_workspace_branch(workspace_id: &str, new_branch: &str) -> R
     Ok(())
 }
 
+/// Splice a stack layer out from under its children.
+///
+/// Every direct child of `layer_id` is reparented onto that layer's OWN parent
+/// (the grandparent) and its cached `intended_target_branch` is repointed to the
+/// grandparent's branch — or, when `layer_id` was the bottom of the stack (no
+/// live grandparent), the child detaches to a root targeting the repo default
+/// branch. The `layer_id` row itself is left untouched, so a merged layer
+/// survives as a standalone workspace.
+///
+/// This is the shared primitive behind every event that removes a layer from the
+/// active stack: a lower layer's PR merged, or the stack root was deleted. In
+/// both cases the layer stops being part of the stack and its children must
+/// re-home onto whatever is now below them. Crucially the post-splice state still
+/// satisfies the stack invariant (`child.intended_target_branch ==
+/// parent(child).branch`), so the startup backfill and the rename cascade leave
+/// it alone.
+///
+/// Runs on the caller's transaction so it commits atomically with the state
+/// change that triggered it, and must run while the `layer_id` row still exists
+/// (the base is resolved from it). Returns the reparented child ids for UI
+/// refresh; empty when `layer_id` has no children (a tip or non-stacked layer).
+pub(crate) fn splice_out_stack_layer_tx(
+    tx: &rusqlite::Transaction<'_>,
+    layer_id: &str,
+) -> Result<Vec<String>> {
+    let children: Vec<String> = {
+        let mut stmt = tx
+            .prepare("SELECT id FROM workspaces WHERE parent_workspace_id = ?1")
+            .context("Failed to prepare stack-children query")?;
+        let rows = stmt
+            .query_map([layer_id], |row| row.get::<_, String>(0))
+            .context("Failed to query stack children")?;
+        rows.collect::<rusqlite::Result<Vec<String>>>()
+            .context("Failed to read stack children")?
+    };
+    if children.is_empty() {
+        return Ok(children);
+    }
+
+    // The layer's own parent becomes the children's new base. Resolve it to a
+    // LIVE row so a dangling parent id degrades to "detach to root".
+    let grandparent: Option<(String, Option<String>)> = tx
+        .query_row(
+            "SELECT p.id, p.branch
+               FROM workspaces layer
+               JOIN workspaces p ON p.id = layer.parent_workspace_id
+              WHERE layer.id = ?1",
+            [layer_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .ok();
+
+    // Fallback target when there is no grandparent (the layer was the bottom).
+    let default_branch: Option<String> = tx
+        .query_row(
+            "SELECT r.default_branch
+               FROM workspaces w JOIN repos r ON r.id = w.repository_id
+              WHERE w.id = ?1",
+            [layer_id],
+            |row| row.get(0),
+        )
+        .ok()
+        .flatten();
+
+    let (new_parent, new_target): (Option<String>, String) = match grandparent {
+        Some((grandparent_id, grandparent_branch)) => (
+            Some(grandparent_id),
+            grandparent_branch
+                .or_else(|| default_branch.clone())
+                .unwrap_or_else(|| "main".to_string()),
+        ),
+        None => (None, default_branch.unwrap_or_else(|| "main".to_string())),
+    };
+
+    tx.execute(
+        "UPDATE workspaces
+            SET parent_workspace_id = ?2,
+                intended_target_branch = ?3,
+                updated_at = datetime('now')
+          WHERE parent_workspace_id = ?1",
+        (layer_id, new_parent.as_deref(), new_target.as_str()),
+    )
+    .context("Failed to reparent stack children")?;
+
+    Ok(children)
+}
+
 /// Set (or clear) the user's custom display name for a workspace. `Some(name)`
 /// overrides the auto-derived title; `None` clears it back to the derived one.
 pub(crate) fn update_workspace_custom_name(

--- a/src-tauri/src/models/workspaces.rs
+++ b/src-tauri/src/models/workspaces.rs
@@ -811,16 +811,21 @@ pub(crate) fn update_workspace_branch(workspace_id: &str, new_branch: &str) -> R
 /// parent(child).branch`), so the startup backfill and the rename cascade leave
 /// it alone.
 ///
-/// Runs on the caller's transaction so it commits atomically with the state
-/// change that triggered it, and must run while the `layer_id` row still exists
+/// Runs directly on the caller's connection, so it participates in whatever
+/// transaction (if any) the caller already holds: pass a `&Transaction` (it
+/// deref-coerces to `&Connection`) to make it atomic with a surrounding change
+/// like the merge flip or a delete, or a bare `&Connection` to autocommit each
+/// UPDATE. It deliberately does NOT open its own transaction — the startup heal
+/// calls it while the Conductor import already holds a `BEGIN IMMEDIATE`, where
+/// a nested `BEGIN` would fail. Must run while the `layer_id` row still exists
 /// (the base is resolved from it). Returns the reparented child ids for UI
 /// refresh; empty when `layer_id` has no children (a tip or non-stacked layer).
-pub(crate) fn splice_out_stack_layer_tx(
-    tx: &rusqlite::Transaction<'_>,
+pub(crate) fn splice_out_stack_layer(
+    conn: &rusqlite::Connection,
     layer_id: &str,
 ) -> Result<Vec<String>> {
     let children: Vec<String> = {
-        let mut stmt = tx
+        let mut stmt = conn
             .prepare("SELECT id FROM workspaces WHERE parent_workspace_id = ?1")
             .context("Failed to prepare stack-children query")?;
         let rows = stmt
@@ -835,7 +840,7 @@ pub(crate) fn splice_out_stack_layer_tx(
 
     // The layer's own parent becomes the children's new base. Resolve it to a
     // LIVE row so a dangling parent id degrades to "detach to root".
-    let grandparent: Option<(String, Option<String>)> = tx
+    let grandparent: Option<(String, Option<String>)> = conn
         .query_row(
             "SELECT p.id, p.branch
                FROM workspaces layer
@@ -847,7 +852,7 @@ pub(crate) fn splice_out_stack_layer_tx(
         .ok();
 
     // Fallback target when there is no grandparent (the layer was the bottom).
-    let default_branch: Option<String> = tx
+    let default_branch: Option<String> = conn
         .query_row(
             "SELECT r.default_branch
                FROM workspaces w JOIN repos r ON r.id = w.repository_id
@@ -868,7 +873,7 @@ pub(crate) fn splice_out_stack_layer_tx(
         None => (None, default_branch.unwrap_or_else(|| "main".to_string())),
     };
 
-    tx.execute(
+    conn.execute(
         "UPDATE workspaces
             SET parent_workspace_id = ?2,
                 intended_target_branch = ?3,

--- a/src-tauri/src/models/workspaces.rs
+++ b/src-tauri/src/models/workspaces.rs
@@ -815,9 +815,10 @@ pub(crate) fn update_workspace_branch(workspace_id: &str, new_branch: &str) -> R
 /// transaction (if any) the caller already holds: pass a `&Transaction` (it
 /// deref-coerces to `&Connection`) to make it atomic with a surrounding change
 /// like the merge flip or a delete, or a bare `&Connection` to autocommit each
-/// UPDATE. It deliberately does NOT open its own transaction — the startup heal
-/// calls it while the Conductor import already holds a `BEGIN IMMEDIATE`, where
-/// a nested `BEGIN` would fail. Must run while the `layer_id` row still exists
+/// UPDATE. It deliberately does NOT open its own transaction — the startup
+/// reconcile calls it from inside `run_migrations`, which can itself run inside
+/// a caller's transaction where a nested `BEGIN` would fail. Must run while the
+/// `layer_id` row still exists
 /// (the base is resolved from it). Returns the reparented child ids for UI
 /// refresh; empty when `layer_id` has no children (a tip or non-stacked layer).
 pub(crate) fn splice_out_stack_layer(

--- a/src-tauri/src/schema.rs
+++ b/src-tauri/src/schema.rs
@@ -237,11 +237,10 @@ fn heal_children_of_merged_stack_layers(connection: &Connection) -> Result<()> {
             .context("Failed to read merged layers")?
     };
     // Splice directly on `connection` rather than opening our own transaction:
-    // the Conductor import calls `ensure_schema` / `run_migrations` inside a
-    // `BEGIN IMMEDIATE` (see `import.rs`), so an `unchecked_transaction()` here
-    // would fail with "cannot start a transaction within a transaction". Each
-    // splice is a single idempotent UPDATE, so a crash mid-loop just heals on the
-    // next run.
+    // `ensure_schema` / `run_migrations` can run inside a caller's transaction,
+    // where an `unchecked_transaction()` here would fail with "cannot start a
+    // transaction within a transaction". Each splice is a single idempotent
+    // UPDATE, so a crash mid-loop just heals on the next run.
     for layer_id in &merged_layers {
         crate::models::workspaces::splice_out_stack_layer(connection, layer_id)
             .with_context(|| format!("Failed to splice merged stack layer {layer_id}"))?;
@@ -1477,10 +1476,9 @@ mod tests {
 
     #[test]
     fn heal_runs_inside_an_ambient_transaction_without_nesting() {
-        // Regression: the Conductor import runs ensure_schema / run_migrations
-        // inside a `BEGIN IMMEDIATE` (import.rs). The heal must NOT open its own
-        // transaction, or it aborts with "cannot start a transaction within a
-        // transaction" and breaks the import for anyone with a merged workspace.
+        // Regression: `ensure_schema` / `run_migrations` can run inside a
+        // caller's transaction. The heal must NOT open its own transaction, or it
+        // aborts with "cannot start a transaction within a transaction".
         let (connection, _dir) = open_test_db();
         ensure_schema(&connection).unwrap();
         insert_ws(&connection, "root", "feat/root", Some("main"), None);

--- a/src-tauri/src/schema.rs
+++ b/src-tauri/src/schema.rs
@@ -213,7 +213,7 @@ fn backfill_stacked_target_branches(connection: &Connection) -> Result<()> {
 /// Startup reconcile for stacks whose base merged under an older build, before
 /// merge-time splicing existed. Every workspace still stacked on a merged layer
 /// is spliced out via the shared write-layer primitive
-/// [`crate::models::workspaces::splice_out_stack_layer_tx`], re-homing its
+/// [`crate::models::workspaces::splice_out_stack_layer`], re-homing its
 /// children onto the nearest surviving base — the exact end state a live merge
 /// now produces. Iterating over *all* merged layers converges even for chained
 /// merges (a child of a merged layer always ends on a non-merged ancestor or
@@ -236,17 +236,16 @@ fn heal_children_of_merged_stack_layers(connection: &Connection) -> Result<()> {
         rows.collect::<rusqlite::Result<Vec<String>>>()
             .context("Failed to read merged layers")?
     };
-    if merged_layers.is_empty() {
-        return Ok(());
-    }
-    let tx = connection
-        .unchecked_transaction()
-        .context("Failed to open merged-stack heal transaction")?;
+    // Splice directly on `connection` rather than opening our own transaction:
+    // the Conductor import calls `ensure_schema` / `run_migrations` inside a
+    // `BEGIN IMMEDIATE` (see `import.rs`), so an `unchecked_transaction()` here
+    // would fail with "cannot start a transaction within a transaction". Each
+    // splice is a single idempotent UPDATE, so a crash mid-loop just heals on the
+    // next run.
     for layer_id in &merged_layers {
-        crate::models::workspaces::splice_out_stack_layer_tx(&tx, layer_id)
+        crate::models::workspaces::splice_out_stack_layer(connection, layer_id)
             .with_context(|| format!("Failed to splice merged stack layer {layer_id}"))?;
     }
-    tx.commit().context("Failed to commit merged-stack heal")?;
     Ok(())
 }
 
@@ -1474,6 +1473,38 @@ mod tests {
         heal_children_of_merged_stack_layers(&connection).unwrap();
         assert_eq!(parent_of(&connection, "mid"), None);
         assert_eq!(target_of(&connection, "tip").as_deref(), Some("feat/mid"));
+    }
+
+    #[test]
+    fn heal_runs_inside_an_ambient_transaction_without_nesting() {
+        // Regression: the Conductor import runs ensure_schema / run_migrations
+        // inside a `BEGIN IMMEDIATE` (import.rs). The heal must NOT open its own
+        // transaction, or it aborts with "cannot start a transaction within a
+        // transaction" and breaks the import for anyone with a merged workspace.
+        let (connection, _dir) = open_test_db();
+        ensure_schema(&connection).unwrap();
+        insert_ws(&connection, "root", "feat/root", Some("main"), None);
+        insert_ws(
+            &connection,
+            "mid",
+            "feat/mid",
+            Some("feat/root"),
+            Some("root"),
+        );
+        connection
+            .execute(
+                "UPDATE workspaces SET pr_sync_state = 'merged' WHERE id = 'root'",
+                [],
+            )
+            .unwrap();
+
+        // Mirror the import flow: a transaction is already open on this conn.
+        connection.execute_batch("BEGIN IMMEDIATE").unwrap();
+        heal_children_of_merged_stack_layers(&connection).unwrap();
+        connection.execute_batch("COMMIT").unwrap();
+
+        assert_eq!(parent_of(&connection, "mid"), None);
+        assert_eq!(target_of(&connection, "mid").as_deref(), Some("main"));
     }
 
     #[test]

--- a/src-tauri/src/schema.rs
+++ b/src-tauri/src/schema.rs
@@ -210,6 +210,46 @@ fn backfill_stacked_target_branches(connection: &Connection) -> Result<()> {
     Ok(())
 }
 
+/// Startup reconcile for stacks whose base merged under an older build, before
+/// merge-time splicing existed. Every workspace still stacked on a merged layer
+/// is spliced out via the shared write-layer primitive
+/// [`crate::models::workspaces::splice_out_stack_layer_tx`], re-homing its
+/// children onto the nearest surviving base — the exact end state a live merge
+/// now produces. Iterating over *all* merged layers converges even for chained
+/// merges (a child of a merged layer always ends on a non-merged ancestor or
+/// the repo default). Idempotent: once every merged layer is childless it's a
+/// no-op, so this can run on every startup like the backfill above.
+fn heal_children_of_merged_stack_layers(connection: &Connection) -> Result<()> {
+    if !has_table(connection, "workspaces")
+        || !has_column(connection, "workspaces", "parent_workspace_id")
+        || !has_column(connection, "workspaces", "pr_sync_state")
+    {
+        return Ok(());
+    }
+    let merged_layers: Vec<String> = {
+        let mut stmt = connection
+            .prepare("SELECT id FROM workspaces WHERE pr_sync_state = 'merged'")
+            .context("Failed to prepare merged-layer query")?;
+        let rows = stmt
+            .query_map([], |row| row.get::<_, String>(0))
+            .context("Failed to query merged layers")?;
+        rows.collect::<rusqlite::Result<Vec<String>>>()
+            .context("Failed to read merged layers")?
+    };
+    if merged_layers.is_empty() {
+        return Ok(());
+    }
+    let tx = connection
+        .unchecked_transaction()
+        .context("Failed to open merged-stack heal transaction")?;
+    for layer_id in &merged_layers {
+        crate::models::workspaces::splice_out_stack_layer_tx(&tx, layer_id)
+            .with_context(|| format!("Failed to splice merged stack layer {layer_id}"))?;
+    }
+    tx.commit().context("Failed to commit merged-stack heal")?;
+    Ok(())
+}
+
 fn run_migrations(connection: &Connection) -> Result<()> {
     // Migration: rename claude_session_id → provider_session_id (supports any agent provider)
     let has_old_column: bool = connection
@@ -558,6 +598,13 @@ fn run_migrations(connection: &Connection) -> Result<()> {
     // children are touched.
     backfill_stacked_target_branches(connection)
         .context("Failed to backfill stacked-PR target branches")?;
+
+    // A stacked base that merged under an older build never spliced its children
+    // out (merge-time splicing is newer). Re-home any workspace still stacked on
+    // a merged layer so its parent/target point past the merged base — the same
+    // end state a live merge now produces.
+    heal_children_of_merged_stack_layers(connection)
+        .context("Failed to heal children of merged stack layers")?;
 
     let had_workspace_status =
         has_table(connection, "workspaces") && has_column(connection, "workspaces", "status");
@@ -1367,6 +1414,66 @@ mod tests {
             target_of(&connection, "orphan").as_deref(),
             Some("stale-base")
         );
+    }
+
+    fn parent_of(connection: &Connection, id: &str) -> Option<String> {
+        connection
+            .query_row(
+                "SELECT parent_workspace_id FROM workspaces WHERE id = ?1",
+                [id],
+                |r| r.get(0),
+            )
+            .unwrap()
+    }
+
+    #[test]
+    fn heal_splices_children_off_a_merged_base() {
+        let (connection, _dir) = open_test_db();
+        ensure_schema(&connection).unwrap();
+
+        // root(bottom) -> mid -> tip; the bottom's PR is already merged.
+        insert_ws(&connection, "root", "feat/root", Some("main"), None);
+        insert_ws(
+            &connection,
+            "mid",
+            "feat/mid",
+            Some("feat/root"),
+            Some("root"),
+        );
+        insert_ws(
+            &connection,
+            "tip",
+            "feat/tip",
+            Some("feat/mid"),
+            Some("mid"),
+        );
+        connection
+            .execute(
+                "UPDATE workspaces SET pr_sync_state = 'merged' WHERE id = 'root'",
+                [],
+            )
+            .unwrap();
+
+        heal_children_of_merged_stack_layers(&connection).unwrap();
+
+        // mid detaches to a root: it no longer points at the merged root, and
+        // its target falls back to "main" (this fixture has no `repos` row, so
+        // the repo-default lookup misses — the real default_branch path is
+        // covered by the models-layer test).
+        assert_eq!(parent_of(&connection, "mid"), None);
+        assert_eq!(target_of(&connection, "mid").as_deref(), Some("main"));
+
+        // tip is untouched: still stacked on mid, still targeting mid's branch.
+        assert_eq!(parent_of(&connection, "tip").as_deref(), Some("mid"));
+        assert_eq!(target_of(&connection, "tip").as_deref(), Some("feat/mid"));
+
+        // The merged root itself survives as a standalone row.
+        assert_eq!(parent_of(&connection, "root"), None);
+
+        // Idempotent: a second pass changes nothing.
+        heal_children_of_merged_stack_layers(&connection).unwrap();
+        assert_eq!(parent_of(&connection, "mid"), None);
+        assert_eq!(target_of(&connection, "tip").as_deref(), Some("feat/mid"));
     }
 
     #[test]

--- a/src-tauri/src/workspace/workspaces.rs
+++ b/src-tauri/src/workspace/workspaces.rs
@@ -814,18 +814,20 @@ fn next_order_for_target(transaction: &Transaction<'_>, target: &MoveTarget) -> 
 /// `Merged` in this call — combined with the absorbing-state guarantee
 /// in `stabilize_pr_sync_state`, this means it fires at most once per
 /// workspace per merge.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct PrSyncOutcome {
     pub changed: bool,
     pub transitioned_to_merged: bool,
+    /// Ids of stacked children re-homed when this layer's PR merged (empty
+    /// otherwise). The command layer republishes each so the sidebar re-nests
+    /// and the child's header retargets onto the new base. See
+    /// [`crate::models::workspaces::splice_out_stack_layer_tx`].
+    pub retargeted_children: Vec<String>,
 }
 
 impl PrSyncOutcome {
     fn unchanged() -> Self {
-        Self {
-            changed: false,
-            transitioned_to_merged: false,
-        }
+        Self::default()
     }
 }
 
@@ -875,6 +877,7 @@ pub fn sync_workspace_pr_state(
         None
     };
 
+    let mut retargeted_children: Vec<String> = Vec::new();
     let mut connection = db::write_conn()?;
     if let Some(status) = target_status {
         let transaction = connection
@@ -922,6 +925,14 @@ pub fn sync_workspace_pr_state(
                 )
                 .context("Failed to sync workspace PR state")?;
         }
+        // A layer leaving the stack (its PR just merged) pops its children onto
+        // its own base. Same transaction as the merge flip so it's atomic, and
+        // before auto-archive so the children are re-homed while the layer row
+        // still exists.
+        if transitioned_to_merged {
+            retargeted_children =
+                workspace_models::splice_out_stack_layer_tx(&transaction, workspace_id)?;
+        }
         transaction
             .commit()
             .context("Failed to commit PR-sync workspace transaction")?;
@@ -943,6 +954,7 @@ pub fn sync_workspace_pr_state(
     Ok(PrSyncOutcome {
         changed: true,
         transitioned_to_merged,
+        retargeted_children,
     })
 }
 
@@ -1527,14 +1539,14 @@ pub fn permanently_delete_workspace(workspace_id: &str) -> Result<()> {
     // --- Stacked-PR deletion guard: tip free / root = pop-bottom / middle
     // blocked. A middle layer (a live parent below AND layers stacked above)
     // can't be deleted — it would leave an unrebaseable hole in the stack.
-    let (parent_id, default_branch): (Option<String>, Option<String>) = connection
+    let parent_id: Option<String> = connection
         .query_row(
-            "SELECT w.parent_workspace_id, r.default_branch
-               FROM workspaces w JOIN repos r ON r.id = w.repository_id WHERE w.id = ?1",
+            "SELECT parent_workspace_id FROM workspaces WHERE id = ?1",
             [workspace_id],
-            |row| Ok((row.get(0)?, row.get(1)?)),
+            |row| row.get(0),
         )
-        .unwrap_or((None, None));
+        .ok()
+        .flatten();
     let has_children: bool = connection
         .query_row(
             "SELECT EXISTS(SELECT 1 FROM workspaces WHERE parent_workspace_id = ?1)",
@@ -1599,27 +1611,20 @@ pub fn permanently_delete_workspace(workspace_id: &str) -> Result<()> {
             [workspace_id],
         )
         .context("Failed to delete workspace sessions")?;
+    // Pop this layer out of the stack before deleting it: its direct children
+    // re-home onto the layer's own base (the grandparent branch, or the repo
+    // default when this is a stack root — a deleted-with-children layer is
+    // guaranteed rootless by the guard above). Shared with merge-driven
+    // splicing so both paths keep the stack consistent. Must run while the row
+    // still exists so the base can be resolved from it.
+    workspace_models::splice_out_stack_layer_tx(&transaction, workspace_id)?;
+
     let deleted_rows = transaction
         .execute("DELETE FROM workspaces WHERE id = ?1", [workspace_id])
         .context("Failed to delete workspace row")?;
 
     if deleted_rows != 1 {
         bail!("Workspace delete affected {deleted_rows} rows for {workspace_id}");
-    }
-
-    // Root pop: a deleted stack root's direct children become new roots
-    // targeting the repo default branch (they'll need a restack onto it).
-    if has_children {
-        transaction
-            .execute(
-                "UPDATE workspaces
-                   SET parent_workspace_id = NULL,
-                       intended_target_branch = ?2,
-                       updated_at = datetime('now')
-                 WHERE parent_workspace_id = ?1",
-                (workspace_id, default_branch.as_deref().unwrap_or("main")),
-            )
-            .context("Failed to reparent stack children after root delete")?;
     }
 
     transaction

--- a/src-tauri/src/workspace/workspaces.rs
+++ b/src-tauri/src/workspace/workspaces.rs
@@ -821,7 +821,7 @@ pub struct PrSyncOutcome {
     /// Ids of stacked children re-homed when this layer's PR merged (empty
     /// otherwise). The command layer republishes each so the sidebar re-nests
     /// and the child's header retargets onto the new base. See
-    /// [`crate::models::workspaces::splice_out_stack_layer_tx`].
+    /// [`crate::models::workspaces::splice_out_stack_layer`].
     pub retargeted_children: Vec<String>,
 }
 
@@ -931,7 +931,7 @@ pub fn sync_workspace_pr_state(
         // still exists.
         if transitioned_to_merged {
             retargeted_children =
-                workspace_models::splice_out_stack_layer_tx(&transaction, workspace_id)?;
+                workspace_models::splice_out_stack_layer(&transaction, workspace_id)?;
         }
         transaction
             .commit()
@@ -1617,7 +1617,7 @@ pub fn permanently_delete_workspace(workspace_id: &str) -> Result<()> {
     // guaranteed rootless by the guard above). Shared with merge-driven
     // splicing so both paths keep the stack consistent. Must run while the row
     // still exists so the base can be resolved from it.
-    workspace_models::splice_out_stack_layer_tx(&transaction, workspace_id)?;
+    workspace_models::splice_out_stack_layer(&transaction, workspace_id)?;
 
     let deleted_rows = transaction
         .execute("DELETE FROM workspaces WHERE id = ?1", [workspace_id])


### PR DESCRIPTION
## Problem

In a stacked-PR setup, when a lower layer's PR is **merged**, the layers above it kept pointing at the now-merged branch. The stack's structural relationship is stored eagerly and redundantly (`parent_workspace_id` + a cached `intended_target_branch`), and the code only maintained it on three transitions — **create**, **rename**, and **delete-root**. "Base PR merged" is a fourth transition that removes a layer from the active stack, but it was never wired up: the merge handler only archived the merged workspace and did nothing for its children.

Result: the upper layer's header still showed `→ <merged layer>`, and its branch diff + `gh pr create --base` kept targeting a merged branch. (`restack.md` already flagged "automatic restack-on-merge" as a planned feature.)

## Fix (structural, not patchwork)

Add one shared primitive `splice_out_stack_layer_tx` (models/workspaces.rs): a layer's direct children re-home onto its **own** parent (the grandparent), or detach to the **repo default branch** for a bottom-of-stack merge. The merged layer itself is left intact and survives as a standalone "Done" workspace.

Crucially the post-splice state still satisfies the stack invariant (`child.intended_target_branch == parent(child).branch`), so the startup backfill and rename cascade leave it alone, and **the frontend re-nests / re-targets with no UI changes** (sidebar + header are driven by `parentWorkspaceId` / `intendedTargetBranch`).

Wired up three ways, all through the one primitive:

- **Merge (live):** called atomically inside the `sync_workspace_pr_state` flip to `Merged` — covers both the poll path and the explicit-merge button, and runs before auto-archive.
- **Delete:** the existing delete-root-pop reparent is unified onto the same primitive (removes duplicated SQL; behaviour preserved).
- **Startup reconcile:** `heal_children_of_merged_stack_layers` (schema.rs) heals stacks already left pointing at a merged base under older builds. Converges even for chained merges; idempotent.

Scope is **metadata-only**: header / diff / PR base become correct immediately. Actually rebasing the child branch onto the new base stays on the existing manual Restack button.

## Tests

- New: `stack_bottom_merge_pops_children_to_default_and_keeps_merged_row` (models-layer live merge), `heal_splices_children_off_a_merged_base` (startup reconcile).
- Existing delete-root-pop, PR-sync state-machine, and backfill tests still pass.
- Full lib suite: **1557 passed / 0 failed**; `cargo clippy --all-targets -D warnings` clean.