### PR TITLE
[codex] Add Helmor debug skills

### DIFF
--- a/.agents/skills/helmor-debug-loop/SKILL.md
+++ b/.agents/skills/helmor-debug-loop/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: helmor-debug-loop
+description: Autonomous local-development debugging loop for Helmor bugs. Use when the user asks an agent to reproduce, diagnose, instrument, fix, or verify a Helmor local dev build issue using repeated local UI simulation, temporary logging, Tauri MCP/towery MCP, screenshots, DOM/accessibility snapshots, IPC traces, console/system logs, terminal/run-script logs, or multi-attempt verification. This skill coordinates with $helmor-debug-operate for operating the running desktop app.
+---
+
+# Helmor Debug Loop
+
+Use this skill to drive a bounded reproduce -> instrument -> inspect -> fix -> verify loop for Helmor local-dev bugs. Always use `$helmor-debug-operate` for actual local app control through Tauri MCP; this skill owns the debugging strategy and evidence discipline.
+
+## Core Loop
+
+1. Define the suspected behavior, expected behavior, and success signal in one or two sentences.
+2. Reproduce through `$helmor-debug-operate` with real UI actions when possible. Start with screenshots, DOM/accessibility snapshots, IPC monitor, console/system logs, and terminal buffers.
+3. If evidence is insufficient, add the smallest temporary log or probe with a unique prefix such as `[debug-loop:<slug>]`, rerun the flow, then remove or justify the probe before finalizing.
+4. Analyze the evidence before editing product code. Prefer a narrow fix that explains the observed signal.
+5. Verify the fix with the same user path. For user-visible flows, require three consecutive successful runs unless the user explicitly lowers the bar.
+6. Produce an evidence pack under `.agent-contexts/<task-slug>/` with repro attempts, logs, screenshots, IPC, fix summary, and remaining uncertainty.
+
+## Fault Tolerance
+
+- If you cannot reproduce after three distinct attempts, do not invent a failure. Mark the state as `not reproduced`, preserve evidence, inspect code paths that should have fired, and report the most likely missing precondition.
+- If the bug is flaky, run at least three attempts and compare evidence. Treat intermittent pass/fail as a valid finding, not a failure of the loop.
+- If Tauri MCP cannot connect, use `$helmor-debug-operate` recovery steps. If the bridge remains unavailable, fall back to static code analysis and terminal tests, and label UI verification as blocked.
+- If a skill recipe fails three times, follow `$helmor-debug-operate` stale-skill rules: reason from fresh screenshots/DOM/code, record a candidate skill update, and ask before editing that skill unless the user explicitly requested it.
+- If adding logs risks exposing secrets, log shape/count/state only. Never print access tokens, credentials, API keys, cookies, or private account details.
+- If verification cannot be run safely because it would mutate durable user data, switch to a disposable workspace/session or stop and state the risk.
+
+## Evidence Sources
+
+Use the available signals in this order:
+
+- Terminal buffers: use `$helmor-debug-operate`'s **Call App Commands** helper to run `debug_list_terminal_buffers`, then `debug_read_terminal_buffer` with the returned raw `scriptType`.
+- UI state: screenshot plus accessibility or structure snapshot.
+- IPC: start monitor, perform one action, capture filtered commands/events, then stop monitor.
+- Logs: Tauri console/system logs, sidecar JSONL logs under the dev data dir when relevant.
+- Code probes: temporary logs with unique prefixes, guarded by debug context when possible.
+
+Read `references/debug-loop.md` when the task needs the full loop checklist or when reproduction fails. Use scripts in `scripts/` to summarize logs and build evidence packs instead of pasting raw dumps into the chat.

--- a/.agents/skills/helmor-debug-loop/agents/openai.yaml
+++ b/.agents/skills/helmor-debug-loop/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Helmor Debug Loop"
+  short_description: "Autonomous Helmor local-dev bug loop."
+  default_prompt: "Use $helmor-debug-loop to reproduce, instrument, inspect, fix, and verify a Helmor local-dev bug."

--- a/.agents/skills/helmor-debug-loop/references/debug-loop.md
+++ b/.agents/skills/helmor-debug-loop/references/debug-loop.md
@@ -1,0 +1,95 @@
+# Helmor Debug Loop Reference
+
+Use this reference after loading `SKILL.md` when a bug needs iterative local verification.
+
+## Attempt Structure
+
+Each attempt should record:
+
+- Attempt number and timestamp.
+- Preconditions: workspace, session, selected model/mode, run action, feature flags, relevant settings.
+- Exact user path driven through `$helmor-debug-operate`.
+- Evidence collected: screenshot path, DOM/snapshot file, IPC capture, console/system logs, terminal buffer ids, and code probes.
+- Result: `reproduced`, `not reproduced`, `flaky`, `fixed`, `blocked`, or `inconclusive`.
+
+Store attempt notes under `.agent-contexts/<task-slug>/attempts.md`.
+
+## Terminal Buffer Commands
+
+When the app has a debug build with the terminal buffer commands registered, use `$helmor-debug-operate`'s **Call App Commands** helper. Do not call the Tauri MCP `ipc_execute_command` tool for these app commands; the current bridge returns `Unsupported Tauri command`.
+
+```json
+{ "id": "list-buffers", "command": "debug_list_terminal_buffers", "payload": {} }
+```
+
+Pick the relevant item from the returned `repoId`, `workspaceId`, and `scriptType`, then read the tail:
+
+```json
+{
+  "id": "read-buffer",
+  "command": "debug_read_terminal_buffer",
+  "payload": {
+    "repoId": "REPO_ID",
+    "workspaceId": "WORKSPACE_ID_OR_NULL",
+    "scriptType": "RAW_SCRIPT_TYPE_FROM_LIST",
+    "maxBytes": 200000
+  }
+}
+```
+
+If the helper result says the command is unavailable, fall back to visible xterm screenshots/DOM and mark terminal-buffer evidence as unavailable. Do not block the whole loop on this one signal.
+
+## Reproduction Branches
+
+### Reproduced
+
+1. Freeze the smallest path that reproduces the bug.
+2. Add temporary probes only where the next unknown remains.
+3. Fix the code.
+4. Repeat the same path three times.
+
+### Not Reproduced
+
+After three distinct attempts:
+
+1. Record every precondition and attempt.
+2. Inspect the code path that should have handled the user flow.
+3. Identify missing preconditions, likely stale recipe, or environment drift.
+4. If a low-risk static fix is obvious, make it and verify with available tests; otherwise report `not reproduced` with next recommended probe.
+
+### Flaky
+
+Treat flaky behavior as a valid bug. Preserve a run table with pass/fail state and compare:
+
+- Logs immediately before divergence.
+- DOM state before the click/keypress.
+- IPC event ordering.
+- Terminal/run-script timing.
+
+Fix the race or state leak only after the divergence has a plausible mechanism.
+
+### Blocked
+
+Use `blocked` only when the loop cannot progress without user input or an external state change, such as missing credentials, no running debug build, destructive verification risk, or unavailable Tauri bridge after recovery attempts.
+
+## Temporary Logging Rules
+
+- Use a unique prefix: `[debug-loop:<short-slug>]`.
+- Log the smallest state needed: ids, booleans, counts, branch names, command names, elapsed times.
+- Avoid secrets and large objects.
+- Prefer existing structured logging in Rust/backend and `console.debug` in frontend only when it is removed before final.
+- Remove temporary logs before final unless they become intentional product diagnostics.
+
+## Evidence Pack Checklist
+
+Create `.agent-contexts/<task-slug>/evidence.md` with:
+
+- User request and expected behavior.
+- Reproduction attempts table.
+- Evidence links and summaries.
+- Root cause.
+- Fix summary.
+- Verification table with three pass rows or a clear exception.
+- Residual risk and unverified paths.
+
+Use `scripts/terminal_log_summary.py` for terminal text and `scripts/build_evidence_pack.py` to assemble a markdown pack.

--- a/.agents/skills/helmor-debug-loop/scripts/build_evidence_pack.py
+++ b/.agents/skills/helmor-debug-loop/scripts/build_evidence_pack.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Build a compact markdown evidence pack from local debugging artifacts."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+TEXT_EXTENSIONS = {
+    ".txt",
+    ".log",
+    ".json",
+    ".jsonl",
+    ".md",
+    ".html",
+    ".xml",
+    ".yaml",
+    ".yml",
+}
+
+
+def tail_text(path: Path, max_lines: int) -> str:
+    text = path.read_text(errors="replace")
+    lines = text.splitlines()
+    return "\n".join(lines[-max_lines:])
+
+
+def parse_artifact(value: str) -> tuple[str, Path]:
+    if "=" not in value:
+        path = Path(value)
+        return (path.stem or "artifact", path)
+    label, raw_path = value.split("=", 1)
+    return (label.strip() or "artifact", Path(raw_path))
+
+
+def render_artifact(label: str, path: Path, max_lines: int) -> str:
+    exists = path.exists()
+    out = [f"## {label}", "", f"- Path: `{path}`", f"- Exists: `{str(exists).lower()}`"]
+    if not exists:
+        return "\n".join(out) + "\n"
+
+    if path.suffix.lower() in TEXT_EXTENSIONS:
+        out.extend(["", "```text", tail_text(path, max_lines), "```"])
+    else:
+        out.extend(["", f"![{label}]({path})"])
+    return "\n".join(out) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", required=True, help="Markdown output path.")
+    parser.add_argument("--title", default="Helmor Debug Evidence")
+    parser.add_argument("--status", default="inconclusive")
+    parser.add_argument("--summary", default="")
+    parser.add_argument(
+        "--artifact",
+        action="append",
+        default=[],
+        help="Artifact as label=path, repeatable. Text files are tailed; images are linked.",
+    )
+    parser.add_argument("--max-lines", type=int, default=200)
+    args = parser.parse_args()
+
+    parts = [
+        f"# {args.title}",
+        "",
+        f"- Status: `{args.status}`",
+    ]
+    if args.summary:
+        parts.extend(["", args.summary])
+
+    for value in args.artifact:
+        label, path = parse_artifact(value)
+        parts.extend(["", render_artifact(label, path, max(0, args.max_lines)).rstrip()])
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text("\n".join(parts).rstrip() + "\n")
+    print(out_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/helmor-debug-loop/scripts/terminal_log_summary.py
+++ b/.agents/skills/helmor-debug-loop/scripts/terminal_log_summary.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Summarize Helmor terminal/run-script logs for debugging evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+ANSI_RE = re.compile(r"\x1b(?:\[[0-9;?=<>]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\)|[@-Z\\-_])")
+URL_RE = re.compile(r"https?://(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\]|::1|[^\s'\"<>]+)[^\s'\"<>]*")
+ERROR_RE = re.compile(
+    r"\b(error|exception|panic|failed|failure|traceback|unhandled|cannot|could not|enoent|eaddrinuse)\b",
+    re.IGNORECASE,
+)
+WARNING_RE = re.compile(r"\b(warn|warning|deprecated)\b", re.IGNORECASE)
+
+
+def read_text(path: str | None) -> str:
+    if path:
+        return Path(path).read_text(errors="replace")
+    return sys.stdin.read()
+
+
+def strip_ansi(text: str) -> str:
+    return ANSI_RE.sub("", text)
+
+
+def unique(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        out.append(value)
+    return out
+
+
+def summarize(text: str, tail_lines: int) -> dict[str, object]:
+    clean = strip_ansi(text).replace("\r\n", "\n").replace("\r", "\n")
+    lines = clean.splitlines()
+    error_lines = [line for line in lines if ERROR_RE.search(line)]
+    warning_lines = [line for line in lines if WARNING_RE.search(line)]
+    urls = unique(URL_RE.findall(clean))
+    return {
+        "bytes": len(text.encode()),
+        "cleanBytes": len(clean.encode()),
+        "lineCount": len(lines),
+        "urls": urls[:20],
+        "errorCount": len(error_lines),
+        "warningCount": len(warning_lines),
+        "errors": error_lines[-20:],
+        "warnings": warning_lines[-20:],
+        "tail": lines[-tail_lines:],
+    }
+
+
+def print_markdown(summary: dict[str, object]) -> None:
+    print("# Terminal Log Summary\n")
+    print(f"- Bytes: {summary['bytes']}")
+    print(f"- Clean bytes: {summary['cleanBytes']}")
+    print(f"- Lines: {summary['lineCount']}")
+    print(f"- Errors: {summary['errorCount']}")
+    print(f"- Warnings: {summary['warningCount']}")
+
+    urls = summary["urls"]
+    if urls:
+        print("\n## URLs")
+        for url in urls:
+            print(f"- `{url}`")
+
+    errors = summary["errors"]
+    if errors:
+        print("\n## Recent Error Lines")
+        for line in errors:
+            print(f"- `{line[:500]}`")
+
+    warnings = summary["warnings"]
+    if warnings:
+        print("\n## Recent Warning Lines")
+        for line in warnings:
+            print(f"- `{line[:500]}`")
+
+    print("\n## Tail")
+    print("```text")
+    for line in summary["tail"]:
+        print(line)
+    print("```")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", nargs="?", help="Log file path. Reads stdin when omitted.")
+    parser.add_argument("--tail-lines", type=int, default=120)
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of markdown.")
+    args = parser.parse_args()
+
+    summary = summarize(read_text(args.path), max(0, args.tail_lines))
+    if args.json:
+        print(json.dumps(summary, ensure_ascii=False, indent=2))
+    else:
+        print_markdown(summary)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/helmor-debug-operate/SKILL.md
+++ b/.agents/skills/helmor-debug-operate/SKILL.md
@@ -1,0 +1,484 @@
+---
+name: helmor-debug-operate
+description: Operate, reproduce, and debug a running local Helmor desktop development build through the Tauri MCP bridge. Use when the user asks to use Tauri MCP, towery MCP, the local dev build, the Tauri webview, visual end-to-end validation, UI automation, screenshots, DOM/accessibility snapshots, IPC or log tracing, terminal/run-script buffer inspection, switching workspaces or sessions, creating/renaming/closing sessions, typing or sending composer prompts, inspecting styles/logs, or reproducing Helmor desktop behavior as a user would.
+---
+
+# Helmor Debug Operate
+
+Use this skill to operate and debug a running Helmor dev build through Tauri MCP with the least possible exploration. It is the visual/runtime counterpart to `helmor-cli`: prefer Tauri MCP for webview UI, screenshots, CSS, accessibility, and IPC tracing; prefer `helmor-cli` for terminal-first data inspection or workspace orchestration.
+
+Examples below use bare tool names such as `driver_session`; call the same tool through whatever namespace the runtime exposes.
+
+## References
+
+Read these only when needed:
+
+- `references/verified-recipes.md` for action-specific recipes that have passed three consecutive Tauri MCP verification attempts.
+- `references/ui-map.md` for selectors, Settings panels, Inspector/Editor preconditions, and destructive-action boundaries.
+
+## Ground Rules
+
+- Treat every action as real user input against the active app. Do not send prompts, close sessions, archive/delete workspaces, stop streams, or mutate settings unless the user asked for that outcome or it is necessary for the verification.
+- Use the Tauri MCP bridge only for Helmor desktop debugging. Do not switch to Chrome DevTools, Browser, Playwright, or `/agent-browser` unless the user explicitly asks for another surface.
+- Require a debug Tauri build. The bridge is absent in release builds. If connection fails, ask the user to run `bun run dev` or call `get_setup_instructions` only when bridge setup itself is suspect.
+- Default to `port: 9223` and `windowId: "main"`.
+- Re-run `webview_dom_snapshot` after every meaningful UI change. `ref=eN` handles are per-snapshot and expire after DOM changes.
+- Prefer accessibility snapshots for finding controls, but fall back to structure snapshots and read-only DOM rect inspection when accessibility support is unavailable.
+- Prefer UI operations for end-to-end validation. Do not use the Tauri MCP tool `ipc_execute_command` for Helmor app commands such as `list_workspace_groups`, `reveal_workspace_in_main_window`, or `debug_list_terminal_buffers`: the current bridge returns `Unsupported Tauri command` because dynamic app-command execution is not implemented there. Use the verified app-command helper in **Call App Commands** instead.
+- Do not use `webview_execute_js` to dispatch synthetic user events. Use it only for read-only, JSON-serializable inspection when MCP tools cannot answer the question.
+- Exception: Helmor's composer is a Lexical `contenteditable`, not a native input. If `webview_keyboard type` fails with the current bridge, `document.execCommand("insertText", false, text)` after real MCP focus/click is the last-resort smoke-test input path. Label it as a fallback and verify visible state afterward.
+- If you start `ipc_monitor`, always stop it before finishing, even if the task fails.
+- Save screenshots or scratch logs under `.agent-contexts/<task-slug>/` when working inside this repository.
+- If a Settings dialog appears stuck visible with `data-state="closed"`, press `Cmd+,` to reopen it, then `Escape` to close. Verify `document.querySelectorAll('[role="dialog"]').length === 0` and `main[aria-hidden]` is absent.
+- If `webview_execute_js` or console log reads start timing out while screenshots and `driver_session status` still work, restart only the MCP driver session (`driver_session stop appIdentifier=9223`, then `driver_session start port=9223`). Do not restart the Helmor dev build unless the bridge cannot reconnect.
+- If you launch a disposable app with `HELMOR_DATA_DIR` for validation, create both the data dir and its `run/` subdir first. Missing `run/` can make the UI sync socket fail to bind, leaving backend mutations invisible until you force a reveal or restart.
+- Treat this skill as an operation hint, not an authoritative source of truth. The local UI can drift ahead of these recipes. If a recipe fails three times, stop repeating it mechanically: take a fresh screenshot/snapshot, reason from the visible UI, and inspect the relevant code if needed.
+- Keep this skill self-improving by proposal, not silent mutation. When you discover a better path, missing pitfall, stale selector, or unverified workaround, record a candidate update under `.agent-contexts/<task-slug>/skill-update-candidates.md` with the scenario, failing attempts, evidence, proposed recipe, and verification status. Ask the user before editing this skill unless the current user request explicitly asks you to update it.
+
+## Connect
+
+1. Check the bridge:
+
+```json
+driver_session { "action": "status", "port": 9223 }
+```
+
+2. Start only when not connected:
+
+```json
+driver_session { "action": "start", "port": 9223 }
+```
+
+3. Sanity-check the target:
+
+```json
+ipc_get_backend_state {}
+manage_window { "action": "list" }
+```
+
+Expect `app.identifier` to be `ai.helmor.desktop`, `app.name` to be `Helmor`, `environment.debug` to be `true`, and a visible `main` window. If multiple apps are connected, pass the returned port or bundle id as `appIdentifier` on later calls.
+
+## Baseline Snapshot
+
+Start every UI task with both a visual and semantic read:
+
+```json
+webview_screenshot { "windowId": "main", "format": "png" }
+webview_dom_snapshot { "windowId": "main", "type": "accessibility" }
+```
+
+If accessibility fails with `aria-api library not loaded`, immediately use:
+
+```json
+webview_dom_snapshot { "windowId": "main", "type": "structure" }
+```
+
+Avoid taking screenshots with `maxWidth` when you need click coordinates. A scaled screenshot changes the coordinate space; direct `webview_interact { "x": ..., "y": ... }` expects the webview's real coordinates from `getBoundingClientRect()` or `manage_window info`.
+
+Use this stable mental map:
+
+- Shell: `Application shell`, `Workspace sidebar`, `Workspace panel`, `Workspace viewport`.
+- Sidebar buttons: `Workspace location`, `Filter and sort sidebar`, `Add repository`, `New workspace`, `Collapse left sidebar`.
+- Workspace rows: role `button` with the displayed workspace title. Nested actions include `Archive workspace`, `Confirm archive workspace`, and `Delete permanently`.
+- Session header: tablist `Sessions`; tabs are named by session title, often `Untitled`; buttons include `New session` and `Session history`.
+- Session tab actions: `Rename session` and `Close session` appear in the accessibility tree when visible. If not targetable, use the keyboard or the **Call App Commands** helper recipes below.
+- Hidden session history: `Session history` opens rows with `Restore session` and `Delete session permanently`.
+- Composer: `Workspace composer`, textbox `Workspace input`, placeholder `Ask to make changes, @mention files, run /commands`.
+- Composer controls: model selector, `Fast mode`, `Carry room context`, effort dropdown such as `High`, `Plan mode`, `Terminal mode`, `Add context`, `Context usage`, and trailing `Send`, `Stop`, `Steer`, `Request Changes`, or `Implement`.
+
+## Selector Repair And Coordinate Targeting
+
+Some bridge versions inject `window.__MCP__` but omit helper functions used by selector-based tools. If `webview_dom_snapshot`, `webview_find_element`, `webview_interact selector=...`, or `webview_keyboard type selector=...` fails with `window.__MCP__.resolveAll is not a function` or `window.__MCP__.resolveRef is not a function`, install this compatibility shim once per page load:
+
+```json
+webview_execute_js {
+  "windowId": "main",
+  "script": "(() => {\n  if (!window.__MCP__) window.__MCP__ = {};\n  if (!window.__MCP__.refs) window.__MCP__.refs = new Map();\n  if (!window.__MCP__.reverseRefs) window.__MCP__.reverseRefs = new Map();\n  const all = (selector, strategy = 'css') => {\n    if (!selector) return [];\n    if (String(selector).startsWith('ref=')) {\n      const el = window.__MCP__.refs.get(String(selector).slice(4));\n      return el ? [el] : [];\n    }\n    if (strategy === 'xpath') {\n      const result = document.evaluate(selector, document, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);\n      return Array.from({ length: result.snapshotLength }, (_, i) => result.snapshotItem(i)).filter(Boolean);\n    }\n    if (strategy === 'text') {\n      const needle = String(selector).trim();\n      return Array.from(document.querySelectorAll('button,[role=\"button\"],[role=\"tab\"],input,textarea,[contenteditable=\"true\"],[role=\"textbox\"],a,[aria-label],[title]')).filter((el) => {\n        const text = (el.textContent || '').trim();\n        return text === needle || text.includes(needle) || el.getAttribute('aria-label') === needle || el.getAttribute('title') === needle || el.getAttribute('placeholder') === needle;\n      });\n    }\n    return Array.from(document.querySelectorAll(selector));\n  };\n  window.__MCP__.resolveAll = (selector, strategy = 'css') => all(selector, strategy);\n  window.__MCP__.resolveRef = (selector, strategy = 'css') => all(selector, strategy)[0] || null;\n  window.__MCP__.countAll = (selector, strategy = 'css') => all(selector, strategy).length;\n  return { installed: true, hasResolveAll: typeof window.__MCP__.resolveAll };\n})()"
+}
+```
+
+Even with selector repair, coordinate targeting is often the fastest reliable path:
+
+```json
+webview_execute_js {
+  "windowId": "main",
+  "script": "(() => Array.from(document.querySelectorAll('button,[role=\"button\"],[role=\"tab\"],[role=\"textbox\"]')).map((el) => { const r = el.getBoundingClientRect(); return { text: (el.textContent || '').trim(), ariaLabel: el.getAttribute('aria-label'), role: el.getAttribute('role'), selected: el.getAttribute('aria-selected'), x: r.x, y: r.y, width: r.width, height: r.height, disabled: !!el.disabled }; }))()"
+}
+```
+
+Click the center of the returned rect:
+
+```json
+webview_interact { "action": "click", "windowId": "main", "x": 1254, "y": 52 }
+```
+
+For Radix dropdown/menu triggers, direct click is sometimes ignored even when the selector resolves. Prefer:
+
+```json
+webview_interact { "action": "focus", "selector": "BUTTON_OR_TEXT", "strategy": "text", "windowId": "main" }
+webview_keyboard { "action": "press", "key": "Enter", "windowId": "main" }
+```
+
+For model/effort menu triggers, `ArrowDown` was more reliable than `Enter`:
+
+```json
+webview_keyboard { "action": "press", "key": "ArrowDown", "windowId": "main" }
+```
+
+## Call App Commands
+
+The MCP bridge's `ipc_execute_command` tool currently cannot invoke Helmor's ordinary Tauri commands. Use this click-triggered low-level IPC helper whenever you need a deterministic backend command. It was verified against a fresh debug build on port `9224` for repository/workspace setup, `debug_list_terminal_buffers`, `debug_read_terminal_buffer`, and terminal stdin writes.
+
+Install the helper once per page load:
+
+```json
+webview_execute_js {
+  "windowId": "main",
+  "script": "(() => {\n  window.__helmorDebugResults = window.__helmorDebugResults || {};\n  let btn = document.getElementById('__helmor_debug_ipc_runner');\n  if (!btn) {\n    btn = document.createElement('button');\n    btn.id = '__helmor_debug_ipc_runner';\n    btn.textContent = 'ipc runner';\n    btn.style.position = 'fixed';\n    btn.style.left = '4px';\n    btn.style.top = '244px';\n    btn.style.zIndex = '2147483647';\n    btn.style.width = '120px';\n    btn.style.height = '32px';\n    document.body.appendChild(btn);\n  }\n  btn.onclick = () => {\n    const request = window.__helmorDebugRequest;\n    if (!request) return;\n    const id = request.id || `${Date.now()}-${Math.random()}`;\n    window.__helmorDebugResults[id] = { pending: true, command: request.command };\n    const callback = window.__TAURI_INTERNALS__.transformCallback((value) => {\n      window.__helmorDebugResults[id] = { ok: true, command: request.command, value };\n    }, true);\n    const error = window.__TAURI_INTERNALS__.transformCallback((err) => {\n      window.__helmorDebugResults[id] = { ok: false, command: request.command, error: String(err) };\n    }, true);\n    window.__TAURI_INTERNALS__.ipc({ cmd: request.command, callback, error, payload: request.payload || {} });\n  };\n  const r = btn.getBoundingClientRect();\n  return { installed: true, x: r.x + r.width / 2, y: r.y + r.height / 2 };\n})()"
+}
+```
+
+Run a command by setting `window.__helmorDebugRequest`, clicking the helper button center returned above, then polling the result:
+
+```json
+webview_execute_js {
+  "windowId": "main",
+  "script": "(() => { window.__helmorDebugRequest = { id: 'list-buffers', command: 'debug_list_terminal_buffers', payload: {} }; return window.__helmorDebugRequest; })()"
+}
+webview_interact { "action": "click", "windowId": "main", "x": 64, "y": 260 }
+webview_execute_js {
+  "windowId": "main",
+  "script": "(() => window.__helmorDebugResults?.['list-buffers'] || null)()"
+}
+```
+
+Important constraints:
+
+- Never call `window.__TAURI_INTERNALS__.invoke(...)` or `window.__TAURI_INTERNALS__.ipc(...)` directly from the same `webview_execute_js` stack; it can time out.
+- Do not inject Promise chains in handlers for this bridge path; use `transformCallback` callback ids as shown.
+- Keep the helper only for debug sessions. It mutates the visible DOM by adding a small fixed button; remove or ignore it before taking polished UI screenshots.
+- Use the returned raw `scriptType` when reading buffers. Run actions can appear as values such as `run:run:<id>` because action ids may already include a `run:` prefix.
+
+## Workspace Operations
+
+### Switch By UI
+
+1. Snapshot accessibility, or structure if accessibility is unavailable.
+2. Prefer selector/text click only if selector repair is working and the name is unique:
+
+```json
+webview_interact { "action": "click", "selector": "My Workspace", "strategy": "text", "windowId": "main" }
+```
+
+3. If selector click fails, list workspace row rects and click the target row center:
+
+```json
+webview_execute_js {
+  "windowId": "main",
+  "script": "(() => Array.from(document.querySelectorAll('[role=\"button\"],button')).filter((el) => (el.textContent || '').trim()).map((el) => { const r = el.getBoundingClientRect(); return { text: (el.textContent || '').trim(), className: String(el.className || ''), x: r.x, y: r.y, width: r.width, height: r.height }; }).filter((row) => row.className.includes('workspace-row') || row.text === 'TARGET_WORKSPACE'))()"
+}
+```
+
+4. Verify the workspace row has `workspace-row-selected`, the panel header/title changed, and the visible session tabs belong to the target workspace.
+
+### Switch Deterministically
+
+Use this when duplicate workspace names make text selection ambiguous. Install **Call App Commands** first, then run helper requests:
+
+```json
+{ "id": "list-workspace-groups", "command": "list_workspace_groups", "payload": {} }
+{ "id": "reveal-workspace", "command": "reveal_workspace_in_main_window", "payload": { "workspaceId": "WORKSPACE_ID", "sessionId": null } }
+```
+
+Then re-snapshot and verify the visible UI. For details on one workspace:
+
+```json
+{ "id": "get-workspace", "command": "get_workspace", "payload": { "workspaceId": "WORKSPACE_ID" } }
+```
+
+### Archive Or Restore
+
+Archive is destructive enough to require explicit user intent. If asked to test it as UI:
+
+1. Click `Archive workspace` on the target row.
+2. Click `Confirm archive workspace`.
+3. Verify the row leaves active groups or appears under `Archived`.
+
+For setup/cleanup only, prefer helper commands after confirming intent:
+
+```json
+{ "id": "validate-archive", "command": "validate_archive_workspace", "payload": { "workspaceId": "WORKSPACE_ID" } }
+{ "id": "start-archive", "command": "start_archive_workspace", "payload": { "workspaceId": "WORKSPACE_ID" } }
+{ "id": "restore-workspace", "command": "restore_workspace", "payload": { "workspaceId": "WORKSPACE_ID", "targetBranchOverride": null } }
+```
+
+## Session Operations
+
+### List And Select
+
+Read sessions for the current or target workspace:
+
+```json
+{ "id": "list-sessions", "command": "list_workspace_sessions", "payload": { "workspaceId": "WORKSPACE_ID" } }
+```
+
+Select a visible tab by clicking its snapshot `ref=eN`, or use a deterministic reveal:
+
+```json
+{ "id": "reveal-session", "command": "reveal_workspace_in_main_window", "payload": { "workspaceId": "WORKSPACE_ID", "sessionId": "SESSION_ID" } }
+```
+
+Re-snapshot and confirm the selected tab and message thread.
+
+### Create
+
+UI path:
+
+```json
+webview_interact { "action": "click", "selector": "New session", "strategy": "text", "windowId": "main" }
+```
+
+Coordinate-safe UI path when selectors are broken:
+
+```json
+webview_execute_js {
+  "windowId": "main",
+  "script": "(() => { const el = document.querySelector('button[aria-label=\"New session\"]'); if (!el) return null; const r = el.getBoundingClientRect(); return { x: r.x, y: r.y, width: r.width, height: r.height, disabled: !!el.disabled }; })()"
+}
+webview_interact { "action": "click", "windowId": "main", "x": 1254, "y": 52 }
+```
+
+Backend helper path:
+
+```json
+{ "id": "create-session", "command": "create_session", "payload": { "workspaceId": "WORKSPACE_ID" } }
+```
+
+If using helper creation, reveal the returned session id, then verify the new tab:
+
+```json
+{ "id": "reveal-new-session", "command": "reveal_workspace_in_main_window", "payload": { "workspaceId": "WORKSPACE_ID", "sessionId": "NEW_SESSION_ID" } }
+```
+
+For terminal sessions:
+
+```json
+{ "id": "create-terminal-session", "command": "create_session", "payload": { "workspaceId": "WORKSPACE_ID", "sessionKind": "terminal", "agentType": "claude" } }
+```
+
+### Rename
+
+The most reliable non-UI path is the helper, followed by UI verification:
+
+```json
+{ "id": "rename-session", "command": "rename_session", "payload": { "sessionId": "SESSION_ID", "title": "New title" } }
+```
+
+Re-snapshot and verify the tab/history label. Use UI rename only when `Rename session` is visible and targetable in the latest snapshot.
+
+### Close, Hide, Restore, Delete
+
+Close the selected visible session like a user:
+
+```json
+webview_keyboard { "action": "press", "key": "w", "modifiers": ["Meta"], "windowId": "main" }
+```
+
+If the session is running, expect a `Close running chat?` dialog. Click `Close anyway` only when cancellation is intended.
+
+Backend equivalents:
+
+```json
+{ "id": "hide-session", "command": "hide_session", "payload": { "sessionId": "SESSION_ID" } }
+{ "id": "unhide-session", "command": "unhide_session", "payload": { "sessionId": "SESSION_ID" } }
+{ "id": "delete-session", "command": "delete_session", "payload": { "sessionId": "SESSION_ID" } }
+```
+
+`hide_session` is the normal recoverable close for non-empty sessions. `delete_session` is permanent and should normally be limited to empty sessions or hidden-session cleanup explicitly requested by the user.
+
+## Composer Operations
+
+### Type Without Sending
+
+1. Select the target workspace and session first.
+2. Get the composer rect and click it:
+
+```json
+webview_execute_js {
+  "windowId": "main",
+  "script": "(() => { const el = document.querySelector('#workspace-input'); if (!el) return null; const r = el.getBoundingClientRect(); return { x: r.x, y: r.y, width: r.width, height: r.height, text: el.textContent || '' }; })()"
+}
+webview_interact { "action": "click", "windowId": "main", "x": 340, "y": 850 }
+```
+
+3. Try the native MCP typing path only if the bridge supports `contenteditable` targets:
+
+```json
+webview_interact { "action": "focus", "selector": "Workspace input", "strategy": "text", "windowId": "main" }
+webview_keyboard { "action": "type", "selector": "Workspace input", "strategy": "text", "text": "Prompt text here", "windowId": "main" }
+```
+
+In the known Helmor bridge state, this can fail with `The HTMLInputElement.value setter can only be used on instances of HTMLInputElement`. For a short smoke test, use the fallback:
+
+```json
+webview_execute_js {
+  "windowId": "main",
+  "script": "(() => { const el = document.querySelector('#workspace-input'); if (!el) return { ok: false }; el.focus(); const ok = document.execCommand('insertText', false, 'Prompt text here'); const send = document.querySelector('button[aria-label=\"Send\"]'); return { ok, text: el.textContent || '', sendDisabled: send ? !!send.disabled : null }; })()"
+}
+```
+
+4. Verify the text is present and `Send` is enabled:
+
+```json
+webview_execute_js {
+  "windowId": "main",
+  "script": "(() => { const input = document.querySelector('#workspace-input'); const send = document.querySelector('button[aria-label=\"Send\"]'); return { text: input ? input.textContent : null, sendDisabled: send ? !!send.disabled : null }; })()"
+}
+```
+
+### Send A Prompt
+
+Only send when the user supplied the exact target and message, or the task explicitly requires sending.
+
+1. Optional but recommended: start IPC monitor.
+
+```json
+ipc_monitor { "action": "start" }
+```
+
+2. Focus/type as above.
+3. Click `Send`. Prefer the rect center when selectors are unreliable:
+
+```json
+webview_interact { "action": "click", "selector": "Send", "strategy": "text", "windowId": "main" }
+```
+
+or:
+
+```json
+webview_execute_js {
+  "windowId": "main",
+  "script": "(() => { const el = document.querySelector('button[aria-label=\"Send\"]'); if (!el) return null; const r = el.getBoundingClientRect(); return { x: r.x, y: r.y, width: r.width, height: r.height, disabled: !!el.disabled }; })()"
+}
+webview_interact { "action": "click", "windowId": "main", "x": 1267, "y": 916 }
+```
+
+4. Verify the UI changed: the composer clears, the user message appears in the thread, `Send` may become `Stop`, and `list_active_streams` may include the session if helper command access is available:
+
+```json
+{ "id": "list-active-streams", "command": "list_active_streams", "payload": {} }
+ipc_get_captured { "filter": "send_agent_message_stream" }
+ipc_monitor { "action": "stop" }
+```
+
+If `ipc_get_captured` returns `[]` despite the UI changing, treat it as an IPC monitor limitation in that bridge session and use visible UI evidence plus logs instead.
+
+Do not call `send_agent_message_stream` directly through `ipc_execute_command`; the real frontend call uses an IPC `Channel` callback that the generic MCP command runner cannot provide safely.
+
+### Proven Smoke Test Recipe
+
+Use this when the user asks whether the local dev build can be controlled end-to-end:
+
+1. Connect and sanity-check: `driver_session status`, `ipc_get_backend_state`, `manage_window info`.
+2. Snapshot. If accessibility fails, use structure plus read-only rect inspection.
+3. Switch workspace by row rect center; verify `workspace-row-selected` and the panel title.
+4. Click `button[aria-label="New session"]` by rect center; verify a selected `Untitled` tab.
+5. Click `#workspace-input`, insert a short test prompt using the best available input path, verify `Send` is enabled.
+6. Start `ipc_monitor`, click Send by rect center, verify the composer clears and the user message appears, then stop `ipc_monitor`.
+7. Save a screenshot under `.agent-contexts/<task-slug>/` if the result matters.
+
+### Stop Or Steer
+
+To stop the selected active turn through the UI:
+
+```json
+webview_interact { "action": "click", "selector": "Stop", "strategy": "text", "windowId": "main" }
+```
+
+To stop deterministically:
+
+```json
+{ "id": "stop-agent-stream", "command": "stop_agent_stream", "payload": { "request": { "sessionId": "SESSION_ID", "provider": null } } }
+```
+
+To steer an active turn, type additional content while `Stop` is visible, then click `Steer`. If using the helper:
+
+```json
+{ "id": "steer-agent-stream", "command": "steer_agent_stream", "payload": { "request": { "sessionId": "SESSION_ID", "provider": "claude", "prompt": "Additional instruction", "files": [], "images": [] } } }
+```
+
+## Inspection And Debugging
+
+- Screenshot visible UI:
+
+```json
+webview_screenshot { "windowId": "main", "format": "png", "filePath": ".agent-contexts/TASK/shot.png" }
+```
+
+- Accessibility snapshot for controls:
+
+```json
+webview_dom_snapshot { "windowId": "main", "type": "accessibility" }
+```
+
+- DOM structure snapshot for selectors/classes:
+
+```json
+webview_dom_snapshot { "windowId": "main", "type": "structure", "selector": ".some-css-selector" }
+```
+
+- Styles:
+
+```json
+webview_get_styles { "windowId": "main", "selector": "Workspace input", "strategy": "text", "properties": ["display", "color", "background-color", "font-size"] }
+```
+
+- Console/system logs:
+
+```json
+read_logs { "source": "console", "windowId": "main", "lines": 100 }
+read_logs { "source": "system", "filter": "helmor", "lines": 200 }
+```
+
+- Terminal/run-script buffers:
+
+```json
+/* Use Call App Commands helper */
+{ "id": "list-buffers", "command": "debug_list_terminal_buffers", "payload": {} }
+```
+
+Read the relevant buffer by using the returned `repoId`, `workspaceId`, and raw `scriptType` such as `setup`, `run:<actionId>`, `run:run:<actionId>`, or `terminal:<instanceId>`:
+
+```json
+/* Use Call App Commands helper */
+{
+  "id": "read-buffer",
+  "command": "debug_read_terminal_buffer",
+  "payload": {
+    "repoId": "REPO_ID",
+    "workspaceId": "WORKSPACE_ID_OR_NULL",
+    "scriptType": "RAW_SCRIPT_TYPE_FROM_LIST",
+    "maxBytes": 200000
+  }
+}
+```
+
+If the helper result is an error saying the command is unknown, the connected build predates the debug buffer feature. Fall back to visible xterm evidence, screenshots, and system logs; do not pretend full terminal history was inspected.
+
+- IPC tracing:
+
+```json
+ipc_monitor { "action": "start" }
+/* perform the UI action */
+ipc_get_captured { "filter": "COMMAND_NAME" }
+ipc_monitor { "action": "stop" }
+```
+
+## Verification Pattern
+
+End every Tauri MCP task with evidence:
+
+1. State the target app from `ipc_get_backend_state`.
+2. State the user flow performed.
+3. State the verification signal: visible text/control from accessibility snapshot, screenshot path, IPC command captured, backend command result, or logs.
+4. If anything was not verified, say exactly what is missing.

--- a/.agents/skills/helmor-debug-operate/agents/openai.yaml
+++ b/.agents/skills/helmor-debug-operate/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Helmor Debug Operations"
+  short_description: "Operate and debug Helmor dev builds through Tauri MCP."
+  default_prompt: "Use $helmor-debug-operate to operate the local Helmor dev build through Tauri MCP and verify the UI flow."

--- a/.agents/skills/helmor-debug-operate/references/ui-map.md
+++ b/.agents/skills/helmor-debug-operate/references/ui-map.md
@@ -1,0 +1,263 @@
+# Helmor UI Map For Tauri MCP
+
+Use this map to decide which recipe or selector to use. It is not a substitute for live verification; always re-snapshot or inspect DOM state after each action.
+
+## Shell
+
+- Application shell: `[aria-label="Application shell"]`
+- Workspace sidebar: `[aria-label="Workspace sidebar"]`, `[data-helmor-sidebar-root]`, `[data-shell-pane="sidebar"]`
+- Workspace panel: `[aria-label="Workspace panel"]`
+- Workspace viewport: `[aria-label="Workspace viewport"]`
+- Workspace header: `[aria-label="Workspace header"]`
+- Left resize handle: `[aria-label="Resize sidebar"]`, `role="separator"`
+- Right inspector sidebar: `[aria-label="Inspector sidebar"]`, `[data-shell-pane="inspector"]`
+- Right resize handle: `[aria-label="Resize inspector sidebar"]`
+
+## Sidebar And Workspaces
+
+- Top buttons:
+  - `Workspace location`
+  - `Filter and sort sidebar`
+  - `Add repository`
+  - `New workspace`
+  - `Collapse left sidebar`
+- Workspace rows:
+  - Prefer `[data-workspace-row-id]` when available.
+  - Fallback: row `role="button"` with `workspace-row` classes and matching text/aria-label.
+  - Selected row class: `.workspace-row-selected`
+- Row actions:
+  - `Archive workspace`
+  - `Restore workspace`
+  - `Delete permanently`
+  - Context-menu actions in code include `Pin/Unpin`, `Set status`, `Mark as unread`, `Open in Finder`, and `Move into a new worktree`.
+- Group headings observed:
+  - `Chats`
+  - `Done`
+  - `In review`
+  - `In progress`
+  - `Backlog`
+  - `Canceled`
+  - `Archived`
+  - Group headers are safe to collapse/expand; click the header rect, then verify child row visibility.
+
+## Header And Sessions
+
+- Session tabs: `[role="tablist"][aria-label="Sessions"]`, `[role="tab"]`
+- Session tab actions:
+  - `Rename session`
+  - `Close session`
+- Header buttons:
+  - `New session`
+  - `Session history`
+- Hidden session history can show:
+  - `No hidden sessions`
+  - `Restore session`
+  - `Delete session permanently`
+- Non-chat workspaces may show workspace header actions:
+  - `Open in <editor>`
+  - Open-in dropdown trigger near `Open in Warp` (`button[data-slot="dropdown-menu-trigger"][data-size="xs"]`) with `Finder`, `Cursor`, `VS Code`, `Xcode`, `Terminal`, `Warp`
+  - `More workspace actions`
+  - `Expand right sidebar` / `Collapse right sidebar`
+  - Right sidebar state is best verified by the button label plus `[aria-label="Inspector sidebar"]` `aria-hidden`, not only by raw DOM width.
+  - `Create PR options` opens `Create draft PR` / `Create PR manually`; opening is safe, selecting is a real PR action.
+
+## Composer
+
+- Composer: `[aria-label="Workspace composer"]`
+- Input: `#workspace-input`, `[aria-label="Workspace input"]`, `role="textbox"`
+- Model menu: Radix dropdown trigger whose text includes the current model, for example `ClaudeOpus 4.8 1M`
+- Controls:
+  - `Fast mode`
+  - `Carry room context`
+  - Effort menu text such as `high`
+  - `Plan mode`
+  - `Terminal mode` when enabled
+  - `Add context`
+  - `Context usage`
+  - `Usage Stats` when enabled
+  - Terminal mode enabled class includes `text-emerald-500`; disabled class includes `text-muted-foreground/70`.
+  - `Add context` toggles the right inspector between normal Git and `Contexts` mode in repo-backed workspaces.
+  - `Context usage` and `Usage Stats` may require hover or another precondition; click/long-press did not open stable pickers in observed states.
+- Submit states:
+  - `Send`
+  - `Stop`
+  - `Steer`
+  - `Request Changes`
+  - `Implement`
+- Start surface can show:
+  - `What should we work on?`
+  - `New Workspace`
+  - `Start options`
+  - `Just chat`
+  - `Save for later`
+  - `Start now`
+
+## Settings
+
+Open from the first bottom-left sidebar icon or `Cmd+,`.
+
+Sections observed:
+
+- General:
+  - `Desktop Notifications`
+  - `Notification sound`
+  - `Expand terminals on hover`
+  - `Terminal Mode`
+  - `Always show context usage`
+  - `Usage Stats`
+  - `Auto-archive on merge`
+  - `Follow-up behavior`
+  - `Queue`
+  - `Steer`
+  - `Claude Code Thinking Display`
+  - `Clean up archived workspaces`
+  - `App Updates`
+  - `Helmor Components`
+- Appearance:
+  - `Theme`
+  - `Color Theme`
+  - `Chat font size`
+  - `UI font`
+  - `Code font`
+  - `Terminal font`
+  - `Use pointer cursors`
+- Models:
+  - `Default model`
+  - `Review model`
+  - `Action model`
+- Providers:
+  - `OpenCode`
+  - `MiMo Code`
+  - `Claude Code`
+  - `Codex`
+  - `Kimi`
+  - `Cursor`
+  - `Proxy`
+  - Provider actions include `Log in`, `Sync models`, `Fetch models`, `Add provider`, `Get your API key`
+- Shortcuts:
+  - Full shortcut table including navigation, session, workspace, actions, system, composer, start surface, editor, and terminal.
+  - Shortcut buttons begin keybinding edit flow. Do not click them unless the user wants to edit keybindings.
+- Accounts:
+  - Connected forge accounts synced from local `gh` / `glab`.
+  - Do not copy account names or emails into skill output.
+- Team:
+  - `Join with invite link`
+  - `Team mode`
+  - `Worker URL`
+  - `Access token`
+  - `Test connection`
+  - `Create team`
+  - `Mint invite`
+  - Cloud identity authorization for Codex and Claude.
+  - Do not copy token values into skill output.
+- Contexts:
+  - Provider tabs `GitHub`, `GitLab`, `Slack`, `Linear`, `Mobile`
+  - Repository selector
+  - Issue/PR feed switches, sort dropdowns, selected labels, and `Remove All`
+  - Treat switches and remove actions as configuration mutations.
+- Experimental:
+  - `Local LLM`
+  - `Mobile companion`
+  - `Smart triage`
+  - Triage source connections, model add/delete/apply controls, mobile pair/revoke controls
+  - Treat connect, delete, run, pair, revoke, and apply actions as high-impact.
+- Developer:
+  - `Show Onboarding Again`
+  - `Reset Onboarding`
+  - `Reset All Dev Data`
+  - Treat reset actions as destructive. Do not execute during ordinary verification.
+- Repository-specific settings:
+  - Left-nav repo entries appear below `Repositories`.
+  - Use button rects instead of text selectors; repo names also appear in the body.
+  - Sections include Remote origin, base branch, branch prefix, setup/run/archive scripts, built-in prompt preferences, and Delete Repository.
+  - Do not record script contents, edit textareas, add scripts, change remotes/branches, or delete repositories without explicit user intent.
+
+## Feedback
+
+- Button selector: `button:has(svg.lucide-message-square-warning)`
+- Dialog:
+  - Title/text `Send feedback`
+  - Input `#feedback-input`, aria-label `Feedback`
+  - Actions: `Create issue`, `Quick fix`, `Close`
+  - Follow-up flow may include `Confirm send` and `Send to agent`
+
+## Inspector And Editor
+
+These require a repository-backed, non-chat workspace.
+
+- Chat-mode workspaces hide the inspector toggle and the inspector pane.
+- Inspector pane selectors:
+  - `[aria-label="Inspector sidebar"]`
+  - `[data-shell-pane="inspector"]`
+- Inspector sections from code:
+  - `[aria-label="Inspector section Git"]`
+  - `[aria-label="Changes panel body"]`
+  - `[data-change-path]`
+  - `[aria-label="Inspector section Actions"]`
+  - `[aria-label="Inspector section Tabs"]`
+- Inspector actions from code:
+  - `Stage all changes`
+  - `Unstage all changes`
+  - `Stage file`
+  - `Unstage file`
+  - `Discard file changes`
+  - `Review changes`
+  - `Commit and push`
+  - `Push`
+  - `Resolve`
+  - `Pull`
+  - `Run setup`
+  - `Add run script`
+  - `Run`
+  - `Stop`
+  - `Force Stop`
+  - `Open dev server`
+  - `Switch to list view`
+  - `Switch to tree view`
+- Inspector tabs from code:
+  - `#inspector-tab-setup`
+  - `#inspector-panel-setup`
+  - `#inspector-tab-run`
+  - `#inspector-panel-run`
+  - `button[aria-label="Switch run action"]`
+  - `#inspector-tab-terminal-*`
+  - `#inspector-panel-terminal-*`
+  - `#inspector-tab-terminal-placeholder`
+  - `button[aria-label="Close Terminal"]`
+  - `button[aria-label="New terminal"]`
+  - `button[aria-label="Toggle inspector actions section"]`
+  - `button[aria-label="Toggle inspector tabs section"]`
+- Editor selectors from code:
+  - `[aria-label="Workspace editor surface"]`
+  - `[data-focus-scope="editor"]`
+  - `[aria-label="Editor canvas"]`
+  - `[data-change-path="<relative/path>"]` opens a Git change in the editor/diff surface.
+  - `button[aria-label="Close diff view"]`
+  - `button[aria-label="Close editor view"]`
+  - `button[aria-label="Copy absolute path"]`
+  - `button[aria-label="Open file"]`
+- Editor operations from code:
+  - `Open file`
+  - `Search files`
+  - `Source`
+  - `Preview`
+  - `Edit`
+  - `Diff`
+  - `Close diff view`
+  - `Close editor view`
+  - `Copy absolute path`
+  - Diff mode shows top button text `Edit⌘E`.
+  - Edit mode shows top button text `Diff⌘E` and `.monaco-editor`.
+
+## Destructive Or High-Impact Operations
+
+Do not execute these unless explicitly requested or operating on a disposable test workspace:
+
+- `Archive workspace`
+- `Delete permanently`
+- `Reset All Dev Data`
+- `Discard file changes`
+- `Delete session permanently`
+- Git remote operations: push, merge, close PR/MR
+- Running arbitrary scripts or terminal commands
+- Cloning or adding repositories into persistent app data

--- a/.agents/skills/helmor-debug-operate/references/verified-recipes.md
+++ b/.agents/skills/helmor-debug-operate/references/verified-recipes.md
@@ -1,0 +1,694 @@
+# Verified Tauri MCP Recipes
+
+Use these recipes after loading `SKILL.md`. Each recipe below was exercised against the local Helmor debug build through Tauri MCP and passed three consecutive verification attempts unless marked otherwise.
+
+## Global Notes
+
+- Use `windowId: "main"` and the connected app default unless multiple apps are attached.
+- Prefer real UI input. Use `webview_execute_js` only for read-only rect/state inspection, selector repair, or the documented Lexical composer fallback.
+- When a recipe needs a Helmor app command, use `SKILL.md`'s **Call App Commands** helper. The Tauri MCP `ipc_execute_command` tool currently cannot invoke ordinary Helmor commands and returns `Unsupported Tauri command`; any `ipc_execute_command` examples should be treated as logical shorthand, not the literal MCP tool call.
+- For Radix triggers, `click` is not always sufficient. The most stable pattern is `webview_interact focus` followed by `webview_keyboard Enter` or `ArrowDown`.
+- Closed Radix popovers may remain in the DOM with `data-state="closed"`. Verify open state with `data-state !== "closed"` instead of raw element count.
+- If Settings gets stuck visible with `data-state="closed"`, press `Cmd+,` to reopen it, then press `Escape`. Verify no `[role="dialog"]` remains and `main[aria-hidden]` is absent.
+- If `webview_execute_js` and `read_logs source=console` begin timing out while screenshots and `driver_session status` still work, restart only the MCP driver session. Use `driver_session { "action": "stop", "appIdentifier": 9223 }`, then `driver_session { "action": "start", "port": 9223 }`. This restored JS execution without restarting the Helmor dev build.
+
+## Workspace
+
+### Switch Workspace
+
+1. Inspect workspace rows:
+
+```json
+webview_execute_js {
+  "windowId": "main",
+  "script": "(() => Array.from(document.querySelectorAll('[role=\"button\"],button')).filter((el) => (el.textContent || '').trim()).map((el) => { const r = el.getBoundingClientRect(); return { text: (el.textContent || '').replace(/\\s+/g, ' ').trim(), className: String(el.className || ''), x: r.x, y: r.y, width: r.width, height: r.height }; }).filter((row) => row.className.includes('workspace-row')))()"
+}
+```
+
+2. Click the target row center.
+3. Verify:
+
+```json
+webview_execute_js {
+  "windowId": "main",
+  "script": "(() => ({ selected: Array.from(document.querySelectorAll('.workspace-row-selected')).map((el) => (el.textContent || '').replace(/\\s+/g, ' ').trim()), header: document.querySelector('[aria-label=\"Workspace header\"]')?.textContent || null }))()"
+}
+```
+
+Observed 3x pass: `Hihihi! -> 用户身份查询 -> Hihihi!`.
+
+### New Workspace Entry
+
+This is a high-impact operation. It may switch to a start surface and change current selection. Do not use it as a casual smoke test.
+
+Observed behavior:
+- `focus "New workspace"` + `Enter` can enter a start/source-preview surface with `What should we work on?`, `New Workspace`, `Start options`, and `Just chat`.
+- In chat-only environments there may be no repository-backed workspace, so Inspector/Editor are unavailable.
+- To exit the start surface, select an existing workspace row. The `Close source preview` / `Esc` button was observed not to close reliably in one run.
+
+## Sessions
+
+### Create Session And Close Empty Session
+
+1. Get `New session` center:
+
+```json
+webview_execute_js {
+  "windowId": "main",
+  "script": "(() => { const el = document.querySelector('button[aria-label=\"New session\"]'); if (!el) return null; const r = el.getBoundingClientRect(); return { x: r.x + r.width / 2, y: r.y + r.height / 2 }; })()"
+}
+```
+
+2. Click the center.
+3. Verify selected `Untitled` tab:
+
+```json
+webview_execute_js {
+  "windowId": "main",
+  "script": "(() => ({ tabs: Array.from(document.querySelectorAll('[role=\"tab\"]')).map((el) => ({ text: (el.textContent || '').replace(/\\s+/g, ' ').trim(), selected: el.getAttribute('aria-selected') })) }))()"
+}
+```
+
+4. Close the empty selected session with `Cmd+W`:
+
+```json
+webview_keyboard { "action": "press", "key": "w", "modifiers": ["Meta"], "windowId": "main" }
+```
+
+5. Verify the original tab is selected again.
+
+Observed 3x pass on `Hihihi!`.
+
+### Session History
+
+1. Focus `Session history`.
+2. Press `Enter`.
+3. Verify open menu text. Empty state is `No hidden sessions`.
+4. Press `Escape` and verify `aria-expanded="false"`.
+
+Observed 3x pass.
+
+### Rename Session
+
+Use a temporary empty session for smoke tests so cleanup is trivial.
+
+1. Create/select the session.
+2. Ensure selector repair is installed if selector tools fail after a React re-render.
+3. Click the rename control for the selected tab:
+
+```json
+webview_interact {
+  "action": "click",
+  "selector": "[role=\"tab\"][aria-selected=\"true\"] [aria-label=\"Rename session\"]",
+  "strategy": "css",
+  "windowId": "main"
+}
+```
+
+4. Verify a native input appears with current title:
+
+```json
+webview_execute_js {
+  "windowId": "main",
+  "script": "(() => Array.from(document.querySelectorAll('input')).map((el) => ({ value: el.value, active: document.activeElement === el })))()"
+}
+```
+
+5. Select all, type the new title, and press `Enter`:
+
+```json
+webview_keyboard { "action": "press", "key": "a", "modifiers": ["Meta"], "windowId": "main" }
+webview_keyboard { "action": "type", "selector": "input[data-slot=\"input\"]", "strategy": "css", "text": "New title", "windowId": "main" }
+webview_keyboard { "action": "press", "key": "Enter", "windowId": "main" }
+```
+
+6. Verify the selected tab text changed.
+
+Observed 3x pass using temporary session titles `tmp-rename-1`, `tmp-rename-2`, and `tmp-rename-3`, then `Cmd+W` cleanup.
+
+## Sidebar Menus
+
+### Workspace Location
+
+Direct click did not open reliably. Use keyboard activation:
+
+```json
+webview_interact { "action": "focus", "selector": "Workspace location", "strategy": "text", "windowId": "main" }
+webview_keyboard { "action": "press", "key": "Enter", "windowId": "main" }
+```
+
+Verify menu text: `Workspace locationLocalTeamConfigure team backend…`.
+
+Observed 3x pass.
+
+### Filter And Sort Sidebar
+
+Click the button center or use selector after repair:
+
+```json
+webview_interact { "action": "click", "selector": "Filter and sort sidebar", "strategy": "text", "windowId": "main" }
+```
+
+Verify open dialog text includes `Repository`, `Group by`, `Status`, `Repository`, `Sort by`, `Draggable order`, `Repository name`, `Last updated`, and `Created time`.
+
+Observed 3x pass.
+
+### Add Repository Menu
+
+Direct click did not open reliably. Use keyboard activation:
+
+```json
+webview_interact { "action": "focus", "selector": "Add repository", "strategy": "text", "windowId": "main" }
+webview_keyboard { "action": "press", "key": "Enter", "windowId": "main" }
+```
+
+Verify menu text: `Clone from URL`. Do not select it unless the user asks to clone.
+
+Observed 3x pass.
+
+### Clone From URL Dialog
+
+Use this only to inspect the clone dialog unless the user explicitly asks to clone a repository.
+
+1. Open the Add repository menu with the recipe above.
+2. Click the menu item by role:
+
+```json
+webview_interact { "action": "click", "selector": "[role=\"menuitem\"]", "strategy": "css", "windowId": "main" }
+```
+
+3. Verify:
+
+```json
+webview_execute_js {
+  "windowId": "main",
+  "script": "(() => ({ open: Array.from(document.querySelectorAll('[role=\"dialog\"]')).some((el) => el.getAttribute('data-state') !== 'closed' && (el.textContent || '').includes('Clone from URL')), gitUrl: !!document.querySelector('#clone-git-url'), location: !!document.querySelector('#clone-location'), cloneDisabled: !!Array.from(document.querySelectorAll('[role=\"dialog\"] button')).find((b) => (b.textContent || '').includes('Clone repository'))?.disabled }))()"
+}
+```
+
+4. Press `Escape` to close.
+
+Observed 3x pass. Text selector for `Clone from URL` failed once while `[role="menuitem"]` was stable.
+
+### Collapse Workspace Groups
+
+Workspace group headers such as `Proposed tasks7`, `In review1`, `In progress3`, and `Archived23` are safe to toggle. Use the header rect center, not a workspace row.
+
+1. Locate the header and child rows:
+
+```json
+webview_execute_js {
+  "windowId": "main",
+  "script": "(() => Array.from(document.querySelectorAll('[role=\"button\"],button,div')).map((el) => { const r = el.getBoundingClientRect(); const text = String(el.textContent || '').replace(/\\s+/g, ' ').trim(); return { text, aria: el.getAttribute('aria-label'), role: el.getAttribute('role'), x: Math.round(r.x), y: Math.round(r.y), width: Math.round(r.width), height: Math.round(r.height), className: String(el.className || '').slice(0, 120) }; }).filter((x) => x.width > 0 && x.height > 0 && x.x < 280 && x.text.match(/In progress|Add Search|Initial Greeting 2|Initial Greeting 4/)).slice(0, 80))()"
+}
+```
+
+2. Click the group header center.
+3. Verify child row count for that group drops to `0`.
+4. Click the same header again.
+5. Verify the child row count returns.
+
+Observed 3 collapse/expand cycles passed for `In progress3`, with child rows `Add Search`, `Initial Greeting 2`, and `Initial Greeting 4`.
+
+## Composer Controls
+
+### Model Menu
+
+Direct click and `Enter` were unreliable. Use exact trigger focus plus `ArrowDown`.
+
+1. Locate the model trigger by text or id:
+
+```json
+webview_execute_js {
+  "windowId": "main",
+  "script": "(() => Array.from(document.querySelectorAll('button')).filter((b) => (b.textContent || '').includes('Opus')).map((b) => ({ id: b.id, text: (b.textContent || '').replace(/\\s+/g, ' ').trim() })))()"
+}
+```
+
+2. Focus the returned id and press `ArrowDown`:
+
+```json
+webview_interact { "action": "focus", "selector": "#MODEL_TRIGGER_ID", "strategy": "css", "windowId": "main" }
+webview_keyboard { "action": "press", "key": "ArrowDown", "windowId": "main" }
+```
+
+Verify menu text includes `Claude Code`, `Claude`, current selected model, `Codex`, and `GPT-5.5`.
+
+Observed 3x pass.
+
+### Effort Menu
+
+Use exact trigger focus plus `ArrowDown`:
+
+```json
+webview_execute_js {
+  "windowId": "main",
+  "script": "(() => Array.from(document.querySelectorAll('button')).filter((b) => (b.textContent || '').replace(/\\s+/g, ' ').trim().toLowerCase() === 'high').map((b) => ({ id: b.id, text: b.textContent })))()"
+}
+webview_interact { "action": "focus", "selector": "#EFFORT_TRIGGER_ID", "strategy": "css", "windowId": "main" }
+webview_keyboard { "action": "press", "key": "ArrowDown", "windowId": "main" }
+```
+
+Verify menu text: `Effortlowmediumhigh✓Extra Highmax`.
+
+Observed 3x pass.
+
+### Add Context
+
+In a repo-backed workspace, this toggles the right inspector between the normal Git inspector and the Contexts inspector. It does not open a dialog/popper.
+
+1. Click `Add context`.
+2. Verify the right inspector text starts with `Contexts` and source tabs `GitHub`, `Slack`, `Linear`, and `Mobile` exist.
+3. Click `Add context` again.
+4. Verify the right inspector text starts with `Git` and Git controls such as `Create PR options` return.
+
+Verification:
+
+```json
+webview_execute_js {
+  "windowId": "main",
+  "script": "(() => { const text = String(document.querySelector('[aria-label=\"Inspector sidebar\"], [data-shell-pane=\"inspector\"]')?.textContent || '').replace(/\\s+/g, ' ').trim(); return { context: text.startsWith('Contexts'), git: text.startsWith('Git'), hasSourceTabs: Array.from(document.querySelectorAll('button')).some((b) => ['GitHub', 'Slack', 'Linear', 'Mobile'].includes(b.getAttribute('aria-label') || '')) }; })()"
+}
+```
+
+Observed 3 open/restore cycles passed. Focus + Enter on the button surfaced only tooltip text `Add context⌘⇧C`; `Cmd+Shift+C` with either the button focused or the composer focused did not open a picker in the observed build.
+
+### Contexts Source Tabs
+
+Use only read-only tab switching unless the user asks to add context. Do not click `Add to context`.
+
+1. Open the Contexts inspector with `Add context`.
+2. Click a source tab such as `Slack`.
+3. Verify the clicked tab no longer has `text-muted-foreground` while the other tabs do.
+4. Click `GitHub` to restore the default source.
+
+Verification:
+
+```json
+webview_execute_js {
+  "windowId": "main",
+  "script": "(() => Array.from(document.querySelectorAll('button')).map((b) => { const r = b.getBoundingClientRect(); const aria = b.getAttribute('aria-label'); const cls = String(b.className || ''); return { aria, selected: !cls.includes('text-muted-foreground'), x: Math.round(r.x), y: Math.round(r.y), width: Math.round(r.width), height: Math.round(r.height) }; }).filter((x) => x.width > 0 && x.height > 0 && ['GitHub', 'Slack', 'Linear', 'Mobile'].includes(x.aria)))()"
+}
+```
+
+Observed 3 GitHub/Slack cycles passed, restored GitHub, then restored the Git inspector by clicking `Add context` again.
+
+### Context Usage
+
+Not yet stable. Click and long-press did not open a visible dialog/popper in the observed states. The current Tauri MCP toolset lacks a hover action, so treat this as unverified unless a hover-capable tool is available.
+
+### Usage Stats
+
+Not yet stable. Click and long-press did not open a visible dialog/popper in the observed repo-backed workspace. Treat as unverified unless a hover-capable tool is available or code inspection shows a non-hover activation path.
+
+### Fast Mode Toggle
+
+Use a temporary session for smoke tests and restore the original state afterward.
+
+1. Click `Fast mode`.
+2. Verify enabled class contains `text-amber-500`.
+3. Click `Fast mode` again.
+4. Verify disabled class contains `text-muted-foreground`.
+
+Observed 3 toggle/restore cycles passed.
+
+### Plan Mode Toggle
+
+Use a temporary session for smoke tests and restore the original state afterward.
+
+1. Click `Plan mode`.
+2. Verify the class no longer contains the disabled marker `text-muted-foreground/70`.
+3. Click `Plan mode` again.
+4. Verify the disabled class contains `text-muted-foreground/70`.
+
+Observed 3 toggle/restore cycles passed.
+
+### Terminal Mode Toggle
+
+Use a temporary session or restore the original state afterward. This only toggles composer mode; it does not create an inspector terminal unless a prompt is later sent in terminal mode.
+
+1. Click `Terminal mode`.
+2. Verify enabled class contains `text-emerald-500`.
+3. Click `Terminal mode` again.
+4. Verify disabled class contains `text-muted-foreground/70`.
+
+Observed 3 toggle/restore cycles passed, restored disabled.
+
+### Carry Room Context Toggle
+
+The enabled state uses blue styling; disabled state uses muted styling.
+
+1. Click `Carry room context`.
+2. Verify disabled class contains `text-muted-foreground`.
+3. Click it again.
+4. Verify enabled class contains `text-blue-500`.
+
+Observed 3 toggle/restore cycles passed, restored to enabled.
+
+### Send Smoke Prompt
+
+Use a temporary session unless the user explicitly wants to send in the current session.
+
+1. Click the composer.
+2. Insert short text. In the current bridge, the Lexical fallback is the reliable input path:
+
+```json
+webview_execute_js {
+  "windowId": "main",
+  "script": "(() => { const el = document.querySelector('#workspace-input'); if (!el) return { ok: false }; el.focus(); const ok = document.execCommand('insertText', false, 'smoke'); const send = document.querySelector('button[aria-label=\"Send\"]'); return { ok, text: el.textContent || '', html: el.innerHTML, sendDisabled: send ? !!send.disabled : null }; })()"
+}
+```
+
+3. Read back before retrying. `execCommand` can return before Lexical state visibly updates:
+
+```json
+webview_execute_js {
+  "windowId": "main",
+  "script": "(() => ({ text: document.querySelector('#workspace-input')?.textContent || '', html: document.querySelector('#workspace-input')?.innerHTML || '', sendDisabled: !!document.querySelector('button[aria-label=\"Send\"]')?.disabled }))()"
+}
+```
+
+Do not immediately run `insertText` again after an empty first read; a delayed update can duplicate the prompt.
+
+4. Click `Send` by rect center.
+5. Verify the message appears in the panel, the input is empty, and `Send` is disabled. If `Stop` appears and remains visible, stop the run only if cancellation is intended.
+6. For temporary sessions, close with `Cmd+W` after verification.
+
+Observed 3x pass. One run duplicated to `smokesmoke` when insertion was retried too soon; the send still worked, but the stable recipe is to read back before reinserting.
+
+## Inspector And Editor
+
+These recipes require a repository-backed, non-chat workspace. Chat-only workspaces hide the inspector.
+
+### Header Open-In Dropdown
+
+This opens the workspace "open in app" dropdown. Do not select an app during smoke tests because items such as Finder, Cursor, VS Code, Xcode, Terminal, and Warp can launch external applications.
+
+Direct click did not open reliably. Use focus plus `ArrowDown`:
+
+```json
+webview_interact { "action": "focus", "selector": "button[data-slot=\"dropdown-menu-trigger\"][data-size=\"xs\"]", "strategy": "css", "windowId": "main" }
+webview_keyboard { "action": "press", "key": "ArrowDown", "windowId": "main" }
+```
+
+Verify menu text includes `Finder`, `Cursor`, `VS Code`, `Xcode`, `Terminal`, and `Warp`; close with Escape.
+
+Observed 3x pass.
+
+### Switch Setup And Run Tabs
+
+This is safe: it only changes the visible inspector panel and does not run scripts.
+
+1. Click Setup:
+
+```json
+webview_interact { "action": "click", "selector": "#inspector-tab-setup", "strategy": "css", "windowId": "main" }
+```
+
+2. Verify `#inspector-panel-setup` is visible and `#inspector-panel-run` is hidden:
+
+```json
+webview_execute_js {
+  "windowId": "main",
+  "script": "(() => Array.from(document.querySelectorAll('[id^=\"inspector-panel-\"]')).map((el) => { const r = el.getBoundingClientRect(); const cs = getComputedStyle(el); return { id: el.id, display: cs.display, hidden: el.hidden, width: Math.round(r.width), height: Math.round(r.height), text: String(el.textContent || '').replace(/\\s+/g, ' ').trim().slice(0, 120) }; }))()"
+}
+```
+
+3. Click Run:
+
+```json
+webview_interact { "action": "click", "selector": "#inspector-tab-run", "strategy": "css", "windowId": "main" }
+```
+
+4. Verify `#inspector-panel-run` is visible. Observed text included `No output for DB` and `Run⌘R`.
+
+Observed 3 cycles passed.
+
+### Collapse Inspector Sections
+
+Use the toggle button aria labels instead of hard-coded coordinates; the y position changes after collapse.
+
+Actions section:
+
+```json
+webview_interact { "action": "click", "selector": "button[aria-label=\"Toggle inspector actions section\"]", "strategy": "css", "windowId": "main" }
+```
+
+Verify:
+
+```json
+webview_execute_js {
+  "windowId": "main",
+  "script": "(() => Array.from(document.querySelectorAll('section')).map((s) => { const r = s.getBoundingClientRect(); return { label: s.getAttribute('aria-label'), height: Math.round(r.height), text: String(s.textContent || '').replace(/\\s+/g, ' ').trim().slice(0, 80) }; }).filter((x) => String(x.label || '').includes('Inspector section')))()"
+}
+```
+
+Collapsed Actions is about 33px tall with text `Actions`; expanded Actions returns to the larger content panel. Observed 3 collapse/expand cycles passed.
+
+Tabs section:
+
+```json
+webview_interact { "action": "click", "selector": "button[aria-label=\"Toggle inspector tabs section\"]", "strategy": "css", "windowId": "main" }
+```
+
+Collapsed Tabs is about 33px tall with text `SetupDBTerminal`; expanded Tabs restores the Setup/Run/Terminal panel area. Observed 3 collapse/expand cycles passed.
+
+### Switch Run Action Menu
+
+Do not select a script during smoke tests. Opening and closing the menu is safe.
+
+Direct click did not open reliably. Use focus plus `ArrowDown`:
+
+```json
+webview_interact { "action": "focus", "selector": "button[aria-label=\"Switch run action\"]", "strategy": "css", "windowId": "main" }
+webview_keyboard { "action": "press", "key": "ArrowDown", "windowId": "main" }
+```
+
+Verify the open menu text:
+
+```json
+webview_execute_js {
+  "windowId": "main",
+  "script": "(() => Array.from(document.querySelectorAll('[role=\"menu\"],[data-radix-popper-content-wrapper]')).map((el) => { const r = el.getBoundingClientRect(); return { role: el.getAttribute('role'), state: el.getAttribute('data-state'), text: String(el.textContent || '').replace(/\\s+/g, ' ').trim(), width: Math.round(r.width), height: Math.round(r.height) }; }).filter((x) => x.width > 0 && x.height > 0))()"
+}
+```
+
+Observed menu text: `DBBEAPPMarketingCreate`. Close with Escape. Observed 3x pass.
+
+### Create PR Options Menu
+
+Do not select a menu item during smoke tests. `Create draft PR` and `Create PR manually` are real PR actions.
+
+Direct click did not open reliably. Use focus plus `ArrowDown`:
+
+```json
+webview_interact { "action": "focus", "selector": "button[aria-label=\"Create PR options\"]", "strategy": "css", "windowId": "main" }
+webview_keyboard { "action": "press", "key": "ArrowDown", "windowId": "main" }
+```
+
+Verify the open menu text contains `Create draft PR` and `Create PR manually`, then close with Escape:
+
+```json
+webview_execute_js {
+  "windowId": "main",
+  "script": "(() => Array.from(document.querySelectorAll('[role=\"menu\"],[data-radix-popper-content-wrapper]')).map((el) => { const r = el.getBoundingClientRect(); return { role: el.getAttribute('role'), state: el.getAttribute('data-state'), text: String(el.textContent || '').replace(/\\s+/g, ' ').trim(), width: Math.round(r.width), height: Math.round(r.height) }; }).filter((x) => x.width > 0 && x.height > 0))()"
+}
+```
+
+Observed 3x pass.
+
+### Create, Switch, And Close Inspector Terminal
+
+This creates a real inspector terminal panel. Use only on an idle repo-backed workspace, and close it when done.
+
+1. Click the placeholder tab:
+
+```json
+webview_interact { "action": "click", "selector": "#inspector-tab-terminal-placeholder", "strategy": "css", "windowId": "main" }
+```
+
+2. Verify a dynamic terminal panel exists:
+
+```json
+webview_execute_js {
+  "windowId": "main",
+  "script": "(() => ({ terminalPanel: Array.from(document.querySelectorAll('[id^=\"inspector-panel-terminal-\"]')).map((el) => { const r = el.getBoundingClientRect(); return { id: el.id, width: Math.round(r.width), height: Math.round(r.height), visible: r.width > 0 && r.height > 0 }; }), close: !!document.querySelector('button[aria-label=\"Close Terminal\"]') }))()"
+}
+```
+
+3. Switch between Run and the existing terminal tab:
+
+```json
+webview_interact { "action": "click", "selector": "#inspector-tab-run", "strategy": "css", "windowId": "main" }
+webview_interact { "action": "click", "selector": "[id^=\"inspector-tab-terminal-\"]", "strategy": "css", "windowId": "main" }
+```
+
+Verify the visible panel by checking which `[id^="inspector-panel-"]` has `display !== "none"`.
+
+4. Close the terminal:
+
+```json
+webview_interact { "action": "click", "selector": "button[aria-label=\"Close Terminal\"]", "strategy": "css", "windowId": "main" }
+```
+
+Verify `#inspector-tab-terminal-placeholder` exists again and `document.querySelectorAll('[id^="inspector-panel-terminal-"]').length === 0`.
+
+Observed 3x pass for create/close, and 3 cycles passed for Run/Terminal switching after one terminal existed.
+
+### Collapse And Expand The Right Inspector
+
+Click the header button by aria label:
+
+```json
+webview_interact { "action": "click", "selector": "button[aria-label=\"Collapse right sidebar\"]", "strategy": "css", "windowId": "main" }
+```
+
+Verify collapsed state by button label and inspector state:
+
+```json
+webview_execute_js {
+  "windowId": "main",
+  "script": "(() => { const el = document.querySelector('[aria-label=\"Inspector sidebar\"], [data-shell-pane=\"inspector\"]'); const r = el?.getBoundingClientRect(); return { ariaHidden: el?.getAttribute('aria-hidden'), width: r && Math.round(r.width), button: Array.from(document.querySelectorAll('button')).map((b) => { const r = b.getBoundingClientRect(); return { aria: b.getAttribute('aria-label'), width: Math.round(r.width), height: Math.round(r.height) }; }).filter((x) => x.width > 0 && x.height > 0 && String(x.aria || '').includes('right sidebar')) }; })()"
+}
+```
+
+Collapsed state shows `Expand right sidebar` and `aria-hidden="true"`; after the animation, width can be `0`. Expanded state shows `Collapse right sidebar`, `aria-hidden="false"`, and the inspector width restored.
+
+Observed 3 successful cycles. One extra attempt made the bridge JS channel time out even though the action applied; restarting the driver session recovered it.
+
+### Open And Close A Diff From Git Changes
+
+Use `data-change-path`; it is more stable than text.
+
+```json
+webview_interact { "action": "click", "selector": "[data-change-path=\".claude/settings.json\"]", "strategy": "css", "windowId": "main" }
+```
+
+Verify the editor surface:
+
+```json
+webview_execute_js {
+  "windowId": "main",
+  "script": "(() => { const el = document.querySelector('[aria-label=\"Workspace editor surface\"], [data-focus-scope=\"editor\"], [aria-label=\"Editor canvas\"]'); const r = el?.getBoundingClientRect(); return { editor: !!el, rect: el ? { x: Math.round(r.x), y: Math.round(r.y), width: Math.round(r.width), height: Math.round(r.height) } : null, text: String(el?.textContent || '').replace(/\\s+/g, ' ').trim().slice(0, 140), close: !!document.querySelector('button[aria-label=\"Close diff view\"]') }; })()"
+}
+```
+
+Close:
+
+```json
+webview_interact { "action": "click", "selector": "button[aria-label=\"Close diff view\"]", "strategy": "css", "windowId": "main" }
+```
+
+Verify the editor surface is gone and `[data-change-path]` rows are visible again. Observed 3x pass.
+
+### Toggle Editor Edit/Diff Mode
+
+From an open diff, click the mode button by rect or by visible text if unique. Do not type into Monaco unless the user asked to edit a file.
+
+Signals:
+
+- Diff mode has button text `Edit⌘E` and close aria `Close diff view`.
+- Edit mode has button text `Diff⌘E`, close aria `Close editor view`, and `.monaco-editor` is present.
+
+Observed 3 Edit/Diff cycles passed with no editor typing.
+
+### Toggle Git Changes Tree/List View
+
+This is safe: it only changes the visible Git changes layout.
+
+1. Click the small view toggle in the Git section header. In tree mode its aria label is `Switch to list view`.
+2. Verify list mode:
+
+```json
+webview_execute_js {
+  "windowId": "main",
+  "script": "(() => { const buttons = Array.from(document.querySelectorAll('button')).map((el) => { const r = el.getBoundingClientRect(); return { aria: el.getAttribute('aria-label'), width: Math.round(r.width), height: Math.round(r.height) }; }).filter((x) => x.width > 0 && x.height > 0 && (String(x.aria || '').includes('list view') || String(x.aria || '').includes('tree view'))); const treeItems = Array.from(document.querySelectorAll('[role=\"treeitem\"]')).filter((el) => { const r = el.getBoundingClientRect(); return r.width > 0 && r.height > 0 && r.x > 900; }).length; return { buttons, treeItems }; })()"
+}
+```
+
+List mode shows `Switch to tree view` and visible `treeItems: 0`.
+
+3. Click the same button again.
+4. Verify tree mode shows `Switch to list view` and visible `treeItems` restored.
+
+Observed 3 cycles passed, restored tree view.
+
+## Settings And Feedback
+
+### Open Settings
+
+Click the first bottom-left sidebar icon.
+
+Verify open dialog contains `General`, `Appearance`, and `Desktop Notifications`. `Escape` closes.
+
+Observed 3x pass.
+
+## Global Overlays
+
+### Quick Switch Workspace
+
+Open with `Ctrl+Tab`:
+
+```json
+webview_keyboard { "action": "press", "key": "Tab", "modifiers": ["Control"], "windowId": "main" }
+```
+
+Verify `[data-testid="quick-switch-overlay"]` exists and an open dialog has aria-label `Quick switch workspace`.
+
+Close with `Escape`.
+
+Observed 3x pass.
+
+### Switch Settings Section
+
+Click the left section row in the Settings dialog.
+
+Observed 3x pass for `General -> Appearance`, verified by `Theme`, `Color Theme`, and `Chat font size`.
+
+### Read Settings Sections Without Mutating
+
+Open Settings first. Then use the left-nav button rects for duplicated names, especially repository names:
+
+```json
+webview_execute_js {
+  "windowId": "main",
+  "script": "(() => Array.from(document.querySelectorAll('[role=\"dialog\"] button')).map((el) => { const r = el.getBoundingClientRect(); return { text: String(el.textContent || '').replace(/\\s+/g, ' ').trim(), x: Math.round(r.x), y: Math.round(r.y), width: Math.round(r.width), height: Math.round(r.height), className: String(el.className || '').slice(0, 120) }; }).filter((x) => x.width > 0 && x.height > 0 && x.x < 420))()"
+}
+```
+
+Click the center of the target left-nav row. Avoid plain text selectors for repository names because the same name appears in the settings body.
+
+Read only labels, buttons, placeholders, and control states. Do not copy token values, account details, or script bodies into user-facing output:
+
+```json
+webview_execute_js {
+  "windowId": "main",
+  "script": "(() => { const compact = (s, n = 120) => String(s || '').replace(/\\s+/g, ' ').trim().slice(0, n); const dialog = document.querySelector('[role=\"dialog\"][data-state=\"open\"]'); return { labels: Array.from(dialog?.querySelectorAll('h1,h2,h3,p,label,span,button') || []).map((el) => { const r = el.getBoundingClientRect(); return { tag: el.tagName.toLowerCase(), role: el.getAttribute('role'), aria: el.getAttribute('aria-label'), text: compact(el.textContent, 100), disabled: !!el.disabled || el.getAttribute('aria-disabled') === 'true', x: Math.round(r.x), y: Math.round(r.y), width: Math.round(r.width), height: Math.round(r.height) }; }).filter((x) => x.width > 0 && x.height > 0 && x.text).slice(0, 120), inputs: Array.from(dialog?.querySelectorAll('input,textarea') || []).map((el) => { const r = el.getBoundingClientRect(); return { tag: el.tagName.toLowerCase(), aria: el.getAttribute('aria-label'), placeholder: el.getAttribute('placeholder'), type: el.getAttribute('type'), disabled: !!el.disabled, x: Math.round(r.x), y: Math.round(r.y), width: Math.round(r.width), height: Math.round(r.height) }; }).filter((x) => x.width > 0 && x.height > 0) }; })()"
+}
+```
+
+One read-only mapping pass observed:
+
+- `Models`: Default/Review/Action model rows with model picker, effort picker, and fast-mode switches.
+- `Providers`: provider cards and API/provider controls. Do not click login, sync, fetch, add-provider, or API-key actions during smoke tests.
+- `Shortcuts`: shortcut search/input, shortcut key buttons, and reset-to-default controls. Clicking a shortcut button starts keybinding edit flow.
+- `Accounts`: local forge account list. Do not copy account details into skill output.
+- `Team`: invite link, Team mode, Worker URL, Access token, Test connection. Inputs are sensitive configuration.
+- `Contexts`: GitHub/GitLab/Slack/Linear/Mobile tabs, repo selector, issue/PR switches, filters, and `Remove All`. Switches and remove actions mutate configuration.
+- `Experimental`: Local LLM, Smart triage, triage sources, Mobile companion, pair/revoke controls. Treat connect/delete/run/revoke/model actions as high-impact.
+- `Developer`: Reset Onboarding and Reset All Dev Data. Do not execute in ordinary verification.
+- Repository settings entries: Remote, base branch, branch prefix, setup/run/archive scripts, built-in prompt preferences, and Delete Repository. Do not record script contents or change textareas.
+
+Only `General -> Appearance` section switching has 3x verification so far; the full section map is read-only observed and should be rechecked for current UI before relying on exact labels.
+
+### Feedback Dialog
+
+The feedback button has no aria-label. Use its icon selector:
+
+```json
+webview_interact { "action": "click", "selector": "button:has(svg.lucide-message-square-warning)", "strategy": "css", "windowId": "main" }
+```
+
+Verify dialog text contains `Send feedback`, `Create issue`, `Quick fix`, and `Close`; input `#feedback-input` exists with aria-label `Feedback`. `Escape` closes.
+
+Observed 3x pass.

--- a/.claude/skills/helmor-debug-loop
+++ b/.claude/skills/helmor-debug-loop
@@ -1,0 +1,1 @@
+../../.agents/skills/helmor-debug-loop

--- a/.claude/skills/helmor-debug-operate
+++ b/.claude/skills/helmor-debug-operate
@@ -1,0 +1,1 @@
+../../.agents/skills/helmor-debug-operate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,6 +190,14 @@ Terminal Mode is a composer toggle (settings opt-in) that sends prompts directly
 
 > **Hard rule:** Use the Tauri MCP bridge (`tauri-plugin-mcp-bridge`) only. No `chrome-devtools` MCP, no `/agent-browser`. Helmor runs in Tauri webview only.
 
+### Skill routing
+
+When the user asks to use Tauri MCP (including misspellings like "towery MCP"), debug the local dev build, simulate user actions, switch workspaces/sessions, type or send composer text, inspect the webview, take screenshots, trace IPC, or run visual end-to-end checks against Helmor, first use the project skill `helmor-debug-operate` (`.agents/skills/helmor-debug-operate/SKILL.md`). Treat it as the operation manual for controlling the local desktop build. Use `helmor-cli` instead only for terminal-first data/workspace automation where the UI is not under test.
+
+When the user asks for an autonomous local-dev bug loop, repeated reproduction, temporary logging/instrumentation, self-directed debugging, or "fix and verify through the app", first use `helmor-debug-loop` (`.agents/skills/helmor-debug-loop/SKILL.md`). That loop skill must use `helmor-debug-operate` for all Tauri MCP app operations and must explicitly handle `not reproduced`, `flaky`, and `blocked` outcomes rather than pretending a reproduction succeeded.
+
+The Helmor local-dev debug skill is a prompt, not a source of truth. It can be stale if the local UI changed without the skill being updated. If a skill recipe fails three times, stop repeating it mechanically: take fresh screenshots/snapshots, reason from the visible UI, and inspect the relevant source code if needed. If you discover a better path, missing pitfall, stale selector, or unverified workaround, record a candidate update under `.agent-contexts/<task-slug>/skill-update-candidates.md` with evidence and verification status, then ask the user for confirmation before editing the skill unless the current user request explicitly asks you to update it.
+
 ### Prerequisites
 
 1. **Debug build only.** MCP bridge is behind `#[cfg(debug_assertions)]`. Always `bun run dev`.
@@ -201,7 +209,7 @@ Terminal Mode is a composer toggle (settings opt-in) that sends prompts directly
 - **UI state**: `webview_screenshot` -> `webview_dom_snapshot type=accessibility` (prefer ref IDs for follow-ups)
 - **User input**: `webview_interact` + `webview_keyboard`. Never dispatch synthetic events via `webview_execute_js`.
 - **IPC tracing**: `ipc_monitor start` -> trigger flow -> `ipc_get_captured filter=<cmd>` -> `ipc_monitor stop`. Always stop when done.
-- **Direct backend call**: `ipc_execute_command command=... args=...` to bypass frontend.
+- **Direct backend call**: do not use Tauri MCP `ipc_execute_command` for Helmor app commands; current bridge dynamic command execution returns `Unsupported Tauri command`. Use `helmor-debug-operate`'s click-triggered **Call App Commands** helper, or drive the UI.
 - **Async waits**: `webview_wait_for type=ipc-event value=<event>` for streaming/pipeline events.
 - **Console/system logs**: `read_logs source=console` or `source=system filter=helmor`.
 - **JS eval**: `webview_execute_js script="(() => <expr>)()"` (IIFE, JSON-serializable return). Cannot see React state.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,14 @@ When a snapshot drifts: look at the diff first. Only accept after confirming the
 
 > **Hard rule:** Use the Tauri MCP bridge (`tauri-plugin-mcp-bridge`) only. No `chrome-devtools` MCP, no `/agent-browser`. Helmor runs in Tauri webview only.
 
+### Skill routing
+
+When the user asks to use Tauri MCP (including misspellings like "towery MCP"), debug the local dev build, simulate user actions, switch workspaces/sessions, type or send composer text, inspect the webview, take screenshots, trace IPC, or run visual end-to-end checks against Helmor, first use the project skill `helmor-debug-operate` (`.agents/skills/helmor-debug-operate/SKILL.md`). Treat it as the operation manual for controlling the local desktop build. Use `helmor-cli` instead only for terminal-first data/workspace automation where the UI is not under test.
+
+When the user asks for an autonomous local-dev bug loop, repeated reproduction, temporary logging/instrumentation, self-directed debugging, or "fix and verify through the app", first use `helmor-debug-loop` (`.agents/skills/helmor-debug-loop/SKILL.md`). That loop skill must use `helmor-debug-operate` for all Tauri MCP app operations and must explicitly handle `not reproduced`, `flaky`, and `blocked` outcomes rather than pretending a reproduction succeeded.
+
+The Helmor local-dev debug skill is a prompt, not a source of truth. It can be stale if the local UI changed without the skill being updated. If a skill recipe fails three times, stop repeating it mechanically: take fresh screenshots/snapshots, reason from the visible UI, and inspect the relevant source code if needed. If you discover a better path, missing pitfall, stale selector, or unverified workaround, record a candidate update under `.agent-contexts/<task-slug>/skill-update-candidates.md` with evidence and verification status, then ask the user for confirmation before editing the skill unless the current user request explicitly asks you to update it.
+
 ### Prerequisites
 
 1. **Debug build only.** MCP bridge is behind `#[cfg(debug_assertions)]`. Always `bun run dev`.
@@ -172,7 +180,7 @@ When a snapshot drifts: look at the diff first. Only accept after confirming the
 - **UI state**: `webview_screenshot` -> `webview_dom_snapshot type=accessibility` (prefer ref IDs for follow-ups)
 - **User input**: `webview_interact` + `webview_keyboard`. Never dispatch synthetic events via `webview_execute_js`.
 - **IPC tracing**: `ipc_monitor start` -> trigger flow -> `ipc_get_captured filter=<cmd>` -> `ipc_monitor stop`. Always stop when done.
-- **Direct backend call**: `ipc_execute_command command=... args=...` to bypass frontend.
+- **Direct backend call**: do not use Tauri MCP `ipc_execute_command` for Helmor app commands; current bridge dynamic command execution returns `Unsupported Tauri command`. Use `helmor-debug-operate`'s click-triggered **Call App Commands** helper, or drive the UI.
 - **Async waits**: `webview_wait_for type=ipc-event value=<event>` for streaming/pipeline events.
 - **Console/system logs**: `read_logs source=console` or `source=system filter=helmor`.
 - **JS eval**: `webview_execute_js script="(() => <expr>)()"` (IIFE, JSON-serializable return). Cannot see React state.


### PR DESCRIPTION
## Summary

Adds project-local debug skills for operating and debugging Helmor through the Tauri MCP bridge.

## Scope

- Adds `helmor-debug-operate` and `helmor-debug-loop` under `.agents/skills/`.
- Adds Claude-compatible symlinks under `.claude/skills/`.
- Updates `AGENTS.md` and `CLAUDE.md` to route Tauri MCP/debug-loop requests to these skills and to avoid unsupported direct backend command execution.

This PR intentionally does not include any Team Cloud runtime, UI, Worker, D1, or product behavior changes.

## Validation

- Confirmed staged diff contains only the debug skill paths, symlinks, `AGENTS.md`, and `CLAUDE.md`.
- Confirmed `.claude/skills/helmor-debug-*` entries are symlinks.
- Ran Python syntax validation for the helper scripts.
- Ran `git diff --cached --check` before commit.