### PR TITLE
fix(sidecar): keep draining after background tasks settle so the agent's continuation survives

### DIFF
--- a/.changeset/patient-drain-continues.md
+++ b/.changeset/patient-drain-continues.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix Claude turns ending the moment background tasks finished, cutting off the agent's follow-up synthesis before it could report the results.

--- a/sidecar/src/claude/background-resume.test.ts
+++ b/sidecar/src/claude/background-resume.test.ts
@@ -26,6 +26,8 @@ let hangAfterScenario = false;
 let queryCloseCount = 0;
 const releaseHangingQueries = new Set<() => void>();
 const previousBgDrainTimeout = process.env.HELMOR_CLAUDE_BG_DRAIN_TIMEOUT_MS;
+const previousContinuationGrace =
+	process.env.HELMOR_CLAUDE_BG_CONTINUATION_GRACE_MS;
 const LONG_BG_DRAIN_TIMEOUT_MS = "60000";
 
 function makeQuery(messages: SDKMessage[]) {
@@ -131,7 +133,10 @@ function assistant(text: string): SDKMessage {
 	} as unknown as SDKMessage;
 }
 
-function result(terminalReason: string): SDKMessage {
+function result(
+	terminalReason: string,
+	uuid = `r-${terminalReason}`,
+): SDKMessage {
 	return {
 		type: "result",
 		subtype: "success",
@@ -140,7 +145,7 @@ function result(terminalReason: string): SDKMessage {
 		usage: USAGE,
 		modelUsage: MODEL_USAGE,
 		session_id: "s1",
-		uuid: `r-${terminalReason}`,
+		uuid,
 	} as unknown as SDKMessage;
 }
 
@@ -209,6 +214,12 @@ afterEach(() => {
 		delete process.env.HELMOR_CLAUDE_BG_DRAIN_TIMEOUT_MS;
 	} else {
 		process.env.HELMOR_CLAUDE_BG_DRAIN_TIMEOUT_MS = previousBgDrainTimeout;
+	}
+	if (previousContinuationGrace === undefined) {
+		delete process.env.HELMOR_CLAUDE_BG_CONTINUATION_GRACE_MS;
+	} else {
+		process.env.HELMOR_CLAUDE_BG_CONTINUATION_GRACE_MS =
+			previousContinuationGrace;
 	}
 });
 
@@ -300,14 +311,19 @@ describe("ClaudeSessionManager run_in_background drain (completed with pending b
 				(m as { terminal_reason?: string }).terminal_reason === "completed",
 		).length;
 
-	test("defers `completed` while a bg task is pending, replays it on task_notification, ends once", async () => {
+	// Recorded contract (claude 2.1.205, .agent-contexts/bg-drain-contract):
+	// after `task_notification` the CLI re-invokes the main agent on the SAME
+	// query (the continuation may even use tools) and then emits a SECOND,
+	// genuinely terminal `completed`. Replaying the deferred `completed` at
+	// notification time — the pre-fix behavior — killed that continuation.
+	test("keeps draining after task_notification: the continuation passes through and the SECOND completed ends the turn", async () => {
 		scenario = [
 			assistant("dispatching"),
 			taskStarted("bg1"),
-			result("completed"), // intermediate — bg1 still pending, must be deferred
-			taskNotification("bg1"), // bg1 settles
+			result("completed", "r-intermediate"), // bg1 still pending — deferred
+			taskNotification("bg1"), // bg1 settles; continuation follows
 			assistant("synthesizing"),
-			result("completed"), // genuinely terminal
+			result("completed", "r-final"), // genuinely terminal
 		];
 		const spy = makeSpyEmitter();
 		await new ClaudeSessionManager().sendMessage(
@@ -318,24 +334,52 @@ describe("ClaudeSessionManager run_in_background drain (completed with pending b
 
 		// One terminal end — the intermediate `completed` must not fire it.
 		expect(spy.ends).toBe(1);
-		// Only one `completed` reaches the pipeline (one result per turn).
+		// Only one `completed` reaches the pipeline (one result per turn) and it
+		// is the CONTINUATION's result, not the stale deferred one.
 		expect(completedResultCount(spy)).toBe(1);
-		// Notification flows through before the deferred terminal result is replayed.
-		const subtypes = spy.passthroughs.map(
-			(m) => (m as { subtype?: string }).subtype,
+		const completed = spy.passthroughs.find(
+			(m) => (m as { type?: string }).type === "result",
 		);
-		const notificationIndex = subtypes.findIndex(
-			(subtype) => subtype === "task_notification",
-		);
-		const replayedCompletedIndex = spy.passthroughs.findIndex(
-			(m) =>
-				(m as { type?: string }).type === "result" &&
-				(m as { terminal_reason?: string }).terminal_reason === "completed",
-		);
-		expect(notificationIndex).toBeGreaterThanOrEqual(0);
-		expect(replayedCompletedIndex).toBe(notificationIndex + 1);
-		// Usage recorded at the deferred pause and when replayed as terminal.
+		expect((completed as { uuid?: string }).uuid).toBe("r-final");
+		// The continuation (the synthesis the user actually asked for) survives.
+		const texts = spy.passthroughs
+			.filter((m) => (m as { type?: string }).type === "assistant")
+			.map(
+				(m) =>
+					(m as { message?: { content?: { text?: string }[] } }).message
+						?.content?.[0]?.text,
+			);
+		expect(texts).toContain("synthesizing");
+		// Usage recorded at the deferred pause and at the terminal result.
 		expect(spy.contextUsageUpdates).toBeGreaterThanOrEqual(2);
+	});
+
+	test("continuation that spawns ANOTHER bg task re-defers and ends on the final completed", async () => {
+		scenario = [
+			assistant("dispatching"),
+			taskStarted("bg1"),
+			result("completed", "r-c1"), // deferred (bg1 pending)
+			taskNotification("bg1"),
+			assistant("first continuation"),
+			taskStarted("bg2"), // continuation fans out again
+			result("completed", "r-c2"), // deferred (bg2 pending)
+			taskNotification("bg2"),
+			assistant("final synthesis"),
+			result("completed", "r-c3"), // genuinely terminal
+		];
+		const spy = makeSpyEmitter();
+		await new ClaudeSessionManager().sendMessage(
+			"req-bg-refan",
+			baseParams(),
+			spy.emitter,
+		);
+
+		expect(spy.ends).toBe(1);
+		expect(completedResultCount(spy)).toBe(1);
+		const completed = spy.passthroughs.find(
+			(m) => (m as { type?: string }).type === "result",
+		);
+		expect((completed as { uuid?: string }).uuid).toBe("r-c3");
 	});
 
 	test("waits for ALL of several bg tasks before ending", async () => {
@@ -424,8 +468,9 @@ describe("ClaudeSessionManager run_in_background drain (completed with pending b
 		expect(reasons).toContain("max_turns"); // passed through, not deferred
 	});
 
-	test("deferred completed closes immediately when task_notification drains the last pending task even if the iterator hangs", async () => {
+	test("grace fallback: notification drains the last task but NO continuation ever arrives — deferred completed is replayed after the grace", async () => {
 		process.env.HELMOR_CLAUDE_BG_DRAIN_TIMEOUT_MS = LONG_BG_DRAIN_TIMEOUT_MS;
+		process.env.HELMOR_CLAUDE_BG_CONTINUATION_GRACE_MS = "5";
 		hangAfterScenario = true;
 		scenario = [
 			assistant("dispatching"),
@@ -444,7 +489,7 @@ describe("ClaudeSessionManager run_in_background drain (completed with pending b
 		);
 
 		expect(spy.ends).toBe(1);
-		expect(queryCloseCount).toBe(1);
+		expect(queryCloseCount).toBeGreaterThanOrEqual(1);
 		expect(completedResultCount(spy)).toBe(1);
 		expect(
 			spy.passthroughs.some(
@@ -453,8 +498,9 @@ describe("ClaudeSessionManager run_in_background drain (completed with pending b
 		).toBe(true);
 	});
 
-	test("deferred completed closes when killed task_updated drains the last pending task without notification", async () => {
+	test("grace fallback: killed task_updated drains the last pending task without notification or continuation", async () => {
 		process.env.HELMOR_CLAUDE_BG_DRAIN_TIMEOUT_MS = LONG_BG_DRAIN_TIMEOUT_MS;
+		process.env.HELMOR_CLAUDE_BG_CONTINUATION_GRACE_MS = "5";
 		hangAfterScenario = true;
 		scenario = [
 			assistant("dispatching"),
@@ -473,13 +519,40 @@ describe("ClaudeSessionManager run_in_background drain (completed with pending b
 		);
 
 		expect(spy.ends).toBe(1);
-		expect(queryCloseCount).toBe(1);
+		expect(queryCloseCount).toBeGreaterThanOrEqual(1);
 		expect(completedResultCount(spy)).toBe(1);
 		expect(
 			spy.passthroughs.some(
 				(m) => (m as { subtype?: string }).subtype === "task_updated",
 			),
 		).toBe(true);
+	});
+
+	test("system-only drips after the drain do NOT cancel the grace fallback", async () => {
+		process.env.HELMOR_CLAUDE_BG_DRAIN_TIMEOUT_MS = LONG_BG_DRAIN_TIMEOUT_MS;
+		process.env.HELMOR_CLAUDE_BG_CONTINUATION_GRACE_MS = "5";
+		hangAfterScenario = true;
+		scenario = [
+			assistant("dispatching"),
+			taskStarted("bg1"),
+			result("completed"),
+			taskUpdated("bg1", "completed"), // drains pending without notification
+			taskUpdated("bg1", "completed"), // #922's motivating drip
+			taskUpdated("bg1", "completed"),
+		];
+		const spy = makeSpyEmitter();
+		await expectSettles(
+			new ClaudeSessionManager().sendMessage(
+				"req-bg-drip",
+				baseParams(),
+				spy.emitter,
+			),
+			"task_updated drips",
+		);
+
+		expect(spy.ends).toBe(1);
+		expect(queryCloseCount).toBeGreaterThanOrEqual(1);
+		expect(completedResultCount(spy)).toBe(1);
 	});
 
 	test("deferred completed replay is idempotent when another completed result arrives before finalization", async () => {

--- a/sidecar/src/claude/session-manager.ts
+++ b/sidecar/src/claude/session-manager.ts
@@ -77,6 +77,21 @@ const BACKGROUND_TASK_DRAIN_TIMEOUT_MS = 20 * 60_000;
 const BACKGROUND_TASK_DRAIN_TIMEOUT_ENV = "HELMOR_CLAUDE_BG_DRAIN_TIMEOUT_MS";
 
 /**
+ * After the last pending background task settles, the CLI re-invokes the main
+ * agent on the SAME query to synthesize the results and then emits a second,
+ * genuinely terminal `completed` (contract recorded against claude 2.1.205:
+ * task_updated(patch.status) + task_notification arrive together, the
+ * continuation starts ~2s later and may use tools). We therefore keep draining
+ * after the pending count hits zero. This grace bounds the wait for the FIRST
+ * sign of that continuation — if nothing but system events arrives (e.g. a
+ * task killed with no notification), we fall back to replaying the deferred
+ * `completed` instead of hanging until the 20-minute drain timeout.
+ */
+const BACKGROUND_TASK_CONTINUATION_GRACE_MS = 60_000;
+const BACKGROUND_TASK_CONTINUATION_GRACE_ENV =
+	"HELMOR_CLAUDE_BG_CONTINUATION_GRACE_MS";
+
+/**
  * Resolve the Claude Code native binary for `pathToClaudeCodeExecutable`.
  * Prefers `HELMOR_CLAUDE_CODE_BIN_PATH` (release), then the platform
  * sub-package (dev/test); falls back to the wrapper bin for `--omit=optional`.
@@ -714,12 +729,19 @@ export class ClaudeSessionManager implements SessionManager {
 		const pendingBgTasks = new Map<string, PendingBgTask>();
 		let bgDrainTimer: ReturnType<typeof setTimeout> | null = null;
 		let bgDrainTimedOut = false;
+		let continuationGraceTimer: ReturnType<typeof setTimeout> | null = null;
+		let bgDrainSettledByGrace = false;
 		let deferredCompletedResult: SDKMessage | null = null;
 		let turnEnded = false;
 		const clearBgDrainTimer = () => {
 			if (bgDrainTimer === null) return;
 			clearTimeout(bgDrainTimer);
 			bgDrainTimer = null;
+		};
+		const clearContinuationGraceTimer = () => {
+			if (continuationGraceTimer === null) return;
+			clearTimeout(continuationGraceTimer);
+			continuationGraceTimer = null;
 		};
 		const endTurnOnce = () => {
 			if (turnEnded) return false;
@@ -731,6 +753,7 @@ export class ClaudeSessionManager implements SessionManager {
 			if (turnEnded) return false;
 			deferredCompletedResult = null;
 			clearBgDrainTimer();
+			clearContinuationGraceTimer();
 			emitter.passthrough(requestId, terminalResult);
 			const meta = buildClaudeStoredMeta(terminalResult, model ?? "");
 			if (meta) {
@@ -743,6 +766,42 @@ export class ClaudeSessionManager implements SessionManager {
 			if (!deferredCompletedResult || pendingBgTasks.size > 0) return false;
 			const terminalResult = deferredCompletedResult;
 			return passthroughTerminalResult(terminalResult);
+		};
+		// Armed when the pending count hits zero while a `completed` is deferred.
+		// The expected next step is the CLI re-invoking the main agent (assistant/
+		// user/stream messages, then a second terminal result) — any such message
+		// cancels this timer. If only system events trickle in (a task settled
+		// with no follow-up continuation), fire the fallback: replay the deferred
+		// `completed` and close, instead of hanging until the 20-min drain timeout.
+		const armContinuationGraceTimer = () => {
+			if (continuationGraceTimer !== null || turnEnded) return;
+			if (!deferredCompletedResult || pendingBgTasks.size > 0) return;
+			const graceMs = backgroundTaskContinuationGraceMs();
+			logger.info(
+				`[${requestId}] background tasks drained; awaiting agent continuation`,
+				{ graceMs },
+			);
+			continuationGraceTimer = setTimeout(() => {
+				continuationGraceTimer = null;
+				if (turnEnded || pendingBgTasks.size > 0) return;
+				if (this.turns.isAbortRequested(sessionId)) return;
+				logger.error(
+					`[${requestId}] no agent continuation after background drain; replaying deferred completed`,
+					{ graceMs },
+				);
+				bgDrainSettledByGrace = true;
+				passthroughDeferredCompletedIfReady();
+				try {
+					q.close();
+				} catch (closeErr) {
+					logger.error("Claude continuation grace q.close() failed", {
+						requestId,
+						sessionId,
+						...errorDetails(closeErr),
+					});
+				}
+			}, graceMs);
+			(continuationGraceTimer as { unref?: () => void }).unref?.();
 		};
 		const summarizePendingBgTasks = () =>
 			Array.from(pendingBgTasks.values())
@@ -801,6 +860,10 @@ export class ClaudeSessionManager implements SessionManager {
 				// `result`. Drop them and return: passing them through or emitting
 				// `end` here would violate the "exactly one terminal event" contract.
 				if (this.turns.isAbortRequested(sessionId)) return;
+				// The continuation-grace fallback can end the turn from its timer
+				// while the iterator still has buffered messages — drop them, the
+				// terminal event has already been emitted.
+				if (turnEnded) return;
 				logger.sdkEvent(requestId, message);
 				if (message.type === "rate_limit_event") {
 					lastRateLimitInfo = (
@@ -857,6 +920,7 @@ export class ClaudeSessionManager implements SessionManager {
 					const toolUseId = (message as { tool_use_id?: string }).tool_use_id;
 					if (taskId) {
 						if (subtype === "task_started") {
+							clearContinuationGraceTimer();
 							pendingBgTasks.set(taskId, {
 								taskId,
 								toolUseId,
@@ -882,6 +946,19 @@ export class ClaudeSessionManager implements SessionManager {
 							}
 						}
 					}
+					// Last pending task settled while a `completed` sits deferred:
+					// keep draining (the CLI re-invokes the agent to synthesize and
+					// then emits the real terminal result), with a bounded grace in
+					// case that continuation never comes.
+					armContinuationGraceTimer();
+				} else if (
+					message.type === "assistant" ||
+					message.type === "user" ||
+					message.type === "stream_event"
+				) {
+					// Continuation underway — the genuinely terminal result will
+					// follow (or the drain timeout / post-loop fallback catches it).
+					clearContinuationGraceTimer();
 				}
 				// A `completed` result while background tasks are still pending is
 				// NOT terminal: ending here closes the query and kills the
@@ -912,13 +989,16 @@ export class ClaudeSessionManager implements SessionManager {
 				// the tool_result answers into it), so stripping them here
 				// would lose the card on finalize/persist/reload.
 				emitter.passthrough(requestId, message);
-				if (passthroughDeferredCompletedIfReady()) {
-					return;
-				}
 			}
-			if (!this.turns.isAbortRequested(sessionId)) endTurnOnce();
+			// Iterator ended naturally. If a deferred `completed` is still held
+			// with nothing pending (CLI exited without the expected continuation),
+			// deliver it so the pipeline still gets the turn's result.
+			if (!this.turns.isAbortRequested(sessionId)) {
+				passthroughDeferredCompletedIfReady();
+				endTurnOnce();
+			}
 		} catch (err) {
-			if (bgDrainTimedOut) {
+			if (bgDrainTimedOut || bgDrainSettledByGrace) {
 				if (!this.turns.isAbortRequested(sessionId)) endTurnOnce();
 				return;
 			}
@@ -932,6 +1012,7 @@ export class ClaudeSessionManager implements SessionManager {
 			throw err;
 		} finally {
 			clearBgDrainTimer();
+			clearContinuationGraceTimer();
 			// `abortController.abort()` alone leaves Node-level exit listeners,
 			// pending control/MCP promises, and the SDK's internal child handle
 			// dangling. `Query.close()` is the documented hard cleanup —
@@ -1499,6 +1580,17 @@ function backgroundTaskDrainTimeoutMs(): number {
 		}
 	}
 	return BACKGROUND_TASK_DRAIN_TIMEOUT_MS;
+}
+
+function backgroundTaskContinuationGraceMs(): number {
+	const raw = process.env[BACKGROUND_TASK_CONTINUATION_GRACE_ENV];
+	if (raw) {
+		const parsed = Number(raw);
+		if (Number.isFinite(parsed) && parsed > 0) {
+			return parsed;
+		}
+	}
+	return BACKGROUND_TASK_CONTINUATION_GRACE_MS;
 }
 
 function terminalTaskUpdateStatus(message: SDKMessage): string | null {


### PR DESCRIPTION
## Problem

#922 replays the deferred `completed` result — and closes the query — the instant the pending background-task count reaches zero (terminal `task_updated` or `task_notification`). But the real CLI contract is that the drain is not the end of the turn: after `task_notification`, the CLI re-invokes the main agent **on the same query** to synthesize the results (the continuation can even use tools) and then emits a second, genuinely terminal `completed`.

Closing at drain time killed that continuation. Symptom: the agent fans out background verify/research subagents, says "I'll summarize when they all return", the subagents all finish — and the turn just ends. The summary never arrives; it looks like the agent stopped thinking mid-work.

## Contract (recorded, claude 2.1.205)

Pinned with controlled experiments against the bundled binary (streaming-input `query()`, no close after the first `completed`), both `Bash run_in_background` and `Agent run_in_background`:

```
11.5s  result:completed          ← first result, task still running
54.9s  task_updated(patch.status=completed) + task_notification   (same instant)
57.2s  assistant continuation    ← CLI auto re-invokes the agent (used a tool)
58.8s  result:completed          ← the REAL terminal
```

## Fix

- After the pending count hits zero, **keep draining the same query**; the continuation streams through and its own terminal result ends the turn (exactly once — `end` is idempotent).
- **Continuation grace** (default 60s, `HELMOR_CLAUDE_BG_CONTINUATION_GRACE_MS`): if only system events trickle in after the drain and no continuation ever starts (the `task_updated`-drip case #922 was written for), replay the deferred `completed` and close — no more premature end, and no 20-minute hang either.
- Natural iterator end with a drained deferred `completed` still delivers it to the pipeline.
- The 20-minute drain timeout remains the hard backstop.

## Tests

- Rewrote the drain tests to match the recorded event stream — one of them previously **asserted the continuation being dropped** (`assistant("synthesizing")` never reaching the pipeline).
- New regressions: continuation that fans out another background task re-defers correctly; system-only drips do not cancel the grace fallback.
- `bun test` (sidecar, 419 pass), typecheck, biome all green.
- E2E against the real bundled binary through the fixed `ClaudeSessionManager`: continuation `SUMMARY_DELIVERED` passes through, exactly one result, exactly one `end` after the summary — PASS.