### PR TITLE
Add GPT-5.6 family and recommend Sol by default

### DIFF
--- a/.announcements/gpt-5-6-family.json
+++ b/.announcements/gpt-5-6-family.json
@@ -1,7 +1,7 @@
 {
 	"items": [
 		{
-			"text": "GPT-5.6 Sol, Terra, and Luna are now available, with Sol recommended by default and older Codex models still available under Models.",
+			"text": "GPT-5.6 Sol, Terra, and Luna are now available, with Sol recommended by default and older Codex and Opus models still available under Models.",
 			"action": {
 				"label": "Open Models",
 				"value": { "type": "openSettings", "section": "model" }

--- a/.announcements/gpt-5-6-family.json
+++ b/.announcements/gpt-5-6-family.json
@@ -1,0 +1,11 @@
+{
+	"items": [
+		{
+			"text": "GPT-5.6 Sol, Terra, and Luna are now available, with Sol recommended by default and older Codex models still available under Models.",
+			"action": {
+				"label": "Open Models",
+				"value": { "type": "openSettings", "section": "model" }
+			}
+		}
+	]
+}

--- a/.changeset/gpt-5-6-family.md
+++ b/.changeset/gpt-5-6-family.md
@@ -4,4 +4,4 @@
 
 Add the GPT-5.6 model family to Codex with a streamlined default picker:
 - Recommend GPT-5.6 Sol by default and expose all six supported effort levels on Sol, Terra, and Luna.
-- Keep GPT-5.5 and GPT-5.4 hidden by default but available to re-enable in Settings, without disrupting existing sessions that use them.
+- Keep GPT-5.5, GPT-5.4, Opus 4.7, and Opus 4.6 hidden by default but available to re-enable in Settings, without disrupting existing sessions that use them.

--- a/.changeset/gpt-5-6-family.md
+++ b/.changeset/gpt-5-6-family.md
@@ -1,0 +1,7 @@
+---
+"helmor": minor
+---
+
+Add the GPT-5.6 model family to Codex with a streamlined default picker:
+- Recommend GPT-5.6 Sol by default and expose all six supported effort levels on Sol, Terra, and Luna.
+- Keep GPT-5.5 and GPT-5.4 hidden by default but available to re-enable in Settings, without disrupting existing sessions that use them.

--- a/.changeset/gpt-5-6-family.md
+++ b/.changeset/gpt-5-6-family.md
@@ -3,5 +3,5 @@
 ---
 
 Add the GPT-5.6 model family to Codex with a streamlined default picker:
-- Recommend GPT-5.6 Sol by default and expose all six supported effort levels on Sol, Terra, and Luna.
+- Recommend GPT-5.6 Sol by default and expose each model's supported effort levels, including `ultra` on Sol and Terra.
 - Keep GPT-5.5, GPT-5.4, Opus 4.7, and Opus 4.6 hidden by default but available to re-enable in Settings, without disrupting existing sessions that use them.

--- a/sidecar/src/model-catalog.test.ts
+++ b/sidecar/src/model-catalog.test.ts
@@ -20,7 +20,7 @@ describe("Codex model catalog", () => {
 		]);
 	});
 
-	test("uses Luna for lightweight background work", () => {
-		expect(pickFastestCodexModel()).toBe("gpt-5.6-luna");
+	test("keeps GPT-5.4 Mini for lightweight background work", () => {
+		expect(pickFastestCodexModel()).toBe("gpt-5.4-mini");
 	});
 });

--- a/sidecar/src/model-catalog.test.ts
+++ b/sidecar/src/model-catalog.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { listProviderModels, pickFastestCodexModel } from "./model-catalog.js";
 
 describe("Codex model catalog", () => {
-	test("lists the GPT-5.6 family with all six effort levels", () => {
+	test("lists the GPT-5.6 family with its runtime effort levels", () => {
 		const models = listProviderModels("codex");
 
 		expect(models.slice(0, 3).map((model) => model.id)).toEqual([
@@ -11,7 +11,22 @@ describe("Codex model catalog", () => {
 			"gpt-5.6-luna",
 		]);
 		expect(models[0]?.effortLevels).toEqual([
-			"none",
+			"low",
+			"medium",
+			"high",
+			"xhigh",
+			"max",
+			"ultra",
+		]);
+		expect(models[1]?.effortLevels).toEqual([
+			"low",
+			"medium",
+			"high",
+			"xhigh",
+			"max",
+			"ultra",
+		]);
+		expect(models[2]?.effortLevels).toEqual([
 			"low",
 			"medium",
 			"high",

--- a/sidecar/src/model-catalog.test.ts
+++ b/sidecar/src/model-catalog.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { listProviderModels, pickFastestCodexModel } from "./model-catalog.js";
+
+describe("Codex model catalog", () => {
+	test("lists the GPT-5.6 family with all six effort levels", () => {
+		const models = listProviderModels("codex");
+
+		expect(models.slice(0, 3).map((model) => model.id)).toEqual([
+			"gpt-5.6-sol",
+			"gpt-5.6-terra",
+			"gpt-5.6-luna",
+		]);
+		expect(models[0]?.effortLevels).toEqual([
+			"none",
+			"low",
+			"medium",
+			"high",
+			"xhigh",
+			"max",
+		]);
+	});
+
+	test("uses Luna for lightweight background work", () => {
+		expect(pickFastestCodexModel()).toBe("gpt-5.6-luna");
+	});
+});

--- a/sidecar/src/model-catalog.test.ts
+++ b/sidecar/src/model-catalog.test.ts
@@ -20,7 +20,7 @@ describe("Codex model catalog", () => {
 		]);
 	});
 
-	test("keeps GPT-5.4 Mini for lightweight background work", () => {
-		expect(pickFastestCodexModel()).toBe("gpt-5.4-mini");
+	test("uses GPT-5.6 Luna for lightweight background work", () => {
+		expect(pickFastestCodexModel()).toBe("gpt-5.6-luna");
 	});
 });

--- a/sidecar/src/model-catalog.ts
+++ b/sidecar/src/model-catalog.ts
@@ -1,6 +1,20 @@
 import type { Provider, ProviderModelInfo } from "./session-manager.js";
 
-const CODEX_EFFORT_LEVELS = ["low", "medium", "high", "xhigh"] as const;
+const GPT_5_6_EFFORT_LEVELS = [
+	"none",
+	"low",
+	"medium",
+	"high",
+	"xhigh",
+	"max",
+] as const;
+const LEGACY_CODEX_EFFORT_LEVELS = [
+	"none",
+	"low",
+	"medium",
+	"high",
+	"xhigh",
+] as const;
 const CURSOR_REASONING_LEVELS = ["low", "medium", "high"] as const;
 
 // NOTE: the Claude/Codex sections here MUST stay in sync with the Rust
@@ -9,18 +23,16 @@ const CURSOR_REASONING_LEVELS = ["low", "medium", "high"] as const;
 // `list_agent_model_sections` command; this one feeds `listModels`.
 const MODEL_CATALOG: Record<Provider, readonly ProviderModelInfo[]> = {
 	claude: [
-		// Fable 5 leads the list as the most capable pick, but it burns limits
-		// ~2x faster than Opus — `useEnsureDefaultModel` pins the app default
-		// to the Opus 4.8 entry below, NOT to the first entry. No fast
-		// mode (Opus 4.6+ only).
+		// Fable 5 leads the Claude list as the most capable pick, but the
+		// cross-provider app default is selected separately by
+		// `useEnsureDefaultModel`. No fast mode (Opus 4.6+ only).
 		{
 			id: "claude-fable-5[1m]",
 			label: "Fable 5 1M",
 			cliModel: "claude-fable-5[1m]",
 			effortLevels: ["low", "medium", "high", "xhigh", "max"],
 		},
-		// App default selection (see `useEnsureDefaultModel`, which pins this
-		// id). Pinned to the explicit `claude-opus-4-8[1m]` wire id — the `[1m]`
+		// Pinned to the explicit `claude-opus-4-8[1m]` wire id — the `[1m]`
 		// suffix selects the 1M-context variant, matching the label. We do NOT
 		// use the CLI's `default` sentinel: it resolves to whatever the bundled
 		// claude-code decides is "default" (non-deterministic across CLI bumps),
@@ -64,24 +76,45 @@ const MODEL_CATALOG: Record<Provider, readonly ProviderModelInfo[]> = {
 	],
 	codex: [
 		{
+			id: "gpt-5.6-sol",
+			label: "GPT-5.6 Sol",
+			cliModel: "gpt-5.6-sol",
+			effortLevels: GPT_5_6_EFFORT_LEVELS,
+			supportsFastMode: true,
+		},
+		{
+			id: "gpt-5.6-terra",
+			label: "GPT-5.6 Terra",
+			cliModel: "gpt-5.6-terra",
+			effortLevels: GPT_5_6_EFFORT_LEVELS,
+			supportsFastMode: true,
+		},
+		{
+			id: "gpt-5.6-luna",
+			label: "GPT-5.6 Luna",
+			cliModel: "gpt-5.6-luna",
+			effortLevels: GPT_5_6_EFFORT_LEVELS,
+			supportsFastMode: true,
+		},
+		{
 			id: "gpt-5.5",
 			label: "GPT-5.5",
 			cliModel: "gpt-5.5",
-			effortLevels: CODEX_EFFORT_LEVELS,
+			effortLevels: LEGACY_CODEX_EFFORT_LEVELS,
 			supportsFastMode: true,
 		},
 		{
 			id: "gpt-5.4",
 			label: "GPT-5.4",
 			cliModel: "gpt-5.4",
-			effortLevels: CODEX_EFFORT_LEVELS,
+			effortLevels: LEGACY_CODEX_EFFORT_LEVELS,
 			supportsFastMode: true,
 		},
 		{
 			id: "gpt-5.4-mini",
-			label: "GPT-5.4-Mini",
+			label: "GPT-5.4 Mini",
 			cliModel: "gpt-5.4-mini",
-			effortLevels: CODEX_EFFORT_LEVELS,
+			effortLevels: LEGACY_CODEX_EFFORT_LEVELS,
 			supportsFastMode: true,
 		},
 	],
@@ -169,25 +202,11 @@ export function modelSupportsFastMode(
 	);
 }
 
-// Heuristic for lightweight background tasks (e.g. title generation):
-// pick the lowest version number in the catalog; when versions tie,
-// prefer a `-mini` variant. Older/smaller variants are usually fast and
-// cheap enough for a one-shot title prompt.
+// Lightweight background tasks (e.g. title generation) use the cheapest
+// member of the current GPT-5.6 family.
 export function pickFastestCodexModel(): string {
-	let best: { cliModel: string; version: number; isMini: boolean } | undefined;
-	for (const m of MODEL_CATALOG.codex) {
-		const match = m.id.match(/(\d+(?:\.\d+)?)/);
-		const version = match?.[1]
-			? Number.parseFloat(match[1])
-			: Number.POSITIVE_INFINITY;
-		const isMini = m.id.includes("mini");
-		if (
-			!best ||
-			version < best.version ||
-			(version === best.version && isMini && !best.isMini)
-		) {
-			best = { cliModel: m.cliModel, version, isMini };
-		}
-	}
-	return best?.cliModel ?? "gpt-5.4-mini";
+	return (
+		MODEL_CATALOG.codex.find((model) => model.id === "gpt-5.6-luna")
+			?.cliModel ?? "gpt-5.6-luna"
+	);
 }

--- a/sidecar/src/model-catalog.ts
+++ b/sidecar/src/model-catalog.ts
@@ -1,7 +1,14 @@
 import type { Provider, ProviderModelInfo } from "./session-manager.js";
 
-const GPT_5_6_EFFORT_LEVELS = [
-	"none",
+const GPT_5_6_SOL_TERRA_EFFORT_LEVELS = [
+	"low",
+	"medium",
+	"high",
+	"xhigh",
+	"max",
+	"ultra",
+] as const;
+const GPT_5_6_LUNA_EFFORT_LEVELS = [
 	"low",
 	"medium",
 	"high",
@@ -73,21 +80,21 @@ const MODEL_CATALOG: Record<Provider, readonly ProviderModelInfo[]> = {
 			id: "gpt-5.6-sol",
 			label: "GPT-5.6 Sol",
 			cliModel: "gpt-5.6-sol",
-			effortLevels: GPT_5_6_EFFORT_LEVELS,
+			effortLevels: GPT_5_6_SOL_TERRA_EFFORT_LEVELS,
 			supportsFastMode: true,
 		},
 		{
 			id: "gpt-5.6-terra",
 			label: "GPT-5.6 Terra",
 			cliModel: "gpt-5.6-terra",
-			effortLevels: GPT_5_6_EFFORT_LEVELS,
+			effortLevels: GPT_5_6_SOL_TERRA_EFFORT_LEVELS,
 			supportsFastMode: true,
 		},
 		{
 			id: "gpt-5.6-luna",
 			label: "GPT-5.6 Luna",
 			cliModel: "gpt-5.6-luna",
-			effortLevels: GPT_5_6_EFFORT_LEVELS,
+			effortLevels: GPT_5_6_LUNA_EFFORT_LEVELS,
 			supportsFastMode: true,
 		},
 		{

--- a/sidecar/src/model-catalog.ts
+++ b/sidecar/src/model-catalog.ts
@@ -196,25 +196,11 @@ export function modelSupportsFastMode(
 	);
 }
 
-// Heuristic for lightweight background tasks (e.g. title generation):
-// pick the lowest version number in the catalog; when versions tie,
-// prefer a `-mini` variant. Older/smaller variants are usually fast and
-// cheap enough for a one-shot title prompt.
+// Lightweight background tasks (e.g. title generation) use the efficient,
+// high-volume member of the current GPT-5.6 family.
 export function pickFastestCodexModel(): string {
-	let best: { cliModel: string; version: number; isMini: boolean } | undefined;
-	for (const m of MODEL_CATALOG.codex) {
-		const match = m.id.match(/(\d+(?:\.\d+)?)/);
-		const version = match?.[1]
-			? Number.parseFloat(match[1])
-			: Number.POSITIVE_INFINITY;
-		const isMini = m.id.includes("mini");
-		if (
-			!best ||
-			version < best.version ||
-			(version === best.version && isMini && !best.isMini)
-		) {
-			best = { cliModel: m.cliModel, version, isMini };
-		}
-	}
-	return best?.cliModel ?? "gpt-5.4-mini";
+	return (
+		MODEL_CATALOG.codex.find((model) => model.id === "gpt-5.6-luna")
+			?.cliModel ?? "gpt-5.6-luna"
+	);
 }

--- a/sidecar/src/model-catalog.ts
+++ b/sidecar/src/model-catalog.ts
@@ -8,13 +8,7 @@ const GPT_5_6_EFFORT_LEVELS = [
 	"xhigh",
 	"max",
 ] as const;
-const LEGACY_CODEX_EFFORT_LEVELS = [
-	"none",
-	"low",
-	"medium",
-	"high",
-	"xhigh",
-] as const;
+const LEGACY_CODEX_EFFORT_LEVELS = ["low", "medium", "high", "xhigh"] as const;
 const CURSOR_REASONING_LEVELS = ["low", "medium", "high"] as const;
 
 // NOTE: the Claude/Codex sections here MUST stay in sync with the Rust
@@ -202,11 +196,25 @@ export function modelSupportsFastMode(
 	);
 }
 
-// Lightweight background tasks (e.g. title generation) use the cheapest
-// member of the current GPT-5.6 family.
+// Heuristic for lightweight background tasks (e.g. title generation):
+// pick the lowest version number in the catalog; when versions tie,
+// prefer a `-mini` variant. Older/smaller variants are usually fast and
+// cheap enough for a one-shot title prompt.
 export function pickFastestCodexModel(): string {
-	return (
-		MODEL_CATALOG.codex.find((model) => model.id === "gpt-5.6-luna")
-			?.cliModel ?? "gpt-5.6-luna"
-	);
+	let best: { cliModel: string; version: number; isMini: boolean } | undefined;
+	for (const m of MODEL_CATALOG.codex) {
+		const match = m.id.match(/(\d+(?:\.\d+)?)/);
+		const version = match?.[1]
+			? Number.parseFloat(match[1])
+			: Number.POSITIVE_INFINITY;
+		const isMini = m.id.includes("mini");
+		if (
+			!best ||
+			version < best.version ||
+			(version === best.version && isMini && !best.isMini)
+		) {
+			best = { cliModel: m.cliModel, version, isMini };
+		}
+	}
+	return best?.cliModel ?? "gpt-5.4-mini";
 }

--- a/sidecar/test/codex-app-server-manager.test.ts
+++ b/sidecar/test/codex-app-server-manager.test.ts
@@ -284,15 +284,17 @@ describe("CodexAppServerManager", () => {
 			expect.arrayContaining([
 				expect.objectContaining({
 					id: "gpt-5.6-sol",
-					effortLevels: ["none", "low", "medium", "high", "xhigh", "max"],
+					effortLevels: ["low", "medium", "high", "xhigh", "max", "ultra"],
 					supportsFastMode: true,
 				}),
 				expect.objectContaining({
 					id: "gpt-5.6-terra",
+					effortLevels: ["low", "medium", "high", "xhigh", "max", "ultra"],
 					supportsFastMode: true,
 				}),
 				expect.objectContaining({
 					id: "gpt-5.6-luna",
+					effortLevels: ["low", "medium", "high", "xhigh", "max"],
 					supportsFastMode: true,
 				}),
 				expect.objectContaining({ id: "gpt-5.5" }),

--- a/sidecar/test/codex-app-server-manager.test.ts
+++ b/sidecar/test/codex-app-server-manager.test.ts
@@ -279,21 +279,25 @@ describe("CodexAppServerManager", () => {
 
 		const models = await manager.listModels();
 
-		expect(models).toHaveLength(3);
+		expect(models).toHaveLength(6);
 		expect(models).toEqual(
 			expect.arrayContaining([
 				expect.objectContaining({
-					id: "gpt-5.5",
+					id: "gpt-5.6-sol",
+					effortLevels: ["none", "low", "medium", "high", "xhigh", "max"],
 					supportsFastMode: true,
 				}),
 				expect.objectContaining({
-					id: "gpt-5.4",
+					id: "gpt-5.6-terra",
 					supportsFastMode: true,
 				}),
 				expect.objectContaining({
-					id: "gpt-5.4-mini",
+					id: "gpt-5.6-luna",
 					supportsFastMode: true,
 				}),
+				expect.objectContaining({ id: "gpt-5.5" }),
+				expect.objectContaining({ id: "gpt-5.4" }),
+				expect.objectContaining({ id: "gpt-5.4-mini" }),
 			]),
 		);
 		expect(serverState.requests).toEqual([]);

--- a/src-tauri/src/agents/catalog.rs
+++ b/src-tauri/src/agents/catalog.rs
@@ -38,6 +38,12 @@ pub struct AgentModelSection {
 }
 
 const DEFAULT_CODEX_MODEL_IDS: &[&str] = &["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"];
+const DEFAULT_CLAUDE_MODEL_IDS: &[&str] = &[
+    "claude-fable-5[1m]",
+    "claude-opus-4-8[1m]",
+    "sonnet",
+    "haiku",
+];
 
 /// The composer/CLI picker catalog: full catalog with the user's model
 /// selection applied. Empty sections are omitted.
@@ -106,9 +112,15 @@ fn apply_official_enabled_filter(
         .into_iter()
         .map(|mut section| {
             match section.id.as_str() {
-                "claude" => section
-                    .options
-                    .retain(|opt| crate::provider::is_enabled(claude_enabled, &opt.id)),
+                "claude" => section.options.retain(|opt| {
+                    claude_enabled.map_or_else(
+                        || {
+                            opt.provider_key.is_some()
+                                || DEFAULT_CLAUDE_MODEL_IDS.contains(&opt.id.as_str())
+                        },
+                        |enabled| crate::provider::is_enabled(Some(enabled), &opt.id),
+                    )
+                }),
                 "codex" => section.options.retain(|opt| {
                     codex_enabled.map_or_else(
                         || {
@@ -345,20 +357,12 @@ fn codex_section() -> AgentModelSection {
                 "GPT-5.6 Luna",
                 &["none", "low", "medium", "high", "xhigh", "max"],
             ),
-            codex_model(
-                "gpt-5.5",
-                "GPT-5.5",
-                &["none", "low", "medium", "high", "xhigh"],
-            ),
-            codex_model(
-                "gpt-5.4",
-                "GPT-5.4",
-                &["none", "low", "medium", "high", "xhigh"],
-            ),
+            codex_model("gpt-5.5", "GPT-5.5", &["low", "medium", "high", "xhigh"]),
+            codex_model("gpt-5.4", "GPT-5.4", &["low", "medium", "high", "xhigh"]),
             codex_model(
                 "gpt-5.4-mini",
                 "GPT-5.4 Mini",
-                &["none", "low", "medium", "high", "xhigh"],
+                &["low", "medium", "high", "xhigh"],
             ),
         ],
     }
@@ -1276,7 +1280,7 @@ mod tests {
     }
 
     #[test]
-    fn official_filter_defaults_to_gpt_5_6_and_keeps_custom_codex_models() {
+    fn official_filter_uses_curated_defaults_and_keeps_custom_codex_models() {
         let custom = codex_custom_model("hundun", "codex:hundun", "custom-model", "Custom");
         let base = model_sections_for_inputs(Vec::new(), vec![custom], None, None, None);
         let filtered = apply_official_enabled_filter(base, None, None);
@@ -1293,6 +1297,36 @@ mod tests {
                 "gpt-5.6-luna",
                 "codex:hundun|custom-model",
             ]
+        );
+        let claude = filtered.iter().find(|s| s.id == "claude").unwrap();
+        assert_eq!(
+            claude
+                .options
+                .iter()
+                .map(|o| o.id.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "claude-fable-5[1m]",
+                "claude-opus-4-8[1m]",
+                "sonnet",
+                "haiku",
+            ]
+        );
+    }
+
+    #[test]
+    fn official_filter_can_reenable_hidden_opus_models() {
+        let base = model_sections_for_inputs(Vec::new(), Vec::new(), None, None, None);
+        let filtered =
+            apply_official_enabled_filter(base, Some(&["claude-opus-4-7[1m]".to_string()]), None);
+        let claude = filtered.iter().find(|s| s.id == "claude").unwrap();
+        assert_eq!(
+            claude
+                .options
+                .iter()
+                .map(|o| o.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["claude-opus-4-7[1m]"]
         );
     }
 

--- a/src-tauri/src/agents/catalog.rs
+++ b/src-tauri/src/agents/catalog.rs
@@ -345,17 +345,17 @@ fn codex_section() -> AgentModelSection {
             codex_model(
                 "gpt-5.6-sol",
                 "GPT-5.6 Sol",
-                &["none", "low", "medium", "high", "xhigh", "max"],
+                &["low", "medium", "high", "xhigh", "max", "ultra"],
             ),
             codex_model(
                 "gpt-5.6-terra",
                 "GPT-5.6 Terra",
-                &["none", "low", "medium", "high", "xhigh", "max"],
+                &["low", "medium", "high", "xhigh", "max", "ultra"],
             ),
             codex_model(
                 "gpt-5.6-luna",
                 "GPT-5.6 Luna",
-                &["none", "low", "medium", "high", "xhigh", "max"],
+                &["low", "medium", "high", "xhigh", "max"],
             ),
             codex_model("gpt-5.5", "GPT-5.5", &["low", "medium", "high", "xhigh"]),
             codex_model("gpt-5.4", "GPT-5.4", &["low", "medium", "high", "xhigh"]),
@@ -1068,7 +1068,15 @@ mod tests {
             .all(|model| model.supports_fast_mode));
         assert_eq!(
             sections[1].options[0].effort_levels,
-            vec!["none", "low", "medium", "high", "xhigh", "max"]
+            vec!["low", "medium", "high", "xhigh", "max", "ultra"]
+        );
+        assert_eq!(
+            sections[1].options[1].effort_levels,
+            vec!["low", "medium", "high", "xhigh", "max", "ultra"]
+        );
+        assert_eq!(
+            sections[1].options[2].effort_levels,
+            vec!["low", "medium", "high", "xhigh", "max"]
         );
 
         // No opencode prefs row → Unavailable, no options.

--- a/src-tauri/src/agents/catalog.rs
+++ b/src-tauri/src/agents/catalog.rs
@@ -37,6 +37,8 @@ pub struct AgentModelSection {
     pub options: Vec<AgentModelOption>,
 }
 
+const DEFAULT_CODEX_MODEL_IDS: &[&str] = &["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"];
+
 /// The composer/CLI picker catalog: full catalog with the user's model
 /// selection applied. Empty sections are omitted.
 pub fn static_model_sections() -> Vec<AgentModelSection> {
@@ -86,7 +88,7 @@ pub fn full_catalog_sections() -> Vec<AgentModelSection> {
 }
 
 fn load_enabled_model_ids(key: &str) -> Option<Vec<String>> {
-    // null/absent → None (all enabled); `[]` → Some(empty) (none enabled).
+    // null/absent → None (provider default); `[]` → Some(empty) (none enabled).
     crate::settings::load_setting_json::<Vec<String>>(key)
         .ok()
         .flatten()
@@ -107,9 +109,15 @@ fn apply_official_enabled_filter(
                 "claude" => section
                     .options
                     .retain(|opt| crate::provider::is_enabled(claude_enabled, &opt.id)),
-                "codex" => section
-                    .options
-                    .retain(|opt| crate::provider::is_enabled(codex_enabled, &opt.id)),
+                "codex" => section.options.retain(|opt| {
+                    codex_enabled.map_or_else(
+                        || {
+                            opt.provider != "codex"
+                                || DEFAULT_CODEX_MODEL_IDS.contains(&opt.id.as_str())
+                        },
+                        |enabled| crate::provider::is_enabled(Some(enabled), &opt.id),
+                    )
+                }),
                 _ => {}
             }
             section
@@ -275,18 +283,16 @@ fn official_claude_section() -> AgentModelSection {
         label: "Claude Code".to_string(),
         status: AgentModelSectionStatus::Ready,
         options: vec![
-            // Fable 5 leads the list as the most capable pick, but it burns
-            // limits ~2x faster than Opus — `useEnsureDefaultModel` therefore
-            // pins the app default to the Opus 4.8 entry below, NOT
-            // to options[0]. No fast mode (Opus 4.6+ only).
+            // Fable 5 leads the Claude list as the most capable pick, but the
+            // cross-provider app default is selected separately by
+            // `useEnsureDefaultModel`. No fast mode (Opus 4.6+ only).
             claude_model(
                 "claude-fable-5[1m]",
                 "Fable 5 1M",
                 &["low", "medium", "high", "xhigh", "max"],
                 false,
             ),
-            // App default selection (see `useEnsureDefaultModel`, which pins
-            // this id). Pinned to the explicit `claude-opus-4-8[1m]` wire id —
+            // Pinned to the explicit `claude-opus-4-8[1m]` wire id —
             // the `[1m]` suffix selects the 1M-context variant, matching the
             // label. We do NOT use the CLI's `default` sentinel: it resolves to
             // whatever the bundled claude-code decides (non-deterministic
@@ -324,9 +330,36 @@ fn codex_section() -> AgentModelSection {
         label: "Codex".to_string(),
         status: AgentModelSectionStatus::Ready,
         options: vec![
-            codex_model("gpt-5.5", "GPT-5.5"),
-            codex_model("gpt-5.4", "GPT-5.4"),
-            codex_model("gpt-5.4-mini", "GPT-5.4-Mini"),
+            codex_model(
+                "gpt-5.6-sol",
+                "GPT-5.6 Sol",
+                &["none", "low", "medium", "high", "xhigh", "max"],
+            ),
+            codex_model(
+                "gpt-5.6-terra",
+                "GPT-5.6 Terra",
+                &["none", "low", "medium", "high", "xhigh", "max"],
+            ),
+            codex_model(
+                "gpt-5.6-luna",
+                "GPT-5.6 Luna",
+                &["none", "low", "medium", "high", "xhigh", "max"],
+            ),
+            codex_model(
+                "gpt-5.5",
+                "GPT-5.5",
+                &["none", "low", "medium", "high", "xhigh"],
+            ),
+            codex_model(
+                "gpt-5.4",
+                "GPT-5.4",
+                &["none", "low", "medium", "high", "xhigh"],
+            ),
+            codex_model(
+                "gpt-5.4-mini",
+                "GPT-5.4 Mini",
+                &["none", "low", "medium", "high", "xhigh"],
+            ),
         ],
     }
 }
@@ -750,16 +783,16 @@ fn claude_model(
     }
 }
 
-fn codex_model(id: &str, label: &str) -> AgentModelOption {
+fn codex_model(id: &str, label: &str, effort_levels: &[&str]) -> AgentModelOption {
     AgentModelOption {
         id: id.to_string(),
         provider: "codex".to_string(),
         label: label.to_string(),
         cli_model: id.to_string(),
         provider_key: None,
-        effort_levels: ["low", "medium", "high", "xhigh"]
-            .into_iter()
-            .map(str::to_string)
+        effort_levels: effort_levels
+            .iter()
+            .map(|level| level.to_string())
             .collect(),
         supports_fast_mode: true,
         supports_context_usage: true,
@@ -1016,12 +1049,23 @@ mod tests {
                 .iter()
                 .map(|model| model.id.as_str())
                 .collect::<Vec<_>>(),
-            vec!["gpt-5.5", "gpt-5.4", "gpt-5.4-mini",]
+            vec![
+                "gpt-5.6-sol",
+                "gpt-5.6-terra",
+                "gpt-5.6-luna",
+                "gpt-5.5",
+                "gpt-5.4",
+                "gpt-5.4-mini",
+            ]
         );
         assert!(sections[1]
             .options
             .iter()
             .all(|model| model.supports_fast_mode));
+        assert_eq!(
+            sections[1].options[0].effort_levels,
+            vec!["none", "low", "medium", "high", "xhigh", "max"]
+        );
 
         // No opencode prefs row → Unavailable, no options.
         assert_eq!(sections[2].id, "opencode");
@@ -1232,6 +1276,27 @@ mod tests {
     }
 
     #[test]
+    fn official_filter_defaults_to_gpt_5_6_and_keeps_custom_codex_models() {
+        let custom = codex_custom_model("hundun", "codex:hundun", "custom-model", "Custom");
+        let base = model_sections_for_inputs(Vec::new(), vec![custom], None, None, None);
+        let filtered = apply_official_enabled_filter(base, None, None);
+        let codex = filtered.iter().find(|s| s.id == "codex").unwrap();
+        assert_eq!(
+            codex
+                .options
+                .iter()
+                .map(|o| o.id.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "gpt-5.6-sol",
+                "gpt-5.6-terra",
+                "gpt-5.6-luna",
+                "codex:hundun|custom-model",
+            ]
+        );
+    }
+
+    #[test]
     fn official_filter_empty_list_empties_options() {
         let base = model_sections_for_inputs(Vec::new(), Vec::new(), None, None, None);
         let filtered = apply_official_enabled_filter(base, Some(&[]), None);
@@ -1255,9 +1320,9 @@ mod tests {
             options,
         };
         let kept = drop_empty_sections(vec![
-            section("alpha", vec![codex_model("m1", "M1")]),
+            section("alpha", vec![codex_model("m1", "M1", &[])]),
             section("beta", Vec::new()),
-            section("gamma", vec![codex_model("m2", "M2")]),
+            section("gamma", vec![codex_model("m2", "M2", &[])]),
         ]);
         assert_eq!(
             kept.iter().map(|s| s.id.as_str()).collect::<Vec<_>>(),

--- a/src-tauri/src/service.rs
+++ b/src-tauri/src/service.rs
@@ -124,6 +124,39 @@ pub struct SendMessageResult {
     pub persisted: bool,
 }
 
+const FALLBACK_DEFAULT_MODEL_ID: &str = "gpt-5.6-sol";
+
+fn load_app_default_model() -> Option<crate::agents::model_ref::StoredModel> {
+    crate::settings::load_setting_value("app.default_model_id")
+        .ok()
+        .flatten()
+        .and_then(|raw| crate::agents::model_ref::parse_stored_model(&raw))
+}
+
+fn select_send_model(
+    explicit_model: Option<&str>,
+    session_model: Option<String>,
+    session_provider: Option<String>,
+    app_default: Option<crate::agents::model_ref::StoredModel>,
+) -> crate::agents::model_ref::StoredModel {
+    if let Some(model_id) = explicit_model {
+        return crate::agents::model_ref::StoredModel {
+            provider: session_provider,
+            model_id: model_id.to_string(),
+        };
+    }
+    if let Some(model_id) = session_model {
+        return crate::agents::model_ref::StoredModel {
+            provider: session_provider,
+            model_id,
+        };
+    }
+    app_default.unwrap_or_else(|| crate::agents::model_ref::StoredModel {
+        provider: None,
+        model_id: FALLBACK_DEFAULT_MODEL_ID.to_string(),
+    })
+}
+
 /// Send a prompt to an AI agent. When the Helmor desktop app is running,
 /// the message is queued as a pending CLI send so the app's shared sidecar
 /// handles it — this gives the frontend live streaming updates. When the
@@ -164,20 +197,25 @@ pub fn send_message(
         },
     };
 
-    // 3. Resolve model — param > session row > app default (Opus 4.8 1M).
+    // 3. Resolve model — param > session row > configured app default > Sol.
     //    Provider hint is required so cursor's `default` doesn't infer to
     //    claude.
     let (session_model, session_provider) =
         crate::models::sessions::get_session_model_and_provider(&session_id)
             .unwrap_or((None, None));
-    let model_id = params
-        .model
-        .as_deref()
-        .map(str::to_string)
-        .or(session_model)
-        .unwrap_or_else(|| "claude-opus-4-8[1m]".to_string());
-    let provider_hint = session_provider.as_deref();
-    let model = crate::agents::resolve_model(&model_id, provider_hint);
+    let app_default = if params.model.is_none() && session_model.is_none() {
+        load_app_default_model()
+    } else {
+        None
+    };
+    let selection = select_send_model(
+        params.model.as_deref(),
+        session_model,
+        session_provider,
+        app_default,
+    );
+    let model_id = selection.model_id;
+    let model = crate::agents::resolve_model(&model_id, selection.provider.as_deref());
 
     // ── App delegation ──────────────────────────────────────────────
     // When the desktop app is running, queue the prompt as a pending
@@ -721,6 +759,63 @@ mod tests {
             std::env::remove_var("HELMOR_DATA_DIR");
             let _ = fs::remove_dir_all(&self.root);
         }
+    }
+
+    #[test]
+    fn send_model_selection_uses_explicit_then_session_then_app_default() {
+        let app_default = crate::agents::model_ref::StoredModel {
+            provider: Some("codex".to_string()),
+            model_id: "gpt-5.6-terra".to_string(),
+        };
+        let explicit = select_send_model(
+            Some("cursor-default"),
+            Some("gpt-5.6-luna".to_string()),
+            Some("cursor".to_string()),
+            Some(app_default.clone()),
+        );
+        assert_eq!(explicit.model_id, "cursor-default");
+        assert_eq!(explicit.provider.as_deref(), Some("cursor"));
+
+        let session = select_send_model(
+            None,
+            Some("gpt-5.6-luna".to_string()),
+            Some("codex".to_string()),
+            Some(app_default.clone()),
+        );
+        assert_eq!(session.model_id, "gpt-5.6-luna");
+        assert_eq!(session.provider.as_deref(), Some("codex"));
+
+        let default = select_send_model(None, None, None, Some(app_default));
+        assert_eq!(default.model_id, "gpt-5.6-terra");
+        assert_eq!(default.provider.as_deref(), Some("codex"));
+    }
+
+    #[test]
+    fn send_model_selection_falls_back_to_sol() {
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
+        let _dir = TestDataDir::new("fallback-default-model");
+        let selection = select_send_model(None, None, None, None);
+        assert_eq!(selection.model_id, FALLBACK_DEFAULT_MODEL_ID);
+        assert_eq!(selection.provider, None);
+
+        let resolved = crate::agents::resolve_model(&selection.model_id, None);
+        assert_eq!(resolved.provider, "codex");
+        assert_eq!(resolved.cli_model, "gpt-5.6-sol");
+    }
+
+    #[test]
+    fn loads_provider_aware_app_default_model() {
+        let _lock = TEST_ENV_LOCK.lock().unwrap();
+        let _dir = TestDataDir::new("app-default-model");
+        crate::settings::upsert_setting_value(
+            "app.default_model_id",
+            r#"{"provider":"codex","modelId":"gpt-5.6-terra"}"#,
+        )
+        .unwrap();
+
+        let default = load_app_default_model().unwrap();
+        assert_eq!(default.model_id, "gpt-5.6-terra");
+        assert_eq!(default.provider.as_deref(), Some("codex"));
     }
 
     #[test]

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -73,6 +73,7 @@ import {
 } from "./input-history";
 import type { PermissionPanelProps } from "./permission-panel";
 import { SessionContextInjector } from "./session-context-injector";
+import { includePinnedLegacyCodexModel } from "./session-model-sections";
 import type { StartSubmitMode } from "./start-submit-mode";
 import { SubmitQueueList } from "./submit-queue-list";
 import type { UserInputResponseHandler } from "./user-input";
@@ -535,12 +536,13 @@ export const WorkspaceComposerContainer = memo(
 			],
 		);
 
-		const modelSections = modelSectionsQuery.data ?? EMPTY_MODEL_SECTIONS;
+		const availableModelSections =
+			modelSectionsQuery.data ?? EMPTY_MODEL_SECTIONS;
 		const modelsLoading =
 			modelSectionsQuery.isLoading &&
-			modelSections.every((s) => s.options.length === 0);
+			availableModelSections.every((s) => s.options.length === 0);
 		// Drives the OpenCode "Add custom model…" jump; only fetched when an OpenCode section exists.
-		const opencodeSectionPresent = modelSections.some(
+		const opencodeSectionPresent = availableModelSections.some(
 			(s) => s.id === "opencode",
 		);
 		const opencodeCustomProvidersQuery = useQuery({
@@ -554,6 +556,11 @@ export const WorkspaceComposerContainer = memo(
 			(sessionsQuery.data ?? []).find(
 				(session) => session.id === displayedSessionId,
 			) ?? null;
+		const modelSections = useMemo(
+			() =>
+				includePinnedLegacyCodexModel(availableModelSections, currentSession),
+			[availableModelSections, currentSession],
+		);
 		const composerContextKey =
 			contextKeyOverride ??
 			getComposerContextKey(displayedWorkspaceId, displayedSessionId);

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -73,7 +73,7 @@ import {
 } from "./input-history";
 import type { PermissionPanelProps } from "./permission-panel";
 import { SessionContextInjector } from "./session-context-injector";
-import { includePinnedLegacyCodexModel } from "./session-model-sections";
+import { includePinnedHiddenModel } from "./session-model-sections";
 import type { StartSubmitMode } from "./start-submit-mode";
 import { SubmitQueueList } from "./submit-queue-list";
 import type { UserInputResponseHandler } from "./user-input";
@@ -557,8 +557,7 @@ export const WorkspaceComposerContainer = memo(
 				(session) => session.id === displayedSessionId,
 			) ?? null;
 		const modelSections = useMemo(
-			() =>
-				includePinnedLegacyCodexModel(availableModelSections, currentSession),
+			() => includePinnedHiddenModel(availableModelSections, currentSession),
 			[availableModelSections, currentSession],
 		);
 		const composerContextKey =

--- a/src/features/composer/session-model-sections.test.ts
+++ b/src/features/composer/session-model-sections.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import type { AgentModelSection } from "@/lib/api";
+import { includePinnedLegacyCodexModel } from "./session-model-sections";
+
+const SECTIONS: AgentModelSection[] = [
+	{
+		id: "codex",
+		label: "Codex",
+		status: "ready",
+		options: [
+			{
+				id: "gpt-5.6-sol",
+				provider: "codex",
+				label: "GPT-5.6 Sol",
+				cliModel: "gpt-5.6-sol",
+			},
+		],
+	},
+];
+
+describe("includePinnedLegacyCodexModel", () => {
+	it("keeps the hidden model available to an existing Codex session", () => {
+		const result = includePinnedLegacyCodexModel(SECTIONS, {
+			agentType: "codex",
+			model: "gpt-5.5",
+		});
+
+		expect(result[0]?.options.map((model) => model.id)).toEqual([
+			"gpt-5.6-sol",
+			"gpt-5.5",
+		]);
+	});
+
+	it("does not add a legacy model to unrelated sessions", () => {
+		expect(
+			includePinnedLegacyCodexModel(SECTIONS, {
+				agentType: "claude",
+				model: "gpt-5.5",
+			}),
+		).toBe(SECTIONS);
+	});
+
+	it("does not duplicate a legacy model that the user re-enabled", () => {
+		const withLegacy = [
+			{
+				...SECTIONS[0]!,
+				options: [
+					...SECTIONS[0]!.options,
+					{
+						id: "gpt-5.5",
+						provider: "codex" as const,
+						label: "GPT-5.5",
+						cliModel: "gpt-5.5",
+					},
+				],
+			},
+		];
+
+		expect(
+			includePinnedLegacyCodexModel(withLegacy, {
+				agentType: "codex",
+				model: "gpt-5.5",
+			}),
+		).toBe(withLegacy);
+	});
+});

--- a/src/features/composer/session-model-sections.test.ts
+++ b/src/features/composer/session-model-sections.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { AgentModelSection } from "@/lib/api";
-import { includePinnedLegacyCodexModel } from "./session-model-sections";
+import { includePinnedHiddenModel } from "./session-model-sections";
 
 const SECTIONS: AgentModelSection[] = [
 	{
@@ -18,9 +18,9 @@ const SECTIONS: AgentModelSection[] = [
 	},
 ];
 
-describe("includePinnedLegacyCodexModel", () => {
+describe("includePinnedHiddenModel", () => {
 	it("keeps the hidden model available to an existing Codex session", () => {
-		const result = includePinnedLegacyCodexModel(SECTIONS, {
+		const result = includePinnedHiddenModel(SECTIONS, {
 			agentType: "codex",
 			model: "gpt-5.5",
 		});
@@ -31,9 +31,23 @@ describe("includePinnedLegacyCodexModel", () => {
 		]);
 	});
 
+	it("keeps a hidden Opus model available to an existing Claude session", () => {
+		const result = includePinnedHiddenModel([], {
+			agentType: "claude",
+			model: "claude-opus-4-7[1m]",
+		});
+
+		expect(result[0]).toEqual(
+			expect.objectContaining({
+				id: "claude",
+				options: [expect.objectContaining({ id: "claude-opus-4-7[1m]" })],
+			}),
+		);
+	});
+
 	it("does not add a legacy model to unrelated sessions", () => {
 		expect(
-			includePinnedLegacyCodexModel(SECTIONS, {
+			includePinnedHiddenModel(SECTIONS, {
 				agentType: "claude",
 				model: "gpt-5.5",
 			}),
@@ -57,7 +71,7 @@ describe("includePinnedLegacyCodexModel", () => {
 		];
 
 		expect(
-			includePinnedLegacyCodexModel(withLegacy, {
+			includePinnedHiddenModel(withLegacy, {
 				agentType: "codex",
 				model: "gpt-5.5",
 			}),

--- a/src/features/composer/session-model-sections.ts
+++ b/src/features/composer/session-model-sections.ts
@@ -1,0 +1,65 @@
+import type {
+	AgentModelOption,
+	AgentModelSection,
+	WorkspaceSessionSummary,
+} from "@/lib/api";
+
+const LEGACY_CODEX_MODELS: Record<string, AgentModelOption> = {
+	"gpt-5.5": {
+		id: "gpt-5.5",
+		provider: "codex",
+		label: "GPT-5.5",
+		cliModel: "gpt-5.5",
+		effortLevels: ["none", "low", "medium", "high", "xhigh"],
+		supportsFastMode: true,
+		supportsContextUsage: true,
+	},
+	"gpt-5.4": {
+		id: "gpt-5.4",
+		provider: "codex",
+		label: "GPT-5.4",
+		cliModel: "gpt-5.4",
+		effortLevels: ["none", "low", "medium", "high", "xhigh"],
+		supportsFastMode: true,
+		supportsContextUsage: true,
+	},
+	"gpt-5.4-mini": {
+		id: "gpt-5.4-mini",
+		provider: "codex",
+		label: "GPT-5.4 Mini",
+		cliModel: "gpt-5.4-mini",
+		effortLevels: ["none", "low", "medium", "high", "xhigh"],
+		supportsFastMode: true,
+		supportsContextUsage: true,
+	},
+};
+
+export function includePinnedLegacyCodexModel(
+	sections: AgentModelSection[],
+	session: Pick<WorkspaceSessionSummary, "agentType" | "model"> | null,
+): AgentModelSection[] {
+	if (session?.agentType !== "codex" || !session.model) return sections;
+	const legacyModel = LEGACY_CODEX_MODELS[session.model];
+	if (!legacyModel) return sections;
+	if (
+		sections.some((section) =>
+			section.options.some((o) => o.id === session.model),
+		)
+	) {
+		return sections;
+	}
+
+	const codexIndex = sections.findIndex((section) => section.id === "codex");
+	if (codexIndex === -1) {
+		return [
+			...sections,
+			{ id: "codex", label: "Codex", status: "ready", options: [legacyModel] },
+		];
+	}
+
+	return sections.map((section, index) =>
+		index === codexIndex
+			? { ...section, options: [...section.options, legacyModel] }
+			: section,
+	);
+}

--- a/src/features/composer/session-model-sections.ts
+++ b/src/features/composer/session-model-sections.ts
@@ -4,13 +4,30 @@ import type {
 	WorkspaceSessionSummary,
 } from "@/lib/api";
 
-const LEGACY_CODEX_MODELS: Record<string, AgentModelOption> = {
+const HIDDEN_MODELS: Record<string, AgentModelOption> = {
+	"claude-opus-4-7[1m]": {
+		id: "claude-opus-4-7[1m]",
+		provider: "claude",
+		label: "Opus 4.7 1M",
+		cliModel: "claude-opus-4-7[1m]",
+		effortLevels: ["low", "medium", "high", "xhigh", "max"],
+		supportsContextUsage: true,
+	},
+	"claude-opus-4-6[1m]": {
+		id: "claude-opus-4-6[1m]",
+		provider: "claude",
+		label: "Opus 4.6 1M",
+		cliModel: "claude-opus-4-6[1m]",
+		effortLevels: ["low", "medium", "high", "max"],
+		supportsFastMode: true,
+		supportsContextUsage: true,
+	},
 	"gpt-5.5": {
 		id: "gpt-5.5",
 		provider: "codex",
 		label: "GPT-5.5",
 		cliModel: "gpt-5.5",
-		effortLevels: ["none", "low", "medium", "high", "xhigh"],
+		effortLevels: ["low", "medium", "high", "xhigh"],
 		supportsFastMode: true,
 		supportsContextUsage: true,
 	},
@@ -19,7 +36,7 @@ const LEGACY_CODEX_MODELS: Record<string, AgentModelOption> = {
 		provider: "codex",
 		label: "GPT-5.4",
 		cliModel: "gpt-5.4",
-		effortLevels: ["none", "low", "medium", "high", "xhigh"],
+		effortLevels: ["low", "medium", "high", "xhigh"],
 		supportsFastMode: true,
 		supportsContextUsage: true,
 	},
@@ -28,19 +45,20 @@ const LEGACY_CODEX_MODELS: Record<string, AgentModelOption> = {
 		provider: "codex",
 		label: "GPT-5.4 Mini",
 		cliModel: "gpt-5.4-mini",
-		effortLevels: ["none", "low", "medium", "high", "xhigh"],
+		effortLevels: ["low", "medium", "high", "xhigh"],
 		supportsFastMode: true,
 		supportsContextUsage: true,
 	},
 };
 
-export function includePinnedLegacyCodexModel(
+export function includePinnedHiddenModel(
 	sections: AgentModelSection[],
 	session: Pick<WorkspaceSessionSummary, "agentType" | "model"> | null,
 ): AgentModelSection[] {
-	if (session?.agentType !== "codex" || !session.model) return sections;
-	const legacyModel = LEGACY_CODEX_MODELS[session.model];
-	if (!legacyModel) return sections;
+	if (!session?.agentType || !session.model) return sections;
+	const hiddenModel = HIDDEN_MODELS[session.model];
+	if (!hiddenModel || hiddenModel.provider !== session.agentType)
+		return sections;
 	if (
 		sections.some((section) =>
 			section.options.some((o) => o.id === session.model),
@@ -49,17 +67,24 @@ export function includePinnedLegacyCodexModel(
 		return sections;
 	}
 
-	const codexIndex = sections.findIndex((section) => section.id === "codex");
-	if (codexIndex === -1) {
+	const sectionIndex = sections.findIndex(
+		(section) => section.id === hiddenModel.provider,
+	);
+	if (sectionIndex === -1) {
 		return [
 			...sections,
-			{ id: "codex", label: "Codex", status: "ready", options: [legacyModel] },
+			{
+				id: hiddenModel.provider,
+				label: hiddenModel.provider === "codex" ? "Codex" : "Claude Code",
+				status: "ready",
+				options: [hiddenModel],
+			},
 		];
 	}
 
 	return sections.map((section, index) =>
-		index === codexIndex
-			? { ...section, options: [...section.options, legacyModel] }
+		index === sectionIndex
+			? { ...section, options: [...section.options, hiddenModel] }
 			: section,
 	);
 }

--- a/src/features/settings/panels/providers/adapters/hooks.ts
+++ b/src/features/settings/panels/providers/adapters/hooks.ts
@@ -10,7 +10,7 @@ import {
 import {
 	type CustomProvider,
 	type ProviderFamily,
-	resolveEnabled,
+	resolveOfficialEnabled,
 	toggleEnabled,
 } from "@/lib/provider-config";
 import {
@@ -85,7 +85,7 @@ export function useOfficialSectionModels(
 		family === "claude"
 			? settings.claudeEnabledModelIds
 			: settings.codexEnabledModelIds;
-	const enabledIds = resolveEnabled(stored, available);
+	const enabledIds = resolveOfficialEnabled(family, stored, available);
 	const enabledSet = useMemo(() => new Set(enabledIds), [enabledIds]);
 
 	const persist = useCallback(
@@ -116,7 +116,7 @@ export function useOfficialSectionModels(
 		available,
 		enabledIds,
 		enabledSet,
-		toggle: (id: string) => persist(toggleEnabled(stored, available, id)),
+		toggle: (id: string) => persist(toggleEnabled(enabledIds, available, id)),
 		clear: () => persist([]),
 		loading: sectionsQuery.isLoading,
 		refresh,

--- a/src/lib/provider-config.test.ts
+++ b/src/lib/provider-config.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { resolveOfficialEnabled } from "./provider-config";
+
+const AVAILABLE = [
+	{ slug: "gpt-5.6-sol" },
+	{ slug: "gpt-5.6-terra" },
+	{ slug: "gpt-5.6-luna" },
+	{ slug: "gpt-5.5" },
+	{ slug: "gpt-5.4" },
+	{ slug: "gpt-5.4-mini" },
+	{ slug: "codex:custom|model" },
+];
+
+describe("resolveOfficialEnabled", () => {
+	it("defaults Codex to GPT-5.6 models and user-configured custom models", () => {
+		expect(resolveOfficialEnabled("codex", null, AVAILABLE)).toEqual([
+			"gpt-5.6-sol",
+			"gpt-5.6-terra",
+			"gpt-5.6-luna",
+			"codex:custom|model",
+		]);
+	});
+
+	it("preserves an explicit Codex model selection", () => {
+		expect(resolveOfficialEnabled("codex", ["gpt-5.5"], AVAILABLE)).toEqual([
+			"gpt-5.5",
+		]);
+	});
+
+	it("keeps Claude null semantics as all enabled", () => {
+		expect(resolveOfficialEnabled("claude", null, AVAILABLE)).toEqual(
+			AVAILABLE.map((model) => model.slug),
+		);
+	});
+});

--- a/src/lib/provider-config.test.ts
+++ b/src/lib/provider-config.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { resolveOfficialEnabled } from "./provider-config";
 
-const AVAILABLE = [
+const CODEX_AVAILABLE = [
 	{ slug: "gpt-5.6-sol" },
 	{ slug: "gpt-5.6-terra" },
 	{ slug: "gpt-5.6-luna" },
@@ -11,9 +11,19 @@ const AVAILABLE = [
 	{ slug: "codex:custom|model" },
 ];
 
+const CLAUDE_AVAILABLE = [
+	{ slug: "claude-fable-5[1m]" },
+	{ slug: "claude-opus-4-8[1m]" },
+	{ slug: "claude-opus-4-7[1m]" },
+	{ slug: "claude-opus-4-6[1m]" },
+	{ slug: "sonnet" },
+	{ slug: "haiku" },
+	{ slug: "claude-custom|gateway|model" },
+];
+
 describe("resolveOfficialEnabled", () => {
 	it("defaults Codex to GPT-5.6 models and user-configured custom models", () => {
-		expect(resolveOfficialEnabled("codex", null, AVAILABLE)).toEqual([
+		expect(resolveOfficialEnabled("codex", null, CODEX_AVAILABLE)).toEqual([
 			"gpt-5.6-sol",
 			"gpt-5.6-terra",
 			"gpt-5.6-luna",
@@ -22,14 +32,18 @@ describe("resolveOfficialEnabled", () => {
 	});
 
 	it("preserves an explicit Codex model selection", () => {
-		expect(resolveOfficialEnabled("codex", ["gpt-5.5"], AVAILABLE)).toEqual([
-			"gpt-5.5",
-		]);
+		expect(
+			resolveOfficialEnabled("codex", ["gpt-5.5"], CODEX_AVAILABLE),
+		).toEqual(["gpt-5.5"]);
 	});
 
-	it("keeps Claude null semantics as all enabled", () => {
-		expect(resolveOfficialEnabled("claude", null, AVAILABLE)).toEqual(
-			AVAILABLE.map((model) => model.slug),
-		);
+	it("defaults Claude to current models and user-configured custom models", () => {
+		expect(resolveOfficialEnabled("claude", null, CLAUDE_AVAILABLE)).toEqual([
+			"claude-fable-5[1m]",
+			"claude-opus-4-8[1m]",
+			"sonnet",
+			"haiku",
+			"claude-custom|gateway|model",
+		]);
 	});
 });

--- a/src/lib/provider-config.ts
+++ b/src/lib/provider-config.ts
@@ -2,6 +2,12 @@
 
 export type ProviderFamily = "claude" | "codex" | "opencode" | "kimi";
 
+export const DEFAULT_CODEX_MODEL_IDS = [
+	"gpt-5.6-sol",
+	"gpt-5.6-terra",
+	"gpt-5.6-luna",
+] as const;
+
 export type CustomProviderModel = {
 	slug: string;
 	label: string;
@@ -43,6 +49,24 @@ export function resolveEnabled(
 	available: readonly { slug: string }[],
 ): string[] {
 	return enabled ?? available.map((m) => m.slug);
+}
+
+export function resolveOfficialEnabled(
+	family: "claude" | "codex",
+	enabled: string[] | null,
+	available: readonly { slug: string }[],
+): string[] {
+	if (family !== "codex" || enabled !== null) {
+		return resolveEnabled(enabled, available);
+	}
+
+	return available
+		.filter(
+			(model) =>
+				DEFAULT_CODEX_MODEL_IDS.some((id) => id === model.slug) ||
+				model.slug.startsWith("codex:"),
+		)
+		.map((model) => model.slug);
 }
 
 export function toggleEnabled(

--- a/src/lib/provider-config.ts
+++ b/src/lib/provider-config.ts
@@ -8,6 +8,13 @@ export const DEFAULT_CODEX_MODEL_IDS = [
 	"gpt-5.6-luna",
 ] as const;
 
+export const DEFAULT_CLAUDE_MODEL_IDS = [
+	"claude-fable-5[1m]",
+	"claude-opus-4-8[1m]",
+	"sonnet",
+	"haiku",
+] as const;
+
 export type CustomProviderModel = {
 	slug: string;
 	label: string;
@@ -56,15 +63,17 @@ export function resolveOfficialEnabled(
 	enabled: string[] | null,
 	available: readonly { slug: string }[],
 ): string[] {
-	if (family !== "codex" || enabled !== null) {
-		return resolveEnabled(enabled, available);
-	}
+	if (enabled !== null) return resolveEnabled(enabled, available);
+
+	const defaultIds =
+		family === "codex" ? DEFAULT_CODEX_MODEL_IDS : DEFAULT_CLAUDE_MODEL_IDS;
+	const customPrefix = family === "codex" ? "codex:" : "claude-custom|";
 
 	return available
 		.filter(
 			(model) =>
-				DEFAULT_CODEX_MODEL_IDS.some((id) => id === model.slug) ||
-				model.slug.startsWith("codex:"),
+				defaultIds.some((id) => id === model.slug) ||
+				model.slug.startsWith(customPrefix),
 		)
 		.map((model) => model.slug);
 }

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -346,7 +346,8 @@ export type AppSettings = {
 	autoArchiveOnMerge: boolean;
 	onboardingCompleted: boolean;
 	shortcuts: ShortcutOverrides;
-	/** Claude model ids in the picker. `null` = all (default), `[]` = none. */
+	/** Claude model ids in the picker. `null` = recommended official models plus
+	 *  all custom models; `[]` = none. */
 	claudeEnabledModelIds: string[] | null;
 	/** Codex model ids in the picker. `null` = recommended official models plus
 	 *  all custom models; `[]` = none. */

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -348,7 +348,8 @@ export type AppSettings = {
 	shortcuts: ShortcutOverrides;
 	/** Claude model ids in the picker. `null` = all (default), `[]` = none. */
 	claudeEnabledModelIds: string[] | null;
-	/** Codex model ids in the picker. Same `null`/`[]` semantics. */
+	/** Codex model ids in the picker. `null` = recommended official models plus
+	 *  all custom models; `[]` = none. */
 	codexEnabledModelIds: string[] | null;
 	cursorProvider: CursorProviderSettings;
 	opencodeProvider: OpencodeProviderSettings;

--- a/src/lib/workspace-helpers.test.ts
+++ b/src/lib/workspace-helpers.test.ts
@@ -1048,6 +1048,12 @@ describe("clampEffort", () => {
 	it("clamps down to nearest available", () => {
 		expect(clampEffort("max", ["low", "medium"])).toBe("medium");
 	});
+
+	it("clamps ultra down to a model's maximum effort", () => {
+		expect(
+			clampEffort("ultra", ["low", "medium", "high", "xhigh", "max"]),
+		).toBe("max");
+	});
 });
 
 describe("clampEffortToModel", () => {

--- a/src/lib/workspace-helpers.ts
+++ b/src/lib/workspace-helpers.ts
@@ -1094,6 +1094,7 @@ export function createLiveThreadMessage({
 // ── Effort-level helpers ──────────────────────────────────────────────
 
 const EFFORT_RANK: Record<string, number> = {
+	none: 0,
 	minimal: 0,
 	low: 1,
 	medium: 2,

--- a/src/lib/workspace-helpers.ts
+++ b/src/lib/workspace-helpers.ts
@@ -1100,7 +1100,8 @@ const EFFORT_RANK: Record<string, number> = {
 	medium: 2,
 	high: 3,
 	xhigh: 4,
-	max: 4,
+	max: 5,
+	ultra: 6,
 };
 
 // No fake default — when the SDK doesn't return effort levels for a model

--- a/src/shell/hooks/use-ensure-default-model.test.tsx
+++ b/src/shell/hooks/use-ensure-default-model.test.tsx
@@ -171,9 +171,7 @@ describe("useEnsureDefaultModel", () => {
 		});
 	});
 
-	it("pins the repaired default to the Opus 4.8 1M entry, not the first option", () => {
-		// Fable 5 leads the picker but is too expensive to be the app
-		// default — the repair must skip it and land on Opus 4.8 1M.
+	it("pins the repaired default to GPT-5.6 Sol", () => {
 		const { updateSettings } = renderUseEnsureDefaultModel({
 			defaultModelId: null,
 			sections: [
@@ -196,13 +194,25 @@ describe("useEnsureDefaultModel", () => {
 						},
 					],
 				},
-				{ id: "codex", label: "Codex", status: "unavailable", options: [] },
+				{
+					id: "codex",
+					label: "Codex",
+					status: "ready",
+					options: [
+						{
+							id: "gpt-5.6-sol",
+							provider: "codex",
+							label: "GPT-5.6 Sol",
+							cliModel: "gpt-5.6-sol",
+						},
+					],
+				},
 			],
 		});
 
 		expect(updateSettings).toHaveBeenCalledWith(
 			expect.objectContaining({
-				defaultModel: { provider: "claude", modelId: "claude-opus-4-8[1m]" },
+				defaultModel: { provider: "codex", modelId: "gpt-5.6-sol" },
 			}),
 		);
 	});

--- a/src/shell/hooks/use-ensure-default-model.ts
+++ b/src/shell/hooks/use-ensure-default-model.ts
@@ -59,13 +59,12 @@ export function useEnsureDefaultModel() {
 		// Repair the default when it's never been set, or was set but is now
 		// definitively gone (wait for every provider to settle first).
 		if (!defaultOption && (settled || !settings.defaultModel)) {
-			// Prefer the pinned Opus 4.8 1M entry over the first listed option —
-			// pricier models (Fable 5) sit above it in the picker but must not
-			// become the app default. A legacy stored "default" id no longer
-			// matches any option, so this re-pins it to the explicit wire id.
+			// GPT-5.6 Sol is the recommended cross-provider default. Opus 4.8
+			// remains the fallback when Codex is unavailable or fully disabled.
 			const claudeOptions =
 				sections.find((s) => s.id === "claude")?.options ?? [];
 			const pickOption =
+				allOptions.find((o) => o.id === "gpt-5.6-sol") ??
 				claudeOptions.find((o) => o.id === "claude-opus-4-8[1m]") ??
 				claudeOptions[0] ??
 				allOptions[0] ??


### PR DESCRIPTION
## Summary

- Add GPT-5.6 Sol, Terra, and Luna with their official model IDs and six effort levels: `none`, `low`, `medium`, `high`, `xhigh`, and `max`.
- Recommend GPT-5.6 Sol for fresh or repaired defaults.
- Keep the default Codex picker focused on GPT-5.6 while leaving GPT-5.5, GPT-5.4, and GPT-5.4 Mini available under Settings → Models.
- Hide Opus 4.7 and Opus 4.6 from the default picker while keeping them available under Settings → Models.
- Preserve hidden models inside existing sessions that already have one pinned, and keep user-configured custom models enabled by default.
- Use GPT-5.6 Luna, the current efficient high-volume tier, for lightweight Codex title generation; legacy Codex effort choices remain unchanged.

## Why

GPT-5.6 introduces a clearer capability/price ladder. Helmor should make the strong current-generation choice for each workload while reducing the default model surface and preserving explicit legacy preferences.

## Release

- Minor changeset for the new model family and streamlined default model selection.
- In-app announcement linking directly to Models settings.

## Checks

- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `bun run lint`
- [x] `bun run release:verify`
