### PR TITLE
Fix new workspace repository picker alignment

### DIFF
--- a/.changeset/steady-repo-headings.md
+++ b/.changeset/steady-repo-headings.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix repository names shifting vertically on the new workspace screen when switching between generated initials and image icons.

--- a/src/App.create.test.tsx
+++ b/src/App.create.test.tsx
@@ -362,6 +362,10 @@ describe("App create workspace flow", () => {
 		await user.click(screen.getByRole("button", { name: "New workspace" }));
 
 		expect(await screen.findByLabelText("Workspace input")).toBeInTheDocument();
+		const repositoryPicker = await screen.findByRole("button", {
+			name: "dosu-cli",
+		});
+		expect(repositoryPicker.parentElement).toHaveClass("flex");
 		await waitFor(() => {
 			expect(
 				screen.getByRole("button", { name: "New Workspace" }),

--- a/src/features/workspace-start/index.tsx
+++ b/src/features/workspace-start/index.tsx
@@ -531,7 +531,8 @@ export function WorkspaceStartPage({
 										onOpenChange={setRepoTooltipOpen}
 									>
 										<TooltipTrigger asChild>
-											<div>
+											{/* Avoid avatar-dependent inline baselines shifting the button. */}
+											<div className="flex">
 												<RepositoryPicker
 													repositories={repositories}
 													selectedRepository={selectedRepository}


### PR DESCRIPTION
## Summary

- Keep the repository picker vertically aligned when switching between generated initials and image-backed icons.
- Add a regression assertion for the tooltip wrapper layout.
- Add a patch changeset for the user-visible fix.

## Root cause

The tooltip wrapper placed the inline-flex picker button in an inline formatting context. Its baseline changed depending on whether the avatar rendered an image or an initials fallback, moving the fallback-backed picker down by 6px.

Using a flex wrapper removes the avatar-dependent inline baseline while preserving the avatar component's existing optical alignment.

## Validation

- `bun x vitest run src/App.create.test.tsx`
- `bun x biome check src/features/workspace-start/index.tsx src/App.create.test.tsx`
- `bun run typecheck`
- `bun run release:verify`
- Three consecutive Tauri UI cycles confirmed the heading, wrapper, button, avatar, and repository name remain centered at the same Y coordinate for both avatar branches.