### PR TITLE
chore(deps): bump bundled agents to latest + add Claude Opus 5

### DIFF
--- a/.announcements/opus-5.json
+++ b/.announcements/opus-5.json
@@ -1,0 +1,11 @@
+{
+	"items": [
+		{
+			"text": "Claude Opus 5 is now the default Claude model. If you've customized which models appear in the picker, enable it in Settings — Opus 4.8 stays available there too.",
+			"action": {
+				"label": "Open Models",
+				"value": { "type": "openSettings", "section": "model" }
+			}
+		}
+	]
+}

--- a/.changeset/add-opus-5-model.md
+++ b/.changeset/add-opus-5-model.md
@@ -1,0 +1,8 @@
+---
+"helmor": minor
+---
+
+Add Claude Opus 5 to the Claude Code model picker and make it the default:
+
+- Opus 5 replaces Opus 4.8 in the default model set, with all five effort levels and fast mode support.
+- Opus 4.8 stays in the catalog and can be re-enabled from Settings, without disrupting existing sessions that use it.

--- a/.changeset/bump-bundled-agents.md
+++ b/.changeset/bump-bundled-agents.md
@@ -2,4 +2,4 @@
 "helmor": patch
 ---
 
-Update bundled Claude Code, Codex, Cursor, and OpenCode agents to their latest stable releases.
+Update bundled Claude Code, Codex, Cursor, OpenCode, and Kimi agents to their latest stable releases.

--- a/sidecar/bun.lock
+++ b/sidecar/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "@helmor/sidecar",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.217",
-        "@anthropic-ai/claude-code": "2.1.217",
+        "@anthropic-ai/claude-agent-sdk": "0.3.219",
+        "@anthropic-ai/claude-code": "2.1.219",
         "@cursor/sdk": "1.0.24",
         "@openai/codex": "0.145.0",
         "@opencode-ai/sdk": "1.18.4",
@@ -22,41 +22,41 @@
     "@anthropic-ai/claude-code",
   ],
   "packages": {
-    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.217", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.217", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.217", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.217", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.217", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.217", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.217", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.217", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.217" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-juszT3itL8R6OQ6nb/8IZE34UjKps8Jf7N8vjCXLx+vbJc+k3EojZOs93tJwT5iTRvfV1a0N53zJbKn/iJpKrQ=="],
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.219", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.219", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.219", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.219", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.219", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.219", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.219", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.219", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.219" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-dJjzKxoyCQSEEEo9a0g3wBQprRMCpsqjmsNOZaGOWw+W+JHZsolDBhoYfoZ9BA8EdwgaJmbQUvhkAZjROUsBnQ=="],
 
-    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.217", "", { "os": "darwin", "cpu": "arm64" }, "sha512-dl119zmL1Ssyd8Fx0xfVMpss2scrGCZwf+rhZwl2lHa2dYuXVluLgqi4DUIWDj3rRYdrAvaMpjCAv6a5w07ddw=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.219", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TQhGAlbMsOGXi03dwf4nD274Lc5BOJg4QFJTuXcQyhLhx0hUqzxCmtvpXt6S70K6yl1Zgc+2n5W/r1Dgt8G8iw=="],
 
-    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.217", "", { "os": "darwin", "cpu": "x64" }, "sha512-IeKL1HN8fEcRQ4uw5d02by1ThpjhRtOgfHcCTBQ2KS4JfEIHvc1VGWt6Exb2a7VHhT8uRcfjPk9urbmYayZmaw=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.219", "", { "os": "darwin", "cpu": "x64" }, "sha512-zA/wHN+os4yqXASXJxvGGNSD1p7LZ6BMN71CCphoy5u+d6IpNOCtATnZwINEc2fGFHpv/QDci6jhywJ2O9Flbw=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.217", "", { "os": "linux", "cpu": "arm64" }, "sha512-KtrnfEwUSCdq2cc4Pgysl+U66vqw3h7u04N5/OLHmYZ4AZYy8JcqdOaSJZ27iL2bgbAxyKwu5/9YmEk9A4IswA=="],
+    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.219", "", { "os": "linux", "cpu": "arm64" }, "sha512-lizasky9Xj0ouYrz/Akst573Sm8NO3k/0iGCeCDBoQKLnONbVFwc7sHq9x426Pfcllgb4C2Xyc79/1iOALh/9g=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.217", "", { "os": "linux", "cpu": "arm64" }, "sha512-Bb4AJxqrVPouM4sYIdvX3/AO5womhe70u3Euv+6B5J2OoqcRaWarVvYevX3KRruC5TvlV2Josw14dsL5qVNL+A=="],
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.219", "", { "os": "linux", "cpu": "arm64" }, "sha512-yiZo+UBCp42FAYqSakgVj/g6LfTH0AklWqIZNEHfVDPaofledXdSu0QJM5yScWNg0hVMaNRXPt0DmuS1oIWW6g=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.3.217", "", { "os": "linux", "cpu": "x64" }, "sha512-JsAQyfl4n0PR4LX0h1SxMo0raERGb8B8dvbaoNQRRSpb9A2vvcwPEjyKu0eRKHRhTvspvuD6TfNxzxrmnouX9A=="],
+    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.3.219", "", { "os": "linux", "cpu": "x64" }, "sha512-yzXhEsT5XcKa8Dc3sM4D1CQ92/6YGmsBbAhRAdw0PYNkG8x6wbHqfzYZS491Bdjry4tSWemNFtGPNkHiWVo3Hg=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.217", "", { "os": "linux", "cpu": "x64" }, "sha512-qhugNZd77vAoPMIGM8vFHlbwTltFyI1POmfyl0ZJSpc6v7RE9+5+nqL2aGbGSDsDQkEHrJasXURxIeTMn9ut2w=="],
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.219", "", { "os": "linux", "cpu": "x64" }, "sha512-IhfG57/XorWOQTB6BVdjEFPGH0LwOWO6HnAi+FNuCeiC+XRFl9QI9AKY43opS0gbvJWRobZO865tHX5j7Ou+ow=="],
 
-    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.217", "", { "os": "win32", "cpu": "arm64" }, "sha512-LuaQ+PXZvIToAR81JoiGa6Me9HDma2WH2oiYlAWh43IWaXHyOqgaI1aqSM0BjDhy2UiYWTvGzAopnqPnk+jSBw=="],
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.219", "", { "os": "win32", "cpu": "arm64" }, "sha512-L/cAT27t3FGP4GlJ16WpXMtaeqDu9olpOlIaqqmjElQp5Lknd8alJ3NIY/SlRAtHDvm4WXug74wnfBOSlwppkg=="],
 
-    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.3.217", "", { "os": "win32", "cpu": "x64" }, "sha512-4r/T+ze/S/CLZ58tP4Mw52XPmsc/LOrCOd8jZOqM13FCPWdCMU2osWmszEIKGVMRG2cGsaLVDYcks5cWFqjCjw=="],
+    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.3.219", "", { "os": "win32", "cpu": "x64" }, "sha512-Fl8Rb9K64jbpC/omIF9y828LIvwRmm1zhZgO8zjalTpjZR/0C31Kl+5FwAS9KkXXUXwmdHSY+82e9dyvBrbIRw=="],
 
-    "@anthropic-ai/claude-code": ["@anthropic-ai/claude-code@2.1.217", "", { "optionalDependencies": { "@anthropic-ai/claude-code-darwin-arm64": "2.1.217", "@anthropic-ai/claude-code-darwin-x64": "2.1.217", "@anthropic-ai/claude-code-linux-arm64": "2.1.217", "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.217", "@anthropic-ai/claude-code-linux-x64": "2.1.217", "@anthropic-ai/claude-code-linux-x64-musl": "2.1.217", "@anthropic-ai/claude-code-win32-arm64": "2.1.217", "@anthropic-ai/claude-code-win32-x64": "2.1.217" }, "bin": { "claude": "bin/claude.exe" } }, "sha512-EIcc3GmI7x+qPlKCjpcLIjCh7YOaCFbOqKfL4BmwZS6QmtduVNT5E98oyr8n2cxsgeWVbnQ0mSVljTw5C/kFtA=="],
+    "@anthropic-ai/claude-code": ["@anthropic-ai/claude-code@2.1.219", "", { "optionalDependencies": { "@anthropic-ai/claude-code-darwin-arm64": "2.1.219", "@anthropic-ai/claude-code-darwin-x64": "2.1.219", "@anthropic-ai/claude-code-linux-arm64": "2.1.219", "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.219", "@anthropic-ai/claude-code-linux-x64": "2.1.219", "@anthropic-ai/claude-code-linux-x64-musl": "2.1.219", "@anthropic-ai/claude-code-win32-arm64": "2.1.219", "@anthropic-ai/claude-code-win32-x64": "2.1.219" }, "bin": { "claude": "bin/claude.exe" } }, "sha512-6PVBrRsKHFi0gzv5bCabVL+XSqI3F8AR6ekFx4gpzdE5a9XotqewolID0PbcdD9IyWVYCIDET4GDCcUdA89i3Q=="],
 
-    "@anthropic-ai/claude-code-darwin-arm64": ["@anthropic-ai/claude-code-darwin-arm64@2.1.217", "", { "os": "darwin", "cpu": "arm64" }, "sha512-w1n/sitmcNyR0G8VzJ4j2RuNVd+K1oVO7YD69y2Je0kzTJ0XMhMXSe1DDd5i0Q93CabhftvRBo1Ja/ZEOvDALg=="],
+    "@anthropic-ai/claude-code-darwin-arm64": ["@anthropic-ai/claude-code-darwin-arm64@2.1.219", "", { "os": "darwin", "cpu": "arm64" }, "sha512-/t/JlmaHh6vtXbZ0R8iRnSBzhc1OSQLybS8HB5RA/BtbueODKQKvtCiCBVwdXXjmdn3aBFrmWRbGzpYZRVcZtw=="],
 
-    "@anthropic-ai/claude-code-darwin-x64": ["@anthropic-ai/claude-code-darwin-x64@2.1.217", "", { "os": "darwin", "cpu": "x64" }, "sha512-aXEI06uRiJw5aeM1PWRo8iiSLAwbTp60cI8+A6UFY3MII9HCWauGcya8n9peSB83Qxz0i63hjVLpVrgt92cHAg=="],
+    "@anthropic-ai/claude-code-darwin-x64": ["@anthropic-ai/claude-code-darwin-x64@2.1.219", "", { "os": "darwin", "cpu": "x64" }, "sha512-+xuRyR76Q4ZtorDuZVaTvfFEKunCsthZxR+c8/cHtvViaYt4cZ11Aof2GYH0qQhyY5DaoQphO21Lnr/VfzpGqQ=="],
 
-    "@anthropic-ai/claude-code-linux-arm64": ["@anthropic-ai/claude-code-linux-arm64@2.1.217", "", { "os": "linux", "cpu": "arm64" }, "sha512-u0uRgmcZTL1vVQVvFbQ2GVjmmFQ+MhEGNrWaqm5xddqpVPE3RGVlm6wt1icMieV+wGdwCAzBNb89MeRM5giwzw=="],
+    "@anthropic-ai/claude-code-linux-arm64": ["@anthropic-ai/claude-code-linux-arm64@2.1.219", "", { "os": "linux", "cpu": "arm64" }, "sha512-G5yLidk2u6djL5PPuBYXVwVhTsZY5zLoZwh1Jnrd/IRyYb0P0x4gKTzVvGlsGepkBrOp0H2k/KuicyNPrXt57Q=="],
 
-    "@anthropic-ai/claude-code-linux-arm64-musl": ["@anthropic-ai/claude-code-linux-arm64-musl@2.1.217", "", { "os": "linux", "cpu": "arm64" }, "sha512-gw/12P/vY0WIV9babBvk5M4c4J2BT3A09tX5KcGsqcnYf+wuYnOSmUFTVImb7OMlCDIBGPjCDmgfSUVs0pTGQg=="],
+    "@anthropic-ai/claude-code-linux-arm64-musl": ["@anthropic-ai/claude-code-linux-arm64-musl@2.1.219", "", { "os": "linux", "cpu": "arm64" }, "sha512-l3v1ngKE5Y75TD8vqkE/yHTHIZ7bzcfWhyi9jmtXnYQ2Q2GVcBDasaD4K8wkFsf7iEZtioSRYtxdi0FBuTYYJQ=="],
 
-    "@anthropic-ai/claude-code-linux-x64": ["@anthropic-ai/claude-code-linux-x64@2.1.217", "", { "os": "linux", "cpu": "x64" }, "sha512-tZbghQ8V49xA2uWuooi5+ZkN1l9JMC6cVCKUFL95qevNgi9HmAB312IgsbKdJd733QvVkBDeHqrvMuihcdtLvg=="],
+    "@anthropic-ai/claude-code-linux-x64": ["@anthropic-ai/claude-code-linux-x64@2.1.219", "", { "os": "linux", "cpu": "x64" }, "sha512-Eq8aJpMrfy5rwQZQys/MdDD5Ph96ugZMgmwZmo4mXveEvp7JTZX8vUvqN/sHBn/yVmhzJNWcvepzQuBkcrLXZw=="],
 
-    "@anthropic-ai/claude-code-linux-x64-musl": ["@anthropic-ai/claude-code-linux-x64-musl@2.1.217", "", { "os": "linux", "cpu": "x64" }, "sha512-NRqy7DkptF+cPVwOu99JOo4E5KIFwY7XNfXefbPYUmJQEaZT6GakLaRY7KZnb7QCzV6G2ib40IU/IE4cpfzOdQ=="],
+    "@anthropic-ai/claude-code-linux-x64-musl": ["@anthropic-ai/claude-code-linux-x64-musl@2.1.219", "", { "os": "linux", "cpu": "x64" }, "sha512-fEgmLQZWn6yvfGChyr781+pXaFPNMTSlGyujW3J8lM1CqobFOQSvk/8kepxgibmjeRxQn/O6BIgSxwp1vzvlSA=="],
 
-    "@anthropic-ai/claude-code-win32-arm64": ["@anthropic-ai/claude-code-win32-arm64@2.1.217", "", { "os": "win32", "cpu": "arm64" }, "sha512-MNXUzpmAvcTw3q8k4mrAxmJTTPr72Kwz+USHaXNn9Dnuf00fzPRtpxAbvRoP8rmiAvaxkx1FhIDMrx9MTr3OEA=="],
+    "@anthropic-ai/claude-code-win32-arm64": ["@anthropic-ai/claude-code-win32-arm64@2.1.219", "", { "os": "win32", "cpu": "arm64" }, "sha512-Do0M4zVIF8ULCvttXwi1d4D6U19sqgjCLOSRsgOGjaa/G1QUzkTn8BiGAi2vkp8EEIYQKJpPXmWVzWYcZnKAWQ=="],
 
-    "@anthropic-ai/claude-code-win32-x64": ["@anthropic-ai/claude-code-win32-x64@2.1.217", "", { "os": "win32", "cpu": "x64" }, "sha512-NOopwp5bEXPR6TQiomDkRIKX1MQ24MzzTRUj6Oo7or2k4STB4qmCMHpYSJafllhv77HEQAWk4x+EVzp1hiHpVg=="],
+    "@anthropic-ai/claude-code-win32-x64": ["@anthropic-ai/claude-code-win32-x64@2.1.219", "", { "os": "win32", "cpu": "x64" }, "sha512-W5yKQOYnMmPFUa0//e8dVMAn0oYK2iMk9dS5QvfIZnNc32exXlRWjVDtTUhwxL5wbeIom3GbGk4lrOYwD4h/cw=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.91.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw=="],
 

--- a/sidecar/package.json
+++ b/sidecar/package.json
@@ -14,8 +14,8 @@
 		"typecheck": "bunx tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.3.217",
-		"@anthropic-ai/claude-code": "2.1.217",
+		"@anthropic-ai/claude-agent-sdk": "0.3.219",
+		"@anthropic-ai/claude-code": "2.1.219",
 		"@cursor/sdk": "1.0.24",
 		"@openai/codex": "0.145.0",
 		"@opencode-ai/sdk": "1.18.4",

--- a/sidecar/scripts/vendor-platform.ts
+++ b/sidecar/scripts/vendor-platform.ts
@@ -174,6 +174,10 @@ export const CLAUDE_CODE_SHA256: Readonly<
 		arm64: "748221efe210b823b85cbf4225206519c014408a2f80174aa7156fc2a873c7b5",
 		x64: "b35a5c2b892ce774a6c71c156fbc50db1629908929b1332f9d881eb5965502ef",
 	},
+	"2.1.219": {
+		arm64: "36a0a1e56ac982f3122c88fc836f69a9d139975ceb9b5ddf44e2b01f75998bda",
+		x64: "970f8f3c79063f0dae7e42fe7876c14e2c704764409cf814bb21b48a068c4dc8",
+	},
 };
 
 export const OPENCODE_SHA256: Readonly<
@@ -230,7 +234,7 @@ export const OPENCODE_SHA256: Readonly<
 // release URL rather than from node_modules. Bumping: pull each platform's
 // SHA256 from the release's `*.zip.sha256` sidecar (or the GitHub asset
 // `digest`) and wipe sidecar/.bundle-cache. Keyed `version → platformSlug`.
-export const KIMI_VERSION = "0.21.0";
+export const KIMI_VERSION = "0.29.1";
 export const KIMI_SHA256: Readonly<Record<string, Record<string, string>>> = {
 	"0.19.1": {
 		"darwin-arm64":
@@ -271,6 +275,16 @@ export const KIMI_SHA256: Readonly<Record<string, Record<string, string>>> = {
 			"65c410c38e193c4c99da6b64a536440ea5896796995e7963fa7911cdcb2580d2",
 		"win32-x64":
 			"b6e875f1fcd7967713f0b99c040c72b853962d1e7f88377e6125478b79e5999d",
+	},
+	"0.29.1": {
+		"darwin-arm64":
+			"0f2ff623a88eab6edfef131c2663ca312de5af81c7e30a8830bd6d566bbe78cb",
+		"darwin-x64":
+			"f83e86d32c27370e5dedbb0a75fc4340d8da5cb8fbe5e4e06a51de66615284a0",
+		"win32-arm64":
+			"269559f980a0d64a14e58df00187ea5f6711312fb395335eaa01de2b9da11a22",
+		"win32-x64":
+			"f1447930a2d5422ae15bb0c73a7a5fba5fdb679beecf162cc460439785014310",
 	},
 };
 

--- a/sidecar/src/model-catalog.ts
+++ b/sidecar/src/model-catalog.ts
@@ -33,12 +33,22 @@ const MODEL_CATALOG: Record<Provider, readonly ProviderModelInfo[]> = {
 			cliModel: "claude-fable-5[1m]",
 			effortLevels: ["low", "medium", "high", "xhigh", "max"],
 		},
-		// Pinned to the explicit `claude-opus-4-8[1m]` wire id — the `[1m]`
+		// Pinned to the explicit `claude-opus-5[1m]` wire id — the `[1m]`
 		// suffix selects the 1M-context variant, matching the label. We do NOT
 		// use the CLI's `default` sentinel: it resolves to whatever the bundled
 		// claude-code decides is "default" (non-deterministic across CLI bumps),
 		// whereas a pinned id is stable. Bump when a newer Opus ships. MUST stay
 		// in sync with the Rust catalog (`official_claude_section`).
+		{
+			id: "claude-opus-5[1m]",
+			label: "Opus 5 1M",
+			cliModel: "claude-opus-5[1m]",
+			effortLevels: ["low", "medium", "high", "xhigh", "max"],
+			supportsFastMode: true,
+		},
+		// Explicit 4.8 pin — previously this slot was the pinned newest Opus;
+		// now that Opus 5 has it, 4.8 stays in the catalog (off by default) so
+		// users can re-enable it from settings.
 		{
 			id: "claude-opus-4-8[1m]",
 			label: "Opus 4.8 1M",

--- a/sidecar/test/claude-session-manager.test.ts
+++ b/sidecar/test/claude-session-manager.test.ts
@@ -1776,6 +1776,13 @@ describe("ClaudeSessionManager.listModels", () => {
 				effortLevels: ["low", "medium", "high", "xhigh", "max"],
 			},
 			{
+				id: "claude-opus-5[1m]",
+				label: "Opus 5 1M",
+				cliModel: "claude-opus-5[1m]",
+				effortLevels: ["low", "medium", "high", "xhigh", "max"],
+				supportsFastMode: true,
+			},
+			{
 				id: "claude-opus-4-8[1m]",
 				label: "Opus 4.8 1M",
 				cliModel: "claude-opus-4-8[1m]",

--- a/src-tauri/src/agents/catalog.rs
+++ b/src-tauri/src/agents/catalog.rs
@@ -38,12 +38,8 @@ pub struct AgentModelSection {
 }
 
 const DEFAULT_CODEX_MODEL_IDS: &[&str] = &["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"];
-const DEFAULT_CLAUDE_MODEL_IDS: &[&str] = &[
-    "claude-fable-5[1m]",
-    "claude-opus-4-8[1m]",
-    "sonnet",
-    "haiku",
-];
+const DEFAULT_CLAUDE_MODEL_IDS: &[&str] =
+    &["claude-fable-5[1m]", "claude-opus-5[1m]", "sonnet", "haiku"];
 
 /// The composer/CLI picker catalog: full catalog with the user's model
 /// selection applied. Empty sections are omitted.
@@ -304,13 +300,22 @@ fn official_claude_section() -> AgentModelSection {
                 &["low", "medium", "high", "xhigh", "max"],
                 false,
             ),
-            // Pinned to the explicit `claude-opus-4-8[1m]` wire id —
+            // Pinned to the explicit `claude-opus-5[1m]` wire id —
             // the `[1m]` suffix selects the 1M-context variant, matching the
             // label. We do NOT use the CLI's `default` sentinel: it resolves to
             // whatever the bundled claude-code decides (non-deterministic
             // across CLI bumps), whereas a pinned id is stable. Bump when a
             // newer Opus ships. MUST stay in sync with
             // `sidecar/src/model-catalog.ts`.
+            claude_model(
+                "claude-opus-5[1m]",
+                "Opus 5 1M",
+                &["low", "medium", "high", "xhigh", "max"],
+                true,
+            ),
+            // Explicit 4.8 pin — previously this slot was the pinned newest
+            // Opus; now that Opus 5 has it, 4.8 stays in the catalog (off by
+            // default) so users can re-enable it from settings.
             claude_model(
                 "claude-opus-4-8[1m]",
                 "Opus 4.8 1M",
@@ -1033,6 +1038,7 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![
                 "claude-fable-5[1m]",
+                "claude-opus-5[1m]",
                 "claude-opus-4-8[1m]",
                 "claude-opus-4-7[1m]",
                 "claude-opus-4-6[1m]",
@@ -1122,6 +1128,7 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![
                 "claude-fable-5[1m]",
+                "claude-opus-5[1m]",
                 "claude-opus-4-8[1m]",
                 "claude-opus-4-7[1m]",
                 "claude-opus-4-6[1m]",
@@ -1131,14 +1138,14 @@ mod tests {
             ]
         );
         assert_eq!(
-            sections[0].options[6].provider_key.as_deref(),
+            sections[0].options[7].provider_key.as_deref(),
             Some("minimax")
         );
         assert_eq!(
-            sections[0].options[6].effort_levels,
+            sections[0].options[7].effort_levels,
             vec!["low", "medium", "high", "xhigh", "max"]
         );
-        assert!(!sections[0].options[6].supports_context_usage);
+        assert!(!sections[0].options[7].supports_context_usage);
         assert_eq!(sections[1].id, "codex");
     }
 
@@ -1313,20 +1320,23 @@ mod tests {
                 .iter()
                 .map(|o| o.id.as_str())
                 .collect::<Vec<_>>(),
-            vec![
-                "claude-fable-5[1m]",
-                "claude-opus-4-8[1m]",
-                "sonnet",
-                "haiku",
-            ]
+            vec!["claude-fable-5[1m]", "claude-opus-5[1m]", "sonnet", "haiku",]
         );
     }
 
     #[test]
     fn official_filter_can_reenable_hidden_opus_models() {
         let base = model_sections_for_inputs(Vec::new(), Vec::new(), None, None, None);
-        let filtered =
-            apply_official_enabled_filter(base, Some(&["claude-opus-4-7[1m]".to_string()]), None);
+        let filtered = apply_official_enabled_filter(
+            base,
+            // 4.8 dropped out of the default set when Opus 5 took its slot;
+            // settings must still be able to bring it back.
+            Some(&[
+                "claude-opus-4-8[1m]".to_string(),
+                "claude-opus-4-7[1m]".to_string(),
+            ]),
+            None,
+        );
         let claude = filtered.iter().find(|s| s.id == "claude").unwrap();
         assert_eq!(
             claude
@@ -1334,7 +1344,7 @@ mod tests {
                 .iter()
                 .map(|o| o.id.as_str())
                 .collect::<Vec<_>>(),
-            vec!["claude-opus-4-7[1m]"]
+            vec!["claude-opus-4-8[1m]", "claude-opus-4-7[1m]"]
         );
     }
 
@@ -1683,20 +1693,21 @@ mod tests {
         let sections = model_sections_for_inputs(Vec::new(), Vec::new(), None, None, None);
         let claude = sections.iter().find(|s| s.id == "claude").unwrap();
         let ids: Vec<&str> = claude.options.iter().map(|o| o.id.as_str()).collect();
-        // User-facing ordering: Fable 5 on top, then 4.8 (default), 4.7, 4.6.
+        // User-facing ordering: Fable 5 on top, then 5 (default), 4.8, 4.7, 4.6.
         assert_eq!(
-            &ids[..4],
+            &ids[..5],
             &[
                 "claude-fable-5[1m]",
+                "claude-opus-5[1m]",
                 "claude-opus-4-8[1m]",
                 "claude-opus-4-7[1m]",
                 "claude-opus-4-6[1m]"
             ],
-            "Fable 5 must lead, with Opus 4.8 (default) / 4.7 / 4.6 beneath it"
+            "Fable 5 must lead, with Opus 5 (default) / 4.8 / 4.7 / 4.6 beneath it"
         );
 
         // Fable 5: most capable, leads the list, but is NOT the app default
-        // (too expensive) — `useEnsureDefaultModel` pins to the Opus 4.8 id.
+        // (too expensive) — `useEnsureDefaultModel` pins to the Opus 5 id.
         // No fast mode (Opus 4.6+ only); full effort tiers incl. xhigh.
         let fable = &claude.options[0];
         assert_eq!(fable.label, "Fable 5 1M");
@@ -1707,19 +1718,26 @@ mod tests {
             vec!["low", "medium", "high", "xhigh", "max"]
         );
 
-        // Opus 4.8: the app default selection, supports fast mode, and keeps
+        // Opus 5: the app default selection, supports fast mode, and keeps
         // the xhigh effort tier. Pinned to its explicit `[1m]` wire id.
         let default = &claude.options[1];
-        assert_eq!(default.label, "Opus 4.8 1M");
-        assert_eq!(default.cli_model, "claude-opus-4-8[1m]");
-        assert!(default.supports_fast_mode, "Opus 4.8 supports fast mode");
+        assert_eq!(default.label, "Opus 5 1M");
+        assert_eq!(default.cli_model, "claude-opus-5[1m]");
+        assert!(default.supports_fast_mode, "Opus 5 supports fast mode");
         assert_eq!(
             default.effort_levels,
             vec!["low", "medium", "high", "xhigh", "max"]
         );
 
+        // Opus 4.8: still in the catalog so users can re-enable it from
+        // settings, though it is no longer in the default-enabled set.
+        let prev = &claude.options[2];
+        assert_eq!(prev.label, "Opus 4.8 1M");
+        assert_eq!(prev.cli_model, "claude-opus-4-8[1m]");
+        assert!(prev.supports_fast_mode, "Opus 4.8 supports fast mode");
+
         // Explicit 4.7 pin: same effort tiers as before, still no fast mode.
-        let opus47 = &claude.options[2];
+        let opus47 = &claude.options[3];
         assert_eq!(opus47.label, "Opus 4.7 1M");
         assert_eq!(opus47.cli_model, "claude-opus-4-7[1m]");
         assert!(!opus47.supports_fast_mode);
@@ -1729,7 +1747,7 @@ mod tests {
         );
 
         // 4.6 unchanged.
-        let opus46 = &claude.options[3];
+        let opus46 = &claude.options[4];
         assert_eq!(opus46.label, "Opus 4.6 1M");
         assert!(opus46.supports_fast_mode);
     }

--- a/src/features/composer/session-model-sections.test.ts
+++ b/src/features/composer/session-model-sections.test.ts
@@ -45,6 +45,30 @@ describe("includePinnedHiddenModel", () => {
 		);
 	});
 
+	// Opus 5 took 4.8's place in the default set, so 4.8 became hidden-by-
+	// default. Without an entry here, a session pinned to it would have its
+	// persisted pick dropped as a dangling id and get silently switched to the
+	// default model (see `resolveSessionSelectedModelId`).
+	it("keeps Opus 4.8 available to a session still pinned to it", () => {
+		const result = includePinnedHiddenModel([], {
+			agentType: "claude",
+			model: "claude-opus-4-8[1m]",
+		});
+
+		expect(result[0]).toEqual(
+			expect.objectContaining({
+				id: "claude",
+				options: [
+					expect.objectContaining({
+						id: "claude-opus-4-8[1m]",
+						label: "Opus 4.8 1M",
+						supportsFastMode: true,
+					}),
+				],
+			}),
+		);
+	});
+
 	it("does not add a legacy model to unrelated sessions", () => {
 		expect(
 			includePinnedHiddenModel(SECTIONS, {

--- a/src/features/composer/session-model-sections.ts
+++ b/src/features/composer/session-model-sections.ts
@@ -5,6 +5,15 @@ import type {
 } from "@/lib/api";
 
 const HIDDEN_MODELS: Record<string, AgentModelOption> = {
+	"claude-opus-4-8[1m]": {
+		id: "claude-opus-4-8[1m]",
+		provider: "claude",
+		label: "Opus 4.8 1M",
+		cliModel: "claude-opus-4-8[1m]",
+		effortLevels: ["low", "medium", "high", "xhigh", "max"],
+		supportsFastMode: true,
+		supportsContextUsage: true,
+	},
 	"claude-opus-4-7[1m]": {
 		id: "claude-opus-4-7[1m]",
 		provider: "claude",

--- a/src/lib/provider-config.test.ts
+++ b/src/lib/provider-config.test.ts
@@ -13,6 +13,7 @@ const CODEX_AVAILABLE = [
 
 const CLAUDE_AVAILABLE = [
 	{ slug: "claude-fable-5[1m]" },
+	{ slug: "claude-opus-5[1m]" },
 	{ slug: "claude-opus-4-8[1m]" },
 	{ slug: "claude-opus-4-7[1m]" },
 	{ slug: "claude-opus-4-6[1m]" },
@@ -40,7 +41,7 @@ describe("resolveOfficialEnabled", () => {
 	it("defaults Claude to current models and user-configured custom models", () => {
 		expect(resolveOfficialEnabled("claude", null, CLAUDE_AVAILABLE)).toEqual([
 			"claude-fable-5[1m]",
-			"claude-opus-4-8[1m]",
+			"claude-opus-5[1m]",
 			"sonnet",
 			"haiku",
 			"claude-custom|gateway|model",

--- a/src/lib/provider-config.ts
+++ b/src/lib/provider-config.ts
@@ -10,7 +10,7 @@ export const DEFAULT_CODEX_MODEL_IDS = [
 
 export const DEFAULT_CLAUDE_MODEL_IDS = [
 	"claude-fable-5[1m]",
-	"claude-opus-4-8[1m]",
+	"claude-opus-5[1m]",
 	"sonnet",
 	"haiku",
 ] as const;

--- a/src/shell/hooks/use-ensure-default-model.ts
+++ b/src/shell/hooks/use-ensure-default-model.ts
@@ -59,13 +59,13 @@ export function useEnsureDefaultModel() {
 		// Repair the default when it's never been set, or was set but is now
 		// definitively gone (wait for every provider to settle first).
 		if (!defaultOption && (settled || !settings.defaultModel)) {
-			// GPT-5.6 Sol is the recommended cross-provider default. Opus 4.8
+			// GPT-5.6 Sol is the recommended cross-provider default. Opus 5
 			// remains the fallback when Codex is unavailable or fully disabled.
 			const claudeOptions =
 				sections.find((s) => s.id === "claude")?.options ?? [];
 			const pickOption =
 				allOptions.find((o) => o.id === "gpt-5.6-sol") ??
-				claudeOptions.find((o) => o.id === "claude-opus-4-8[1m]") ??
+				claudeOptions.find((o) => o.id === "claude-opus-5[1m]") ??
 				claudeOptions[0] ??
 				allOptions[0] ??
 				null;


### PR DESCRIPTION
Two changes on this branch: the automated daily bundled-agent version sweep, plus Claude Opus 5 support (requested separately — say the word and I'll split it into its own PR).

---

# 1. Add Claude Opus 5 (`feat`, minor)

Opus 5 joins the Claude Code model picker and takes Opus 4.8's slot as the default. Opus 4.8 stays in the catalog and can be re-enabled from Settings, so existing sessions using it are unaffected. Mirrors the pattern used for the GPT-5.6 rollout in #923.

| File | Change |
|---|---|
| `src-tauri/src/agents/catalog.rs` | Add `claude-opus-5[1m]` above 4.8 in `official_claude_section()`; repoint `DEFAULT_CLAUDE_MODEL_IDS` |
| `sidecar/src/model-catalog.ts` | Same entry (kept in sync with the Rust catalog per its own header comment) |
| `src/lib/provider-config.ts` | Same default swap on the frontend |
| `src/shell/hooks/use-ensure-default-model.ts` | Repoint the Claude fallback default |
| `.changeset/add-opus-5-model.md` | New `minor` changeset |

Model config: `claude-opus-5[1m]`, label "Opus 5 1M", effort levels `low`/`medium`/`high`/`xhigh`/`max`, fast mode enabled.

**Two things worth a reviewer's attention:**

- **The `[1m]` suffix was verified, not assumed.** It's a CLI routing identifier rather than a public model ID, so a new model doesn't automatically have one. Confirmed `claude-opus-5[1m]` is present in the bundled claude-code 2.1.219 binary before pinning it.
- **`use-ensure-default-model.ts` was changed beyond the literal ask.** It hard-looked-up `claude-opus-4-8[1m]` as the Claude fallback. Once 4.8 left the default-enabled set that lookup would miss and fall through to `claudeOptions[0]` — Fable 5, the most expensive option. Repointing it to Opus 5 preserves the original intent.

Test coverage: extended the existing `official_filter_can_reenable_hidden_opus_models` case to assert 4.8 can still be re-enabled, which is the behavior this change is meant to preserve.

---

# 2. Bundled-agent version sweep (`chore`, patch)

| Vendor | Current | Target | Notes |
|---|---|---|---|
| `@anthropic-ai/claude-agent-sdk` | 0.3.217 | **0.3.219** | lockstep with claude-code |
| `@anthropic-ai/claude-code` | 2.1.217 | **2.1.219** | lockstep; SHA256 added (arm64 + x64) |
| Kimi (`KIMI_VERSION`) | 0.21.0 | **0.29.1** | SHA256 added (darwin-arm64/x64, win32-arm64/x64) |
| `@openai/codex` | 0.145.0 | 0.145.0 | already current |
| `@cursor/sdk` | 1.0.24 | 1.0.24 | already current |
| `@opencode-ai/sdk` + `opencode-ai` | 1.18.4 | 1.18.4 | already current |

All targets are the **stable** channel (npm `latest` dist-tag; latest non-prerelease GitHub release for Kimi). Codex `0.146.0-alpha.6` was deliberately **not** taken — alpha.

**Claude lockstep verified:** `node_modules/@anthropic-ai/claude-agent-sdk/package.json` reports `claudeCodeVersion: "2.1.219"`, matching the pinned CLI.

**Kimi 0.21.0 → 0.29.1** is a larger jump (8 minor versions), so the ACP handshake was checked explicitly. Helmor hard-enforces `ACP_PROTOCOL_VERSION = 1` (`sidecar/src/kimi/acp-types.ts`) and throws on mismatch. The 0.29.1 binary still carries `protocolVersion: 1` along with the `initialize` / `session/new` / `session/prompt` / `session/update` methods Helmor drives, so the handshake contract is unchanged. **Worth a manual `kimi acp` smoke-test on macOS before merge** — this sandbox is Linux and cannot execute the darwin binary.

Files: `sidecar/package.json`, `sidecar/bun.lock`, `sidecar/scripts/vendor-platform.ts`, `.changeset/bump-bundled-agents.md`.

---

## Verification

| Gate | Result |
|---|---|
| `bun install` | pass |
| `bun run typecheck` (frontend + sidecar) | pass |
| `bun test` (sidecar) | pass — 418 pass, 1 skip, 0 fail |
| `vitest run` (frontend) | pass — 1666 pass across 161 files |
| `cargo test --lib agents::catalog` | pass — 46 pass |
| `cargo test --test pipeline_scenarios --test pipeline_fixtures --test pipeline_streams` | pass — 119 scenarios + fixtures + stream_replay |
| `biome check` | clean |
| `cargo fmt --check` | clean |

**Two known-unrelated failures in the Linux sandbox, both verified against a clean checkout of this branch's base:**

- `workspace::scripts::tests` — 2 PTY/process tests fail. A clean checkout fails the same count (1556 passed / 2 failed), and the second failing test differs run to run (`initial_size_sets_pty_winsize` vs `script_env_includes_helmor_port_vars_when_range_present`), so these are flaky in this environment rather than caused by either change.
- `cargo clippy -D warnings` — fails on pre-existing dead-code warnings for `bytes_to_rounded_gb` / `recommend_for_ram` in `src/local_llm/hardware.rs`. Their only callers sit behind `#[cfg(target_os = "macos")]`, so they read as unused on Linux. Identical on a clean checkout; CI's macOS Clippy job is the real signal here.

`bun run build` was not run locally (heavy; `stage-vendor.ts` untouched) — CI exercises the full staging + SHA256 verification, which is the gate that would catch a bad hash.