### PR TITLE
fix: hide setup scripts from background task bar

### DIFF
--- a/.changeset/quiet-setup-task-bar.md
+++ b/.changeset/quiet-setup-task-bar.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Keep workspace setup scripts out of the background task bar above the composer.

--- a/src/features/composer/task-progress/index.test.tsx
+++ b/src/features/composer/task-progress/index.test.tsx
@@ -3,12 +3,21 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useStreamingStore } from "@/features/conversation/state/streaming-store";
-import type { TaskState } from "@/lib/api";
+import type { RepoScripts, TaskState } from "@/lib/api";
 import { helmorQueryKeys } from "@/lib/query-client";
 import { shellEventName } from "@/shell/event-bus";
 import { TaskProgressPanel } from "./index";
 
 const SESSION_ID = "session-1";
+const WORKSPACE_ID = "workspace-1";
+const REPO_ID = "repo-1";
+
+const scriptStoreMocks = vi.hoisted(() => ({
+	getScriptState: vi.fn(),
+	subscribeStatus: vi.fn(() => () => {}),
+}));
+
+vi.mock("@/features/inspector/script-store", () => scriptStoreMocks);
 
 function makeTask(overrides: Partial<TaskState> = {}): TaskState {
 	return {
@@ -41,9 +50,52 @@ function renderPanel(tasks: TaskState[]) {
 	return render(<TaskProgressPanel sessionId={SESSION_ID} />, { wrapper });
 }
 
+function renderPanelWithScripts(repoScripts: RepoScripts) {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false, enabled: false } },
+	});
+	queryClient.setQueryData(
+		[...helmorQueryKeys.sessionMessages(SESSION_ID), "thread"],
+		[],
+	);
+	queryClient.setQueryData(
+		helmorQueryKeys.repoScripts(REPO_ID, WORKSPACE_ID),
+		repoScripts,
+	);
+	return render(
+		<TaskProgressPanel
+			sessionId={SESSION_ID}
+			workspaceId={WORKSPACE_ID}
+			repoId={REPO_ID}
+		/>,
+		{
+			wrapper: ({ children }) => (
+				<QueryClientProvider client={queryClient}>
+					{children}
+				</QueryClientProvider>
+			),
+		},
+	);
+}
+
+function makeRepoScripts(overrides: Partial<RepoScripts> = {}): RepoScripts {
+	return {
+		setupScript: null,
+		archiveScript: null,
+		setupFromProject: false,
+		runFromProject: false,
+		archiveFromProject: false,
+		autoRunSetup: true,
+		runActions: [],
+		...overrides,
+	};
+}
+
 beforeEach(() => {
 	cleanup();
 	useStreamingStore.setState({ activeTasksBySession: {} });
+	scriptStoreMocks.getScriptState.mockReset().mockReturnValue(null);
+	scriptStoreMocks.subscribeStatus.mockClear();
 });
 
 describe("TaskProgressPanel", () => {
@@ -91,6 +143,47 @@ describe("TaskProgressPanel", () => {
 	it("renders nothing without tasks or fallbacks", () => {
 		const { container } = renderPanel([]);
 		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("does not surface a running setup script as a background task", () => {
+		scriptStoreMocks.getScriptState.mockImplementation(
+			(_workspaceId, scriptType) =>
+				scriptType === "setup" ? { status: "running" } : null,
+		);
+
+		const { container } = renderPanelWithScripts(
+			makeRepoScripts({ setupScript: "bun install" }),
+		);
+
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("continues surfacing running run actions as background tasks", () => {
+		scriptStoreMocks.getScriptState.mockImplementation(
+			(_workspaceId, scriptType, actionId) =>
+				scriptType === "run" && actionId === "dev"
+					? { status: "running" }
+					: null,
+		);
+
+		renderPanelWithScripts(
+			makeRepoScripts({
+				runFromProject: true,
+				runActions: [
+					{
+						id: "dev",
+						name: "Dev server",
+						command: "bun run dev",
+						mode: "non-concurrent",
+						fromProject: true,
+					},
+				],
+			}),
+		);
+
+		const strip = screen.getByRole("button", { name: "Background tasks" });
+		expect(strip).toHaveTextContent("Dev server");
+		expect(strip).toHaveTextContent("0/1");
 	});
 
 	it("collapses by default showing current task, progress, and status", () => {

--- a/src/features/composer/task-progress/use-background-tasks.ts
+++ b/src/features/composer/task-progress/use-background-tasks.ts
@@ -99,19 +99,9 @@ function runningScriptFallbacks(
 ): BackgroundFallbackItem[] {
 	if (!workspaceId || !repoScripts) return [];
 	const items: BackgroundFallbackItem[] = [];
-	if (repoScripts.setupScript?.trim()) {
-		const setup = getScriptState(workspaceId, "setup");
-		if (setup?.status === "running") {
-			items.push({
-				id: `${workspaceId}:setup`,
-				kind: "script",
-				title: "setup",
-				typeKey: "taskPanelTypeScript",
-				command: repoScripts.setupScript,
-				status: "running",
-			});
-		}
-	}
+	// Setup is workspace initialization with its own inspector status/output,
+	// not background work owned by the active chat session. Keep this fallback
+	// focused on long-lived Run actions and terminals.
 	for (const action of repoScripts.runActions) {
 		if (!action.command.trim()) continue;
 		const run = getScriptState(workspaceId, "run", action.id);
@@ -139,7 +129,6 @@ function useScriptFallbacks(
 	);
 	const runActions = repoScripts?.runActions ?? EMPTY_RUN_ACTIONS;
 	const runActionKey = runActions.map((action) => action.id).join("|");
-	const setupEnabled = Boolean(repoScripts?.setupScript?.trim());
 
 	useEffect(() => {
 		if (!enabled || !workspaceId || !repoScripts) {
@@ -151,9 +140,6 @@ function useScriptFallbacks(
 		};
 		refresh();
 		const unsubscribers: Array<() => void> = [];
-		if (setupEnabled) {
-			unsubscribers.push(subscribeStatus(workspaceId, "setup", refresh));
-		}
 		for (const action of runActions) {
 			unsubscribers.push(
 				subscribeStatus(workspaceId, "run", refresh, action.id),
@@ -162,14 +148,7 @@ function useScriptFallbacks(
 		return () => {
 			for (const unsubscribe of unsubscribers) unsubscribe();
 		};
-	}, [
-		enabled,
-		repoScripts,
-		runActions,
-		runActionKey,
-		setupEnabled,
-		workspaceId,
-	]);
+	}, [enabled, repoScripts, runActions, runActionKey, workspaceId]);
 
 	return items;
 }


### PR DESCRIPTION
## Summary

- Keep workspace setup scripts out of the composer background task bar.
- Preserve fallback progress for running Run actions and terminal sessions.
- Add regression coverage for both setup exclusion and Run action visibility.

## Root cause

The task-progress fallback treated a running workspace setup script as chat-owned background work. Automatic workspace initialization therefore appeared above the composer as `setup · 0/1 · Running`, even though setup already has dedicated lifecycle and Inspector surfaces.

## User impact

Workspace initialization continues to run and report through its existing setup UI, while the composer task bar stays focused on agent tasks and long-lived Run or terminal processes.

## Validation

- `bun x vitest run src/features/composer/task-progress/index.test.tsx`
- `bun run typecheck`
- `bun run test`
- `bun run lint` (passes; Biome reports one pre-existing warning in `src/features/composer/input-history.ts`)
- `git diff --check`
