### PR TITLE
Fix repo avatars falling back to initials when icon can't load

### DIFF
--- a/.changeset/repo-icon-fallback.md
+++ b/.changeset/repo-icon-fallback.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix repo avatars rendering blank instead of falling back to the name initials when a repository's icon file can't be displayed (e.g. an empty or undecodable `favicon.ico`).

--- a/src-tauri/src/workspace/helpers.rs
+++ b/src-tauri/src/workspace/helpers.rs
@@ -263,6 +263,13 @@ pub fn repo_icon_src_for_root_path(root_path: Option<&str>) -> Option<String> {
     let data_uri = icon_path.as_deref().and_then(|path| {
         let mime_type = repo_icon_mime_type(Path::new(path));
         let bytes = fs::read(path).ok()?;
+        // A 0-byte icon file (e.g. the empty `public/favicon.ico` placeholder
+        // scaffolded API repos ship) would otherwise become a valid-looking but
+        // image-less `data:` URI — the frontend can't render it and the avatar
+        // ends up blank. Treat it as "no icon" so the UI falls back to initials.
+        if bytes.is_empty() {
+            return None;
+        }
         Some(format!(
             "data:{mime_type};base64,{}",
             BASE64_STANDARD.encode(bytes)
@@ -1365,6 +1372,22 @@ mod tests {
 
         assert!(repo_icon_src_for_root_path(Some(&root_str)).is_none());
         // Second call exercises the negative-cache path.
+        assert!(repo_icon_src_for_root_path(Some(&root_str)).is_none());
+    }
+
+    #[test]
+    fn repo_icon_src_returns_none_for_empty_icon_file() {
+        // A matched-but-empty icon file (e.g. a 0-byte `public/favicon.ico`
+        // placeholder) must NOT produce a blank `data:` URI — the avatar has to
+        // fall back to initials instead of rendering nothing.
+        let dir = tempfile::tempdir().unwrap();
+        let root_str = dir.path().to_str().unwrap().to_string();
+
+        fs::create_dir_all(dir.path().join("public")).unwrap();
+        fs::write(dir.path().join("public/favicon.ico"), b"").unwrap();
+
+        assert!(repo_icon_src_for_root_path(Some(&root_str)).is_none());
+        // Second call exercises the cached path.
         assert!(repo_icon_src_for_root_path(Some(&root_str)).is_none());
     }
 

--- a/src/features/navigation/avatar.test.tsx
+++ b/src/features/navigation/avatar.test.tsx
@@ -1,8 +1,55 @@
-import { render } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { WorkspaceAvatar } from "./avatar";
 
 describe("WorkspaceAvatar", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("falls back to initials when the icon src fails to load", async () => {
+		// Radix's <Avatar.Image> never mounts the underlying <img> on error — it
+		// renders null — so a native `onError` never fires. jsdom also never
+		// loads images, leaving Radix's internal probe stuck in "loading"
+		// forever. Stub window.Image so setting a src dispatches an error, which
+		// drives our `onLoadingStatusChange` path. Without the fix this repo
+		// (a non-empty but undecodable `data:image/x-icon;base64,` URI) would
+		// render a permanently blank avatar.
+		class FailingImage {
+			#src = "";
+			complete = false;
+			naturalWidth = 0;
+			#onError: (() => void) | null = null;
+			addEventListener(type: string, cb: () => void) {
+				if (type === "error") this.#onError = cb;
+			}
+			removeEventListener() {}
+			set src(value: string) {
+				this.#src = value;
+				queueMicrotask(() => this.#onError?.());
+			}
+			get src() {
+				return this.#src;
+			}
+		}
+		vi.stubGlobal("Image", FailingImage);
+
+		const { container } = render(
+			<WorkspaceAvatar
+				repoIconSrc="data:image/x-icon;base64,"
+				repoInitials="RA"
+				repoName="retail-api"
+				title="retail-api"
+			/>,
+		);
+
+		await waitFor(() => {
+			const fallback = container.querySelector('[data-slot="avatar-fallback"]');
+			expect(fallback).toBeInTheDocument();
+			expect(fallback).toHaveTextContent("RA");
+		});
+	});
+
 	it("renders fallback immediately when switching from an icon repo to a repo without an icon", () => {
 		const { container, rerender } = render(
 			<WorkspaceAvatar

--- a/src/features/navigation/avatar.tsx
+++ b/src/features/navigation/avatar.tsx
@@ -31,6 +31,9 @@ function getWorkspaceAvatarSrc(repoIconSrc?: string | null) {
 	return repoIconSrc?.trim() ? repoIconSrc : null;
 }
 
+/** Mirrors Radix's `ImageLoadingStatus` union (not exported by the package). */
+type AvatarLoadingStatus = "idle" | "loading" | "loaded" | "error";
+
 export const WorkspaceAvatar = memo(function WorkspaceAvatar({
 	repoIconSrc,
 	repoInitials,
@@ -63,12 +66,24 @@ export const WorkspaceAvatar = memo(function WorkspaceAvatar({
 		.slice(0, 2)
 		.toUpperCase();
 	const src = getWorkspaceAvatarSrc(repoIconSrc);
-	const [hasImage, setHasImage] = useState(Boolean(src));
+	// Radix's <Avatar.Image> never mounts the underlying <img> unless its own
+	// probe reports "loaded" — on failure it just renders `null`. A native
+	// <img onError> therefore never fires, so we drive the fallback from
+	// Radix's `onLoadingStatusChange` instead. Without this, a broken or
+	// undecodable icon (an empty `favicon.ico`, an `.ico` WebKit can't render,
+	// a corrupt file) leaves the avatar permanently blank instead of showing
+	// the initials.
+	const [status, setStatus] = useState<AvatarLoadingStatus>("idle");
 
+	// Reset when the icon source changes so a new icon gets a fresh chance to
+	// load before we decide to fall back.
 	useEffect(() => {
-		setHasImage(Boolean(src));
+		setStatus("idle");
 	}, [src]);
-	const showFallback = !src || !hasImage;
+
+	// Stay optimistic while idle/loading (no initials flash for good icons);
+	// only fall back once the load actually errors or there's no src at all.
+	const showFallback = !src || status === "error";
 
 	return (
 		<Avatar
@@ -86,12 +101,7 @@ export const WorkspaceAvatar = memo(function WorkspaceAvatar({
 				<AvatarImage
 					src={src}
 					alt={`${repoName ?? title} icon`}
-					onError={() => {
-						setHasImage(false);
-					}}
-					onLoad={() => {
-						setHasImage(true);
-					}}
+					onLoadingStatusChange={(nextStatus) => setStatus(nextStatus)}
 				/>
 			) : null}
 			{showFallback ? (

--- a/src/features/navigation/row-item.tsx
+++ b/src/features/navigation/row-item.tsx
@@ -470,7 +470,7 @@ export const WorkspaceRowItem = memo(
 						<div className="flex min-w-0 flex-1 items-center gap-2">
 							<WorkspaceAvatar
 								repoIconSrc={row.repoIconSrc}
-								repoInitials={row.repoInitials ?? row.avatar ?? null}
+								repoInitials={row.repoInitials || row.avatar || null}
 								repoName={row.repoName}
 								title={displayTitle}
 								badgeClassName={showStatusDot ? statusDotClassName : null}

--- a/src/features/navigation/workspace-hover-card.tsx
+++ b/src/features/navigation/workspace-hover-card.tsx
@@ -663,7 +663,7 @@ export function WorkspaceHoverCard({
 						<div className="flex min-w-0 items-center gap-2">
 							<WorkspaceAvatar
 								repoIconSrc={row.repoIconSrc}
-								repoInitials={row.repoInitials ?? row.avatar ?? null}
+								repoInitials={row.repoInitials || row.avatar || null}
 								repoName={row.repoName}
 								title={title}
 								className="size-4 rounded-[4px]"


### PR DESCRIPTION
## Summary

Fixes repo avatars rendering blank instead of falling back to the name initials when a repository's icon file can't be displayed (e.g. an empty `favicon.ico` placeholder or an undecodable `.ico` file).

## What changed

**Backend (`helpers.rs`):**
- Added check to treat empty icon files as "no icon" to avoid creating invalid `data:` URIs that render as blank
- Added test coverage for the empty icon file scenario

**Frontend (`avatar.tsx`):**
- Replaced naive `onError`/`onLoad` handlers with proper `onLoadingStatusChange` tracking from Radix Avatar
- Radix's `Avatar.Image` never mounts the underlying `<img>` on error, so native `onError` never fires
- Now explicitly track the loading status and fall back to initials only when the status is `"error"`
- Added detailed comments explaining the fix

**Tests (`avatar.test.tsx`):**
- Added test that stubs `window.Image` to simulate broken icons and verifies the fallback renders
- Existing tests still pass and verify the fallback shows immediately when switching from an icon repo

**Misc (`row-item.tsx`, `workspace-hover-card.tsx`):**
- Fixed nullish coalescing operators (`??`) to logical OR (`||`) for consistency with repoInitials

## Test plan

- ✅ Frontend tests pass (new test for fallback behavior)
- ✅ Rust tests pass (new test for empty icon files)
- ✅ Manual testing: navigate to a workspace with a broken or empty icon file — the avatar should display initials instead of rendering blank
- ✅ Pre-commit hooks passed (biome, cargo clippy)