### PR TITLE
feat(inspector): let run scripts declare their Open menu URL

### DIFF
--- a/.changeset/run-script-declared-url.md
+++ b/.changeset/run-script-declared-url.md
@@ -1,0 +1,5 @@
+---
+"helmor": patch
+---
+
+Let run scripts declare their own URL for the Open menu by printing `helmor:url=<URL>` on a line of their own — useful for reverse-proxy dev setups (portless, Caddy, ngrok, Tailscale Funnel) where Helmor's sniffed `localhost:PORT` banners are ephemeral ports that aren't reachable through the proxy. Declared URLs accept any host and fully replace the sniffed ones.

--- a/src/features/inspector/detect-urls.test.ts
+++ b/src/features/inspector/detect-urls.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
 	dedupUrlKey,
+	extractDeclaredUrls,
 	extractLocalUrls,
 	extractPort,
 	stripAnsi,
+	trailingPartialLine,
 } from "./detect-urls";
 
 describe("stripAnsi", () => {
@@ -167,5 +169,75 @@ describe("extractPort", () => {
 	it("returns null when port is omitted", () => {
 		expect(extractPort("http://localhost/")).toBeNull();
 		expect(extractPort("https://localhost")).toBeNull();
+	});
+});
+
+describe("extractDeclaredUrls", () => {
+	it("extracts a marker URL with a named host and no port", () => {
+		expect(
+			extractDeclaredUrls("helmor:url=https://achernar.localhost"),
+		).toEqual(["https://achernar.localhost"]);
+	});
+
+	it("survives ANSI wrapping and CRLF line endings", () => {
+		expect(
+			extractDeclaredUrls(
+				"\x1b[32mhelmor:url=https://achernar.localhost\x1b[0m\r\nbooting…\r\n",
+			),
+		).toEqual(["https://achernar.localhost"]);
+	});
+
+	it("tolerates leading indentation", () => {
+		expect(extractDeclaredUrls("  \thelmor:url=http://app.test\n")).toEqual([
+			"http://app.test",
+		]);
+	});
+
+	it("collects multiple declarations in order", () => {
+		expect(
+			extractDeclaredUrls(
+				"helmor:url=https://web.localhost\nnoise\nhelmor:url=https://api.localhost\n",
+			),
+		).toEqual(["https://web.localhost", "https://api.localhost"]);
+	});
+
+	it("ignores markers that are not at the start of a line", () => {
+		expect(
+			extractDeclaredUrls("see helmor:url=https://evil.test for details"),
+		).toEqual([]);
+	});
+
+	it("ignores non-http schemes", () => {
+		expect(extractDeclaredUrls("helmor:url=ftp://nope.test\n")).toEqual([]);
+		expect(extractDeclaredUrls("helmor:url=nonsense\n")).toEqual([]);
+	});
+
+	it("strips trailing sentence punctuation", () => {
+		expect(extractDeclaredUrls("helmor:url=https://app.test.\n")).toEqual([
+			"https://app.test",
+		]);
+	});
+
+	it("is stateless across calls despite the shared global regex", () => {
+		const input = "helmor:url=https://app.test\n";
+		expect(extractDeclaredUrls(input)).toEqual(extractDeclaredUrls(input));
+	});
+});
+
+describe("trailingPartialLine", () => {
+	it("returns text after the last newline", () => {
+		expect(trailingPartialLine("a\nb\nhelmor:url=htt")).toBe("helmor:url=htt");
+	});
+
+	it("returns the whole input when there is no newline", () => {
+		expect(trailingPartialLine("partial")).toBe("partial");
+	});
+
+	it("returns empty when the chunk ends on a newline", () => {
+		expect(trailingPartialLine("done\n")).toBe("");
+	});
+
+	it("caps runaway single-line output", () => {
+		expect(trailingPartialLine("x".repeat(5000), 2048)).toHaveLength(2048);
 	});
 });

--- a/src/features/inspector/detect-urls.ts
+++ b/src/features/inspector/detect-urls.ts
@@ -31,8 +31,60 @@ const ANSI_RE = new RegExp(
 const LOCAL_URL_RE =
 	/\bhttps?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0)(?::\d+)?(?:\/[^\s"'`<>)\]]*)?/gi;
 
+// Marker a run script prints to declare the URL Helmor should offer in the
+// Open menu. Anchored to the start of a line (leading whitespace allowed) so
+// it can't be triggered by a URL appearing mid-prose. The host part is
+// deliberately unrestricted — unlike LOCAL_URL_RE this must accept named
+// domains, which is the entire point of the feature.
+const DECLARED_URL_RE = /^[ \t]*helmor:url=(https?:\/\/[^\s"'`<>]+)/gim;
+
 export function stripAnsi(input: string): string {
 	return input.replace(ANSI_RE, "");
+}
+
+/**
+ * Extract URLs a run script has explicitly declared via `helmor:url=<URL>`
+ * lines in its output.
+ *
+ * Sniffing `http://localhost:PORT` out of stdout works for plain dev servers
+ * but breaks under a reverse proxy: with portless, Caddy, ngrok, or Tailscale
+ * Funnel the services behind the proxy print ephemeral ports that are neither
+ * reachable nor stable, while the address users actually need is a named
+ * domain nobody prints in a recognizable banner. Declaring it explicitly is
+ * the escape hatch:
+ *
+ *     echo "helmor:url=https://${HELMOR_WORKSPACE_NAME}.localhost"
+ *
+ * Repeating the marker declares multiple URLs (e.g. web + api in a monorepo),
+ * which surface in the Open menu's picker. Declared URLs take precedence over
+ * sniffed ones — see the script store.
+ */
+export function extractDeclaredUrls(input: string): string[] {
+	const clean = stripAnsi(input);
+	const out: string[] = [];
+	// Shared regex object with the `g` flag carries `lastIndex` between calls.
+	DECLARED_URL_RE.lastIndex = 0;
+	let match = DECLARED_URL_RE.exec(clean);
+	while (match !== null) {
+		out.push(match[1].replace(/[.,;:!?]+$/, ""));
+		match = DECLARED_URL_RE.exec(clean);
+	}
+	return out;
+}
+
+/**
+ * Return the trailing partial line of a chunk — everything after the last
+ * newline — capped so a pathological single-line stream (a progress bar
+ * redrawing with `\r`) can't grow the carry buffer without bound.
+ *
+ * PTY output is split on arbitrary 4096-byte boundaries, so a marker line can
+ * straddle two chunks. Carrying the partial line forward and re-scanning it
+ * with the next chunk makes detection boundary-proof.
+ */
+export function trailingPartialLine(input: string, cap = 2048): string {
+	const idx = input.lastIndexOf("\n");
+	const tail = idx === -1 ? input : input.slice(idx + 1);
+	return tail.length > cap ? tail.slice(-cap) : tail;
 }
 
 /**

--- a/src/features/inspector/script-store.test.ts
+++ b/src/features/inspector/script-store.test.ts
@@ -217,6 +217,19 @@ describe("script-store URL detection", () => {
 		]);
 	});
 
+	it("still sees an uppercase-scheme declaration after a URL was detected", () => {
+		// Regression: the fast-path probe guarding detection must be case-
+		// insensitive like the parsers it guards. With a case-sensitive
+		// `includes("http")` this chunk was skipped outright, so the
+		// declaration never landed and the Open menu kept the stale port.
+		const emit = startAndCapture();
+		emit({ type: "stdout", data: "web ready http://localhost:4761\n" });
+		emit({ type: "stdout", data: "helmor:url=HTTPS://achernar.localhost\n" });
+
+		const entry = getScriptState("ws1", "run");
+		expect(effectiveScriptUrls(entry!)).toEqual(["HTTPS://achernar.localhost"]);
+	});
+
 	it("notifies listeners when a declaration supersedes sniffed URLs", () => {
 		const seen: string[][] = [];
 		const emit = startAndCapture();

--- a/src/features/inspector/script-store.test.ts
+++ b/src/features/inspector/script-store.test.ts
@@ -30,6 +30,8 @@ vi.mock("@/lib/api", async (importOriginal) => {
 // Dynamic import so vi.mock is applied before module evaluation.
 const {
 	_resetForTesting,
+	attach,
+	effectiveScriptUrls,
 	getScriptState,
 	startScript,
 	stopScript,
@@ -157,5 +159,75 @@ describe("script-store userStopped tracking", () => {
 
 		startAndCapture();
 		expect(getScriptState("ws1", "run")?.userStopped).toBe(false);
+	});
+});
+
+describe("script-store URL detection", () => {
+	it("sniffs localhost banners when nothing is declared", () => {
+		const emit = startAndCapture();
+		emit({ type: "stdout", data: "  Local: http://localhost:5173/\n" });
+
+		const entry = getScriptState("ws1", "run");
+		expect(effectiveScriptUrls(entry!)).toEqual(["http://localhost:5173/"]);
+	});
+
+	it("lets a declared URL replace already-sniffed ephemeral ports", () => {
+		const emit = startAndCapture();
+		// A portless-style boot: proxied services announce raw ephemeral ports
+		// that are not reachable through the proxy…
+		emit({ type: "stdout", data: "web ready http://localhost:4761\n" });
+		emit({ type: "stdout", data: "api ready http://localhost:4786\n" });
+		const entry = getScriptState("ws1", "run");
+		expect(effectiveScriptUrls(entry!)).toHaveLength(2);
+
+		// …then the run script declares the address that actually works.
+		emit({ type: "stdout", data: "helmor:url=https://achernar.localhost\n" });
+
+		expect(effectiveScriptUrls(entry!)).toEqual(["https://achernar.localhost"]);
+	});
+
+	it("stops collecting sniffed URLs once one is declared", () => {
+		const emit = startAndCapture();
+		emit({ type: "stdout", data: "helmor:url=https://achernar.localhost\n" });
+		emit({ type: "stdout", data: "listening on http://localhost:4761\n" });
+
+		const entry = getScriptState("ws1", "run");
+		expect(effectiveScriptUrls(entry!)).toEqual(["https://achernar.localhost"]);
+	});
+
+	it("detects a marker split across PTY chunk boundaries", () => {
+		const emit = startAndCapture();
+		emit({ type: "stdout", data: "booting\nhelmor:url=https://ach" });
+		emit({ type: "stdout", data: "ernar.localhost\nready\n" });
+
+		const entry = getScriptState("ws1", "run");
+		expect(effectiveScriptUrls(entry!)).toEqual(["https://achernar.localhost"]);
+	});
+
+	it("keeps multiple declared URLs in first-seen order without duplicates", () => {
+		const emit = startAndCapture();
+		emit({ type: "stdout", data: "helmor:url=https://web.localhost\n" });
+		emit({ type: "stdout", data: "helmor:url=https://api.localhost\n" });
+		emit({ type: "stdout", data: "helmor:url=https://web.localhost\n" });
+
+		const entry = getScriptState("ws1", "run");
+		expect(effectiveScriptUrls(entry!)).toEqual([
+			"https://web.localhost",
+			"https://api.localhost",
+		]);
+	});
+
+	it("notifies listeners when a declaration supersedes sniffed URLs", () => {
+		const seen: string[][] = [];
+		const emit = startAndCapture();
+		attach("ws1", "run", {
+			onChunk: () => {},
+			onStatusChange: () => {},
+			onUrlsChange: (urls) => seen.push(urls),
+		});
+		emit({ type: "stdout", data: "http://localhost:4761\n" });
+		emit({ type: "stdout", data: "helmor:url=https://achernar.localhost\n" });
+
+		expect(seen.at(-1)).toEqual(["https://achernar.localhost"]);
 	});
 });

--- a/src/features/inspector/script-store.test.ts
+++ b/src/features/inspector/script-store.test.ts
@@ -204,6 +204,33 @@ describe("script-store URL detection", () => {
 		expect(effectiveScriptUrls(entry!)).toEqual(["https://achernar.localhost"]);
 	});
 
+	it("detects a split marker even after a URL was already sniffed", () => {
+		// Regression: the fast-path probe must consider the carried tail, not
+		// just the fresh chunk. Here the marker's "http" bytes sit in the tail
+		// while the completing fragment has none — probing only `event.data`
+		// sent this chunk down the fast path, which discarded the completed
+		// marker line unscanned and kept the stale port for the whole run.
+		const emit = startAndCapture();
+		emit({ type: "stdout", data: "web ready http://localhost:4761\n" });
+		emit({ type: "stdout", data: "helmor:url=https://ach" });
+		emit({ type: "stdout", data: "ernar.localhost\nready\n" });
+
+		const entry = getScriptState("ws1", "run");
+		expect(effectiveScriptUrls(entry!)).toEqual(["https://achernar.localhost"]);
+	});
+
+	it("detects a split marker whose scheme itself straddles the boundary", () => {
+		// Same regression, harder variant: neither fragment contains "http"
+		// on its own — only the rejoined text does.
+		const emit = startAndCapture();
+		emit({ type: "stdout", data: "web ready http://localhost:4761\n" });
+		emit({ type: "stdout", data: "helmor:url=ht" });
+		emit({ type: "stdout", data: "tps://achernar.localhost\nready\n" });
+
+		const entry = getScriptState("ws1", "run");
+		expect(effectiveScriptUrls(entry!)).toEqual(["https://achernar.localhost"]);
+	});
+
 	it("keeps multiple declared URLs in first-seen order without duplicates", () => {
 		const emit = startAndCapture();
 		emit({ type: "stdout", data: "helmor:url=https://web.localhost\n" });

--- a/src/features/inspector/script-store.ts
+++ b/src/features/inspector/script-store.ts
@@ -278,22 +278,28 @@ function runScriptInternal(
 				//
 				// We still run detection on every chunk until we've seen at
 				// least one URL, so the initial banner is never missed.
+				//
+				// The probe must also look at the rejoined tail + chunk, not
+				// the fresh chunk alone: a marker split across a PTY boundary
+				// can leave its "http" bytes in the carried tail while the
+				// completing fragment has none — probing only `event.data`
+				// would send that chunk down the fast path and discard the
+				// very line the tail was carried to protect.
+				const scan = entry.tail + event.data;
 				if (
 					entry.urls.length + entry.declaredUrls.length > 0 &&
-					!HTTP_HINT_RE.test(event.data)
+					!HTTP_HINT_RE.test(scan)
 				) {
-					entry.tail = trailingPartialLine(entry.tail + event.data);
+					entry.tail = trailingPartialLine(scan);
 					break;
 				}
 
-				// Rejoin the previous chunk's trailing partial line with the new
-				// data, then consider only the newline-terminated portion. A
-				// marker split across a PTY chunk boundary would otherwise be
-				// committed truncated — `helmor:url=https://ach` is a perfectly
-				// well-formed URL as far as the regex is concerned, so waiting
-				// for the terminating newline is the only safe signal that we
-				// have the whole thing.
-				const scan = entry.tail + event.data;
+				// Consider only the newline-terminated portion of the rejoined
+				// text. A marker split across a PTY chunk boundary would
+				// otherwise be committed truncated — `helmor:url=https://ach`
+				// is a perfectly well-formed URL as far as the regex is
+				// concerned, so waiting for the terminating newline is the
+				// only safe signal that we have the whole thing.
 				const lastNewline = scan.lastIndexOf("\n");
 				const completeLines =
 					lastNewline === -1 ? "" : scan.slice(0, lastNewline + 1);

--- a/src/features/inspector/script-store.ts
+++ b/src/features/inspector/script-store.ts
@@ -54,6 +54,12 @@ type StatusListener = (
  */
 const MAX_CHUNK_BYTES = 2 * 1024 * 1024;
 
+/**
+ * Cheap case-insensitive probe for "could this chunk contain a URL?". No `g`
+ * flag, so it carries no `lastIndex` state between calls.
+ */
+const HTTP_HINT_RE = /http/i;
+
 /** Inserted once at the head of replay when earlier output was dropped. */
 export const TRUNCATION_NOTICE =
 	"\r\n\x1b[2m… earlier output truncated (buffer limit reached) …\x1b[0m\r\n";
@@ -259,17 +265,22 @@ function runScriptInternal(
 
 				// Cheap short-circuit: once a dev server has settled into
 				// steady-state, ~every chunk is HMR / request-log noise with
-				// no URL. Skip the regex work when the chunk can't possibly
-				// contain one. `event.data.includes("http")` is a plain
-				// substring scan — ~100x faster than the ANSI+URL regex
-				// combo and totally safe (any real URL, sniffed or declared,
-				// has "http" verbatim in bytes, even when wrapped in ANSI).
+				// no URL. Skip the heavy work when the chunk can't possibly
+				// contain one — any real URL, sniffed or declared, has "http"
+				// in its bytes even when wrapped in ANSI.
+				//
+				// The probe must be case-INsensitive to match the parsers it
+				// guards: both URL regexes carry the `i` flag, so a bare
+				// `includes("http")` would silently drop a script printing
+				// `helmor:url=HTTPS://…`. A no-flag regex `test` stays cheap
+				// (no allocation, unlike `toLowerCase()`) while keeping the
+				// fast path and the parsers in agreement.
 				//
 				// We still run detection on every chunk until we've seen at
 				// least one URL, so the initial banner is never missed.
 				if (
 					entry.urls.length + entry.declaredUrls.length > 0 &&
-					!event.data.includes("http")
+					!HTTP_HINT_RE.test(event.data)
 				) {
 					entry.tail = trailingPartialLine(entry.tail + event.data);
 					break;

--- a/src/features/inspector/script-store.ts
+++ b/src/features/inspector/script-store.ts
@@ -6,7 +6,12 @@ import {
 	stopRepoScript,
 	writeRepoScriptStdin,
 } from "@/lib/api";
-import { dedupUrlKey, extractLocalUrls } from "./detect-urls";
+import {
+	dedupUrlKey,
+	extractDeclaredUrls,
+	extractLocalUrls,
+	trailingPartialLine,
+} from "./detect-urls";
 
 export type ScriptStatus = "idle" | "running" | "exited";
 
@@ -80,7 +85,28 @@ export type ScriptEntry = {
 	 * to its pre-run glyph. Cleared on the next `startScript`.
 	 */
 	userStopped: boolean;
+	/**
+	 * URLs the script explicitly declared via `helmor:url=<URL>` lines. When
+	 * non-empty these fully replace {@link urls} in the Open menu — a script
+	 * that declares its address is telling us the sniffed localhost ports are
+	 * wrong (typically ephemeral ports behind a reverse proxy), not that they
+	 * are extra options worth offering.
+	 */
+	declaredUrls: string[];
+	/**
+	 * Trailing partial line carried over from the previous chunk, so marker
+	 * lines split across PTY chunk boundaries are still detected.
+	 */
+	tail: string;
 };
+
+/**
+ * URLs to surface in the Open menu: explicitly declared ones win over sniffed
+ * localhost banners.
+ */
+export function effectiveScriptUrls(entry: ScriptEntry): string[] {
+	return entry.declaredUrls.length > 0 ? entry.declaredUrls : entry.urls;
+}
 
 /** Append a chunk and evict from the head until under the byte cap. */
 function appendChunk(entry: ScriptEntry, data: string) {
@@ -192,6 +218,8 @@ function runScriptInternal(
 		urls: [],
 		stopping: false,
 		userStopped: false,
+		declaredUrls: [],
+		tail: "",
 	};
 	entries.set(k, entry);
 
@@ -234,14 +262,50 @@ function runScriptInternal(
 				// no URL. Skip the regex work when the chunk can't possibly
 				// contain one. `event.data.includes("http")` is a plain
 				// substring scan — ~100x faster than the ANSI+URL regex
-				// combo and totally safe (any real localhost URL has "http"
-				// verbatim in bytes, even when wrapped in ANSI).
+				// combo and totally safe (any real URL, sniffed or declared,
+				// has "http" verbatim in bytes, even when wrapped in ANSI).
 				//
 				// We still run detection on every chunk until we've seen at
 				// least one URL, so the initial banner is never missed.
-				if (entry.urls.length > 0 && !event.data.includes("http")) {
+				if (
+					entry.urls.length + entry.declaredUrls.length > 0 &&
+					!event.data.includes("http")
+				) {
+					entry.tail = trailingPartialLine(entry.tail + event.data);
 					break;
 				}
+
+				// Rejoin the previous chunk's trailing partial line with the new
+				// data, then consider only the newline-terminated portion. A
+				// marker split across a PTY chunk boundary would otherwise be
+				// committed truncated — `helmor:url=https://ach` is a perfectly
+				// well-formed URL as far as the regex is concerned, so waiting
+				// for the terminating newline is the only safe signal that we
+				// have the whole thing.
+				const scan = entry.tail + event.data;
+				const lastNewline = scan.lastIndexOf("\n");
+				const completeLines =
+					lastNewline === -1 ? "" : scan.slice(0, lastNewline + 1);
+				entry.tail = trailingPartialLine(scan);
+
+				// Explicit `helmor:url=` declarations win outright: once a script
+				// has told us its address, sniffed localhost banners are noise
+				// (ephemeral ports behind a reverse proxy) and we stop collecting
+				// them entirely.
+				const declared = extractDeclaredUrls(completeLines);
+				if (declared.length > 0) {
+					let changed = false;
+					for (const url of declared) {
+						if (!entry.declaredUrls.includes(url)) {
+							entry.declaredUrls.push(url);
+							changed = true;
+						}
+					}
+					if (changed) {
+						listeners.get(k)?.onUrlsChange?.([...entry.declaredUrls]);
+					}
+				}
+				if (entry.declaredUrls.length > 0) break;
 
 				// Scan the fresh chunk for dev-server URLs. We keep a deduped,
 				// first-seen-ordered list on the entry and only fire the listener

--- a/src/features/inspector/sections/run.tsx
+++ b/src/features/inspector/sections/run.tsx
@@ -29,6 +29,7 @@ import {
 	attach,
 	cleanupScript,
 	detach,
+	effectiveScriptUrls,
 	resizeScript,
 	type ScriptStatus,
 	startScript,
@@ -234,7 +235,7 @@ export function RunTab({
 			setStopping(existing.stopping);
 			// Replay URLs already detected on this entry so the parent's state
 			// mirrors the store the moment the component mounts.
-			onUrlsChange?.([...existing.urls]);
+			onUrlsChange?.(effectiveScriptUrls(existing));
 			const replay = () => {
 				const t = termRef.current;
 				if (!t) return;


### PR DESCRIPTION
## Problem

The Run tab's Open menu is derived by regex-sniffing script stdout for `http://{localhost,127.0.0.1,0.0.0.0}:PORT` banners (`detect-urls.ts`). That works for a plain dev server, but breaks under a reverse proxy.

With portless (and equally Caddy, ngrok, Tailscale Funnel), each workspace gets a named URL like `https://achernar.localhost` and the underlying services are assigned ephemeral ports. Helmor surfaces those raw ports — `localhost:4761`, `localhost:4786` — which:

- aren't reachable through the proxy,
- aren't the address the app actually serves on,
- change on every boot.

The run script knows the right URL and already prints it, but there's no way to tell Helmor about it.

## Solution

A run script can declare its URL by printing a marker line:

```sh
echo "helmor:url=https://${HELMOR_WORKSPACE_NAME}.localhost"
```

Chosen over a schema column or a well-known file because it needs no per-repo config beyond one `echo`, and works for any proxy-based setup. `HELMOR_WORKSPACE_NAME` is already exported into the script environment (`workspace/scripts.rs:416`), so per-workspace interpolation comes for free — no migration, no new CLI flag, no backend change at all.

## Behaviour

- **Any host accepted.** Unlike `LOCAL_URL_RE`, the marker's host is unrestricted — named domains are the entire point.
- **Declared replaces sniffed.** A script that declares its address is telling us the sniffed ports are wrong, not that they're extra options. Once a declaration lands, sniffing stops.
- **Multiple markers supported.** A monorepo printing web + api URLs gets the existing 2+ picker.
- **Line-anchored.** `^[ \t]*helmor:url=` so a URL in prose can't spoof it.
- **ANSI-safe.** Parsed after `stripAnsi`, so a colored marker still matches.
- **Marker stays visible** in the terminal — it doubles as a debugging signal when detection isn't firing.

`OpenDevServerButton` needed no change: it already falls back to a plain `"Open"` label when `extractPort` returns null, which is exactly the portless case.

## Chunk-boundary correctness

PTY output splits on arbitrary 4096-byte boundaries, so a marker can straddle two chunks. The naive fix — carry the partial line forward and rescan — is wrong: `helmor:url=https://ach` parses as a perfectly well-formed URL and gets committed truncated. Detection therefore only accepts declarations from newline-terminated lines, with the incomplete tail carried into the next chunk (capped at 2 KB so a `\r`-redrawing progress bar can't grow the buffer unbounded). Covered by a regression test.

## Changes

| File | |
| --- | --- |
| `detect-urls.ts` | `extractDeclaredUrls()`, `trailingPartialLine()` |
| `script-store.ts` | `declaredUrls` + `tail` on `ScriptEntry`; `effectiveScriptUrls()` |
| `sections/run.tsx` | re-attach replay path routed through `effectiveScriptUrls` so declared URLs survive a tab switch |

Frontend only — no Rust, no `schema.rs`, no `pipeline/`, so no snapshot coverage required.

## Testing

15 new tests (8 parser, 4 boundary helper, 6 store-level precedence/dedup/notification). Full frontend suite green at 833 passing. `tsc` clean for `src/`; biome clean.

Note: `sidecar/test/codex-app-server-manager.test.ts` has two pre-existing `SendMessageParams` typecheck errors on `main`, untouched by this PR.