### PR TITLE
fix(sidecar): bundle codex-code-mode-host companion binary

### DIFF
--- a/.changeset/stage-codex-code-mode-host.md
+++ b/.changeset/stage-codex-code-mode-host.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix Codex tool calls failing after the 0.144 upgrade by bundling the new `codex-code-mode-host` companion binary that Codex spawns for code-mode execution.

--- a/sidecar/scripts/stage-vendor.ts
+++ b/sidecar/scripts/stage-vendor.ts
@@ -497,6 +497,20 @@ function stageCodexFromVendorRoot(archRoot: string): void {
 	chmodSync(binDest, 0o755);
 	maybeSignMacBinary(binDest, false);
 
+	// codex >= 0.144 ships a `codex-code-mode-host` companion next to the main
+	// binary in `bin/`. The descriptor does not advertise it (only `entrypoint`),
+	// but codex spawns it as a sibling of itself at runtime for "code mode" tool
+	// execution — omit it and every code-mode tool call fails with ENOENT. Copy
+	// it next to the flattened codex binary when present (guarded for older
+	// layouts / platforms that don't ship it).
+	const hostSrc = join(dirname(binSrc), `codex-code-mode-host${EXE}`);
+	if (existsSync(hostSrc)) {
+		const hostDest = join(DIST_VENDOR, "codex", `codex-code-mode-host${EXE}`);
+		copyFile(hostSrc, hostDest);
+		chmodSync(hostDest, 0o755);
+		maybeSignMacBinary(hostDest, false);
+	}
+
 	const pathSrc = join(archRoot, pathDir);
 	if (existsSync(pathSrc)) {
 		const pathDest = join(DIST_VENDOR, "codex", "path");


### PR DESCRIPTION
## Problem

Today's #916 bumped codex from `0.142.5` to `0.144.0`. codex 0.144 added a companion binary `codex-code-mode-host` (46 MB) inside the npm package's `bin/` directory, which codex forks as a **sibling of itself** when executing tool calls in "code mode".

However, the `codex-package.json` descriptor only advertises `entrypoint: bin/codex` — it never mentions the sibling. `stageCodexFromVendorRoot()` in `stage-vendor.ts` follows the descriptor and stages only the entrypoint, so the bundled App shipped without `codex-code-mode-host`. Every code-mode tool call then failed before execution with `ENOENT / No such file or directory`.

Observed symptoms: bash commands in a codex session error out before running; a review sub-agent's structured result (`file/line/summary/failure_scenario`) degrades into raw JSON body text and the task never closes cleanly.

## Fix

After copying the entrypoint in `stageCodexFromVendorRoot()`, also copy `codex-code-mode-host` (when it exists next to the entrypoint) to sit beside the flattened `codex` binary, chmod 755, and sign it. Guarded with `existsSync` so older layouts / platforms that don't ship it are unaffected.

## Verification

- After `bun run scripts/stage-vendor.ts`, `dist/vendor/codex/` now contains `codex-code-mode-host`; the codex bundle grows from 252.9 MB to 297.1 MB.
- sidecar `tsc --noEmit` passes; biome is clean.

No Rust changes needed — codex locates code-mode-host itself, relative to argv[0].