### PR TITLE
fix: sign Codex code-mode host with JIT entitlements

### DIFF
--- a/.changeset/fresh-tools-work.md
+++ b/.changeset/fresh-tools-work.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Fix Codex code-mode tool calls failing in signed macOS builds.

--- a/sidecar/scripts/stage-vendor.ts
+++ b/sidecar/scripts/stage-vendor.ts
@@ -508,7 +508,9 @@ function stageCodexFromVendorRoot(archRoot: string): void {
 		const hostDest = join(DIST_VENDOR, "codex", `codex-code-mode-host${EXE}`);
 		copyFile(hostSrc, hostDest);
 		chmodSync(hostDest, 0o755);
-		maybeSignMacBinary(hostDest, false);
+		// The host embeds V8, which needs executable-memory entitlements under
+		// the hardened runtime or it traps during isolate initialization.
+		maybeSignMacBinary(hostDest, true);
 	}
 
 	const pathSrc = join(archRoot, pathDir);


### PR DESCRIPTION
## Summary

Sign Codex's V8-based code-mode host with the executable-memory entitlements it requires in hardened macOS builds. Without them, the host trapped during V8 initialization and every code-mode tool call failed.

## Verification

- `APPLE_SIGNING_IDENTITY=- bun run stage-vendor`
- Verified the staged host contains `allow-jit` and `allow-unsigned-executable-memory`
- `bun run typecheck`
- `bun run test:sidecar`
- `bun run lint`
