### PR TITLE
feat: add info tooltips for max/ultra effort levels

### DIFF
--- a/src/features/composer/index.tsx
+++ b/src/features/composer/index.tsx
@@ -11,6 +11,7 @@ import {
 	ChevronDown,
 	ClipboardList,
 	Clock3,
+	Info,
 	Layers,
 	MessageSquareMore,
 	Plus,
@@ -1224,6 +1225,36 @@ export const WorkspaceComposer = memo(function WorkspaceComposer({
 																			? t("composerExtraHigh")
 																			: level}
 																	</span>
+																	{(level === "max" || level === "ultra") && (
+																		<TooltipProvider delayDuration={200}>
+																			<Tooltip>
+																				<TooltipTrigger asChild>
+																					<span
+																						aria-label={
+																							level === "max"
+																								? t("effortMaxHint")
+																								: t("effortUltraHint")
+																						}
+																						className="inline-flex cursor-pointer text-muted-foreground/50 hover:text-muted-foreground"
+																					>
+																						<Info
+																							className="size-3"
+																							strokeWidth={2}
+																						/>
+																					</span>
+																				</TooltipTrigger>
+																				<TooltipContent
+																					side="right"
+																					sideOffset={6}
+																					className="max-w-[13rem]"
+																				>
+																					{level === "max"
+																						? t("effortMaxHint")
+																						: t("effortUltraHint")}
+																				</TooltipContent>
+																			</Tooltip>
+																		</TooltipProvider>
+																	)}
 																</div>
 																{level === effectiveEffort ? (
 																	<span className="text-mini text-foreground">

--- a/src/features/settings/index.tsx
+++ b/src/features/settings/index.tsx
@@ -3,6 +3,7 @@ import {
 	CheckCircle2,
 	ChevronDown,
 	HelpCircle,
+	Info,
 	Settings,
 	Volume2,
 } from "lucide-react";
@@ -818,8 +819,39 @@ function ModelSettingRow({
 						className="min-w-[8rem]"
 					>
 						{effortLevels.map((l) => (
-							<DropdownMenuItem key={l} onClick={() => onChange({ effort: l })}>
-								{effortLabel(l)}
+							<DropdownMenuItem
+								key={l}
+								onClick={() => onChange({ effort: l })}
+								className="flex items-center gap-2"
+							>
+								<span>{effortLabel(l)}</span>
+								{(l === "max" || l === "ultra") && (
+									<TooltipProvider delayDuration={200}>
+										<Tooltip>
+											<TooltipTrigger asChild>
+												<span
+													aria-label={
+														l === "max"
+															? t("effortMaxHint")
+															: t("effortUltraHint")
+													}
+													className="inline-flex cursor-pointer text-muted-foreground/50 hover:text-muted-foreground"
+												>
+													<Info className="size-3" strokeWidth={2} />
+												</span>
+											</TooltipTrigger>
+											<TooltipContent
+												side="right"
+												sideOffset={6}
+												className="max-w-[13rem]"
+											>
+												{l === "max"
+													? t("effortMaxHint")
+													: t("effortUltraHint")}
+											</TooltipContent>
+										</Tooltip>
+									</TooltipProvider>
+								)}
 							</DropdownMenuItem>
 						))}
 					</DropdownMenuContent>

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -296,6 +296,8 @@
 	"composerEnableAutoClose": "Enable Auto Close",
 	"composerExpectedFormOrUrl": "Expected form or url payload.",
 	"composerExtraHigh": "Extra High",
+	"effortMaxHint": "Deepest reasoning, single agent.",
+	"effortUltraHint": "Deepest reasoning + auto multi-agent delegation; uses usage limits faster.",
 	"composerFailedDeliverResponse": "Failed to deliver user-input response.",
 	"composerFailedSendMessage": "Failed to send message.",
 	"composerFormMissingProperties": "Form user-input request is missing properties.",

--- a/src/lib/i18n/locales/zh-CN.json
+++ b/src/lib/i18n/locales/zh-CN.json
@@ -296,6 +296,8 @@
 	"composerEnableAutoClose": "启用自动关闭",
 	"composerExpectedFormOrUrl": "应为表单或 URL 载荷。",
 	"composerExtraHigh": "超高",
+	"effortMaxHint": "最深推理,单个智能体。",
+	"effortUltraHint": "最深推理 + 自动派生多个子智能体,消耗额度更快。",
 	"composerFailedDeliverResponse": "用户输入响应投递失败。",
 	"composerFailedSendMessage": "消息发送失败。",
 	"composerFormMissingProperties": "表单输入请求缺少字段。",


### PR DESCRIPTION
## What changed

- Added an info icon with tooltip next to the **max** and **ultra** effort levels in two places:
  - Composer effort-level dropdown (`src/features/composer/index.tsx`)
  - Settings model row effort dropdown (`src/features/settings/index.tsx`)
- New i18n keys `effortMaxHint` / `effortUltraHint` in both `en.json` and `zh-CN.json`.

## Why

The distinction between max and ultra effort is not obvious from the labels alone — ultra triggers automatic multi-agent delegation and burns usage limits faster. The tooltips explain this at the point of selection so users can make an informed choice.

## Test notes

- UI-only change; no pipeline/persistence surfaces touched, so no snapshot tests required.
- Verify manually: hover the info icon on max/ultra in both the composer effort menu and Settings → model effort dropdown, in both EN and zh-CN locales.