### PR TITLE
fix: exclude Run Action scripts from background task bar

### DIFF
--- a/.changeset/quiet-setup-task-bar.md
+++ b/.changeset/quiet-setup-task-bar.md
@@ -2,4 +2,4 @@
 "helmor": patch
 ---
 
-Keep workspace setup scripts out of the background task bar above the composer.
+Keep workspace setup and Run Action scripts out of the background task bar above the composer.

--- a/src/features/composer/container.tsx
+++ b/src/features/composer/container.tsx
@@ -1310,7 +1310,6 @@ export const WorkspaceComposerContainer = memo(
 					<TaskProgressPanel
 						sessionId={displayedSessionId}
 						workspaceId={displayedWorkspaceId}
-						repoId={effectiveRepoId}
 					/>
 					{/* Docked (open-bottom) bars live in normal flow DIRECTLY above
 					    the composer — nothing may render between them and it. Order

--- a/src/features/composer/task-progress/index.test.tsx
+++ b/src/features/composer/task-progress/index.test.tsx
@@ -63,11 +63,7 @@ function renderPanelWithScripts(repoScripts: RepoScripts) {
 		repoScripts,
 	);
 	return render(
-		<TaskProgressPanel
-			sessionId={SESSION_ID}
-			workspaceId={WORKSPACE_ID}
-			repoId={REPO_ID}
-		/>,
+		<TaskProgressPanel sessionId={SESSION_ID} workspaceId={WORKSPACE_ID} />,
 		{
 			wrapper: ({ children }) => (
 				<QueryClientProvider client={queryClient}>
@@ -158,7 +154,7 @@ describe("TaskProgressPanel", () => {
 		expect(container).toBeEmptyDOMElement();
 	});
 
-	it("continues surfacing running run actions as background tasks", () => {
+	it("does not surface running run actions as background tasks", () => {
 		scriptStoreMocks.getScriptState.mockImplementation(
 			(_workspaceId, scriptType, actionId) =>
 				scriptType === "run" && actionId === "dev"
@@ -166,7 +162,7 @@ describe("TaskProgressPanel", () => {
 					: null,
 		);
 
-		renderPanelWithScripts(
+		const { container } = renderPanelWithScripts(
 			makeRepoScripts({
 				runFromProject: true,
 				runActions: [
@@ -181,9 +177,7 @@ describe("TaskProgressPanel", () => {
 			}),
 		);
 
-		const strip = screen.getByRole("button", { name: "Background tasks" });
-		expect(strip).toHaveTextContent("Dev server");
-		expect(strip).toHaveTextContent("0/1");
+		expect(container).toBeEmptyDOMElement();
 	});
 
 	it("collapses by default showing current task, progress, and status", () => {

--- a/src/features/composer/task-progress/index.tsx
+++ b/src/features/composer/task-progress/index.tsx
@@ -140,21 +140,19 @@ function toolArgString(tool: ToolCallPart | null, key: string): string | null {
 /**
  * Composer-anchored background-task pill + drill-down card, the sibling of
  * `WorkflowProgressPanel`. The pill appears whenever the session has tasks
- * (or, with none, running workspace processes); clicking it opens a card with
+ * (or, with none, running terminal processes); clicking it opens a card with
  * Level 0 = the task list and Level 1 = one task's detail (metrics, command,
  * summary, error, and a clickable output file that opens in the editor).
  */
 export function TaskProgressPanel({
 	sessionId,
 	workspaceId,
-	repoId,
 }: {
 	sessionId: string | null;
 	workspaceId?: string | null;
-	repoId?: string | null;
 }) {
 	const { f, t } = useI18n();
-	const data = useBackgroundTasks({ sessionId, workspaceId, repoId });
+	const data = useBackgroundTasks({ sessionId, workspaceId });
 	const panelRef = useRef<HTMLDivElement>(null);
 	const scrollContentRef = useRef<HTMLDivElement>(null);
 	const activeRef = useRef<HTMLButtonElement>(null);

--- a/src/features/composer/task-progress/use-background-tasks.ts
+++ b/src/features/composer/task-progress/use-background-tasks.ts
@@ -2,10 +2,6 @@ import { useQuery } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
 import { useStreamingStore } from "@/features/conversation/state/streaming-store";
 import {
-	getScriptState,
-	subscribeStatus,
-} from "@/features/inspector/script-store";
-import {
 	getTerminalDisplayTitle,
 	getTerminals,
 	subscribeToWorkspaceList,
@@ -16,23 +12,17 @@ import {
 } from "@/features/terminal/terminal-session-store";
 import type {
 	ExtendedMessagePart,
-	RepoScripts,
 	TaskState,
 	ThreadMessageLike,
 	ToolCallPart,
 } from "@/lib/api";
-import { loadRepoScripts } from "@/lib/api";
-import {
-	helmorQueryKeys,
-	sessionThreadMessagesQueryOptions,
-} from "@/lib/query-client";
+import { sessionThreadMessagesQueryOptions } from "@/lib/query-client";
 
 const EMPTY_TASKS: readonly TaskState[] = Object.freeze([]);
-const EMPTY_RUN_ACTIONS = Object.freeze([]);
 
 export type BackgroundFallbackItem = {
 	id: string;
-	kind: "script" | "inspector-terminal" | "terminal-session";
+	kind: "inspector-terminal" | "terminal-session";
 	title: string;
 	typeKey: string;
 	command?: string | null;
@@ -91,66 +81,6 @@ export function extractTaskStatesFromMessages(
 		}
 	}
 	return Array.from(tasksById.values());
-}
-
-function runningScriptFallbacks(
-	workspaceId: string | null | undefined,
-	repoScripts: RepoScripts | null | undefined,
-): BackgroundFallbackItem[] {
-	if (!workspaceId || !repoScripts) return [];
-	const items: BackgroundFallbackItem[] = [];
-	// Setup is workspace initialization with its own inspector status/output,
-	// not background work owned by the active chat session. Keep this fallback
-	// focused on long-lived Run actions and terminals.
-	for (const action of repoScripts.runActions) {
-		if (!action.command.trim()) continue;
-		const run = getScriptState(workspaceId, "run", action.id);
-		if (run?.status === "running") {
-			items.push({
-				id: `${workspaceId}:run:${action.id}`,
-				kind: "script",
-				title: action.name.trim() || "run",
-				typeKey: "taskPanelTypeScript",
-				command: action.command,
-				status: "running",
-			});
-		}
-	}
-	return items;
-}
-
-function useScriptFallbacks(
-	workspaceId: string | null | undefined,
-	repoScripts: RepoScripts | null | undefined,
-	enabled: boolean,
-): BackgroundFallbackItem[] {
-	const [items, setItems] = useState<BackgroundFallbackItem[]>(() =>
-		enabled ? runningScriptFallbacks(workspaceId, repoScripts) : [],
-	);
-	const runActions = repoScripts?.runActions ?? EMPTY_RUN_ACTIONS;
-	const runActionKey = runActions.map((action) => action.id).join("|");
-
-	useEffect(() => {
-		if (!enabled || !workspaceId || !repoScripts) {
-			setItems([]);
-			return;
-		}
-		const refresh = () => {
-			setItems(runningScriptFallbacks(workspaceId, repoScripts));
-		};
-		refresh();
-		const unsubscribers: Array<() => void> = [];
-		for (const action of runActions) {
-			unsubscribers.push(
-				subscribeStatus(workspaceId, "run", refresh, action.id),
-			);
-		}
-		return () => {
-			for (const unsubscribe of unsubscribers) unsubscribe();
-		};
-	}, [enabled, repoScripts, runActions, runActionKey, workspaceId]);
-
-	return items;
 }
 
 function useInspectorTerminalFallbacks(
@@ -231,16 +161,14 @@ function useTerminalSessionFallbacks(
  * from the streaming store during a turn; historical terminal states are
  * re-derived from the rendered thread cache (same source the conversation
  * reads). When the session has no tasks at all, running workspace processes
- * (scripts / terminals) surface as fallback items.
+ * (terminals) surface as fallback items.
  */
 export function useBackgroundTasks({
 	sessionId,
 	workspaceId,
-	repoId,
 }: {
 	sessionId: string | null;
 	workspaceId?: string | null;
-	repoId?: string | null;
 }): BackgroundTasksData {
 	const activeTasks = useStreamingStore((state) =>
 		sessionId
@@ -269,22 +197,6 @@ export function useBackgroundTasks({
 		return Array.from(byId.values());
 	}, [activeTasks, historicalTasks]);
 	const fallbackEnabled = tasks.length === 0;
-	// Scripts are only needed for fallback mode — don't fetch (or refetch on
-	// window focus) while real tasks own the panel.
-	const { data: repoScripts } = useQuery({
-		queryKey: helmorQueryKeys.repoScripts(
-			repoId ?? "__none__",
-			workspaceId ?? null,
-		),
-		queryFn: () => loadRepoScripts(repoId!, workspaceId ?? null),
-		enabled: fallbackEnabled && Boolean(repoId && workspaceId),
-		staleTime: 30_000,
-	});
-	const scriptFallbacks = useScriptFallbacks(
-		workspaceId,
-		repoScripts,
-		fallbackEnabled,
-	);
 	const inspectorTerminalFallbacks = useInspectorTerminalFallbacks(
 		workspaceId,
 		fallbackEnabled,
@@ -299,7 +211,6 @@ export function useBackgroundTasks({
 			return { mode: "tasks", tasks, fallbacks: [] };
 		}
 		const fallbacks = [
-			...scriptFallbacks,
 			...inspectorTerminalFallbacks,
 			...terminalSessionFallbacks,
 		];
@@ -307,10 +218,5 @@ export function useBackgroundTasks({
 			return { mode: "fallbacks", tasks: [], fallbacks };
 		}
 		return { mode: "hidden", tasks: [], fallbacks: [] };
-	}, [
-		inspectorTerminalFallbacks,
-		scriptFallbacks,
-		tasks,
-		terminalSessionFallbacks,
-	]);
+	}, [inspectorTerminalFallbacks, tasks, terminalSessionFallbacks]);
 }


### PR DESCRIPTION
## What changed
Removed the Run Action script fallback from the composer's background task bar (`TaskProgressPanel` / `useBackgroundTasks`). The panel no longer fetches repo scripts or subscribes to script status; the `repoId` prop was dropped from the component. The fallback now only surfaces inspector terminals and terminal sessions.

## Why
Follow-up to #932 (which hid setup scripts): Run Action scripts (e.g. dev servers) are workspace processes with their own inspector status/output, not background work owned by the active chat session, so they shouldn't appear in the task bar above the composer either.

## Test notes
- Updated `index.test.tsx`: the previous "continues surfacing running run actions" test now asserts the panel renders empty instead.
- Changeset body updated to cover Run Actions.
- Suggested verification: `bun run test:frontend` and a manual check that a running Run Action no longer shows a background-task pill.